### PR TITLE
Fix rails 4.2+ deprecated warnings for MessageDelivery.deliver()

### DIFF
--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -5,7 +5,7 @@ class CsvExportWorker
     csv_export = CsvExport.find(csv_export_id)
     return if csv_export.sent?
     csv_export.export!
-    CsvExportMailer.csv_download(csv_export).deliver
+    CsvExportMailer.csv_download(csv_export).deliver_now
     csv_export.mark_sent!
   end
 end


### PR DESCRIPTION
Rails 4.2+ deprecated `ActionMailer::MessageDelivery.deliver()` in favor of a split interface `deliver_now()` and `deliver_later()`.

The old `deliver()` was plumbed through to `deliver_now()`. Let's just use that directly.

empirical-core currently uses rails (4.2.5.1) per Gemfile.lock.

This fixes the following warnings in Travis-CI:

> DEPRECATION WARNING: `#deliver` is deprecated and will be removed in Rails 5. Use `#deliver_now` to deliver immediately or `#deliver_later` to deliver through Active Job. (called from perform at ($TEMPDIR)/empirical-core/app/workers/csv_export_worker.rb:8)

See:
-  http://apidock.com/rails/v4.2.1/ActionMailer/MessageDelivery/deliver
-  http://guides.rubyonrails.org/4_2_release_notes.html

There were no new `rake spec` test regressions with this change.