### PR TITLE
give tools tabs no bottom margin

### DIFF
--- a/client/app/assets/styles/tool-section.scss
+++ b/client/app/assets/styles/tool-section.scss
@@ -573,6 +573,9 @@ $tool-grey: #f8f9f9;
 }
 
 .tools-tabs {
+  .q-nav-bar ul.desktop-nav-list {
+    margin-bottom: 0px;
+  }
     li {
       &.active {
         border-top: 3px solid #027360;


### PR DESCRIPTION
Addresses issue #3548

**Changes proposed in this pull request:**
- give tool tabs specific style rule so they don't get weird green line beneath them

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2017-12-06 at 10 41 26 am](https://user-images.githubusercontent.com/18669014/33670143-5ea75dca-da72-11e7-8462-13577099bbe2.png)
![screen shot 2017-12-06 at 10 42 18 am](https://user-images.githubusercontent.com/18669014/33670152-65ea6c62-da72-11e7-868f-c9c929a15dac.png)

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?**no

**Reviewer:** @ddmck
