### PR TITLE
fix #3245 - reset lessons cache when classrooms get archived

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -16,8 +16,8 @@ class Teachers::ClassroomActivitiesController < ApplicationController
   def hide
     cas = ClassroomActivity.where(activity_id: @classroom_activity.activity_id, unit_id: @classroom_activity.unit_id)
     activity_sessions = ActivitySession.where(classroom_activity_id: cas.ids)
-    # cannot use update_all here bc we need the callbacks to run
     cas.update_all(visible: false)
+    SetTeacherLessonCache.perform_async(current_user.id)
     activity_sessions.update_all(visible: false)
     @classroom_activity.unit.hide_if_no_visible_classroom_activities
     render json: {}
@@ -80,7 +80,12 @@ private
   end
 
   def lessons_cache
-    JSON.parse($redis.get("user_id:#{current_user.id}_lessons_array") || '[]')
+    lessons_cache = $redis.get("user_id:#{current_user.id}_lessons_array")
+    if lessons_cache
+      JSON.parse(lessons_cache)
+    else
+      current_user.set_and_return_lessons_cache_data
+    end
   end
 
   def classroom_activity_params

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -104,6 +104,7 @@ class Classroom < ActiveRecord::Base
   def hide_all_classroom_activities
     ActivitySession.where(classroom_activity: self.classroom_activities).update_all(visible: false)
     self.classroom_activities.update_all(visible: false)
+    SetTeacherLessonCache.perform_async(self.teacher_id)
     ids = Unit.find_by_sql("
       SELECT unit.id FROM units unit
       LEFT JOIN classroom_activities as ca ON ca.unit_id = unit.id AND ca.visible = true

--- a/app/models/concerns/teacher.rb
+++ b/app/models/concerns/teacher.rb
@@ -275,9 +275,21 @@ module Teacher
       AND actsesh.state = 'finished'")
   end
 
-  def set_lessons_cache
-    lessons_cache = self.classroom_activities.select{|ca| ca.activity.activity_classification_id == 6}.map{|ca| ca.lessons_cache_info_formatter}
-    $redis.set("user_id:#{self.id}_lessons_array", lessons_cache.to_json)
+  def set_and_return_lessons_cache_data
+    lessons_cache = get_data_for_lessons_cache
+    set_lessons_cache(lessons_cache)
+    lessons_cache
+  end
+
+  def set_lessons_cache(lessons_data=nil)
+    if !lessons_data
+      lessons_data = get_data_for_lessons_cache
+    end
+    $redis.set("user_id:#{self.id}_lessons_array", lessons_data.to_json)
+  end
+
+  def get_data_for_lessons_cache
+    self.classroom_activities.select{|ca| ca.activity.activity_classification_id == 6}.map{|ca| ca.lessons_cache_info_formatter}
   end
 
 

--- a/app/models/concerns/teacher.rb
+++ b/app/models/concerns/teacher.rb
@@ -275,4 +275,10 @@ module Teacher
       AND actsesh.state = 'finished'")
   end
 
+  def set_lessons_cache
+    lessons_cache = self.classroom_activities.select{|ca| ca.activity.activity_classification_id == 6}.map{|ca| ca.lessons_cache_info_formatter}
+    $redis.set("user_id:#{self.id}_lessons_array", lessons_cache.to_json)
+  end
+
+
 end

--- a/app/services/units/updater.rb
+++ b/app/services/units/updater.rb
@@ -66,7 +66,7 @@ module Units::Updater
     new_cas.each{|ca| ClassroomActivity.create(ca)}
     # TODO: same as above -- efficient, but we need the callbacks
     # hidden_cas_ids.any? ? ClassroomActivity.where(id: hidden_cas_ids).update_all(visible: false) : nil
-    hidden_cas_ids.each{|ca_id| ClassroomActivity.find(ca_id).update!(visible: false)}
+    hidden_cas_ids.each{|ca_id| ClassroomActivity.find_by_id(ca_id)&.update(visible: false)}
     unit = Unit.find unit_id
     if (hidden_cas_ids.any?) && (new_cas.none?)
       # then there is a chance that there are no existing classroom activities

--- a/app/workers/set_teacher_lesson_cache.rb
+++ b/app/workers/set_teacher_lesson_cache.rb
@@ -1,0 +1,9 @@
+class SetTeacherLessonCache
+  include Sidekiq::Worker
+
+  def perform(teacher_id)
+    @user = Teacher.find(teacher_id)
+    @user.set_lessons_cache
+  end
+
+end


### PR DESCRIPTION
Also, fixes issue where teachers couldn't update classroom activities when one was already archived.