### PR TITLE
Make links on activity lesson planner green

### DIFF
--- a/app/assets/javascripts/lesson_planner/unit_tabs.jsx
+++ b/app/assets/javascripts/lesson_planner/unit_tabs.jsx
@@ -11,9 +11,9 @@ EC.UnitTabs = React.createClass({
 		var createUnitClass, manageUnitsClass;
 		if (this.props.tab == 'createUnit') {
 			createUnitClass = 'active';
-			manageUnitsClass = '';
+			manageUnitsClass = 'button-green';
 		} else {
-			createUnitClass = '';
+			createUnitClass = 'button-green';
 			manageUnitsClass = 'active';
 		}
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109231813) do
+ActiveRecord::Schema.define(version: 20151123211533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.datetime "started_at"
     t.boolean  "is_retry",              default: false
     t.boolean  "is_final_score",        default: false
+    t.boolean  "visible",               default: true,        null: false
   end
 
   add_index "activity_sessions", ["activity_id"], name: "index_activity_sessions_on_activity_id", using: :btree
@@ -362,6 +363,7 @@ ActiveRecord::Schema.define(version: 20151109231813) do
     t.integer  "classroom_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "visible",      default: true, null: false
   end
 
   create_table "users", force: true do |t|


### PR DESCRIPTION
This is for issue #1028 . I added the class button-green to app/assets/javascripts/lesson_planner/unit_tabs.jsx on lines 14 and 16. While you are on the page, the button stays grey due to having the active class, I figured this was intended behavior so only added the button-green class. If you need me to add a test for seeing if the button is green I can do that but did not think it was needed.