### PR TITLE
hiding ca from manage units hides all cas in unit w same activity id

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -19,7 +19,9 @@ class Teachers::ClassroomActivitiesController < ApplicationController
   end
 
   def hide
-    @classroom_activity.update(visible: false)
+    cas = ClassroomActivity.where(activity: @classroom_activity.activity, unit: @classroom_activity.unit)
+    # cannot use update_all here bc we need the callbacks to run
+    cas.each { |ca| ca.try(:update_attributes, {visible: false}) }
     @classroom_activity.unit.hide_if_no_visible_classroom_activities
     render json: {}
   end


### PR DESCRIPTION
When hiding a classroom activity from the lesson planner, only one classroom activity was being hidden instead of every classroom activity with that activity id in that unit. This fixes that.