### PR TITLE
Add Teacher and Student sign up feature spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - 2.1.2
 script:
-- bundle exec rake
+- xvfb-run bundle exec rake spec
 before_script:
 - cp config/database.yml.travis config/database.yml
 - psql -c 'create database test;' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'carrierwave'
 gem 'fog', require: 'fog/aws/storage'
 
 # OTHERS
+gem 'global'
 gem 'google-api-client'
 gem 'mailchimp-api', require: 'mailchimp'
 gem 'faraday_middleware'

--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,8 @@ group :test, :development do
 end
 
 group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver', '>=2.45.0.dev3' # works with Firefox 35
   gem "vcr"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
+    global (0.1.2)
+      activesupport (>= 2.0)
     google-api-client (0.7.1)
       addressable (>= 2.3.2)
       autoparse (>= 0.3.3)
@@ -549,6 +551,7 @@ DEPENDENCIES
   foreman
   forgery
   fuubar (~> 2.0.0.rc1)
+  global
   google-api-client
   guard
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,12 @@ GEM
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
     cancancan (1.9.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     carrierwave (0.10.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -116,6 +122,8 @@ GEM
       mime-types (>= 1.16)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    childprocess (0.5.5)
+      ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.1)
     coderay (1.1.0)
     coffee-rails (4.0.1)
@@ -429,10 +437,16 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-support (3.1.0)
     ruby-progressbar (1.5.1)
+    rubyzip (1.1.7)
     safe_yaml (1.0.3)
     sass (3.4.4)
     select2-rails (3.5.9.1)
       thor (~> 0.14)
+    selenium-webdriver (2.45.0.dev3)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sentry-raven (0.12.2)
       faraday (>= 0.7.6)
     sidekiq (3.2.4)
@@ -499,6 +513,9 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    websocket (1.2.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -517,6 +534,7 @@ DEPENDENCIES
   bootstrap-sass (~> 2.1.1.0)
   byebug
   cancancan
+  capybara
   carrierwave
   clever-ruby!
   coffee-rails
@@ -574,6 +592,7 @@ DEPENDENCIES
   sass
   sass-rails!
   select2-rails
+  selenium-webdriver (>= 2.45.0.dev3)
   sentry-raven (>= 0.12.2)
   sidekiq
   sidekiq-retries

--- a/Guardfile
+++ b/Guardfile
@@ -17,7 +17,8 @@ guard :rspec, cmd: 'spring rspec' do
   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+  watch(%r{^spec/support/(?!pages/).+\.rb$})          { "spec" }
+  watch(%r{^spec/support/pages/.+\.rb$})              { "spec/features" }
   watch('config/routes.rb')                           { "spec/routing" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
   watch('spec/rails_helper.rb')                       { "spec" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,17 +145,8 @@ class User < ActiveRecord::Base
   end
 
   def subscribe_to_newsletter
-    return nil unless newsletter?
-
     ## FIXME this class should just get replaced with the mailchimp-api gem
-    MailchimpConnection.connection.lists.subscribe('eadf6d8153', { email: email },
-                                                   merge_vars=nil,
-                                                   email_type='html',
-                                                   double_optin=false,
-                                                   update_existing=false,
-                                                   replace_interests=true,
-                                                   send_welcome=false
-                                                  )
+    MailchimpConnection.subscribe_to_newsletter(email) if newsletter?
   end
 
   def imported_from_clever?

--- a/app/views/teachers/classrooms/new.html.erb
+++ b/app/views/teachers/classrooms/new.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: 'teachers/classrooms/subnav' %>
 
 <%= javascript_include_tag 'jquery.js' %>
-<%= javascript_include_tag 'create_a_class.js' %>
+<%= javascript_include_tag 'scorebook/create_a_class.js' %>
 
 
 <div class="container">

--- a/config/global/call_external_service.yml
+++ b/config/global/call_external_service.yml
@@ -1,0 +1,6 @@
+production:
+  mailchimp: true
+development:
+  mailchimp: false
+test:
+  mailchimp: false

--- a/config/initializers/global.rb
+++ b/config/initializers/global.rb
@@ -1,0 +1,4 @@
+Global.configure do |config|
+  config.environment      = Rails.env.to_s
+  config.config_directory = Rails.root.join('config/global').to_s
+end

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -1,6 +1,14 @@
 module MailchimpConnection
-  def connection
-    Mailchimp::API.new(ENV['MAILCHIMP_API_KEY'])
+  def subscribe_to_newsletter(email)
+    connection = Mailchimp::API.new(ENV['MAILCHIMP_API_KEY'])
+    connection.lists.subscribe('eadf6d8153',     # id
+                               { email: email }, # email
+                               nil,              # merge_vars
+                               'html',           # email_type
+                               false,            # double_optin
+                               false,            # update_existing
+                               true,             # replace_interests
+                               false)            # send_welcome
   end
 
   extend self

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -1,14 +1,16 @@
 module MailchimpConnection
   def subscribe_to_newsletter(email)
-    connection = Mailchimp::API.new(ENV['MAILCHIMP_API_KEY'])
-    connection.lists.subscribe('eadf6d8153',     # id
-                               { email: email }, # email
-                               nil,              # merge_vars
-                               'html',           # email_type
-                               false,            # double_optin
-                               false,            # update_existing
-                               true,             # replace_interests
-                               false)            # send_welcome
+    if Global.call_external_service.mailchimp
+      connection = Mailchimp::API.new(ENV['MAILCHIMP_API_KEY'])
+      connection.lists.subscribe('eadf6d8153',     # id
+                                 { email: email }, # email
+                                 nil,              # merge_vars
+                                 'html',           # email_type
+                                 false,            # double_optin
+                                 false,            # update_existing
+                                 true,             # replace_interests
+                                 false)            # send_welcome
+    end
   end
 
   extend self

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,6 +36,24 @@ FactoryGirl.define do
       role 'student'
       username
       classroom
+
+      factory :arnold_horshack do
+        first_name            'Arnold'
+        last_name             'Horshack'
+        username              'horshack'
+        password              'dingfelder'
+        password_confirmation { password }
+        email                 'ahorshack@coldmail.com'
+      end
+
+      factory :vinnie_barbarino do
+        first_name            'Vinnie'
+        last_name             'Barbarino'
+        username              'vinnie_barbarino'
+        password              'sally'
+        password_confirmation { password }
+        email                 'vinnieb@geemail.com'
+      end
     end
 
     factory :student_with_many_activities do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,15 @@ FactoryGirl.define do
 
     factory :teacher do
       role 'teacher'
+
+      factory :mr_kotter do
+        first_name            'Gabe'
+        last_name             'Kotter'
+        username              'mrkotter'
+        email                 'gabe.kotter@jamesbuchananhigh.edu'
+        password              'sweathogs'
+        password_confirmation { password }
+      end
     end
 
     factory :student do

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -5,6 +5,21 @@ feature 'Signing up', js: true do
 
   let(:sign_up_page) { SignUpPage.visit }
 
+  def self.disallows_submission; 'submission is disallowed and'; end
+  shared_examples_for disallows_submission do
+    it 'remains on the new-form page' do
+      expect(current_path).to eq sign_up_page.new_form_path
+    end
+  end
+
+  def password_cannot_be_blank
+    "Password can't be blank"
+  end
+
+  def username_already_taken
+    'Username has already been taken'
+  end
+
   context 'a Teacher' do
     let(:user_type)         { :teacher }
     let(:mr_kotter)         { FactoryGirl.build :mr_kotter }
@@ -31,13 +46,6 @@ feature 'Signing up', js: true do
     shared_examples_for signup_succeeded do
       it 'prompts for class creation' do
         expect(current_path).to eq new_teachers_classroom_path
-      end
-    end
-
-    def self.disallows_submission; 'submission is disallowed and'; end
-    shared_examples_for disallows_submission do
-      it 'remains on the new-form page' do
-        expect(current_path).to eq sign_up_page.new_form_path
       end
     end
 
@@ -98,7 +106,7 @@ feature 'Signing up', js: true do
         end
 
         it 'shows the problem on the form' do
-          expect(sign_up_page).to have_content "Password can't be blank"
+          expect(sign_up_page).to have_content password_cannot_be_blank
 
           expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
                                                           type: user_type,
@@ -159,14 +167,167 @@ feature 'Signing up', js: true do
       end
 
       it 'shows the errors on the form' do
-        expect(sign_up_page).to have_content 'Username has already been taken'
-        expect(sign_up_page).to have_content    'Email has already been taken'
+        expect(sign_up_page).to have_content username_already_taken
+        expect(sign_up_page).to have_content 'Email has already been taken'
 
         expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
                                                         type: user_type,
                                                accept_terms?: accept_terms,
                                              end_newsletter?: send_newsletter)
       end
+    end
+  end
+
+  context 'a Student' do
+    let(:user_type)    { :student }
+    let(:vinnie)       { FactoryGirl.build :vinnie_barbarino }
+
+    let(:accept_terms) { true }
+
+    before(:each) do
+      # at least 1 Section must already exist
+      FactoryGirl.create :section
+    end
+
+    def sign_up_student(user)
+      sign_up_page.sign_up(type: user_type,
+                           name: user.name,
+                       username: user.username,
+                       password: user.password,
+          password_confirmation: user.password_confirmation,
+                          email: user.email,
+                   accept_terms: accept_terms)
+    end
+
+    def self.signup_succeeded; 'signup succeeded and'; end
+    shared_examples_for signup_succeeded do
+      it 'goes to the profile page' do
+        expect(current_path).to eq '/profile'
+      end
+    end
+
+    context 'with no info' do
+      before(:each) do
+        sign_up_page.be_a_student
+        sign_up_page.submit_form
+      end
+
+      it 'shows the problem(s) on the form' do
+        expect(sign_up_page).to have_content "Username can't be blank"
+        expect(sign_up_page).to have_content password_cannot_be_blank
+        expect(sign_up_page).to have_content "Email can't be blank"
+        expect(sign_up_page).to have_content 'Terms of service must be accepted'
+      end
+    end
+
+    context 'with new info' do
+      before(:each) { sign_up_student vinnie }
+
+      it_behaves_like signup_succeeded
+
+      context 'without accepting the Terms of Service' do
+        let(:accept_terms) { false }
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content 'Terms of service must be accepted'
+
+          expect(sign_up_page).to be_errored_sign_up_form(vinnie,
+                                                          type: user_type)
+        end
+
+        context 'with a mixed-case username' do
+          let(:username)  { 'Vinnie_Barbarino' }
+          let(:vinnie) { FactoryGirl.build :vinnie_barbarino, username: username }
+
+          describe 'the errored form' do
+            it 'down-cases the username' do
+              # make it expect downcase for comparing against the form
+              vinnie.username.downcase!
+
+              expect(sign_up_page).to be_errored_sign_up_form(vinnie,
+                                                              type: user_type)
+            end
+          end
+        end
+      end
+
+      context 'with blank password' do
+        let(:vinnie) do
+          FactoryGirl.build :vinnie_barbarino, password: ''
+        end
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content password_cannot_be_blank
+
+          expect(sign_up_page).to be_errored_sign_up_form(vinnie,
+                                                          type: user_type)
+        end
+      end
+
+      context 'with mismatched password and confirmation' do
+        let(:vinnie) do
+          FactoryGirl.build :vinnie_barbarino, password:              'something',
+                                               password_confirmation: 'different'
+        end
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content "Password confirmation doesn't match Password"
+
+          expect(sign_up_page).to be_errored_sign_up_form(vinnie,
+                                                          type: user_type)
+        end
+      end
+
+      context 'with a bogus e-mail address' do
+        let(:vinnie) { FactoryGirl.build :vinnie_barbarino, email: 'bogus' }
+
+        it_behaves_like disallows_submission
+      end
+    end
+
+    context 'with minimal info' do
+      let(:x) { 'x' }
+
+      let(:student_x) do
+        FactoryGirl.build :student,
+                          first_name: '',
+                           last_name: '',
+                            username: x,
+                            password: x,
+               password_confirmation: x,
+                               email: ''
+      end
+
+      before(:each) { sign_up_student student_x }
+
+      it_behaves_like signup_succeeded
+    end
+
+    context 'with duplicate info' do
+      before(:each) do
+        FactoryGirl.create :vinnie_barbarino
+
+        sign_up_student vinnie
+      end
+
+      it 'shows the errors on the form' do
+        expect(sign_up_page).to have_content username_already_taken
+
+        expect(sign_up_page).to be_errored_sign_up_form(vinnie, type: user_type)
+      end
+    end
+
+    context 'with duplicate e-mail' do
+      let(:dup_email) { 'sweathog@yarhoo.com' }
+      let(:horshack)  { FactoryGirl.build :arnold_horshack, email: dup_email }
+
+      before(:each) do
+        FactoryGirl.create :vinnie_barbarino, email: dup_email
+
+        sign_up_student horshack
+      end
+
+      it_behaves_like signup_succeeded
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+feature 'Signing up', js: true do
+  before(:each) { VCR.configuration.ignore_localhost = true }
+
+  let(:sign_up_page) { SignUpPage.visit }
+
+  context 'a Teacher' do
+    let(:user_type)         { :teacher }
+    let(:mr_kotter)         { FactoryGirl.build :mr_kotter }
+
+    let(:accept_terms)      { true }
+    let(:school_not_listed) { true }
+    let(:send_newsletter)   { true }
+    let(:zipcode)           { '11214' }
+
+    def sign_up_teacher(user)
+      sign_up_page.sign_up(type: user_type,
+                           name: user.name,
+                       username: user.username,
+                       password: user.password,
+          password_confirmation: user.password_confirmation,
+                          email: user.email,
+                        zipcode: zipcode,
+              school_not_listed: school_not_listed,
+                   accept_terms: accept_terms,
+                send_newsletter: send_newsletter)
+    end
+
+    def self.signup_succeeded; 'signup succeeded and'; end
+    shared_examples_for signup_succeeded do
+      it 'prompts for class creation' do
+        expect(current_path).to eq new_teachers_classroom_path
+      end
+    end
+
+    def self.disallows_submission; 'submission is disallowed and'; end
+    shared_examples_for disallows_submission do
+      it 'remains on the new-form page' do
+        expect(current_path).to eq sign_up_page.new_form_path
+      end
+    end
+
+    context 'with no info' do
+      before(:each) do
+        sign_up_page.be_a_teacher
+        sign_up_page.submit_form
+      end
+
+      it_behaves_like disallows_submission
+    end
+
+    context 'with new info' do
+      before(:each) { sign_up_teacher mr_kotter }
+
+      it_behaves_like signup_succeeded
+
+      context 'with no zipcode/school info' do
+        let(:school_not_listed) { false }
+        let(:zipcode)           { '' }
+
+        it_behaves_like signup_succeeded
+      end
+
+      context 'without accepting the Terms of Service' do
+        let(:accept_terms) { false }
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content 'Terms of service must be accepted'
+
+          expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
+                                                          type: user_type,
+                                                 accept_terms?: accept_terms,
+                                              send_newsletter?: send_newsletter)
+        end
+
+        context 'with a mixed-case username' do
+          let(:username)  { 'MrKotter' }
+          let(:mr_kotter) { FactoryGirl.build :mr_kotter, username: username }
+
+          describe 'the errored form' do
+            it 'down-cases the username' do
+              # make it expect downcase for comparing against the form
+              mr_kotter.username.downcase!
+
+              expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
+                                                              type: user_type,
+                                                     accept_terms?: accept_terms,
+                                                  send_newsletter?: send_newsletter)
+            end
+          end
+        end
+      end
+
+      context 'with blank password' do
+        let(:mr_kotter) do
+          FactoryGirl.build :mr_kotter, password: ''
+        end
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content "Password can't be blank"
+
+          expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
+                                                          type: user_type,
+                                                 accept_terms?: accept_terms,
+                                              send_newsletter?: send_newsletter)
+        end
+      end
+
+      context 'with mismatched password and confirmation' do
+        let(:mr_kotter) do
+          FactoryGirl.build :mr_kotter, password:              'something',
+                                        password_confirmation: 'different'
+        end
+
+        it 'shows the problem on the form' do
+          expect(sign_up_page).to have_content "Password confirmation doesn't match Password"
+
+          expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
+                                                          type: user_type,
+                                                 accept_terms?: accept_terms,
+                                              send_newsletter?: send_newsletter)
+        end
+      end
+
+      context 'with a bogus e-mail address' do
+        let(:mr_kotter) { FactoryGirl.build :mr_kotter, email: 'bogus' }
+
+        it_behaves_like disallows_submission
+      end
+    end
+
+    context 'with minimal info' do
+      let(:x) { 'x' }
+
+      let(:professor_x) do
+        FactoryGirl.build :teacher,
+                          first_name: '',
+                           last_name: '',
+                            password: x,
+               password_confirmation: x,
+                               email: 'x@x.x'
+      end
+
+      let(:zipcode)           { '' }
+      let(:school_not_listed) { false }
+      let(:send_newsletter)   { false }
+
+      before(:each) { sign_up_teacher professor_x }
+
+      it_behaves_like signup_succeeded
+    end
+
+    context 'with duplicate info' do
+      before(:each) do
+        FactoryGirl.create :mr_kotter
+
+        sign_up_teacher mr_kotter
+      end
+
+      it 'shows the errors on the form' do
+        expect(sign_up_page).to have_content 'Username has already been taken'
+        expect(sign_up_page).to have_content    'Email has already been taken'
+
+        expect(sign_up_page).to be_errored_sign_up_form(mr_kotter,
+                                                        type: user_type,
+                                               accept_terms?: accept_terms,
+                                             end_newsletter?: send_newsletter)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -491,22 +491,28 @@ describe User, :type => :model do
   end
 
   describe "#subscribe_to_newsletter" do
