### PR TITLE
Updating copy for twitter assigned activity

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile_share_buttons.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/unit_templates_manager/unit_template_profile/unit_template_profile_share_buttons.jsx
@@ -20,7 +20,7 @@
       {
         icon: 'fa-twitter',
         className: 'btn-twitter',
-        href: `http://twitter.com/home?status=${url} check out this ${this.props.data.name} Activity pack by @Quill_org`,
+        href: `http://twitter.com/home?status=I’m using the ${this.props.data.name} Activity Pack from Quill.org to teach writing & grammar. ${url}`
         title: 'Share on Twitter',
         action: 'Tweet'
       },


### PR DESCRIPTION
I just updated the copy for the twitter share. It was different from the text we have on the page. Now it should say: I'm using the "activity name" activity pack from Quill.org to teach writing & grammar. [link]