### PR TITLE
restores missing report, all grade limits come from single source

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -17,7 +17,7 @@ class ChargesController < ApplicationController
     :receipt_email =>  params['source']['email']
   )
 
-  Subscription.start_premium(current_user) if charge
+  Subscription.start_premium(current_user.id) if charge
 
   respond_to  do |format|
     format.json { render :json => {route: premium_redirect}}

--- a/app/helpers/scorebook_helper.rb
+++ b/app/helpers/scorebook_helper.rb
@@ -3,15 +3,17 @@ module ScorebookHelper
 
 
   def percentage_color(score)
+    proficiency_cutoff = ProficiencyEvaluator.proficiency_cutoff
+    near_proficiency_cutoff = ProficiencyEvaluator.near_proficiency_cutoff
     return 'gray' unless score
     score = score.to_f / 100.0 if score > 1
     score = score.round(2)
     case score
-    when 0.8..1.0
+    when proficiency_cutoff..1.0
       'green'
-    when 0.6..0.79
+    when near_proficiency_cutoff...proficiency_cutoff
       'orange'
-    when 0.0..0.59
+    when 0.0...near_proficiency_cutoff
       'red'
     else
       'gray'

--- a/app/helpers/scorebook_helper.rb
+++ b/app/helpers/scorebook_helper.rb
@@ -4,16 +4,16 @@ module ScorebookHelper
 
   def percentage_color(score)
     proficiency_cutoff = ProficiencyEvaluator.proficiency_cutoff
-    near_proficiency_cutoff = ProficiencyEvaluator.near_proficiency_cutoff
+    nearly_proficient_cutoff = ProficiencyEvaluator.nearly_proficient_cutoff
     return 'gray' unless score
     score = score.to_f / 100.0 if score > 1
     score = score.round(2)
     case score
     when proficiency_cutoff..1.0
       'green'
-    when near_proficiency_cutoff...proficiency_cutoff
+    when nearly_proficient_cutoff...proficiency_cutoff
       'orange'
-    when 0.0...near_proficiency_cutoff
+    when 0.0...nearly_proficient_cutoff
       'red'
     else
       'gray'

--- a/app/models/activity_session.rb
+++ b/app/models/activity_session.rb
@@ -129,16 +129,7 @@ class ActivitySession < ActiveRecord::Base
   end
 
   def percentile
-    case percentage
-    when 0.75..1.0
-      1.0
-    when 0.5..0.75
-      0.75
-    when 0.0..0.5
-      0.5
-    else
-      0.0
-    end
+    ProficiencyEvaluator.lump_into_center_of_proficiency_band(percentage)
   end
 
   def percentage_as_percent_prefixed_by_scored

--- a/app/models/concerns/proficiency_evaluator.rb
+++ b/app/models/concerns/proficiency_evaluator.rb
@@ -2,12 +2,16 @@ module ProficiencyEvaluator
   extend ActiveSupport::Concern
 
   def self.proficiency_cutoff
-    0.8
+    cutoffs_hash['proficient']
+  end
+
+  def self.nearly_proficient_cutoff
+    cutoffs_hash['nearly_proficient']
   end
 
   def self.proficient_and_not_sql
