### PR TITLE
Style/fix high school nav  - Issue #720

### DIFF
--- a/app/assets/stylesheets/shared/tabs.scss
+++ b/app/assets/stylesheets/shared/tabs.scss
@@ -57,3 +57,7 @@
     margin-right: 9px;
   }
 }
+
+span.avoidwrap {
+  display: inline-block;
+ }

--- a/app/views/pages/shared/_activities_subtabs.html.slim
+++ b/app/views/pages/shared/_activities_subtabs.html.slim
@@ -2,8 +2,8 @@
   .container
     ul
       li
-        =active_link_to "Benchmark Assessments", activities_section_path(section_id: 27)
-        =active_link_to "Elementary School", activities_section_path(section_id: 7)
-        =active_link_to "Middle School", activities_section_path(section_id: 10)
-        =active_link_to "High School", activities_section_path(section_id: 18)
+        span class="avoidwrap" =active_link_to "Benchmark Assessments", activities_section_path(section_id: 27)
+        span class="avoidwrap" =active_link_to "Elementary School", activities_section_path(section_id: 7)
+        span class="avoidwrap" =active_link_to "Middle School", activities_section_path(section_id: 10)
+        span class="avoidwrap" =active_link_to "High School", activities_section_path(section_id: 18)
         =active_link_to "University", activities_section_path(section_id: 17)


### PR DESCRIPTION
Fix Issue: Activities list on iPad #720

Add spans to the activities nav bar links to prevent word breaking between "high school", "middle school" etc. 