### PR TITLE
faq collapsing and linking behavior

### DIFF
--- a/app/views/pages/faq.html.slim
+++ b/app/views/pages/faq.html.slim
@@ -5,7 +5,6 @@ hr
 p.leader
   em Quill is a web based application that provides personalized grammar lessons. Students using Quill learn English grammar by writing sentences and proofreading passages.
 
-
 h3.names You may reach us at:
 p 
   strong Peter Gault - peter@quill.org 
@@ -20,154 +19,235 @@ p
 p.title 
   em Creative Director, Teacher Liaison   
 
+
+
 hr
 h3 General Questions
 
+.accordion#general-questions
+  .accordion-group
 
-p.question 
-  strong What is Quill?
+    .accordion-heading.question
+      a.accordion-toggle href="#what-is-quill" data-toggle="collapse" data-parent="#general-questions"
+        strong What is Quill?
+    #what-is-quill.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill is a web based application that provides personalized grammar
+          lessons. Students using Quill learn English grammar by writing
+          sentences and proofreading passages. Our focus is on learning by
+          writing, and all of our practice questions require students to write
+          complete sentences.
 
-p Quill is a web based application that provides personalized grammar lessons. Students using Quill learn English grammar by writing sentences and proofreading passages. Our focus is on learning by writing, and all of our practice questions require students to write complete sentences.
+    .accordion-heading.question
+      a.accordion-toggle href="#who-uses-quill" data-toggle="collapse" data-parent="#general-questions"
+        strong Who is using Quill?
+    #who-uses-quill.accordion-body.collapse.in
+      p.accordion-inner
+        | As of October 28th, 500 students have signed up for Quill and have
+          completed over 1,000 lessons. These students hail from Providence,
+          Los Angeles and New Orleans.
 
- 
+    .accordion-heading.question
+      a.accordion-toggle href="#how-many-lessons" data-toggle="collapse" data-parent="#general-questions"
+        strong How many lessons do you have?
+    #how-many-lessons.accordion-body.collapse.in
+      p.accordion-inner
+        | As of October 31rst we have built 42 lessons covering Common Core
+          topics for grades 1-8. Each lesson is approximately 15 minutes in
+          length. Students may repeat lessons and see new content each time they
+          complete the lesson.
 
-p.question 
-  strong Who is using Quill?
+    .accordion-heading.question
+      a.accordion-toggle href="#quill-cost" data-toggle="collapse" data-parent="#general-questions"
+        strong How much does Quill cost?
+    #quill-cost.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill's lessons will always be available for free. Empirical provides
+          enterprise level support for school systems. This includes importing
+          student data, exporting results, and providing customer support.
 
-p As of October 28th, 500 students have signed up for Quill and have completed over 1,000 lessons. These students hail from Providence, Los Angeles and New Orleans.
-
- 
-
-p.question 
-  strong How many lessons do you have?
-
-p As of October 31rst we have built 42 lessons covering Common Core topics for grades 1-8. Each lesson is approximately 15 minutes in length. Students may repeat lessons and see new content each time they complete the lesson.
-
- 
-
-p.question 
-  strong How much does Quill cost?
-
-p Quill's lessons will always be available for free. Empirical provides enterprise level support for school systems. This includes importing student data, exporting results, and providing customer support.
-
- 
-
- 
 hr
 h3 Technical Questions
 
-p.question 
-  strong What are Quill's technical requirements?
+.accordion#technical-questions
+  .accordion-group
 
-p Quill is built in HTML5 and runs on all tablets and modern browsers. Quill runs in Firefox, Chrome, Safari and Internet Explorer 8-11. Empirical recommends that students have access to keyboards so that they can type their responses.
-
+    .accordion-heading.question
+      a.accordion-toggle href="#technical-requirements" data-toggle="collapse" data-parent="#technical-questions"
+        strong What are Quill's technical requirements?
+    #technical-requirements.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill is built in HTML5 and runs on all tablets and modern browsers.
+          Quill runs in Firefox, Chrome, Safari and Internet Explorer 8-11.
+          Empirical recommends that students have access to keyboards so that
+          they can type their responses.
  
