### PR TITLE
Speed up test suite by eliminating a bunch of unnecessary rendered views

### DIFF
--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe ActivitiesController, type: :controller, redis: true do
-  render_views
-
   let(:student) { create(:student) }
   let(:activity) { create(:activity) }
   let(:activity_session) { create(:activity_session,

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe ProfilesController, type: :controller do
-  render_views
-
   describe 'as a student' do
     let(:classroom) {create(:classroom)}
     let(:student) { create(:student) }

--- a/spec/controllers/students_classrooms_controller.spec.rb
+++ b/spec/controllers/students_classrooms_controller.spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe StudentsClassroomsController, type: :controller do
-  render_views
-
   let(:student) { create(:student) }
   let(:classroom) { create(:classroom)}
   let(:classroom2) { create(:classroom, code: 'merry-honey')}

--- a/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 
 describe Teachers::ClassroomsController, type: :controller do
   describe 'creating a classroom' do
-    render_views
     let(:teacher) { create(:teacher) }
     let(:classroom_attributes) {attributes_for(:classroom)}
 

--- a/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
+++ b/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
@@ -10,8 +10,6 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
   end
 
   context 'GET #index' do
-    render_views
-
     subject { get :index, student_id: student.id }
     before do
       session[:user_id] = teacher.id

--- a/spec/support/shared/api_request.rb
+++ b/spec/support/shared/api_request.rb
@@ -1,8 +1,6 @@
 require 'active_support/inflector'
 
 shared_context "calling the api" do
-  render_views
-
   let(:application) { Doorkeeper::Application.create!(name: "MyApp", redirect_uri: "http://app.com") }
   let(:user) { create(:user) }
   let(:token) { Doorkeeper::AccessToken.create! application_id: application.id, resource_owner_id: user.id }


### PR DESCRIPTION
As I've been writing tests, I've noticed a bunch of these render_views popping up, so I deleted all of them with the exception of one that was actually necessary. This should speed up the test suite by a few minutes.