### PR TITLE
fix #2069 - anchor links for creating activity packs

### DIFF
--- a/app/controllers/teachers/classroom_manager_controller.rb
+++ b/app/controllers/teachers/classroom_manager_controller.rb
@@ -140,7 +140,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   def scores
     classrooms = current_user.classrooms_i_teach.includes(classroom_activities: [:unit])
-    units = classrooms.map(&:classroom_activities).flatten.map(&:unit).uniq.compact
+    units = classrooms.map(&:classroom_activities).flatten.map(&:unit).uniq.compact.sort_by { |unit| unit.created_at }
     selected_classroom =  Classroom.find_by id: params[:classroom_id]
     scores, is_last_page = current_user.scorebook_scores params[:current_page].to_i, selected_classroom.try(:id), params[:unit_id], params[:begin_date], params[:end_date]
     render json: {

--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -25,6 +25,10 @@ class Teachers::UnitsController < ApplicationController
     render json: { prohibitedUnitNames: unitNames.concat(unitTemplateNames) }.to_json
   end
 
+  def last_assigned_unit_id
+    render json: {id: Unit.where(user: current_user).last.id}.to_json
+  end
+
   def update
     unit_template_names = UnitTemplate.all.map{ |u| u.name.downcase }
     if unit_params[:name] && unit_params[:name] === ''
@@ -114,8 +118,8 @@ class Teachers::UnitsController < ApplicationController
     end
 
     arr1, arr2 = arr.partition{|a| a[:unit].created_at.present? }
-    arr1 = arr1.sort_by{|ele| ele[:unit].created_at}.reverse
-    render json: {units: arr1.concat(arr2)}.to_json
+    arr1 = arr1.sort_by{|ele| ele[:unit].created_at}
+    render json: {units: arr2.concat(arr1)}.to_json
   end
 
   def hide

--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -16,7 +16,7 @@ class Teachers::UnitsController < ApplicationController
     else
       Units::Creator.run(current_user, params[:unit][:name], params[:unit][:activities], params[:unit][:classrooms])
     end
-    render json: {}
+    render json: {id: Unit.where(user: current_user).last.id}
   end
 
   def prohibited_unit_names

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/create_unit.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/create_unit.jsx
@@ -17,7 +17,8 @@ export default React.createClass({
 
 	getInitialState () {
 		return {
-			prohibitedUnitNames: []
+			prohibitedUnitNames: [],
+			newUnitId: null
 		}
 	},
 
@@ -132,7 +133,7 @@ export default React.createClass({
 			data: JSON.stringify(this.formatCreateRequestData()),
 			dataType: 'json',
 			contentType: 'application/json',
-			success: this.onCreateSuccess
+			success: (response) => this.onCreateSuccess(response)
 		});
 	},
 
@@ -182,14 +183,14 @@ export default React.createClass({
 		return x;
 	},
 
-	onCreateSuccess: function() {
+	onCreateSuccess: function(response) {
+		this.setState({newUnitId: response.id})
 		this.props.actions.toggleStage(3);
 	},
 
 	isUnitNameValid: function() {
 		return ((this.getUnitName() != null) && (this.getUnitName() != ''));
 	},
-
 
 
 	determineIfInputProvidedAndValid: function() {
@@ -294,7 +295,7 @@ export default React.createClass({
 		if ((!!this.props.actions.assignSuccessActions) && (!!this.props.data.assignSuccessData)) {
 			return (<UnitTemplatesAssigned actions={this.props.actions.assignSuccessActions} data={this.props.data.assignSuccessData}/>);
 		} else {
-			window.location.href = '/teachers/classrooms/activity_planner';
+			window.location.href = `/teachers/classrooms/activity_planner#${this.state.newUnitId}`;
 		}
 	},
 

--- a/client/app/bundles/HelloWorld/components/lesson_planner/diagnostic_assigned.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/diagnostic_assigned.jsx
@@ -11,7 +11,8 @@ export default  React.createClass({
     return {
       loading: true,
       actions: this.unitTemplateAssignedActions,
-      data: null
+      data: null,
+      diagnosticId: ''
     }
   },
 
@@ -50,6 +51,13 @@ export default  React.createClass({
           that.setState({loading: false, studentsPresent: that.anyClassroomsWithStudents(data.classrooms) });
         }
       });
+      $.ajax({
+        url: '/teachers/last_assigned_unit_id',
+        dataType: 'json',
+        success: function(data) {
+          that.setState({loading: false, diagnosticId: data.id });
+        }
+      });
   },
 
   activityName: function() {
@@ -70,7 +78,7 @@ export default  React.createClass({
     let text;
 
     if (this.props.type === 'diagnostic' || this.state.studentsPresent) {
-      href = '/teachers/classrooms/activity_planner';
+      href = `/teachers/classrooms/activity_planner#${this.state.diagnosticId}`
       text = 'View Assigned Activity Packs';
     } else {
       href = this.state.actions.getInviteStudentsUrl();

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
@@ -25,10 +25,21 @@
 		});
 	},
 
+  hashLinkScroll: function() {
+  const hash = window.location.hash
+  if (hash !== '') {
+      const id = hash.replace('#', '')
+      const element = document.getElementById(id)
+      element ? element.scrollIntoView() : null
+    }
+  },
+
 	displayUnits: function (data) {
 		this.setState({units: data.units,
 									 loaded: true});
+    this.hashLinkScroll()
 	},
+
 	hideUnit: function (id) {
 		var units, x1;
 		units = this.state.units;

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/unit.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/unit.jsx
@@ -153,7 +153,7 @@
 							data={ca} />);
 		}, this);
 		return (
-			<section >
+			<section>
 				<div className='row unit-header-row' id={this.props.data.unit.id}>
           <span className="unit-name">
             {this.showOrEditName()}

--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_template_assigned.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_template_assigned.jsx
@@ -11,7 +11,8 @@ export default  React.createClass({
     return {
       loading: true,
       actions: this.unitTemplateAssignedActions,
-      data: null
+      data: null,
+      lastUnitId: ''
     }
   },
 
@@ -57,6 +58,13 @@ export default  React.createClass({
           that.setState({data})
         }
       })
+      $.ajax({
+        url: '/teachers/last_assigned_unit_id',
+        dataType: 'json',
+        success: function(data) {
+          that.setState({loading: false, lastUnitId: data.id });
+        }
+      });
   },
 
   activityName: function() {
@@ -77,7 +85,7 @@ export default  React.createClass({
     let text;
 
     if (this.props.type === 'diagnostic' || this.state.studentsPresent) {
-      href = '/teachers/classrooms/activity_planner';
+      href = `/teachers/classrooms/activity_planner#${this.state.lastUnitId}`;
       text = 'View Assigned Activity Packs';
     } else {
       href = this.getInviteStudentsUrl();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ EmpiricalGrammar::Application.routes.draw do
     end # moved from within classroom, since units are now cross-classroom
 
     get 'prohibited_unit_names' => 'units#prohibited_unit_names'
+    get 'last_assigned_unit_id' => 'units#last_assigned_unit_id'
 
 
     resources :unit_templates, only: [:index] do


### PR DESCRIPTION
this branch adds anchor links to activity packs on 'My Activity Packs', and links directly to them when you create a new unit. In addition, the packs on 'My Activity Packs' are now sorted in descending order of creation, so the first created are the first on the page.