### PR TITLE
fix #2584 - teachers choose students before assigning diagnostics

### DIFF
--- a/app/assets/stylesheets/pages/diagnostic-planner.scss
+++ b/app/assets/stylesheets/pages/diagnostic-planner.scss
@@ -202,6 +202,9 @@ $green: #00c2a2;
                 text-align: center;
             }
         }
+        .panel-group {
+          text-align: left;
+        }
     }
     #intro-page {
         #preview {

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
@@ -42,13 +42,13 @@ export default React.createClass({
         return (
             <div id='intro-page'>
                 <div>
-                    <h2>Would you like to preview the {diagnosticName} diagnostic?</h2>
+                    <h2>Would you like to preview the {diagnosticName} Diagnostic?</h2>
                       {/*<span>
                       <DropdownButton bsStyle='default' title={this.state.selectedGrade || 'st'} id='select-grade' onSelect={this.handleSelect}>
                         {this.grades()}
                       </DropdownButton>
                         </span>grade */}
-                      <span id='subtext'>You'll be previewing the diagnostic as a student and will be able to assign at any time.</span>
+                      <span id='subtext'>You'll be previewing the diagnostic as a student and will be able to assign it at any time.</span>
                 </div>
                 <a href={`/activity_sessions/anonymous?activity_id=${activityId}`} target='_blank'><button id='preview' className='button-green'>Preview the Diagnostic</button></a>
                 <br/>

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/__test__/ClassroomPage.test.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/__test__/ClassroomPage.test.jsx
@@ -2,13 +2,20 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 import ClassroomPage from '../ClassroomPage';
+import Classroom from '../../../lesson_planner/create_unit/stage2/classroom'
+
 import Modal from 'react-bootstrap/lib/Modal';
 
 const classroom = {checked: false,
                   code: 'royal-act',
                   grade: null,
                   id: 726,
-                  name: 'Sample Class'}
+                  name: 'Sample Class',
+                  students: [
+                    {id: 1}, {id: 2}, {id: 3}
+                  ],
+                  selectedStudentIds: []
+                }
 
 describe('ClassroomPage component', () => {
   it('renders a classroom table with the same number of rows as classrooms', () => {
@@ -16,8 +23,7 @@ describe('ClassroomPage component', () => {
         <ClassroomPage/>
     );
     wrapper.setState({classrooms: [classroom]}, () => wrapper.setState({loading: false}))
-    expect(wrapper.find('#classroom-table-wrapper')).toHaveLength(1)
-    expect(wrapper.find('.classroom-row')).toHaveLength(wrapper.state('classrooms').length)
+    expect(wrapper.find(Classroom)).toHaveLength(wrapper.state('classrooms').length)
   })
 
   describe('when no classes are selected', () => {
@@ -40,7 +46,7 @@ describe('ClassroomPage component', () => {
         <ClassroomPage/>
     );
     wrapper.setState({classrooms: [classroom]}, () => wrapper.setState({loading: false}))
-    wrapper.find('.css-checkbox').simulate('change')
+    wrapper.find('.css-checkbox').first().simulate('change')
 
     it('sets the checked property of the classroom object in state to be true', () => {
       expect(wrapper.state('classrooms')[0].checked).toBe(true)
@@ -55,13 +61,13 @@ describe('ClassroomPage component', () => {
     })
   })
 
-  describe('when a checkbox is unselected', () => {
+  describe('when a classroom checkbox is unselected', () => {
     const wrapper = mount(
         <ClassroomPage/>
     );
     const checkedClassroom = {...classroom, checked: true}
     wrapper.setState({classrooms: [checkedClassroom], hiddenButton: false, selectedClassrooms: [checkedClassroom]}, () => wrapper.setState({loading: false}))
-    wrapper.find('.css-checkbox').simulate('change')
+    wrapper.find('.css-checkbox').first().simulate('change')
 
     it('sets the checked property of the classroom object in state to be false', () => {
       expect(wrapper.state('classrooms')[0].checked).toBe(false)
@@ -70,6 +76,36 @@ describe('ClassroomPage component', () => {
     it('removes the classroom object from the selectedClassrooms array in state', () => {
       expect(wrapper.state('selectedClassrooms')).toEqual([])
     })
+
+  })
+
+  describe('when a student checkbox is selected', () => {
+    const wrapper = mount(
+        <ClassroomPage/>
+    );
+    // const checkedStudentClassroom = _.cloneDeep(classroom)
+    // checkedStudentClassroom.students[0].isSelected = true
+    // wrapper.setState({classrooms: checkedStudentClassroom})
+        wrapper.setState({classrooms: [classroom]}, () => wrapper.setState({loading: false}))
+        wrapper.find('.css-checkbox').at(1).simulate('change')
+
+        const student = wrapper.state('classrooms')[0]['students'][0]
+
+        it('sets the isSelected property of the student in the classroom object in state to be true', () => {
+          expect(student.isSelected).toBe(true)
+        })
+
+        it('adds the student id to the selectedStudentIds array of the classrom object in state', () => {
+          expect(wrapper.state('classrooms')[0].selectedStudentIds).toEqual([student.id])
+        })
+
+        it('adds the classroom object to the selectedClassrooms array in state', () => {
+          expect(wrapper.state('selectedClassrooms')[0].id).toEqual(wrapper.state('classrooms')[0].id)
+        })
+
+        it('sets the hiddenButton state to be false', () => {
+          expect(wrapper.state('hiddenButton')).toBe(false)
+        })
 
   })
 


### PR DESCRIPTION
This branch incorporates the classroom checkbox component (the one that expands to reveal the checklist of all students in the class) into the ClassroomPage component used in the diagnostic assignment page, so that teachers can assign the diagnostic to specific students instead of being required to select the entire class.