### PR TITLE
Fix #3284: Improve empty state based on date range selection in scorebook

### DIFF
--- a/client/app/bundles/HelloWorld/components/general_components/__test__/date_range_filter.test.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/__test__/date_range_filter.test.jsx
@@ -8,43 +8,24 @@ import DateRangeFilter from '../date_range_filter'
 
 describe('DateRangeFilter component', () => {
 
-  it('should render a DateRangePicker', () => {
-    const wrapper = shallow(
-      <DateRangeFilter selectDates={() => {}} />
-    );
-    expect(wrapper.find(DateRangePicker).length).toEqual(1);
-  });
-
-  describe('getInitialState', () => {
-    it('should set beginDate and endDate based on props', () => {
-      const beginDate = moment();
-      const endDate = moment();
+  describe('DateRangePicker', () => {
+    it('should render', () => {
       const wrapper = shallow(
-        <DateRangeFilter beginDate={beginDate} endDate={endDate} />
+        <DateRangeFilter selectDates={() => {}} />
       );
-      expect(wrapper.state().beginDate).toEqual(beginDate);
-      expect(wrapper.state().endDate).toEqual(endDate);
+      expect(wrapper.find(DateRangePicker).length).toEqual(1);
     });
 
-    it('should set beginDate and endDate to null if not specified in props', () => {
-      const wrapper = shallow(<DateRangeFilter />);
-      expect(wrapper.state().beginDate).toBe(null);
-      expect(wrapper.state().endDate).toBe(null);
+    it('should call props.selectDates with correct params onDatesChange', () => {
+      const mockSelectDates = jest.fn();
+      const wrapper = mount(<DateRangeFilter selectDates={mockSelectDates} />);
+      const startDate = moment();
+      const endDate = moment().add(1, 'days');
+      wrapper.find(DateRangePicker).props().onDatesChange({startDate, endDate});
+      expect(mockSelectDates).toHaveBeenCalled();
+      expect(mockSelectDates.mock.calls[0][0]).toEqual(startDate);
+      expect(mockSelectDates.mock.calls[0][1]).toEqual(endDate);
     });
-  });
-
-  it('the function selectDates calls the selectDates prop function, passing beginDate and endDate from state', () => {
-    const mockSelectDates = jest.fn();
-    const beginDate = moment();
-    const endDate = moment();
-    const wrapper = shallow(
-      <DateRangeFilter selectDates={mockSelectDates} />
-    );
-    wrapper.setState({ beginDate: beginDate, endDate: endDate })
-    wrapper.instance().selectDates();
-    expect(mockSelectDates.mock.calls).toHaveLength(1);
-    expect(mockSelectDates.mock.calls[0][0]).toEqual(beginDate);
-    expect(mockSelectDates.mock.calls[0][0]).toEqual(endDate);
   });
 
   describe('setDateFromFilter', () => {
@@ -56,12 +37,6 @@ describe('DateRangeFilter component', () => {
     wrapper.instance().setDateFromFilter(beginDate);
     it('should call selectDates on callback', () => {
       expect(mockSelectDates).toHaveBeenCalled();
-    });
-
-    it('should set state', () => {
-      // TODO: mock 'moment' so we can ensure the endDate is set properly
-      expect(wrapper.state().beginDate).toEqual(beginDate);
-      expect(wrapper.state().focusedInput).toBe(null);
     });
   });
 

--- a/client/app/bundles/HelloWorld/components/general_components/date_range_filter.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/date_range_filter.jsx
@@ -10,28 +10,24 @@ export default React.createClass({
   },
 
   getInitialState: function () {
-    return ({
-      beginDate: this.props.beginDate || null,
-      endDate: this.props.endDate || null
-    });
-  },
-
-  selectDates: function () {
-    this.props.selectDates(this.state.beginDate, this.state.endDate);
+    return {};
   },
 
   setDateFromFilter: function(beginDate) {
-    this.setState({beginDate: beginDate, endDate: moment().add(1, 'days'), focusedInput: null}, this.selectDates);
+    this.setState({focusedInput: null});
+    this.props.selectDates(beginDate, moment().add(1, 'days'));
   },
 
   renderFilterOptions: function () {
     return (
       <div className='calendar-prefill-options'>
-        {this.props.filterOptions.map(filter => <DateRangeFilterOption
-          key={filter.title}
-          title={filter.title}
-          onClickFunction={() => { this.setDateFromFilter(filter.beginDate) }}
-        />)}
+        {this.props.filterOptions.map(filter =>
+          <DateRangeFilterOption
+            key={filter.title}
+            title={filter.title}
+            onClickFunction={() => { this.setDateFromFilter(filter.beginDate) }}
+          />
+        )}
       </div>
     );
   },
@@ -39,9 +35,9 @@ export default React.createClass({
   render: function() {
     return (
       <DateRangePicker
-        startDate={this.state.beginDate}
-        endDate={this.state.endDate}
-        onDatesChange={({ startDate, endDate }) => this.setState({ beginDate: startDate, endDate }, this.selectDates)}
+        startDate={this.props.beginDate}
+        endDate={this.props.endDate}
+        onDatesChange={({ startDate, endDate }) => this.props.selectDates(startDate, endDate)}
         focusedInput={this.state.focusedInput}
         onFocusChange={focusedInput => this.setState({ focusedInput })}
         numberOfMonths={1}

--- a/client/app/bundles/HelloWorld/components/progress_reports/dropdown_filter.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/dropdown_filter.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
     this.props.selectOption(option);
   },
   getButtonClassName() {
-    if (this.props.selectedOption.value == '') {
+    if (this.props.selectedOption && this.props.selectedOption.value == '') {
       return 'select-gray';
     }
     return 'select-white';
@@ -35,7 +35,7 @@ export default React.createClass({
     return (
         <div className={`button-select ${this.props.className}`}>
           <button type="button" className={this.getButtonClassName() + " select-mixin button-select button-select-wrapper"} data-toggle="dropdown">
-            {this.props.selectedOption.name || this.props.placeholder}
+            {(this.props.selectedOption && this.props.selectedOption.name) ? this.props.selectedOption.name : this.props.placeholder}
             <i className="fa fa-caret-down"></i>
           </button>
           {this.getFilterOptions()}

--- a/client/app/bundles/HelloWorld/components/scorebook/scorebook_filters.jsx
+++ b/client/app/bundles/HelloWorld/components/scorebook/scorebook_filters.jsx
@@ -40,6 +40,7 @@ export default React.createClass({
             options={this.props.classroomFilters}
             selectOption={this.props.selectClassroom}
             selectedOption={this.props.selectedClassroom}
+            placeholder={'Select a Classroom'}
           />
         </div>
         <div className="col-xs-12 col-sm-3 col-md-3 col-lg-3 col-xl-3">

--- a/client/app/bundles/HelloWorld/components/shared/EmptyProgressReport.jsx
+++ b/client/app/bundles/HelloWorld/components/shared/EmptyProgressReport.jsx
@@ -3,28 +3,37 @@ import React from 'react';
 export default React.createClass({
 
   render() {
-    let link,
+    let onButtonClick,
       buttonText,
-      content;
+      content,
+      title;
     if (this.props.missing === 'activities') {
-      link = '/teachers/classrooms/assign_activities';
+      title = 'You have no reports yet!';
+      onButtonClick = () => { window.location = '/teachers/classrooms/assign_activities'; }
       buttonText = 'Assign an Activity';
       content = 'In order to access our different reports, you need to assign activities to your students.';
     } else if (this.props.missing === 'students') {
-      link = '/teachers/classrooms/invite_students';
+      title = 'You have no reports yet!';
+      onButtonClick = () => { window.location = '/teachers/classrooms/invite_students'; }
       buttonText = 'Invite Students';
       content = 'In order to access our different reports, you need to invite your students and assign activities.'
+    } else if(this.props.missing === 'activitiesWithinDateRange') {
+      title = 'You have no reports in that range.';
+      onButtonClick = this.props.onButtonClick || null;
+      buttonText = 'Reset Date Range';
+      content = 'Please select a date range in which you assigned activities or your students worked on them.';
     } else {
-      link = '/teachers/classrooms/new';
+      title = 'You have no reports yet!';
+      onButtonClick = () => { window.location = '/teachers/classrooms/new'; }
       buttonText = 'Create a Class';
       content = 'In order to access our different reports, you need to create a class and assign activities to your students.'
     }
  		return (
    <div className="empty-progress-report">
      <img src='/images/empty_state_illustration.png' />
-     <h1>You have no reports yet!</h1>
+     <h1>{title}</h1>
      <p>{content}</p>
-     <button onClick={() => { window.location = link; }} className="button-green create-unit featured-button">{buttonText}</button>
+     <button onClick={onButtonClick} className="button-green create-unit featured-button">{buttonText}</button>
      <a href="/teacher_resources">Teacher Resources</a>
    </div>
  );

--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -85,21 +85,26 @@ export default React.createClass({
       url: `${process.env.DEFAULT_URL}/teachers/classrooms/${classroomId}/units`,
     }, (error, httpStatus, body) => {
       const parsedBody = JSON.parse(body);
-      that.setState({ unitFilters: parsedBody.units, selectedUnit: { name: 'All Activity Packs', value: '', }, });
+      that.setState({
+        unitFilters: parsedBody.units,
+        selectedUnit: { name: 'All Activity Packs', value: '', },
+        missing: this.checkMissing(this.state.scores)
+      });
     });
   },
 
-  checkMissing(newScores) {
-    if(!this.state.anyScoresHaveLoadedPreviously && newScores.size > 0) {
+  checkMissing(scores) {
+    if(!this.state.anyScoresHaveLoadedPreviously && scores.size > 0) {
       this.setState({anyScoresHaveLoadedPreviously: true});
       localStorage.setItem('anyScoresHaveLoadedPreviously', true);
     }
-
     if (!this.state.classroomFilters || this.state.classroomFilters.length === 0) {
       return 'classrooms';
-    } else if(this.state.anyScoresHaveLoadedPreviously && (!newScores || newScores.size === 0)) {
+    } else if(this.state.anyScoresHaveLoadedPreviously && (!scores || scores.size === 0)) {
       return 'activitiesWithinDateRange';
-    } else if (!newScores || newScores.size === 0) {
+    } else if (this.state.unitFilters.length && (!scores || scores.size === 0)) {
+      return 'students';
+    } else if (!scores || scores.size === 0) {
       return 'activities';
     }
   },

--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -37,6 +37,7 @@ export default React.createClass({
       loading: false,
       is_last_page: false,
       noLoadHasEverOccurredYet: true,
+      anyScoresHaveLoadedPreviously: localStorage.getItem('anyScoresHaveLoadedPreviously') || false
     };
   },
 
@@ -89,8 +90,15 @@ export default React.createClass({
   },
 
   checkMissing(newScores) {
+    if(!this.state.anyScoresHaveLoadedPreviously && newScores.size > 0) {
+      this.setState({anyScoresHaveLoadedPreviously: true});
+      localStorage.setItem('anyScoresHaveLoadedPreviously', true);
+    }
+
     if (!this.state.classroomFilters || this.state.classroomFilters.length === 0) {
       return 'classrooms';
+    } else if(this.state.anyScoresHaveLoadedPreviously && (!newScores || newScores.size === 0)) {
+      return 'activitiesWithinDateRange';
     } else if (!newScores || newScores.size === 0) {
       return 'activities';
     }
@@ -176,7 +184,8 @@ export default React.createClass({
     }
 
     if (this.state.missing) {
-      content = <EmptyProgressReport missing={this.state.missing} />;
+      const onButtonClick = this.state.missing == 'activitiesWithinDateRange' ? () => { this.selectDates(null, null); } : null;
+      content = <EmptyProgressReport missing={this.state.missing} onButtonClick={onButtonClick} />;
     } else {
       content =
         (<div>
@@ -196,8 +205,8 @@ export default React.createClass({
                 selectedUnit={this.state.selectedUnit}
                 unitFilters={this.state.unitFilters}
                 selectUnit={this.selectUnit} selectDates={this.selectDates}
-                beginDate={this.convertStoredDateToMoment(window.localStorage.getItem('scorebookBeginDate'))}
-                endDate={this.convertStoredDateToMoment(window.localStorage.getItem('scorebookEndDate'))}
+                beginDate={this.state.beginDate}
+                endDate={this.state.endDate}
               />
               <ScoreLegend />
               <AppLegend />

--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -43,7 +43,9 @@ export default React.createClass({
 
   componentDidMount() {
     this.setStateFromLocalStorage(this.fetchData);
-    this.getUpdatedUnits(this.props.selectedClassroom.value);
+    if(this.props.selectedClassroom) {
+      this.getUpdatedUnits(this.props.selectedClassroom.value);
+    }
     this.modules.scrollify.scrollify('#page-content-wrapper', this);
   },
 
@@ -63,6 +65,10 @@ export default React.createClass({
   fetchData() {
     const newCurrentPage = this.state.currentPage + 1;
     this.setState({ loading: true, currentPage: newCurrentPage, });
+    if(!this.state.selectedClassroom) {
+      this.setState({ missing: 'classrooms' });
+      return;
+    }
     $.ajax({
       url: '/teachers/classrooms/scores',
       data: {
@@ -209,7 +215,8 @@ export default React.createClass({
                 selectClassroom={this.selectClassroom}
                 selectedUnit={this.state.selectedUnit}
                 unitFilters={this.state.unitFilters}
-                selectUnit={this.selectUnit} selectDates={this.selectDates}
+                selectUnit={this.selectUnit}
+                selectDates={this.selectDates}
                 beginDate={this.state.beginDate}
                 endDate={this.state.endDate}
               />

--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -100,13 +100,13 @@ export default React.createClass({
   },
 
   checkMissing(scores) {
-    if(!this.state.anyScoresHaveLoadedPreviously && scores.size > 0) {
+    if(!(this.state.anyScoresHaveLoadedPreviously == 'true') && scores.size > 0) {
       this.setState({anyScoresHaveLoadedPreviously: true});
       localStorage.setItem('anyScoresHaveLoadedPreviously', true);
     }
     if (!this.state.classroomFilters || this.state.classroomFilters.length === 0) {
       return 'classrooms';
-    } else if(this.state.anyScoresHaveLoadedPreviously && (!scores || scores.size === 0)) {
+    } else if(this.state.anyScoresHaveLoadedPreviously == 'true' && (!scores || scores.size === 0)) {
       return 'activitiesWithinDateRange';
     } else if (this.state.unitFilters.length && (!scores || scores.size === 0)) {
       return 'students';

--- a/client/app/bundles/HelloWorld/containers/__tests__/Scorebook.test.jsx
+++ b/client/app/bundles/HelloWorld/containers/__tests__/Scorebook.test.jsx
@@ -33,13 +33,39 @@ describe('Scorebook component', () => {
     const wrapper = shallow(<Scorebook />);
     expect(wrapper).toMatchSnapshot();
   });
-  //
+
   describe('if state.missing has a value', () => {
     const wrapper = shallow(<Scorebook />);
     wrapper.setState({ missing: 'activities', });
 
-    it('renders EmptyProgressReport', () => {
-      expect(wrapper.find(EmptyProgressReport).length).toEqual(1);
+    describe('EmptyProgressReport', () => {
+      it('renders', () => {
+        expect(wrapper.find(EmptyProgressReport).length).toEqual(1);
+      });
+
+      it('receives classrooms as the missing prop value when appropriate', () => {
+        const wrapper = shallow(<Scorebook />);
+        wrapper.setState({ classroomFilters: [] });
+        expect(wrapper.instance().checkMissing(new Map())).toBe('classrooms');
+      });
+
+      it('receives activities as the missing prop value when appropriate', () => {
+        const wrapper = shallow(<Scorebook />);
+        wrapper.setState({ anyScoresHaveLoadedPreviously: 'true', classroomFilters: [''] });
+        expect(wrapper.instance().checkMissing(new Map())).toBe('activitiesWithinDateRange');
+      });
+
+      it('receives students as the missing prop value when appropriate', () => {
+        const wrapper = shallow(<Scorebook />);
+        wrapper.setState({ unitFilters: [''], classroomFilters: [''] });
+        expect(wrapper.instance().checkMissing(new Map())).toBe('students');
+      });
+
+      it('receives activitiesWithinDateRange as the missing prop value when appropriate', () => {
+        const wrapper = shallow(<Scorebook />);
+        wrapper.setState({ classroomFilters: [''] });
+        expect(wrapper.instance().checkMissing(new Map())).toBe('activities');
+      });
     });
 
     it('does not render LoadingIndicator', () => {
@@ -61,11 +87,6 @@ describe('Scorebook component', () => {
     it('does not render StudentScores', () => {
       expect(wrapper.find(StudentScores).length).toEqual(0);
     });
-
-    // it('does not get rendered if it is not passed a value for missing', () => {
-    //   const wrapper = shallow(<Scorebook missing={''}/>)
-    //   expect(wrapper.find(EmptyProgressReport).length).toEqual(0)
-    // })
   });
 
   describe('if state.loading is true', () => {


### PR DESCRIPTION
*Note: this won't work properly in the edge case that the teacher archives everything and returns to the visual overview. In this instance, it will show a 'You have no reports in that range.' message though it should show a different one. The other area where it's possible for this to not work fully correctly is if two teachers are sharing the same login, browser, and computer. In this case, it's possible that the 'You have no reports in that range.' message will display inappropriately as well.*

This PR also fixes #3337, adds an empty state to the Scorebook for when the teacher has assigned activities but doesn't have students, and adds/removes/modifies tests where appropriate.