### PR TITLE
Preview Lessons section has been removed from Join Classroom page

### DIFF
--- a/app/views/profiles/join-classroom.html.slim
+++ b/app/views/profiles/join-classroom.html.slim
@@ -12,13 +12,3 @@ article.student-profile-page.simple-rounded-box
 
         p.explanation: em
           | Enter your class code to join your class. Your teacher can provide you with this.
-
-    .l-section.table-stripe
-      h3 Preview Lessons
-      p Join a class to track your progress.
-
-      = render 'large_section_select'
-
-      - @topics.each do |topic|
-        h4 style="text-decoration: underline ; margin-top: 50px"= topic.name
-        = render partial: 'teachers/classrooms/activity', collection: topic.activities


### PR DESCRIPTION
Pulled out this whole sections so that there's only one call to action.