### PR TITLE
fixed schema

### DIFF
--- a/db/migrate/20151109222903_remove_hidden_from_classrooms.rb
+++ b/db/migrate/20151109222903_remove_hidden_from_classrooms.rb
@@ -1,0 +1,5 @@
+class RemoveHiddenFromClassrooms < ActiveRecord::Migration
+  def change
+    remove_column :classrooms, :hidden
+  end
+end

--- a/db/migrate/20151109223356_add_hidden_column_to_classroom.rb
+++ b/db/migrate/20151109223356_add_hidden_column_to_classroom.rb
@@ -1,0 +1,5 @@
+class AddHiddenColumnToClassroom < ActiveRecord::Migration
+  def change
+    add_column :classrooms, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151103143507) do
+ActiveRecord::Schema.define(version: 20151109223356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
-- last two migrations drop `hidden` column and then add it back in so that it will retroactively be set to `false` for every classroom record
