### PR TITLE
Fix #2973: Simplify logic and fix undefined classroom id error

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -42,16 +42,11 @@ class TeachersController < ApplicationController
   end
 
   def get_completed_diagnostic_unit_info
-    if current_user.milestones.where(name: 'Complete Diagnostic')
-      unit_ids = current_user.finished_diagnostic_unit_ids
-      if unit_ids.length > 0
-        unit_id = unit_ids.first.id
-        ca = ClassroomActivity.find_by(unit_id: unit_id, activity_id: [413, 447])
-        unit_info = { unit_id: unit_id, classroom_id: ca.classroom_id, activity_id: ca.activity_id }
-      else
-        unit_info = nil
-      end
-    else
+    begin
+      unit_id = current_user.finished_diagnostic_unit_ids.first.id
+      ca = ClassroomActivity.find_by(unit_id: unit_id, activity_id: [413, 447])
+      unit_info = { unit_id: unit_id, classroom_id: ca.classroom_id, activity_id: ca.activity_id }
+    rescue
       unit_info = nil
     end
     render json: {unit_info: unit_info}


### PR DESCRIPTION
The logic in this was getting messy and not very Ruby-ish, so I broke it into a much simpler begin/rescue block instead. In this case, we don't even need to run the milestone check. An alternative is to fix the `finished_diagnostic_unit_ids` query so it only responds with `unit_ids` for classes that haven't been archived; however, the begin/rescue block way eliminates a couple queries and conditionals.

I'm not convinced that what I've done here is a good approach though.