### PR TITLE
Modularize Travis database setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - bundle exec teaspoon
 before_script:
   - cp config/database.yml.travis config/database.yml
-  - psql -c 'create database test;' -U postgres
+  - bundle exec rake db:create
   - bundle exec rake db:migrate
 addons:
   postgresql: "9.3"

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,4 +1,4 @@
 test:
   adapter: postgresql
-  database: test
+  database: empiricalgrammar_test
   username: postgres


### PR DESCRIPTION
One of the final components of my proposed cleanup of the pre-react_on_rails Travis CI infrastructure.
 
----
Avoid using database-specific commands directly, and utilize `rake db:*` commands instead.

`rake db:create` creates the databases for the current RAILS_ENV environment variable. If RAILS_ENV is not specified it defaults to the `development` and `test` databases.

We rely upon this latter behavior.

The application name will be pre-pended to both database names.

See:
-  http://jacopretorius.net/2014/02/all-rails-db-rake-tasks-and-what-they-do.html
-  https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railties/databases.rake