### PR TITLE
fixes #2169 - students can now update emails from account settings page

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -5,8 +5,11 @@ class StudentsController < ApplicationController
   end
 
   def make_teacher
-    current_user.update(role: 'teacher')
-    render json: {status: 'success'}.to_json
+    if current_user.update(role: params[:role], email: params[:email])
+      render json: {status: 200}
+    else
+      render json: {errors: 'Please enter a valid email address.'}, status: 422
+    end
   end
 
 end

--- a/app/views/students/account_settings.html.erb
+++ b/app/views/students/account_settings.html.erb
@@ -1,3 +1,3 @@
 <div class="page-content-wrapper">
-  <%= react_component('AccountSettingsApp', props: {role: current_user.role}) %>
+  <%= react_component('AccountSettingsApp', props: {role: current_user.role, email: current_user.email}) %>
 </div>

--- a/client/app/bundles/HelloWorld/components/accounts/edit/user_accessible_select_role.jsx
+++ b/client/app/bundles/HelloWorld/components/accounts/edit/user_accessible_select_role.jsx
@@ -6,11 +6,11 @@ import $ from 'jquery';
 export default React.createClass({
 
   getInitialState: function () {
-    return {role: this.props.role}
+    return {role: this.props.role, email: this.props.email, errors: []}
   },
 
   handleSelect: function(role){
-    if (window.confirm('Are you sure you want to change your account type?')) {
+    if (role === 'teacher' && window.confirm('Are you sure you want to change your account type?')) {
       if (this.props.updateRole) {
         this.props.updateRole(role)
       }
@@ -18,28 +18,53 @@ export default React.createClass({
     }
   },
 
+  updateEmail: function(e){
+    this.setState({email: e.target.value})
+  },
+
   handleClick: function(){
+    let that = this
     $.ajax({
       url: '/make_teacher',
-      method: 'PUT'})
-    .success(
-      ()=>window.location = '/profile'
-    )
+      method: 'PUT',
+      data: {email: this.state.email, role: this.state.role},
+      statusCode: {
+        200: function() {
+          window.location = '/profile'        },
+        422: function(response) {
+          that.setState({errors: response.responseJSON.errors})
+        }
+      }
+    })
+  },
+
+  showErrors: function(){
+    return this.state.errors ? <span>{this.state.errors}</span> : null
   },
 
   render: function () {
-    let submitButton;
-    // only has update role if it a teacher account
-    if (this.state.role !== this.props.role && !this.props.updateRole) {
-      submitButton = (
+    const submitButton = (
         <div className="row">
           <div className="col-xs-4 offset-xs-2">
             <button className="button-green" onClick={this.handleClick}>Submit</button>
           </div>
         </div>)
-    }
+
     return (
       <div>
+        <div className="row">
+          <div className="form-label col-xs-2">
+            Email
+          </div>
+          <div className="col-xs-4">
+            <input
+              name='Email'
+              label='Email'
+              defaultValue={this.props.email}
+              onChange={this.updateEmail}
+            />
+          </div>
+        </div>
         <div className="row">
           <div className="form-label col-xs-2">
             Role
@@ -52,6 +77,7 @@ export default React.createClass({
           </div>
         </div>
         {submitButton}
+        {this.showErrors()}
       </div>
     );
   }

--- a/client/app/bundles/HelloWorld/components/accounts/edit/user_accessible_select_role.jsx
+++ b/client/app/bundles/HelloWorld/components/accounts/edit/user_accessible_select_role.jsx
@@ -43,15 +43,10 @@ export default React.createClass({
   },
 
   render: function () {
-    const submitButton = (
-        <div className="row">
-          <div className="col-xs-4 offset-xs-2">
-            <button className="button-green" onClick={this.handleClick}>Submit</button>
-          </div>
-        </div>)
-
-    return (
-      <div>
+    let submitButton, email
+    // email and submitButton should only show for the student page
+    if (window.location.pathname === 'account_settings') {
+      email = (
         <div className="row">
           <div className="form-label col-xs-2">
             Email
@@ -65,6 +60,17 @@ export default React.createClass({
             />
           </div>
         </div>
+      )
+      submitButton = (
+        <div className="row">
+          <div className="col-xs-4 offset-xs-2">
+            <button className="button-green" onClick={this.handleClick}>Submit</button>
+          </div>
+        </div>)}
+
+    return (
+      <div>
+        {email}
         <div className="row">
           <div className="form-label col-xs-2">
             Role


### PR DESCRIPTION
- students can update emails from account settings page
- students cannot change their role without having an email, and will receive an error message if they attempt to do so
- students cannot change their email to an invalid email