### PR TITLE
fix #3562 - make sure loading indicator renders below scores

### DIFF
--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -191,9 +191,9 @@ export default React.createClass({
       const sData = s.scores[0];
       scores.push(<StudentScores key={`${sData.userId}`} data={{ scores: s.scores, name: s.name, activity_name: sData.activity_name, userId: sData.userId, classroomId: this.state.selectedClassroom.id }} premium_state={this.props.premium_state} />);
     });
-    
+
     if (this.state.loading) {
-      content = <LoadingIndicator />;
+      content = <div>{scores}<LoadingIndicator /></div>;
     } else if (this.state.missing) {
       const onButtonClick = this.state.missing == 'activitiesWithinDateRange' ? () => { this.selectDates(null, null); } : null;
       content = <EmptyProgressReport missing={this.state.missing} onButtonClick={onButtonClick} />;


### PR DESCRIPTION
Addresses issue #3562

**Changes proposed in this pull request:**
- loading spinner will no longer replace scores when the user scrolls to load more

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
