### PR TITLE
standards premium pages now have filtered unit lists

### DIFF
--- a/app/controllers/concerns/units_with_completed_activities.rb
+++ b/app/controllers/concerns/units_with_completed_activities.rb
@@ -1,0 +1,13 @@
+module UnitsWithCompletedActivities
+  extend ActiveSupport::Concern
+
+  def units_with_completed_activities(cas)
+    all_assigned_units = cas.group_by{|ca| ca.unit_id}
+    relevant_unit_ids = []
+    all_assigned_units.each do |unit_id, classroom_activities|
+      relevant_unit_ids << unit_id if classroom_activities.select { |ca| ca.has_a_completed_session? }.any?
+    end
+    Unit.where(id: relevant_unit_ids)
+  end
+
+end

--- a/app/controllers/teachers/progress_reports/standards/classroom_students_controller.rb
+++ b/app/controllers/teachers/progress_reports/standards/classroom_students_controller.rb
@@ -1,4 +1,6 @@
 class Teachers::ProgressReports::Standards::ClassroomStudentsController < Teachers::ProgressReportsController
+  include UnitsWithCompletedActivities
+
   def index
     respond_to do |format|
       format.html
@@ -10,10 +12,13 @@ class Teachers::ProgressReports::Standards::ClassroomStudentsController < Teache
           serializer.classroom_id = params[:classroom_id]
           serializer.as_json(root: false)
         end
+
+        cas = Classroom.where(id: params[:classroom_id]).includes(:classroom_activities).map(&:classroom_activities).flatten
+
         render json: {
           students: students_json,
           classroom: current_user.classrooms_i_teach.find(params[:classroom_id]),
-          units: ProgressReports::Standards::Unit.new(current_user).results({}),
+          units: units_with_completed_activities(cas),
           teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
         }
       end

--- a/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
+++ b/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
@@ -1,4 +1,6 @@
 class Teachers::ProgressReports::Standards::ClassroomTopicsController < Teachers::ProgressReportsController
+  include UnitsWithCompletedActivities
+
   def index
     respond_to do |format|
       format.html
@@ -10,9 +12,12 @@ class Teachers::ProgressReports::Standards::ClassroomTopicsController < Teachers
           serializer.classroom_id = params[:classroom_id]
           serializer.as_json(root: false)
         end
+
+        cas = Classroom.where(id: params[:classroom_id]).includes(:classroom_activities).map(&:classroom_activities).flatten
+
         render json: {
           topics: topics_json,
-          units: ProgressReports::Standards::Unit.new(current_user).results({}),
+          units: units_with_completed_activities(cas),
           classroom: current_user.classrooms_i_teach.find(params[:classroom_id]),
           teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
         }


### PR DESCRIPTION
- the unit dropdown menu on the 'Sort by Standard' and 'Sort by Students' premium pages now only show units that have been completed by at least one student in the page's class
- fixes #2093 