### PR TITLE
Fix spurious serializer spec failures (esp. in/for Travis builds!)

### DIFF
--- a/spec/serializers/activity_serializer_spec.rb
+++ b/spec/serializers/activity_serializer_spec.rb
@@ -1,33 +1,42 @@
 require 'spec_helper'
 
 describe ActivitySerializer, type: :serializer do
+  let(:activity)   { FactoryGirl.create(:activity) }
+  let(:serializer) { ActivitySerializer.new(activity) }
 
-  let!(:activity) { FactoryGirl.create(:activity) }
-  let!(:serializer) { ActivitySerializer.new(activity) }
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
+    activity_key = 'activity'
 
-  context "has expected attributes" do
-
-    let!(:parsed) { JSON.parse(serializer.to_json) }
-
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('activity')
+    it "includes '#{activity_key}' key" do
+      expect(parsed.keys).to include(activity_key)
     end
 
-    context "activity object" do
-      let!(:activity_json) { parsed['activity'] }
+    describe "'#{activity_key}' object" do
+      let(:parsed_activity) { parsed[activity_key] }
 
-      it "should have these keys" do
-        expected = ["uid", "id", "name", "description", "flags", "data", "created_at", "updated_at", "anonymous_path", "classification", "topic"]
-        expect(activity_json.keys).to match_array(expected)
+      topic_key = 'topic'
+
+      it "has the correct keys" do
+        expect(parsed_activity.keys)
+          .to match_array %w(anonymous_path
+                             classification
+                             created_at
+                             data
+                             description
+                             flags
+                             id
+                             name) +
+                            [topic_key] +
+                          %w(uid
+                             updated_at)
       end
 
-      it "should include a topic" do
-        expect(activity_json['topic'].class).to eq(Hash)
+      it "includes '#{topic_key}' Hash" do
+        expect(parsed_activity[topic_key]).to be_a(Hash)
       end
-
     end
-
   end
-
 end

--- a/spec/serializers/activity_serializer_spec.rb
+++ b/spec/serializers/activity_serializer_spec.rb
@@ -19,7 +19,7 @@ describe ActivitySerializer, type: :serializer do
 
       it "should have these keys" do
         expected = ["uid", "id", "name", "description", "flags", "data", "created_at", "updated_at", "anonymous_path", "classification", "topic"]
-        expect(activity_json.keys).to eq(expected)
+        expect(activity_json.keys).to match_array(expected)
       end
 
       it "should include a topic" do

--- a/spec/serializers/activity_session_serializer_spec.rb
+++ b/spec/serializers/activity_session_serializer_spec.rb
@@ -1,42 +1,54 @@
 require 'spec_helper'
 
 describe ActivitySessionSerializer, type: :serializer do
+  let(:concept_class)              { FactoryGirl.create(:concept_class) }
+  let(:concept_tag)                { FactoryGirl.create(:concept_tag, concept_class: concept_class) }
+  let(:concept_tag_metadata_key)   { 'foo' }
+  let(:concept_tag_metadata_value) { 'bar' }
+  let(:concept_tag_metadata)       { { concept_tag_metadata_key => concept_tag_metadata_value } }
+  let(:concept_tag_result)         { FactoryGirl.create(:concept_tag_result, metadata: concept_tag_metadata, concept_tag: concept_tag) }
+  let(:activity_session)           { FactoryGirl.create(:activity_session, concept_tag_results: [concept_tag_result]) }
 
-  let!(:concept_class) { FactoryGirl.create(:concept_class) }
-  let!(:concept_tag) { FactoryGirl.create(:concept_tag, concept_class: concept_class) }
-  let!(:concept_tag_result) { FactoryGirl.create(:concept_tag_result, metadata: {"foo" => "bar"}, concept_tag: concept_tag) }
-  let!(:activity_session) { FactoryGirl.create(:activity_session, concept_tag_results: [concept_tag_result]) }
-  let!(:serializer) { ActivitySessionSerializer.new(activity_session) }
+  let(:serializer)                 { ActivitySessionSerializer.new(activity_session) }
 
-  context "has expected attributes" do
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
-    let!(:parsed) { JSON.parse(serializer.to_json) }
+    activity_session_key = 'activity_session'
 
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('activity_session')
+    it "includes '#{activity_session_key}' key" do
+      expect(parsed.keys).to include(activity_session_key)
     end
 
-    context "activity_session object" do
-      let!(:activity_session_json) { parsed['activity_session'] }
+    describe "'#{activity_session_key}' object" do
+      let(:parsed_activity_session) { parsed[activity_session_key] }
 
-      it "should have these keys" do
-        expected = ["uid", "percentage", "time_spent", "state", "completed_at", "data", "temporary", 
-                    "activity_uid", "anonymous", "concept_tag_results"]
-        expect(activity_session_json.keys).to match_array(expected)
+      concept_tag_results_key = 'concept_tag_results'
+
+      it 'has the correct keys' do
+        expect(parsed_activity_session.keys)
+          .to match_array %w(activity_uid
+                             anonymous
+                             completed_at) +
+                            [concept_tag_results_key] +
+                          %w(data
+                             percentage
+                             state
+                             temporary
+                             time_spent
+                             uid)
       end
 
