### PR TITLE
Fixed issue #482

### DIFF
--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -2,6 +2,8 @@ class Classroom < ActiveRecord::Base
   GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)
 
   validates_uniqueness_of :code
+  validates_uniqueness_of :name, scope: :teacher_id, message: "A classroom called %{value} already exists. Please rename this classroom to a different name."
+
   validates :grade, presence: true, inclusion: { in: Classroom::GRADES, message: "%{value} is not a valid grade" }
 
   has_many :units do


### PR DESCRIPTION
This fix won't allow a teacher who updates or creates a classroom to have classrooms with the same name. contributors: @s12dsow, @alcastaneda