### PR TITLE
Stop running Jest on silent mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   # - npm run lint
   - bundle exec rake spec
   - bash <(curl -s https://codecov.io/bash) -cF rspec -f coverage/coverage.json
-  - npm run jest:silent
+  - npm run jest
   - bash <(curl -s https://codecov.io/bash) -cF jest
   - bundle exec brakeman
   - bundle exec teaspoon


### PR DESCRIPTION
We had changed Jest to run silently on Travis awhile back when we were running into log length errors due to the size of our linter output. This is no longer a problem, so we should run Jest normally again.

This may also help with the Travis timeout errors we've been seeing as there will be more frequent output. (Though, we should continue working to find the proximate cause of those timeouts.)