### PR TITLE
Safe operator check for user.id in login worker call

### DIFF
--- a/lib/quill_authentication.rb
+++ b/lib/quill_authentication.rb
@@ -31,7 +31,7 @@ module QuillAuthentication
     if !session[:staff_id] || session[:staff_id] == user.id
       # only kick off login worker if there is no staff id,
       # or if the user getting logged into is staff
-      UserLoginWorker.perform_async(user.id, remote_ip) unless user.id.nil?
+      UserLoginWorker.perform_async(user.id, remote_ip) if user&.id
     end
     session[:user_id] = user.id
     session[:admin_id] = user.id if user.admin?


### PR DESCRIPTION
Demo is currently broken. This should fix it.