### PR TITLE
Fixed failing migration for empty database for issue #535

### DIFF
--- a/db/migrate/20141014162137_add_app_name_to_classification.rb
+++ b/db/migrate/20141014162137_add_app_name_to_classification.rb
@@ -3,8 +3,8 @@ class AddAppNameToClassification < ActiveRecord::Migration
 
     add_column :activity_classifications, :app_name, :string
 
-    ActivityClassification.where(key: 'story').first.update_column(:app_name, 'grammar')
-    ActivityClassification.where(key: 'practice_question_set').first.update_column(:app_name, 'grammar')
+    ActivityClassification.where(key: 'story').first.try(:update_column,:app_name, 'grammar')
+    ActivityClassification.where(key: 'practice_question_set').first.try(:update_column, :app_name, 'grammar')
 
   end
 end


### PR DESCRIPTION
* Defaulting ActivityClassification in migration fails on empty database
* Use :try to fix

Issue
https://github.com/empirical-org/Empirical-Core/issues/535