### PR TITLE
Return Scroll position to top of page after selecting activities.

### DIFF
--- a/app/assets/javascripts/lesson_planner/create_unit/create_unit.jsx
+++ b/app/assets/javascripts/lesson_planner/create_unit/create_unit.jsx
@@ -81,6 +81,11 @@ EC.CreateUnit = React.createClass({
 		this.props.analytics.track('click Continue in lesson planner');
 		this.fetchClassrooms();
 		this.setState({stage: 2});
+		this.resetWindowPosition();
+	},
+
+	resetWindowPosition: function () {
+		window.scrollTo(500, 0);
 	},
 
 	fetchClassrooms: function() {

--- a/app/views/activity_sessions/play.slim
+++ b/app/views/activity_sessions/play.slim
@@ -1,3 +1,15 @@
 .container
   article.extra-padding.activity-form.activity-show
     iframe#activity-iframe src=@module_url name='activity-iframe'
+
+javascript:
+  window.addEventListener("message", receiveMessage, false);
+
+  function receiveMessage(event)
+  {
+    if (event.origin !== "http://localhost:3001") {
+      return;
+    } else {
+      window.location.reload();
+    }
+  }

--- a/app/views/activity_sessions/play.slim
+++ b/app/views/activity_sessions/play.slim
@@ -7,9 +7,11 @@ javascript:
 
   function receiveMessage(event)
   {
-    if (event.origin !== "http://localhost:3001") {
-      return;
-    } else {
+    if (event.origin === "http://localhost:3001") {
       window.location.reload();
+    } else if (event.origin === "https://grammar.quill.org"){
+      window.location.reload();
+    } else {
+      return
     }
   }


### PR DESCRIPTION
This prevents users from missing the assigning students step that can be above the current scroll position.