### PR TITLE
activity search page resets to 1 when filters change #3757

### DIFF
--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
@@ -139,7 +139,7 @@ export default React.createClass({
       }
       return filter;
     }, this);
-    this.setState({ filters, activeFilterOn }, this.changeViewableActivities);
+    this.setState({ filters, activeFilterOn, }, this.changeViewableActivities);
   },
 
   activityContainsSearchTerm(activity) {
@@ -164,9 +164,10 @@ export default React.createClass({
       return (matchingFieldCount === sFFLength) && matchesSearchQuery;
     });
     this.setState({ viewableActivities,
-      maxPageNumber: Math.ceil(viewableActivities.length/resultsPerPage),
-      numberOfPages: Math.ceil(viewableActivities.length / resultsPerPage)
-      }, this.updateFilterOptionsAfterChange);
+      currentPage: 1,
+      maxPageNumber: Math.ceil(viewableActivities.length / resultsPerPage),
+      numberOfPages: Math.ceil(viewableActivities.length / resultsPerPage),
+    }, this.updateFilterOptionsAfterChange);
   },
 
   updateSort(field, asc_or_desc) {
@@ -188,7 +189,7 @@ export default React.createClass({
     this.state.sorts.forEach((sortObj) => {
       // iterate through each sorter, and activate it;
       if (sortObj.selected) {
-        visActs = _.sortBy(visActs, obj => _l.get(obj, sortObj.sortPath))
+        visActs = _.sortBy(visActs, obj => _l.get(obj, sortObj.sortPath));
         if (sortObj.asc_or_desc === 'desc') {
           // reverse sorter if necessary
           visActs = visActs.reverse();
@@ -222,9 +223,9 @@ export default React.createClass({
     }
     return (
       <section>
-        <div className='flex-row space-between vertically-centered header-and-link'>
+        <div className="flex-row space-between vertically-centered header-and-link">
           <h1 className="explore-activities-header">Explore Activities & Create Activity Pack</h1>
-          <a className='how-we-grade' href="https://support.quill.org/activities-implementation/how-does-grading-work">Common Core Standards vs. Students’ Levels<i className="fa fa-long-arrow-right"></i></a>
+          <a className="how-we-grade" href="https://support.quill.org/activities-implementation/how-does-grading-work">Common Core Standards vs. Students’ Levels<i className="fa fa-long-arrow-right" /></a>
         </div>
         <ActivitySearchAndFilters
           showAllId={showAllId}
@@ -235,7 +236,7 @@ export default React.createClass({
           clearFilters={this.clearFilters}
           activeFilterOn={this.state.activeFilterOn}
         />
-      <table className="table activity-table search-and-select green-rows-on-hover">
+        <table className="table activity-table search-and-select green-rows-on-hover">
           <thead>
             <ActivitySearchSorts updateSort={this.updateSort} sorts={this.state.sorts} />
           </thead>


### PR DESCRIPTION
Addresses issue #3757

**Changes proposed in this pull request:**
The activity search page resets when the filters change

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
