### PR TITLE
Tell Travis to kill redis when we no longer need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - npm run build:test
   # - npm run lint
   - bundle exec rake spec
+  - ps -ef | grep 'redis-server' | awk '{ print $2}' | xargs kill -9 # kill redis instances
   - bash <(curl -s https://codecov.io/bash) -cF rspec -f coverage/coverage.json
   - npm run jest:silent
   - bash <(curl -s https://codecov.io/bash) -cF jest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - npm run build:test
   # - npm run lint
   - bundle exec rake spec
-  - ps -ef | grep 'redis-server' | awk '{ print $2}' | xargs kill -9 # kill redis instances
+  - ps -ef | grep 'redis-server' | head -n 3 | awk '{ print $2}' | xargs kill -9 # kill the three redis instances
   - bash <(curl -s https://codecov.io/bash) -cF rspec -f coverage/coverage.json
   - npm run jest:silent
   - bash <(curl -s https://codecov.io/bash) -cF jest


### PR DESCRIPTION
Having these redis instances running in the background unnecessarily might be contributing to our slower Travis build times.