### PR TITLE
Keep up with react_on_rails requirements for npm_build_test_command

### DIFF
--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -9,6 +9,10 @@ ReactOnRails.configure do |config|
 
   config.webpack_generated_files = %w( client-bundle.js )
 
+  # If you are using the ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
+  # with rspec then this controls what npm command is run
+  # to automatically refresh your webpack assets on every test run.
+  config.npm_build_test_command = "npm run build:test"
 
   # Server rendering:
   # Server bundle is a single file for all server rendering of components.


### PR DESCRIPTION
Per react_on_rails documentation, when using `ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)` with rspec, `npm_build_test_command` controls what npm command is run to automatically refresh webpack assets on every test run.

We cannot rely upon the old behavior of running `npm run build:test` automatically.

Fixes regression:
```
  React on Rails will ensure your JavaScript generated files are up to date, using your
  /client level package.json `` command.

  Building Webpack assets...
  sh: 1: Syntax error: end of file unexpected
  2nd Try error in ./spec/features/teacher/class_manager/create_class_spec.rb:54:
   Error in building assets!
```

See:
- https://github.com/shakacode/react_on_rails/pull/398/commits/39adba24caba58e166fd40e4387dd81d79434a53