### PR TITLE
Fix factory bot gems so they are not required in every env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,8 +159,8 @@ group :test, :development do
   gem "rspec-rails"
   gem 'fuubar', '~> 2.0.0.rc1'
   gem "timecop"
-  gem "factory_bot"
-  gem "factory_bot_rails"
+  gem "factory_bot", require: false
+  gem "factory_bot_rails", require: false
   gem "database_cleaner"
   gem 'byebug', '8.2.1' # getting errors on mac yosemite when trying to install 8.2.2
   gem 'guard'


### PR DESCRIPTION
Apparently, we've had this configured wrong for all of eternity but only just now noticed in the course of starting to write good tests again! 😱 