### PR TITLE
fixes bug on delete students page

### DIFF
--- a/app/views/teachers/students/edit.html.erb
+++ b/app/views/teachers/students/edit.html.erb
@@ -69,6 +69,7 @@
 											<p class='button-helper'>After resetting a password, the student's password will be the student's last name.</p>
 									</div>
 
+										<% end %>
 								<div class='row'>
 									<div class="col-xs-2 col-xs-offset-2">
 										<%= button_to "Delete Account", teachers_classroom_student_path(@classroom, @student),data: {confirm: 'Are you sure you want to delete this account?'}, method: 'delete', class: 'delete-account btn btn-danger' %>
@@ -76,7 +77,7 @@
 								</div>
 
 
-							<% end %>
+
 
 
 						</section>


### PR DESCRIPTION
moves forms `end` so that it doesn't include the delete button, thereby fixing students needlessly being deleted.