### PR TITLE
Use correct roles joins in CMS, improve documentation

### DIFF
--- a/app/assets/javascripts/application_non_webpack.js
+++ b/app/assets/javascripts/application_non_webpack.js
@@ -13,4 +13,3 @@
 
 //= require jquery.turbolinks
 //= require jquery-fileupload/basic
-  

--- a/app/assets/javascripts/application_non_webpack.js
+++ b/app/assets/javascripts/application_non_webpack.js
@@ -12,4 +12,3 @@
 //= require tabslet.js
 
 //= require jquery.turbolinks
-//= require jquery-fileupload/basic

--- a/app/assets/javascripts/application_non_webpack.js
+++ b/app/assets/javascripts/application_non_webpack.js
@@ -12,3 +12,5 @@
 //= require tabslet.js
 
 //= require jquery.turbolinks
+//= require jquery-fileupload/basic
+  

--- a/app/controllers/cms/schools_controller.rb
+++ b/app/controllers/cms/schools_controller.rb
@@ -43,12 +43,12 @@ class Cms::SchoolsController < ApplicationController
       SELECT
         users.name AS teacher_name,
         COUNT(DISTINCT(classrooms.id)) AS number_classrooms,
-    		COUNT(DISTINCT(students_classrooms.student_id)) AS number_students,
-    		COUNT(activity_sessions) AS number_activities_completed,
-    		TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
-    		subscriptions.account_type AS subscription,
-    		users.id AS user_id,
-    		users.role AS user_role
+        COUNT(DISTINCT(students_classrooms.student_id)) AS number_students,
+        COUNT(activity_sessions) AS number_activities_completed,
+        TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
+        subscriptions.account_type AS subscription,
+        users.id AS user_id,
+        schools_admins.id AS admin_id
       FROM schools_users
       LEFT JOIN users ON schools_users.user_id = users.id
       LEFT JOIN classrooms ON schools_users.user_id = classrooms.teacher_id AND classrooms.visible = true
@@ -56,8 +56,9 @@ class Cms::SchoolsController < ApplicationController
       LEFT JOIN activity_sessions ON students_classrooms.student_id = activity_sessions.user_id AND completed_at IS NOT NULL
       LEFT JOIN user_subscriptions ON schools_users.user_id = user_subscriptions.user_id
       LEFT JOIN subscriptions ON subscriptions.id = user_subscriptions.subscription_id
-      WHERE school_id = #{ActiveRecord::Base.sanitize(params[:id])}
-      GROUP BY users.name, users.last_sign_in, subscriptions.account_type, users.id;
+      LEFT JOIN schools_admins ON users.id = schools_admins.user_id
+      WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(params[:id])}
+      GROUP BY users.name, users.last_sign_in, subscriptions.account_type, users.id, schools_admins.id
     ").to_a
   end
 

--- a/app/controllers/cms/schools_controller.rb
+++ b/app/controllers/cms/schools_controller.rb
@@ -39,27 +39,7 @@ class Cms::SchoolsController < ApplicationController
       'NCES ID' => @school_info.nces_id,
       'PPIN' => @school_info.ppin
     }
-    @teacher_data = ActiveRecord::Base.connection.execute("
-      SELECT
-        users.name AS teacher_name,
-        COUNT(DISTINCT(classrooms.id)) AS number_classrooms,
-        COUNT(DISTINCT(students_classrooms.student_id)) AS number_students,
-        COUNT(activity_sessions) AS number_activities_completed,
-        TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
-        subscriptions.account_type AS subscription,
-        users.id AS user_id,
-        schools_admins.id AS admin_id
-      FROM schools_users
-      LEFT JOIN users ON schools_users.user_id = users.id
-      LEFT JOIN classrooms ON schools_users.user_id = classrooms.teacher_id AND classrooms.visible = true
-      LEFT JOIN students_classrooms ON classrooms.id =  students_classrooms.classroom_id
-      LEFT JOIN activity_sessions ON students_classrooms.student_id = activity_sessions.user_id AND completed_at IS NOT NULL
-      LEFT JOIN user_subscriptions ON schools_users.user_id = user_subscriptions.user_id
-      LEFT JOIN subscriptions ON subscriptions.id = user_subscriptions.subscription_id
-      LEFT JOIN schools_admins ON users.id = schools_admins.user_id
-      WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(params[:id])}
-      GROUP BY users.name, users.last_sign_in, subscriptions.account_type, users.id, schools_admins.id
-    ").to_a
+    @teacher_data = teacher_search_query_for_school(params[:id])
   end
 
   # This allows staff members to edit certain details about a school.
@@ -142,9 +122,7 @@ class Cms::SchoolsController < ApplicationController
   end
 
   def school_query(params)
-    # This should return an array of hashes with the following order.
-    # (Order matters because of the order in which these are being
-    # displayed in the table on the front end.)
+    # This should return an array of hashes that look like this:
     # [
     #   {
     #     school_name: 'school name',
@@ -160,6 +138,8 @@ class Cms::SchoolsController < ApplicationController
     #   }
     # ]
 
