### PR TITLE
moves stripe script from header to footer and only pulls it for premium

### DIFF
--- a/app/views/application/_head_embed_codes.html.erb
+++ b/app/views/application/_head_embed_codes.html.erb
@@ -21,9 +21,3 @@
   </script>
   <!-- end Segment.io -->
 <% end %>
-
-<script>var stripePubKey="<%=ENV["STRIPE_PUBLIC_KEY"] %>"</script>
-<script src="https://checkout.stripe.com/checkout.js" class="stripe-button">
-      data-key= stripePubKey
-      data-locale="auto">
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,5 +15,15 @@
 
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%= render partial: 'footer' %>
+    <% if controller.controller_name == "pages" && controller.action_name == "premium" %>
+    <script>var stripePubKey="<%=ENV["STRIPE_PUBLIC_KEY"] %>"</script>
+    <script src="https://checkout.stripe.com/checkout.js" class="stripe-button">
+          data-key= stripePubKey
+          data-locale="auto">
+    </script>
+    <%end%>
+
   </body>
+
 </html>


### PR DESCRIPTION
It was previously loading on every page, but we only use it on one.