-      it "should have a properly formatted concept tags response" do
-        expected = [
-          {
-            "concept_tag" => concept_tag.name,
-            "foo" => "bar"
-          }
-        ]
-        expect(activity_session_json["concept_tag_results"]).to eq(expected)
+      describe "'#{concept_tag_results_key}' object" do
+        it 'has the correct contents' do
+          actual = parsed_activity_session[concept_tag_results_key]
+          expect(actual).to match_array [
+            { 'concept_tag'            => concept_tag.name,
+              concept_tag_metadata_key => concept_tag_metadata_value
+            }]
+        end
       end
-
     end
-
   end
-
 end

--- a/spec/serializers/activity_session_serializer_spec.rb
+++ b/spec/serializers/activity_session_serializer_spec.rb
@@ -22,7 +22,7 @@ describe ActivitySessionSerializer, type: :serializer do
       it "should have these keys" do
         expected = ["uid", "percentage", "time_spent", "state", "completed_at", "data", "temporary", 
                     "activity_uid", "anonymous", "concept_tag_results"]
-        expect(activity_session_json.keys).to eq(expected)
+        expect(activity_session_json.keys).to match_array(expected)
       end
 
       it "should have a properly formatted concept tags response" do

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -18,7 +18,7 @@ describe ClassificationSerializer, type: :serializer do
 
       it "should have these keys" do
         expected = ["uid", "id", "name", "key", "form_url", "module_url", "created_at", "updated_at", "image_class", "scorebook_icon_class", "alias"]
-        expect(classification_json.keys).to eq(expected)
+        expect(classification_json.keys).to match_array(expected)
       end
 
 

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -1,28 +1,36 @@
 require 'spec_helper'
 
 describe ClassificationSerializer, type: :serializer do
-  let!(:classification) { FactoryGirl.create(:classification) }
-  let!(:serializer) { ClassificationSerializer.new(classification) }
+  let(:classification) { FactoryGirl.create(:classification) }
+  let(:serializer)     { ClassificationSerializer.new(classification) }
 
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
-  context "has expected attributes" do
+    classification_key = 'classification'
 
-    let!(:parsed) { JSON.parse(serializer.to_json) }
-
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('classification')
+    it "includes '#{classification_key}' key" do
+      expect(parsed.keys).to include(classification_key)
     end
 
-    context "classification object" do
-      let!(:classification_json) { parsed['classification'] }
+    describe "'#{classification_key}' object" do
+      let(:parsed_classification) { parsed[classification_key] }
 
-      it "should have these keys" do
-        expected = ["uid", "id", "name", "key", "form_url", "module_url", "created_at", "updated_at", "image_class", "scorebook_icon_class", "alias"]
-        expect(classification_json.keys).to match_array(expected)
+      it 'has the correct keys' do
+        expect(parsed_classification.keys)
+          .to match_array %w(alias
+                             created_at
+                             form_url
+                             id
+                             image_class
+                             key
+                             module_url
+                             name
+                             scorebook_icon_class
+                             uid
+                             updated_at)
       end
-
-
     end
-
   end
 end

--- a/spec/serializers/section_serializer_spec.rb
+++ b/spec/serializers/section_serializer_spec.rb
@@ -1,28 +1,36 @@
 require 'spec_helper'
 
 describe SectionSerializer, type: :serializer do
-  let!(:section) { FactoryGirl.create(:section, workbook: FactoryGirl.create(:workbook)) }
-  let!(:serializer) { SectionSerializer.new(section) }
+  let(:workbook)   { FactoryGirl.create(:workbook) }
+  let(:section)    { FactoryGirl.create(:section, workbook: workbook) }
+  let(:serializer) { SectionSerializer.new(section) }
 
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
-  context "has expected attributes" do
+    section_key = 'section'
 
-    let!(:parsed) { JSON.parse(serializer.to_json) }
-
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('section')
+    it "includes '#{section_key}' key" do
+      expect(parsed.keys).to include(section_key)
     end
 
-    context "section object" do
-      let!(:section_json) { parsed['section'] }
+    describe "'#{section_key}' object" do
+      let(:parsed_section) { parsed[section_key] }
 
-      it "should have these keys" do
-        expected = ["id", "name", "created_at", "updated_at", "workbook"]
-        expect(section_json.keys).to match_array(expected)
+      workbook_key = 'workbook'
+
+      it 'has the correct keys' do
+        expect(parsed_section.keys)
+          .to match_array %w(id
+                             name
+                             created_at
+                             updated_at) +
+                            [workbook_key]
       end
 
