### PR TITLE
fix #3507 - students only in progress when joined lesson

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -72,7 +72,7 @@ class Teachers::ClassroomActivitiesController < ApplicationController
 private
 
   def find_or_create_lesson_activity_sessions_for_classroom
-    @classroom_activity.assigned_student_ids.each{|id| @classroom_activity.find_or_create_started_activity_session(id)}
+    @classroom_activity.assigned_student_ids.each{|id| ActivitySession.unscoped.find_or_create_by(classroom_activity_id: @classroom_activity.id, activity_id: @classroom_activity.activity_id, user_id: id).update(visible: true)}
   end
 
   def authorize!

--- a/app/models/classroom_activity.rb
+++ b/app/models/classroom_activity.rb
@@ -84,9 +84,12 @@ class ClassroomActivity < ActiveRecord::Base
   end
 
   def find_or_create_started_activity_session(student_id)
-    started_activity = ActivitySession.find_by(state: 'started', classroom_activity_id: self.id, user_id: student_id)
-    if started_activity
-      started_activity
+    activity_session = ActivitySession.find_by(classroom_activity_id: self.id, user_id: student_id)
+    if activity_session && activity_session.state == 'started'
+      activity_session
+    elsif activity_session && activity_session.state == 'unstarted'
+      activity_session.update(state: 'started')
+      activity_session
     else
       ActivitySession.create(classroom_activity_id: self.id, user_id: student_id, activity_id: self.activity_id, state: 'started', started_at: Time.now)
     end


### PR DESCRIPTION
Addresses issue #3507

**Changes proposed in this pull request:**
- create unstarted, rather than started, activity sessions when teachers launch a lesson for each of the students
- change it to started only when student joins the lesson

**Has this branch been QA'd on staging?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
