### PR TITLE
Correct Ruby target version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Mailing List, Chat, Issues, and Docs can all be accessed from the community 
 
 If you want a simple guide to install Empirical Core, then you've come to the right place! Here's the step-by-step process to get Empirical Core running on your system:
 
-1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or a Ruby version manager of your choice). You need to install Ruby version 2.2.2 to properly use Empirical Core. The best way to do this is follow the README and wiki of whatever Ruby version manager you download, but if you decide to use rbenv, then [homebrew](http://brew.sh/) has a really great and easy-to-use setup and install process:
+1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or a Ruby version manager of your choice). You need to install Ruby version 2.3.0 to properly use Empirical Core. The best way to do this is follow the README and wiki of whatever Ruby version manager you download, but if you decide to use rbenv, then [homebrew](http://brew.sh/) has a really great and easy-to-use setup and install process:
   1. ```brew update```
   2. ```brew install rbenv ruby-build```
   3. ```echo 'eval "$(rbenv init -)"' >> ~/.bash_profile```


### PR DESCRIPTION
This is my first contribution to Quill's projects.

Starting with a simple little change to reflect in documentation the minimum target Ruby version. This change was probably a simple oversight when `.ruby-version` was updated to Ruby 2.3.0.

There were no new `rake spec` test regressions with this change.

I have accepted the Contributor Licensing Agreement.