### PR TITLE
Edited example class code by removing upper case

### DIFF
--- a/app/views/profiles/student.html.slim
+++ b/app/views/profiles/student.html.slim
@@ -11,7 +11,7 @@ article.student-profile-page.simple-rounded-box
         = f.submit 'Join', class: 'btn btn-primary'
 
         p.explanation: em
-          | Enter your class code, such as "Blue-Cow", to join your class.
+          | Enter your class code, such as "blue-cow", to join your class.
 
     .l-section
       h3 Preview Lessons


### PR DESCRIPTION
All actual class codes are only in lower case, so the example should not have upper case.
