### PR TITLE
Fix #3617: "fix" user id not found error

### DIFF
--- a/app/services/analytics/segment_analytics.rb
+++ b/app/services/analytics/segment_analytics.rb
@@ -25,9 +25,9 @@ class SegmentAnalytics
       })
   end
 
-  def track_activity_assignment(teacher)
+  def track_activity_assignment(teacher_id)
     track({
-      user_id: teacher.id,
+      user_id: teacher_id,
       event: SegmentIo::Events::ACTIVITY_ASSIGNMENT
     })
   end

--- a/app/workers/assign_activity_worker.rb
+++ b/app/workers/assign_activity_worker.rb
@@ -2,9 +2,7 @@ class AssignActivityWorker
   include Sidekiq::Worker
 
   def perform(teacher_id)
-    teacher = User.find(teacher_id)
-
     analytics = SegmentAnalytics.new
-    analytics.track_activity_assignment(teacher)
+    analytics.track_activity_assignment(teacher_id)
   end
 end

--- a/app/workers/assign_activity_worker.rb
+++ b/app/workers/assign_activity_worker.rb
@@ -3,6 +3,6 @@ class AssignActivityWorker
 
   def perform(teacher_id)
     analytics = SegmentAnalytics.new
-    analytics.track_activity_assignment(teacher_id)
+    analytics.track_activity_assignment(teacher_id) if teacher_id
   end
 end

--- a/spec/services/analytics/segment_analytics_spec.rb
+++ b/spec/services/analytics/segment_analytics_spec.rb
@@ -26,7 +26,7 @@ describe 'SegmentAnalytics' do
     let(:teacher) { create(:teacher) }
 
     it 'sends an event' do
-      analytics.track_activity_assignment(teacher)
+      analytics.track_activity_assignment(teacher.id)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::Events::ACTIVITY_ASSIGNMENT)


### PR DESCRIPTION
https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/0ce54d89-efe4-11e7-ab11-0242ac110005_0_3892

There's still something wonky going on here, and I'm not 100% certain what it is, but this should at least maintain parity with our current tracking without causing any more errors to be raised.