### PR TITLE
Improve initial setup experiences (both rake empirical:setup and bin/setup)

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,10 +12,10 @@ Dir.chdir APP_ROOT do
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   system "cp config/database.yml.sample config/database.yml"
-  # end
+  unless File.exist?("config/database.yml")
+    puts "\n== Copying sample files =="
+    system "cp config/database.yml.sample config/database.yml"
+  end
 
   puts "\n== Preparing database =="
   system "bin/rake db:setup"

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -5,8 +5,10 @@ namespace :empirical do
     puts "** Creating tmp directories..."
     Rake::Task["tmp:create"].invoke
 
-    puts "** Copying DB Credentials..."
-    `cp config/database.yml.example config/database.yml`
+    unless File.exist?("config/database.yml")
+      puts "** Copying DB Credentials..."
+      `cp config/database.yml.example config/database.yml`
+    end
 
     puts '** Copying env variables...'
     `cp .env-sample .env`


### PR DESCRIPTION
In support of #1811:
1. Address an issue in `rake empirical:setup` that would cause database authentication failures.
2. Increase the consistency of initial developer setup command `bin/setup` to other alternatives. 