### PR TITLE
Add examples of username/email case-insensitivity on sign-in

### DIFF
--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -23,7 +23,13 @@ feature 'Signing in' do
     shared_context using_sym_succeeds(sym) do
       context "using #{sym}" do
         include_context use_credential_context_name do
-          include_examples :sign_in_succeeds
+          %i(as_is changed).each do |cred_case|
+            context "case #{cred_case}" do
+              let(:credential_input_case) { cred_case }
+
+              include_examples :sign_in_succeeds
+            end
+          end
         end
       end
     end
@@ -56,7 +62,8 @@ feature 'Signing in' do
     let(:mr_kotter) { FactoryGirl.create :mr_kotter }
 
     def sign_in_user
-      sign_in_page.sign_in mr_kotter, using: credential
+      sign_in_page.sign_in mr_kotter, using: credential,
+                                  cred_case: credential_input_case
     end
 
     context '-- with no classrooms --' do
@@ -88,7 +95,10 @@ feature 'Signing in' do
 
     # doesn't matter whether/not student is already in a class
 
-    before(:each) { sign_in_page.sign_in vinnie, using: credential }
+    before(:each) do
+      sign_in_page.sign_in vinnie, using: credential,
+                               cred_case: credential_input_case
+    end
 
     include_examples :sign_in_methods_succeed
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,28 +36,42 @@ describe User, :type => :model do
 
   #TODO: email is taken as username and email
   describe ".authenticate" do
+    let(:username)          { 'test' }
+    let(:username_password) { '123456' }
+
+    let(:email)          { 'test@example.com' }
+    let(:email_password) { '654321' }
+
     before do
-      FactoryGirl.create(:user, username: 'test',          password: '123456', password_confirmation: '123456')
-      FactoryGirl.create(:user, email: 'test@example.com', password: '654321', password_confirmation: '654321')
+      FactoryGirl.create(:user, username: username, password: username_password, password_confirmation: username_password)
+      FactoryGirl.create(:user,    email: email,    password:    email_password, password_confirmation:    email_password)
     end
 
-    context "when username present" do
-      it "password is not valid" do
-        expect(User.authenticate(email: 'test',             password: 'xxxxxx')).to be_falsy
-      end
-
-      it 'authenticate a user by username' do
-        expect(User.authenticate(email: 'test',             password: '123456')).to be_truthy
-      end
+    subject(:authentication_result) do
+      User.authenticate(email: login_name,
+                     password: password)
     end
 
-    context "when email present" do
-      it "password is not valid" do
-        expect(User.authenticate(email: 'test@example.com', password: 'xxxxxx')).to be_falsy
-      end
+    %i(email username).each do |cred_base|
+      context "with #{cred_base}" do
+        let(:login_name)   { send(cred_base) } # e.g., send(:username)
+        let(:password_val) { send(:"#{cred_base}_password") }
 
-      it 'authenticate a user by email' do
-        expect(User.authenticate(email: 'test@example.com', password: '654321')).to be_truthy
+        context 'with incorrect password' do
+          let(:password) { "wrong #{password_val} wrong" }
+
+          it 'fails' do
+            expect(authentication_result).to be_falsy
+          end
+        end
+
+        context 'with correct password' do
+          let(:password) { password_val }
+
+          it 'succeeds' do
+            expect(authentication_result).to be_truthy
+          end
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,10 +36,10 @@ describe User, :type => :model do
 
   #TODO: email is taken as username and email
   describe ".authenticate" do
-    let(:username)          { 'test' }
+    let(:username)          { 'Test' }
     let(:username_password) { '123456' }
 
-    let(:email)          { 'test@example.com' }
+    let(:email)          { 'Test@example.com' }
     let(:email_password) { '654321' }
 
     before do
@@ -54,22 +54,36 @@ describe User, :type => :model do
 
     %i(email username).each do |cred_base|
       context "with #{cred_base}" do
-        let(:login_name)   { send(cred_base) } # e.g., send(:username)
         let(:password_val) { send(:"#{cred_base}_password") }
 
-        context 'with incorrect password' do
-          let(:password) { "wrong #{password_val} wrong" }
+        %i(original swapped).each do |name_case|
+          case_mod = if name_case == :swapped
+                       :swapcase # e.g., "a B c" => "A b C"
+                     else
+                       :to_s
+                     end
 
-          it 'fails' do
-            expect(authentication_result).to be_falsy
-          end
-        end
+          context "#{name_case} case" do
+            # e.g., send(:username).send(:to_s),
+            #       send(:email   ).send(:swapcase),
+            #       etc.
+            let(:login_name) { send(cred_base).send(case_mod) }
 
-        context 'with correct password' do
-          let(:password) { password_val }
+            context 'with incorrect password' do
+              let(:password) { "wrong #{password_val} wrong" }
 
-          it 'succeeds' do
-            expect(authentication_result).to be_truthy
+              it 'fails' do
+                expect(authentication_result).to be_falsy
+              end
+            end
+
+            context 'with correct password' do
+              let(:password) { password_val }
+
+              it 'succeeds' do
+                expect(authentication_result).to be_truthy
+              end
+            end
           end
         end
       end

--- a/spec/support/pages/sign_in_page.rb
+++ b/spec/support/pages/sign_in_page.rb
@@ -5,8 +5,12 @@ class SignInPage < Page
     "#{BASE_PATH}/new"
   end
 
-  def sign_in(user, using: :username)
-    fill_in :user_email,    with: user[using]
+  def sign_in(user, using: :username,
+                cred_case: :as_is)
+    user_cred = user[using]
+    user_cred.swapcase! if cred_case == :changed
+
+    fill_in :user_email,    with: user_cred
     fill_in :user_password, with: user.password
 
     submit_form


### PR DESCRIPTION
Existing examples use same case for both `User` creation and sign-in/authentication.

`User.authenticate` (and, therefore, sign-in) already treat `email` and `username` case insensitively.

Add examples showing this (existing) behavior.

Related to #696.