### PR TITLE
Fix #2903: Only show launch button in modal if lesson not completed

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/classroom_activity.jsx
@@ -122,6 +122,7 @@ export default React.createClass({
 				lessonUID={this.props.data.activity.uid}
 				classroomActivityID={this.props.data.id}
 				closeModal={this.closeModal}
+				completed={this.props.data.completed}
 			/>
 		}
 	},

--- a/client/app/bundles/HelloWorld/components/shared/preview_or_launch_modal.jsx
+++ b/client/app/bundles/HelloWorld/components/shared/preview_or_launch_modal.jsx
@@ -22,6 +22,7 @@ export default class PreviewOrLaunchModal extends React.Component {
 
   render() {
     const {classroomActivityID, lessonUID} = this.props
+    const launchLessonButton = !this.props.completed ? <a href={this.launchLessonLink()} className="bg-quillgreen">Launch Lesson</a> : null;
     return (
       <div>
         <div className="preview-or-launch-modal-background"></div>
@@ -30,7 +31,7 @@ export default class PreviewOrLaunchModal extends React.Component {
           <img alt="close-icon" src="/images/close_icon.svg" onClick={this.props.closeModal}/>
           <p>You can either preview this lesson or launch it. If you are ready to use this lesson with your students now, launch it.</p>
           <a href={this.previewLessonLink()} className="bg-quillgreen">Preview Lesson</a>
-          <a href={this.launchLessonLink()} className="bg-quillgreen">Launch Lesson</a>
+          {launchLessonButton}
         </div>
       </div>
     )


### PR DESCRIPTION
**NOTE: I don't have lessons in my local DB, so I couldn't test this manually.**