### PR TITLE
diagnostic and sign in fixes

### DIFF
--- a/app/controllers/teachers/classrooms_controller.rb
+++ b/app/controllers/teachers/classrooms_controller.rb
@@ -13,7 +13,8 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   def new
-    # just here to render the new view, then react takes care of everything
+    class_ids = current_user.classrooms_i_teach.map(&:id)
+    @has_activities = ClassroomActivity.where(classroom_id: class_ids).exists?
   end
 
   def classrooms_i_teach

--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -34,9 +34,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def default_diagnostic_report
-    if default_diagnostic_url
-      redirect_to default_diagnostic_url
-    end
+    redirect_to default_diagnostic_url
   end
 
 
@@ -61,7 +59,9 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     if first_completed_diagnostic
       ca = first_completed_diagnostic
       custom_url = "#u/#{ca.unit.id}/a/#{Activity.diagnostic.id}/c/#{ca.classroom_id}"
-      return base_url = "/teachers/progress_reports/diagnostic_reports/#{custom_url}/questions"
+      return "/teachers/progress_reports/diagnostic_reports/#{custom_url}/questions"
+    else
+      return "/teachers/progress_reports/diagnostic_reports/#not_completed"
     end
   end
 

--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -95,7 +95,9 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   def classrooms_with_students_that_completed_activity unit_id, activity_id
     h = {}
     unit = Unit.find(unit_id)
-    class_act = unit.classroom_activities.find_by(activity_id: activity_id)
+    class_ids = current_user.classrooms_i_teach.map(&:id)
+    #without definining class ids, it may default to a classroom activity from a non-existant classroom
+    class_act = unit.classroom_activities.where(activity_id: activity_id, classroom_id: class_ids).limit(1).first
     classroom = class_act.classroom.attributes
     activity_sessions = class_act.activity_sessions.completed
     activity_sessions.each do |activity_session|

--- a/app/views/teachers/classrooms/new.html.erb
+++ b/app/views/teachers/classrooms/new.html.erb
@@ -1,1 +1,1 @@
-<%= react_component('CreateClassApp')%>
+<%= react_component('CreateClassApp', props: {hasClassroomActivities: @has_activities})%>

