### PR TITLE
fix #2327 - evaluate params sent to clever link

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,7 +3,7 @@
   <h3>Welcome Back to Quill</h3>
     <div class="text-center">
       <a href='/auth/google_oauth2' className='google-sign-in''><img src='/images/login_with_google.png'></a>
-      <a href="https://clever.com/oauth/authorize?#{ {response_type: 'code', redirect_uri: Clever::REDIRECT_URL, client_id: Clever::CLIENT_ID, scope: QuillClever.scope}.to_param }">
+      <a href=<%="https://clever.com/oauth/authorize?#{ {response_type: 'code', redirect_uri: Clever::REDIRECT_URL, client_id: Clever::CLIENT_ID, scope: QuillClever.scope}.to_param }"%>>
         <img src='/images/login_with_clever.png' alt="Login with Clever" data-pin-nopin="true">
       </a>
       <div class="row">


### PR DESCRIPTION
clever login button was broken because the params weren't being evaluated as ruby