### PR TITLE
fix #2663 - units will be hidden when they have no classroom activities

### DIFF
--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -20,10 +20,8 @@ class Unit < ActiveRecord::Base
   default_scope { where(visible: true)}
   after_save :hide_classroom_activities_if_visible_false
 
-
-
   def hide_if_no_visible_classroom_activities
-    if  ClassroomActivity.unscoped.where(unit_id: self.id, visible: false).length == self.classroom_activities.length
+    if self.classroom_activities.length == 0
       self.update(visible: false)
     end
   end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -65,6 +65,7 @@ describe Unit, type: :model do
   describe '#hide_if_no_visible_classroom_activities' do
     it 'updates the unit to visible == false if all of its classroom activities are visible == false' do
       unit.classroom_activities.each{|ca| ca.update(visible: false)}
+      unit.reload
       unit.hide_if_no_visible_classroom_activities
       expect(unit.visible).to eq(false)
     end

--- a/spec/services/units/updater_spec.rb
+++ b/spec/services/units/updater_spec.rb
@@ -22,16 +22,10 @@ describe Units::Updater do
   # and array of student ids.
   # self.run(unit, activities_data, classrooms_data)
   describe 'the unit' do
-    it "is updates its visibility to false if all of its classroom activities are visibility false" do
-        classrooms_data = [{id: classroom.id, student_ids: false}]
-        Units::Updater.run(unit, activities_data, classrooms_data)
-        expect(unit.visible).to eq(false)
-    end
-
-    it "does not update visibility to false if any of its classroom activities are visible" do
-        classrooms_data = [{id: classroom.id, student_ids: [student.id]}]
-        Units::Updater.run(unit, activities_data, classrooms_data)
-        expect(unit.visible).to eq(true)
+    it "gets hide_if_no_visible_classroom_activities called on it" do
+      expect(unit).to receive(:hide_if_no_visible_classroom_activities)
+      classrooms_data = [{id: classroom.id, student_ids: [student.id]}]
+      Units::Updater.run(unit, activities_data, classrooms_data)
     end
   end
 


### PR DESCRIPTION
The method that was hiding units was checking the length of the unit's hidden classroom activities against their visible classroom activities, which would have had the fun effect of both a) not consistently hiding a unit when it had no classroom activities, and b) hiding the unit when half of its classroom activities were hidden. This should fix that.