### PR TITLE
Fix #1810: wrong 3rd party student info for login pdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'pointpin', '~> 1.0.0' #IP-GEOLOCATION
 gem 'stripe'
 gem 'prawn'
 gem 'pdf-core'
+gem 'pdf-inspector'
 gem 'ttfunk'
 
 # PARSING

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.0.2)
     CFPropertyList (2.3.3)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
@@ -42,6 +43,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    afm (0.2.2)
     analytics-ruby (2.0.13)
     ancestry (2.1.0)
       activerecord (>= 3.0.0)
@@ -323,6 +325,7 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashdiff (0.3.0)
+    hashery (2.1.2)
     hashie (3.4.6)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
@@ -438,6 +441,14 @@ GEM
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
     pdf-core (0.6.1)
+    pdf-inspector (1.2.1)
+      pdf-reader (~> 1.0)
+    pdf-reader (1.4.1)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (0.19.0)
     pg_array_parser (0.0.9)
     pointpin (1.0.1)
@@ -615,6 +626,7 @@ GEM
       rspec-core (> 3.3, < 3.6)
     rspec-support (3.5.0)
     ruby-progressbar (1.8.1)
+    ruby-rc4 (0.1.5)
     ruby_dep (1.4.0)
     ruby_parser (3.8.2)
       sexp_processor (~> 4.1)
@@ -776,6 +788,7 @@ DEPENDENCIES
   paperclip
   parslet
   pdf-core
+  pdf-inspector
   pg
   pointpin (~> 1.0.0)
   poltergeist
@@ -832,4 +845,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/app/pdfs/login_pdf.rb
+++ b/app/pdfs/login_pdf.rb
@@ -21,9 +21,9 @@ class LoginPdf
         count += 1
 
         if student.clever_id.present?
-          text "<b>#{student.name} (has clever)</b>\nusername: #{student.username}\npassword: Login with Clever with the above email address\n\n\n", inline_format: true
+          text "<b>#{student.name} (has clever)</b>\nemail: #{student.email}\npassword: Login with Clever with the above email address\n\n\n", inline_format: true
         elsif student.signed_up_with_google?
-          text "<b>#{student.name} (has google)</b>\nusername: #{student.username}\npassword: Login with Google with the above email address\n\n\n", inline_format: true
+          text "<b>#{student.name} (has google)</b>\nemail: #{student.email}\npassword: Login with Google with the above email address\n\n\n", inline_format: true
         else
           text "<b>#{student.name}</b>\nusername: #{student.username}\ndefault password: #{student.last_name}\n\n\n", inline_format: true
         end

--- a/spec/pdfs/login_pdf_spec.rb
+++ b/spec/pdfs/login_pdf_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe LoginPdf do
+  describe 'generate a login pdf' do
+    let(:arnold) { FactoryGirl.create(:arnold_horshack) }
+    let(:clever_student) { FactoryGirl.create(:student, clever_id: 'clever_id_1', email: 'clever@gmail.com') }
+    let(:google_student) { FactoryGirl.create(:student, signed_up_with_google: true, email: 'googler@gmail.com') }
+    let(:students) { [arnold, clever_student, google_student] }
+    let(:classroom) { FactoryGirl.create(:classroom, students: students) }
+
+    before do
+      pdf = LoginPdf.new(classroom)
+      rendered_pdf = pdf.render
+      @text_analysis = PDF::Inspector::Text.analyze(rendered_pdf)
+      puts @text_analysis.strings
+    end
+
+    it 'lists google students by email' do
+      expect(@text_analysis.strings).to include("email: googler@gmail.com")
+    end
+
+    it 'lists clever students by email' do
+      expect(@text_analysis.strings).to include("email: clever@gmail.com")
+    end
+
+    it 'lists regular students by username' do
+      expect(@text_analysis.strings).to include("username: #{arnold.username}")
+    end
+  end
+end


### PR DESCRIPTION
Google classroom and Clever students were shown their username instead of their email when generating a login pdf:
![pdf_login_before](https://cloud.githubusercontent.com/assets/6083856/23009829/2f7db0ec-f429-11e6-8f31-bf1a1102bb12.png)

This fix replaces the username field with email for 3rd party auth students:
![login_pdf_after](https://cloud.githubusercontent.com/assets/6083856/23009693/6e906cee-f428-11e6-8981-a406c44fedd9.png)

Closes #1810