### PR TITLE
Use poltergeist/PhantomJS for headless testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: ruby
 rvm:
   - 2.1.2
 script:
-  - xvfb-run bundle exec rake spec
+  - bundle exec rake spec
 before_script:
   - cp config/database.yml.travis config/database.yml
   - psql -c 'create database test;' -U postgres
   - ! 'RAILS_ENV=test bundle exec rake db:schema:load || :'
 addons:
-  firefox: "35.0.1"
   postgresql: "9.3"
 env:
   FOG_DIRECTORY=empirical-core-travis-test

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem 'slim-rails'
 gem 'haml-rails'
 gem 'haml_coffee_assets', github: 'netzpirat/haml_coffee_assets'
 
+gem 'es5-shim-rails'
 gem 'react-rails', '~>0.12.0.0'
 
 # ASSET/UI

--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver', '>=2.45.0.dev3' # works with Firefox 35
+  gem 'poltergeist'
   gem "vcr"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,13 +118,12 @@ GEM
       mime-types (>= 1.16)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    childprocess (0.5.5)
-      ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.1)
     clever-ruby (0.10.0)
       activesupport (~> 4.1.5)
       multi_json (~> 1.10.0)
       rest-client (~> 1.6.7)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -320,6 +319,11 @@ GEM
       blankslate (~> 2.0)
     pg (0.17.1)
     pg_array_parser (0.0.9)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     postgres_ext (2.4.1)
@@ -444,16 +448,10 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-support (3.1.0)
     ruby-progressbar (1.5.1)
-    rubyzip (1.1.7)
     safe_yaml (1.0.3)
     sass (3.4.4)
     select2-rails (3.5.9.1)
       thor (~> 0.14)
-    selenium-webdriver (2.45.0.dev3)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     sentry-raven (0.12.2)
       faraday (>= 0.7.6)
     sidekiq (3.2.4)
@@ -521,7 +519,9 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    websocket (1.2.1)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -581,6 +581,7 @@ DEPENDENCIES
   omniauth-clever
   parslet
   pg
+  poltergeist
   postgres_ext
   pry
   pry-coolline
@@ -604,7 +605,6 @@ DEPENDENCIES
   sass
   sass-rails!
   select2-rails
-  selenium-webdriver (>= 2.45.0.dev3)
   sentry-raven (>= 0.12.2)
   sidekiq
   sidekiq-retries

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
     eco-source (1.1.0.rc.1)
     ejs (1.1.1)
     erubis (2.7.0)
+    es5-shim-rails (4.0.1)
+      actionpack (>= 3.1)
+      railties (>= 3.1)
     excon (0.39.5)
     execjs (2.2.1)
     extlib (0.9.16)
@@ -552,6 +555,7 @@ DEPENDENCIES
   database_cleaner
   doorkeeper
   dotenv-rails
+  es5-shim-rails
   factory_girl
   factory_girl_rails
   faraday_middleware

