### PR TITLE
Bug/activity pack sorting

### DIFF
--- a/app/controllers/teachers/unit_templates_controller.rb
+++ b/app/controllers/teachers/unit_templates_controller.rb
@@ -8,7 +8,7 @@ class Teachers::UnitTemplatesController < ApplicationController
     respond_to do |format|
       format.json do
         render json: UnitTemplate.user_scope(current_user.try(:flag) || 'production')
-                      .includes(:author, :unit_template_category, activities: [{topic: [:topic_category]}, :classification])
+                      .includes(:author, :unit_template_category)
                       .map{|ut| UnitTemplateSerializer.new(ut).as_json(root: false)}
       end
 

--- a/app/services/units/creator.rb
+++ b/app/services/units/creator.rb
@@ -23,7 +23,7 @@ module Units::Creator
   private
 
   def self.create_helper(teacher, name, activities_data, classrooms)
-    unit = Unit.create(name: name, user: teacher)
+    unit = Unit.create!(name: name, user: teacher)
     # makes a permutation of each classroom with each activity to
     # create all necessary activity sessions
     classrooms.each do |classroom|

--- a/spec/factories/classroom_activity.rb
+++ b/spec/factories/classroom_activity.rb
@@ -12,6 +12,5 @@ FactoryGirl.define do
         create_list(:activity_session_with_random_completed_date, 5, classroom_activity: ca, state: 'finished')
       end
     end
-    assigned_student_ids {[]}
   end
 end


### PR DESCRIPTION
resolves error that was stopping activity packs from rendering in the correct order due to unexpected behavior resulting from ```.includes```