### PR TITLE
Turn off autofill for various CMS forms

### DIFF
--- a/app/views/cms/schools/edit.html.erb
+++ b/app/views/cms/schools/edit.html.erb
@@ -18,7 +18,7 @@
         <% @editable_attributes.each do |attribute_name, attribute_field| %>
           <div class='cms-form-row'>
             <%= f.label attribute_field, attribute_name %>
-            <%= f.text_field attribute_field %>
+            <%= f.text_field attribute_field, autocomplete: 'off' %>
           </div>
         <% end %>
 

--- a/app/views/cms/schools/edit_subscription.html.erb
+++ b/app/views/cms/schools/edit_subscription.html.erb
@@ -8,12 +8,12 @@
       <%= form_tag update_subscription_cms_school_path(params[:id]) do %>
         <div class='cms-form-row'>
           <%= label_tag 'premium_status', 'Premium Status' %>
-          <%= select_tag 'premium_status', options_for_select(@school_premium_types, @account_type), include_blank: true %>
+          <%= select_tag 'premium_status', options_for_select(@school_premium_types, @account_type), include_blank: true, autocomplete: 'off' %>
         </div>
 
         <div class='cms-form-row'>
           <%= label_tag 'expiration_date', 'Expiration Date' %>
-          <%= select_date @expiration_date, prefix: :expiration_date %>
+          <%= select_date @expiration_date, prefix: :expiration_date, autocomplete: 'off' %>
         </div>
 
         <div class='cms-submit-row'>

--- a/app/views/cms/schools/new.html.erb
+++ b/app/views/cms/schools/new.html.erb
@@ -19,7 +19,7 @@
         <% @editable_attributes.each do |attribute_name, attribute_field| %>
           <div class='cms-form-row'>
             <%= f.label attribute_field, attribute_name %>
-            <%= f.text_field attribute_field %>
+            <%= f.text_field attribute_field, autocomplete: 'off' %>
           </div>
         <% end %>
 

--- a/app/views/cms/users/_form.html.erb
+++ b/app/views/cms/users/_form.html.erb
@@ -26,11 +26,11 @@
     </div>
     <div class='cms-form-row'>
       <%= f.label :password %>
-      <%= f.password_field :password, autocomplete: 'off' %>
+      <%= f.password_field :password, autocomplete: 'new-password' %>
     </div>
     <div class='cms-form-row'>
       <%= f.label :password_confirmation %>
-      <%= f.password_field :password_confirmation, autocomplete: 'off' %>
+      <%= f.password_field :password_confirmation, autocomplete: 'new-password' %>
     </div>
     <div class='cms-submit-row'>
       <%= f.submit 'Save', class: 'button-green' %>

--- a/app/views/cms/users/edit_subscription.html.erb
+++ b/app/views/cms/users/edit_subscription.html.erb
@@ -8,12 +8,12 @@
       <%= form_tag update_subscription_cms_user_path(params[:id]) do %>
         <div class='cms-form-row'>
           <%= label_tag 'premium_status', 'Premium Status' %>
-          <%= select_tag 'premium_status', options_for_select(@user_premium_types, @account_type), include_blank: true %>
+          <%= select_tag 'premium_status', options_for_select(@user_premium_types, @account_type), include_blank: true, autocomplete: 'off' %>
         </div>
 
         <div class='cms-form-row'>
           <%= label_tag 'expiration_date', 'Expiration Date' %>
-          <%= select_date @expiration_date, prefix: :expiration_date %>
+          <%= select_date @expiration_date, prefix: :expiration_date, autocomplete: 'off' %>
         </div>
 
         <div class='cms-submit-row'>


### PR DESCRIPTION
Unfortunately, certain modern browsers like to override explicit requests to _not_ autofill passwords and dynamically guessed username fields* (c'mon Chrome, what are you doing?!), so this is the closest we can get without doing something super hacky.

If even this fix ends up being problematic for staff, we can look into something a little hackier.

*Seriously, Firefox and Chrome will just guess which of the fields is the associated username/email field by looking at whichever input field is closest to the password one.