### PR TITLE
add grades 1 + 2 to Classroom::GRADES

### DIFF
--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -1,5 +1,5 @@
 class Classroom < ActiveRecord::Base
-  GRADES = %w(3 4 5 6 7 8 9 10 11 12 University)
+  GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)
 
   validates_uniqueness_of :code
   validates :grade, presence: true, inclusion: { in: Classroom::GRADES, message: "%{value} is not a valid grade" }


### PR DESCRIPTION
Hi - new to the project, referred by Code Montage. 

I made small change to Classroom::GRADES, adding 1 + 2 as @RyanNovas requested in the issues queue --

didn't test this as it's not a new feature --- 
in the tests that exist, I had 248 examples, 7 failures, 5 pending before and after the change--- so this doesn't seem to break anything new!

please let me know if I'm missing anything for standard workflow, I'd like to contribute some more.
Thnx!
AFR
