### PR TITLE
Prevent double registration of PDF Mime Type

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,4 +4,4 @@
 # Mime::Type.register "text/richtext", :rtf
 # Mime::Type.register_alias "text/html", :iphone
 
-Mime::Type.register "application/pdf", :pdf
+Mime::Type.register "application/pdf", :pdf unless Mime::Type.lookup_by_extension :pdf

--- a/spec/pdfs/login_pdf_spec.rb
+++ b/spec/pdfs/login_pdf_spec.rb
@@ -12,7 +12,6 @@ describe LoginPdf do
       pdf = LoginPdf.new(classroom)
       rendered_pdf = pdf.render
       @text_analysis = PDF::Inspector::Text.analyze(rendered_pdf)
-      puts @text_analysis.strings
     end
 
     it 'lists google students by email' do
@@ -26,5 +25,10 @@ describe LoginPdf do
     it 'lists regular students by username' do
       expect(@text_analysis.strings).to include("username: #{arnold.username}")
     end
+
+    it 'registers a pdf Mime Type' do
+      expect(Mime::Type.lookup_by_extension(:pdf)).to_not be_nil
+    end
+
   end
 end


### PR DESCRIPTION
- PDF Mime type is automatically registered in Rails 4. See this [commit](https://github.com/rails/rails/commit/d73269ba53992d8a01e5721aad3d23bc2b11dc4f)
- Removes console warnings