### PR TITLE
Remove Iframe, track anonymous sessions.

### DIFF
--- a/app/assets/javascripts/activities/results_page/results_page.jsx
+++ b/app/assets/javascripts/activities/results_page/results_page.jsx
@@ -1,31 +1,55 @@
 'use strict'
 EC.ResultsPage = React.createClass({
-
-    headerMessage: function() {
-        return (
-            <div>
-                <h1>Lesson Complete!</h1>
-                <h3>You completed the activity: {this.props.activityName}</h3>
-                <a href='/profile'><button className='btn button-green'>Back to Your Dashboard<i className="fa fa-long-arrow-right" aria-hidden="true"></i>
-                </button></a>
-            </div>
-        );
-    },
-
-    render: function() {
-        return (
-            <div id='results-page' className='container-fluid'>
-              <div className='top-section'>
-                <EC.ResultsIcon percentage={this.props.percentage} activityType={this.props.activityType}/>
-                {this.headerMessage()}
-              </div>
-              <div className='bottom-section'>
-                <div className='results-wrapper'>
-                  <EC.StudentResultsTables results={this.props.results}/>
-                </div>
-              </div>
-            </div>
-        );
+  headerButton: function () {
+    if (this.props.anonymous) {
+      return (<a href='/account/new'>
+        <button className='btn button-green'>
+          Sign Up<i className="fa fa-long-arrow-right" aria-hidden="true"></i>
+        </button>
+      </a>)
+    } else {
+      return (
+        <a href='/profile'>
+          <button className='btn button-green'>
+            Back to Your Dashboard<i className="fa fa-long-arrow-right" aria-hidden="true"></i>
+          </button>
+        </a>
+      )
     }
+  },
+
+  headerMessage: function() {
+    return (
+      <div>
+        <h1>
+          Lesson Complete!
+        </h1>
+        <h3>
+          You completed the activity: {this.props.activityName}
+        </h3>
+        {this.headerButton()}
+      </div>
+    );
+  },
+
+  render: function() {
+    return (
+      <div
+        id='results-page'
+        className='container-fluid'>
+        <div className='top-section'>
+          <EC.ResultsIcon
+            percentage={this.props.percentage}
+            activityType={this.props.activityType}/>
+          {this.headerMessage()}
+        </div>
+        <div className='bottom-section'>
+          <div className='results-wrapper'>
+            <EC.StudentResultsTables results={this.props.results}/>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
 });

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -15,7 +15,7 @@
 }
 
 .section-mixin {
-  padding: 30px 0;
+  padding: 30px 0px;
   border-bottom: 1px solid #cecece;
 }
 

--- a/app/assets/stylesheets/pages/student_results.scss
+++ b/app/assets/stylesheets/pages/student_results.scss
@@ -8,7 +8,7 @@
         text-align: left;
         .results-wrapper {
             max-width: 950px;
-            margin: 0 auto;
+            margin: 0 auto 50px;
         }
     }
     .icon {

--- a/app/controllers/activity_sessions_controller.rb
+++ b/app/controllers/activity_sessions_controller.rb
@@ -61,7 +61,9 @@ class ActivitySessionsController < ApplicationController
   end
 
   def activity_session_authorize!
-    unless ActivityAuthorizer.new(current_user, @activity_session).authorize || @activity_session.user_id.nil?
+    if @activity_session.user_id.nil?
+      return true
+    elsif !ActivityAuthorizer.new(current_user, @activity_session).authorize
       render_error(404)
     end
   end

--- a/app/controllers/activity_sessions_controller.rb
+++ b/app/controllers/activity_sessions_controller.rb
@@ -20,6 +20,7 @@ class ActivitySessionsController < ApplicationController
     @activity_session.start
     @activity_session.save!
     @module_url = @activity.module_url(@activity_session)
+    redirect_to(@module_url.to_s)
   end
 
   def result

--- a/app/controllers/activity_sessions_controller.rb
+++ b/app/controllers/activity_sessions_controller.rb
@@ -16,11 +16,12 @@ class ActivitySessionsController < ApplicationController
        is_retry: true
       )
       redirect_to play_activity_session_path(newSession)
+    else
+      @activity_session.start
+      @activity_session.save!
+      @module_url = @activity.module_url(@activity_session)
+      redirect_to(@module_url.to_s)
     end
-    @activity_session.start
-    @activity_session.save!
-    @module_url = @activity.module_url(@activity_session)
-    redirect_to(@module_url.to_s)
   end
 
   def result
@@ -31,13 +32,13 @@ class ActivitySessionsController < ApplicationController
   def anonymous
     @activity = Activity.find(params[:activity_id])
     @module_url = @activity.anonymous_module_url
-    render 'play'
+    redirect_to(@module_url.to_s)
   end
 
   private
 
   def activity_session_from_id
-    @activity_session ||= ActivitySession.where(id: params[:id]).first
+    @activity_session ||= ActivitySession.where(id: params[:id]).first || ActivitySession.where(uid: params[:id]).first
     unless @activity_session
       render_error(404)
     end

--- a/app/controllers/activity_sessions_controller.rb
+++ b/app/controllers/activity_sessions_controller.rb
@@ -61,7 +61,7 @@ class ActivitySessionsController < ApplicationController
   end
 
   def activity_session_authorize!
-    if not ActivityAuthorizer.new(current_user, @activity_session).authorize
+    unless ActivityAuthorizer.new(current_user, @activity_session).authorize || @activity_session.user_id.nil?
       render_error(404)
     end
   end

--- a/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/app/controllers/api/v1/activity_sessions_controller.rb
@@ -37,6 +37,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
     @activity_session = ActivitySession.new(activity_session_params)
     crs = @activity_session.concept_results
+    @activity_session.user = current_user if current_user
     @activity_session.concept_results = []
     # activity_session.set_owner(current_user) if activity_session.ownable?
     # activity_session.data = @data # FIXME: may no longer be necessary?

--- a/app/models/concerns/concepts.rb
+++ b/app/models/concerns/concepts.rb
@@ -4,7 +4,7 @@ module Concepts
   def all_concept_stats(activity_session)
     return '' unless activity_session.present?
     # Generate a header for each applicable concept class (activity session has concept tag results for that class)
-    concept_results = activity_session.concept_results.partition{|c| c.metadata['wpm']}
+    concept_results = activity_session.concept_results.partition{|c| c.metadata['questionUid']}
     # concept_results[0] is from sentence writing, [1] from story
     concepts = activity_session.concepts
     organize_by_type(concept_results, concepts)

--- a/app/views/activity_sessions/result.html.erb
+++ b/app/views/activity_sessions/result.html.erb
@@ -2,5 +2,6 @@
           results: @results,
           percentage: @activity_session.percentage,
           activityName: @activity_session.activity.name,
-          activityType: ActivityClassification.find(@activity_session.activity.activity_classification_id).name
+          activityType: ActivityClassification.find(@activity_session.activity.activity_classification_id).name,
+          anonymous: !@activity_session.user_id && current_user.nil?
           ) %>


### PR DESCRIPTION
Activities are no longer iframed, the controller redirects the page. 
3rd party apps can now create activity sessions, and are given a results view.
Activity sessions do not need to have a user id or a classroom activity id.

The results page takes into account the state of the activity session, and if there is a current user in the UI.