### PR TITLE
Remove classroom name validation, as it is not always unique on cleve…

### DIFF
--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -2,7 +2,7 @@ class Classroom < ActiveRecord::Base
   GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)
   include CheckboxCallback
   validates_uniqueness_of :code
-  validates_uniqueness_of :name, scope: :teacher_id
+  # validates_uniqueness_of :name, scope: :teacher_id # Can't guarantee Clever and Google obey this.
   # NO LONGER POSSIBLE WITH GOOGLE CLASSROOM : validates :grade, presence: true
   validates_presence_of :name
   default_scope { where(visible: true)}


### PR DESCRIPTION
…r or google classroom.

Before this was a problem because of forms being submitted twice, but now with our React forms we prevent this on the front end. Also its easily changed.