### PR TITLE
fixes out of order activities

### DIFF
--- a/app/controllers/teachers/progress_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports_controller.rb
@@ -14,7 +14,7 @@ class Teachers::ProgressReportsController < ApplicationController
       @user = User.find_by_email 'hello+demoteacher@quill.org'
     end
     sign_in @user
-    if params[:name] == 'partneraccount'
+    if params[:name] == 'demoaccount'
       redirect_to teachers_progress_reports_concepts_students_path
     else
       redirect_to scorebook_teachers_classrooms_path

--- a/app/controllers/teachers/progress_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports_controller.rb
@@ -14,7 +14,11 @@ class Teachers::ProgressReportsController < ApplicationController
       @user = User.find_by_email 'hello+demoteacher@quill.org'
     end
     sign_in @user
-    redirect_to teachers_progress_reports_standards_classrooms_path
+    if params[:name] == 'partneraccount'
+      redirect_to teachers_progress_reports_concepts_students_path
+    else
+      redirect_to scorebook_teachers_classrooms_path
+    end
   end
 
   def landing_page

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -151,7 +151,11 @@ module PublicProgressReports
     end
 
     def get_score_for_question concept_results
-      concept_results.inject(0) {|sum, crs| sum + crs[:metadata]["correct"]} / concept_results.length * 100
+      if concept_results.length > 0 && concept_results.first[:metadata]['questionScore']
+        concept_results.first[:metadata]['questionScore'] * 100
+      else
+        concept_results.inject(0) {|sum, crs| sum + crs[:metadata]["correct"]} / concept_results.length * 100
+      end
     end
 
     def get_average_score formatted_results

--- a/app/queries/profile/query.rb
+++ b/app/queries/profile/query.rb
@@ -10,7 +10,7 @@ class Profile::Query
            .order("units.created_at DESC")
            .order(unfinished_first)
            .order("classroom_activities.due_date")
-           .order("activity_sessions.created_at")
+           .order("classroom_activities.created_at")
   end
 
   private


### PR DESCRIPTION
- we care about classroom activity created at date, not the activity session
- partner account demo redirect to concepts report, all other demo accounts redirect to visual overview