### PR TITLE
Revert update to doorkeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'atomic_arrays'
 
 # USER AUTH, ETC
 gem 'bcrypt'
-gem 'doorkeeper', '~> 4.2.0'
+gem 'doorkeeper', '1.4.1'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-clever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,8 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
-    doorkeeper (4.2.6)
-      railties (>= 4.2)
+    doorkeeper (1.4.1)
+      railties (>= 3.1)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -695,7 +695,7 @@ DEPENDENCIES
   codecov
   coffee-rails
   database_cleaner
-  doorkeeper (~> 4.2.0)
+  doorkeeper (= 1.4.1)
   dotenv-rails
   es5-shim-rails
   factory_bot

--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ActivitiesController < Api::ApiController
 
-  before_action :doorkeeper_authorize!, only: [:create, :update, :destroy]
+  doorkeeper_for :create, :update, :destroy
   before_action :find_activity, except: [:index, :create, :uids_and_flags]
 
   # GET

--- a/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/app/controllers/api/v1/activity_sessions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ActivitySessionsController < Api::ApiController
 
-  before_action :doorkeeper_authorize!, only: [:destroy]
+  doorkeeper_for :destroy
   before_action :find_activity_session, only: [:show, :update, :destroy]
   before_action :strip_access_token_from_request
   before_action :transform_incoming_request, only: [:update, :create]

--- a/app/controllers/api/v1/concepts_controller.rb
+++ b/app/controllers/api/v1/concepts_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ConceptsController < Api::ApiController
-  before_action :doorkeeper_authorize!, only: [:create]
+  doorkeeper_for :create
 
   def create
     concept = Concept.new(concept_params)


### PR DESCRIPTION
Doorkeeper 4.0 does not work with Quill Grammar Auth methods, therefore it needs to be reverted.