+    let(:user) { FactoryGirl.build(:user, newsletter: newsletter) }
 
-    let(:user) { FactoryGirl.build(:user) }
+    context 'when #newsletter = 0' do
+      let(:newsletter) { 0 }
 
-    it "returns nil when user newletter attribute is 0" do
-      user.newsletter="0"
-      expect(user.send(:subscribe_to_newsletter)).to eq(nil)
+      it 'does not call MailchimpConnection.subscribe_to_newsletter' do
+        expect(MailchimpConnection).not_to receive(:subscribe_to_newsletter)
+
+        user.subscribe_to_newsletter
+      end
     end
 
-    it "calls MailchimpConnection subscribe when newletter attribute is 1" do
-      user.newsletter="1"
-      expect(MailchimpConnection).to receive(:connection).at_least(:once).and_return(double())
-      expect(MailchimpConnection.connection).to receive(:lists).at_least(:once).and_return(double())
-      expect(MailchimpConnection.connection.lists).to receive(:subscribe).and_return(true)
-      user.send(:subscribe_to_newsletter)
-    end
+    context 'when #newsletter = 1' do
+      let(:newsletter) { 1 }
 
+      it 'calls MailchimpConnection.subscribe_to_newsletter' do
+        expect(MailchimpConnection).to receive(:subscribe_to_newsletter)
+                                       .with(user.email)
+
+        user.subscribe_to_newsletter
+      end
+    end
   end
 
   describe "#send_welcome_email" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = 'test'
 require File.expand_path("../../config/environment", __FILE__)
 
 require 'rspec/rails'
