### PR TITLE
Fix lesson_planner/unit_serializer spec

### DIFF
--- a/spec/serializers/lesson_planner/unit_serializer_spec.rb
+++ b/spec/serializers/lesson_planner/unit_serializer_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe LessonPlanner::UnitSerializer, type: :serializer do
+  before do
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+  end
+
+  after do
+    Timecop.return
+  end
+
   it_behaves_like 'serializer' do
     let!(:record_instance) { FactoryGirl.create(:unit) }
 


### PR DESCRIPTION
Spec failed due to differing precision between time units when passed through the database and Ruby's own internal Time precision.

Avoid the precision delta issue by freezing a fixed, rounded time for this spec only using Timecop.

Resolves:
- spec/serializers/lesson_planner/unit_serializer_spec