### PR TITLE
fix manage units code for filtering units

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/manage_units/manage_units.jsx
@@ -61,7 +61,7 @@ export default React.createClass({
   getUnitsForCurrentClass() {
     if (this.state.selectedClassroomId) {
       const selectedClassroom = this.state.classrooms.find(c => c.id === Number(this.state.selectedClassroomId))
-      const unitsInCurrentClassroom = _.reject(this.state.allUnits, unit => !unit.classrooms.findIndex(c => c.name === selectedClassroom.name) !== -1);
+      const unitsInCurrentClassroom = this.state.allUnits.filter(unit => unit.classrooms.find(c => c.name === selectedClassroom.name));
       this.setState({ units: unitsInCurrentClassroom, loaded: true, });
     } else {
       this.setState({units: this.state.allUnits, loaded: true})


### PR DESCRIPTION
Addresses issue #3638

**Changes proposed in this pull request:**
- classroom dropdown should now be working on manage units page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