-    "SUM(CASE WHEN user_info.average_score >= 0.8 THEN 1 ELSE 0 END) as proficient_student_count,
-     SUM(CASE WHEN user_info.average_score < 0.8 THEN 1 ELSE 0 END) as not_proficient_student_count"
+    "SUM(CASE WHEN user_info.average_score >= #{proficiency_cutoff} THEN 1 ELSE 0 END) as proficient_student_count,
+     SUM(CASE WHEN user_info.average_score < #{proficiency_cutoff} THEN 1 ELSE 0 END) as not_proficient_student_count"
   end
 
   def self.evaluate(score)
@@ -18,17 +22,24 @@ module ProficiencyEvaluator
     end
   end
 
-  def lump_into_center_of_proficiency_band(percentage)
+  def self.lump_into_center_of_proficiency_band(percentage)
     case percentage
     when proficiency_cutoff..1.0
-      1.0
-    when 0.6...0.8
-      0.75
-    when 0.0...0.6
-      0.5
+      (proficiency_cutoff + 1) / 2
+    when nearly_proficient_cutoff...proficiency_cutoff
+      (proficiency_cutoff + nearly_proficient_cutoff) / 2
+    when 0.0...nearly_proficient_cutoff
+      nearly_proficient_cutoff / 2
     else
       0.0
     end
+  end
+
+
+  private
+
+  def self.cutoffs_hash
+    JSON.parse(File.read(Rails.root.join('lib', 'proficiency_cutoffs.json')))
   end
 
 

--- a/app/models/concerns/proficiency_evaluator.rb
+++ b/app/models/concerns/proficiency_evaluator.rb
@@ -1,0 +1,36 @@
+module ProficiencyEvaluator
+  extend ActiveSupport::Concern
+
+  def self.proficiency_cutoff
+    0.8
+  end
+
+  def self.proficient_and_not_sql
+    "SUM(CASE WHEN user_info.average_score >= 0.8 THEN 1 ELSE 0 END) as proficient_student_count,
+     SUM(CASE WHEN user_info.average_score < 0.8 THEN 1 ELSE 0 END) as not_proficient_student_count"
+  end
+
+  def self.evaluate(score)
+    if score >= proficiency_cutoff
+      return "Proficient"
+    else
+      return "Not Yet Proficient"
+    end
+  end
+
+  def lump_into_center_of_proficiency_band(percentage)
+    case percentage
+    when proficiency_cutoff..1.0
+      1.0
+    when 0.6...0.8
+      0.75
+    when 0.0...0.6
+      0.5
+    else
+      0.0
+    end
+  end
+
+
+
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -4,6 +4,10 @@ class School < ActiveRecord::Base
   validate :lower_grade_within_bounds, :upper_grade_within_bounds,
            :lower_grade_greater_than_upper_grade
 
+  def grant_premium_to_users
+    self.users.each{|u| Subscription.start_premium(u.id)}
+  end
+
   private
 
   def lower_grade_within_bounds

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,15 +3,15 @@ class Subscription < ActiveRecord::Base
   validates :expiration, presence: true
   validates :account_limit, presence: true
 
-  def self.start_premium current_user
-    subscription = Subscription.find_by_user_id current_user.id
+  def self.start_premium user_id
+    subscription = Subscription.find_by_user_id user_id
     # if a subscription already exists, we just update it by adding an additional 365 days to the expiration
     if subscription
-      subscription.update(expiration: [subscription.expiration + 365, Date.new(2018, 7, 1)].max, account_limit: 1000, account_type: 'paid')
+      subscription.update!(expiration: [subscription.expiration + 365, Date.new(2018, 7, 1)].max, account_limit: 1000, account_type: 'paid')
     else
-      self.create(user_id: current_user.id, expiration: [Date.today + 365, Date.new(2018, 7, 1)].max, account_limit: 1000, account_type: 'paid')
+      self.create!(user_id: user_id, expiration: [Date.today + 365, Date.new(2018, 7, 1)].max, account_limit: 1000, account_type: 'paid')
     end
-    PremiumAnalyticsWorker.perform_async(current_user.id, 'paid')
+    PremiumAnalyticsWorker.perform_async(user_id, 'paid')
   end
 
   def is_not_paid?

--- a/app/queries/progress_reports/standards/classroom.rb
+++ b/app/queries/progress_reports/standards/classroom.rb
@@ -5,15 +5,12 @@ class ProgressReports::Standards::Classroom
 
   def results(filters)
     Classroom.with(user_info: ProgressReports::Standards::Student.new(@teacher).results(filters))
-      .select(<<-SQL
+      .select("
         classrooms.name as name,
         classrooms.id as id,
         classrooms.teacher_id,
         COUNT(DISTINCT(user_info.id)) as total_student_count,
-        SUM(CASE WHEN user_info.average_score > 0.75 THEN 1 ELSE 0 END) as proficient_student_count,
-        SUM(CASE WHEN user_info.average_score >= 0.50 AND user_info.average_score <= 0.75 THEN 1 ELSE 0 END) as near_proficient_student_count,
-        SUM(CASE WHEN user_info.average_score <= 0.75 THEN 1 ELSE 0 END) as not_proficient_student_count
-      SQL
+        #{ProficiencyEvaluator.proficient_and_not_sql}"
       )
       .where(teacher: @teacher)
       .joins(:students)

--- a/app/serializers/progress_reports/standards/classroom_serializer.rb
+++ b/app/serializers/progress_reports/standards/classroom_serializer.rb
@@ -4,7 +4,6 @@ class ProgressReports::Standards::ClassroomSerializer  < ActiveModel::Serializer
   attributes :name,
              :total_student_count,
              :proficient_student_count,
-             :near_proficient_student_count,
              :not_proficient_student_count,
              :total_standard_count,
              :students_href,

--- a/app/serializers/progress_reports/standards/student_serializer.rb
+++ b/app/serializers/progress_reports/standards/student_serializer.rb
@@ -27,6 +27,7 @@ class ProgressReports::Standards::StudentSerializer < ActiveModel::Serializer
 
   def mastery_status
     if average_score >= 0.75
+    # consolidate me
       "Proficient"
     else
       "Not Yet Proficient"

--- a/app/serializers/progress_reports/standards/student_serializer.rb
+++ b/app/serializers/progress_reports/standards/student_serializer.rb
@@ -26,11 +26,7 @@ class ProgressReports::Standards::StudentSerializer < ActiveModel::Serializer
   end
 
   def mastery_status
-    if average_score >= 0.75
-    # consolidate me
-      "Proficient"
-    else
-      "Not Yet Proficient"
-    end
+    ProficiencyEvaluator.evaluate(average_score)
   end
+
 end

--- a/app/serializers/progress_reports/standards/topic_serializer.rb
+++ b/app/serializers/progress_reports/standards/topic_serializer.rb
@@ -28,6 +28,7 @@ class ProgressReports::Standards::TopicSerializer < ActiveModel::Serializer
 
   def mastery_status
     if average_score >= 0.75
+    # consolidate me
       "Proficient"
     else
       "Not Yet Proficient"

--- a/app/serializers/progress_reports/standards/topic_serializer.rb
+++ b/app/serializers/progress_reports/standards/topic_serializer.rb
@@ -8,7 +8,6 @@ class ProgressReports::Standards::TopicSerializer < ActiveModel::Serializer
              :section_name,
              :total_student_count,
              :proficient_student_count,
-             :near_proficient_student_count,
              :not_proficient_student_count,
              :total_activity_count,
              :average_score,
@@ -27,11 +26,7 @@ class ProgressReports::Standards::TopicSerializer < ActiveModel::Serializer
   end
 
   def mastery_status
-    if average_score >= 0.75
-    # consolidate me
-      "Proficient"
-    else
-      "Not Yet Proficient"
-    end
+    ProficiencyEvaluator.evaluate(average_score)
   end
+
 end

--- a/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
@@ -8,7 +8,6 @@ export default React.createClass({
 
   circleClass: function() {
     if (this.props.score > cutOff.proficient) {
-    // consolidate me
       return 'circle proficient';
     } else {
       return 'circle not-proficient';
@@ -17,7 +16,6 @@ export default React.createClass({
 
   text: function() {
     if (this.props.score > cutOff.proficient) {
-    // consolidate me
       return 'Proficient';
     } else {
       return 'Not Yet Proficient';

--- a/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
@@ -7,6 +7,7 @@ export default React.createClass({
 
   circleClass: function() {
     if (this.props.score > 0.75) {
+    // consolidate me
       return 'circle proficient';
     } else {
       return 'circle not-proficient';
@@ -15,6 +16,7 @@ export default React.createClass({
 
   text: function() {
     if (this.props.score > 0.75) {
+    // consolidate me
       return 'Proficient';
     } else if (this.props.score <= 0.75) {
       return 'Not Yet Proficient';

--- a/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/mastery_status.jsx
@@ -1,12 +1,13 @@
-"use strict";
+'use strict';
 import React from 'react'
+import cutOff from '../../../../modules/proficiency_cutoffs.js'
 export default React.createClass({
   propTypes: {
     score: React.PropTypes.number.isRequired
   },
 
   circleClass: function() {
-    if (this.props.score > 0.75) {
+    if (this.props.score > cutOff.proficient) {
     // consolidate me
       return 'circle proficient';
     } else {
@@ -15,10 +16,10 @@ export default React.createClass({
   },
 
   text: function() {
-    if (this.props.score > 0.75) {
+    if (this.props.score > cutOff.proficient) {
     // consolidate me
       return 'Proficient';
-    } else if (this.props.score <= 0.75) {
+    } else {
       return 'Not Yet Proficient';
     }
   },

--- a/client/app/bundles/HelloWorld/components/progress_reports/standards_topic_students_progress_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/standards_topic_students_progress_report.jsx
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 import React from 'react'
 import ProgressReport from './progress_report.jsx'
 import MasteryStatus from './mastery_status.jsx'
@@ -71,9 +71,11 @@ export default  React.createClass({
   },
 
   onFetchSuccess: function(responseData) {
-    this.setState({
-      topic: responseData.topic
-    });
+    if (responseData.topics && responseData.topics.length) {
+      this.setState({
+        topic: responseData.topics[0]
+      });
+    }
   },
 
   render: function() {
@@ -87,7 +89,7 @@ export default  React.createClass({
                          onFetchSuccess={this.onFetchSuccess}
                          filterTypes={['unit']}
                          premiumStatus={this.props.premiumStatus}>
-        <h2>Standards: {this.state.topic.name}</h2>
+        <h2>Standard: {this.state.topic.name}</h2>
       </ProgressReport>
     );
   }

--- a/client/app/bundles/HelloWorld/components/scorebook/score_legend.jsx
+++ b/client/app/bundles/HelloWorld/components/scorebook/score_legend.jsx
@@ -1,7 +1,10 @@
-"use strict";
+'use strict';
 import React from 'react'
+import {proficiencyCutoffsAsPercentage} from '../../../../modules/proficiency_cutoffs.js'
+
 export default React.createClass({
 	render: function () {
+		const cutOff = proficiencyCutoffsAsPercentage();
 		return (
 			 <div className="icons-wrapper icon-legend score-legend">
 		        <div className="row no-pl">
@@ -10,21 +13,21 @@ export default React.createClass({
 		              <div className="icon-wrapper icon-green"></div>
 		              <div className="icons-description-wrapper">
 		                <p className="title">At Proficiency</p>
-		                <p className="explanation">80-100%</p>
+		                <p className="explanation">{`${cutOff.proficient}-100%`}</p>
 		              </div>
 		            </div>
 		            <div className="col-xs-6 col-sm-3 col-xl-3 no-pl">
 		              <div className="icon-wrapper icon-orange"></div>
 		              <div className="icons-description-wrapper">
 		                <p className="title">Nearly Proficient</p>
-		                <p className="explanation">60-79%</p>
+		                <p className="explanation">{`${cutOff.nearlyProficient}-${cutOff.proficient - 1}%`}</p>
 		              </div>
 		            </div>
 		            <div className="col-xs-6 col-sm-3 col-xl-3 no-pl">
 		              <div className="icon-wrapper icon-red"></div>
 		              <div className="icons-description-wrapper">
 		                <p className="title">Not Yet Proficient</p>
-		                <p className="explanation">0-59%</p>
+		                <p className="explanation">{`0-${cutOff.nearlyProficient - 1}%`}</p>
 		              </div>
 		            </div>
 		            <div className="col-xs-6 col-sm-3 col-xl-3 no-pl">

--- a/client/app/bundles/HelloWorld/containers/ProgressReportIndex.jsx
+++ b/client/app/bundles/HelloWorld/containers/ProgressReportIndex.jsx
@@ -3,7 +3,7 @@ import StandardsAllClassroomsProgressReport from '../components/progress_reports
 import StandardsClassroomStudentsProgressReport from '../components/progress_reports/standards_classroom_students_progress_report.jsx'
 import StandardsTopicsProgressReport from '../components/progress_reports/standards_topics_progress_report.jsx'
 import StandardsClassroomTopicsProgressReport from '../components/progress_reports/standards_classroom_topics_progress_report.jsx'
-import StandardsTopicStudentsProgressReport from '../components/progress_reports/standards_topics_progress_report.jsx'
+import StandardsTopicStudentsProgressReport from '../components/progress_reports/standards_topic_students_progress_report.jsx'
 import ConceptsStudentsProgressReport from '../components/progress_reports/concepts_students_progress_report.jsx'
 import ConceptsConceptsProgressReport from '../components/progress_reports/concepts_concepts_progress_report.jsx'
 import PremiumBannerBuilder from '../components/scorebook/premium_banners/premium_banner_builder'

--- a/client/app/modules/proficiency_cutoffs.js
+++ b/client/app/modules/proficiency_cutoffs.js
@@ -1,0 +1,12 @@
+import proficiency_cutoffs from '../../../lib/proficiency_cutoffs.json'
+
+export function proficiencyCutoffsAsPercentage(){
+  return (
+    {
+      proficient: proficiency_cutoffs.proficient * 100,
+      nearlyProficient: proficiency_cutoffs.nearly_proficient * 100
+  })
+}
+
+
+export default proficiency_cutoffs

--- a/lib/proficiency_cutoffs.json
+++ b/lib/proficiency_cutoffs.json
@@ -1,0 +1,1 @@
+{"proficient": 0.8, "nearly_proficient": 0.6}

--- a/spec/helpers/scorebook_helper_spec.rb
+++ b/spec/helpers/scorebook_helper_spec.rb
@@ -8,9 +8,15 @@ describe ScorebookHelper, type: :helper do
       end
     end
 
-    context 'when the score is > 79%' do
-      it 'is orange' do
-        expect(helper.percentage_color(0.80)).to eq('green')
+    context "when the score is greater than the proficiency cut off of  > #{ProficiencyEvaluator.proficiency_cutoff}" do
+      it 'is green' do
+        expect(helper.percentage_color(ProficiencyEvaluator.proficiency_cutoff + 0.01)).to eq('green')
+      end
+    end
+
+    context "when the score is equal to the proficiency cut off of #{ProficiencyEvaluator.proficiency_cutoff}" do
+      it 'is green' do
+        expect(helper.percentage_color(ProficiencyEvaluator.proficiency_cutoff)).to eq('green')
       end
     end
 
@@ -24,21 +30,22 @@ describe ScorebookHelper, type: :helper do
       end
     end
 
-    context 'when the score is 75%' do
+    context "when the score is equal to nearly proficiency cutoff of #{ProficiencyEvaluator.nearly_proficient_cutoff}" do
       it 'is orange' do
-        expect(helper.percentage_color(0.75)).to eq('orange')
+        expect(helper.percentage_color(ProficiencyEvaluator.nearly_proficient_cutoff)).to eq('orange')
       end
     end
 
-    context 'when the score is 59%' do
+    context "when the score is less than the nearly proficiency cutoff of #{ProficiencyEvaluator.nearly_proficient_cutoff}" do
       it 'is red' do
-        expect(helper.percentage_color(0.59)).to eq('red')
+        expect(helper.percentage_color(ProficiencyEvaluator.nearly_proficient_cutoff - 0.1)).to eq('red')
       end
     end
 
-    context 'when the score is < 59%' do
-      it 'is red' do
-        expect(helper.percentage_color(0.49)).to eq('red')
+    context "when the score is between the greater than the nearly proficiency cutoff, but less than the proficient cutoff" do
+      it 'is orange' do
+        between_score = (ProficiencyEvaluator.nearly_proficient_cutoff + ProficiencyEvaluator.proficiency_cutoff) / 2
+        expect(helper.percentage_color(between_score)).to eq('orange')
       end
     end
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 describe School, type: :model do
+  let!(:bk_school) { FactoryGirl.create :school, name: "Brooklyn Charter School", zipcode: '11206'}
+  let!(:queens_school) { FactoryGirl.create :school, name: "Queens Charter School", zipcode: '11385'}
+  let!(:bk_teacher) { FactoryGirl.create(:teacher, schools: [bk_school]) }
+  let!(:bk_teacher_colleague) { FactoryGirl.create(:teacher, schools: [bk_school]) }
+  let!(:queens_teacher) { FactoryGirl.create(:teacher, schools: [queens_school]) }
+
   describe 'validations' do
     before do
       @school = School.new
@@ -45,6 +51,22 @@ describe School, type: :model do
 
       expect(@school.valid?).to eq(false)
       expect(@school.errors[:lower_grade]).to eq([ 'must be less than or equal to upper grade' ])
+    end
+
+  end
+
+
+  describe '#grant_premium_to_users' do
+
+    it "gives premium to all of a schools users" do
+      expect(bk_school.users.map(&:subscriptions).flatten.any?).to eq(false)
+      bk_school.grant_premium_to_users
+      expect(bk_school.users.reload.map(&:subscriptions).flatten.count).to eq(bk_school.users.count)
+    end
+
+    it 'does not give premium to users of other schools' do
+      bk_school.grant_premium_to_users
+      expect(queens_school.users.map(&:subscriptions).flatten.any?).to eq(false)
     end
 
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -6,7 +6,7 @@ describe Subscription, type: :model do
     let!(:subscription) { FactoryGirl.create(:subscription, user: user) }
 
     it "updates the expirary to the later of one year from today or July 1, 2018" do
-        Subscription.start_premium(user)
+        Subscription.start_premium(user.id)
         july_1_2017 = Date.new(2017, 7, 1)
         expected_date = [Date.today, july_1_2017].max + 365
         expect(subscription.reload.expiration).to eq(expected_date)
@@ -18,12 +18,12 @@ describe Subscription, type: :model do
 
     it "creates one" do
       expect {
-        Subscription.start_premium(user)
+        Subscription.start_premium(user.id)
       }.to change { Subscription.count }.by(1)
     end
 
     it "gives the subscription an expiration of to the later of one year from today or July 1, 2018" do
-      Subscription.start_premium(user)
+      Subscription.start_premium(user.id)
       july_1_2017 = Date.new(2017, 7, 1)
       expected_date = [Date.today, july_1_2017].max + 365
       expect(user.reload.subscriptions.last.expiration).to eq(expected_date)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -56,7 +56,6 @@ describe Topic, type: :model do
       expect(found_topics[0].name).to be_present
       expect(found_topics[0].total_student_count).to be_present
       expect(found_topics[0].proficient_student_count).to be_present
-      expect(found_topics[0].near_proficient_student_count).to be_present
       expect(found_topics[0].not_proficient_student_count).to be_present
       expect(found_topics[0].total_activity_count).to be_present
       expect(found_topics[0].average_score).to be_present

--- a/spec/queries/progress_reports/standards/classroom_spec.rb
+++ b/spec/queries/progress_reports/standards/classroom_spec.rb
@@ -15,7 +15,6 @@ describe ProgressReports::Standards::Classroom do
       expect(classrooms[0]["id"]).to eq(classrooms.first.id)
       expect(classrooms[0]["total_student_count"]).to eq(classrooms.first.total_student_count)
       expect(classrooms[0]["proficient_student_count"]).to eq(classrooms.first.proficient_student_count)
-      expect(classrooms[0]["near_proficient_student_count"]).to eq(classrooms.first.near_proficient_student_count)
       expect(classrooms[0]["not_proficient_student_count"]).to eq(classrooms.first.not_proficient_student_count)
       # expect(classrooms[0]["total_standard_count"]).to eq(classrooms.first.total_standard_count)
     end

--- a/spec/serializers/progress_reports/standards/classroom_serializer_spec.rb
+++ b/spec/serializers/progress_reports/standards/classroom_serializer_spec.rb
@@ -27,7 +27,6 @@ describe ProgressReports::Standards::ClassroomSerializer, type: :serializer do
         .to match_array %w(name
                            total_student_count
                            proficient_student_count
-                           near_proficient_student_count
                            not_proficient_student_count
                            total_standard_count
                            students_href

--- a/spec/serializers/progress_reports/standards/topic_serializer_spec.rb
+++ b/spec/serializers/progress_reports/standards/topic_serializer_spec.rb
@@ -35,7 +35,6 @@ describe ProgressReports::Standards::TopicSerializer, type: :serializer do
                            section_name
                            total_student_count
                            proficient_student_count
-                           near_proficient_student_count
                            not_proficient_student_count
                            total_activity_count
                            average_score


### PR DESCRIPTION
merge PR #2522 first

restores missing concepts report as per issue #2503 

adds a json file, with the cut offs for proficient and nearly proficient, from which both the front and back end both get the numbers