### PR TITLE
Fix last of #3182: allow unit templates to be set to prod in CMS

### DIFF
--- a/app/controllers/cms/unit_templates_controller.rb
+++ b/app/controllers/cms/unit_templates_controller.rb
@@ -25,7 +25,9 @@ class Cms::UnitTemplatesController < ApplicationController
   end
 
   def update
-    if @unit_template.update_attributes(unit_template_params)
+    params = unit_template_params
+    params['flag'] = nil if params['flag'] == 'production'
+    if @unit_template.update_attributes(params)
       render json: @unit_template
     else
       render json: {errors: @unit_template.errors}, status: 422

--- a/client/app/bundles/HelloWorld/components/unit_templates/unit_template.jsx
+++ b/client/app/bundles/HelloWorld/components/unit_templates/unit_template.jsx
@@ -49,7 +49,7 @@ export default React.createClass({
       {name: 'grades', value: [], fromServer: true},
       {name: 'unit_template_categories', value: [], fromServer: true, cmsController: true},
       {name: 'authors', value: [], fromServer: true, cmsController: true},
-      {name: 'flag', value: ['alpha', 'beta', 'archived'], fromServer: false, cmsController: true},
+      {name: 'flag', value: ['production', 'alpha', 'beta', 'archived'], fromServer: false, cmsController: true},
       {name: 'order_number', value: _.range(1, 30), fromServer: false}
     ];
     return this.modelOptions;
@@ -168,7 +168,7 @@ export default React.createClass({
     // The label is a quick hack as it wasn't automatically turning to the correct one
     return <DropdownSelector
                 select={this.modules.indicatorGenerator.selector('flag')}
-                defaultValue={this.props.unitTemplate.flag}
+                defaultValue={this.state.model.flag}
                 options={this.state.options.flag}
                 label={'Select Flag'} />;
   },
@@ -176,10 +176,9 @@ export default React.createClass({
   getOrderNumber: function () {
     return <DropdownSelector
       select={this.modules.indicatorGenerator.selector('order_number')}
-      defaultValue={this.props.unitTemplate.order_number}
+      defaultValue={this.state.model.order_number}
       options={this.state.options.order_number}
-      label={'Select Order Number'}
-    />
+      label={'Select Order Number'} />;
   },
 
   getAuthorSelect: function () {


### PR DESCRIPTION
This also fixes the dropdowns, which previously were not working.