+    # NOTE: IF YOU CHANGE THIS QUERY'S CONDITIONS, PLEASE BE SURE TO
+    # ADJUST THE PAGINATION QUERY STRING AS WELL.
     ActiveRecord::Base.connection.execute("
       SELECT
         schools.name AS school_name,
@@ -270,5 +250,42 @@ class Cms::SchoolsController < ApplicationController
 
   def subscription_params
     params.permit([:id, :premium_status, :expiration_date => [:day, :month, :year]] + default_params)
+  end
+
+  def teacher_search_query_for_school(school_id)
+    # This query return an array of hashes that look like this:
+    # [
+    #   {
+    #     teacher_name: 'teacher name',
+    #     number_classrooms: 3,
+    #     number_students: 61,
+    #     number_activities_completed: 212,
+    #     last_active: 'Sep 19, 2017',
+    #     subscription: 'School Paid',
+    #     user_id: 42,
+    #     admin_id: null
+    #   }
+    # ]
+    ActiveRecord::Base.connection.execute("
+      SELECT
+        users.name AS teacher_name,
+        COUNT(DISTINCT(classrooms.id)) AS number_classrooms,
+        COUNT(DISTINCT(students_classrooms.student_id)) AS number_students,
+        COUNT(activity_sessions) AS number_activities_completed,
+        TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
+        subscriptions.account_type AS subscription,
+        users.id AS user_id,
+        schools_admins.id AS admin_id
+      FROM schools_users
+      LEFT JOIN users ON schools_users.user_id = users.id
+      LEFT JOIN classrooms ON schools_users.user_id = classrooms.teacher_id AND classrooms.visible = true
+      LEFT JOIN students_classrooms ON classrooms.id =  students_classrooms.classroom_id
+      LEFT JOIN activity_sessions ON students_classrooms.student_id = activity_sessions.user_id AND completed_at IS NOT NULL
+      LEFT JOIN user_subscriptions ON schools_users.user_id = user_subscriptions.user_id
+      LEFT JOIN subscriptions ON subscriptions.id = user_subscriptions.subscription_id
+      LEFT JOIN schools_admins ON users.id = schools_admins.user_id
+      WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(school_id)}
+      GROUP BY users.name, users.last_sign_in, subscriptions.account_type, users.id, schools_admins.id
+    ").to_a
   end
 end

--- a/app/controllers/cms/users_controller.rb
+++ b/app/controllers/cms/users_controller.rb
@@ -48,12 +48,16 @@ class Cms::UsersController < ApplicationController
   end
 
   def make_admin
-    User.find(params[:id]).update(role: 'admin')
+    admin = SchoolsAdmins.new
+    admin.school_id = params[:school_id]
+    admin.user_id = params[:user_id]
+    flash[:error] = 'Something went wrong.' unless admin.save
     redirect_to :back
   end
 
   def remove_admin
-    User.find(params[:id]).update(role: 'teacher')
+    admin = SchoolsAdmins.where(user_id: params[:user_id], school_id: params[:school_id]).first
+    flash[:error] = 'Something went wrong.' unless admin.destroy
     redirect_to :back
   end
 

--- a/app/controllers/cms/users_controller.rb
+++ b/app/controllers/cms/users_controller.rb
@@ -139,9 +139,7 @@ protected
   end
 
   def user_query(params)
-    # This should return an array of hashes with the following order.
-    # (Order matters because of the order in which these are being
-    # displayed in the table on the front end.)
+    # This should return an array of hashes that look like this:
     # [
     #   {
     #     name: 'first last',
@@ -155,6 +153,8 @@ protected
     #   }
     # ]
 
+    # NOTE: IF YOU CHANGE THIS QUERY'S CONDITIONS, PLEASE BE SURE TO
+    # ADJUST THE PAGINATION QUERY STRING AS WELL.
     ActiveRecord::Base.connection.execute("
       SELECT
       	users.name AS name,

--- a/app/views/cms/schools/show.html.erb
+++ b/app/views/cms/schools/show.html.erb
@@ -21,10 +21,10 @@
               <td><%= teacher[attribute] || 'N/A' %></td>
             <% end %>
             <td>
-              <% if teacher['user_role'] == 'admin' %>
-                <%= link_to 'Remove Admin', remove_admin_cms_user_path(teacher['user_id']), method: :put %>
+              <% unless teacher['admin_id'].blank? %>
+                <%= link_to 'Remove Admin', cms_user_remove_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
               <% else %>
-                <%= link_to 'Make Admin', make_admin_cms_user_path(teacher['user_id']), method: :put %>
+                <%= link_to 'Make Admin', cms_user_make_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
               <% end %>
             </td>
             <td><%= link_to 'Sign In', sign_in_cms_user_path(teacher['user_id']), method: :put %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,7 +304,6 @@ EmpiricalGrammar::Application.routes.draw do
 
     resources :users do
       resource :subscription
-
       collection do
         post :search
         get :search, to: 'users#index'
@@ -314,9 +313,9 @@ EmpiricalGrammar::Application.routes.draw do
         put :sign_in
         put :clear_data
         get :sign_in
-        put :make_admin
-        put :remove_admin
       end
+      put 'make_admin/:school_id', to: 'users#make_admin', as: :make_admin
+      put 'remove_admin/:school_id', to: 'users#remove_admin', as: :remove_admin
     end
 
     resources :schools do


### PR DESCRIPTION
This will still not allow searching for 'admin' in the user manager and having it show results other than role. (Not sure if that's problematic.)