### PR TITLE
Fix teacher/lesson_planner/create_unit spec failure

### DIFF
--- a/spec/features/teacher/lesson_planner/create_unit_spec.rb
+++ b/spec/features/teacher/lesson_planner/create_unit_spec.rb
@@ -9,7 +9,8 @@ feature 'Create Unit', js: true do
     vcr_ignores_localhost
     sign_in_user teacher
     visit('/teachers/classrooms/lesson_planner')
-    page.find('a', text: 'Create').trigger(:click)
+    page.find('a',  text: 'Assign A New Activity').trigger(:click)
+    page.find('h3', text: 'Custom Activity Packs').trigger(:click)
   end
 
   context 'stage1' do


### PR DESCRIPTION
A spec related to teacher/lesson_planner has been failing for some time following a prior refactor.

Correct the spec context stage1 setup to reflect the current usage.

No changes made to the remainder of the spec that remains commented out.

Fixes:
```
  Create Unit stage1 displays the right page
```