### PR TITLE
Fix #2480: hacky workarounds for fixing the og meta description on public activity pack pages

### DIFF
--- a/app/controllers/teachers/unit_templates_controller.rb
+++ b/app/controllers/teachers/unit_templates_controller.rb
@@ -6,15 +6,15 @@ class Teachers::UnitTemplatesController < ApplicationController
 
   def index
     respond_to do |format|
+      format.html do
+        redirect_to "/teachers/classrooms/activity_planner/featured-activity-packs/#{params[:id]}" if @is_teacher
+      end
+      
       format.json do
         render json: UnitTemplate.user_scope(current_user.try(:flag) || 'production')
                       .includes(:author, :unit_template_category)
                       .map{|ut| UnitTemplateSerializer.new(ut).as_json(root: false)}
                       .sort{ |ut| ut[:order_number] }.reverse
-      end
-
-      format.html do
-        redirect_to "/teachers/classrooms/activity_planner/featured-activity-packs/#{params[:id]}" if @is_teacher
       end
     end
   end

--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile.jsx
@@ -79,6 +79,7 @@
     if (this.state.loading) {
       return <LoadingIndicator />
     } else {
+      document.querySelector("meta[name='og:description']").content = `Check out the '${this.state.data.name}' activity pack I just assigned on Quill.org!`;
       return (
         <div className='unit-template-profile'>
           {this.showListFilterOptions()}


### PR DESCRIPTION
This doesn't _really_ fix it, but it at least removes the ugly JSON blob from the description.

We might want to think about how better to interact with head interactions between Rails and React.