### PR TITLE
Fix datepicker date display on Firefox

### DIFF
--- a/app/assets/stylesheets/scorebook/custom.css.scss
+++ b/app/assets/stylesheets/scorebook/custom.css.scss
@@ -210,7 +210,7 @@ input:focus {
   border: 1px solid #5bc1a9;
 }
 .datepicker-input {
-  height: 26px;
+  height: 31px;
   width: 148px;
   /*background-image: url(../images/icon-calendar.png);*/
   background-image: image-url('scorebook/icon-calendar.png');


### PR DESCRIPTION
Fix #554

Given a .datepicker-input height of 26px, Chrome 41.0.2272.89;
Safari 8.0.3 (10600.3.18); and Firefox 35.0.1 all appear to subtract off
the padding (9 x 2 = 18) and border (1 x 2 = 2) to reach a content
height of 6px.

Firefox, however, appears to be the only one of the three that actually
honors it &mdash; the others appear to use a minimum value of 11 or so.

Increase it to 31px so Firefox is left with 11px to honor.