### PR TITLE
Fix setup failing due to calling `run`

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -3,10 +3,10 @@ namespace :empirical do
     puts "** Starting setup..."
 
     puts "** Creating tmp directories..."
-    Rake::Task["temp:create"].invoke
+    Rake::Task["tmp:create"].invoke
 
     puts "** Copying DB Credentials..."
-    run "cp config/database.yml.example config/database.yml"
+    `cp config/database.yml.example config/database.yml`
 
     puts "** Creating database..."
     Rake::Task["db:create"].invoke


### PR DESCRIPTION
* Use backticks instead
* Also incorporates #538

Issue:
Set up fails due to calling `run` #537
https://github.com/empirical-org/Empirical-Core/issues/537