### PR TITLE
Changes scope of Google CR sync so it won't update archived classes

### DIFF
--- a/app/services/google_integration/classroom/creators/classrooms.rb
+++ b/app/services/google_integration/classroom/creators/classrooms.rb
@@ -8,7 +8,7 @@ module GoogleIntegration::Classroom::Creators::Classrooms
   private
 
   def self.create_classroom(teacher, course)
-    classroom = ::Classroom.find_or_initialize_by(google_classroom_id: course[:id])
+    classroom = ::Classroom.unscoped.find_or_initialize_by(google_classroom_id: course[:id])
     if classroom.new_record?
       classroom.attributes = {name: course[:name], teacher_id: teacher.id}
       classroom.save


### PR DESCRIPTION
When classrooms were syncing, it was missing any archived classes (because they were out of the default scope) and re-creating them.