### PR TITLE
fixes #2128 - sorting logic changed for activity planner

### DIFF
--- a/app/queries/activity_search.rb
+++ b/app/queries/activity_search.rb
@@ -18,7 +18,7 @@ class ActivitySearch
   private
 
   def self.search_sort_sql(sort)
-    return 'sections.name asc' if sort.blank?
+    return 'activity_classifications.order_number asc, sections.position asc' if sort.blank?
 
     if sort['asc_or_desc'] == 'desc'
       order = 'desc'
@@ -30,13 +30,14 @@ class ActivitySearch
     when 'activity'
       field = 'activities.name'
     when 'activity_classification'
-      field = 'activity_classifications.name'
+      field = 'activity_classifications.order_number'
+      field2 = 'sections.position'
     when 'section'
-      field = 'sections.name'
+      field = 'sections.position'
     when 'topic_category'
       field = 'topic_categories.name'
     end
 
-    field + ' ' + order
+    field + ' ' + order + ' ' + field2 + ' ' + order
   end
 end

--- a/app/views/cms/activity_classifications/_form.html.slim
+++ b/app/views/cms/activity_classifications/_form.html.slim
@@ -8,4 +8,6 @@
     = f.text_field :form_url
     = f.label :module_url
     = f.text_field :form_url
+    = f.label :order_number
+    = f.number_field :order_number
     = f.submit

--- a/db/migrate/20170222165119_add_order_number_to_activity_classification.rb
+++ b/db/migrate/20170222165119_add_order_number_to_activity_classification.rb
@@ -1,0 +1,5 @@
+class AddOrderNumberToActivityClassification < ActiveRecord::Migration
+  def change
+    add_column :activity_classifications, :order_number, :integer, default: 999999999
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -136,7 +136,8 @@ CREATE TABLE activity_classifications (
     module_url character varying(255),
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    app_name character varying(255)
+    app_name character varying(255),
+    order_number integer DEFAULT 999999999
 );
 
 
@@ -2419,4 +2420,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170127014847');
 INSERT INTO schema_migrations (version) VALUES ('20170127020417');
 
 INSERT INTO schema_migrations (version) VALUES ('20170217201048');
+
+INSERT INTO schema_migrations (version) VALUES ('20170222165119');
 


### PR DESCRIPTION
- adds order number attribute to activity classifications so we can give priority to diagnostic and connect activities (NOTE: migration will have to be run once deployed)
- activity planner now default sorts activities by order number of app and then by section position
- order number can be assigned from CMS activity classification edit page

Once this gets deployed, the migration will have to be run, and the order numbers of the Activity Classifications will have to be set as follows from either from the heroku console or the CMS Activity Classification edit page:

#1 - Diagnostic
#2 - Connect
#3 - Grammar
#4 - Proofreader