### PR TITLE
Use Firefox 35.0.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_script:
 - psql -c 'create database test;' -U postgres
 - ! 'RAILS_ENV=test bundle exec rake db:schema:load || :'
 addons:
+  firefox: "35.0.1"
   postgresql: "9.3"


### PR DESCRIPTION
matches the selenium-webdriver version added in d0638a84

Part of ongoing attempt to understand & fix the intermittent `feature` spec failures
_e.g._, builds [751](https://travis-ci.org/empirical-org/Empirical-Core/builds/54234859) & [723](https://travis-ci.org/empirical-org/Empirical-Core/builds/53519649)