--- a/app/assets/javascripts/scorebook/create_a_class.js
+++ b/app/assets/javascripts/scorebook/create_a_class.js
@@ -1,5 +1,3 @@
-
-
 $(document).ready(function () {
 	$('.generate-code').click(function(){
 		$.ajax({
@@ -8,8 +6,5 @@ $(document).ready(function () {
 				$('.class-code').val(data.code);
 			}
 		});
-	  
 	});
-
 });
-

--- a/app/assets/javascripts/scorebook/create_a_class.js
+++ b/app/assets/javascripts/scorebook/create_a_class.js
@@ -2,16 +2,10 @@
 
 $(document).ready(function () {
 	$('.generate-code').click(function(){
-		console.log('clicked on generate-code');
 		$.ajax({
 			url: '/teachers/classrooms/regenerate_code',
 			success: function(data, status, jqXHR) {
-				console.log('success regenerating code!');
-				console.log(data);
 				$('.class-code').val(data.code);
-			},
-			error: function () {
-				console.log('error regenerating code');
 			}
 		});
 	  

--- a/app/assets/javascripts/scorebook/progress_reports/sortable_table.jsx
+++ b/app/assets/javascripts/scorebook/progress_reports/sortable_table.jsx
@@ -20,7 +20,7 @@ EC.SortableTable = React.createClass({
                             sortHandler={this.sortByColumn(column.sortByField)}
                             displayName={column.name}
                             displayClass={column.className}
-                            sortDirection={this.props.currentSort.direction}
+                            sortDirection={this.props.currentSort.direction || 'asc'}
                             isCurrentSort={isCurrentSort} />
     }, this);
   },

--- a/app/assets/javascripts/scorebook/progress_reports/sortable_table.jsx
+++ b/app/assets/javascripts/scorebook/progress_reports/sortable_table.jsx
@@ -27,7 +27,7 @@ EC.SortableTable = React.createClass({
 
   rows: function() {
     return _.map(this.props.rows, function(row, i) {
-      return <EC.SortableTr key={row.id} row={row} columns={this.props.columns} />
+      return <EC.SortableTr key={row.id || i} row={row} columns={this.props.columns} />
     }, this);
   },
 

--- a/app/assets/javascripts/scorebook/scorebook.js
+++ b/app/assets/javascripts/scorebook/scorebook.js
@@ -5,6 +5,7 @@
 //= require lodash.min.js
 //= require underscore.string
 
+//= require es5-shim/es5-shim
 //= require react
 
 //= require selecter.js

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -5,13 +5,6 @@ feature 'Signing up', js: true do
 
   let(:sign_up_page) { SignUpPage.visit }
 
-  def self.disallows_submission; 'submission is disallowed and'; end
-  shared_examples_for disallows_submission do
-    it 'remains on the new-form page' do
-      expect(current_path).to eq sign_up_page.path
-    end
-  end
-
   def password_cannot_be_blank
     "Password can't be blank"
   end
@@ -28,6 +21,8 @@ feature 'Signing up', js: true do
     let(:school_not_listed) { true }
     let(:send_newsletter)   { true }
     let(:zipcode)           { '11214' }
+
+    before(:each) { sign_up_page.be_a_teacher }
 
     def sign_up_teacher(user)
       sign_up_page.sign_up(type: user_type,
@@ -49,13 +44,10 @@ feature 'Signing up', js: true do
       end
     end
 
-    context 'with no info' do
-      before(:each) do
-        sign_up_page.be_a_teacher
-        sign_up_page.submit_form
+    context 'the form' do
+      it "marks the 'email' field as 'required'" do
+        expect(sign_up_page).to have_email_required
       end
-
-      it_behaves_like disallows_submission
     end
 
     context 'with new info' do
@@ -130,12 +122,6 @@ feature 'Signing up', js: true do
                                               send_newsletter?: send_newsletter)
         end
       end
-
-      context 'with a bogus e-mail address' do
-        let(:mr_kotter) { FactoryGirl.build :mr_kotter, email: 'bogus' }
-
-        it_behaves_like disallows_submission
-      end
     end
 
     context 'with minimal info' do
@@ -186,6 +172,8 @@ feature 'Signing up', js: true do
     before(:each) do
       # at least 1 Section must already exist
       FactoryGirl.create :section
+
+      sign_up_page.be_a_student
     end
 
     def sign_up_student(user)
@@ -202,6 +190,12 @@ feature 'Signing up', js: true do
     shared_examples_for signup_succeeded do
       it 'goes to the profile page' do
         expect(current_path).to eq '/profile'
+      end
+    end
+
+    context 'the form' do
+      it "does not mark the 'email' field as 'required'" do
+        expect(sign_up_page).not_to have_email_required
       end
     end
 
@@ -275,12 +269,6 @@ feature 'Signing up', js: true do
           expect(sign_up_page).to be_errored_sign_up_form(vinnie,
                                                           type: user_type)
         end
-      end
-
-      context 'with a bogus e-mail address' do
-        let(:vinnie) { FactoryGirl.build :vinnie_barbarino, email: 'bogus' }
-
-        it_behaves_like disallows_submission
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = 'test'
 require File.expand_path("../../config/environment", __FILE__)
 
 require 'rspec/rails'
+require 'capybara/poltergeist'
 require 'capybara/rails'
 require 'database_cleaner'
 require 'byebug'
@@ -23,6 +24,12 @@ Capybara.configure do |config|
   # Use a high(er) timeout for JS-based UI -- e.g., React.js
   # cf http://docs.travis-ci.com/user/common-build-problems/#Capybara%3A-I'm-getting-errors-about-elements-not-being-found
   config.default_wait_time = 100  # increased from 15 since we were getting Net Timeout errors on Tracis CI (and not on local)
+
+  Capybara.register_driver :poltergeist do |app|
+    Capybara::Poltergeist::Driver.new(app, js_errors: false)
+  end
+
+  config.javascript_driver = :poltergeist
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/support/pages/sign_up_page.rb
+++ b/spec/support/pages/sign_up_page.rb
@@ -38,6 +38,10 @@ class SignUpPage < Page
     teacher_radio.set true
   end
 
+  def has_email_required?
+    email_field[:required]
+  end
+
   def path
     self.class.path
   end


### PR DESCRIPTION
Use headless testing to speed up `js: true` examples so external library loads (#614) seem less significant

Got these successful builds as I refined things:

Build # | Total<br>time | `rake spec` time<br>(553 examples)
----- | ---------- | ---------
[61](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58994818) | 4:21 | 1:14
[63](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58995548) | 4:20 | 1:19
[64](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58999349) | 4:14 | 1:21
[65](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58999479) | 3:58 | 1:10
[66](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58999596) | 5:24 | 1:35
[67](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58999638) | 4:14 | 1:11
[68](https://travis-ci.org/bobmazanec/Empirical-Core/builds/58999944) | 6:51 | 1:36
compare to<br>#[1031](https://travis-ci.org/empirical-org/Empirical-Core/builds/58521254)<br>(45bc80e &mdash; on which<br>this branch is based) | 8:46 | 3:37<br>(554 examples)