### PR TITLE
fix #2954 and #2947

### DIFF
--- a/app/assets/stylesheets/pages/activity_categories.scss
+++ b/app/assets/stylesheets/pages/activity_categories.scss
@@ -1,0 +1,28 @@
+.activity-categories-container {
+  h1 {
+    margin: 20px 0px;
+  }
+  label {
+    margin-right: 5px;
+  }
+  input {
+    margin-right: 10px;
+    &:first-of-type {
+      width: 300px;
+    }
+  }
+  .activity-categories {
+    margin: 20px 0px;
+    .list {
+      margin-bottom: 20px;
+      .list-item {
+        font-size: 20px;
+        background-color: white;
+        border: 1px #adabab solid;
+        border-radius: 6px;
+        padding: 5px 20px;
+        margin-bottom: 5px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/activity_categories.scss
+++ b/app/assets/stylesheets/pages/activity_categories.scss
@@ -33,8 +33,9 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      .delete {
+      .delete, .show {
         font-size: 14px;
+        cursor: pointer;
       }
     }
   }

--- a/app/assets/stylesheets/pages/activity_categories.scss
+++ b/app/assets/stylesheets/pages/activity_categories.scss
@@ -11,19 +11,24 @@
       width: 300px;
     }
   }
+  .selected-activities-section {
+    .deselect-activity {
+      width: 50px;
+    }
+  }
+  .list {
+    margin: 20px 0x;;
+    .list-item {
+      font-size: 20px;
+      background-color: white;
+      border: 1px #adabab solid;
+      border-radius: 6px;
+      padding: 5px 20px;
+      margin-bottom: 5px;
+    }
+  }
   .activity-categories {
     margin: 20px 0px;
-    .list {
-      margin-bottom: 20px;
-      .list-item {
-        font-size: 20px;
-        background-color: white;
-        border: 1px #adabab solid;
-        border-radius: 6px;
-        padding: 5px 20px;
-        margin-bottom: 5px;
-      }
-    }
     .activity-category {
       display: flex;
       justify-content: space-between;

--- a/app/assets/stylesheets/pages/activity_categories.scss
+++ b/app/assets/stylesheets/pages/activity_categories.scss
@@ -24,5 +24,13 @@
         margin-bottom: 5px;
       }
     }
+    .activity-category {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      .delete {
+        font-size: 14px;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/pages/cms_unit_templates.scss
+++ b/app/assets/stylesheets/pages/cms_unit_templates.scss
@@ -1,4 +1,7 @@
 .cms-unit-templates {
+  .save-button {
+    margin-left: 10px;
+  }
   .sortable-table {
     width: 100%;
     border: #cecece 1px solid;

--- a/app/assets/stylesheets/pages/cms_unit_templates.scss
+++ b/app/assets/stylesheets/pages/cms_unit_templates.scss
@@ -1,0 +1,39 @@
+.cms-unit-templates {
+  .sortable-table {
+    width: 100%;
+    border: #cecece 1px solid;
+    .header {
+      padding: 6px;
+      border-bottom: 1px solid #cecece;
+      font-weight: bold;
+      display: flex;
+      justify-content: space-between;
+      font-size: 16px;
+      span:first-of-type {
+        flex: 2;
+      }
+      span:last-of-type {
+        flex: 1;
+      }
+    }
+    .list {
+      background-color: white;
+      .list-item {
+        padding: 6px;
+        border-bottom: 1px solid #cecece;
+        justify-content: space-between;
+        font-size: 16px;
+        tr {
+          display: flex;
+          justify-content: space-between;
+          td:first-of-type {
+            flex: 2;
+          }
+          td:last-of-type {
+            flex: 1;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/cms/activity_categories_controller.rb
+++ b/app/controllers/cms/activity_categories_controller.rb
@@ -8,6 +8,15 @@ class Cms::ActivityCategoriesController < ApplicationController
   def update
   end
 
+  def show
+    @activity_category = ActivityCategory.find(params[:id])
+    @activities = Activity.select("activities.id, activities.name, activity_category_activities.order_number")
+    .joins('INNER JOIN activity_category_activities on activity_category_activities.activity_id = activities.id')
+    .joins('INNER JOIN activity_categories on activity_category_activities.activity_category_id = activity_categories.id')
+    .where('activity_categories.id = ?', @activity_category.id)
+    .order('activity_category_activities.order_number').to_a
+  end
+
   def update_order_numbers
     params[:activity_categories].each { |ac| ActivityCategory.find(ac['id']).update(order_number: ac['order_number'])}
     render json: {activity_categories: ActivityCategory.order(order_number: :asc)}

--- a/app/controllers/cms/activity_categories_controller.rb
+++ b/app/controllers/cms/activity_categories_controller.rb
@@ -22,10 +22,10 @@ class Cms::ActivityCategoriesController < ApplicationController
     new_activity_category_activities = params[:activities]
     ActivityCategory.find(params[:activity_category_id]).activity_category_activities.destroy_all
     errors = []
-    new_activity_category_activities.each do |activity|
+    new_activity_category_activities.each do |activity, i|
       aca = ActivityCategoryActivity.new
       aca.activity_id = activity['id']
-      aca.order_number = activity['order_number']
+      aca.order_number = activity['order_number'] || i
       aca.activity_category_id = params[:activity_category_id]
       aca.save!
       errors << aca.errors if aca.errors.any?

--- a/app/controllers/cms/activity_categories_controller.rb
+++ b/app/controllers/cms/activity_categories_controller.rb
@@ -19,5 +19,12 @@ class Cms::ActivityCategoriesController < ApplicationController
   end
 
   def destroy
+    activity_category = ActivityCategory.find(params[:id])
+    activity_category.destroy
+    if activity_category.errors.any?
+      render json: activity_category.errors, status: 400
+    else
+      render json: {}, status: 200
+    end
   end
 end

--- a/app/controllers/cms/activity_categories_controller.rb
+++ b/app/controllers/cms/activity_categories_controller.rb
@@ -1,0 +1,23 @@
+class Cms::ActivityCategoriesController < ApplicationController
+  before_filter :staff!
+
+  def index
+    @activity_categories = ActivityCategory.order(order_number: :asc)
+  end
+
+  def update
+  end
+
+  def update_order_numbers
+    params[:activity_categories].each { |ac| ActivityCategory.find(ac['id']).update(order_number: ac['order_number'])}
+    render json: {activity_categories: ActivityCategory.order(order_number: :asc)}
+  end
+
+  def create
+    ActivityCategory.create(params[:activity_category].permit(:name, :order_number))
+    return redirect_to cms_activity_categories_path
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/cms/activity_categories_controller.rb
+++ b/app/controllers/cms/activity_categories_controller.rb
@@ -25,7 +25,7 @@ class Cms::ActivityCategoriesController < ApplicationController
     new_activity_category_activities.each do |activity|
       aca = ActivityCategoryActivity.new
       aca.activity_id = activity['id']
-      aca.order_number = activity['activity_order']
+      aca.order_number = activity['order_number']
       aca.activity_category_id = params[:activity_category_id]
       aca.save!
       errors << aca.errors if aca.errors.any?

--- a/app/controllers/cms/unit_templates_controller.rb
+++ b/app/controllers/cms/unit_templates_controller.rb
@@ -6,7 +6,7 @@ class Cms::UnitTemplatesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render json: UnitTemplate.all.map{|u| Cms::UnitTemplateSerializer.new(u).as_json(root: false)}
+        render json: UnitTemplate.order(order_number: :asc).map{|u| Cms::UnitTemplateSerializer.new(u).as_json(root: false)}
       end
     end
   end
@@ -30,6 +30,12 @@ class Cms::UnitTemplatesController < ApplicationController
     else
       render json: {errors: @unit_template.errors}, status: 422
     end
+  end
+
+  def update_order_numbers
+    unit_templates = params[:unit_templates]
+    unit_templates.each { |ut| UnitTemplate.find(ut['id']).update(order_number: ut['order_number']) }
+    render json: {unit_templates: UnitTemplate.order(order_number: :asc)}
   end
 
   def destroy

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -13,7 +13,7 @@ class Activity < ActiveRecord::Base
   has_many :classroom_activities, dependent: :destroy
   has_many :classrooms, through: :classroom_activities
   has_many :units, through: :classroom_activities
-  has_many :activity_category_activities
+  has_many :activity_category_activities, dependent: :destroy
   has_many :activity_categories, through: :activity_category_activities
   before_create :flag_as_beta, unless: :flags?
   after_commit :clear_activity_search_cache

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -13,6 +13,8 @@ class Activity < ActiveRecord::Base
   has_many :classroom_activities, dependent: :destroy
   has_many :classrooms, through: :classroom_activities
   has_many :units, through: :classroom_activities
+  has_many :activity_category_activities
+  has_many :activity_categories, through: :activity_category_activities
   before_create :flag_as_beta, unless: :flags?
   after_commit :clear_activity_search_cache
 

--- a/app/models/activity_category.rb
+++ b/app/models/activity_category.rb
@@ -1,4 +1,12 @@
 class ActivityCategory < ActiveRecord::Base
   has_many :activity_category_activities
   has_many :activities, through: :activity_category_activities
+
+  before_create :set_order_number
+
+  def set_order_number
+    if !self.order_number
+      self.update(order_number: ActivityCategory.count)
+    end
+  end
 end

--- a/app/models/activity_category.rb
+++ b/app/models/activity_category.rb
@@ -1,12 +1,12 @@
 class ActivityCategory < ActiveRecord::Base
-  has_many :activity_category_activities
+  has_many :activity_category_activities, dependent: :destroy
   has_many :activities, through: :activity_category_activities
 
   before_create :set_order_number
 
   def set_order_number
-    if !self.order_number
-      self.update(order_number: ActivityCategory.count)
+    if self.order_number.nil?
+      self.order_number =  ActivityCategory.count
     end
   end
 end

--- a/app/models/activity_category.rb
+++ b/app/models/activity_category.rb
@@ -1,0 +1,4 @@
+class ActivityCategory < ActiveRecord::Base
+  has_many :activity_category_activities
+  has_many :activities, through: :activity_category_activities
+end

--- a/app/models/activity_category_activity.rb
+++ b/app/models/activity_category_activity.rb
@@ -1,0 +1,5 @@
+class ActivityCategoryActivity < ActiveRecord::Base
+  belongs_to :activity_category
+  belongs_to :activity
+  
+end

--- a/app/models/activity_category_activity.rb
+++ b/app/models/activity_category_activity.rb
@@ -1,5 +1,4 @@
 class ActivityCategoryActivity < ActiveRecord::Base
   belongs_to :activity_category
   belongs_to :activity
-  
 end

--- a/app/queries/activity_search.rb
+++ b/app/queries/activity_search.rb
@@ -2,7 +2,7 @@ class ActivitySearch
   # filters = hash of model_name/model_id pairs
   # sort = hash with 'field' and 'asc_or_desc' (?) as keys
   def self.search(search_text, filters, sort, flag)
-    query = Activity.user_scope(flag).includes(:classification, topic: [:section, :topic_category])
+    query = Activity.user_scope(flag).includes(:classification, topic: [:section, :topic_category], activity_category_activities: [:activity_category])
       .where("(activities.name ILIKE ?) OR (topic_categories.name ILIKE ?)", "%#{search_text}%", "%#{search_text}%")
       .where("topic_categories.id IS NOT NULL AND sections.id IS NOT NULL")
       .order(search_sort_sql(sort)).references(:topic)
@@ -18,7 +18,7 @@ class ActivitySearch
   private
 
   def self.search_sort_sql(sort)
-    return 'activity_classifications.order_number asc, sections.position asc' if sort.blank?
+    return 'activity_categories.order_number asc, activity_classifications.order_number asc, activity_category_activities.order_number asc' if sort.blank?
 
     if sort['asc_or_desc'] == 'desc'
       order = 'desc'

--- a/app/queries/activity_search.rb
+++ b/app/queries/activity_search.rb
@@ -3,7 +3,7 @@ class ActivitySearch
   # sort = hash with 'field' and 'asc_or_desc' (?) as keys
   def self.search(search_text, filters, sort, flag)
     query = Activity.user_scope(flag).includes(:classification, topic: [:section, :topic_category], activity_category_activities: [:activity_category])
-      .where("(activities.name ILIKE ?) OR (topic_categories.name ILIKE ?)", "%#{search_text}%", "%#{search_text}%")
+      .where("(activities.name ILIKE ?) OR (activity_categories.name ILIKE ?) OR (activities.description ILIKE ?)", "%#{search_text}%", "%#{search_text}%", "%#{search_text}%")
       .where("topic_categories.id IS NOT NULL AND sections.id IS NOT NULL")
       .order(search_sort_sql(sort)).references(:topic)
 

--- a/app/views/cms/activity_categories/index.html.erb
+++ b/app/views/cms/activity_categories/index.html.erb
@@ -1,0 +1,15 @@
+<%= react_component('ActivityCategoriesApp', props: {activity_categories: @activity_categories}) %>
+
+<% @activity_categories.each do |activity_category| %>
+  <%= "##{activity_category.order_number}: #{activity_category.name}" %>
+<% end %>
+
+<%= form_for ActivityCategory.new, url: cms_activity_categories_path do |f| %>
+  <%= f.label      :name, 'Name' %>
+  <%= f.text_field :name %>
+
+  <%= f.label      :order_number, 'Order Number' %>
+  <%= f.text_field :order_number %>
+
+  <%= f.button 'Add Activity Category' %>
+<% end %>

--- a/app/views/cms/activity_categories/index.html.erb
+++ b/app/views/cms/activity_categories/index.html.erb
@@ -1,15 +1,14 @@
-<%= react_component('ActivityCategoriesApp', props: {activity_categories: @activity_categories}) %>
+<div class="container activity-categories-container">
+  <h1>Activity Categories</h1>
 
-<% @activity_categories.each do |activity_category| %>
-  <%= "##{activity_category.order_number}: #{activity_category.name}" %>
-<% end %>
-
-<%= form_for ActivityCategory.new, url: cms_activity_categories_path do |f| %>
+  <%= form_for ActivityCategory.new, url: cms_activity_categories_path do |f| %>
   <%= f.label      :name, 'Name' %>
   <%= f.text_field :name %>
-
   <%= f.label      :order_number, 'Order Number' %>
   <%= f.text_field :order_number %>
-
   <%= f.button 'Add Activity Category' %>
-<% end %>
+  <% end %>
+
+  <%= react_component('ActivityCategoriesApp', props: {activity_categories: @activity_categories}) %>
+
+</div>

--- a/app/views/cms/activity_categories/index.html.erb
+++ b/app/views/cms/activity_categories/index.html.erb
@@ -4,8 +4,6 @@
   <%= form_for ActivityCategory.new, url: cms_activity_categories_path do |f| %>
   <%= f.label      :name, 'Name' %>
   <%= f.text_field :name %>
-  <%= f.label      :order_number, 'Order Number' %>
-  <%= f.text_field :order_number %>
   <%= f.button 'Add Activity Category' %>
   <% end %>
 

--- a/app/views/cms/activity_categories/show.html.erb
+++ b/app/views/cms/activity_categories/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container activity-categories-container">
-  <h1>Activity Categories</h1>
+  <h1><%= link_to "Activity Categories", cms_activity_categories_path %></h1>
   <h2><%= @activity_category.name %></h2>
   <%= react_component('ActivityCategoryApp',
   props: {activity_category: @activity_category, activities: @activities}) %>

--- a/app/views/cms/activity_categories/show.html.erb
+++ b/app/views/cms/activity_categories/show.html.erb
@@ -1,0 +1,7 @@
+<div class="container activity-categories-container">
+  <h1>Activity Categories</h1>
+  <h2><%= @activity_category.name %></h2>
+  <%= react_component('ActivityCategoryApp',
+  props: {activity_category: @activity_category, activities: @activities}) %>
+
+</div>

--- a/app/views/profiles/staff.html.slim
+++ b/app/views/profiles/staff.html.slim
@@ -25,6 +25,8 @@
       tr: td= link_to "Topic Categories Manager", cms_topic_categories_path
       tr: td= link_to 'Topics Manager (Standard)', cms_topics_path
       tr: td= link_to "Concepts Manager (Create level 2 & 1 here)", cms_concepts_path
+      tr: td= link_to "Activity Category Manager", cms_activity_categories_path
+
 
     article.simple-rounded-box: table.table
       thead: th Data Dashboards

--- a/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table.jsx
@@ -27,24 +27,27 @@ export default React.createClass({
 
   renderRows: function () {
     if(this.props.isSortable) {
-      return <SortableList data={this.furnishRows()} sortCallback={this.props.updateOrder} />;
+      return <div className="sortable-table">
+        <div className="header"><span>Name</span><span>Actions</span></div>
+        <SortableList data={this.furnishRows()} sortCallback={this.props.updateOrder} />
+      </div>
     } else {
-      return <tbody>{this.furnishRows()}</tbody>;
-    }
-  },
-
-  render: function () {
-    return (
-      <table className='table'>
+      return (<table className='table'>
         <thead>
           <tr>
             <th>{this.identifier()}</th>
             <th>Actions</th>
           </tr>
         </thead>
-          {this.renderRows()}
-      </table>
-    );
+        <tbody>
+          {this.furnishRows()}
+        </tbody>
+      </table>)
+    }
+  },
+
+  render: function () {
+    return this.renderRows();
   }
 
 });

--- a/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import _ from 'underscore'
+import SortableList from '../../../components/shared/sortableList'
 import CmsIndexTableRow from './cms_index_table_row.jsx'
 
 export default React.createClass({
@@ -9,14 +10,14 @@ export default React.createClass({
   },
 
   furnishRows: function () {
-    var rows = _.map(this.props.data.resources, this.furnishRow, this);
+    var rows = this.props.data.resources.map((resource, index) => this.furnishRow(resource, index) );
     return rows;
   },
 
-  furnishRow: function (resource) {
+  furnishRow: function (resource, index) {
     return <CmsIndexTableRow
                   data={{resource: resource, identifier: this.props.data.identifier}}
-                  key={resource.id}
+                  key={index}
                   actions={this.props.actions} />;
   },
 
@@ -24,8 +25,15 @@ export default React.createClass({
     return this.props.data.identifier || 'Name'
   },
 
+  renderRows: function () {
+    if(this.props.isSortable) {
+      return <SortableList data={this.furnishRows()} sortCallback={this.props.updateOrder} />;
+    } else {
+      return <tbody>{this.furnishRows()}</tbody>;
+    }
+  },
+
   render: function () {
-    var rows = this.furnishRows()
     return (
       <table className='table'>
         <thead>
@@ -34,9 +42,7 @@ export default React.createClass({
             <th>Actions</th>
           </tr>
         </thead>
-        <tbody>
-          {rows}
-        </tbody>
+          {this.renderRows()}
       </table>
     );
   }

--- a/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table_row.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/cms_index_table/cms_index_table_row.jsx
@@ -13,7 +13,7 @@ export default React.createClass({
   },
 
   delete: function () {
-    var confirm = confirm('are you sure you want to delete ' + this.props.data.resource[this.identifier()] + '?');
+    var confirm = window.confirm('are you sure you want to delete ' + this.props.data.resource[this.identifier()] + '?');
     if (confirm) {
       this.props.actions.delete(this.props.data.resource);
     }

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
@@ -280,6 +280,8 @@ export default React.createClass({
           errorMessage={this.props.errorMessage || ''}
           selectedActivities={this.props.selectedActivities}
           toggleActivitySelection={this.props.toggleActivitySelection}
+          sortable={this.props.sortable}
+          sortCallback={this.props.sortCallback}
         />
       </section>
     );

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
@@ -21,6 +21,14 @@
 
 	render: function () {
     const selectedClass = this.props.selected ? 'selected' : ''
+    const toolTip = this.props.data.classification
+    ? <div ref='activateTooltip'
+      className={this.props.data.classification.gray_image_class}
+      data-html='true'
+      data-toggle='tooltip'
+      data-placement='top'
+    	title={"<h1>" + this.props.data.name + "</h1><p>App: " + this.props.data.classification.alias + "</p><p>" + this.props.data.topic.name +  "</p><p>" + this.props.data.description + "</p>"} />
+    : <span/>
 		return (
 			<tr onMouseEnter={this.tooltipTrigger} onMouseLeave={this.tooltipTriggerStop} className={`tooltip-trigger ${selectedClass}`}>
       <td>
@@ -29,11 +37,7 @@
 				</td>
 
         <td>
-					<div ref='activateTooltip' className={this.props.data.classification.gray_image_class} data-html='true' data-toggle='tooltip' data-placement='top'
-
-						title={"<h1>" + this.props.data.name + "</h1><p>App: " + this.props.data.classification.alias + "</p><p>" + this.props.data.topic.name +  "</p><p>" + this.props.data.description + "</p>"}>
-
-					</div>
+          {toolTip}
 				</td>
 
 

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activities.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activities.jsx
@@ -2,6 +2,7 @@
 
  import React from 'react'
  import SelectedActivity from './selected_activity'
+ import SortableList from '../../../../shared/sortableList'
 
  export default  React.createClass({
 	propTypes: {
@@ -12,16 +13,12 @@
 	render: function () {
 		let rows, buttonClassName, content
 
-		rows = this.props.selectedActivities.map((ele) => <SelectedActivity key={ele.id} toggleActivitySelection={this.props.toggleActivitySelection} data={ele} />);
-
+		rows = this.props.selectedActivities.map((ele, i) => <SelectedActivity key={i} toggleActivitySelection={this.props.toggleActivitySelection} data={ele} />);
+    const sortableRows = this.props.sortable ? <SortableList data={rows} sortCallback={this.props.sortCallback}/> : null
     if (this.props.selectedActivities.length > 0) {
       content = <section className="selected-activities-section">
 				<h3 className="section-header">Selected Activities For New Activity Pack:</h3>
-				<table className="table activity-table selected-activities headless-rounded-table">
-					<tbody>
-						{rows}
-					</tbody>
-				</table>
+				{sortableRows ? sortableRows : <table className="table activity-table selected-activities headless-rounded-table"><tbody>rows</tbody></table>}
 			</section>
     } else {
       content = <span/>

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activities.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activities.jsx
@@ -18,7 +18,7 @@
     if (this.props.selectedActivities.length > 0) {
       content = <section className="selected-activities-section">
 				<h3 className="section-header">Selected Activities For New Activity Pack:</h3>
-				{sortableRows ? sortableRows : <table className="table activity-table selected-activities headless-rounded-table"><tbody>rows</tbody></table>}
+				{sortableRows ? sortableRows : <table className="table activity-table selected-activities headless-rounded-table"><tbody>{rows}</tbody></table>}
 			</section>
     } else {
       content = <span/>

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activity.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/selected_activities/selected_activity.jsx
@@ -10,7 +10,7 @@
 
 		return (
 			<tr data-model-id={this.props.data.id}>
-				<td className={this.props.data.classification.gray_image_class}></td>
+				<td className={this.props.data.classification ? this.props.data.classification.gray_image_class : ''}></td>
 				<td>
 					<a className='activity_link' href={this.props.data.anonymous_path} target='_new'>
 						{this.props.data.name}

--- a/client/app/bundles/HelloWorld/components/shared/listItem.jsx
+++ b/client/app/bundles/HelloWorld/components/shared/listItem.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default class ListItem extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <div {...this.props} className="list-item">{this.props.children}</div>
+    )
+  }
+}

--- a/client/app/bundles/HelloWorld/components/shared/sortableList.jsx
+++ b/client/app/bundles/HelloWorld/components/shared/sortableList.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {sortable} from 'react-sortable';
+import ListItem from './listItem.jsx'
+
+const SortableListItem = sortable(ListItem);
+
+export default class SortableList extends React.Component {
+
+	constructor(props) {
+    super(props)
+
+    this.state = {
+      draggingIndex: null,
+      data: {
+        items: this.props.data
+      }
+    }
+
+    this.updateState = this.updateState.bind(this)
+  }
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.data !== this.state.data.items) {
+			this.setState({data: {items: nextProps.data}})
+		}
+	}
+
+	updateState(obj) {
+		this.setState(obj, this.props.sortCallback(this.state));
+	}
+
+	render() {
+		const childProps = {
+			className: 'myClass1'
+		};
+		const listItems = this.state.data.items.map(function(item, i) {
+			return (
+				<SortableListItem
+          key={i}
+          updateState={this.updateState}
+          items={this.state.data.items}
+          draggingIndex={this.state.draggingIndex}
+          sortId={i}
+          outline="list"
+          childProps={childProps}
+          >
+            {item}
+        </SortableListItem>
+			);
+		}, this);
+
+		return (
+			<div className="list">{listItems}</div>
+		);
+	}
+}

--- a/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import SortableList from '../components/shared/sortableList'
+import request from 'request'
+import getAuthToken from '../components/modules/get_auth_token'
+
+export default class ActivityCategories extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      activity_categories: props.activity_categories
+    }
+
+    this.updateActivityCategoryOrder = this.updateActivityCategoryOrder.bind(this)
+    this.saveActivityCategories = this.saveActivityCategories.bind(this)
+  }
+
+  updateActivityCategoryOrder(sortInfo) {
+    const originalOrderedActivityCategories = this.state.activity_categories
+    const newOrder = sortInfo.data.items.map(item => item.key);
+    const newOrderedActivityCategories = newOrder.map((key, i) => {
+      const newActivityCategory = originalOrderedActivityCategories[key]
+      newActivityCategory.order_number = i
+      return newActivityCategory
+    })
+    this.setState({activity_categories: newOrderedActivityCategories})
+  }
+
+  saveActivityCategories() {
+    console.log(getAuthToken())
+    const that = this
+    request.put(`${process.env.DEFAULT_URL}/cms/activity_categories/update_order_numbers`, {
+      json: {
+        activity_categories: this.state.activity_categories,
+        authenticity_token: getAuthToken()
+      }}, (e, r, response) => {
+      this.setState({activity_categories: response.activity_categories})
+      // that.setState({activity_categories: })
+    })
+  }
+
+  renderActivityCategory(name, key) {
+    return <span key={key}>{name}</span>
+  }
+
+  render() {
+    // return <div>I am not the problem</div>
+    const activityCategoryItems = this.state.activity_categories.map((ac, i) => this.renderActivityCategory(ac.name, i))
+    return <div className="activity-categories">
+      <SortableList data={activityCategoryItems} sortCallback={this.updateActivityCategoryOrder} />
+      <button onClick={this.saveActivityCategories}>Save Activity Categories</button>
+    </div>
+  }
+}

--- a/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
@@ -34,7 +34,14 @@ export default class ActivityCategories extends React.Component {
         activity_categories: this.state.activity_categories,
         authenticity_token: getAuthToken()
       }}, (e, r, response) => {
-      this.setState({activity_categories: response.activity_categories})
+        if (e) {
+          console.log(e)
+          alert(`We could not save the updated activity category order. Here is the error: ${e}`)
+        } else {
+          this.setState({activity_categories: response.activity_categories})
+          alert('The updated classroom order has been saved.')
+
+        }
       // that.setState({activity_categories: })
     })
   }

--- a/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
@@ -42,12 +42,32 @@ export default class ActivityCategories extends React.Component {
           alert('The updated classroom order has been saved.')
 
         }
-      // that.setState({activity_categories: })
+    })
+  }
+
+  deleteActivityCategory(key) {
+    const activityCategoryToDelete = this.state.activity_categories[key]
+    request.del(`${process.env.DEFAULT_URL}/cms/activity_categories/${activityCategoryToDelete.id}`, {
+      json: {
+        authenticity_token: getAuthToken()
+      }}, (e, r, response) => {
+      if (r.statusCode === 400) {
+        console.log(e)
+        alert(`We could not delete this activity category. Here is the response: ${response}`)
+      } else {
+        const newActivityCategories = this.state.activity_categories
+        newActivityCategories.splice(key, 1)
+        this.setState({activity_categories: newActivityCategories})
+        alert('Your activity category has been deleted.')
+      }
     })
   }
 
   renderActivityCategory(name, key) {
-    return <span key={key}>{name}</span>
+    return <div key={key} className="activity-category">
+      <span className="name">{name}</span>
+      <span className="delete" onClick={() => this.deleteActivityCategory(key)}>Delete Activity Category</span>
+    </div>
   }
 
   render() {

--- a/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
@@ -63,16 +63,17 @@ export default class ActivityCategories extends React.Component {
     })
   }
 
-  renderActivityCategory(name, key) {
+  renderActivityCategory(name, key, id) {
     return <div key={key} className="activity-category">
       <span className="name">{name}</span>
-      <span className="delete" onClick={() => this.deleteActivityCategory(key)}>Delete Activity Category</span>
+      <a href={`/cms/activity_categories/${id}`}>Show</a>
+      <span className="delete" onClick={() => this.deleteActivityCategory(key)}>Delete</span>
     </div>
   }
 
   render() {
     // return <div>I am not the problem</div>
-    const activityCategoryItems = this.state.activity_categories.map((ac, i) => this.renderActivityCategory(ac.name, i))
+    const activityCategoryItems = this.state.activity_categories.map((ac, i) => this.renderActivityCategory(ac.name, i, ac.id))
     return <div className="activity-categories">
       <SortableList data={activityCategoryItems} sortCallback={this.updateActivityCategoryOrder} />
       <button onClick={this.saveActivityCategories}>Save Activity Categories</button>

--- a/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategories.jsx
@@ -66,8 +66,10 @@ export default class ActivityCategories extends React.Component {
   renderActivityCategory(name, key, id) {
     return <div key={key} className="activity-category">
       <span className="name">{name}</span>
-      <a href={`/cms/activity_categories/${id}`}>Show</a>
-      <span className="delete" onClick={() => this.deleteActivityCategory(key)}>Delete</span>
+      <span>
+        <a className="show" href={`/cms/activity_categories/${id}`}>Show</a>
+        <span className="delete" onClick={() => this.deleteActivityCategory(key)}>Delete</span>
+      </span>
     </div>
   }
 

--- a/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
@@ -13,6 +13,7 @@ export default class ActivityCategory extends React.Component {
 
     this.toggleActivitySelection = this.toggleActivitySelection.bind(this)
     this.updateActivityOrder = this.updateActivityOrder.bind(this)
+    this.destroyAndRecreateOrderNumbers = this.destroyAndRecreateOrderNumbers.bind(this)
   }
 
   toggleActivitySelection(activity) {

--- a/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import ActivitySearchAndSelect from '../components/lesson_planner/create_unit/activity_search/activity_search_and_select'
+
+export default class ActivityCategory extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selectedActivities: props.activities
+    }
+
+    this.toggleActivitySelection = this.toggleActivitySelection.bind(this)
+    this.updateActivityOrder = this.updateActivityOrder.bind(this)
+  }
+
+  toggleActivitySelection(activity) {
+    const newSelectedActivities = this.state.selectedActivities
+    const activityIndex = newSelectedActivities.indexOf(a => a.id === e.id)
+    if (activityIndex === -1) {
+      const activityWithOrderNumber = Object.assign({}, activity)
+      activityWithOrderNumber.order_number = newSelectedActivities.length
+      newSelectedActivities.push(activityWithOrderNumber)
+    } else {
+      newSelectedActivities.splice(activityIndex, 1)
+    }
+    this.setState({selectedActivities: newSelectedActivities})
+  }
+
+  updateActivityOrder(sortInfo) {
+    const originalOrderedActivities = this.state.selectedActivities
+    const newOrder = sortInfo.data.items.map(item => item.key);
+    const newOrderedActivities = newOrder.map((key, i) => {
+      const newActivity = originalOrderedActivities[key]
+      newActivity.order_number = i
+      return newActivity
+    })
+    this.setState({selectedActivities: newOrderedActivities})
+  }
+
+  render() {
+    return(<div>
+      <ActivitySearchAndSelect
+        selectedActivities={this.state.selectedActivities}
+        toggleActivitySelection={this.toggleActivitySelection}
+        sortable={true}
+        sortCallback={this.updateActivityOrder}
+      />
+      <button>Save Activities</button>
+    </div>
+  )
+  }
+}

--- a/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
+++ b/client/app/bundles/HelloWorld/containers/ActivityCategory.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import request from 'request'
+import getAuthToken from '../components/modules/get_auth_token'
 import ActivitySearchAndSelect from '../components/lesson_planner/create_unit/activity_search/activity_search_and_select'
 
 export default class ActivityCategory extends React.Component {
@@ -15,7 +17,7 @@ export default class ActivityCategory extends React.Component {
 
   toggleActivitySelection(activity) {
     const newSelectedActivities = this.state.selectedActivities
-    const activityIndex = newSelectedActivities.indexOf(a => a.id === e.id)
+    const activityIndex = newSelectedActivities.findIndex(a => a.id === activity.id)
     if (activityIndex === -1) {
       const activityWithOrderNumber = Object.assign({}, activity)
       activityWithOrderNumber.order_number = newSelectedActivities.length
@@ -37,6 +39,25 @@ export default class ActivityCategory extends React.Component {
     this.setState({selectedActivities: newOrderedActivities})
   }
 
+  destroyAndRecreateOrderNumbers() {
+    const that = this
+    const activities = this.state.selectedActivities;
+    request.post(`${process.env.DEFAULT_URL}/cms/activity_categories/destroy_and_recreate_acas`, {
+      json: {
+        authenticity_token: getAuthToken(),
+        activities: activities,
+        activity_category_id: that.props.activity_category.id
+      }}, (e, r, response) => {
+        if (e) {
+          alert(`We could not save the updated activity order. Here is the error: ${e}`)
+        } else {
+          this.setState({selectedActivities: response.activities})
+          alert('The updated activity order has been saved.')
+        }
+      }
+    )
+  }
+
   render() {
     return(<div>
       <ActivitySearchAndSelect
@@ -45,7 +66,7 @@ export default class ActivityCategory extends React.Component {
         sortable={true}
         sortCallback={this.updateActivityOrder}
       />
-      <button>Save Activities</button>
+      <button onClick={this.destroyAndRecreateOrderNumbers}>Save Activities</button>
     </div>
   )
   }

--- a/client/app/bundles/HelloWorld/containers/Cms.jsx
+++ b/client/app/bundles/HelloWorld/containers/Cms.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import request from 'request'
 import CmsIndexTable from '../components/cms/cms_index_table/cms_index_table.jsx'
 import Server from '../components/modules/server/server'
+import getAuthToken from '../components/modules/get_auth_token'
 
 
 export default React.createClass({
@@ -62,12 +64,15 @@ export default React.createClass({
         <div className='row'>
           <div className='col-xs-12'>
             <button className='button-green button-top' onClick={this.crudNew}>New</button>
+            {this.renderSaveButton()}
           </div>
         </div>
         <div className='row'>
           <div className='col-xs-12'>
             <CmsIndexTable data={{resources: this.state[this.props.resourceNamePlural] }}
-                              actions={{edit: this.edit, delete: this.delete}}/>
+                              actions={{edit: this.edit, delete: this.delete}}
+                              isSortable={this.isSortable()}
+                              updateOrder={this.updateOrder}/>
           </div>
         </div>
       </span>
@@ -94,6 +99,48 @@ export default React.createClass({
 
   crudNew: function () {
     this.setState({crudState: 'new', resourceToEdit: {}});
+  },
+
+  updateOrder: function (sortInfo) {
+    if(this.isSortable()) {
+      const originalOrder = this.state[this.props.resourceNamePlural];
+      const newOrder = sortInfo.data.items.map(item => item.key);
+      const newOrderedResources = newOrder.map((key, i) => {
+        const newResource = originalOrder[key];
+        newResource.order_number = i;
+        return newResource;
+      });
+      this.setState({[this.props.resourceNamePlural]: newOrderedResources});
+    }
+  },
+
+  saveOrder: function () {
+    if(this.isSortable()) {
+      const resourceName = this.props.resourceNamePlural;
+      const that = this;
+      request.put(`${process.env.DEFAULT_URL}/cms/${resourceName}/update_order_numbers`, {
+        json: {
+          [resourceName]: that.state[resourceName],
+          authenticity_token: getAuthToken()
+        }}, (e, r, response) => {
+          if (e) {
+            console.log(e);
+            alert(`We could not save the updated order. Here is the error: ${e}`);
+          } else {
+            that.setState({[resourceName]: response[resourceName]});
+            alert('The updated order has been saved.');
+          }
+      })
+    }
+  },
+
+  renderSaveButton: function () {
+    return this.isSortable() ? <button className='button-green button-top' onClick={this.saveOrder}>Save Order</button> : null
+  },
+
+  isSortable: function () {
+    if(this.state[this.props.resourceNamePlural].length == 0) { return false }
+    return this.props.resourceNamePlural == 'unit_templates';
   },
 
   render: function () {

--- a/client/app/bundles/HelloWorld/containers/Cms.jsx
+++ b/client/app/bundles/HelloWorld/containers/Cms.jsx
@@ -135,7 +135,7 @@ export default React.createClass({
   },
 
   renderSaveButton: function () {
-    return this.isSortable() ? <button className='button-green button-top' onClick={this.saveOrder}>Save Order</button> : null
+    return this.isSortable() ? <button className='button-green button-top save-button' onClick={this.saveOrder}>Save Order</button> : null
   },
 
   isSortable: function () {

--- a/client/app/bundles/HelloWorld/containers/UnitTemplates.jsx
+++ b/client/app/bundles/HelloWorld/containers/UnitTemplates.jsx
@@ -13,9 +13,11 @@ export default React.createClass({
 
   render: function () {
     return (
-      <Cms resourceNameSingular='unit_template'
-              resourceNamePlural='unit_templates'
-              resourceComponentGenerator={this.resourceComponentGenerator}/>
+      <div className="cms-unit-templates">
+        <Cms resourceNameSingular='unit_template'
+                resourceNamePlural='unit_templates'
+                resourceComponentGenerator={this.resourceComponentGenerator}/>
+      </div>
 
     )
   }

--- a/client/app/bundles/HelloWorld/startup/ActivityCategoriesAppClient.jsx
+++ b/client/app/bundles/HelloWorld/startup/ActivityCategoriesAppClient.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ActivityCategories from '../containers/ActivityCategories.jsx';
+
+export default (props) => (
+  <ActivityCategories {...props} />
+);

--- a/client/app/bundles/HelloWorld/startup/ActivityCategoryAppClient.jsx
+++ b/client/app/bundles/HelloWorld/startup/ActivityCategoryAppClient.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ActivityCategory from '../containers/ActivityCategory.jsx';
+
+export default (props) => (
+  <ActivityCategory {...props} />
+);

--- a/client/app/bundles/HelloWorld/startup/clientRegistration.jsx
+++ b/client/app/bundles/HelloWorld/startup/clientRegistration.jsx
@@ -23,6 +23,7 @@ import GoogleMismatchApp from './GoogleMismatchAppClient.jsx'
 import AssignActivitiesApp from './AssignActivitiesAppClient'
 import TutorialsApp from './TutorialsAppClient'
 import ActivityCategoriesApp from './ActivityCategoriesAppClient'
+import ActivityCategoryApp from './ActivityCategoryAppClient'
 
 require('../../../assets/styles/home.scss')
 
@@ -34,4 +35,4 @@ ReactOnRails.register({  TeacherGuideApp, DashboardApp,
   ArchivedClassroomsManagerApp, ResultsPageApp, AdminDashboardApp, AdminAccountsApp,
   AdminsEditorApp, PublicActivityPacksApp, AddStudentApp,
   DiagnosticPlannerApp, DiagnosticReportsApp, CreateClassApp, UnitTemplatesApp, PublicUnitTemplatesApp,
-  GoogleSyncApp, GoogleMismatchApp, AssignActivitiesApp, TutorialsApp, ActivityCategoriesApp});
+  GoogleSyncApp, GoogleMismatchApp, AssignActivitiesApp, TutorialsApp, ActivityCategoriesApp, ActivityCategoryApp});

--- a/client/app/bundles/HelloWorld/startup/clientRegistration.jsx
+++ b/client/app/bundles/HelloWorld/startup/clientRegistration.jsx
@@ -22,6 +22,7 @@ import GoogleSyncApp from './GoogleSyncAppClient.jsx'
 import GoogleMismatchApp from './GoogleMismatchAppClient.jsx'
 import AssignActivitiesApp from './AssignActivitiesAppClient'
 import TutorialsApp from './TutorialsAppClient'
+import ActivityCategoriesApp from './ActivityCategoriesAppClient'
 
 require('../../../assets/styles/home.scss')
 
@@ -33,4 +34,4 @@ ReactOnRails.register({  TeacherGuideApp, DashboardApp,
   ArchivedClassroomsManagerApp, ResultsPageApp, AdminDashboardApp, AdminAccountsApp,
   AdminsEditorApp, PublicActivityPacksApp, AddStudentApp,
   DiagnosticPlannerApp, DiagnosticReportsApp, CreateClassApp, UnitTemplatesApp, PublicUnitTemplatesApp,
-  GoogleSyncApp, GoogleMismatchApp, AssignActivitiesApp, TutorialsApp});
+  GoogleSyncApp, GoogleMismatchApp, AssignActivitiesApp, TutorialsApp, ActivityCategoriesApp});

--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
     "react-on-rails": "=6.5.0",
     "react-redux": "^4.4.1",
     "react-router": "^2.0.1",
+    "react-sortable": "^1.2.0",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
     "request": "^2.81.0",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,8 @@ EmpiricalGrammar::Application.routes.draw do
   put '/select_school', to: 'accounts#select_school'
 
   namespace :cms do
+    put '/activity_categories/update_order_numbers', to: 'activity_categories#update_order_numbers'
+    resources :activity_categories, only: [:index, :create, :update, :destroy]
     resources :admin_accounts, only: [:index, :create, :update, :destroy]
     resources :admins, only: [:index, :create, :update, :destroy]
     resources :categories

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,7 @@ EmpiricalGrammar::Application.routes.draw do
     resources :topics
     resources :topic_categories
     resources :authors, only: [:index, :create, :update, :destroy]
+    put '/unit_templates/update_order_numbers', to: 'unit_templates#update_order_numbers'
     resources :unit_templates, only: [:index, :create, :update, :destroy]
     resources :unit_template_categories, only: [:index, :create, :update, :destroy]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   namespace :cms do
     put '/activity_categories/update_order_numbers', to: 'activity_categories#update_order_numbers'
+    post '/activity_categories/destroy_and_recreate_acas', to: 'activity_categories#destroy_and_recreate_acas'
     resources :activity_categories, only: [:index, :show, :create, :update, :destroy]
     resources :admin_accounts, only: [:index, :create, :update, :destroy]
     resources :admins, only: [:index, :create, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,7 +277,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   namespace :cms do
     put '/activity_categories/update_order_numbers', to: 'activity_categories#update_order_numbers'
-    resources :activity_categories, only: [:index, :create, :update, :destroy]
+    resources :activity_categories, only: [:index, :show, :create, :update, :destroy]
     resources :admin_accounts, only: [:index, :create, :update, :destroy]
     resources :admins, only: [:index, :create, :update, :destroy]
     resources :categories

--- a/db/migrate/20170911191447_create_activity_category_and_activity_category_activities_tables.rb
+++ b/db/migrate/20170911191447_create_activity_category_and_activity_category_activities_tables.rb
@@ -1,0 +1,15 @@
+class CreateActivityCategoryAndActivityCategoryActivitiesTables < ActiveRecord::Migration
+  def change
+    create_table :activity_categories do |t|
+      t.string :name
+      t.integer :order_number
+      t.timestamps
+    end
+    create_table :activity_category_activities do |t|
+      t.integer :activity_category_id
+      t.integer :activity_id
+      t.integer :order_number
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,9 @@
+--
+-- PostgreSQL database dump
+--
 
--- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped from database version 9.6.4
+-- Dumped by pg_dump version 9.6.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -120,6 +123,71 @@ CREATE TABLE activities_unit_templates (
     unit_template_id integer NOT NULL,
     activity_id integer NOT NULL
 );
+
+
+--
+-- Name: activity_categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE activity_categories (
+    id integer NOT NULL,
+    name character varying,
+    order_number integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: activity_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE activity_categories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: activity_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE activity_categories_id_seq OWNED BY activity_categories.id;
+
+
+--
+-- Name: activity_category_activities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE activity_category_activities (
+    id integer NOT NULL,
+    activity_category_id integer,
+    activity_id integer,
+    order_number integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: activity_category_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE activity_category_activities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: activity_category_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE activity_category_activities_id_seq OWNED BY activity_category_activities.id;
 
 
 --
@@ -1575,6 +1643,20 @@ ALTER TABLE ONLY activities ALTER COLUMN id SET DEFAULT nextval('activities_id_s
 
 
 --
+-- Name: activity_categories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY activity_categories ALTER COLUMN id SET DEFAULT nextval('activity_categories_id_seq'::regclass);
+
+
+--
+-- Name: activity_category_activities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY activity_category_activities ALTER COLUMN id SET DEFAULT nextval('activity_category_activities_id_seq'::regclass);
+
+
+--
 -- Name: activity_classifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1860,6 +1942,22 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 ALTER TABLE ONLY activities
     ADD CONSTRAINT activities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: activity_categories activity_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY activity_categories
+    ADD CONSTRAINT activity_categories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: activity_category_activities activity_category_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY activity_category_activities
+    ADD CONSTRAINT activity_category_activities_pkey PRIMARY KEY (id);
 
 
 --
@@ -3242,4 +3340,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170817144049');
 INSERT INTO schema_migrations (version) VALUES ('20170824150025');
 
 INSERT INTO schema_migrations (version) VALUES ('20170824171451');
+
+INSERT INTO schema_migrations (version) VALUES ('20170911191447');
 

--- a/spec/factories/activity_categories.rb
+++ b/spec/factories/activity_categories.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
   factory :activity_category do
-    
+
+    name 'An Activity Category'
+    order_number 0
+
   end
 end

--- a/spec/factories/activity_categories.rb
+++ b/spec/factories/activity_categories.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :activity_category do
+    
+  end
+end

--- a/spec/factories/activity_category_activities.rb
+++ b/spec/factories/activity_category_activities.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :activity_category_activity do
-    
+
+    order_number 0
+    activity_category { ActivityCategory.first || FactoryGirl.create(:activity_category) }
+    activity { Activity.first || FactoryGirl.create(:activity) }
+
   end
 end

--- a/spec/factories/activity_category_activities.rb
+++ b/spec/factories/activity_category_activities.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :activity_category_activity do
+    
+  end
+end

--- a/spec/models/activity_category_activity_spec.rb
+++ b/spec/models/activity_category_activity_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ActivityCategoryActivity, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/activity_category_spec.rb
+++ b/spec/models/activity_category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ActivityCategory, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/activity_category_spec.rb
+++ b/spec/models/activity_category_spec.rb
@@ -1,5 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe ActivityCategory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:activity_category) {FactoryGirl.build(:activity_category, order_number: nil)}
+
+  describe('#set_order_number') do
+    it('sets the order number to the count of activity categories that already exist if there is no order number') do
+      activity_category.set_order_number
+      expect(activity_category.order_number).to eq(ActivityCategory.count)
+    end
+
+    it('does not change  the order number if it is already set') do
+      activity_category.order_number = 7
+      activity_category.set_order_number
+      expect(activity_category.order_number).to eq(7)
+    end
+
+    it('gets called before create') do
+      expect(activity_category).to receive(:set_order_number)
+      activity_category.save
+    end
+
+    it('does not get called before update') do
+      created_activity_category = ActivityCategory.create(name: 'Another')
+      expect(created_activity_category).not_to receive(:set_order_number)
+      created_activity_category.update(name: 'Different')
+    end
+
+  end
+
 end

--- a/spec/serializers/classification_serializer_spec.rb
+++ b/spec/serializers/classification_serializer_spec.rb
@@ -10,7 +10,8 @@ describe ClassificationSerializer, type: :serializer do
          created_at
          form_url
          id
-         image_class
+         gray_image_class,
+         green_image_class,
          key
          module_url
          name


### PR DESCRIPTION
***migrations***
***new npm package***

This branch adds two new models, ActivityCategory and the join table ActivityCategoryActivity. These both have order_number attributes, which are adjustable from the CMS Activity Category Manager link found in the admin profile.

The activity search and sort component now defaults to displaying activities sorted by Activity Category order number, Activity Classification order number, and Activity Category Activity order number, in that order. It has also been updated to search activity category names and activity descriptions for keywords entered in its search bar.