### PR TITLE
Fix Travis in react_on_rails world

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ cache: bundler
 rvm:
   - 2.3.0
 script:
-  - bundle exec rake spec
+  - npm run test
   - bundle exec teaspoon
 before_script:
   - cp config/database.yml.travis config/database.yml
   - bundle exec rake db:create
   - bundle exec rake db:migrate
+  - npm install  # Make use of 'postinstall' to run 'cd ./client npm install'
 addons:
   postgresql: "9.3"
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 sudo: false
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - node_modules
+    - client/node_modules
 rvm:
   - 2.3.0
 script:

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,56 @@
+/**
+ * eslint.json: this file provides a configuration of rules that eslint will
+ *              implement, to validate 'jsx' files, when imported via the
+ *              '-c [path/to/eslint.json]' flag.
+ *
+ * Note: eslint rules, and options are available:
+ *
+ *       https://github.com/yannickcr/eslint-plugin-react#configuration
+ *       http://eslint.org/docs/rules/
+ */
+{
+    "plugins": [
+        "react"
+    ],
+    "parser": "babel-eslint",
+    "rules": {
+        "react/jsx-boolean-value": 1,
+        "react/jsx-curly-spacing": 1,
+        "react/jsx-key": 1,
+        "react/jsx-no-bind": 1,
+        "react/jsx-no-duplicate-props": 1,
+        "react/jsx-no-undef": 1,
+        "react/jsx-pascal-case": 1,
+        "react/jsx-uses-react": 1,
+        "react/jsx-uses-vars": 1,
+        "react/no-danger": 1,
+        "react/no-did-mount-set-state": 1,
+        "react/no-did-update-set-state": 1,
+        "react/no-direct-mutation-state": 1,
+        "react/no-multi-comp": 1,
+        "react/no-unknown-property": 1,
+        "react/react-in-jsx-scope": 1,
+        "react/require-extension": 1,
+        "react/self-closing-comp": 1
+        
+        /**
+         * Omit for now to improve signal to noise ratio
+         * "jsx-quotes": 1,
+         * "react/display-name": 1,
+         * "react/forbid-prop-types": 1,
+         * "react/jsx-closing-bracket-location": 1,
+         * "react/jsx-handler-names": 1,
+         * "react/jsx-indent-props": 1,
+         * "react/jsx-max-props-per-line": 1,
+         * "react/jsx-no-literals": 1,
+         * "react/jsx-sort-props": 1,
+         * "react/no-set-state": 1,
+         * "react/prefer-es6-class": 1,
+         * "react/prop-types": 1,
+         * "react/sort-comp": 1,
+         * "react/sort-prop-types": 1,
+         * "react/wrap-multilines": 1
+         */
+    }
+}
+

--- a/client/app/bundles/HelloWorld/components/dashboard/mini_row.jsx
+++ b/client/app/bundles/HelloWorld/components/dashboard/mini_row.jsx
@@ -2,7 +2,7 @@
 
  import React from 'react'
  import _ from 'underscore'
- import 'ClassMini' from './class_mini'
+ import ClassMini from './class_mini'
 
  export default React.createClass({
 

--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
     "eslint": "^2.6.0",
     "eslint-config-shakacode": "^4.0.0",
     "eslint-plugin-react": "^4.2.3",
+    "estraverse-fb": "^1.3.1",
     "jscs": "^2.11.0",
     "moments": "0.0.2",
     "react": "^15.2.0",
@@ -70,7 +71,7 @@
     "fs": false
   },
   "scripts": {
-    "lint": "npm run eslint --silent && npm run jscs --silent",
+    "lint": "npm run eslint --silent",
     "eslint": "eslint --ext .js,.jsx .",
     "jscs": "jscs --verbose .",
     "jscs:fix": "jscs --verbose -x . --silent",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "cd ./client && npm install",
     "gulp": "cd ./client && npm run gulp",
-    "test": "npm run build:test && rspec",
+    "test": "npm run build:test && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "install-react-on-rails": "cd client && npm run install-react-on-rails",
     "build:clean": "rm app/assets/webpack/* || true",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "cd client && npm run lint",
     "install-react-on-rails": "cd client && npm run install-react-on-rails",
     "build:clean": "rm app/assets/webpack/* || true",
+    "build:test": "cd client && npm run build:test",
     "build:production:client": "(echo 'prod client assets' && cd client && npm run build:production:client --silent)",
     "build:production:server": "(echo 'prod server assets' && cd client && npm run build:production:server --silent)",
     "build:client": "(cd client && npm run build:client --silent",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "cd ./client && npm install",
     "gulp": "cd ./client && npm run gulp",
-    "test": "npm run build:test && npm run lint && rspec",
+    "test": "npm run build:test && rspec",
     "lint": "cd client && npm run lint",
     "install-react-on-rails": "cd client && npm run install-react-on-rails",
     "build:clean": "rm app/assets/webpack/* || true",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "cd ./client && npm install",
     "gulp": "cd ./client && npm run gulp",
-    "test": "npm run build:test && bundle exec rake spec",
+    "test": "npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "install-react-on-rails": "cd client && npm run install-react-on-rails",
     "build:clean": "rm app/assets/webpack/* || true",


### PR DESCRIPTION
In the post `react_on_rails` world Travis needs to be modified to install the npm-based dependencies and utilize the npm-based test runners.

- [x] Confirm Travis-CI installs all npm-based dependencies.
- [x] Confirm Travis-CI completes a test run.
- [x] Improve performance with caching.