### PR TITLE
Fix #3321: fix how units query looks for students

### DIFF
--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -215,9 +215,8 @@ class Teachers::UnitsController < ApplicationController
       INNER JOIN activities ON ca.activity_id = activities.id
       INNER JOIN classrooms ON ca.classroom_id = classrooms.id
       LEFT JOIN activity_sessions AS act_sesh ON act_sesh.classroom_activity_id = ca.id
-      LEFT JOIN students_classrooms AS sc ON sc.classroom_id = ca.classroom_id
+      LEFT JOIN students_classrooms AS sc ON sc.classroom_id = ca.classroom_id AND sc.visible = TRUE
     WHERE units.user_id = #{current_user.id}
-      AND sc.visible = true
       AND classrooms.visible = true
       AND units.visible = true
       AND ca.visible = true


### PR DESCRIPTION
This fixes two things:

First, it ensures that we're showing units that aren't yet assigned to students.

Second, it corrects the count of students to ensure that we aren't counting students who have been removed from a classroom (i.e. StudentsClassrooms.visible = false).