-      it "should include a workbook" do
-        expect(section_json['workbook'].class).to eq(Hash)
+      it "includes a '#{workbook_key}' Hash" do
+        expect(parsed_section[workbook_key]).to be_a(Hash)
       end
 
     end

--- a/spec/serializers/section_serializer_spec.rb
+++ b/spec/serializers/section_serializer_spec.rb
@@ -18,7 +18,7 @@ describe SectionSerializer, type: :serializer do
 
       it "should have these keys" do
         expected = ["id", "name", "created_at", "updated_at", "workbook"]
-        expect(section_json.keys).to eq(expected)
+        expect(section_json.keys).to match_array(expected)
       end
 
       it "should include a workbook" do

--- a/spec/serializers/topic_serializer_spec.rb
+++ b/spec/serializers/topic_serializer_spec.rb
@@ -18,7 +18,7 @@ describe TopicSerializer, type: :serializer do
 
       it "should have these keys" do
         expected = ["id", "name", "created_at", "updated_at", "section", "topic_category"]
-        expect(topic_json.keys).to eq(expected)
+        expect(topic_json.keys).to match_array(expected)
       end
 
       it "should include a section" do

--- a/spec/serializers/topic_serializer_spec.rb
+++ b/spec/serializers/topic_serializer_spec.rb
@@ -1,31 +1,37 @@
 require 'spec_helper'
 
 describe TopicSerializer, type: :serializer do
-  let!(:topic) { FactoryGirl.create(:topic) }
-  let!(:serializer) { TopicSerializer.new(topic) }
+  let(:topic)      { FactoryGirl.create(:topic) }
+  let(:serializer) { TopicSerializer.new(topic) }
 
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
-  context "has expected attributes" do
+    topic_key = 'topic'
 
-    let!(:parsed) { JSON.parse(serializer.to_json) }
-
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('topic')
+    it "includes '#{topic_key}' key" do
+      expect(parsed.keys).to include(topic_key)
     end
 
-    context "topic object" do
-      let!(:topic_json) { parsed['topic'] }
+    describe "'#{topic_key}' object" do
+      let(:parsed_topic) { parsed[topic_key] }
 
-      it "should have these keys" do
-        expected = ["id", "name", "created_at", "updated_at", "section", "topic_category"]
-        expect(topic_json.keys).to match_array(expected)
+      section_key = 'section'
+
+      it 'has the correct keys' do
+        expect(parsed_topic.keys)
+          .to match_array %w(id
+                             created_at
+                             name) +
+                            [section_key] +
+                          %w(topic_category
+                             updated_at)
       end
 
-      it "should include a section" do
-        expect(topic_json['section'].class).to eq(Hash)
+      it "includes a '#{section_key}' Hash" do
+        expect(parsed_topic[section_key]).to be_a(Hash)
       end
-
     end
-
   end
 end

--- a/spec/serializers/workbook_serializer_spec.rb
+++ b/spec/serializers/workbook_serializer_spec.rb
@@ -18,7 +18,7 @@ describe WorkbookSerializer, type: :serializer do
 
       it "should have these keys" do
         expected = ["id", "title", "created_at", "updated_at"]
-        expect(workbook_json.keys).to eq(expected)
+        expect(workbook_json.keys).to match_array(expected)
       end
 
 

--- a/spec/serializers/workbook_serializer_spec.rb
+++ b/spec/serializers/workbook_serializer_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe WorkbookSerializer, type: :serializer do
-  let!(:workbook) { FactoryGirl.create(:workbook) }
-  let!(:serializer) { WorkbookSerializer.new(workbook) }
+  let(:workbook)   { FactoryGirl.create(:workbook) }
+  let(:serializer) { WorkbookSerializer.new(workbook) }
 
+  describe '#to_json output' do
+    let(:json)   { serializer.to_json }
+    let(:parsed) { JSON.parse(json) }
 
-  context "has expected attributes" do
+    workbook_key = 'workbook'
 
-    let!(:parsed) { JSON.parse(serializer.to_json) }
-
-    it "should contain a root attribute" do
-      expect(parsed.keys).to include('workbook')
+    it "includes '#{workbook_key}' key" do
+      expect(parsed.keys).to include(workbook_key)
     end
 
-    context "workbook object" do
-      let!(:workbook_json) { parsed['workbook'] }
+    describe "'#{workbook_key}' object" do
+      let(:parsed_workbook) { parsed[workbook_key] }
 
-      it "should have these keys" do
-        expected = ["id", "title", "created_at", "updated_at"]
-        expect(workbook_json.keys).to match_array(expected)
+      it 'has the correct keys' do
+        expect(parsed_workbook.keys).to match_array %w(created_at
+                                                       id
+                                                       title
+                                                       updated_at)
       end
-
-
     end
-
   end
 end


### PR DESCRIPTION
- fix spurious CI/test failures by using `match_array` to make key-array expectations order-independent
- re-organize, DRY-up, _etc_.