### PR TITLE
adds callback to units that hides classroom activities if unit archived

### DIFF
--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -18,12 +18,19 @@ class Unit < ActiveRecord::Base
   has_many :activities, through: :classroom_activities
   has_many :topics, through: :activities
   default_scope { where(visible: true)}
+  after_save :hide_classroom_activities_if_visible_false
 
 
 
   def hide_if_no_visible_classroom_activities
     if  ClassroomActivity.unscoped.where(unit_id: self.id, visible: false).length == self.classroom_activities.length
       self.update(visible: false)
+    end
+  end
+
+  def hide_classroom_activities_if_visible_false
+    if self.visible == false
+      ClassroomActivity.where(unit_id: self.id, visible: true).each{|ca| ca.update(visible: false)}
     end
   end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,6 +3,8 @@
 
 if Rails.env.production?
   EmpiricalGrammar::Application.config.session_store :cookie_store, key: '_quill_session', domain: '.quill.org'
+elsif Rails.env.staging?
+  EmpiricalGrammar::Application.config.session_store :cookie_store, key: '_quill_staging_session', domain: 'staging.quill.org'
 else
   EmpiricalGrammar::Application.config.session_store :cookie_store, key: '_quill_session'
 end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -82,6 +82,30 @@ describe Unit, type: :model do
     end
   end
 
+  describe '#hide_classroom_activities_if_visible_false' do
+    it 'is called when the unit is saved' do
+      expect(unit).to receive(:hide_classroom_activities_if_visible_false)
+      unit.update(name: 'new name')
+    end
+
+    it "does not update the unit's classroom activities unless the unit is archived" do
+      old_ca_attributes = classroom_activity.attributes
+      unit.update(name: 'something else')
+      expect(classroom_activity.attributes).to eq(old_ca_attributes)
+    end
+
+    it "archives the unit's classroom activities if the unit archived" do
+      old_ca_attributes = classroom_activity.attributes
+      unit.update(name: 'something else')
+      expect(classroom_activity.attributes).to eq(old_ca_attributes)
+    end
+
+
+
+  end
+
+
+
 
 
 end


### PR DESCRIPTION
Previously, when an activity was archived, it would not archive its classroom activities. This caused discrepancies between a student's view and a teachers.