+require 'capybara/rails'
 require 'database_cleaner'
 require 'byebug'
 require 'vcr'
@@ -40,7 +41,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
@@ -55,7 +56,6 @@ RSpec.configure do |config|
 
   # database cleaner config
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
 
     begin
@@ -65,6 +65,16 @@ RSpec.configure do |config|
       # (re-?)clean the database after
       DatabaseCleaner.clean_with(:truncation)
     end
+  end
+
+  # most examples
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  # examples running in a browser
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
   end
 
   config.before(:each) do
@@ -116,4 +126,3 @@ end
 if defined?(Coveralls)
   Coveralls.wear!('rails')
 end
-

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -1,0 +1,72 @@
+# cf http://www.neo.com/2014/10/17/clean-up-after-your-capybara
+class Page
+  extend Capybara::DSL
+  include Capybara::DSL
+
+  protected
+
+  def self.has_checkbutton(value_method, element_method, locator)
+    # e.g.,
+    #   has_checkbutton :accept_terms?,
+    #                        :accept_terms_checkbutton,
+    #                        :user_terms_of_service
+    #   'produces'
+    #     has_form_element :accept_terms_checkbutton, :user_terms_of_service
+    #     def accept_terms?
+    #       accept_terms_checkbutton.checked?
+    #     end
+    has_form_element element_method, locator
+
+    module_eval_str __LINE__, %{
+      public def #{value_method}
+        #{element_method}.checked?
+      end
+    }
+  end
+
+  def self.has_form_element(method_name, locator)
+    # e.g.,
+    #   has_form_element :accepted_tos_field, :user_terms_of_service
+    #   'produces'
+    #     private def accepted_tos_field
+    #       find_field :user_terms_of_service
+    #     end
+    module_eval_str __LINE__, %{
+      private def #{method_name}
+        find_field :#{locator}
+      end
+    }
+  end
+
+  def self.has_form_field_value(method_name, element_method)
+    # e.g.,
+    #   has_form_field_value :zipcode, :zipcode_field
+    #   'produces'
+    #     def zipcode
+    #       zipcode_field.value
+    #     end
+    module_eval_str __LINE__, %{
+      public def #{method_name}
+        #{element_method}.value
+      end
+    }
+  end
+
+  def self.has_input_field(value_method, element_method, locator)
+    has_form_element   element_method, locator
+    has_form_field_value value_method, element_method
+  end
+
+  # make :has_radiobutton an alias for :has_checkbutton
+  self.singleton_class.send(:alias_method, :has_radiobutton, :has_checkbutton)
+
+  def fill(field, value)
+    field.set value if value.present?
+  end
+
+  private
+
+  def self.module_eval_str(line_no, str)
+    module_eval(str, __FILE__, line_no)
+  end
+end

