### PR TITLE
Address some stuff on NewRelic

### DIFF
--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -46,7 +46,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
         ORDER BY activity_sessions.updated_at DESC
         LIMIT 1;").to_a
       if !classroom_hash[0]
-        return render status: 404
+        return render json: {}, status: 404
       end
       classroom_id = classroom_hash[0]['classroom_id']
       return render json: { url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/students" }

--- a/app/models/classroom_activity.rb
+++ b/app/models/classroom_activity.rb
@@ -293,6 +293,12 @@ class ClassroomActivity < ActiveRecord::Base
         raise 'This classroom activity is a duplicate'
       rescue => e
         NewRelic::Agent.notice_error(e)
+        NewRelic::Agent.add_custom_attributes({
+          classroom_id: self.classroom_id,
+          activity_id: self.activity_id,
+          unit_id: self.unit_id,
+          visible: self.visible
+        })
         errors.add(:duplicate_classroom_activity, "this classroom activity is a duplicate")
       end
     else

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -1,6 +1,6 @@
 module PublicProgressReports
     extend ActiveSupport::Concern
-    include ::NewRelic::Agent
+    include NewRelic::Agent
 
     def last_completed_diagnostic
       diagnostic_activity_ids = ActivityClassification.find(4).activities.map(&:id)

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -1,5 +1,6 @@
 module PublicProgressReports
     extend ActiveSupport::Concern
+    include ::NewRelic::Agent
 
     def last_completed_diagnostic
       diagnostic_activity_ids = ActivityClassification.find(4).activities.map(&:id)
@@ -73,6 +74,10 @@ module PublicProgressReports
 
     def classrooms_with_students_that_completed_activity unit_id, activity_id
       h = {}
+      if unit_id.nil?
+        NewRelic::Agent.notice_error('classrooms_with_students_that_completed_activity undefined unit_id error')
+        NewRelic::Agent.add_custom_attributes({ current_user_id: current_user.id })
+      end
       unit = Unit.find(unit_id)
       class_ids = current_user.classrooms_i_teach.map(&:id)
       #without definining class ids, it may default to a classroom activity from a non-existant classroom


### PR DESCRIPTION
Fixes: 
- [x] https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/cea87e4f-a457-11e7-8b63-0242ac110009_0_20397

Adds more robust error reporting for:
- [x] https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/067c7ff3-a45a-11e7-8b63-0242ac110009_0_8221
- [x] https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/a1549b48-a45a-11e7-8b63-0242ac110009_21457_39057

----

Notes for future self: 
* Where are we linking to the diagnostic reports? One of these links is probably resulting in both the /undefined/ routing errors and also the NaN issue.
