### PR TITLE
Silence non-unique classroom name specs

### DIFF
--- a/spec/features/teacher/class_manager/create_class_spec.rb
+++ b/spec/features/teacher/class_manager/create_class_spec.rb
@@ -98,6 +98,7 @@ feature 'Create-a-Class page' do
       end
 
       it 'cannot create a new class with the same name' do
+        pending("need to reflect and handle non-unique class name specs")
         same_class_name = sweathogs.name
 
         expect {

--- a/spec/models/classroom_spec.rb
+++ b/spec/models/classroom_spec.rb
@@ -33,6 +33,7 @@ describe Classroom, type: :model do
       @classroom = FactoryGirl.create(:classroom)
     end
     it "must have a unique name" do
+      pending("need to reflect and handle non-unique class name specs")
       other_classroom = FactoryGirl.build(:classroom, teacher_id: @classroom.teacher_id, name: @classroom.name)
       other_classroom.save
       expect(other_classroom.errors).to include(:name)


### PR DESCRIPTION
Since the removal of classroom name uniqueness validation in 8b1a8a269920ca36afaf48df5738532c0d0e2e9f these two specs have regressed.

Silence these failures until decision can be made on future approach to these two specs.

The specific change was:
```
  commit 8b1a8a269920ca36afaf48df5738532c0d0e2e9f
  Author: Donald McKendrick <ddmckendrick@gmail.com>
  Date:   Fri Aug 5 17:39:42 2016 -0400

    Remove classroom name validation, as it is not always unique on
    clever or google classroom.

    Before this was a problem because of forms being submitted twice,
    but now with our React forms we prevent this on the front end.
    Also its easily changed.
```
These two specs can be run standalone with:

  `bundle exec rspec spec/models/classroom_spec.rb spec/features/teacher/class_manager/create_class_spec.rb`