### PR TITLE
Change migrations so that they run with a clean DB

### DIFF
--- a/db/migrate/20130309011601_create_cms.rb
+++ b/db/migrate/20130309011601_create_cms.rb
@@ -1,4 +1,4 @@
-class CreateCMS < ActiveRecord::Migration
+class CreateCms < ActiveRecord::Migration
   def change
     create_table :file_uploads do |t|
       t.string :name

--- a/db/migrate/20141014162137_add_app_name_to_classification.rb
+++ b/db/migrate/20141014162137_add_app_name_to_classification.rb
@@ -3,8 +3,5 @@ class AddAppNameToClassification < ActiveRecord::Migration
 
     add_column :activity_classifications, :app_name, :string
 
-    ActivityClassification.find(1).try(:update_column,:app_name, 'grammar')
-    ActivityClassification.find(2).try(:update_column, :app_name, 'grammar')
-
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 20150908190948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
-  enable_extension "pg_stat_statements"
 
   create_table "activities", force: true do |t|
     t.string   "name"
@@ -78,8 +77,8 @@ ActiveRecord::Schema.define(version: 20150908190948) do
 
   create_table "categories", force: true do |t|
     t.text     "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "classroom_activities", force: true do |t|
@@ -154,8 +153,8 @@ ActiveRecord::Schema.define(version: 20150908190948) do
     t.string   "name"
     t.string   "file"
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "firebase_apps", force: true do |t|
@@ -208,8 +207,8 @@ ActiveRecord::Schema.define(version: 20150908190948) do
     t.string   "name"
     t.string   "description"
     t.text     "content"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "schools", force: true do |t|
@@ -276,10 +275,6 @@ ActiveRecord::Schema.define(version: 20150908190948) do
     t.datetime "updated_at"
   end
 
-  create_table "t1", id: false, force: true do |t|
-    t.integer "id"
-  end
-
   create_table "topic_categories", force: true do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -312,8 +307,8 @@ ActiveRecord::Schema.define(version: 20150908190948) do
     t.string   "email"
     t.string   "password_digest"
     t.string   "role",                  default: "user"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "classcode"
     t.boolean  "active",                default: false
     t.string   "username"
@@ -332,8 +327,8 @@ ActiveRecord::Schema.define(version: 20150908190948) do
 
   create_table "workbooks", force: true do |t|
     t.string   "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
rake empirical:setup failed raising 
```
NameError: uninitialized constant CreateCms
```
changing the class of the migration to CreateCms from CreateCMS fixed this.

Following that change the next error raised was

``` 
Couldn't find ActivityClassification with 'id'=1/Users/donald/Programming/Ruby/Empirical-Core/db/migrate/20141014162137_add_app_name_to_classification.rb:6:in 'change'
ActiveRecord::RecordNotFound: Couldn't find ActivityClassification with 'id'=1
```
removing the lines 

```
ActivityClassification.find(1).try(:update_column,:app_name, 'grammar')
ActivityClassification.find(2).try(:update_column, :app_name, 'grammar')
```
fixed this.

All tests still pass (608 examples, 0 failures, 6 pending)