--- a/client/app/assets/styles/app-variables.scss
+++ b/client/app/assets/styles/app-variables.scss
@@ -1,65 +1,10 @@
-// .activity-filter.button-row {
-//   padding: 0;
-//   display: -webkit-box;
-//   display: -ms-flexbox;
-//   display: flex;
-//   -ms-flex-wrap: wrap;
-//       flex-wrap: wrap;
-//   button {
-//     padding: 13px;
-//     width: 228px;
-//     height: 75px;
-//     box-sizing:border-box;
-//     border-radius: 6px;
-//     background-color: #ffffff;
-//     border: solid 1px #cecece;
-//     display: -webkit-box;
-//     display: -ms-flexbox;
-//     display: flex;
-//     -webkit-box-orient: horizontal;
-//     -webkit-box-direction: normal;
-//         -ms-flex-direction: row;
-//             flex-direction: row;
-//     margin-right: 12px;
-//     margin-top: 12px;
-//     div:first-of-type {
-//       width: 30px;
-//     }
-//     div:last-of-type {
-//       margin-left: 8px;
-//       text-align: left;
-//       width: 160px;
-//     }
-//     &:hover, &.active {
-//       border: solid 2px #00c2a2;
-//     }
-//     h4 {
-//       text-align: left;
-//       padding-top: 4px;
-//       font-size: 14px;
-//       font-weight: 600;
-//       margin-bottom: 6px;
-//     }
-//     p {
-//       font-size: 12.5px;
-//       font-weight: 400;
-//     }
-//   }
-//
-//   button:last-of-type {
-//     margin-right: 0;
-//   }
-//   .clear-filters {
-//     padding: 1em;
-//     display: -webkit-box;
-//     display: -ms-flexbox;
-//     display: flex;
-//     -webkit-box-align: center;
-//         -ms-flex-align: center;
-//             align-items: center;
-//     img {
-//       padding-right: 8px;
-//       margin-bottom: 2px;
-//     }
-//   }
-// }
+.not-completed {
+  padding: 3em;
+  h2 {
+    margin-bottom: 30px;
+  }
+  a {
+    // color: $green;
+    text-decoration: underline;
+  }
+}

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
@@ -46,7 +46,7 @@ export default React.createClass({
 
   urlForReport: function(){
     const d = this.props.data;
-    return `/teachers/progress_reports/diagnostic_reports#/u/${d.unit_id}/a/${d.activity_id}/c/${d.classroom_id}/questions`
+    return `/teachers/progress_reports/diagnostic_reports#/u/${d.unit_id}/a/${d.activity_id}/c/${d.classroom_id}/students`
   },
 
 	finalCell: function() {

--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_minis/unit_template_minis.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_minis/unit_template_minis.jsx
@@ -5,6 +5,7 @@
  import ListFilterOptions from '../../../shared/list_filter_options/list_filter_options'
  import UnitTemplateMinisHeader from './unit_template_minis_header'
  import RowsCreator from '../../../modules/rows_creator'
+ import _ from 'underscore'
 
 
  export default  React.createClass({
@@ -104,8 +105,9 @@
               <div className='row'>
                 {this.listFilterOptions()}
               </div>
+                {this.generateShowAllGradesView()}
               <div className='row'>
-                {this.generateUnitTemplateViews()}
+              {this.generateUnitTemplateViews()}
               </div>
               <div className='row'>
                 {this.generateShowAllGradesView()}

--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_minis/unit_template_minis_header.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_minis/unit_template_minis_header.jsx
@@ -2,6 +2,7 @@
 
  import React from 'react'
  import $ from 'jquery'
+ import SuffixBuilder from '../../../modules/numberSuffixBuilder.js'
 
  export default  React.createClass({
   propTypes: {
@@ -15,9 +16,9 @@
   stateSpecificComponent: function () {
     var grade = this.props.data.grade;
     if (grade) {
-      return "Great Activity Packs for Your Class";
+      return `Great Activity Packs for Your ${SuffixBuilder(grade)} Grade Class`;
     } else {
-      return "Featured Activity Packs"
+      return "Featured Activity Packs";
     }
   },
 

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
 	},
 
 	switchToExploreActivityPacks: function(){
-		window.location.href = '/teachers/classrooms/lesson_planner?tab=exploreActivityPacks'
+		window.location.href = '/teachers/classrooms/lesson_planner?tab=exploreActivityPacks';
 	},
 
 	stateBasedComponent: function() {
@@ -39,7 +39,7 @@ export default React.createClass({
 			return (
 				<div>
 					<h2>Activity Analysis</h2>
-					<p>Open an activity analysis to view the student responses, the overall results on each question, and the concepts students need practice for each concept.</p>
+					<p>Open an activity analysis to view students' responses, the overall results on each question, and the concepts students need practice for each concept.</p>
 					<Units report={Boolean(true)} data={this.state.units}/>
 				</div>
 			);

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -18,12 +18,16 @@ export default React.createClass({
 		this.setState({units: data.units, loaded: true});
 	},
 
+	switchToExploreActivityPacks: function(){
+		window.location.href = '/teachers/classrooms/lesson_planner?tab=exploreActivityPacks'
+	},
+
 	stateBasedComponent: function() {
 		if (this.state.units.length === 0 && this.state.loaded) {
 			return (
 				<div className="row empty-unit-manager">
 					<div className="col-xs-7">
-						<p>Welcome! This is where your assigned activity packs are stored, but it's empty at the moment.</p>
+						<p>Welcome! This is where you'll be able to see reports detailing your students' answers, but they haven't completed any activities yet.</p>
 						<p>Let's add your first activity from the Featured Activity Pack library.</p>
 					</div>
 					<div className="col-xs-4">

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/index.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/index.jsx
@@ -15,12 +15,12 @@ export default React.createClass({
 			classrooms: null,
 			selectedClassroom: null,
 			selectedStudent: null,
-			selectedActivity: {}})
+			selectedActivity: {}});
 	},
 
 	componentDidMount: function() {
-		// /activity_packs is the only report that doesn't require the classroom, unit, etc...
-		if (this.props.location.pathname != '/activity_packs') {
+		// /activity_packs and not /not_completed are the only report that doesn't require the classroom, unit, etc...
+		if (['/activity_packs', '/not_completed'].indexOf(this.props.location.pathname) === -1) {
 			this.getClassroomsWithStudents();
 			this.getActivityData();
 		}
@@ -111,8 +111,8 @@ export default React.createClass({
 	},
 
 	render: function() {
-		// we don't want to render a navbar for the activity packs report
-		if (this.props.location.pathname === '/activity_packs') {
+		// we don't want to render a navbar for the activity packs or not_complted
+		if (['/activity_packs', '/not_completed'].indexOf(this.props.location.pathname) !== -1) {
 			return (
 				<div>{this.props.children}</div>
 			)

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/index.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/index.jsx
@@ -24,11 +24,15 @@ export default React.createClass({
 			this.getClassroomsWithStudents();
 			this.getActivityData();
 		}
+
+		if (this.props.params.studentId) {
+			this.setStudentId(this.props.params.studentId);
+		}
 	},
 
 	componentWillReceiveProps: function(nextProps) {
 		if (nextProps.params && nextProps.params.studentId) {
-			this.setState({selectedStudentId: Number(nextProps.params.studentId)})
+			this.setStudentId(nextProps.params.studentId);
 		}
 	},
 
@@ -39,6 +43,10 @@ export default React.createClass({
 				call.abort();
 			}
 		}
+	},
+
+	setStudentId: function(studentId){
+		this.setState({selectedStudentId: Number(studentId)});
 	},
 
 	getClassroomsWithStudents: function() {

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/not_completed.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/not_completed.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default React.createClass({
+
+  switchToDiagnosticAssign: function(){
+    window.location.href = '/diagnostic#/stage/1'
+  },
+
+	render: function() {
+		return (
+        <div className="container manage-units">
+          <div className="row empty-unit-manager">
+            <div className="col-xs-7">
+              <p>Welcome! This is where you'll be able to see reports detailing your students' diagnostic results, but they haven't completed a diagnostic yet.</p>
+              <p>Let's add your first diagnostic!</p>
+            </div>
+            <div className="col-xs-4">
+              <button onClick={this.switchToDiagnosticAssign} className="button-green create-unit featured-button">Assign Diagnostic</button>
+            </div>
+          </div>
+      </div>
+		);
+	}
+});

--- a/client/app/bundles/HelloWorld/containers/CreateClass.jsx
+++ b/client/app/bundles/HelloWorld/containers/CreateClass.jsx
@@ -8,8 +8,13 @@ require('../../../assets/styles/app-variables.scss')
 
 export default React.createClass({
 
+    propTypes: {
+      hasClassroomActivities: React.PropTypes.bool
+    },
+
+
     componentDidMount: function() {
-        this.getClassCode();
+      this.getClassCode();
     },
 
     getInitialState: function() {
@@ -76,15 +81,18 @@ export default React.createClass({
       let that = this;
       $.post('/teachers/classrooms/', {classroom: this.state.classroom})
         .success(function(data){
-            let nextPage
+            let nextPage;
             if (that.props.closeModal) {
               // only used if it is rendered within a modal
               that.props.closeModal('because class added');
             }
+            else if (that.props.hasClassroomActivities === false) {
+              window.location.assign(`/teachers/classrooms/lesson_planner?tab=exploreActivityPacks&grade=${that.state.classroom.grade}`);
+            }
             else if (data.toInviteStudents) {
-              window.location.assign(`/teachers/classrooms/${data.classroom.id}/invite_students`)
+              window.location.assign(`/teachers/classrooms/${data.classroom.id}/invite_students`);
             } else {
-              window.location.assign('/teachers/classrooms/scorebook')
+              window.location.assign('/teachers/classrooms/scorebook');
             }
         })
         .error(function(data){

--- a/client/app/bundles/HelloWorld/containers/DiagnosticReports.jsx
+++ b/client/app/bundles/HelloWorld/containers/DiagnosticReports.jsx
@@ -7,6 +7,7 @@ import ClassReport from '../components/progress_reports/diagnostic_reports/class
 import QuestionReport from '../components/progress_reports/diagnostic_reports/question_report.jsx'
 import Recommendations from '../components/progress_reports/diagnostic_reports/recommendations.jsx'
 import ActivityPacks from '../components/progress_reports/diagnostic_reports/activity_packs.jsx'
+import NotCompleted from '../components/progress_reports/diagnostic_reports/not_completed.jsx'
 const hashhistory = createHashHistory({queryKey: false})
 
 export default React.createClass({
@@ -21,6 +22,7 @@ export default React.createClass({
 					<Route path='u/:unitId/a/:activityId/c/:classroomId/recommendations' component={Recommendations}/>
 					<Route path='u/:unitId/a/:activityId/c/:classroomId/questions' component={QuestionReport}/>
 					<Route path='activity_packs' component={ActivityPacks}/>
+					<Route path='not_completed' component={NotCompleted}/>
 				</Route>
 			</Router>
 		);


### PR DESCRIPTION
- teachers were previously brought from add class to invite students, even if they hadn't yet created activities

- diagnostic reports were sometimes defaulting to an archived classroom -- this fixes that.

- diagnostic report now checks for student id on both mounting and updating

- adds empty state to diagnostic/activity analysis reports