### PR TITLE
fix #2623 - remove location.reload from unit template profile; scrolltop now works

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile.jsx
@@ -24,15 +24,15 @@
    }
 
   componentDidMount() {
-    this.getProfileInfo()
+    this.getProfileInfo(this.props.params.activityPackId)
   }
 
-  getProfileInfo() {
+  getProfileInfo(id) {
     const that = this;
     $.ajax({
       type: 'get',
       datatype: 'json',
-      data: {id: this.props.params.activityPackId},
+      data: {id: id},
       url: '/teachers/unit_templates/profile_info',
       statusCode: {
         200: function(response) {
@@ -43,8 +43,9 @@
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.params.activityPackId !== nextProps.params.activityPackId) {
-      location.reload()
+    if (this.props.location !== nextProps.location) {
+      this.setState({loading: true})
+      this.getProfileInfo(nextProps.params.activityPackId)
     }
   }
 

--- a/client/app/bundles/HelloWorld/components/shared/scroll_to_top.jsx
+++ b/client/app/bundles/HelloWorld/components/shared/scroll_to_top.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 export default class ScrollToTop extends React.Component {
- constructor() {
-   super()
+  constructor() {
+    super()
     window.scrollTo(0, 0)
   }
 


### PR DESCRIPTION
The location.reload() being called in the componentWillReceiveProps method of the Unit Template Profile component was occasionally interfering with the scroll reset method, as well as slowing down the render time for the Unit Template pages. That method has been refactored and both problems are now resolved.