--- a/spec/support/pages/sign_up_page.rb
+++ b/spec/support/pages/sign_up_page.rb
@@ -1,0 +1,177 @@
+require_relative 'page'
+
+class SignUpPage < Page
+  def self.visit
+    page.visit new_form_path
+    new
+  end
+
+  # perhaps these are kept in the order presented on the form to ease
+  # visual comparison...?
+
+  has_radiobutton :student?, :student_radio, :user_role_student
+  has_radiobutton :teacher?, :teacher_radio, :user_role_teacher
+
+  %i(name username password password_confirmation email).each do |attrib|
+    attrib_field = "#{attrib}_field".to_sym # e.g., :email_field
+    user_attrib  = "user_#{attrib}" .to_sym # e.g., :user_email
+
+    # e.g.,
+    #   has_input_field :email, :email_field, :user_email
+    # producces
+    #   #email       - fetch the form's 'email' value
+    #   #email_field - private method to access the :user_email element
+    has_input_field attrib, attrib_field, user_attrib
+  end
+
+  has_input_field :zipcode, :zipcode_field, :zipcode
+
+  has_checkbutton :school_not_listed?, :school_not_listed_checkbutton, :school_not_found
+  has_checkbutton :accept_terms?,           :accept_terms_checkbutton, :user_terms_of_service
+  has_checkbutton :send_newsletter?,     :send_newsletter_checkbutton, :user_newsletter
+
+  def be_a_student
+    student_radio.set true
+  end
+
+  def be_a_teacher
+    teacher_radio.set true
+  end
+
+  def new_form_path
+    self.class.new_form_path
+  end
+
+  def sign_up(type: nil,
+              name: '',
+          username: '',
+          password: '', password_confirmation: '',
+             email: '',
+           zipcode: '',
+ school_not_listed: true,
+      accept_terms: true,
+   send_newsletter: true)
+
+    send :"be_a_#{type}" if type.present?
+
+    # ideally these are in the order seen on the form
+    # so that the form appears to be filled out from
+    # top to bottom
+    fill                  name_field, name
+    fill              username_field, username
+    fill              password_field, password
+    fill password_confirmation_field, password_confirmation
+    fill                 email_field, email
+    fill               zipcode_field, zipcode
+
+    school_not_listed_checkbutton.set school_not_listed
+    accept_terms_checkbutton     .set accept_terms
+    send_newsletter_checkbutton  .set send_newsletter
+
+    submit_form
+  end
+
+  def submit_form
+    click_on 'Sign up'
+  end
+
+  private
+
+  def self.new_form_path
+    "#{submit_target_path}/new"
+  end
+
+  def self.submit_target_path
+    '/account'
+  end
+
+end
+
+RSpec::Matchers.define :be_errored_sign_up_form do |user, options|
+  match do |actual|
+    @errors = []
+
+    if current_path == SignUpPage.submit_target_path
+      if options.has_key?(:type)
+        type = options[:type].to_sym
+
+        @errors << "form is not for a #{type}" unless actual.send(:"#{type}?")
+      end
+
+      # ideally in the same order as seen on the form
+      # so the error output 'matches' the form
+      expect_equal user,     actual, :name
+      expect_equal user,     actual, :username
+      expect_blank           actual, :password
+      expect_blank           actual, :password_confirmation
+      expect_equal user,     actual, :email
+      expect_blank           actual, :zipcode
+      expect_false           actual, :school_not_listed?
+      expect_option options, actual, :accept_terms?
+      expect_option options, actual, :send_newsletter?
+    else
+      expected_label, got_label = expected_got_labels(:path)
+      @errors << ["#{expected_label} '#{SignUpPage.submit_target_path}'",
+                       "#{got_label} '#{current_path}'"]
+    end
+
+    @errors.empty?
+  end
+
+  def expect_blank(page, sym)
+    actual = page.send(sym)
+
+    add_expected_got_error('to be blank', actual, sym) unless actual.blank?
+  end
+
+  def expect_equal(source, page, sym)
+    actual   = page.send(sym)
+    expected = if source.respond_to?(sym)
+                 source.send(sym)
+               else
+                 source
+               end
+
+    add_expected_got_error("'#{expected}'", actual, sym) if actual != expected
+  end
+
+  def expect_false(page, sym)
+    actual = page.send(sym)
+
+    add_expected_got_error("'false'", actual, sym) unless !actual
+  end
+
+  def expect_option(hash, actual, sym)
+    if hash.has_key?(sym)
+      expect_equal hash[sym], actual, sym
+    end
+  end
+
+  def add_expected_got_error(expected, actual, sym)
+    expected_label, got_label = expected_got_labels(sym)
+
+    @errors << ["#{expected_label} #{expected}",
+                "#{got_label} '#{actual}'"]
+  end
+
+  def expected_got_labels(sym)
+    # right-justify 'got' to the 'expected' line
+    # i.e., make something like
+    #   ["expected blar",
+    #    "          got"]
+    expected_label = "expected #{sym}"
+    [expected_label, "%#{expected_label.length}s" % 'got']
+  end
+
+  failure_message do |actual|
+    unless @errors.empty?
+      ["#{actual} does not look like a sign-up page with errors:",
+       @errors.map do |line|
+        # line = line.join "\n   " if line.respond_to?(:join)
+        line = line.try(:join, "\n   ") || line
+        " - #{line}"
+      end
+      ].join("\n")
+    end
+  end
+end

