### PR TITLE
Fix controllers/activity_sessions_controller spec failure

### DIFF
--- a/spec/controllers/activity_sessions_controller_spec.rb
+++ b/spec/controllers/activity_sessions_controller_spec.rb
@@ -53,8 +53,8 @@ describe ActivitySessionsController, type: :controller do
         subject
       end
 
-      it 'responds with 200' do
-        expect(response.status).to eq(200)
+      it 'responds with 302 redirect' do
+        expect(response).to be_redirect
       end
     end
   end


### PR DESCRIPTION
Spec `controllers/activity_sessions_controller_spec.rb` has been failing for some time following a prior refactor.

Correct the spec to reflect a valid user id will cause a 302 redirect.

Fixes:
-  ActivitySessionsController#show current_user == activity_session.user responds with 200