### PR TITLE
Fix #3412: Better measure our test coverage

### DIFF
--- a/client/app/bundles/HelloWorld/components/general_components/tooltip/__tests__/activity_details.test.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/tooltip/__tests__/activity_details.test.jsx
@@ -20,7 +20,7 @@ describe('ActivityDetails component', () => {
 
   it('should render the objective', () => {
     const wrapper = shallow(<ActivityDetails
-      data={Object.assign({}, baseData, { concept_results: [{ metadata: null, description: 'Combine sentences to create 9 sentences that have an appositive phrase in the middle of the sentence.', name: null, completed_at: null, due_date: '2016-11-04 00:00:00', }], })}
+      data={Object.assign({}, baseData, { activity_description: 'Combine sentences to create 9 sentences that have an appositive phrase in the middle of the sentence.', concept_results: [{ metadata: null, description: 'Combine sentences to create 9 sentences that have an appositive phrase in the middle of the sentence.', name: null, completed_at: null, due_date: '2016-11-04 00:00:00', }], })}
     />);
     expect(wrapper.find('.activity-detail-body').text()).toMatch('Objectives: Combine sentences to create 9 sentences that have an appositive phrase in the middle of the sentence.');
   });

--- a/client/package.json
+++ b/client/package.json
@@ -126,7 +126,8 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js"
-    }
+    },
+    "collectCoverageFrom" : ["app/**/*.{js,jsx}"]
   },
   "author": "Empirical",
   "license": "ISC"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@ require 'simplecov'
 require 'simplecov-json'
 SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 SimpleCov.start do
-  track_files "{app,lib}/**/*.rb"
+  track_files '{app,lib}/**/*.rb'
+  add_filter '/spec/'
 end
 
 require 'rspec/retry'


### PR DESCRIPTION
- Tell CodeCov not to look at the `/spec/` folder
- Tell Jest to look at all relevant files