### PR TITLE
Fix slim 3.0.0+ deprecated warning for set_default_options

### DIFF
--- a/config/initializers/slim.rb
+++ b/config/initializers/slim.rb
@@ -1,1 +1,1 @@
-Slim::Engine.set_default_options pretty: !Rails.env.production?
+Slim::Engine.set_options pretty: !Rails.env.production?


### PR DESCRIPTION
Dependency `slim` deprecated `set_default_options` in versions 3.0.0+ (3.0.6 used here).

See the commit message for further details.

There were no new `rake spec` test regressions with this change.