### PR TITLE
fix #2452 - edit students button is disabled appropriately

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/ClassroomsWithStudents.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/ClassroomsWithStudents.jsx
@@ -64,11 +64,11 @@ export default class extends React.Component {
 	createButton(){
 		return(
 			<EditStudentsButton enabled={this.props.isSaveButtonEnabled}
-												disabledText={'Add Students Before Saving'}
+												disabledText={'Add Students Before Assigning'}
 												requestType={'POST'}
 												url={'/teachers/units'}
 												successCallback={this.resetPage}
-												buttonText={'Add Students'}
+												buttonText={'Assign Activity Pack'}
 												dataFunc={this.ajaxData}
 												/>
 		)
@@ -92,7 +92,7 @@ export default class extends React.Component {
 	}
 
 	render() {
-		let classroomList;
+		let classroomList, warningBlurb;
 		if (this.props.classrooms) {
 			let that = this;
 			classroomList = this.props.classrooms.map((el)=> {
@@ -108,10 +108,13 @@ export default class extends React.Component {
 		} else {
 			classroomList = []
 		}
+		if (this.props.createOrEdit === 'edit') {
+			warningBlurb = <p>Please note that unselecting a student on this page will delete all of their assignments associated with this pack, even if those assignments have already been completed.</p>
+		}
     return (
 			<div>
 				<h2 className='edit-students-h2'>Edit Students for {this.props.unitName}</h2>
-				<p>Please note that unselecting a student on this page will delete all of their assignments associated with this pack, even if those assignments have already been completed.</p>
+				{warningBlurb}
 				{classroomList}
 				{this.createOrUpdateButton()}
 			</div>

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/EditStudentsButton.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/stage2/EditStudentsButton.jsx
@@ -42,7 +42,7 @@ class UpdateUnitButton extends React.Component {
 
 	render() {
     let text, color, clickHandler;
-    if (this.props.enabled() && !this.state.loading) {
+    if (this.props.enabled && !this.state.loading) {
       text = this.props.buttonText;
       color = 'quillgreen';
       clickHandler = this.handleClick

--- a/client/app/bundles/HelloWorld/containers/ClassroomsWithStudentsContainer.jsx
+++ b/client/app/bundles/HelloWorld/containers/ClassroomsWithStudentsContainer.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import $ from 'jquery'
 import ClassroomsWithStudents from '../components/lesson_planner/create_unit/stage2/ClassroomsWithStudents.jsx'
 import LoadingIndicator from '../components/general_components/loading_indicator.jsx'
+import _ from 'underscore'
 
 export default class extends React.Component {
 	constructor(props) {
@@ -61,6 +62,8 @@ export default class extends React.Component {
 		const classy = newState.classrooms[classIndex]
 	  let selectedStudent = classy.students[studentIndex]
 		selectedStudent.isSelected = !selectedStudent.isSelected;
+		newState.classrooms[classIndex].edited = this.classroomUpdated(newState.classrooms[classIndex]);
+		newState.studentsChanged = this.studentsChanged();
 		// we check to see if something has changed because this method gets called when the page loads
 		// as well as when a student's checkbox is clicked
 		if (newState.studentsChanged) {
@@ -71,12 +74,9 @@ export default class extends React.Component {
 	}
 
 	handleStudentCheckboxClick = (studentId, classroomId) =>{
-		const newState = Object.assign({}, this.state);
 		const classIndex = this.findTargetClassIndex(classroomId)
 		const studentIndex = this.findTargetStudentIndex(studentId, classIndex)
-		newState.classrooms[classIndex].edited = this.classroomUpdated(newState.classrooms[classIndex]);
-		newState.studentsChanged = true;
-		this.setState(newState, () => this.toggleStudentSelection(studentIndex, classIndex));
+		this.toggleStudentSelection(studentIndex, classIndex)
 	}
 
 	toggleClassroomSelection = (classy) => {
@@ -87,7 +87,7 @@ export default class extends React.Component {
 		classroom.allSelected = !classroom.allSelected;
 		classroom.noneSelected = !classroom.allSelected
 		classroom.students.forEach((stud)=>stud.isSelected=classroom.allSelected);
-		newState.studentsChanged = true;
+		newState.studentsChanged = this.studentsChanged();
 		this.setState(newState);
 	}
 
@@ -139,12 +139,10 @@ export default class extends React.Component {
 	getAssignedIds = classy => classy.students.filter((student) => student.isSelected).map((stud) => stud.id)
 
 	classroomUpdated(classy) {
-		const assignedStudentIds = getAssignedIds(classy)
+		const assignedStudentIds = this.getAssignedIds(classy).sort()
 		let updated
-		if (assignedStudentIds.length > 0 && classy.classroomActivity) {
-			if (assignedStudentIds == classy.classroomActivity.assigned_student_ids) {
-				updated = false
-			}
+		if (assignedStudentIds.length > 0 && classy.classroom_activity) {
+			updated = !_.isEqual(assignedStudentIds, classy.classroom_activity.assigned_student_ids.filter(Number).sort())
 		} else if (assignedStudentIds.length == 0) {
 			updated = false
 		} else {
@@ -190,20 +188,6 @@ export default class extends React.Component {
 		})
 	}
 
-	noClassroomsSelected(){
-		const classes = this.state.classrooms
-		return (classes.filter((cl)=>cl.noneSelected).length === classes.length)
-	}
-
-	isSaveButtonEnabled(){
-		const s = this.state
-		if (!s.studentsChanged || this.noClassroomsSelected()) {
-			return false
-		} else {
-			return true
-		}
-	}
-
 	render() {
 		if (this.state.loading) {
 			return <LoadingIndicator/>
@@ -219,7 +203,7 @@ export default class extends React.Component {
 									createOrEdit={this.state.newUnit ? 'create' : 'edit'}
 									handleStudentCheckboxClick={this.handleStudentCheckboxClick.bind(this)}
 									toggleClassroomSelection={this.toggleClassroomSelection}
-									isSaveButtonEnabled={this.isSaveButtonEnabled.bind(this)}
+									isSaveButtonEnabled={this.state.studentsChanged}
 									/>
 							</div>
 						</div>)

--- a/client/app/bundles/HelloWorld/containers/ClassroomsWithStudentsContainer.jsx
+++ b/client/app/bundles/HelloWorld/containers/ClassroomsWithStudentsContainer.jsx
@@ -74,7 +74,7 @@ export default class extends React.Component {
 		const newState = Object.assign({}, this.state);
 		const classIndex = this.findTargetClassIndex(classroomId)
 		const studentIndex = this.findTargetStudentIndex(studentId, classIndex)
-		newState.classrooms[classIndex].edited = true;
+		newState.classrooms[classIndex].edited = this.classroomUpdated(newState.classrooms[classIndex]);
 		newState.studentsChanged = true;
 		this.setState(newState, () => this.toggleStudentSelection(studentIndex, classIndex));
 	}
@@ -83,7 +83,7 @@ export default class extends React.Component {
 		const newState = Object.assign({}, this.state);
 		const classIndex = this.findTargetClassIndex(classy.id);
 		const classroom = newState.classrooms[classIndex];
-		classroom.edited = true;
+		classroom.edited = !classroom.edited;
 		classroom.allSelected = !classroom.allSelected;
 		classroom.noneSelected = !classroom.allSelected
 		classroom.students.forEach((stud)=>stud.isSelected=classroom.allSelected);
@@ -135,6 +135,33 @@ export default class extends React.Component {
 	}
 
 	countAssigned = classy => classy.students.filter((student) => student.isSelected).length
+
+	getAssignedIds = classy => classy.students.filter((student) => student.isSelected).map((stud) => stud.id)
+
+	classroomUpdated(classy) {
+		const assignedStudentIds = getAssignedIds(classy)
+		let updated
+		if (assignedStudentIds.length > 0 && classy.classroomActivity) {
+			if (assignedStudentIds == classy.classroomActivity.assigned_student_ids) {
+				updated = false
+			}
+		} else if (assignedStudentIds.length == 0) {
+			updated = false
+		} else {
+			updated = true
+		}
+		return updated
+	}
+
+	studentsChanged() {
+		let changed
+		this.state.classrooms.forEach((classy) => {
+			if (this.classroomUpdated(classy)) {
+				changed = true
+			}
+		})
+		return changed
+	}
 
 	getClassroomsAndStudentsData() {
 		const that = this;

--- a/client/app/bundles/HelloWorld/containers/__tests__/ClassroomsWithStudentsContainer.test.js
+++ b/client/app/bundles/HelloWorld/containers/__tests__/ClassroomsWithStudentsContainer.test.js
@@ -3,6 +3,7 @@ import {
     shallow,
     mount
 } from 'enzyme';
+import _ from 'lodash'
 
 import ClassroomsWithStudentsContainer from '../ClassroomsWithStudentsContainer';
 
@@ -420,28 +421,67 @@ describe('ClassroomsWithStudentsContainer container', () => {
           expect(wrapper.find(ClassroomsWithStudentsContainer).exists()).toBe(true);
       });
 
+  describe('classroomUpdated', () => {
 
+    it('returns false if the selected students are the same as the originally assigned students', () => {
+      const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+      wrapper.setState(_.cloneDeep(state))
+      wrapper.instance().selectPreviouslyAssignedStudents();
+      expect(wrapper.instance().classroomUpdated(wrapper.state().classrooms[0])).toBe(false)
+    })
+
+      it('returns false if the selected students are the same as the originally assigned students', () => {
+        const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+        wrapper.setState(_.cloneDeep(state))
+        expect(wrapper.instance().classroomUpdated(wrapper.state().classrooms[0])).toBe(false)
+      })
+
+    it('returns true otherwise', () => {
+      const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+      const newState = _.cloneDeep(state)
+      newState.classrooms[0].students[0].isSelected = true
+      wrapper.setState(newState)
+      expect(wrapper.instance().classroomUpdated(wrapper.state().classrooms[0])).toBe(true)
+    })
+
+  })
+
+  describe('studentsChanged', () => {
+    it('returns true if a classroom has been updated', () => {
+      const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+      const newState = _.cloneDeep(state)
+      newState.classrooms[0].students[0].isSelected = true
+      wrapper.setState(newState)
+      expect(wrapper.instance().studentsChanged()).toBe(true)
+    })
+
+    it('returns false if no classrooms have been updated', () => {
+      const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+      wrapper.setState(_.cloneDeep(state))
+      wrapper.instance().selectPreviouslyAssignedStudents();
+      expect(wrapper.instance().studentsChanged()).toBe(undefined)
+    })
+  })
 
   describe('selectPreviouslyAssignedStudents', ()=> {
-    // it('selectPreviouslyAssignedStudents marks a student as selected if they are an assigned student', () => {
-    //   const wrapper = mount( < ClassroomsWithStudentsContainer {...props}/>);
-    //     wrapper.setState(state)
-    //     let assignedStudents = wrapper.state().classrooms[0].classroom_activity.assigned_student_ids
-    //     let students = wrapper.state().classrooms[0].students
-    //     wrapper.instance().selectPreviouslyAssignedStudents();
-    //     let selectedStudents = []
-    //     students.forEach((stud)=> {
-    //       if (stud.isSelected) {
-    //         selectedStudents.push(stud.id)
-    //       }
-    //     });
-    //     expect(assignedStudents.sort((a,b)=> a - b)).toEqual(selectedStudents.sort((a,b)=> a - b))
-    // })
+    it('selectPreviouslyAssignedStudents marks a student as selected if they are an assigned student', () => {
+      const wrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+        wrapper.setState(_.cloneDeep(state))
+        let assignedStudents = wrapper.state().classrooms[0].classroom_activity.assigned_student_ids
+        let students = wrapper.state().classrooms[0].students
+        wrapper.instance().selectPreviouslyAssignedStudents();
+        let selectedStudents = []
+        students.forEach((stud)=> {
+          if (stud.isSelected) {
+            selectedStudents.push(stud.id)
+          }
+        });
+        expect(assignedStudents.sort((a,b)=> a - b)).toEqual(selectedStudents.sort((a,b)=> a - b))
+    })
     it('correctly marks when a missing student was assigned the activity', () => {
-      const newWrapper = mount( < ClassroomsWithStudentsContainer {...props}/>);
-        let assignedStudents = state.classrooms[0].classroom_activity.assigned_student_ids
-        assignedStudents = assignedStudents.concat(0)
-        newWrapper.setState(state)
+      const newWrapper = shallow( < ClassroomsWithStudentsContainer {...props}/>);
+      newWrapper.setState(_.cloneDeep(state))
+        let assignedStudents = newWrapper.state().classrooms[0].classroom_activity.assigned_student_ids
         newWrapper.instance().selectPreviouslyAssignedStudents();
         let students = newWrapper.state().classrooms[0].students
         let selectedStudents = []
@@ -450,7 +490,7 @@ describe('ClassroomsWithStudentsContainer container', () => {
             selectedStudents.push(stud.id)
           }
         });
-        expect(selectedStudents.length).toEqual(assignedStudents.length - 1)
+        expect(selectedStudents.length).toEqual(assignedStudents.length)
         expect(selectedStudents).not.toContain(0)
     })
   })


### PR DESCRIPTION
Once a user checked any new boxes on the Edit Students page, the save button became enabled, even if they then unchecked their changes. This branch adds some functions that check the new assigned student arrays against the original ones to see if real changes have been made.