--- a/spec/support/pages/sign_up_page.rb
+++ b/spec/support/pages/sign_up_page.rb
@@ -62,11 +62,15 @@ class SignUpPage < Page
     fill              password_field, password
     fill password_confirmation_field, password_confirmation
     fill                 email_field, email
-    fill               zipcode_field, zipcode
 
-    school_not_listed_checkbutton.set school_not_listed
-    accept_terms_checkbutton     .set accept_terms
-    send_newsletter_checkbutton  .set send_newsletter
+    if type == :teacher
+      fill zipcode_field, zipcode
+
+      school_not_listed_checkbutton.set school_not_listed
+      send_newsletter_checkbutton  .set send_newsletter
+    end
+
+    accept_terms_checkbutton.set accept_terms
 
     submit_form
   end
@@ -100,15 +104,19 @@ RSpec::Matchers.define :be_errored_sign_up_form do |user, options|
 
       # ideally in the same order as seen on the form
       # so the error output 'matches' the form
-      expect_equal user,     actual, :name
-      expect_equal user,     actual, :username
-      expect_blank           actual, :password
-      expect_blank           actual, :password_confirmation
-      expect_equal user,     actual, :email
-      expect_blank           actual, :zipcode
-      expect_false           actual, :school_not_listed?
+      expect_equal user, actual, :name
+      expect_equal user, actual, :username
+      expect_blank       actual, :password
+      expect_blank       actual, :password_confirmation
+      expect_equal user, actual, :email
+
+      if user.teacher?
+        expect_blank           actual, :zipcode
+        expect_false           actual, :school_not_listed?
+        expect_option options, actual, :send_newsletter?
+      end
+
       expect_option options, actual, :accept_terms?
-      expect_option options, actual, :send_newsletter?
     else
       expected_label, got_label = expected_got_labels(:path)
       @errors << ["#{expected_label} '#{SignUpPage.submit_target_path}'",


### PR DESCRIPTION
Configured to run in browser (_i.e._, `js: true`) so as to allow the sign-in page's JS to run

A few basic cases - _e.g._,
- succeeds with new, unique info
- fails...
 - without accepting Terms of Service
 - if duplicate user already exists
 - with blank password
 - with password/confirmation mismatch
    
Supporting infrastructure:
- new Teacher & Student factories
- `spec/support/pages/...`
 - `sign_up_page.rb` - page object for `Accounts#new` form
 - `page.rb` - base class