### PR TITLE
fixes #2129 - resources button links properly

### DIFF
--- a/app/views/pages/shared/_home_navbar.html.erb
+++ b/app/views/pages/shared/_home_navbar.html.erb
@@ -7,7 +7,11 @@
   <div class="home-nav-right wide">
      <!-- tools does not yet have a route set up -->
     <a href="/tools/connect" class="text-white">Tools</a>
-    <a href="/teacher_resources" class="text-white">Resources</a>
+    <% if current_user.nil? %>
+      <a href="/activities/packs" class="text-white">Resources</a>
+    <% else %>
+      <a href="/teacher_resources" class="text-white">Resources</a>
+    <% end %>
     <a href="/mission" class="text-white">Our Story</a>
     <%- if current_user.nil? %>
 


### PR DESCRIPTION
resources now links to topics if no current user, getting started otherwise