### PR TITLE
Pin react_on_rails to avoid wonkiness

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,7 @@
     "react-datepicker": "^0.40.0",
     "react-dom": "^15.2.1",
     "react-markdown": "^2.4.6",
-    "react-on-rails": "^6.0.4",
+    "react-on-rails": "=6.5.0",
     "react-redux": "^4.4.1",
     "react-router": "^2.0.1",
     "redux": "^3.3.1",


### PR DESCRIPTION
At some version above 6.5.0, React on Rails moves where it stores the stringified configuration JSON blob from inside a hidden div to a data attribute on said div.