### PR TITLE
fixes student profile tooltips

### DIFF
--- a/client/app/bundles/HelloWorld/components/general_components/activity_icon_with_tooltip.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/activity_icon_with_tooltip.jsx
@@ -2,6 +2,7 @@
 import _ from 'lodash'
 import React from 'react'
 import TooltipTitleGeneratorGenerator from '../modules/componentGenerators/tooltip_title/tooltip_title_generator_generator'
+import $ from 'jquery'
 
 export default React.createClass({
   propTypes: {

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
@@ -11,17 +11,21 @@
 	},
 	tooltipTrigger: function (e) {
 		e.stopPropagation();
-		ReactDOM.findDOMNode(this).tooltip('show');
-		// $(this.refs.activateTooltip).tooltip('show');
-    // this.refs.activateTooltip.tooltip('show');
-    // this.refs.activateTooltip.tooltip('show');
-
+    // Before the migration to react-on-rails, we just did
+    //  $(this.refs.activateTooltip).tooltip('show')
+    // I am not sure why we need to wrap the whole thing with jQuery now --
+    // they do that in the Bootstrap docs (http://getbootstrap.com/javascript/#tooltips)
+    //  though and it is the only way I could get it to work
+    $(function(){
+      $(this.refs.activateTooltip).tooltip('show');
+    });
 	},
+  
 	tooltipTriggerStop: function (e) {
 		e.stopPropagation();
-		// $(this.refs.activateTooltip.getDOMNode()).tooltip('hide');
-    // $(this.refs.activateTooltip).tooltip('hide');
-    this.refs.activateTooltip.tooltip('hide');
+    $(function(){
+      $(this.refs.activateTooltip).tooltip('hide');
+    });
 	},
 
 	render: function () {

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/classroom.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/classroom.jsx
@@ -5,6 +5,7 @@
  import Student from './student'
  import Button from 'react-bootstrap/lib/Button';
  import Panel from 'react-bootstrap/lib/Panel';
+ import _ from 'underscore'
 
  export default React.createClass({
 

--- a/client/app/bundles/HelloWorld/components/modules/componentGenerators/tooltip_title/student_profile_tooltip_title_generator.jsx
+++ b/client/app/bundles/HelloWorld/components/modules/componentGenerators/tooltip_title/student_profile_tooltip_title_generator.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import TotalScore from '../../../general_components/tooltip/total_score.jsx'
 import ActivityDetails from '../../../general_components/tooltip/activity_details.jsx'
+import ReactDOMServer from 'react-dom/server';
+
 
 export default function (percentageDisplayer) {
 
@@ -14,7 +16,7 @@ export default function (percentageDisplayer) {
       totalScoreOrNot = <TotalScore percentage={_displayPercentage(data.percentage)} />
     }
 
-    return React.renderToString(
+  return ReactDOMServer.renderToString(
       <div className='student-profile-tooltip'>
         <div className='title'>
           ACTIVITY RESULTS


### PR DESCRIPTION
We are getting very different behavior with Bootstrap tooltips since switching to react-on-rails.

I think that this solves the last of the tooltip issues, but here are the takeaways so far:

1. Moving forward, use react-bootstrap tooltips. The React javascript is not playing nicely with the out of the typical Bootstrap js.

2. If ```renderToString``` is necessary, instead of using ```ReactDOM.renderToString```, import ReactDOMServer from 'react-dom/server' and call ```renderToString``` on that

3. Turning refs into jQuery objects can get weird now. It is still unclear to me what is going on that front, but check out my comment in ```activity_search_result.jsx``` for more info.