### PR TITLE
fixes #2416 - add user id to units

### DIFF
--- a/lib/tasks/add_user_id_to_units.rake
+++ b/lib/tasks/add_user_id_to_units.rake
@@ -1,15 +1,26 @@
 namespace :add_user_id_to_units do
   desc 'assign existing units the correct user_id'
   task :update => :environment do
-    Unit.unscoped.where(user_id: nil).each do |unit|
-      classroom_activities = unit.classroom_activities
-      if classroom_activities.any?
-        ca_with_teacher = classroom_activities.find{ |ca| ca.classroom && ca.classroom.teacher }
-        if ca_with_teacher
-          unit.update(user_id: ca_with_teacher.classroom.teacher.id)
-        end
-      end
-    end
-    puts "we're done!!!!"
-  end
+
+    # if we ever start allowing users to restore units they've archived,
+    # this will need to be updated
+
+    Unit.where(user_id: nil).each do |unit|
+     classroom_activities = ClassroomActivity.unscoped.where(unit_id: unit.id)
+     if classroom_activities.any?
+       teacher = nil
+       ca_with_teacher = classroom_activities.find do |ca|
+         classy = Classroom.unscoped.find_by_id(ca.classroom_id)
+         teacher = User.find_by_id(classy.teacher_id) if classy
+         classy && teacher
+       end
+       if ca_with_teacher
+         unit.update_attribute('user_id', teacher.id)
+         puts 'unit_id'
+         puts unit.id
+       end
+     end
+   end
+
+ end
 end

--- a/lib/tasks/handle_units_without_classroom_activities.rake
+++ b/lib/tasks/handle_units_without_classroom_activities.rake
@@ -1,0 +1,16 @@
+namespace :handle_units_without_classroom_activities do
+  desc 'destroy units with no teacher or classroom activities, hide otherwise'
+  task :update => :environment do
+    Unit.unscoped.all.each do |unit|
+     classroom_activities = ClassroomActivity.where(unit_id: unit.id)
+     if classroom_activities.empty?
+       if ClassroomActivity.unscoped.where(unit_id: unit.id).empty? && unit.user_id.nil?
+         unit.destroy
+       else
+         unit.update_attribute('visible', false)
+       end
+     end
+   end
+
+  end
+end


### PR DESCRIPTION
This branch contains an updated version of the rake task that updates existing units to have the appropriate user_id. It has already been run as a script on the production database. It also includes an additional rake task that deals with units that do not have classroom activities. The latter has not been run yet since it is destructive.