### PR TITLE
Fix #2737: Update grade level dropdowns for consistency

### DIFF
--- a/app/views/teachers/students/index.html.erb
+++ b/app/views/teachers/students/index.html.erb
@@ -17,7 +17,12 @@
                 </div>
                 <div id="class-grade">
                   <%= f.label :grade, class: 'class-grade' %>
-                  <%= f.select :grade, %w(1 2 3 4 5 6 7 8 9 10 11 12 other) %>
+                  <%
+                    # Note to maintainers: if you update the grade options here, please also ensure to do so in the following locations:
+                    #   - /app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
+                    #   - /app/bundles/HelloWorld/containers/CreateClass.jsx
+                  %>
+                  <%= f.select :grade, %w(1 2 3 4 5 6 7 8 9 10 11 12 University Other) %>
                 </div>
                 <%= f.button 'Save Changes',          class: 'button-green' %>
               <% end %>

--- a/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
+++ b/client/app/bundles/HelloWorld/components/diagnostic/diagnostic_questionnaire/IntroPage.jsx
@@ -15,25 +15,6 @@ export default React.createClass({
     this.setState({selectedGrade: grade})
   },
 
-  grades: function(){
-    let grades = []
-    let formattedGrade;
-    for(let grade = 1; grade <= 12; grade++){
-      if (grade === 1) {
-        formattedGrade = grade + 'st'
-      } else if (grade === 2) {
-        formattedGrade = grade + 'nd'
-      } else if (grade === 3) {
-        formattedGrade = grade + 'rd'
-      } else {
-        formattedGrade = grade + 'th'
-      }
-      grades.push(<MenuItem key={formattedGrade} eventKey={formattedGrade}>{formattedGrade}</MenuItem>)
-    }
-    return grades
-  },
-
-
     render: function() {
       // TODO: 1. make a styled a element instead of wrapping the buttons.
             // 2. set up pathways for prod/non-prod diagnostic
@@ -43,12 +24,7 @@ export default React.createClass({
             <div id='intro-page'>
                 <div>
                     <h2>Would you like to preview the {diagnosticName} Diagnostic?</h2>
-                      {/*<span>
-                      <DropdownButton bsStyle='default' title={this.state.selectedGrade || 'st'} id='select-grade' onSelect={this.handleSelect}>
-                        {this.grades()}
-                      </DropdownButton>
-                        </span>grade */}
-                      <span id='subtext'>You'll be previewing the diagnostic as a student and will be able to assign it at any time.</span>
+                    <span id='subtext'>You'll be previewing the diagnostic as a student and will be able to assign it at any time.</span>
                 </div>
                 <a href={`/activity_sessions/anonymous?activity_id=${activityId}`} target='_blank'><button id='preview' className='button-green'>Preview the Diagnostic</button></a>
                 <br/>

--- a/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
+++ b/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
@@ -103,7 +103,7 @@ export default class extends React.Component{
   formatTitle(grade){
     // this is the title of the dropdown menu
     if (grade) {
-      return grade == 'University' ? grade : `${NumberSuffix(grade)} Grade`
+      return grade == 'University' || grade == 'Other' ? grade : `${NumberSuffix(grade)} Grade`
     } else {
       return 'Select Grade'
     }
@@ -165,6 +165,10 @@ export default class extends React.Component{
 
   grades(id) {
     // populates dropdown menu with grades
+    // Note to maintainers: if you update the grade options here, please also
+    // ensure to do so in the following locations:
+    //   - /app/views/teachers/students/index.html.erb
+    //   - /app/bundles/HelloWorld/containers/CreateClass.jsx
       let grades = [];
       for (let grade = 1; grade <= 12; grade++) {
           grades.push(
@@ -172,6 +176,7 @@ export default class extends React.Component{
           )
       }
       grades.push(<MenuItem id={`university-${id}`} key={`university-${id}`} eventKey={'University'}>University</MenuItem>)
+      grades.push(<MenuItem id={`other-${id}`} key={`other-${id}`} eventKey={'Other'}>Other</MenuItem>)
       return grades
   }
 

--- a/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
+++ b/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
@@ -175,8 +175,8 @@ export default class extends React.Component{
               <MenuItem id={`${grade}-${id}`} key={`${grade}-${id}`} eventKey={{id, grade: grade}}>{NumberSuffix(grade)}</MenuItem>
           )
       }
-      grades.push(<MenuItem id={`university-${id}`} key={`university-${id}`} eventKey={'University'}>University</MenuItem>)
-      grades.push(<MenuItem id={`other-${id}`} key={`other-${id}`} eventKey={'Other'}>Other</MenuItem>)
+      grades.push(<MenuItem id={`university-${id}`} key={`university-${id}`} eventKey={{id, grade: 'University'}}>University</MenuItem>)
+      grades.push(<MenuItem id={`other-${id}`} key={`other-${id}`} eventKey={{id, grade: 'Other'}}>Other</MenuItem>)
       return grades
   }
 

--- a/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/__tests__/GoogleClassroomsList.test.js
+++ b/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/__tests__/GoogleClassroomsList.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
+
 import GoogleClassroomsList from '../GoogleClassroomsList.jsx'
+
+import DropdownButton from 'react-bootstrap/lib/DropdownButton';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
 
 const googleClasses = [
         {
@@ -154,8 +158,21 @@ describe('the GoogleClassroomsList component', () => {
         wrapper.find('button').last().simulate('click')
         expect(mockSyncClassrooms.mock.calls.length).toEqual(1);
       })
+    })
 
+    describe('the DropdownButton component', () => {
+      it('should render MenuItems for grades K-12, University, and Other', () => {
+        expect(wrapper.find(DropdownButton).at(0).find(MenuItem)).toHaveLength(14);
+      });
 
+      // TODO: write a test to ensure that the onselect event works and
+      // formats the dropdown's title prop properly.
+
+      it('should be disabled if not checked', () => {
+        const classKey = wrapper.state().classrooms[0].id;
+        wrapper.find(`button[id="grade-dropdown-${classKey}"]`).simulate('select', 'Other');
+        expect(wrapper.find(`button[id="grade-dropdown-${classKey}"]`).text()).toEqual('Select Grade ');
+      });
     })
 
 })

--- a/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/__tests__/__snapshots__/GoogleClassroomsList.test.js.snap
+++ b/client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/__tests__/__snapshots__/GoogleClassroomsList.test.js.snap
@@ -639,7 +639,12 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                               bsClass="dropdown"
                               disabled={false}
                               divider={false}
-                              eventKey="University"
+                              eventKey={
+                                Object {
+                                  "grade": "University",
+                                  "id": 4451629374,
+                                }
+                              }
                               header={false}
                               id="university-4451629374"
                               onKeyDown={[Function]}
@@ -666,6 +671,46 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                                     tabIndex="-1"
                                   >
                                     University
+                                  </a>
+                                </SafeAnchor>
+                              </li>
+                            </MenuItem>
+                            <MenuItem
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={
+                                Object {
+                                  "grade": "Other",
+                                  "id": 4451629374,
+                                }
+                              }
+                              header={false}
+                              id="other-4451629374"
+                              onKeyDown={[Function]}
+                              onSelect={[Function]}
+                            >
+                              <li
+                                className=""
+                                role="presentation"
+                              >
+                                <SafeAnchor
+                                  componentClass="a"
+                                  id="other-4451629374"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  <a
+                                    href="#"
+                                    id="other-4451629374"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex="-1"
+                                  >
+                                    Other
                                   </a>
                                 </SafeAnchor>
                               </li>
@@ -1282,7 +1327,12 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                               bsClass="dropdown"
                               disabled={false}
                               divider={false}
-                              eventKey="University"
+                              eventKey={
+                                Object {
+                                  "grade": "University",
+                                  "id": 3799271824,
+                                }
+                              }
                               header={false}
                               id="university-3799271824"
                               onKeyDown={[Function]}
@@ -1309,6 +1359,46 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                                     tabIndex="-1"
                                   >
                                     University
+                                  </a>
+                                </SafeAnchor>
+                              </li>
+                            </MenuItem>
+                            <MenuItem
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={
+                                Object {
+                                  "grade": "Other",
+                                  "id": 3799271824,
+                                }
+                              }
+                              header={false}
+                              id="other-3799271824"
+                              onKeyDown={[Function]}
+                              onSelect={[Function]}
+                            >
+                              <li
+                                className=""
+                                role="presentation"
+                              >
+                                <SafeAnchor
+                                  componentClass="a"
+                                  id="other-3799271824"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  <a
+                                    href="#"
+                                    id="other-3799271824"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex="-1"
+                                  >
+                                    Other
                                   </a>
                                 </SafeAnchor>
                               </li>
@@ -1912,7 +2002,12 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                               bsClass="dropdown"
                               disabled={false}
                               divider={false}
-                              eventKey="University"
+                              eventKey={
+                                Object {
+                                  "grade": "University",
+                                  "id": 3783127312,
+                                }
+                              }
                               header={false}
                               id="university-3783127312"
                               onKeyDown={[Function]}
@@ -1939,6 +2034,46 @@ exports[`the GoogleClassroomsList component should render 1`] = `
                                     tabIndex="-1"
                                   >
                                     University
+                                  </a>
+                                </SafeAnchor>
+                              </li>
+                            </MenuItem>
+                            <MenuItem
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={
+                                Object {
+                                  "grade": "Other",
+                                  "id": 3783127312,
+                                }
+                              }
+                              header={false}
+                              id="other-3783127312"
+                              onKeyDown={[Function]}
+                              onSelect={[Function]}
+                            >
+                              <li
+                                className=""
+                                role="presentation"
+                              >
+                                <SafeAnchor
+                                  componentClass="a"
+                                  id="other-3783127312"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  <a
+                                    href="#"
+                                    id="other-3783127312"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex="-1"
+                                  >
+                                    Other
                                   </a>
                                 </SafeAnchor>
                               </li>

--- a/client/app/bundles/HelloWorld/containers/CreateClass.jsx
+++ b/client/app/bundles/HelloWorld/containers/CreateClass.jsx
@@ -40,6 +40,10 @@ export default React.createClass({
   },
 
   grades() {
+    // Note to maintainers: if you update the grade options here, please also
+    // ensure to do so in the following locations:
+    //   - /app/views/teachers/students/index.html.erb
+    //   - /client/app/bundles/HelloWorld/components/google_classroom/google_classroom_sync/GoogleClassroomsList.jsx
     const grades = [];
     for (let grade = 1; grade <= 12; grade++) {
       grades.push(
@@ -47,6 +51,7 @@ export default React.createClass({
             );
     }
     grades.push(<MenuItem key={'University'} eventKey={'University'}>University</MenuItem>);
+    grades.push(<MenuItem key={'Other'} eventKey={'Other'}>Other</MenuItem>);
     return grades;
   },
 
@@ -125,7 +130,7 @@ export default React.createClass({
   formatTitle() {
     const classroom = this.state.classroom;
     if (classroom.grade) {
-      return classroom.grade == 'University' ? classroom.grade : NumberSuffix(classroom.grade);
+      return classroom.grade == 'University' || classroom.grade == 'Other' ? classroom.grade : NumberSuffix(classroom.grade);
     }
     return 'Select Grade';
   },

--- a/client/app/bundles/HelloWorld/containers/CreateClass.jsx
+++ b/client/app/bundles/HelloWorld/containers/CreateClass.jsx
@@ -130,7 +130,7 @@ export default React.createClass({
   formatTitle() {
     const classroom = this.state.classroom;
     if (classroom.grade) {
-      return classroom.grade == 'University' || classroom.grade == 'Other' ? classroom.grade : NumberSuffix(classroom.grade);
+      return classroom.grade == 'University' || classroom.grade == 'Other' ? classroom.grade : `${NumberSuffix(classroom.grade)} Grade`;
     }
     return 'Select Grade';
   },

--- a/client/app/bundles/HelloWorld/containers/__tests__/CreateClass.test.jsx
+++ b/client/app/bundles/HelloWorld/containers/__tests__/CreateClass.test.jsx
@@ -60,12 +60,28 @@ describe('CreateClass container', () => {
 
     describe('DropdownButton component', () => {
       it('should have correctly formatted title prop', () => {
-        //TODO: test this more thoroughly, and add tests for NumberSuffix
-        expect(wrapper.find(DropdownButton).props().title).toBe('7th');
+        expect(wrapper.find(DropdownButton).props().title).toBe('7th Grade');
+        wrapper.setState({ classroom: { grade: 1 }});
+        expect(wrapper.find(DropdownButton).props().title).toBe('1st Grade');
+        wrapper.setState({ classroom: { grade: 2 }});
+        expect(wrapper.find(DropdownButton).props().title).toBe('2nd Grade');
+        wrapper.setState({ classroom: { grade: 3 }});
+        expect(wrapper.find(DropdownButton).props().title).toBe('3rd Grade');
+        wrapper.setState({ classroom: { grade: 'University' }});
+        expect(wrapper.find(DropdownButton).props().title).toBe('University');
+        wrapper.setState({ classroom: { grade: 'Other' }});
+        expect(wrapper.find(DropdownButton).props().title).toBe('Other');
+        wrapper.setState({
+          classroom: {
+            name: 'English 101',
+            grade: 7,
+            code: 'smelly-fish'
+          }
+        });
       });
 
-      it('should render MenuItems for grades K-12 & University', () => {
-        expect(wrapper.find(MenuItem)).toHaveLength(13);
+      it('should render MenuItems for grades K-12, University, and Other', () => {
+        expect(wrapper.find(MenuItem)).toHaveLength(14);
       });
 
       it('onSelect event should change grade in state', () => {

--- a/client/app/bundles/HelloWorld/containers/__tests__/__snapshots__/CreateClass.test.jsx.snap
+++ b/client/app/bundles/HelloWorld/containers/__tests__/__snapshots__/CreateClass.test.jsx.snap
@@ -165,6 +165,15 @@ exports[`CreateClass container should render a blank create class form if no cla
             >
               University
             </MenuItem>
+            <MenuItem
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey="Other"
+              header={false}
+            >
+              Other
+            </MenuItem>
           </DropdownButton>
         </div>
         <div

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hot-assets": "(cd client && npm run hot-assets)",
     "jest": "cd client && npm run jest",
     "jest:u": "cd client && npm run jest -- -u",
+    "jest:update": "cd client && npm run jest -- -u",
     "jest:watch": "cd client && npm run jest:watch",
     "jest:coverage": "cd client && npm run jest:coverage"
   },


### PR DESCRIPTION
Also removes some of what I presume to be legacy code related to the grades (or maybe we were saving it for a later implementation, though it wouldn't match the new dropdown now).

One of these pages isn't in React, so instead of recreating it in React I just left a comment for future maintainers to update the other two places where it's relevant to save time.