### PR TITLE
marks correct tab as active within progress reports

### DIFF
--- a/app/helpers/progress_report_helper.rb
+++ b/app/helpers/progress_report_helper.rb
@@ -1,7 +1,8 @@
 module ProgressReportHelper
   def is_progress_report_page?
     controller.class.parent == Teachers::ProgressReports ||
-      controller.class.parent == Teachers::ProgressReports::Standards
+    controller.class.parent == Teachers::ProgressReports::Standards ||
+    controller.class.parent == Teachers::ProgressReports::Concepts
   end
 
   def dont_show_premium_bar?


### PR DESCRIPTION
previously, clicking 'Concepts' made 'Class Manager' the active tab. Added a line of code so it properly made 'Progress Reports' the active one.