### PR TITLE
fix copy for 'add more activities' button to make it clearer

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/add_classroom_activity_row.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/add_classroom_activity_row.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
     return (
 			<div className='row' style={styles.row}>
         <a className='q-button bg-white text-black' href={`/teachers/classrooms/activity_planner/units/${this.props.unitId}/activities/edit${this.unitNameURIString()}`}>
-          <span className='fa fa-plus'/>Add More Activities
+          <span className='fa fa-plus'/>Add More Activities To This Pack
         </a>
 			</div>
 		);


### PR DESCRIPTION
The copy on the "Add More Activities" button appears to have been misleading, as teachers have been adding a ton of activities to apparently unrelated units. Copy now reads 'Add More Activities To This Unit'.