### PR TITLE
fix  #3539 - show missed lesson in activity analysis

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -72,7 +72,7 @@ class Teachers::ClassroomActivitiesController < ApplicationController
 private
 
   def find_or_create_lesson_activity_sessions_for_classroom
-    @classroom_activity.assigned_student_ids.each{|id| @classroom_activity.find_or_create_started_activity_session(id)}
+    @classroom_activity.assigned_student_ids.each{|id| ActivitySession.unscoped.find_or_create_by(classroom_activity_id: @classroom_activity.id, activity_id: @classroom_activity.activity_id, user_id: id).update(visible: true)}
   end
 
   def authorize!

--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -127,7 +127,7 @@ class Teachers::UnitsController < ApplicationController
        ca.due_date,
        activities.id AS activity_id,
        activities.uid as activity_uid,
-       SUM(CASE WHEN act_sesh.state = 'finished' THEN 1 ELSE 0 END) AS completed_count,
+       ca.completed AS completed,
        SUM(CASE WHEN act_sesh.state = 'started' THEN 1 ELSE 0 END) AS started_count,
        EXTRACT(EPOCH FROM units.created_at) AS unit_created_at,
        EXTRACT(EPOCH FROM ca.created_at) AS classroom_activity_created_at

--- a/app/models/classroom_activity.rb
+++ b/app/models/classroom_activity.rb
@@ -84,9 +84,12 @@ class ClassroomActivity < ActiveRecord::Base
   end
 
   def find_or_create_started_activity_session(student_id)
-    started_activity = ActivitySession.find_by(state: 'started', classroom_activity_id: self.id, user_id: student_id)
-    if started_activity
-      started_activity
+    activity_session = ActivitySession.find_by(classroom_activity_id: self.id, user_id: student_id)
+    if activity_session && activity_session.state == 'started'
+      activity_session
+    elsif activity_session && activity_session.state == 'unstarted'
+      activity_session.update(state: 'started')
+      activity_session
     else
       ActivitySession.create(classroom_activity_id: self.id, user_id: student_id, activity_id: self.activity_id, state: 'started', started_at: Time.now)
     end

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -71,7 +71,7 @@ module PublicProgressReports
       questions_arr
     end
 
-    def classrooms_with_students_that_completed_activity unit_id, activity_id
+    def classrooms_with_students_that_completed_activity(unit_id, activity_id)
       h = {}
       unit = Unit.find(unit_id)
       class_ids = current_user.classrooms_i_teach.map(&:id)
@@ -81,14 +81,16 @@ module PublicProgressReports
       class_acts.each do |ca|
         classroom = ca.classroom.attributes
         activity_sessions = ca.activity_sessions.completed
-        activity_sessions.each do |activity_session|
+        if activity_sessions || ca.completed
           class_id = classroom['id']
           h[class_id] ||= classroom
-          h[class_id][:students] ||= []
-          if h[class_id][:students].exclude? activity_session.user
-             h[class_id][:students] << activity_session.user
-          end
           h[class_id][:classroom_activity_id] = ca.id
+          activity_sessions.each do |activity_session|
+            h[class_id][:students] ||= []
+            if h[class_id][:students].exclude? activity_session.user
+               h[class_id][:students] << activity_session.user
+            end
+          end
         end
       end
 

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -110,7 +110,8 @@ module PublicProgressReports
         name: classroom.name,
         students: [],
         started_names: [],
-        unstarted_names: []
+        unstarted_names: [],
+        missed_names: []
       }
       classroom_activity.assigned_student_ids.each do |student_id|
         student = User.find_by(id: student_id)
@@ -121,6 +122,8 @@ module PublicProgressReports
           else
             if ActivitySession.find_by(user_id: student_id, state: 'started', classroom_activity_id: ca_id)
               scores[:started_names].push(student.name)
+            elsif classroom_activity.completed
+              scores[:missed_names].push(student.name)
             else
               scores[:unstarted_names].push(student.name)
             end

