### PR TITLE
Bugfix/scorebook concepts

### DIFF
--- a/app/helpers/concept_helper.rb
+++ b/app/helpers/concept_helper.rb
@@ -1,15 +1,12 @@
 module ConceptHelper
   def all_concept_stats(activity_session)
-    # return nothing for now because this is too expensive, killing response times
-
-    # return '' unless activity_session.present?
-    # # Generate a header for each applicable concept class (activity session has concept tag results for that class)
-    # concept_results = activity_session.concept_results
-    # concepts = activity_session.concepts
-    # concepts.reduce "" do |html, concept|
-    #   html += stats_for_concept(concept, concept_results)
-    # end
-    return ''
+    return '' unless activity_session.present?
+    # Generate a header for each applicable concept class (activity session has concept tag results for that class)
+    concept_results = activity_session.concept_results
+    concepts = activity_session.concepts
+    concepts.reduce "" do |html, concept|
+      html += stats_for_concept(concept, concept_results)
+    end
   end
 
   private

--- a/app/queries/scorebook.rb
+++ b/app/queries/scorebook.rb
@@ -72,7 +72,7 @@ class Scorebook
     if begin_date.present?
       results = results.where("activity_sessions.completed_at > ?", (begin_date.to_date - 1.day))
     end
-    if end_date.present?
+    if end_date.present? 
       results = results.where("activity_sessions.completed_at < ?", (end_date.to_date + 1.day) )
     end
     results
@@ -91,7 +91,7 @@ class Scorebook
       percentage: activity_session.percentage,
       due_date_or_completed_at_date: activity_session.display_due_date_or_completed_at_date,
       activity: (ActivitySerializer.new(activity_session.activity)).as_json(root: false),
-      concept_results: []# FIXME: this is too slow, had to cut it out : activity_session.concept_results.map {|result| ConceptResultSerializer.new(result).as_json(root: false) }
+      concept_results: activity_session.concept_results.map {|result| ConceptResultSerializer.new(result).as_json(root: false) }
     }
   end
 end

--- a/app/queries/scorebook.rb
+++ b/app/queries/scorebook.rb
@@ -50,6 +50,7 @@ class Scorebook
     # Find all the 'final' activity sessions for all the students in all the classrooms
     results = ActivitySession.select("users.name, activity_sessions.id, activity_sessions.percentage,
                                 #{User.sorting_name_sql}")
+                              .preload(:concept_results => :concept)
                               .includes(:user, :activity => [:classification, :topic => [:section, :topic_category]])
                               .references(:user)
                               .where(user: users)

--- a/spec/helpers/concept_helper_spec.rb
+++ b/spec/helpers/concept_helper_spec.rb
@@ -21,22 +21,17 @@ describe ConceptHelper, type: :helper do
       )
     end
 
-    it 'displays nothing because weve turned it off since the query is killing response time (need to rewrite query)' do
+    it "displays all concept stats for an activity session" do
       html = helper.all_concept_stats(activity_session)
-      expect(html).to eq('')
+      expect(html).to include(punctuation_concept.name)
+      expect(html).to include(prepositions_concept.name)
     end
 
-    # it "displays all concept stats for an activity session" do
-    #   html = helper.all_concept_stats(activity_session)
-    #   expect(html).to include(punctuation_concept.name)
-    #   expect(html).to include(prepositions_concept.name)
-    # end
-
-    # it "displays a breakdown of the grammar concepts and correct/incorrect" do
-    #   html = helper.all_concept_stats(activity_session)
-    #   expect(html).to include(prepositions_concept.name)
-    #   expect(html).to include("1")
-    #   expect(html).to include("0")
-    # end
+    it "displays a breakdown of the grammar concepts and correct/incorrect" do
+      html = helper.all_concept_stats(activity_session)
+      expect(html).to include(prepositions_concept.name)
+      expect(html).to include("1")
+      expect(html).to include("0")
+    end
   end
 end


### PR DESCRIPTION
This addresses performance problems on the teacher scorebook. Concepts and results are preloaded now instead of being N+1. This could probably be improved further by throwing an index on the `activity_session_id` column of the concept_results table.