### PR TITLE
Fix url redirect on scorebook

### DIFF
--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -42,8 +42,8 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
         redirect_to default_diagnostic_url
     end
 
-    def report_from_activity_session
-        act_sesh_report = activity_session_report(params[:activity_session].to_i)
+    def report_from_classroom_activity_and_user
+        act_sesh_report = activity_session_report(params[:classroom_activity_id].to_i, params[:user_id].to_i)
         render json: act_sesh_report.to_json
     end
 

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -11,15 +11,14 @@ module PublicProgressReports
                   first
     end
 
-    def activity_session_report(activity_session_id)
-      act_sesh = ActivitySession.includes({ classroom_activity: [:classroom, :unit]}, :user).find(activity_session_id)
-      classroom_activity = act_sesh.try(:classroom_activity)
+    def activity_session_report(classroom_activity_id, user_id)
+      act_sesh = ActivitySession.where(is_final_score: true, user_id: user_id, classroom_activity_id: classroom_activity_id).first
+      classroom_activity = ClassroomActivity.find(classroom_activity_id)
       unit_id = classroom_activity.try(:unit).id
       activity_id = classroom_activity.try(:activity).id
       classroom_id = classroom_activity.try(:classroom).id
-      user = act_sesh.try(:user)
-      if user && classroom_id && classroom_id
-        {url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/student_report/#{user.id}"}
+      if unit_id && activity_id && classroom_id
+        {url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/student_report/#{user_id}"}
       end
     end
 

--- a/client/app/bundles/HelloWorld/components/general_components/activity_icon_with_tooltip.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/activity_icon_with_tooltip.jsx
@@ -69,7 +69,7 @@ export default React.createClass({
   },
 
   goToReport() {
-    $.get(`/teachers/progress_reports/report_from_activity_session/${this.props.data.id || this.props.data.activitySessionId}`)
+    $.get(`/teachers/progress_reports/report_from_classroom_activity_and_user/ca/${this.props.data.caId}/user/${this.props.data.userId}`)
       .success((data) => {
         window.location = data.url;
       })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,7 @@ EmpiricalGrammar::Application.routes.draw do
     namespace :progress_reports do
       resources :activity_sessions, only: [:index]
       resources :csv_exports, only: [:create]
-      get 'report_from_activity_session/:activity_session' => 'diagnostic_reports#report_from_activity_session'
+      get 'report_from_classroom_activity_and_user/ca/:classroom_activity_id/user/:user_id' => 'diagnostic_reports#report_from_classroom_activity_and_user'
       get 'diagnostic_reports' => 'diagnostic_reports#show'
       get 'diagnostic_status' => 'diagnostic_reports#diagnostic_status'
       get 'diagnostic_report' => 'diagnostic_reports#default_diagnostic_report'

--- a/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -14,7 +14,7 @@ include_context "Unit Assignments Variables"
       let!(:classroom_activity) { FactoryGirl.create(:classroom_activity, activity: activity, unit: unit) }
       let!(:activity_session) { FactoryGirl.create(:activity_session, classroom_activity: classroom_activity, activity: activity, user: student) }
       it "returns a json with the url" do
-          get :report_from_activity_session, ({activity_session: activity_session.id})
+          get :report_from_classroom_activity_and_user, ({classroom_activity_id: classroom_activity.id, user_id: student.id})
           response_body = JSON.parse(response.body)
           expect(response_body["url"]).to eq("/teachers/progress_reports/diagnostic_reports#/u/#{unit.id}/a/#{activity.id}/c/#{classroom.id}/student_report/#{student.id}")
       end


### PR DESCRIPTION
Now gets the activity session report link based on the passed classroom activity id and user id