### PR TITLE
Bug/activities archived during session

### DIFF
--- a/app/controllers/activity_sessions_controller.rb
+++ b/app/controllers/activity_sessions_controller.rb
@@ -53,7 +53,7 @@ class ActivitySessionsController < ApplicationController
   end
 
   def activity_session_from_uid
-    @activity_session ||= ActivitySession.find_by_uid!(params[:uid])
+    @activity_session ||= ActivitySession.unscoped.find_by_uid!(params[:uid])
   end
 
   def activity_session_for_update

--- a/app/models/activity_session.rb
+++ b/app/models/activity_session.rb
@@ -11,7 +11,7 @@ class ActivitySession < ActiveRecord::Base
   has_many :concepts, -> { uniq }, through: :concept_results
 
 
-  validate :correctly_assigned
+  validate :correctly_assigned, :on => :create
 
   accepts_nested_attributes_for :concept_results, :reject_if => proc { |cr| Concept.where(uid: cr[:concept_uid]).empty? }
 

--- a/app/models/concept_result.rb
+++ b/app/models/concept_result.rb
@@ -5,7 +5,7 @@ class ConceptResult < ActiveRecord::Base
   belongs_to :activity_classification
 
   validates :concept, presence: true
-  validates :activity_session, presence: true
+  validates :activity_session_id, presence: true
 
 
   validates :question_type, inclusion: { in: %w(passage-proofreader sentence-writing sentence-fragment-expansion sentence-fragment-identification sentence-combining),


### PR DESCRIPTION
In the case where students start an activity, the teacher edits them out of the assignment, and they then complete it we were getting a 422 unprocessable entity error.

This was due to activity sessions being validated on the concept result. I have changed this validation to check only for the presence of an activity_session_id, but not the DB record as validations have a nightmare with default scope.

I've also updated the results view to be unscoped so that students can view their results if the teacher archives the activity while before they complete it.