### PR TITLE
Fix sign in spec failures

### DIFF
--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -37,7 +37,7 @@ feature 'Signing in' do
 
   shared_examples_for :sign_in_fails do
     it 'fails' do
-      expect(current_path).to eq sign_in_page.sign_in_failed_path
+      expect(current_path).to eq sign_in_page.path
 
       error_text = 'Incorrect username/email or password'
       expect(sign_in_page).to have_content error_text

--- a/spec/support/pages/sign_in_page.rb
+++ b/spec/support/pages/sign_in_page.rb
@@ -16,7 +16,7 @@ class SignInPage < Page
     submit_form
   end
 
-  def sign_in_failed_path
+  def path
     self.class.path
   end
 

--- a/spec/support/pages/sign_in_page.rb
+++ b/spec/support/pages/sign_in_page.rb
@@ -17,7 +17,7 @@ class SignInPage < Page
   end
 
   def sign_in_failed_path
-    BASE_PATH
+    self.class.path
   end
 
   def submit_form


### PR DESCRIPTION
A series of sign in page specs have been failing for some time following a prior refactor.

Correct the spec helper to properly reflect that a failed sign in will lead to the $URL/session/new page.

Fixes:
```
- Signing in with an unknown username fails
- Signing in with an unknown email fails
- Signing in without filling in the form fails
```

Whilst here, also undertake a small refactor to more closely align the class to its sibling `Page::SignUpPage`.