### PR TITLE
fix #3655 - change 'profile' button to 'my dashboard', give fill

### DIFF
--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -194,7 +194,7 @@
       padding: 18px 0;
       a {
         padding: 4px 11px 2px;
-        margin: 0 5px;
+        margin: 0 2px;
         position: relative;
         display: block;
         line-height: 20px;
@@ -220,6 +220,10 @@
         &:hover {
           background: $white_20;
           color: $white;
+        }
+        &.white-fill {
+          background-color: $white;
+          color: $quillgreen;
         }
       }
       &:hover:not(.sign-up-wrapper) a {
@@ -292,7 +296,7 @@
         .sign-up-btn {
           border: none;
         }
-        &:hover a {
+        &:hover  a {
           background-color: $quillgreen;
           color: $white;
         }

--- a/app/views/application/_sub_header.html.erb
+++ b/app/views/application/_sub_header.html.erb
@@ -26,7 +26,11 @@
 				<li><%= link_to "Login", new_session_path  %></li>
 			<%- else %>
 				<%- if current_user.role == 'teacher' %>
-					<li><%= link_to "Profile", profile_path, class: "sign-up-btn" %></li>
+					<%- if request.path.include?('teachers') %>
+						<li><%= link_to "My Dashboard", profile_path, class: "sign-up-btn" %></li>
+					<%- else %>
+						<li><%= link_to "My Dashboard", profile_path, class: "sign-up-btn white-fill" %></li>
+					<%- end %>
 				<%- end %>
 				<%- if current_user.role == 'student' %>
 					<li><%= link_to raw("<i class='fa fa-fw fa-plus-circle' aria-hidden='true'></i>  Join a Class"), add_classroom_students_classrooms_path %></li>

--- a/app/views/pages/shared/_home_navbar.html.erb
+++ b/app/views/pages/shared/_home_navbar.html.erb
@@ -22,7 +22,11 @@
 
     <% else %>
       <%- if current_user.role == 'teacher' %>
-        <%= link_to "Profile", profile_path, class: "q-button text-white" %>
+        <%- if request.path.include?('teachers') %>
+          <%= link_to "My Dashboard", profile_path, class: "sign-up-btn" %>
+        <%- else %>
+          <%= link_to "My Dashboard", profile_path, class: "sign-up-btn white-fill" %>
+        <%- end %>
         <%= link_to "Logout", '/session', class: "text-white"%>
       <%- end %>
 

--- a/client/app/assets/styles/home.scss
+++ b/client/app/assets/styles/home.scss
@@ -245,6 +245,15 @@ nav.q-navbar-home {
     &.narrow {
       display: none;
     }
+
+    .sign-up-btn {
+      border: 1px solid $white;
+      //Instead of the line below you could use @includeborder-radius($radius, $vertical-radius)
+      border-radius: 4px;
+      padding: 4px 9px 2px;
+      background-color: $white;
+      color: $quillgreen;
+    }
   }
 
   /* Advanced Checkbox Hack */


### PR DESCRIPTION
Adresses issue #3655 

**Changes proposed in this pull request:**
- change "Profile" link in nav bar to "My Dashboard"
- give "My Dashboard" button a white fill on non-dashboard pages

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

![screen shot 2018-01-05 at 12 02 28 pm](https://user-images.githubusercontent.com/18669014/34619516-65a526ba-f210-11e7-83cb-7e54a1e23d61.png)

![screen shot 2018-01-05 at 12 02 09 pm](https://user-images.githubusercontent.com/18669014/34619527-6b8e5f88-f210-11e7-8059-14ab2eaaa081.png)


**Has this branch been QA'd on staging?** no

**Have you updated the docs?**no

**Have the tests been updated?**no

**Reviewer:** @ddmck
