### PR TITLE
Fix spec error 'Ambiguous match, found 2 elements matching link "Classes"'

### DIFF
--- a/app/views/teachers/shared/_scorebook_tabs.html.erb
+++ b/app/views/teachers/shared/_scorebook_tabs.html.erb
@@ -24,7 +24,7 @@
       <%- unless ((current_user.premium_state == 'paid') || (current_user.premium_state == 'school')) %>
         <li class="<%= (action_name == 'premium') ? 'premium-tab active' : 'premium-tab' %>">
           <%= link_to raw(premium_tab_copy), premium_path, role: 'tab' %>
-          <%= link_to 'Premium', premium_path, role: 'tab', role: 'tab', class: 'mobile'  %>
+          <%= link_to 'Premium', premium_path, role: 'tab', class: 'mobile'  %>
         </li>
       <% end %>
     </ul>

--- a/spec/support/pages/teachers/class_manager/class_manager_page.rb
+++ b/spec/support/pages/teachers/class_manager/class_manager_page.rb
@@ -30,7 +30,7 @@ module Teachers
         end
 
         def select_#{sym}
-          click_link '#{text}'
+          first(:link, '#{text}').click
         end
       }
     end


### PR DESCRIPTION
Resolve regression introduced in 5335c86e81faab465e9de89a88823325c32c15c9:

```
  Create-a-Class page when signed in as a Teacher with no existing classes selecting the
  Classes tab navigates to create-a-class

  Failure/Error: end

  Capybara::Ambiguous:
    Ambiguous match, found 2 elements matching link "Classes"
```

Whilst here, also resolve a duplicated key warning in _scorebook_tabs.html.erb

No new regressions introduced.