### PR TITLE
Fix #3564: Tell Brakeman to complain if there is something wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - bash <(curl -s https://codecov.io/bash) -cF rspec -f coverage/coverage.json
   - npm run jest
   - bash <(curl -s https://codecov.io/bash) -cF jest
-  - bundle exec brakeman
+  - bundle exec brakeman -z
   - bundle exec teaspoon
 before_script:
   - cp config/database.yml.travis config/database.yml


### PR DESCRIPTION
Apparently we still need the `-z` flag for Brakeman to not exit 0 if something's wrong.