### PR TITLE
fix #3544 - diagnostic is an empty object, not null, if there is no diagnostic info

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -97,7 +97,7 @@ class TeachersController < ApplicationController
       ca = ClassroomActivity.find_by(unit_id: unit_id, activity_id: [413, 447, 602])
       unit_info = { unit_id: unit_id, classroom_id: ca.classroom_id, activity_id: ca.activity_id }
     rescue
-      unit_info = nil
+      unit_info = {}
     end
     render json: {unit_info: unit_info}
   end

--- a/client/app/bundles/HelloWorld/components/dashboard/lessons_list.jsx
+++ b/client/app/bundles/HelloWorld/components/dashboard/lessons_list.jsx
@@ -99,7 +99,7 @@ export default class extends React.Component {
         </div>
         {this.renderAssignedLessons()}
       </div>
-    } else if (this.state.completedDiagnosticUnitInfo) {
+    } else if (this.state.completedDiagnosticUnitInfo && Object.keys(this.state.completedDiagnosticUnitInfo).length > 0) {
       const {unit_id, classroom_id, activity_id} = this.state.completedDiagnosticUnitInfo
       return <div className="inner-container">
         <div className="header-container flex-row space-between vertically-centered lesson-item">


### PR DESCRIPTION
Addresses issue #3544

**Changes proposed in this pull request:**
- get_completed_diagnostic_unit_info returns empty object, not null, if no diagnostic info, which allows the null check in the lessons list component (meant to ensure the query has returned) to function as desired

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2017-12-06 at 10 59 40 am](https://user-images.githubusercontent.com/18669014/33671336-59293780-da75-11e7-9fcf-a561f3de6238.png)

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
