### PR TITLE
hides teacher resources and discover from student view

### DIFF
--- a/app/views/application/_sub_header.html.erb
+++ b/app/views/application/_sub_header.html.erb
@@ -15,8 +15,10 @@
 
 	<div id="home-collapsed-navbar" class="collapse navbar-collapse">
 		<ul class="home-navbar-list">
-			<li class="active"><%= link_to "Discover", activities_path %></li>
-			<li><%= link_to "Teacher Resources",  teacher_resources_path%></li>
+			<% if !current_user || current_user.role != "student" %>
+				<li class="active"><%= link_to "Discover", activities_path %></li>
+				<li><%= link_to "Teacher Resources",  teacher_resources_path%></li>
+			<% end %>
 
 			<%- if current_user.nil? %>
 				<li><%= link_to "Login", new_session_path  %></li>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109231813) do
+ActiveRecord::Schema.define(version: 20151123211533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
-  enable_extension "pg_stat_statements"
 
   create_table "activities", force: true do |t|
     t.string   "name"
@@ -73,6 +72,7 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.datetime "started_at"
     t.boolean  "is_retry",              default: false
     t.boolean  "is_final_score",        default: false
+    t.boolean  "visible",               default: true,        null: false
   end
 
   add_index "activity_sessions", ["activity_id"], name: "index_activity_sessions_on_activity_id", using: :btree
@@ -95,8 +95,8 @@ ActiveRecord::Schema.define(version: 20151109231813) do
 
   create_table "categories", force: true do |t|
     t.text     "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "classroom_activities", force: true do |t|
@@ -126,19 +126,6 @@ ActiveRecord::Schema.define(version: 20151109231813) do
 
   add_index "classrooms", ["code"], name: "index_classrooms_on_code", using: :btree
   add_index "classrooms", ["grade"], name: "index_classrooms_on_grade", using: :btree
-
-  create_table "comments", force: true do |t|
-    t.string   "title"
-    t.text     "body"
-    t.integer  "user_id"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.string   "ancestry"
-    t.string   "reply_type"
-    t.integer  "lecture_chapter_id"
-  end
-
-  add_index "comments", ["ancestry"], name: "index_comments_on_ancestry", using: :btree
 
   create_table "concept_results", force: true do |t|
     t.integer "activity_session_id"
@@ -185,8 +172,8 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.string   "name"
     t.string   "file"
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "firebase_apps", force: true do |t|
@@ -239,18 +226,8 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.string   "name"
     t.string   "description"
     t.text     "content"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  create_table "rules_misseds", force: true do |t|
-    t.integer  "rule_id"
-    t.integer  "user_id"
-    t.integer  "assessment_id"
-    t.datetime "time_take"
-    t.boolean  "missed"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "schools", force: true do |t|
@@ -362,6 +339,7 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.integer  "classroom_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "visible",      default: true, null: false
   end
 
   create_table "users", force: true do |t|
@@ -369,8 +347,8 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.string   "email"
     t.string   "password_digest"
     t.string   "role",                  default: "user"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "classcode"
     t.boolean  "active",                default: false
     t.string   "username"
@@ -390,8 +368,8 @@ ActiveRecord::Schema.define(version: 20151109231813) do
 
   create_table "workbooks", force: true do |t|
     t.string   "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
This pull request intends to fix Issue #1036. I edited the views/application/_sub_header.html.erb file to wrap the discover and teacher resources links in the following if statement: `if !current_user || current_user.role != "student"` so that users who are logged in as a student will not see the discover and teacher resources links but users logged in as teachers or admin, and users that are not logged in will be able to see them. This was added on line 18 under `<ul class="home-navbar-list">`.