### PR TITLE
Fix #3593: Speed up the test suite

### DIFF
--- a/spec/factories/classroom.rb
+++ b/spec/factories/classroom.rb
@@ -29,9 +29,9 @@ FactoryBot.define do
       end
     end
 
-    factory :classroom_with_100_classroom_activities do
+    factory :classroom_with_35_classroom_activities do
       after(:create) do |classroom|
-        create_list(:classroom_activity_with_activity_sessions, 100, classroom: classroom)
+        create_list(:classroom_activity_with_activity_sessions, 35, classroom: classroom)
       end
     end
 

--- a/spec/queries/dashboard_spec.rb
+++ b/spec/queries/dashboard_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Dashboard', redis: :true do
-  let(:classroom_with_sufficient_data) {create(:classroom_with_100_classroom_activities)}
+  let(:classroom_with_sufficient_data) {create(:classroom_with_35_classroom_activities)}
   let(:teacher_with_sufficient_data) {classroom_with_sufficient_data.owner}
   let(:classroom_with_no_activities) {create(:classroom)}
   let(:teacher_with_no_activities) {classroom_with_no_activities.owner}
@@ -17,7 +17,7 @@ describe 'Dashboard', redis: :true do
     end
   end
 
-  context 'when there are more than 30 completed activities activities' do
+  context 'when there are more than 30 completed activities' do
     it "returns the 5 students" do
       results = Dashboard.queries(teacher_with_sufficient_data)
       expect(results.map{|x| x[:results].length}.uniq).to eq( [5])
@@ -42,7 +42,5 @@ describe 'Dashboard', redis: :true do
       $redis.set('user_id:1_difficult_concepts', "fake cache")
       expect($redis.get("user_id:1_difficult_concepts")).to eq("fake cache")
     end
-
-
   end
 end


### PR DESCRIPTION
This should speed up the test suite by ~60 seconds per run.

It may also fix #3593.