### PR TITLE
fix #2067 - diagnostic planner routing

### DIFF
--- a/app/views/pages/diagnostic_tool.erb
+++ b/app/views/pages/diagnostic_tool.erb
@@ -197,7 +197,7 @@
           <h1 class='q-h1'>
               Start using the Quill Diagnostic in your class today!
           </h1>
-          <a href='/diagnostic#/stage/1' class="q-button cta-button bg-quillgreen text-white">Get Started</a>
+          <a href='/diagnostic/stage/1' class="q-button cta-button bg-quillgreen text-white">Get Started</a>
       </section>
       <% end %>
 

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ClassroomPage.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ClassroomPage.jsx
@@ -62,7 +62,7 @@ export default React.createClass({
 			alert('You must select a classroom before assigning the diagnostic.')
 		} else {
 			$.ajax({type: 'POST', url: '/teachers/units', data: JSON.stringify(data), dataType: 'json', contentType: 'application/json'}).done(function() {
-				window.location = '/diagnostic#/success'
+				window.location = '/diagnostic/success'
 			}).fail(function() {
 				alert('There has been an error assigning the lesson. Please make sure you have selected a classroom');
 			})
@@ -159,7 +159,7 @@ export default React.createClass({
 		return (
 			<Modal {...this.props} show={this.state.show} onHide={this.hideModal} dialogClassName='add-class-modal'>
 				<Modal.Body>
-					<img className='pull-right react-bootstrap-close' onClick={this.hideModal} src='images/close_x.svg' alt='close-modal'/>
+					<img className='pull-right react-bootstrap-close' onClick={this.hideModal} src='/images/close_x.svg' alt='close-modal'/>
 					<CreateClass closeModal={this.hideModal}/>
 				</Modal.Body>
 			</Modal>
@@ -191,7 +191,7 @@ export default React.createClass({
 					<div className='pull-right text-center'>
 						<button style={display} onClick={this.submitClasses} className='button-green'>Save & Assign</button>
 						<br/>
-						<Link to='/stage/2'>Back</Link>
+						<Link to='/diagnostic/stage/2'>Back</Link>
 					</div>
 				</div>
 			</div>

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
                 </div>
                 <a href="/activity_sessions/anonymous?activity_id=413" target='_blank'><button id='preview' className='button-green'>Preview the Diagnostic</button></a>
                 <br/>
-                <Link id='assign' to='/stage/3'><button className='button-green'>Continue to Assign</button></Link>
+                <Link id='assign' to='/diagnostic/stage/3'><button className='button-green'>Continue to Assign</button></Link>
             </div>
         )
     }

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ModalOverview.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ModalOverview.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
 
   hideModal() {
     this.setState({show: false});
-    location.href = 'diagnostic/stage/2'
+    location.href = '/diagnostic/stage/2'
   },
 
   modalContent() {

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ModalOverview.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/ModalOverview.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
 
   hideModal() {
     this.setState({show: false});
-    location.href = 'diagnostic#/stage/2'
+    location.href = 'diagnostic/stage/2'
   },
 
   modalContent() {
@@ -58,7 +58,7 @@ export default React.createClass({
     if (this.state.slideIndex < this.modalSlides().length - 1) {
       this.setState({slideIndex: this.state.slideIndex + 1})
     } else {
-      parent.location.hash = '/stage/2'
+      location.href = '/diagnostic/stage/2'
     }
   },
 

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/StatusBar.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/StatusBar.jsx
@@ -47,7 +47,7 @@ export default React.createClass({
         return (
             <div id='status-bar-wrapper'>
                 <div id='diagnostic-icon-section'>
-                    <img id='diagnostic-icon' src="images/diagnostic_icon.svg" alt="diagnostic_icon"/>
+                    <img id='diagnostic-icon' src="/images/diagnostic_icon.svg" alt="diagnostic_icon"/>
                     <span>Sentence Structure</span><br/><span>Diagnostic</span>
                 </div>
                 <div id="checkpoint-wrapper">

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/assign_a_new_activity.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/assign_a_new_activity.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
   minis: function(){
     let minis =
       [
-        <a href='/diagnostic#/stage/1'
+        <a href='/diagnostic/stage/1'
             key={1}>
           <AssignmentTypeMini
             toggleTab={this.props.toggleTab}

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/not_completed.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/not_completed.jsx
@@ -9,7 +9,7 @@ export default React.createClass({
   },
 
   switchToDiagnosticAssign: function(){
-    window.location.href = '/diagnostic#/stage/1'
+    window.location.href = '/diagnostic/stage/1'
   },
 
 	render: function() {

--- a/client/app/bundles/HelloWorld/containers/DiagnosticPlanner.jsx
+++ b/client/app/bundles/HelloWorld/containers/DiagnosticPlanner.jsx
@@ -1,20 +1,16 @@
 import React from 'react'
-import { Router, Route, Link, hashHistory } from 'react-router'
+import { Router, Route, Link, browserHistory } from 'react-router'
 import App from '../components/diagnostic/diagnostic_questionnaire/index.jsx'
 import Stages from '../components/diagnostic/diagnostic_questionnaire/Stages.jsx'
-import createHashHistory from 'history/lib/createHashHistory'
 import SuccessView from '../components/diagnostic/diagnostic_questionnaire/SuccessView.jsx'
-const hashhistory = createHashHistory({ queryKey: false })
 
 export default React.createClass({
-
-
 
   render: function () {
 
       return (
-        <Router history={hashHistory}>
-          <Route path="/" component={App}>
+        <Router history={browserHistory}>
+          <Route path="/diagnostic" component={App}>
             <Route path='success' component={SuccessView}/>
             <Route path='stage/:stage' component={Stages}/>
           </Route>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,6 +303,8 @@ EmpiricalGrammar::Application.routes.draw do
   get 'lessons' => 'pages#activities' # so that old links still work
   get 'about' => 'pages#activities' # so that old links still work
   get 'diagnostic' =>'activities#diagnostic' # placeholder til we find where this goes
+  get 'diagnostic/stage/:stage' => 'activities#diagnostic'
+  get 'diagnostic/success' => 'activities#diagnostic'
 
   get 'demo' => 'teachers/progress_reports/standards/classrooms#demo'
 

--- a/lib/tasks/build_objectives.rake
+++ b/lib/tasks/build_objectives.rake
@@ -15,7 +15,7 @@ namespace :objectives do
        [{name: 'Create a Classroom', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369605', action_url: '/teachers/classrooms/new', section_placement: 1 },
         {name: 'Add Students', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/369608', action_url: '/teachers/add_students', section_placement: 2 },
         {name: 'Assign Featured Activity Pack', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/843639', action_url: '/activities/packs', section_placement: 3 },
-        {name: 'Assign Entry Diagnostic', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/1144849', action_url: '/diagnostic#/stage/1', section_placement: 4 },
+        {name: 'Assign Entry Diagnostic', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/1144849', action_url: '/diagnostic/stage/1', section_placement: 4 },
         {name: 'Add School', section: 'Getting Started', help_info: 'http://support.quill.org/knowledgebase/articles/897621-add-your-school',  action_url: '/teachers/my_account', section_placement: 5},
         {name: 'Build Your Own Activity Pack', section: 'Other', help_info: 'http://support.quill.org/knowledgebase/articles/369614', action_url: '/teachers/classrooms/lesson_planner', section_placement: 6}]
     end


### PR DESCRIPTION
This branch switches the diagnostic planner router from using hashHistory to browserHistory, which cleans up the urls. Issue #2607 has a list of affected links in the comment, which have been checked by @jaredsilver. When this branch gets merged in, the rake task 'rake objectives:create' will need to be run to prevent the 'Assign Diagnostic' checkbox on the teacher dashboard from breaking.