### PR TITLE
fix #2256 - update topic_students controller to format data the way the table expects

### DIFF
--- a/app/controllers/teachers/progress_reports/standards/topic_students_controller.rb
+++ b/app/controllers/teachers/progress_reports/standards/topic_students_controller.rb
@@ -10,9 +10,16 @@ class Teachers::ProgressReports::Standards::TopicStudentsController < Teachers::
           serializer.classroom_id = params[:classroom_id]
           serializer.as_json(root: false)
         end
+        topics = ::ProgressReports::Standards::Topic.new(current_user).results(params)
+        topics_json = topics.map do |topic|
+          serializer = ::ProgressReports::Standards::TopicSerializer.new(topic)
+          # Doing this because can't figure out how to get custom params into serializers
+          serializer.classroom_id = params[:classroom_id]
+          serializer.as_json(root: false)
+        end
         render json: {
           students: students_json,
-          topic: Topic.find(params[:topic_id]),
+          topics: topics_json,
           units: ProgressReports::Standards::Unit.new(current_user).results({}),
           teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
         }


### PR DESCRIPTION
This commit utilizes the Topic serializers to send data to Individual Standard Progress Report in the way that it expects. This route is only being called for these purposes.