### PR TITLE
Lesson planner path

### DIFF
--- a/client/app/bundles/HelloWorld/components/dashboard/class_mini.jsx
+++ b/client/app/bundles/HelloWorld/components/dashboard/class_mini.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
       );
     } else if (!this.activityCount()) {
       return (
-        <a href="/teachers/classrooms/lesson_planner?tab=exploreActivityPacks">
+        <a href="/teachers/classrooms/activity_planner?tab=exploreActivityPacks">
           <button className='button-green'>Assign Activities</button>
         </a>
       );

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/create_unit.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/create_unit.jsx
@@ -255,7 +255,7 @@ export default React.createClass({
 		if ((!!this.props.actions.assignSuccessActions) && (!!this.props.data.assignSuccessData)) {
 			return (<UnitTemplatesAssigned actions={this.props.actions.assignSuccessActions} data={this.props.data.assignSuccessData}/>);
 		} else {
-			window.location.href = '/teachers/classrooms/lesson_planner';
+			window.location.href = '/teachers/classrooms/activity_planner';
 		}
 	},
 

--- a/client/app/bundles/HelloWorld/components/lesson_planner/success_box.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/success_box.jsx
@@ -13,7 +13,7 @@
 //     if (this.props.actions.studentsPresent() === true) {
 //       proceedButton = (
 //         <span>
-//             <a href = '/teachers/classrooms/lesson_planner'>
+//             <a href = '/teachers/classrooms/activity_planner'>
 //               <button onClick className="button-green add-students pull-right">
 //                 View Assigned Activity Packs <i class="fa fa-long-arrow-right"></i>
 //               </button>

--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_template_assigned.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_template_assigned.jsx
@@ -31,7 +31,7 @@
     this.hideSubNavBars();
     if (this.props.type === 'diagnostic' || this.props.actions.studentsPresent) {
       return (<span>
-            <a href = '/teachers/classrooms/lesson_planner'>
+            <a href = '/teachers/classrooms/activity_planner'>
               <button onClick className="button-green add-students pull-right">
                 View Assigned Activity Packs <i className="fa fa-long-arrow-right"></i>
               </button>

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
 	},
 
 	switchToExploreActivityPacks: function(){
-		window.location.href = '/teachers/classrooms/lesson_planner?tab=exploreActivityPacks';
+		window.location.href = '/teachers/classrooms/activity_planner?tab=exploreActivityPacks';
 	},
 
 	stateBasedComponent: function() {

--- a/client/app/bundles/HelloWorld/containers/CreateClass.jsx
+++ b/client/app/bundles/HelloWorld/containers/CreateClass.jsx
@@ -87,7 +87,7 @@ export default React.createClass({
               that.props.closeModal('because class added');
             }
             else if (that.props.hasClassroomActivities === false) {
-              window.location.assign(`/teachers/classrooms/lesson_planner?tab=exploreActivityPacks&grade=${that.state.classroom.grade}`);
+              window.location.assign(`/teachers/classrooms/activity_planner?tab=exploreActivityPacks&grade=${that.state.classroom.grade}`);
             }
             else if (data.toInviteStudents) {
               window.location.assign(`/teachers/classrooms/${data.classroom.id}/invite_students`);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,7 +132,7 @@ EmpiricalGrammar::Application.routes.draw do
         get :regenerate_code
         get :archived_classroom_manager_data, controller: "classroom_manager", action: 'archived_classroom_manager_data'
         get :manage_archived_classrooms, controller: "classroom_manager", action: 'manage_archived_classrooms'
-        get :lesson_planner, controller: "classroom_manager", action: 'lesson_planner'
+        get :lesson_planner, controller: "classroom_manager", action: 'lesson_planner', path: 'activity_planner'
         post :lesson_planner, controller: "classroom_manager", action: 'lesson_planner'
         get :scorebook, controller: 'classroom_manager', action: 'scorebook'
         get :scores, controller: 'classroom_manager', action: 'scores'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,9 @@ EmpiricalGrammar::Application.routes.draw do
         get :archived_classroom_manager_data, controller: "classroom_manager", action: 'archived_classroom_manager_data'
         get :manage_archived_classrooms, controller: "classroom_manager", action: 'manage_archived_classrooms'
         get :lesson_planner, controller: "classroom_manager", action: 'lesson_planner', path: 'activity_planner'
+        get 'lesson_planner', to: redirect { |params, request|
+          "#{Rails.application.routes.url_helpers.lesson_planner_teachers_classrooms_path}?#{request.params.to_query}"
+        }
         post :lesson_planner, controller: "classroom_manager", action: 'lesson_planner'
         get :scorebook, controller: 'classroom_manager', action: 'scorebook'
         get :scores, controller: 'classroom_manager', action: 'scores'


### PR DESCRIPTION
For issue #743 

- Updated `lesson_planner` GET route to have path `activity_planner`
- Updated hard-coded links from `lesson_planner` to  `activity_planner`
- Added redirect into routes.rb for `teachers/classrooms/lesson_planner` to the new path with `activity_planner` (including any parameters)