### PR TITLE
Fixes an overly "helpful" validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -368,7 +368,7 @@ private
   def validate_username_and_email
     # change_field will return the field (username or email) that is changing
     change_field = detect_username_or_email_updated
-    if change_field && User.find_by(change_field => self[change_field])
+    if change_field && self[change_field].present? && User.find_by(change_field => self[change_field])
       # if the field has been changed, to that of an existing record,
       # raise an error
       errors.add(change_field, "is being updated to a #{change_field} that exists")


### PR DESCRIPTION
This validation was throwing a uniqueness error for email or username even if email or username wasn't present. We should not be checking for uniqueness on blank values. This was was preventing us from editing certain users via the CMS because these validations would consistently fail.

Also, do we want to consider killing some of the user model validations and enforce them on the database level instead?