### PR TITLE
fix #2586 - Chinese to Mandarin in list of languages on home and diagnostic pages

### DIFF
--- a/app/views/pages/diagnostic_tool.erb
+++ b/app/views/pages/diagnostic_tool.erb
@@ -41,7 +41,7 @@
                     <p>
                         Our new ELL Diagnostic assesses your students’ knowledge of 10 different concepts specifically chosen for English language learners. The diagnostic also offers directions in
                         <img src="/images/flags/spain.png">Spanish,
-                        <img src="/images/flags/china.png">Chinese,
+                        <img src="/images/flags/china.png">Mandarin,
                         <img src="/images/flags/france.png">French,<br/>
                         <img src="/images/flags/vietnam.png">Vietnamese,
                         <img src="/images/flags/egypt.png">Arabic, and
@@ -106,7 +106,7 @@
                     <p>
                         Our new ELL Diagnostic assesses your students’ knowledge of 10 different concepts specifically chosen for English language learners. The diagnostic also offers directions in
                         <img src="/images/flags/spain.png">Spanish,
-                        <img src="/images/flags/china.png">Chinese,
+                        <img src="/images/flags/china.png">Mandarin,
                         <img src="/images/flags/france.png">French,
                         <img src="/images/flags/vietnam.png">Vietnamese,
                         <img src="/images/flags/egypt.png">Arabic, and

--- a/app/views/pages/home_new.html.erb
+++ b/app/views/pages/home_new.html.erb
@@ -60,15 +60,19 @@
         <a href="/tools/diagnostic/" target="_blank" class="q-button text-white learn-more-button">Learn More</a>
       </div>
       <div class="ell-section">
-        <span class="header">Quill's new ELL Diagnostic includes translations in:</span>
-        <span class="flags">
-          <img src="/images/flags/spain.png">Spanish
-          <img src="/images/flags/china.png">Chinese
-          <img src="/images/flags/france.png">French
-          <img src="/images/flags/vietnam.png">Vietnamese
-          <img src="/images/flags/egypt.png">Arabic
-          <img src="/images/flags/india.png">Hindi
-        </span>
+        <div class="header">Quill's new ELL Diagnostic includes translations in:</div>
+        <div class="flags">
+          <span>
+            <img src="/images/flags/spain.png">Spanish
+            <img src="/images/flags/china.png">Mandarin
+            <img src="/images/flags/france.png">French
+          </span>
+          <span>
+            <img src="/images/flags/vietnam.png">Vietnamese
+            <img src="/images/flags/egypt.png">Arabic
+            <img src="/images/flags/india.png">Hindi
+          </span>
+        </div>
       </div>
     </div>
 

--- a/client/app/assets/styles/home.scss
+++ b/client/app/assets/styles/home.scss
@@ -143,11 +143,8 @@ $list: (quillgreen: $quillgreen, quillred: $quillred, quillnavbar: $quillnavbar,
     }
     .ell-section {
       height: 66px;
-      width: 490px;
+      max-width: 490px;
       margin-top: 35px;
-      span {
-        display: block;
-      }
       .header {
         line-height: 28px;
         border-top-left-radius: 4px;
@@ -157,6 +154,10 @@ $list: (quillgreen: $quillgreen, quillred: $quillred, quillnavbar: $quillnavbar,
         font-size: 12px;
         padding-left: 9px;
         border-bottom: solid 1px #ff4441;
+        width: 465px;
+        @media (max-width: 1150px) {
+          width: 276px;
+        }
       }
       .flags {
         border-bottom-left-radius: 4px;
@@ -166,6 +167,14 @@ $list: (quillgreen: $quillgreen, quillred: $quillred, quillnavbar: $quillnavbar,
         font-size: 14px;
         line-height: 38px;
         text-align: center;
+        width: 474px;
+        @media (max-width: 1150px) {
+          width: 285px;
+          line-height: 24px;
+          span {
+            display: block;
+          }
+        }
         img {
           width: 16px;
           margin-left: 5px;


### PR DESCRIPTION
This branch also resizes the ELL diagnostic section on the mobile homepage. 