### PR TITLE
Fix lesson_planner/create_unit_spec

### DIFF
--- a/spec/features/teacher/lesson_planner/create_unit_spec.rb
+++ b/spec/features/teacher/lesson_planner/create_unit_spec.rb
@@ -9,7 +9,7 @@ feature 'Create Unit', js: true do
     vcr_ignores_localhost
     sign_in_user teacher
     visit('/teachers/classrooms/lesson_planner')
-    page.find('a',  text: 'Assign A New Activity').trigger(:click)
+    page.find('a',  text: 'Assign a New Activity').trigger(:click)
     page.find('h3', text: 'Custom Activity Packs').trigger(:click)
   end
 


### PR DESCRIPTION
Since tab copy was updated in 4c67e4b5d2bb1f4f499554fbc79fa03a639dfb44 this test has regressed, as the text was used to find the button in spec setup.

The specific change was:
```
  commit 4c67e4b5d2bb1f4f499554fbc79fa03a639dfb44
  Author: Tom Calabrese <tomkentcalabrese@gmail.com>
  Date:   Thu Aug 11 16:28:45 2016 -0400

    Updating tab copy
```
The spec can be run standalone with:

  `bundle exec rspec spec/features/teacher/lesson_planner/create_unit_spec.rb`