### PR TITLE
Rearrange CA method calls in finish_lesson method

### DIFF
--- a/app/controllers/api/v1/classroom_activities_controller.rb
+++ b/app/controllers/api/v1/classroom_activities_controller.rb
@@ -12,8 +12,8 @@ class Api::V1::ClassroomActivitiesController < Api::ApiController
   end
 
   def finish_lesson
-    @classroom_activity.update(locked: true, pinned: false)
     @classroom_activity.mark_all_activity_sessions_complete
+    @classroom_activity.update(locked: true, pinned: false)
     follow_up = JSON.parse(params['json'])['follow_up'] ? @classroom_activity.assign_follow_up_lesson(false) : false
     url = follow_up ? "#{ENV['DEFAULT_URL']}/teachers/classroom_activities/#{follow_up&.id}/activity_from_classroom_activity" : "#{ENV['DEFAULT_URL']}"
     render json: {follow_up_url: url}


### PR DESCRIPTION
Should fix this pursuant to conversation: https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/b39689ca-9976-11e7-b844-0242ac11000f_0_20976