--- a/client/app/bundles/HelloWorld/components/general_components/dropdown_selectors/classroom_dropdown.jsx
+++ b/client/app/bundles/HelloWorld/components/general_components/dropdown_selectors/classroom_dropdown.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
 	},
 
 	classrooms: function() {
-		return this.props.classrooms.map((classroom) => <MenuItem key={classroom.id} eventKey={classroom.id}>{classroom.name}</MenuItem>)
+		return this.props.classrooms.map((classroom) => <MenuItem key={classroom.id} eventKey={classroom.id}>{classroom ? classroom.name : ''}</MenuItem>)
 	},
 
   findClassroomById: function(id) {
@@ -33,7 +33,7 @@ export default React.createClass({
 
 	render: function() {
 		return (
-			<DropdownButton disabled={!this.props.classrooms.length} bsStyle='default' title={this.state.selectedClassroom.name} id='select-classroom-dropdown' onSelect={this.handleSelect}>
+			<DropdownButton disabled={!this.props.classrooms.length} bsStyle='default' title={this.state.selectedClassroom ? this.state.selectedClassroom.name : ''} id='select-classroom-dropdown' onSelect={this.handleSelect}>
 				{this.classrooms()}
 			</DropdownButton>
 		);

--- a/client/app/bundles/HelloWorld/components/lesson_planner/classroom_lessons.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/classroom_lessons.jsx
@@ -115,7 +115,7 @@ export default class ClassroomLessons extends React.Component {
 			classroomId: u.classroom_id,
       dueDate: u.due_date,
       supportingInfo: u.supporting_info,
-      completed: u.completed_count > 0,
+      completed: u.completed,
       studentCount: studentCount,
       started: u.started_count > 0,
       hasEditions: hasEditions
@@ -150,7 +150,7 @@ export default class ClassroomLessons extends React.Component {
           createdAt: u.ca_created_at,
           dueDate: u.due_date,
           supportingInfo: u.supporting_info,
-          completed: u.completed_count > 0,
+          completed: u.completed,
           studentCount: studentCount,
           started: u.started_count > 0,
           hasEditions: hasEditions

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/__snapshots__/missed_lesson.test.jsx.snap
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/__snapshots__/missed_lesson.test.jsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClassReport component matches the snapshot 1`] = `
+<tr
+  className="unstarted-row"
+>
+  <td>
+    Emilia Friedberg
+  </td>
+  <td
+    colSpan="3"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    Missed Lesson
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "background": "#348fdf",
+          "borderRadius": "3px",
+          "bottom": "-34px",
+          "color": "white",
+          "display": "none",
+          "fontSize": "12px",
+          "justifyContent": "center",
+          "left": "11px",
+          "lineHeight": "normal",
+          "padding": "3px 0px 5px",
+          "position": "absolute",
+          "width": "205px",
+          "zIndex": 100,
+        }
+      }
+    >
+      <i
+        className="fa fa-caret-up"
+        style={
+          Object {
+            "bottom": "22px",
+            "color": "#348fdf",
+            "fontSize": "16px",
+            "left": "10px",
+            "position": "relative",
+          }
+        }
+      />
+      You can reassign this lesson to the students who missed it.
+    </div>
+  </td>
+</tr>
+`;

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/class_report.test.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/class_report.test.jsx
@@ -115,14 +115,17 @@ describe('ClassReport component', () => {
       ];
       const startedNames = ['Example A', 'Example B', 'Example C'];
       const unstartedNames = ['Example A', 'Example B', 'Example C'];
+      const missedNames = ['Example A, Example B, Example C'];
       wrapper.find(ProgressReport).props().onFetchSuccess({
         students: students,
         started_names: startedNames,
-        unstarted_names: unstartedNames
+        unstarted_names: unstartedNames,
+        missed_names: missedNames
       });
       expect(wrapper.state().students).toEqual(students);
       expect(wrapper.state().startedNames).toEqual(startedNames);
       expect(wrapper.state().unstartedNames).toEqual(unstartedNames);
+      expect(wrapper.state().missedNames).toEqual(missedNames);
     });
   });
 

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/missed_lesson.test.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__test__/missed_lesson.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import MissedLessonRow from '../missed_lesson_row.jsx';
+
+describe('ClassReport component', () => {
+  const wrapper = shallow(
+    <MissedLessonRow
+      name='Emilia Friedberg'
+    />
+  );
+
+  it('returns the correct initial state', () => {
+    expect(wrapper.state()).toEqual({showTooltip: false});
+  });
+
+  it('matches the snapshot', () => {
+    expect(wrapper).toMatchSnapshot()
+  });
+})

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -73,12 +73,20 @@ export default React.createClass({
     };
   },
 
+  sortByLastName: function(names) {
+    return names.sort((a, b) => {
+      const aLast = a.split(' ')[1]
+      const bLast = b.split(' ')[1]
+      return aLast.localeCompare(bLast)
+    })
+  },
+
   onFetchSuccess: function(responseData) {
     this.setState({
       students: responseData.students,
-      startedNames: responseData.started_names,
-      unstartedNames: responseData.unstarted_names,
-      missedNames: responseData.missed_names
+      startedNames: this.sortByLastName(responseData.started_names),
+      unstartedNames: this.sortByLastName(responseData.unstarted_names),
+      missedNames: this.sortByLastName(responseData.missed_names)
     });
   },
 

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ProgressReport from '../progress_report.jsx'
 import OverviewBoxes from './overview_boxes.jsx'
+import MissedLessonRow from './missed_lesson_row.jsx'
 import _ from 'underscore';
 
 export default React.createClass({
@@ -76,7 +77,8 @@ export default React.createClass({
     this.setState({
       students: responseData.students,
       startedNames: responseData.started_names,
-      unstartedNames: responseData.unstarted_names
+      unstartedNames: responseData.unstarted_names,
+      missedNames: responseData.missed_names
     });
   },
 
@@ -84,11 +86,13 @@ export default React.createClass({
     if (this.state.showInProgressAndUnstartedStudents) {
       const startedRows = _.map(this.state.startedNames, name => <tr key={name} className='in-progress-row'><td>{name}</td><td colSpan='3'>In Progress</td></tr>)
       const unstartedRows = _.map(this.state.unstartedNames, name => <tr key={name} className='unstarted-row'><td>{name}</td><td colSpan='3'>Not Started</td></tr>)
+      const missedRows = _.map(this.state.missedNames, name => <MissedLessonRow name={name}/>)
       return (
         <table className='student-report-box sortable-table'>
           <tbody>
             {startedRows}
             {unstartedRows}
+            {missedRows}
           </tbody>
         </table>
       )

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/missed_lesson_row.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/missed_lesson_row.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+
+export default class MissedLessonRow extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      showTooltip: false
+    }
+
+    this.hideTooltip = this.hideTooltip.bind(this)
+    this.showTooltip = this.showTooltip.bind(this)
+  }
+
+  hideTooltip() {
+    this.setState({ showTooltip: false, });
+  }
+
+  showTooltip() {
+    this.setState({ showTooltip: true, });
+  }
+
+  tooltip() {
+    const tooltipStyle = {
+      display: this.state.showTooltip ? 'flex' : 'none',
+      fontSize: '12px',
+      background: '#348fdf',
+      color: 'white',
+      lineHeight: 'normal',
+      zIndex: 100,
+      borderRadius: '3px',
+      bottom: '-34px',
+      left: '85px',
+      alignItems: 'center',
+      padding: '3px 0px 5px',
+      justifyContent: 'center',
+      position: 'absolute',
+      width: '200px'
+    }
+    const caretStyle={
+      position: 'relative',
+      bottom: '22px',
+      left: '10px',
+      fontSize: '16px',
+      color: '#348fdf',
+    }
+    return <div style={tooltipStyle}>
+      <i style={caretStyle} className="fa fa-caret-up"/>
+      You can reassign this lesson to the students who missed it.
+    </div>
+  }
+
+  render() {
+    return <tr key={this.props.name} className='unstarted-row'>
+      <td>{this.props.name}</td>
+      <td onMouseEnter={this.showTooltip} onMouseLeave={this.hideTooltip} colSpan='3' style={{position: 'relative'}}>
+        Missed Lesson
+        {this.tooltip()}
+      </td>
+    </tr>
+  }
+}

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/missed_lesson_row.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/missed_lesson_row.jsx
@@ -30,12 +30,12 @@ export default class MissedLessonRow extends React.Component {
       zIndex: 100,
       borderRadius: '3px',
       bottom: '-34px',
-      left: '85px',
+      left: '11px',
       alignItems: 'center',
       padding: '3px 0px 5px',
       justifyContent: 'center',
       position: 'absolute',
-      width: '200px'
+      width: '205px'
     }
     const caretStyle={
       position: 'relative',

--- a/client/app/bundles/HelloWorld/components/progress_reports/progress_report.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/progress_report.jsx
@@ -149,7 +149,7 @@ export default  React.createClass({
   fetchData: function(setStateBasedOnURLParams) {
     this.setState({loading: true});
     $.get(this.props.sourceUrl, this.requestParams(), function onSuccess(data) {
-      this.setState({
+        this.setState({
         numPages: data.page_count,
         loading: false,
         results: this.strippedResults(data[this.props.jsonResultsKey]),


### PR DESCRIPTION
Adresses issue #

**Changes proposed in this pull request:**
- classroom activities marked as completed (ie, lessons) can be rendered in report pages without breaking everything via an update to the classrooms_with_students_that_completed_activity method
- students who missed lessons will have 'Missed Lesson' displayed as their score on the Activity Analysis page, with a tooltip that tells the teacher they can reassign it on hover

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2017-12-06 at 10 19 59 am](https://user-images.githubusercontent.com/18669014/33668933-16a5ac6e-da6f-11e7-9902-5de36c7c60ed.png)

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
