### PR TITLE
Fix/assign previous activities

### DIFF
--- a/app/models/concerns/student.rb
+++ b/app/models/concerns/student.rb
@@ -105,10 +105,10 @@ module Student
       assignable = students_classrooms.map do |classroom|
         get_assignable_classroom_activities_for_classroom(classroom)
       end
-      start = Time.now
       if assignable.any?
         begin
-          ActivitySession.bulk_insert values: assignable.flatten
+          # binding.pry
+          ActivitySession.bulk_insert values: assignable.flatten.compact
         rescue NoMethodError
           puts 'rescue from no method error in assign_classroom_activities'
         end

--- a/app/models/concerns/student.rb
+++ b/app/models/concerns/student.rb
@@ -107,7 +107,6 @@ module Student
       end
       if assignable.any?
         begin
-          # binding.pry
           ActivitySession.bulk_insert values: assignable.flatten.compact
         rescue NoMethodError
           puts 'rescue from no method error in assign_classroom_activities'


### PR DESCRIPTION
the bulk insert was crashing due to a nil value in `assignable`. Now it compacts the array to avoid this