### PR TITLE
Update/checkbox for diagnostic

### DIFF
--- a/app/models/classroom_activity.rb
+++ b/app/models/classroom_activity.rb
@@ -158,7 +158,9 @@ class ClassroomActivity < ActiveRecord::Base
 
 
   def checkbox_type
-    if (self.unit && UnitTemplate.find_by_name(self.unit.name))
+    if self.activity_id == 413
+      checkbox_name = 'Assign Entry Diagnostic'
+    elsif self.unit && UnitTemplate.find_by_name(self.unit.name)
       checkbox_name = 'Assign Featured Activity Pack'
     else
       checkbox_name = 'Build Your Own Activity Pack'

--- a/lib/tasks/build_objectives.rake
+++ b/lib/tasks/build_objectives.rake
@@ -15,8 +15,9 @@ namespace :objectives do
        [{name: 'Create a Classroom', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369605', action_url: '/teachers/classrooms/new', section_placement: 1 },
         {name: 'Add Students', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369608', action_url: '/teachers/add_students', section_placement: 2 },
         {name: 'Assign Featured Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/843639', action_url: '/activities/packs', section_placement: 3 },
-        {name: 'Build Your Own Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369614', action_url: '/teachers/classrooms/lesson_planner', section_placement: 4},
-        {name: 'Add School', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/897621-add-your-school',  action_url: '/teachers/my_account', section_placement: 5}]
+        {name: 'Assign Entry Diagnostic', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/843639', action_url: '/activities/packs', section_placement: 4 },
+        {name: 'Add School', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/897621-add-your-school',  action_url: '/teachers/my_account', section_placement: 5},
+        {name: 'Build Your Own Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369614', action_url: '/teachers/classrooms/lesson_planner', section_placement: 6}]
     end
 
     def self.find_or_create_objectives

--- a/lib/tasks/build_objectives.rake
+++ b/lib/tasks/build_objectives.rake
@@ -15,9 +15,9 @@ namespace :objectives do
        [{name: 'Create a Classroom', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369605', action_url: '/teachers/classrooms/new', section_placement: 1 },
         {name: 'Add Students', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369608', action_url: '/teachers/add_students', section_placement: 2 },
         {name: 'Assign Featured Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/843639', action_url: '/activities/packs', section_placement: 3 },
-        {name: 'Assign Entry Diagnostic', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/843639', action_url: '/activities/packs', section_placement: 4 },
+        {name: 'Assign Entry Diagnostic', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/1144849', action_url: '/diagnostic#/stage/1', section_placement: 4 },
         {name: 'Add School', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/897621-add-your-school',  action_url: '/teachers/my_account', section_placement: 5},
-        {name: 'Build Your Own Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369614', action_url: '/teachers/classrooms/lesson_planner', section_placement: 6}]
+        {name: 'Build Your Own Activity Pack', section: 'Other', help_info: 'http://support.quill.org/knowledgebase/articles/369614', action_url: '/teachers/classrooms/lesson_planner', section_placement: 6}]
     end
 
     def self.find_or_create_objectives

--- a/spec/models/classroom_activity_spec.rb
+++ b/spec/models/classroom_activity_spec.rb
@@ -86,6 +86,12 @@ describe ClassroomActivity, type: :model do
             classroom_activity.update!(unit: new_unit)
             expect(classroom_activity.classroom.teacher.checkboxes.last.objective).to eq(obj)
         end
+
+        it 'assigns the entry diagnostic' do
+            obj = Objective.create(name: 'Assign Entry Diagnostic')
+            classroom_activity.update!(activity_id: 413)
+            expect(classroom_activity.classroom.teacher.checkboxes.last.objective).to eq(obj)
+        end
     end
 
     context 'when it has a due_date_string attribute' do


### PR DESCRIPTION
Adds a diagnostic objective and removes build your own activity pak from getting started guide.

Run with `rake objectives:create`