### PR TITLE
Reply to Issue #243: Social Media Text Formatting

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,6 +2,12 @@ doctype html
 html
   head
     title Quill.org &mdash; Interactive Writing and Grammar
+    meta property="og:site_name" content="Quill.org"
+    meta property="og:description" content="Learn English grammar by writing sentences and proofreading passages."
+    meta property="og:image" content="/images/quill-logo.png"
+    meta property="og:type" content="website"
+    meta property="og:url" content="http://www.quill.org/"
+    meta property="og:title" content="Quill.org"
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = stylesheet_link_tag    'codemirror', 'data-turbolinks-track' => true

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,9 +4,10 @@ html
     title Quill.org &mdash; Interactive Writing and Grammar
     meta property="og:site_name" content="Quill.org"
     meta property="og:description" content="Learn English grammar by writing sentences and proofreading passages."
-    meta property="og:image" content="/images/quill-logo.png"
+    meta property="og:image" content="http://www.quill.org/images/ico-engaging.png"
+    meta property="og:image:type" content="image/png"
     meta property="og:type" content="website"
-    meta property="og:url" content="http://www.quill.org/"
+    meta property="og:url" content="http://www.quill.org"
     meta property="og:title" content="Quill.org"
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true


### PR DESCRIPTION
We have added Facebook OG metatags:

Currently OG metatags seem to be parsing correctly, with
exception of the image being used.  OG requires a  200x200px minimum image,
or will try to parse the nearest-sized image in the closest directory (hence the rocket image being displayed).

The error received from Facebook testing tools:

``og:image was not defined, could not be downloaded or was not big enough. Please define a chosen image using the og:image metatag, and use an image that's at least 200x200px and is accessible from Facebook. Image 'http://d2t498vi8pate3.cloudfront.net/assets/ico-engaging-1ee78d7d4807471cb70a58d535cbb134.png'; will be used instead.``

We used Facebook Dev tools here:

https://developers.facebook.com/tools/debug/og/object/