### PR TITLE
fix #2599 - results page does not show results if activity was a diagnostic

### DIFF
--- a/client/app/bundles/HelloWorld/containers/ResultsPage.jsx
+++ b/client/app/bundles/HelloWorld/containers/ResultsPage.jsx
@@ -39,6 +39,18 @@ export default React.createClass({
     );
   },
 
+  resultsSection: function() {
+    if (this.props.activityType === 'diagnostic') {
+      return <span/>
+    } else {
+      return <div className='bottom-section'>
+                <div className='results-wrapper'>
+                  <StudentResultsTables results={this.props.results}/>
+                </div>
+              </div>
+    }
+  },
+
   render: function() {
     return (
       <div
@@ -51,11 +63,7 @@ export default React.createClass({
             activityType={this.props.activityType}/>
           {this.headerMessage()}
         </div>
-        <div className='bottom-section'>
-          <div className='results-wrapper'>
-            <StudentResultsTables results={this.props.results}/>
-          </div>
-        </div>
+        {this.resultsSection()}
       </div>
     );
   }

--- a/client/app/bundles/HelloWorld/containers/__tests__/ResultsPage.test.jsx
+++ b/client/app/bundles/HelloWorld/containers/__tests__/ResultsPage.test.jsx
@@ -19,6 +19,15 @@ describe('ResultsPage container', () => {
 
   const wrapperAnonymous = shallow(<ResultsPage anonymous={true} />);
 
+  const wrapperDiagnostic = shallow(
+    <ResultsPage
+        activityName='Diagnostic'
+        percentage={94}
+        activityType='diagnostic'
+        results={{foo: 'bar'}}
+      />
+)
+
   it('should render ResultsIcon component with correct percentage and activity type', () => {
     expect(wrapperNotAnonymous.find(ResultsIcon).exists()).toBe(true);
     expect(wrapperNotAnonymous.find(ResultsIcon).props().percentage).toBe(94);
@@ -39,9 +48,13 @@ describe('ResultsPage container', () => {
     expect(wrapperNotAnonymous.find('a').text()).toMatch('Back to Your Dashboard');
   });
 
-  it('should render StudentResultsTables component with correct results', () => {
+  it('should render StudentResultsTables component with correct results if it is not a diagnostic', () => {
     expect(wrapperNotAnonymous.find(StudentResultsTables).exists()).toBe(true);
     expect(wrapperNotAnonymous.find(StudentResultsTables).props().results.foo).toBe('bar');
+  });
+
+  it('should not render StudentResultsTables component if it is a diagnostic', () => {
+    expect(wrapperDiagnostic.find(StudentResultsTables).exists()).toBe(false);
   });
 
 });


### PR DESCRIPTION
This PR fixes the problem listed in the title, which is referred to in issue #2599. Almost all of the other bullets listed in that issue are closed in Connect PR #490, found at https://github.com/empirical-org/Quill-Connect/pull/490.