### PR TITLE
Sections no longer require workbooks to be valid

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -6,7 +6,6 @@ class Section < ActiveRecord::Base
   belongs_to :workbook
   has_many :topics, dependent: :destroy
 
-  validates :workbook, presence: true
   validates :name, presence: true
 
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,27 +1,21 @@
 require 'spec_helper'
 
 describe Section, type: :model do
-	
+
 	let(:section){ FactoryGirl.build(:section) }
 
-	context "when it's created/updated" do 
+	context "when it's created/updated" do
 
-		it "must be valid with valid info" do 
+		it "must be valid with valid info" do
 			expect(section).to be_valid
 		end
 
-		context "when it runs validations" do 
+		context "when it runs validations" do
 
-			it "must have a name" do 
+			it "must have a name" do
 				section.name=nil
 				section.valid?
 				expect(section.errors[:name]).to include "can't be blank"
-			end
-
-			it "must have a workbook" do 
-				section.workbook_id=nil
-				section.valid?				
-				expect(section.errors[:workbook]).to include "can't be blank"
 			end
 
 		end


### PR DESCRIPTION
Fixes  #370
Sections couldn't save because they required a workbook object that was not provided. Since workbooks are not really mandatory for a section to work it should be fine to remove them. 
