### PR TITLE
Homepage image needs to be moved. 

### DIFF
--- a/app/assets/stylesheets/pages/home_page.css.scss
+++ b/app/assets/stylesheets/pages/home_page.css.scss
@@ -34,8 +34,7 @@ body.home-page {
 
     .floats-overlay {
       height: 730px;
-      background: image-url('home/floats.png');
-      background-repeat: no-repeat;
+      background: image-url('home/floats.png') top center no-repeat;
       z-index: 1;
     }
   }


### PR DESCRIPTION
On the homepage there is an illustration of a ship sailing on the ocean. However, the way the image is positioned, it does not often show up on the user's screen. This is important because the ship breaks up the monotony of the background, and it creates an immersive vibe. 

Can the image be locked so that the ship is directly to the right of the  story?

Here is a mockup:

![ship position](https://f.cloud.github.com/assets/3667179/1719462/93e4b8a0-61ec-11e3-9415-4f676d6635a2.png)
