### PR TITLE
Fallback to display block if the browser does not support flexbox

### DIFF
--- a/app/assets/stylesheets/pages/accounts_session_and_password_reset.scss
+++ b/app/assets/stylesheets/pages/accounts_session_and_password_reset.scss
@@ -111,8 +111,7 @@
       font-weight: bold;
     }
     .login-password {
-      display: -webkit-box;
-      display: -ms-flexbox;
+      display: block;
       display: flex;
       width: 100%;
       margin-bottom: 20px;


### PR DESCRIPTION
Fixes #3454.

Well, 'fixes' might be a bit generous. In reality, the login form on old browsers that don't support flexbox will now look like this:

<img width="490" alt="screen shot 2018-01-15 at 3 17 49 pm" src="https://user-images.githubusercontent.com/1312199/34960065-4e62d804-fa07-11e7-81a2-0d43ee3b5d3c.png">

But at least the password field is now visible!

Also explored the possibility of using a polyfill for flexbox, but it seems that this would also lead to a bunch of weird display issues, so it's probably not worth it.

I don't think we even officially support browsers this old anyway.