### PR TITLE
Fix spec/requests/sign_up_spec failures

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -56,12 +56,13 @@ protected
   # below two methods are repeated in students_controller. need to abstract them into user_model, but first must clear up name splitting db issue
   def capitalize_first_and_last_name 
     # make sure this is called after fix_full_name_in_first_name_field
-    user_params[:first_name].capitalize!
-    user_params[:last_name].capitalize!
+    %i(first_name last_name).each do |sym|
+      user_params[:sym].capitalize! if user_params[:sym]
+    end
   end
 
   def fix_full_name_in_first_name_field
-    if user_params[:last_name].blank? && (f,l = user_params[:first_name].split(/\s+/)).length > 1
+    if user_params[:first_name].present? && user_params[:last_name].blank? && (f,l = user_params[:first_name].split(/\s+/)).length > 1
       user_params[:first_name] = f
       user_params[:last_name] = l
     end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -46,37 +46,53 @@ describe 'Sign up', :type => :request do
   end
 
   describe 'Create New Student Account (from teacher interface)' do
-    before do
-      @classroom = create(:classroom)
-      @teacher   = @classroom.teacher
-      sign_in(@teacher.email, '123456')
-      post teachers_classroom_students_path(@classroom), user: {first_name: 'Test', last_name: 'Student'}
-      follow_redirect!
+    let(:classroom)                 { create(:classroom) }
+    let(:teacher)                   { classroom.teacher }
+
+    let(:student_first_name)        { 'Test' }
+    let(:student_last_name)         { 'Student' }
+
+    let(:expected_student_email)    { "#{student_first_name}.#{student_last_name}@#{classroom.code}" }
+    let(:expected_student_password) { student_last_name }
+
+    before(:each) { sign_in(teacher.email, '123456') }
+
+    context "when the teacher enters the student's name correctly" do
+      before do
+        post teachers_classroom_students_path(classroom), user: {first_name: student_first_name, last_name: student_last_name}
+        follow_redirect!
+      end
+
+      it 'generates password' do
+        expect(User.authenticate(email: expected_student_email, password: expected_student_password)).to be_truthy
+      end
+
+      it 'generates username' do
+        expect(response.body).to include(student_first_name)
+        expect(response.body).to include(student_last_name)
+        expect(response.body).to include(expected_student_email)
+      end
+
+      it 'allows student to sign in' do
+        sign_in(expected_student_email, expected_student_password)
+        expect(response).to redirect_to(profile_path)
+        expect(User.find(session[:user_id]).classroom).to eq(classroom)
+      end
     end
 
-    it 'generates password' do
-      expect(User.authenticate(email: "Test.Student@#{@classroom.code}", password: 'Student')).to be_truthy
-    end
+    context 'when the teacher accidentally enters the full name in the first name field' do
+      let(:student_full_name)  { "#{student_first_name} #{student_last_name}" }
 
-    it 'generates username' do
-      expect(response.body).to include('Test')
-      expect(response.body).to include('Student')
-      expect(response.body).to include("Test.Student@#{@classroom.code}")
-    end
+      before(:each) do
+        post teachers_classroom_students_path(classroom), user: {first_name: student_full_name}
+        follow_redirect!
+      end
 
-    it 'allows student to sign in' do
-      sign_in("Test.Student@#{@classroom.code}", 'Student')
-      expect(response).to redirect_to(profile_path)
-      expect(User.find(session[:user_id]).classroom).to eq(@classroom)
-    end
-
-    it 'allows the teacher to accidentally enter the full name in the first name field' do
-      post teachers_classroom_students_path(@classroom), user: {first_name: 'Full Name'}
-      follow_redirect!
-
-      expect(response.body).to include('Full')
-      expect(response.body).to include('Name')
-      expect(response.body).to include("Full.Name@#{@classroom.code}")
+      it 'infers the first and last names' do
+        expect(response.body).to include(student_first_name)
+        expect(response.body).to include(student_last_name)
+        expect(response.body).to include(expected_student_email)
+      end
     end
   end
 end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -52,7 +52,7 @@ describe 'Sign up', :type => :request do
     let(:student_first_name)        { 'Test' }
     let(:student_last_name)         { 'Student' }
 
-    let(:expected_student_email)    { "#{student_first_name}.#{student_last_name}@#{classroom.code}" }
+    let(:expected_student_email)    { "#{student_first_name}.#{student_last_name}@#{classroom.code}".downcase }
     let(:expected_student_password) { student_last_name }
 
     before(:each) { sign_in(teacher.email, '123456') }


### PR DESCRIPTION
Fix several failures in `spec/requests/sign_up_spec.rb`

* update spec to expect student e-mail address to be generated lowercase

  assuming spec is out of date w/ SUT behavior
* make `AccountsController` tolerate `nil` user `first_name` & `last_name` params

  assuming the spec supplying neither is an expected case

Along the way, refactored the `when the teacher enters the student's name correctly` section
* DRY it up w/ `let()`s
* split out `'allows the teacher to accidentally enter the full name in the first name field` example to its own context