### PR TITLE
Speed up Travis by enabling bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+cache: bundler
 rvm:
   - 2.3.0
 script:


### PR DESCRIPTION
Currently `bundle install` stage can take 150+ seconds.

See:
-  https://docs.travis-ci.com/user/caching/