### PR TITLE
Fix classrooms_progress_report_spec

### DIFF
--- a/client/app/bundles/HelloWorld/components/progress_reports/standards_all_classrooms_progress_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/standards_all_classrooms_progress_report.jsx
@@ -23,7 +23,7 @@ export default  React.createClass({
         className: 'student-view-column',
         customCell: function(row) {
           return (
-            <a className="student-view" href={row['students_href']}>Student View</a>
+            <a className="student-view" href={row['students_href']}>Sort by Student</a>
           );
         }
       },
@@ -34,7 +34,7 @@ export default  React.createClass({
         className: 'standard-view-column',
         customCell: function(row) {
           return (
-            <a className="standard-view" href={row['topics_href']}>Standard View</a>
+            <a className="standard-view" href={row['topics_href']}>Sort by Standard</a>
           );
         }
       },
@@ -98,7 +98,7 @@ export default  React.createClass({
                          filterTypes={[]}
                          premiumStatus={this.props.premiumStatus}>
         <h2>Standards: All Classrooms</h2>
-        <p className="description">Select Student View to see how each student is performing. Select Standard View to see how the entire class is performing on each each standard.</p>
+        <p className="description">Select Sort by Student to see how each student is performing. Select Sort by Standard to see how the entire class is performing on each each standard.</p>
       </ProgressReport>
     );
   }


### PR DESCRIPTION
Copy was updated in spec in 16013c19f6ca6a6f1c4eef0186cee7882a8ffeb7, since causing the spec to regress and no interface change to actually occur.

Make that change here.

The specific change was:
```
  commit 16013c19f6ca6a6f1c4eef0186cee7882a8ffeb7
  Author: Tom Calabrese <tomkentcalabrese@gmail.com>
  Date:   Mon Aug 29 15:18:57 2016 -0400

      Making the text clearer

      As is, it seems like you're viewing it as a student.
```
The spec can be run standalone with:
```
  bundle exec rspec spec/features/teacher/progress_reports/standards/classrooms_progress_report_spec.rb
```