-
-p.question 
-  strong How do you set up Quill?
-
-p At the moment teachers create teacher accounts and students create student accounts. Teachers are given a class code for each class. Students join their teacher's class by plugging in their teacher's class code. Teachers may also manually create their accounts for their students. We are currently working on allowing teachers to either automatically set up their class, import .csv data, or sign in through Google Apps.
-
- 
-
+    .accordion-heading.question
+      a.accordion-toggle href="#how-to-setup" data-toggle="collapse" data-parent="#technical-questions" 
+        strong How do you set up Quill?
+    #how-to-setup.accordion-body.collapse.in
+      p.accordion-inner
+        | At the moment teachers create teacher accounts and students create
+          student accounts. Teachers are given a class code for each class.
+          Students join their teacher's class by plugging in their teacher's
+          class code. Teachers may also manually create their accounts for
+          their students. We are currently working on allowing teachers to
+          either automatically set up their class, import .csv data, or sign in
+          through Google Apps.
  
 hr
 h3 Implementation Questions
 
-p.question 
-  strong How does Quill fit into the larger classroom experience?
+.accordion#implementation-questions
+  .accordion-group
 
-p Quill lessons are approximately 15 minutes in length. Teachers who have a 1:1 computer ratio tend to use Quill as a warm up lesson at the beginning of a class. Teachers who have a limited availability of laptops tend to have their students rotate through the computers while the rest of the class engages in other activities. We are currently developing a few paper based games for the rest of the class to play while certain students work with Quill.
+    .accordion-heading.question
+      a.accordion-toggle href="#larger-classroom" data-toggle="collapse" data-parent="#implementation-questions"
+        strong How does Quill fit into the larger classroom experience?
+    #larger-classroom.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill lessons are approximately 15 minutes in length. Teachers who have
+          a 1:1 computer ratio tend to use Quill as a warm up lesson at the
+          beginning of a class. Teachers who have a limited availability of
+          laptops tend to have their students rotate through the computers while
+          the rest of the class engages in other activities. We are currently
+          developing a few paper based games for the rest of the class to play
+          while certain students work with Quill.
 
- 
+    .accordion-heading.question
+      a.accordion-toggle href="#student-quit" data-toggle="collapse" data-parent="#implementation-questions"
+        strong What happens if a student quits a lesson half way through?
+    #student-quit.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill saves the student's current progress. A student may resume a
+          lesson at any time.
 
-p.question 
-  strong What happens if a student quits a lesson half way through?
-
-p Quill saves the student's current progress. A student may resume a lesson at any time.
-
- 
-
-p.question 
-  strong Is there a fixed progression of lessons?
-
-p There is not a fixed progression of lessons. Teachers have all of our lessons available to them, and they may choose to assign any lesson they're interested in teaching.
-
- 
-
- 
-
- 
-
+    .accordion-heading.question
+      a.accordion-toggle href="#fixed-progression" data-toggle="collapse" data-parent="#implementation-questions"
+        strong Is there a fixed progression of lessons?
+    #fixed-progression.accordion-body.collapse.in
+      p.accordion-inner
+        | There is not a fixed progression of lessons. Teachers have all of our
+          lessons available to them, and they may choose to assign any lesson
+          they're interested in teaching.
  
 hr
 h3 Pedagogical Questions
 
