### PR TITLE
Feat/order students by last name

### DIFF
--- a/app/models/activity_session.rb
+++ b/app/models/activity_session.rb
@@ -244,11 +244,13 @@ class ActivitySession < ActiveRecord::Base
     # The matching names for this case statement match those returned by
     # the progress reports ActivitySessionSerializer and used as
     # column definitions in the corresponding React component.
+    last_name = "substring(users.name, '(?=\s).*')"
+
     case sort[:field]
     when 'activity_classification_name'
-      "activity_classifications.name #{order}, users.name #{order}"
+      "activity_classifications.name #{order}, #{last_name} #{order}"
     when 'student_name'
-      "users.name #{order}"
+      "#{last_name} #{order}"
     when 'completed_at'
       "activity_sessions.completed_at #{order}"
     when 'activity_name'

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -169,6 +169,7 @@ module PublicProgressReports
       activity_sessions.compact!
       activity_sessions_counted = activity_sessions_with_counted_concepts(activity_sessions)
       unique_students = activity_sessions.map {|activity_session| user = activity_session.user; {id: user.id, name: user.name}}
+                                         .sort_by {|stud| stud[:name].split()[1]}
       recommendations = Recommendations.new.diagnostic.map do |activity_pack_recommendation|
         students = []
         activity_sessions_counted.each do |activity_session|

--- a/app/queries/progress_reports/concepts/user.rb
+++ b/app/queries/progress_reports/concepts/user.rb
@@ -7,6 +7,8 @@ class ProgressReports::Concepts::User
     # total results count
     # percentage score (correct / total)
 
+    last_name = "substring(users.name, '(?=\s).*')"
+
     ::User.with(filtered_correct_results: ::ProgressReports::Concepts::ConceptResult.results(teacher, filters))
       .select(<<-SELECT
         users.id,
@@ -17,6 +19,6 @@ class ProgressReports::Concepts::User
       SELECT
       ).joins('JOIN filtered_correct_results ON users.id = filtered_correct_results.user_id')
       .group('users.id')
-      .order('users.name asc')
+      .order("#{last_name} asc")
   end
 end

--- a/client/app/bundles/HelloWorld/components/general_components/table/sortable_table/table_sorting_mixin.js
+++ b/client/app/bundles/HelloWorld/components/general_components/table/sortable_table/table_sorting_mixin.js
@@ -28,6 +28,12 @@ export default {
     return s.naturalCmp(a[fieldName], b[fieldName]) * sign;
   },
 
+  // Sign = 1 or -1 depending on whether the sort is normal or reverse order
+  lastNameSort: function(sign, fieldName, a, b) {
+    const aLastName = a[fieldName].split(' ')[1]
+    const bLastName = b[fieldName].split(' ')[1]
+    return (aLastName > bLastName ? 1 : -1) * sign;
+  },
   // config = {field: string, sortFunc: function, ...}
   // currentSort = {field: string, direction: string ('asc' or 'desc')}
   defineSorting: function(config, currentSort) {
@@ -40,6 +46,9 @@ export default {
             break
           case 'natural':
             config[key] = this.naturalSort;
+            break;
+          case 'lastName':
+            config[key] = this.lastNameSort;
             break;
           default:
             throw "Sort function named '" + value + "' not recognized";
@@ -70,6 +79,7 @@ export default {
 
     // Partially apply arguments so that the new func has signature -> (a, b)
     var appliedSort = _.partial(sortFunc, sign, sortByFieldName);
+
     results.sort(appliedSort);
     return results;
   },

--- a/client/app/bundles/HelloWorld/components/progress_reports/concepts_students_progress_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/concepts_students_progress_report.jsx
@@ -94,7 +94,6 @@ export default React.createClass({
         </section>
         <h2>Results by Student</h2>
         <br></br>
-        <p>This page shows how students are performing on individual questions. One question equals one results, and you can click on an individual concept to drill down.</p>
       </ProgressReport>
     );
   }

--- a/client/app/bundles/HelloWorld/components/progress_reports/concepts_students_progress_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/concepts_students_progress_report.jsx
@@ -57,7 +57,7 @@ export default React.createClass({
   sortDefinitions: function() {
     return {
       config: {
-        name: 'natural',
+        name: 'lastName',
         total_result_count: 'numeric',
         correct_result_count: 'numeric',
         incorrect_result_count: 'numeric',

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -58,6 +58,7 @@ export default React.createClass({
   sortDefinitions: function() {
     return {
       config: {
+        name: 'lastName',
         question_id: 'natural',
         score: 'numeric',
         instructions: 'natural',
@@ -65,7 +66,7 @@ export default React.createClass({
         time: 'numeric'
       },
       default: {
-        field: 'score',
+        field: 'name',
         direction: 'asc'
       }
     };


### PR DESCRIPTION
Students are now ordered by last name (rather than first) on the following pages:

- List Overview
- Student Results
- Activity Analysis
- Recommendations