### PR TITLE
fixes #2422 - classroom activities now get archived rather than deleted

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -5,7 +5,6 @@ class Teachers::ClassroomActivitiesController < ApplicationController
   before_filter :teacher!
   before_filter :authorize!
 
-
   def update
     cas = ClassroomActivity.where(activity: @classroom_activity.activity, unit: @classroom_activity.unit)
     cas.each{ |ca| ca.try(:update_attributes, classroom_activity_params)}
@@ -13,8 +12,14 @@ class Teachers::ClassroomActivitiesController < ApplicationController
   end
 
   def destroy
-    cas = @classroom_activity.unit.classroom_activities.where(activity: @classroom_activity.activity)
-    cas.each{|ca| ca.destroy}
+    # cas = @classroom_activity.unit.classroom_activities.where(activity: @classroom_activity.activity)
+    # cas.each{|ca| ca.destroy}
+    # @classroom_activity.unit.hide_if_no_visible_classroom_activities
+    # render json: {}
+  end
+
+  def hide
+    @classroom_activity.update(visible: false)
     @classroom_activity.unit.hide_if_no_visible_classroom_activities
     render json: {}
   end

--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -131,7 +131,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def destroy
-    Unit.find(params[:id]).destroy
+    # Unit.find(params[:id]).update(visible: false)
     render json: {}
   end
 

--- a/app/models/classroom_activity.rb
+++ b/app/models/classroom_activity.rb
@@ -6,7 +6,7 @@ class ClassroomActivity < ActiveRecord::Base
   belongs_to :activity
   belongs_to :unit, touch: true
   has_one :topic, through: :activity
-  has_many :activity_sessions, dependent: :destroy
+  has_many :activity_sessions
 
   default_scope { where(visible: true) }
   scope :with_topic, ->(tid) { joins(:topic).where(topics: {id: tid}) }

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
@@ -20,10 +20,10 @@ export default React.createClass({
 		}
 	},
 
-	deleteClassroomActivity: function() {
+	hideClassroomActivity: function() {
 		var x = confirm('Are you sure you want to delete this assignment?');
 		if (x) {
-			this.props.deleteClassroomActivity(this.props.data.id, this.props.data.unit_id);
+			this.props.hideClassroomActivity(this.props.data.id, this.props.data.unit_id);
 		}
 	},
 
@@ -66,7 +66,7 @@ export default React.createClass({
 
   deleteRow:function(){
     if (!this.props.report) {
-      return <div className="pull-right"><img className='delete-classroom-activity h-pointer' onClick={this.deleteClassroomActivity} src="/images/x.svg"/></div>
+      return <div className="pull-right"><img className='delete-classroom-activity h-pointer' onClick={this.hideClassroomActivity} src="/images/x.svg"/></div>
     }
   },
 

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
@@ -57,7 +57,7 @@
 			}
 		});
 	},
-	deleteClassroomActivity: function (ca_id, unit_id) {
+	hideClassroomActivity: function (ca_id, unit_id) {
 		var units, x1;
 		units = this.state.units;
 		x1 = _.map(units, function (unit) {
@@ -71,8 +71,8 @@
 		this.setState({units: x1});
 
 		$.ajax({
-			type: 'delete',
-			url: '/teachers/classroom_activities/' + ca_id,
+			type: 'put',
+			url: '/teachers/classroom_activities/' + ca_id + '/hide',
 			success: function () {
 			},
 			error: function () {
@@ -113,7 +113,7 @@
 				<Units
 					updateDueDate={this.updateDueDate}
 					editUnit={this.props.actions.editUnit}
-					deleteClassroomActivity={this.deleteClassroomActivity}
+					hideClassroomActivity={this.hideClassroomActivity}
 					hideUnit={this.hideUnit} data={this.state.units} />
 				</span>
 			);

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/unit.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/unit.jsx
@@ -149,7 +149,7 @@
 							key={ca.id}
               report={this.props.report}
 							updateDueDate={this.props.updateDueDate}
-							deleteClassroomActivity={this.props.deleteClassroomActivity}
+							hideClassroomActivity={this.props.hideClassroomActivity}
 							data={ca} />);
 		}, this);
 		return (

--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/units.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/units.jsx
@@ -10,7 +10,7 @@
 		var units = _.map(this.props.data, function (data) {
       if (data.classroom_activities.length > 0) {
   			return (<Unit   key={data.unit.id}
-                deleteClassroomActivity={this.props.deleteClassroomActivity}
+                hideClassroomActivity={this.props.hideClassroomActivity}
                 hideUnit={this.props.hideUnit}
                 report={this.props.report}
                 updateDueDate={this.props.updateDueDate}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,12 @@ EmpiricalGrammar::Application.routes.draw do
       end
     end
 
-    resources :classroom_activities, only: [:destroy, :update], as: 'classroom_activities_path'
+    resources :classroom_activities, only: [:destroy, :update], as: 'classroom_activities_path' do
+      collection do
+        put ':id/hide' => 'classroom_activities#hide'
+      end
+    end
+
     get 'getting_started' => 'classroom_manager#getting_started'
     get 'add_students' => 'classroom_manager#generic_add_students'
     get 'teacher_guide' => 'classroom_manager#teacher_guide'

--- a/spec/models/classroom_activity_spec.rb
+++ b/spec/models/classroom_activity_spec.rb
@@ -10,13 +10,6 @@ describe ClassroomActivity, type: :model do
     let!(:unit) { FactoryGirl.create(:unit) }
     let!(:classroom_activity) { ClassroomActivity.create(activity: activity, classroom: classroom, unit: unit) }
 
-    describe '#destroy' do
-        it 'should destroy associated activity_sessions' do
-            classroom_activity.destroy
-            expect(student.activity_sessions.count).to eq(0)
-        end
-    end
-
     describe '#assigned_students' do
         it 'must be empty if none assigned' do
             expect(classroom_activity.assigned_students).to be_empty


### PR DESCRIPTION
I also removed the 'dependent: destroy' relationship between classroom activities and their activity sessions, because we never want to be deleting activity sessions from the database.