### PR TITLE
Fix rake empirical setup

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -14,6 +14,9 @@ namespace :empirical do
     puts "** Creating database..."
     Rake::Task["db:create"].invoke
 
+    puts "** Loading Schema..."
+    Rake::Task['db:schema:load'].invoke
+    
     puts "** Migrating database..."
     Rake::Task["db:migrate"].invoke
 

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -16,9 +16,6 @@ namespace :empirical do
 
     puts "** Loading Schema..."
     Rake::Task['db:schema:load'].invoke
-    
-    puts "** Migrating database..."
-    Rake::Task["db:migrate"].invoke
 
     puts "** Seeding database..."
     Rake::Task["db:seed"].invoke


### PR DESCRIPTION
Fixes issue with running rake empirical:setup twice. 

I removed the db:migration from the rake because it looks like the setup is similar to rake db:setup but with some more work done. Also, I'm assuming the schema would be committed with the new migrations, so the schema will be up to date.