### PR TITLE
getStage wasn’t actually being called when setting the progress bar p…

### DIFF
--- a/app/assets/javascripts/lesson_planner/create_unit/create_unit.jsx
+++ b/app/assets/javascripts/lesson_planner/create_unit/create_unit.jsx
@@ -271,7 +271,7 @@ EC.CreateUnit = React.createClass({
 		}
 		return (
 			<span>
-				<EC.ProgressBar stage={this.getStage}/>
+				<EC.ProgressBar stage={this.getStage()}/>
 				<div className='container lesson_planner_main'>
 					{stageSpecificComponents}
 				</div>


### PR DESCRIPTION
…rops so the activity planner was always showing it was on the final stage.