### PR TITLE
Use the right TravisCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Empirical Core is the Learning Management System that powers Quill.org, a free w
 
 |Front End|Back End|Travis CI|
 |---|---|---|
-|[![codecov](https://codecov.io/gh/empirical-org/Empirical-Core/branch/develop/graph/badge.svg?flag=jest)](https://codecov.io/gh/empirical-org/Empirical-Core)|[![codecov](https://codecov.io/gh/empirical-org/Empirical-Core/branch/develop/graph/badge.svg?flag=rspec)](https://codecov.io/gh/empirical-org/Empirical-Core)|[![Build Status](https://travis-ci.org/empirical-org/Empirical-Core.svg)](https://travis-ci.org/empirical-org/Empirical-Core)
+|[![codecov](https://codecov.io/gh/empirical-org/Empirical-Core/branch/develop/graph/badge.svg?flag=jest)](https://codecov.io/gh/empirical-org/Empirical-Core)|[![codecov](https://codecov.io/gh/empirical-org/Empirical-Core/branch/develop/graph/badge.svg?flag=rspec)](https://codecov.io/gh/empirical-org/Empirical-Core)|[![Build Status](https://travis-ci.org/empirical-org/Empirical-Core.svg?branch=develop)](https://travis-ci.org/empirical-org/Empirical-Core)
 
 
 


### PR DESCRIPTION
We weren't specifying the branch, so it was just using the latest commit (which generally will fail because they're interim, so it's not reflective of develop).