### PR TITLE
Prevent empty arrays from being passed to the Unit Updator from recom

### DIFF
--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -43,17 +43,19 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   def create_or_update_selected_packs
     teacher_id = current_user.id
     params[:selections].each do |value|
-      unit = Unit.find_by(name: UnitTemplate.find(value[:id]).name,
-                         user_id: teacher_id)
-       if unit
-         Units::Updater.assign_unit_template_to_one_class(unit, value[:classrooms])
-       else
+      if value[:classrooms][0][:student_ids].any?
+        unit = Unit.find_by(name: UnitTemplate.find(value[:id]).name,
+                           user_id: teacher_id)
+        if unit
+          Units::Updater.assign_unit_template_to_one_class(unit, value[:classrooms])
+        else
         #  TODO: use a find or create for the unit var above.
         #  This way, we can just pass the units creator a unit argument.
         #  The reason we are not doing so at this time, is because the unit creator
         #  Is used elsewhere, and we do not want to overly optimize it for the diagnostic
-         Units::Creator.assign_unit_template_to_one_class(teacher_id, value[:id], value[:classrooms])
-       end
+          Units::Creator.assign_unit_template_to_one_class(teacher_id, value[:id], value[:classrooms])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Empty from recommended units means no students should get it, however on the classroom activity model an empty array means all students are assigned.