-p.question 
-  strong How do you build your lessons?
-
-p We take each topic from the Common Core language section, and we research how that topic is being taught on BetterLesson, ShareMyLesson, and LearnZillion. We then build our own lesson based on the exercises teachers are already using.
-
+.accordion#pedagogical-questions
+  .accordion-group
+  
+    .accordion-heading.question
+      a.accordion-toggle href="#build-lessons" data-toggle="collapse" data-parent="#pedagogical-questions"
+        strong How do you build your lessons?
+    #build-lessons.accordion-body.collapse.in
+      p.accordion-inner
+        | We take each topic from the Common Core language section, and we
+          research how that topic is being taught on BetterLesson, ShareMyLesson,
+          and LearnZillion. We then build our own lesson based on the exercises
+          teachers are already using.
+        
+    .accordion-heading.question
+      a.accordion-toggle href="#incorrect-answer" data-toggle="collapse" data-parent="#pedagogical-questions"
+        strong What happens if a student answers a question incorrectly?
+    #incorrect-answer.accordion-body.collapse.in
+      p.accordion-inner
+        | Students are able to try again when they incorrectly answer a question.
+          Students may retry each question once.
  
+    .accordion-heading.question
+      a.accordion-toggle href="#assign-lessons" data-toggle="collapse" data-parent="#pedagogical-questions"
+        strong How can I assign lessons to individual students / groups?
+    #assign-lessons.accordion-body.collapse.in
+      p.accordion-inner
+        | Teachers may assign lessons to individual students or groups by
+          creating seperate classes for those groups. Each class has its own
+          lessons assigned to it. We will soon update this system so that
+          students can recieve individual lessons within a single class.
 
-p.question 
-  strong What happens if a student answers a question incorrectly?
-
-p Students are able to try again when they incorrectly answer a question. Students may retry each question once.
-
+    .accordion-heading.question
+      a.accordion-toggle href="#colored-scores" data-toggle="collapse" data-parent="#pedagogical-questions"
+        strong How do the colored scores work?
+    #colored-scores.accordion-body.collapse.in
+      p.accordion-inner
+        | Quill utilizes a stoplight system of green, yellow and red scores. A
+          green square indicates that the student answered most of the questions
+          correctly. A yellow square indicates the student struggled with a few
+          concepts. A red square indicates that the student did not demonstrate
+          mastery of the lesson. A grey square indicates an uncompleted lesson.
  
-
-p.question 
-  strong How can I assign lessons to individual students / groups?
-
-p Teachers may assign lessons to individual students or groups by creating seperate classes for those groups. Each class has its own lessons assigned to it. We will soon update this system so that students can recieve individual lessons within a single class.
-
- 
-
-p.question 
-  strong How do the colored scores work?
-
-p Quill utilizes a stoplight system of green, yellow and red scores. A green square indicates that the student answered most of the questions correctly. A yellow square indicates the student struggled with a few concepts. A red square indicates that the student did not demonstrate mastery of the lesson. A grey square indicates an uncompleted lesson.
-
- 
-
-p.question 
-  strong Why are the Common Core lessons arranged into stages?
-
-p The Common Core State Standards do not always map onto the development stages of students. For example, we have found that our grade two CCSS materials are popular among middle schools. Relavtive pronouns, a 4th grade CCSS concept, is often taught in high schools. Using the word stage, instead of grade level, reinforces the concept that each student will learn grammar at her or his own pace. 
-
+    .accordion-heading.question
+      a.accordion-toggle href="#common-core-lessons" data-toggle="collapse" data-parent="#pedagogical-questions"
+        strong Why are the Common Core lessons arranged into stages?
+    #common-core-lessons.accordion-body.collapse.in
+      p.accordion-inner
+        | The Common Core State Standards do not always map onto the development
+          stages of students. For example, we have found that our grade two CCSS
+          materials are popular among middle schools. Relavtive pronouns, a 4th
+          grade CCSS concept, is often taught in high schools. Using the word
+          stage, instead of grade level, reinforces the concept that each student
+          will learn grammar at her or his own pace. 
  
 hr
 h3 Organizational Questions
 
-p.question 
-  strong Why is Empirical a nonprofit organization?
+.accordion#organizational-questions
+  .accordion-group
+  
+    .accordion-heading.question
+      a.accordion-toggle href="#not-for-profit" data-toggle="collapse" data-parent="#organizational-questions"
+        strong Why is Empirical a nonprofit organization?
+    #not-for-profit.accordion-body.collapse.in
+      p.accordion-inner
+        | Empirical's mission is to collaboratively build educational materials
+          and make those materials freely avaiable. We work with a large team of
+          volunteers that spend their time on this project because they believe
+          in this mission. We, in turn, have no interest of ever being purchased
+          by another company or being sold on the stock market. While we are a
+          commerical nonprofit, and intend to generate sustianable revenue, our
+          mission is to revolutionize how people learn.
 
