### PR TITLE
Fix Brakeman 

### DIFF
--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -76,7 +76,6 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     end
 
     def diagnostic_status
-      diagnostic_activity_ids = [413, 447, 602]
       cas = ActiveRecord::Base.connection.execute("
         SELECT activity_sessions.state
         FROM classrooms_teachers
@@ -86,7 +85,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
         JOIN classroom_activities
           ON  classrooms.id = classroom_activities.classroom_id
           AND classroom_activities.visible = TRUE
-          AND classroom_activities.activity_id IN (#{diagnostic_activity_ids.join(', ')})
+          AND classroom_activities.activity_id IN (#{Activity::DIAGNOSTIC_ACTIVITY_IDS.join(', ')})
         LEFT JOIN activity_sessions
           ON  classroom_activities.id = activity_sessions.classroom_activity_id
           AND activity_sessions.state = 'finished'

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -29,6 +29,8 @@ class Activity < ActiveRecord::Base
 
   scope :with_classification, -> { includes(:classification).joins(:classification) }
 
+  DIAGNOSTIC_ACTIVITY_IDS = [413, 447, 602]
+
   def topic_uid= uid
     self.topic_id = Topic.find_by_uid(uid).id
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -160,6 +160,26 @@
       "note": "This is an API..."
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "987eba4ded8ee9151b02cc136e53b8fc278574a5e2c49e7ff495efde9ff49c50",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb",
+      "line": 88,
+      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"\\n        SELECT activity_sessions.state\\n        FROM classrooms_teachers\\n        JOIN classrooms\\n          ON  classrooms_teachers.classroom_id = classrooms.id\\n          AND classrooms.visible = TRUE\\n        JOIN classroom_activities\\n          ON  classrooms.id = classroom_activities.classroom_id\\n          AND classroom_activities.visible = TRUE\\n          AND classroom_activities.activity_id IN (#{[413, 447, 602].join(\", \")})\\n        LEFT JOIN activity_sessions\\n          ON  classroom_activities.id = activity_sessions.classroom_activity_id\\n          AND activity_sessions.state = 'finished'\\n          AND activity_sessions.visible = TRUE\\n        WHERE classrooms_teachers.user_id = #{current_user.id}\\n      \")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Teachers::ProgressReports::DiagnosticReportsController",
+        "method": "diagnostic_status"
+      },
+      "user_input": "[413, 447, 602].join(\", \")",
+      "confidence": "Medium",
+      "note": "DIAGNOSTIC_ACTIVITY_IDS is a constant we control, so this is a false positive."
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "98c69d29e04c054ad795076081010b159bd38af8163776aee4fd61deb5076f89",
@@ -380,6 +400,6 @@
       "note": "This is in the CMS, so no need to worry."
     }
   ],
-  "updated": "2017-11-30 15:22:04 -0500",
+  "updated": "2017-12-07 09:43:37 -0500",
   "brakeman_version": "3.7.2"
 }


### PR DESCRIPTION
Brakeman is currently failing on develop due to a false positive SQL injection. This fixes it.

This also adds a DIAGNOSTIC_ACTIVITY_IDS constant on Activity instead of hardcoding it into the diagnostic_info method.

~~Please make sure progress_reports tests pass before merging this.~~ _Update: they passed._