-p Empirical's mission is to collaboratively build educational materials and make those materials freely avaiable. We work with a large team of volunteers that spend their time on this project because they believe in this mission. We, in turn, have no interest of ever being purchased by another company or being sold on the stock market. While we are a commerical nonprofit, and intend to generate sustianable revenue, our mission is to revolutionize how people learn.
+    .accordion-heading.question
+      a.accordion-toggle href="#similar-organizations" data-toggle="collapse" data-parent="#organizational-questions"
+        strong What are some other similar nonprofit organizations?
+    #similar-organizations.accordion-body.collapse.in
+      p.accordion-inner
+        | In the educational technology space the closest organization to our own
+          is Reasoning Mind. Reasoning Mind is a nonprofit organization that
+          charges a fee to use it mathmatics software. Another similar nonprofit
+          is EdX. EdX intends to create a sustainable revenue by charging school
+          systems for its services.
 
+    .accordion-heading.question
+      a.accordion-toggle href="#what-is-open-source" data-toggle="collapse" data-parent="#organizational-questions"
+        strong What does Open Source mean?
+    #what-is-open-source.accordion-body.collapse.in
+      p.accordion-inner
+        | Open Source means that all of our code is made freely available. You
+          may download it and install it for free for any non-commerical purpose.
+          Other developers may re-use our code in their programs. We build our
+          code through GitHub, and you can see what we are working on at the
+          moment <a href='https://github.com/empirical-org/quill/issues?state=open_'>here</a>.
  
-
-p.question 
-  strong What are some other similar nonprofit organizations?
-
-p In the educational technology space the closest organization to our own is Reasoning Mind. Reasoning Mind is a nonprofit organization that charges a fee to use it mathmatics software. Another similar nonprofit is EdX. EdX intends to create a sustainable revenue by charging school systems for its services.
-
- 
-
-p.question 
-  strong What does Open Source mean?
-
-p Open Source means that all of our code is made freely available. You may download it and install it for free for any non-commerical purpose. Other developers may re-use our code in their programs. We build our code through GitHub, and you can see what we are working on at the moment <a href='https://github.com/empirical-org/quill/issues?state=open_'>here</a>.
-
- 
-
-p.question 
-  strong What does Open Content mean?
-
-p All of our instructional materials are made available under a Creative Commons BY-SA-NC license. This means that you may re-use our materials for any non-commerical purpose. We build our materials through an open wiki, and you may see what we are working on <a href='http://quill.wikidot.com/ccss-lessons'>here</a>.
+    .accordion-heading.question
+      a.accordion-toggle href="#what-is-open-content" data-toggle="collapse" data-parent="#organizational-questions"
+        strong What does Open Content mean?
+    #what-is-open-content.accordion-body.collapse.in
+      p.accordion-inner
+        | All of our instructional materials are made available under a Creative
+          Commons BY-SA-NC license. This means that you may re-use our materials
+          for any non-commerical purpose. We build our materials through an open
+          wiki, and you may see what we are working on <a href='http://quill.wikidot.com/ccss-lessons'>here</a>.
 
 .bottom
 
- 
-
- 
+javascript:
+  ( function($) {
+    if(window.location.hash) {
+      $('.collapse').collapse().filter(window.location.hash).collapse('toggle');  
+      setTimeout( function() {
+        $(window).scrollTop($(window).scrollTop()-400);
+        console.log($(window).scrollTop());
+      }, 1);
+    }
+  })(jQuery);


### PR DESCRIPTION
This uses Bootstrap's Collapse plugin to create collapsible elements on the FAQ page. It also should allow people to link directly to questions. See https://github.com/empirical-org/quill/issues/73
