### PR TITLE
fix #3873, #3884, #3886, #3888, #3890 - knowledge center

### DIFF
--- a/app/assets/stylesheets/cms/blog_post_table.scss
+++ b/app/assets/stylesheets/cms/blog_post_table.scss
@@ -1,0 +1,29 @@
+.blog-post-table {
+  tr {
+    display: flex;
+    padding: 5px;
+    &.blog-post-row {
+      border: 1px gray solid;
+      margin-top: 3px;
+    }
+    th, td {
+      width: 100px;
+    }
+    th:last-of-type, td:last-of-type, th:nth-of-type(7), td:nth-of-type(7) {
+      width: 50px;
+    }
+    th:first-of-type, td:first-of-type, th:nth-of-type(4), td:nth-of-type(4), th:nth-of-type(5), td:nth-of-type(5), th:nth-of-type(8), td:nth-of-type(8), td:nth-of-type(6), th:nth-of-type(6) {
+      width: 75px;
+    }
+    td:nth-of-type(2), th:nth-of-type(2) {
+      width: 200px;
+      padding-right: 10px;
+    }
+  }
+}
+
+.save-order {
+  font-size: 14px;
+  color: $quillgreen;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/cms/cms.scss
+++ b/app/assets/stylesheets/cms/cms.scss
@@ -138,6 +138,14 @@
       margin-bottom: 20px;
     }
 
+    .article-content-container {
+      border: 1px solid #cecece;
+      border-radius: 6px;
+      div:last-of-type {
+        padding: 0px 10px;
+      }
+    }
+
     #article-preview-bar {
       background: #cecece;
       border-radius: 5px 5px 0 0;
@@ -230,10 +238,15 @@
       }
     }
 
-    .flex-three-cols {
+    .short-fields {
       display: flex;
-      justify-content: space-between;
       margin-bottom: 20px;
+      div {
+        flex: 1
+      }
+      input {
+        width: 214px;
+      }
     }
 
     .markdown-cheatsheet {
@@ -246,10 +259,16 @@
 }
 
 .premium-label {
-  display: inline-block;
+  display: inline-block !important;
 }
 
 .premium-checkbox {
-  width: 20px;
-  display: inline-block;
+  width: 20px !important;
+  display: inline-block !important;
+}
+.create-new-author-link {
+  margin-top: 5px;
+  margin-left: 5px;
+  color: $quillgreen;
+  display: block;
 }

--- a/app/assets/stylesheets/cms/cms.scss
+++ b/app/assets/stylesheets/cms/cms.scss
@@ -249,7 +249,7 @@
   display: inline-block;
 }
 
-.premium-checkbox: {
+.premium-checkbox {
   width: 20px;
   display: inline-block;
 }

--- a/app/assets/stylesheets/cms/cms.scss
+++ b/app/assets/stylesheets/cms/cms.scss
@@ -138,11 +138,25 @@
       margin-bottom: 20px;
     }
 
-    #markdown-shortcuts {
+    #article-preview-bar {
       background: #cecece;
       border-radius: 5px 5px 0 0;
       padding: 5px;
-
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      height: 36px;
+      .article-tab {
+        cursor: pointer;
+        font-size: 14px;
+        margin-right: 10px;
+        padding: 10px;
+        padding-top: 0px;
+        border-radius: 6px 6px 0px 0px;
+        &.active {
+          background-color: white;
+        }
+      }
       i {
         font-size: 16px;
         background: #fff;
@@ -229,4 +243,13 @@
       text-align: right;
     }
   }
+}
+
+.premium-label {
+  display: inline-block;
+}
+
+.premium-checkbox: {
+  width: 20px;
+  display: inline-block;
 }

--- a/app/assets/stylesheets/cms/cms.scss
+++ b/app/assets/stylesheets/cms/cms.scss
@@ -258,11 +258,11 @@
   }
 }
 
-.premium-label {
+.premium-label, .center-images-label {
   display: inline-block !important;
 }
 
-.premium-checkbox {
+.premium-checkbox, .center-images-checkbox {
   width: 20px !important;
   display: inline-block !important;
 }

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -351,6 +351,10 @@ a.all-blog-posts-back-button {
       h1, h2, h3, p, ul, ol, img, blockquote {
         margin: 16px 0;
       }
+
+      p, ul, ol, blockquote {
+        font-size: 21px;
+      }
     }
 
     footer {

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -251,18 +251,19 @@ body {
       font-weight: 700;
       line-height: 1.38;
       margin-bottom: 17px;
+      margin-top: 0px;
       transition: all 0.3s ease-out;
     }
 
-    .author {
-      font-weight: 600;
-      margin: 0;
-      flex-grow: 0;
-    }
+  }
+
+  .preview-card-footer {
+    padding: 0px 15px;
+    color: #666;
   }
 
   &:hover {
-    .preview-card-body {
+    .preview-card:first-child {
       box-shadow: 0 2px 4px 2px #e9e9e9;
 
       h3 {

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -466,7 +466,9 @@ a.all-blog-posts-back-button {
   display: inline-block;
   font-size: 16px;
   padding: 6px 12px;
-
+  height: 40px;
+  margin: 0px 15px;
+  font-weight: bold;
   &:hover {
     text-decoration: none;
   }
@@ -475,7 +477,6 @@ a.all-blog-posts-back-button {
 .article-cta-primary, .article-cta-primary:hover {
   background: $quillgreen;
   color: #fff;
-  font-weight: 600;
 }
 
 .article-cta-secondary, .article-cta-secondary:hover {

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -333,7 +333,7 @@ a.all-blog-posts-back-button {
         width: 45px;
       }
 
-      .author {
+      .author, .published {
         font-weight: 600;
         color: #000000;
       }

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -231,7 +231,6 @@ body {
   .preview-card-body {
     background: $white;
     border-radius: 0 0 6px 6px;
-    box-shadow: 0 0 2px 2px #e9e9e9;
     color: #666;
     padding: 20px 15px 15px;
     transition: all 0.3s ease-out;
@@ -465,4 +464,29 @@ a.all-blog-posts-back-button {
 .article-cta-secondary, .article-cta-secondary:hover {
   background: #eee;
   color: #777;
+}
+
+.side-by-side {
+  display: flex;
+  justify-content: space-between;
+  .preview-card-container {
+    width: 100%;
+    margin-right: 10px;
+    height: 360px;
+    #preview-markdown-content {
+      height: 300px;
+    }
+  }
+  .body-preview {
+    width: 310px;
+  }
+  .body-markdown {
+    width: 100%;
+    margin-right: 10px;
+  }
+}
+
+.preview-card:first-child {
+  box-shadow: 0 0px 2px 2px #e9e9e9;
+  border-radius: 6px;
 }

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -258,9 +258,10 @@ body {
   }
 
   .preview-card-footer {
-    padding: 0px 15px;
+    padding: 5px 15px;
     color: #666;
     background-color: #fff;
+    border-radius: 0px 0px 6px 6px;
   }
 
   &:hover {
@@ -316,6 +317,15 @@ a.all-blog-posts-back-button {
       }
     }
 
+    .center-images {
+      main {
+        img {
+          display: block;
+          margin: auto;
+        }
+      }
+    }
+
     header {
       font-size: 14px;
       padding-top: 60px;
@@ -324,6 +334,7 @@ a.all-blog-posts-back-button {
         font-size: 30px;
         font-weight: 700;
         margin-bottom: 20px;
+        line-height: 2;
       }
 
       img {
@@ -345,7 +356,7 @@ a.all-blog-posts-back-button {
     }
 
     main {
-      line-height: 1.5;
+      line-height: 1.75;
       margin-top: 40px;
 
       h1, h2, h3, p, ul, ol, img, blockquote {
@@ -495,4 +506,7 @@ a.all-blog-posts-back-button {
 .preview-card:first-child {
   box-shadow: 0 0px 2px 2px #e9e9e9;
   border-radius: 6px;
+  &:hover {
+    box-shadow: 0 0 2px 3px #e3e3e3;
+  }
 }

--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -260,6 +260,7 @@ body {
   .preview-card-footer {
     padding: 0px 15px;
     color: #666;
+    background-color: #fff;
   }
 
   &:hover {

--- a/app/assets/stylesheets/pages/premium_page.scss
+++ b/app/assets/stylesheets/pages/premium_page.scss
@@ -57,13 +57,15 @@
 }
 li.active.premium-tab > a,
 li.premium-tab > a:hover {
-  border-top: 3px solid #875A12 !important;
-  padding-top: 0 !important;
+  background-color: #D3982A !important;
+  // border-top: 3px solid #875A12 !important;
+  // padding-top: 0 !important;
 }
 .premium-tab a.active,
 .premium-tab a:hover {
-  border-top: 3px solid #875A12 !important;
-  padding-top: 0 !important;
+  background-color: #D3982A !important;
+  // border-top: 3px solid #875A12 !important;
+  // padding-top: 0 !important;
 }
 .preview-section {
   text-align: center;

--- a/app/assets/stylesheets/shared/tabs.scss
+++ b/app/assets/stylesheets/shared/tabs.scss
@@ -14,6 +14,9 @@
       margin-top: 0px;
       padding: 3px 20px 3px;
       text-decoration: none;
+      &:hover {
+        background-color: #0E927C;
+      }
 
       &.mobile {
         display: none;

--- a/app/controllers/cms/blog_posts_controller.rb
+++ b/app/controllers/cms/blog_posts_controller.rb
@@ -4,7 +4,8 @@ class Cms::BlogPostsController < ApplicationController
   before_action :authors, :topics, only: [:edit, :new]
 
   def index
-    @blog_posts_name_and_id = BlogPost.all.map{|bp| bp.attributes.merge({'rating' => bp.average_rating})} 
+    @blog_posts_name_and_id = BlogPost.all.map{|bp| bp.attributes.merge({'rating' => bp.average_rating})}
+    @topics = BlogPost::TOPICS
     #cms/blog_posts/index.html.erb
   end
 

--- a/app/controllers/cms/blog_posts_controller.rb
+++ b/app/controllers/cms/blog_posts_controller.rb
@@ -62,7 +62,9 @@ class Cms::BlogPostsController < ApplicationController
                     :draft,
                     :premium,
                     :external_link,
-                    :published_at)
+                    :published_at,
+                    :center_images
+                  )
   end
 
   def set_blog_post

--- a/app/controllers/cms/blog_posts_controller.rb
+++ b/app/controllers/cms/blog_posts_controller.rb
@@ -60,7 +60,8 @@ class Cms::BlogPostsController < ApplicationController
                     :read_count,
                     :preview_card_content,
                     :draft,
-                    :premium)
+                    :premium,
+                    :published_at)
   end
 
   def set_blog_post

--- a/app/controllers/cms/blog_posts_controller.rb
+++ b/app/controllers/cms/blog_posts_controller.rb
@@ -61,6 +61,7 @@ class Cms::BlogPostsController < ApplicationController
                     :preview_card_content,
                     :draft,
                     :premium,
+                    :external_link,
                     :published_at)
   end
 

--- a/app/controllers/cms/blog_posts_controller.rb
+++ b/app/controllers/cms/blog_posts_controller.rb
@@ -38,6 +38,11 @@ class Cms::BlogPostsController < ApplicationController
     redirect_to cms_blog_posts_path
   end
 
+  def update_order_numbers
+    JSON.parse(params[:blog_posts]).each { |bp| BlogPost.find(bp['id']).update(order_number: bp['order_number'])}
+    render json: {}
+  end
+
   private
 
   def authors

--- a/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
+++ b/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
@@ -5,7 +5,7 @@ class Teachers::ProgressReports::Standards::ClassroomTopicsController < Teachers
     respond_to do |format|
       format.html
       format.json do
-        return render json: {}, status: 401 unless current_user.classrooms_i_teach.map(&:id).include?(params[:classroom_id])
+        # return render json: {}, status: 401 unless current_user.classrooms_i_teach.map(&:id).include?(params[:classroom_id])
 
         topics = ::ProgressReports::Standards::Topic.new(current_user).results(params)
         topics_json = topics.map do |topic|

--- a/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
+++ b/app/controllers/teachers/progress_reports/standards/classroom_topics_controller.rb
@@ -5,6 +5,8 @@ class Teachers::ProgressReports::Standards::ClassroomTopicsController < Teachers
     respond_to do |format|
       format.html
       format.json do
+        return render json: {}, status: 401 unless current_user.classrooms_i_teach.map(&:id).include?(params[:classroom_id])
+
         topics = ::ProgressReports::Standards::Topic.new(current_user).results(params)
         topics_json = topics.map do |topic|
           serializer = ::ProgressReports::Standards::TopicSerializer.new(topic)

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -6,6 +6,7 @@ class BlogPost < ActiveRecord::Base
 
   belongs_to :author
   has_many :blog_post_user_ratings
+  after_save :add_published_at
 
   def increment_read_count
     self.read_count += 1
@@ -33,6 +34,12 @@ class BlogPost < ActiveRecord::Base
   def average_rating
     ratings = self.blog_post_user_ratings.pluck(:rating)
     return (ratings.sum / ratings.size).round(2) if ratings.any?
+  end
+
+  def add_published_at
+    if !self.draft && !self.published_at
+      self.update(published_at: DateTime.now)
+    end
   end
 
   private

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -1,5 +1,5 @@
 class BlogPost < ActiveRecord::Base
-  TOPICS = ['Case Studies', 'Teacher Stories', 'Webinars', 'Teacher Materials', 'Education Research']
+  TOPICS = ['Case Studies', 'Teacher Stories', 'Webinars', 'Teacher Materials', 'Education Research', 'Announcement']
   TOPIC_SLUGS = TOPICS.map { |topic| topic.downcase.gsub(' ','_') }
 
   before_create :generate_slug, :set_order_number

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -2,11 +2,18 @@ class BlogPost < ActiveRecord::Base
   TOPICS = ['Case Studies', 'Teacher Stories', 'Webinars', 'Teacher Materials', 'Education Research']
   TOPIC_SLUGS = TOPICS.map { |topic| topic.downcase.gsub(' ','_') }
 
-  before_create :generate_slug
+  before_create :generate_slug, :set_order_number
 
   belongs_to :author
   has_many :blog_post_user_ratings
   after_save :add_published_at
+
+  def set_order_number
+    if self.order_number.nil?
+      self.order_number =  BlogPost.where(topic: self.topic).count
+    end
+  end
+
 
   def increment_read_count
     self.read_count += 1

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -1,5 +1,5 @@
 class BlogPost < ActiveRecord::Base
-  TOPICS = ['Case Studies', 'Teacher Stories', 'Webinars', 'Teacher Materials', 'Education Research', 'Announcement']
+  TOPICS = ['Case Studies', 'Teacher Stories', 'Webinars', 'Teacher Materials', 'Education Research', 'Announcements']
   TOPIC_SLUGS = TOPICS.map { |topic| topic.downcase.gsub(' ','_') }
 
   before_create :generate_slug, :set_order_number

--- a/app/views/cms/blog_posts/index.html.erb
+++ b/app/views/cms/blog_posts/index.html.erb
@@ -1,3 +1,3 @@
 <div class="container cms-container" id="blog-posts">
-  <%= react_component('BlogPostsApp', props: {blogPosts: @blog_posts_name_and_id})%>
+  <%= react_component('BlogPostsApp', props: {blogPosts: @blog_posts_name_and_id, topics: @topics})%>
 </div>

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
@@ -65,6 +65,7 @@ export default class BlogPost extends React.Component {
             body={this.props.blogPost.body}
             author={this.props.author}
             displayPaywall={this.props.displayPaywall}
+            centerImages={this.props.blogPost.center_images}
           />
           <footer>
             <a className='back-to-topic' href={`/teacher_resources/topic/${this.state.backLink}`}><i className='fa fa-chevron-left'></i>Back to {this.props.blogPost.topic}</a>

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
@@ -21,7 +21,7 @@ export default class BlogPost extends React.Component {
 
   renderMostRecentPosts() {
     return this.props.mostRecentPosts.map(post =>
-      <PreviewCard key={post.title} content={post.preview_card_content} link={`/teacher_resources/${post.slug}`} />
+      <PreviewCard key={post.title} content={post.preview_card_content} link={post.external_link ? post.external_link : `/teacher_resources/${post.slug}`} />
     )
   }
 

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import moment from 'moment';
 import PreviewCard from '../shared/preview_card.jsx';
-import ReactMarkdown from 'react-markdown';
 import request from 'request';
+import BlogPostContent from './blog_post_content'
 
 const RATING_MESSAGES = {
   instructions: 'Was this article helpful?',
@@ -24,20 +23,6 @@ export default class BlogPost extends React.Component {
     return this.props.mostRecentPosts.map(post =>
       <PreviewCard key={post.title} content={post.preview_card_content} link={`/teacher_resources/${post.slug}`} />
     )
-  }
-
-  renderBodyOrPaywall() {
-    if(this.props.displayPaywall) {
-      return (
-        <div id='quill-article-paywall'>
-          <h2>This article is only for Premium users.</h2>
-          <p>Quill Premium users have access to a slew of awesome features, including premium reports, priority support, and enhanced professional development opportunities.</p>
-          <a href='/premium'>Try Quill Premium <i className='fa fa-star'></i></a>
-        </div>
-      );
-    } else {
-      return <ReactMarkdown source={this.props.blogPost.body} />;
-    }
   }
 
   renderRatingEmoji() {
@@ -74,15 +59,13 @@ export default class BlogPost extends React.Component {
       <div id='article-container'>
         <article>
           <a className='back-to-topic' href={`/teacher_resources/topic/${this.state.backLink}`}><i className='fa fa-chevron-left'></i>Back to {this.props.blogPost.topic}</a>
-          <header>
-            <h1>{this.props.blogPost.title}</h1>
-            <img src={this.props.author.avatar} />
-            <p className='author'>{this.props.author.name}</p>
-            <p className='date'>{moment(this.props.blogPost.updated_at).format('MMMM Do, YYYY')}</p>
-          </header>
-          <main>
-            {this.renderBodyOrPaywall()}
-          </main>
+          <BlogPostContent
+            updatedAt={this.props.blogPost.updated_at}
+            title={this.props.blogPost.title}
+            body={this.props.blogPost.body}
+            author={this.props.author}
+            displayPaywall={this.props.displayPaywall}
+          />
           <footer>
             <a className='back-to-topic' href={`/teacher_resources/topic/${this.state.backLink}`}><i className='fa fa-chevron-left'></i>Back to {this.props.blogPost.topic}</a>
             <p>{this.state.ratingMessage}</p>

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
@@ -17,7 +17,7 @@ export default class BlogPostContent extends React.Component {
         </div>
       );
     } else {
-      return <ReactMarkdown source={this.props.body} />;
+      return <ReactMarkdown source={this.props.body.replace(/\n/g, '<br/>')} />;
     }
   }
 

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import moment from 'moment';
+import ReactMarkdown from 'react-markdown';
+
+export default class BlogPostContent extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  renderBodyOrPaywall() {
+    if(this.props.displayPaywall) {
+      return (
+        <div id='quill-article-paywall'>
+          <h2>This article is only for Premium users.</h2>
+          <p>Quill Premium users have access to a slew of awesome features, including premium reports, priority support, and enhanced professional development opportunities.</p>
+          <a href='/premium'>Try Quill Premium <i className='fa fa-star'></i></a>
+        </div>
+      );
+    } else {
+      return <ReactMarkdown source={this.props.body} />;
+    }
+  }
+
+  render() {
+    return(
+      <div>
+        <header>
+          <h1>{this.props.title}</h1>
+          <img src={this.props.author.avatar} />
+          <p className='author'>{this.props.author.name}</p>
+          <p className='date'>{moment(this.props.updatedAt).format('MMMM Do, YYYY')}</p>
+        </header>
+        <main>
+          {this.renderBodyOrPaywall()}
+        </main>
+      </div>
+    )
+  }
+}

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
@@ -22,8 +22,9 @@ export default class BlogPostContent extends React.Component {
   }
 
   render() {
+    const className = this.props.centerImages ? 'center-images' : ''
     return(
-      <div>
+      <div className={className}>
         <header>
           <h1>{this.props.title}</h1>
           <img src={this.props.author.avatar} />

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_content.jsx
@@ -17,7 +17,8 @@ export default class BlogPostContent extends React.Component {
         </div>
       );
     } else {
-      return <ReactMarkdown source={this.props.body.replace(/\n/g, '<br/>')} />;
+      return <ReactMarkdown escapeHtml={false} source={this.props.body} />;
+      return <ReactMarkdown escapeHtml={false} source={this.props.body.replace(/\n/g, '<br/>').replace(/><br\/>/g, '>\n').replace(/<br\/></g, '\n<')} />;
     }
   }
 

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
@@ -38,7 +38,7 @@ export default class extends React.Component {
       sections.push(<TopicSection
           key={topic}
           title={topic}
-          articles={articlesInThisTopic}
+          articles={articlesInThisTopic.sort(a => a.order_number)}
           articleCount={articlesInThisTopic.length}
         />
       );

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
@@ -20,13 +20,13 @@ export default class extends React.Component {
 
   renderPreviewCards() {
     return this.props.blogPosts.map(article =>
-      <PreviewCard key={article.title} content={article.preview_card_content} link={`/teacher_resources/${article.slug}`} />
+      <PreviewCard key={article.title} content={article.preview_card_content} link={article.external_link ? article.external_link : `/teacher_resources/${article.slug}`} />
     )
   }
 
   renderPreviewCardsByPopularity() {
     return this.state.blogPostsSortedByMostRead.map(article =>
-      <PreviewCard key={article.title} content={article.preview_card_content} link={`/teacher_resources/${article.slug}`} />
+      <PreviewCard key={article.title} content={article.preview_card_content} link={article.external_link ? article.external_link : `/teacher_resources/${article.slug}`} />
     )
   }
 
@@ -115,9 +115,10 @@ export default class extends React.Component {
   renderMostReadPost() {
     const mostReadArticle = this.state.blogPostsSortedByMostRead[0];
     if(window.location.pathname.includes('search')) { return null; }
+    const link = mostReadArticle.external_link ? mostReadArticle.external_link : `/teacher_resources/${mostReadArticle.slug}`
     return (
       <h3>
-        <a href={`/teacher_resources/${mostReadArticle.slug}`}>{mostReadArticle.title}</a>
+        <a href={link}>{mostReadArticle.title}</a>
       </h3>
     )
   }

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
@@ -124,13 +124,21 @@ export default class extends React.Component {
   }
 
   render() {
-    return (
-      <div id="knowledge-center">
-        <header>
-          <div className='container'>
-            <h1>Knowledge Center</h1>
-            <h2>Everything you need to know about Quill's pedgagogy and use in the classroom</h2>
-            <form className='width-422' action={`${process.env.DEFAULT_URL}/teacher_resources/search`}>
+    if (this.props.blogPosts.length === 0) {
+      return <div className="container">
+        <div style={{fontSize: '40px', display: 'flex', justifyContent: 'center', height: '60vh', alignItems: 'center', flexDirection: 'column', fontWeight: 'bold'}}>
+          Coming Soon!
+          <img style={{marginTop: '20px'}} src="https://assets.quill.org/images/illustrations/empty-state-premium-reports.svg"/>
+        </div>
+      </div>
+    } else {
+      return (
+        <div id="knowledge-center">
+          <header>
+            <div className='container'>
+              <h1>Knowledge Center</h1>
+              <h2>Everything you need to know about Quill's pedgagogy and use in the classroom</h2>
+              <form className='width-422' action={`${process.env.DEFAULT_URL}/teacher_resources/search`}>
               <input type='text' placeholder='Search for posts' name='query' defaultValue={this.props.query ? this.props.query : null} />
               {window.location.pathname.includes('search') ? null : <h3 className='most-read-post'>Most Read Post:</h3>}
               {this.renderMostReadPost()}
@@ -141,6 +149,6 @@ export default class extends React.Component {
         {this.renderAnnouncement()}
         {this.renderBasedOnArticleFilter()}
       </div>
-    );
+    )};
   }
 }

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_row.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_row.jsx
@@ -1,0 +1,17 @@
+import React from 'React'
+
+const BlogPostRow = props => {
+  return <tr className="blog-post-row">
+    <td>{props.draft}</td>
+    <td>{props.title}</td>
+    <td>{props.topic}</td>
+    <td>{props.createdAt}</td>
+    <td>{props.updatedAt}</td>
+    <td>{props.rating}</td>
+    <td><a className="button" href={props.editLink}>Edit</a></td>
+    <td><a className="button" href={props.previewLink}>Preview</a></td>
+    <td><a className="button" href={props.deleteLink}>Delete</a></td>
+  </tr>
+}
+
+export default BlogPostRow

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import BlogPostRow from './blog_post_row.jsx';
+import SortableList from '../../shared/sortableList'
+import request from 'request';
+import moment from 'moment';
+import getAuthToken from '../../modules/get_auth_token';
+
+export default class BlogPostTable extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {blogPosts: this.props.blogPosts.sort(bp => bp.order_number)}
+    this.updateOrder = this.updateOrder.bind(this)
+    this.saveOrder = this.saveOrder.bind(this)
+  }
+
+  updateOrder(sortInfo) {
+    const originalOrder = this.state.blogPosts;
+    const newOrder = sortInfo.data.items.map(item => item.key);
+    const newOrderedBlogPosts = newOrder.map((key, i) => {
+      const newBlogPost = originalOrder[key];
+      newBlogPost.order_number = i;
+      return newBlogPost;
+    });
+    this.setState({blogPosts: newOrderedBlogPosts});
+  }
+
+  saveOrder() {
+    const link = `${process.env.DEFAULT_URL}/cms/blog_posts/update_order_numbers`
+    console.log(link)
+    const data = new FormData();
+    data.append( "blog_posts", JSON.stringify(this.state.blogPosts) );
+    fetch(link, {
+      method: 'PUT',
+      mode: 'cors',
+      credentials: 'include',
+      body: data,
+      headers: {
+        'X-CSRF-Token': getAuthToken()
+      }
+    }).then((response) => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      }
+      return response.json();
+    }).then((response) => {
+      alert(`Order for ${this.props.topic} blog posts has been saved.`)
+    }).catch((error) => {
+      console.log('error', error)
+    })
+  }
+
+  confirmDelete(e) {
+    if(window.prompt('To delete this post, please type DELETE.') !== 'DELETE') {
+      e.preventDefault();
+    }
+  }
+
+  renderTableHeader() {
+    return <tr>
+        <th></th>
+        <th>Title</th>
+        <th>Topic</th>
+        <th>Created</th>
+        <th>Updated</th>
+        <th>Rating</th>
+        <th></th>
+        <th></th>
+        <th></th>
+      </tr>
+  }
+
+  renderTableRow(blogPost, index) {
+    return <BlogPostRow
+      draft={blogPost.draft ? 'DRAFT' : ''}
+      title={blogPost.title}
+      topic={blogPost.topic}
+      createdAt={moment(blogPost.created_at).format('MM-DD-YY')}
+      updatedAt={moment(blogPost.updated_at).format('MM-DD-YY')}
+      rating={blogPost.rating}
+      editLink={`/cms/blog_posts/${blogPost.id}/edit`}
+      previewLink={`/teacher_resources/${blogPost.slug}`}
+      deleteLink={`/cms/blog_posts/${blogPost.id}/delete`}
+      key={index}
+    />
+  }
+
+  render() {
+    const blogPostRows = this.state.blogPosts.map((bp, i) => this.renderTableRow(bp, i))
+    return <div>
+      <h1>{this.props.topic} <span className="save-order" onClick={this.saveOrder}>Save Order</span></h1>
+      <div className="blog-post-table">
+        <table>
+          {this.renderTableHeader()}
+          <SortableList data={blogPostRows} sortCallback={this.updateOrder} />
+        </table>
+      </div>
+    </div>
+  }
+
+};

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
@@ -79,7 +79,7 @@ export default class BlogPostTable extends React.Component {
       updatedAt={moment(blogPost.updated_at).format('MM-DD-YY')}
       rating={blogPost.rating}
       editLink={`/cms/blog_posts/${blogPost.id}/edit`}
-      previewLink={`/teacher_resources/${blogPost.slug}`}
+      previewLink={blogPost.external_link ? blogPost.external_link : `/teacher_resources/${blogPost.slug}`}
       deleteLink={`/cms/blog_posts/${blogPost.id}/delete`}
       key={index}
     />

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/blog_post_table.jsx
@@ -27,7 +27,6 @@ export default class BlogPostTable extends React.Component {
 
   saveOrder() {
     const link = `${process.env.DEFAULT_URL}/cms/blog_posts/update_order_numbers`
-    console.log(link)
     const data = new FormData();
     data.append( "blog_posts", JSON.stringify(this.state.blogPosts) );
     fetch(link, {

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -380,7 +380,7 @@ export default class extends React.Component {
             <i onClick={() => this.insertMarkdown("<a href='https://google.com' class='article-cta-secondary'>\n", "\n</a>")} className="fa fa-square-o" />
           </div>
           <textarea rows={4} type="text" id="markdown-content" value={this.state.body} onChange={this.handleBodyChange} />
-          <a href="http://commonmark.org/help/" className='markdown-cheatsheet'>Markdown Cheatsheet</a>
+          <a target="_blank" href="http://commonmark.org/help/" className='markdown-cheatsheet'>Markdown Cheatsheet</a>
 
           <label>Body Preview:</label>
           <MarkdownParser className='markdown-preview' markdownText={this.state.body} />

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -29,6 +29,7 @@ export default class extends React.Component {
       author_id: p ? p.author_id : 11 /* Quill Staff */,
       topic: p ? p.topic : 'Webinars',
       draft: p ? p.draft : true,
+      slug: p ? p.slug : true,
       preview_card_content: p ? p.preview_card_content : null,
       custom_preview_card_content: p ? p.preview_card_content : defaultPreviewCardContent,
       preview_card_type: this.props.action === 'new' ? 'Medium Image' : 'Custom HTML',
@@ -75,6 +76,7 @@ export default class extends React.Component {
     this.hideArticlePreview = this.hideArticlePreview.bind(this)
     this.showArticlePreview = this.showArticlePreview.bind(this)
     this.updatePublishedAt = this.updatePublishedAt.bind(this)
+    this.goToPreview = this.goToPreview.bind(this)
   }
 
   componentDidMount() {
@@ -162,7 +164,7 @@ export default class extends React.Component {
     container.rows = 2 + rows;
   }
 
-  handleSubmitClick(e, shouldPublish, unpublish = false) {
+  handleSubmitClick(e, shouldPublish, unpublish = false, callback) {
     if(unpublish && window.prompt('To unpublish this post, please type UNPUBLISH.') !== 'UNPUBLISH') { e.preventDefault(); return; }
     e.preventDefault();
     let action
@@ -200,6 +202,7 @@ export default class extends React.Component {
       } else {
         alert("😨 Rut roh. Something went wrong! (Don't worry, it's probably not your fault.)");
       }
+      callback ? callback() : null
     })
   }
 
@@ -213,6 +216,16 @@ export default class extends React.Component {
     if(this.props.action === 'edit' && !this.state.draft) {
       return <input type="submit" value="Unpublish & Save Draft" onClick={(e) => { this.handleSubmitClick(e, false, true) }} style={{background: 'white', color: '#00c2a2'}} />
     }
+  }
+
+  renderSaveAndPreviewButton() {
+    if (this.props.action === 'edit') {
+      return <input type="submit" value="Save and Preview" onClick={(e) => { this.handleSubmitClick(e, !this.state.draft, false, this.goToPreview) }} style={{background: 'white', color: '#00c2a2'}} />
+    }
+  }
+
+  goToPreview() {
+    window.location.href = this.state.externalLink ? this.state.externalLink : `/teacher_resources/${this.state.slug}`
   }
 
   insertMarkdown(startChar, endChar = null) {
@@ -556,12 +569,13 @@ export default class extends React.Component {
             <input className="center-images-checkbox" type='checkbox' checked={this.state.centerImages} onClick={this.handleCenterImagesChange} />
           </div>
 
-
           {this.renderArticleMarkdownOrPreview()}
 
           <input type="submit" value="Publish" onClick={(e) => { this.handleSubmitClick(e, true) }} />
+
           {this.renderSaveDraftButton()}
           {this.renderUnpublishButton()}
+          {this.renderSaveAndPreviewButton()}
         </form>
       </div>
     )

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -42,7 +42,8 @@ export default class extends React.Component {
       tweetText: '"Climbing up Ben Bloom’s learning hierarchy won’t be easy, but it is necessary if we want to build education technology capable of helping learners move beyond basic remembering and understanding."',
       tweetAuthor: 'EdSurge',
       premium: p ? p.premium : false,
-      publishedAt: p ? p.published_at : null
+      publishedAt: p ? p.published_at : null,
+      externalLink: p ? p.external_link : null
     };
 
     this.handleTitleChange = this.handleTitleChange.bind(this)
@@ -50,6 +51,7 @@ export default class extends React.Component {
     this.handleBodyChange = this.handleBodyChange.bind(this)
     this.handleSubmitClick = this.handleSubmitClick.bind(this)
     this.handleTopicChange = this.handleTopicChange.bind(this)
+    this.handleExternalLinkChange = this.handleExternalLinkChange.bind(this)
     this.handleAuthorChange = this.handleAuthorChange.bind(this)
     this.handleCustomPreviewChange = this.handleCustomPreviewChange.bind(this)
     this.handlePreviewCardTypeChange = this.handlePreviewCardTypeChange.bind(this)
@@ -138,6 +140,10 @@ export default class extends React.Component {
     this.setState({topic: e})
   }
 
+  handleExternalLinkChange(e) {
+    this.setState({externalLink: e.target.value})
+  }
+
   handleAuthorChange(e) {
     this.setState({author_id: e.id}, this.updatePreviewCardFromBlogPostPreview)
   }
@@ -177,7 +183,8 @@ export default class extends React.Component {
           preview_card_content: this.state.preview_card_content,
           draft: !shouldPublish,
           premium: this.state.premium,
-          published_at: this.state.publishedAt ? this.state.publishedAt.format() : null
+          published_at: this.state.publishedAt ? moment(this.state.publishedAt).format() : null,
+          external_link: this.state.externalLink
         },
         authenticity_token: ReactOnRails.authenticityToken()
       }
@@ -504,6 +511,13 @@ export default class extends React.Component {
           <div className='short-fields'>
             {this.renderPreviewCardTypeDropdown()}
             {this.renderDatepicker()}
+          </div>
+
+          <div className='short-fields'>
+            <div>
+              <label>External Link: (Optional, use only if this card should point to another website)</label>
+              <input onChange={this.handleExternalLinkChange} value={this.state.externalLink}/>
+            </div>
           </div>
 
           <div className="side-by-side">

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -457,9 +457,9 @@ export default class extends React.Component {
         </div>
     } else {
         toolbarLeft = <div>
-          <i onClick={() => this.insertMarkdown('# ')}>H1</i>
-          <i onClick={() => this.insertMarkdown('## ')}>H2</i>
-          <i onClick={() => this.insertMarkdown('### ')}>H3</i>
+          <i onClick={() => this.insertMarkdown('# ')} className="fa">H1</i>
+          <i onClick={() => this.insertMarkdown('## ')} className="fa">H2</i>
+          <i onClick={() => this.insertMarkdown('### ')} className="fa">H3</i>
           <i onClick={() => this.insertMarkdown('**', '**')} className="fa fa-bold" />
           <i onClick={() => this.insertMarkdown('*', '*')} className="fa fa-italic" />
           <i onClick={() => this.insertMarkdown('* ')} className="fa fa-list-ul" />

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -28,7 +28,7 @@ export default class extends React.Component {
       draft: p ? p.draft : true,
       preview_card_content: p ? p.preview_card_content : null,
       custom_preview_card_content: p ? p.preview_card_content : defaultPreviewCardContent,
-      preview_card_type: this.props.action === 'new' ? 'Blog Post' : 'Custom HTML',
+      preview_card_type: this.props.action === 'new' ? 'Medium Image' : 'Custom HTML',
       blogPostPreviewImage: 'http://placehold.it/300x135',
       blogPostPreviewTitle: 'Write Your Title Here',
       blogPostPreviewDescription: 'Write your description here, but be careful not to make it too long!',
@@ -69,6 +69,18 @@ export default class extends React.Component {
     this.updatePreviewCardBasedOnType();
     if(this.props.action === 'new') {
       this.setState({ previewCardHasAlreadyBeenManuallyEdited: false });
+    }
+  }
+
+  appropriatePlaceholderImage() {
+    switch (this.state.preview_card_type) {
+      case 'Large Image':
+        return 'http://placehold.it/300x200'
+      case 'Tiny Image':
+        return 'http://placehold.it/300x90'
+      case 'Medium Image':
+      default:
+        return 'http://placehold.it/300x138'
     }
   }
 
@@ -207,8 +219,10 @@ export default class extends React.Component {
 
   updatePreviewCardBasedOnType() {
     switch (this.state.preview_card_type) {
-      case 'Blog Post':
-        this.updatePreviewCardFromBlogPostPreview();
+      case 'Tiny Image':
+      case 'Medium Image':
+      case 'Large Image':
+        this.setState({blogPostPreviewImage: this.appropriatePlaceholderImage()}, this.updatePreviewCardFromBlogPostPreview)
         break;
       case 'Tweet':
         this.updatePreviewCardTweetContent();
@@ -243,6 +257,7 @@ export default class extends React.Component {
   }
 
   updatePreviewCardFromBlogPostPreview() {
+    this.state.preview_card_type
     const previewCardContent = `<img class='preview-card-image' src='${this.state.blogPostPreviewImage}' />
     <div class='preview-card-body'>
        <h3>${this.state.blogPostPreviewTitle}</h3>
@@ -308,7 +323,7 @@ export default class extends React.Component {
   renderPreviewCardContentFields() {
     const preview_card_type = this.state.preview_card_type;
     let contentFields;
-    if(preview_card_type === 'Blog Post') {
+    if (['Tiny Image', 'Medium Image', 'Large Image'].includes(preview_card_type)) {
       contentFields = [
         <label>Header Image:</label>,
         <input onChange={this.handleBlogPostPreviewImageChange} type='text' value={this.state.blogPostPreviewImage} />,
@@ -347,9 +362,9 @@ export default class extends React.Component {
 
   renderPreviewCardTypeDropdown() {
     return <div>
-        <label>Preview Card Type:</label>
+        <label>Preview Card Template:</label>
         <ItemDropdown
-          items={['Blog Post', 'YouTube Video', 'Tweet', 'Custom HTML']}
+          items={['Tiny Image', 'Medium Image', 'Large Image', 'YouTube Video', 'Tweet', 'Custom HTML']}
           callback={this.handlePreviewCardTypeChange}
           selectedItem={this.state.preview_card_type}
         />

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -449,7 +449,9 @@ export default class extends React.Component {
           />
     } else {
         toolbarLeft = <div>
-          <i onClick={() => this.insertMarkdown('# ')} className="fa fa-header" />
+          <i onClick={() => this.insertMarkdown('# ')}>H1</i>
+          <i onClick={() => this.insertMarkdown('## ')}>H2</i>
+          <i onClick={() => this.insertMarkdown('### ')}>H3</i>
           <i onClick={() => this.insertMarkdown('**', '**')} className="fa fa-bold" />
           <i onClick={() => this.insertMarkdown('*', '*')} className="fa fa-italic" />
           <i onClick={() => this.insertMarkdown('* ')} className="fa fa-list-ul" />

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -43,7 +43,8 @@ export default class extends React.Component {
       tweetAuthor: 'EdSurge',
       premium: p ? p.premium : false,
       publishedAt: p ? p.published_at : null,
-      externalLink: p ? p.external_link : null
+      externalLink: p ? p.external_link : null,
+      centerImages: p ? p.center_images : false
     };
 
     this.handleTitleChange = this.handleTitleChange.bind(this)
@@ -69,6 +70,7 @@ export default class extends React.Component {
     this.updateTweetAuthor = this.updateTweetAuthor.bind(this)
     this.updatePreviewCardTweetContent = this.updatePreviewCardTweetContent.bind(this)
     this.handlePremiumChange = this.handlePremiumChange.bind(this)
+    this.handleCenterImagesChange = this.handleCenterImagesChange.bind(this)
     this.renderArticleMarkdownOrPreview = this.renderArticleMarkdownOrPreview.bind(this)
     this.hideArticlePreview = this.hideArticlePreview.bind(this)
     this.showArticlePreview = this.showArticlePreview.bind(this)
@@ -184,7 +186,8 @@ export default class extends React.Component {
           draft: !shouldPublish,
           premium: this.state.premium,
           published_at: this.state.publishedAt ? moment(this.state.publishedAt).format() : null,
-          external_link: this.state.externalLink
+          external_link: this.state.externalLink,
+          center_images: this.state.centerImages
         },
         authenticity_token: ReactOnRails.authenticityToken()
       }
@@ -440,13 +443,18 @@ export default class extends React.Component {
     let content, toolbarLeft, mdLink
     if (this.state.showArticlePreview) {
       toolbarLeft = <div/>
-      content = <BlogPostContent
+      content = <div id="article-container">
+        <article>
+          <BlogPostContent
             body={this.state.body}
             title={this.state.title}
             updatedAt={this.props.postToEdit.updated_at}
             author={this.props.authors.find(a => a.id == this.state.author_id)}
             displayPaywall={false}
+            centerImages={this.state.centerImages}
           />
+        </article>
+        </div>
     } else {
         toolbarLeft = <div>
           <i onClick={() => this.insertMarkdown('# ')}>H1</i>
@@ -484,6 +492,10 @@ export default class extends React.Component {
 
   handlePremiumChange() {
     this.setState({premium: !this.state.premium});
+  }
+
+  handleCenterImagesChange() {
+    this.setState({centerImages: !this.state.centerImages});
   }
 
   render() {
@@ -534,8 +546,16 @@ export default class extends React.Component {
             </div>
           </div>
 
-          <label className="premium-label">Show Only to Premium Members:</label>
-          <input className="premium-checkbox" type='checkbox' value={this.state.premium} onClick={this.handlePremiumChange} />
+          <div>
+            <label className="premium-label">Show Only to Premium Members:</label>
+            <input className="premium-checkbox" type='checkbox' checked={this.state.premium} onClick={this.handlePremiumChange} />
+          </div>
+
+          <div>
+            <label className="center-images-label">Center Images:</label>
+            <input className="center-images-checkbox" type='checkbox' checked={this.state.centerImages} onClick={this.handleCenterImagesChange} />
+          </div>
+
 
           {this.renderArticleMarkdownOrPreview()}
 

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -177,7 +177,7 @@ export default class extends React.Component {
           preview_card_content: this.state.preview_card_content,
           draft: !shouldPublish,
           premium: this.state.premium,
-          published_at: this.state.publishedAt
+          published_at: this.state.publishedAt ? this.state.publishedAt.format() : null
         },
         authenticity_token: ReactOnRails.authenticityToken()
       }
@@ -282,7 +282,7 @@ export default class extends React.Component {
     } else if (publishDate) {
       footerContent = `<p class='published'>Published on ${moment(publishDate).format('MMMM Do, YYYY')}</p>`
     } else {
-      footerContent = ``
+      footerContent = `<span/>`
     }
     const previewCardContent = `<img class='preview-card-image' src='${this.state.blogPostPreviewImage}' />
     <div class='preview-card-body'>
@@ -332,7 +332,7 @@ export default class extends React.Component {
     } else if (publishDate) {
       footerContent = `<p class='published'>Published on ${moment(publishDate).format('MMMM Do, YYYY')}</p>`
     } else {
-      footerContent = ``
+      footerContent = `<span/>`
     }
     const previewCardContent = `<img class='preview-card-image' src='${this.state.tweetImage}' />
     <div class='preview-card-body'>
@@ -356,7 +356,7 @@ export default class extends React.Component {
     } else if (publishDate) {
       footerContent = `<p class='published'>Published on ${moment(publishDate).format('MMMM Do, YYYY')}</p>`
     } else {
-      footerContent = ``
+      footerContent = `<span/>`
     }
     const previewCardContent = `<div class='video-holder'>
       <iframe src="${embedUrl}" frameborder="0" allow="encrypted-media" allowfullscreen></iframe>
@@ -424,7 +424,7 @@ export default class extends React.Component {
   renderDatepicker() {
     return <div>
         <label>Published At Date:</label>
-        <DatePicker selected={moment(this.state.publishedAt)} onChange={this.updatePublishedAt}
+        <DatePicker selected={ this.state.publishedAt ? moment(this.state.publishedAt) : null } onChange={this.updatePublishedAt}
         />
       </div>
   }
@@ -478,6 +478,7 @@ export default class extends React.Component {
   }
 
   render() {
+    const nullAuthor = {id: null, name: 'None'}
     return (
       <div>
         <a className='all-blog-posts-back-button' href='/cms/blog_posts'><i className='fa fa-chevron-left'></i> All Blog Posts</a>
@@ -491,7 +492,7 @@ export default class extends React.Component {
           <div className='short-fields'>
             <div>
               <label>Author:</label>
-              <ItemDropdown items={this.props.authors.concat({id: null, name: 'None'})} callback={this.handleAuthorChange} selectedItem={this.props.authors.find(a => a.id === this.state.author_id)} />
+              <ItemDropdown items={[nullAuthor].concat(this.props.authors)} callback={this.handleAuthorChange} selectedItem={this.props.authors.find(a => a.id === this.state.author_id) || nullAuthor} />
               <a className="create-new-author-link" href="/cms/authors/new">Create New Author</a>
             </div>
             <div>

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -375,7 +375,7 @@ export default class extends React.Component {
     let contentFields;
     if (['Tiny Image', 'Medium Image', 'Large Image'].includes(preview_card_type)) {
       contentFields = [
-        <label>Header Image:</label>,
+        <label>Link to an image with the dimensions in the preview:</label>,
         <input onChange={this.handleBlogPostPreviewImageChange} type='text' value={this.state.blogPostPreviewImage} />,
         <label>Title:</label>,
         <input onChange={this.handleBlogPostPreviewTitleChange} type='text' value={this.state.blogPostPreviewTitle} />,

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -8,7 +8,9 @@ const defaultPreviewCardContent = `<img class='preview-card-image' src='http://c
 <div class='preview-card-body'>
    <h3>Party Parrot Parade</h3>
    <p>There exist many excellent party parrots.</p>
-   <p class='author'>by Quill Staff</p>
+</div>
+<div class='preview-card-footer'>
+  <p class='author'>by Quill Staff</p>
 </div>`;
 
 export default class extends React.Component {
@@ -245,7 +247,9 @@ export default class extends React.Component {
     <div class='preview-card-body'>
        <h3>${this.state.blogPostPreviewTitle}</h3>
        <p>${this.state.blogPostPreviewDescription}</p>
-       <p class='author'>by ${this.props.authors.find(a => a.id == this.state.author_id).name}</p>
+    </div>
+    <div class='preview-card-footer'>
+      <p class='author'>by ${this.props.authors.find(a => a.id == this.state.author_id).name}</p>
     </div>`;
     this.setState({ preview_card_content: previewCardContent })
   }
@@ -279,6 +283,9 @@ export default class extends React.Component {
     <div class='preview-card-body'>
        <p>${this.state.tweetText}</p>
        <p class='author'>@${this.state.tweetAuthor}</p>
+    </div>
+    <div class='preview-card-footer'>
+      <p class='author'>by ${this.props.authors.find(a => a.id == this.state.author_id).name}</p>
     </div>`;
     this.setState({ preview_card_content: previewCardContent, previewCardHasAlreadyBeenManuallyEdited: true })
   }
@@ -291,7 +298,9 @@ export default class extends React.Component {
     </div>
     <div class='preview-card-body'>
        <p>${this.state.videoDescription}</p>
-       <p class='author'>by ${this.props.authors.find(a => a.id == this.state.author_id).name}</p>
+    </div>
+    <div class='preview-card-footer'>
+      <p class='author'>by ${this.props.authors.find(a => a.id == this.state.author_id).name}</p>
     </div>`;
     this.setState({ preview_card_content: previewCardContent, previewCardHasAlreadyBeenManuallyEdited: true })
   }
@@ -337,18 +346,14 @@ export default class extends React.Component {
   }
 
   renderPreviewCardTypeDropdown() {
-    if(this.props.action === 'new') {
-      return (
-        <div>
-          <label>Preview Card Type:</label>
-          <ItemDropdown
-            items={['Blog Post', 'YouTube Video', 'Tweet', 'Custom HTML']}
-            callback={this.handlePreviewCardTypeChange}
-            selectedItem={this.state.preview_card_type}
-          />
-        </div>
-      )
-    }
+    return <div>
+        <label>Preview Card Type:</label>
+        <ItemDropdown
+          items={['Blog Post', 'YouTube Video', 'Tweet', 'Custom HTML']}
+          callback={this.handlePreviewCardTypeChange}
+          selectedItem={this.state.preview_card_type}
+        />
+      </div>
   }
 
   handlePremiumChange() {
@@ -363,27 +368,8 @@ export default class extends React.Component {
           <label>Title:</label>
           <input type="text" value={this.state.title} onChange={this.handleTitleChange} />
 
-          <label>Subtitle:</label>
+          <label>SEO Meta Description:</label>
           <input type="text" value={this.state.subtitle} onChange={this.handleSubtitleChange} />
-
-          <label>Body:</label>
-          <div id='markdown-shortcuts'>
-            <i onClick={() => this.insertMarkdown('# ')} className="fa fa-header" />
-            <i onClick={() => this.insertMarkdown('**', '**')} className="fa fa-bold" />
-            <i onClick={() => this.insertMarkdown('*', '*')} className="fa fa-italic" />
-            <i onClick={() => this.insertMarkdown('* ')} className="fa fa-list-ul" />
-            <i onClick={() => this.insertMarkdown('1. ')} className="fa fa-list-ol" />
-            <i onClick={() => this.insertMarkdown('> ')} className="fa fa-quote-left" />
-            <i onClick={() => this.insertMarkdown('[', '](http://samepicofdavecoulier.tumblr.com)')} className="fa fa-link" />
-            <i onClick={() => this.insertMarkdown('![', '](http://cultofthepartyparrot.com/parrots/hd/parrot.gif)')} className="fa fa-file-image-o" />
-            <i onClick={() => this.insertMarkdown("<a href='https://google.com' class='article-cta-primary'>\n", "\n</a>")} className="fa fa-square" />
-            <i onClick={() => this.insertMarkdown("<a href='https://google.com' class='article-cta-secondary'>\n", "\n</a>")} className="fa fa-square-o" />
-          </div>
-          <textarea rows={4} type="text" id="markdown-content" value={this.state.body} onChange={this.handleBodyChange} />
-          <a target="_blank" href="http://commonmark.org/help/" className='markdown-cheatsheet'>Markdown Cheatsheet</a>
-
-          <label>Body Preview:</label>
-          <MarkdownParser className='markdown-preview' markdownText={this.state.body} />
 
           <div className='flex-three-cols'>
             <div>
@@ -397,14 +383,46 @@ export default class extends React.Component {
             {this.renderPreviewCardTypeDropdown()}
           </div>
 
-          <label>Preview Card Content:</label>
-          {this.renderPreviewCardContentFields()}
+          <div className="side-by-side">
+            <div className="preview-card-container">
+              <label>Preview Card Content:</label>
+              {this.renderPreviewCardContentFields()}
+            </div>
 
-          <label>Card Preview:</label>
-          <PreviewCard content={this.state.preview_card_content} />
+            <div>
+              <label>Card Preview:</label>
+              <PreviewCard content={this.state.preview_card_content} />
+            </div>
+          </div>
 
           <label>Premium:</label>
           <input type='checkbox' value={this.state.premium} onClick={this.handlePremiumChange} />
+
+          <div className="side-by-side">
+            <div className="body-markdown">
+              <label>Article Contents:</label>
+              <div id='markdown-shortcuts'>
+                <i onClick={() => this.insertMarkdown('# ')} className="fa fa-header" />
+                <i onClick={() => this.insertMarkdown('**', '**')} className="fa fa-bold" />
+                <i onClick={() => this.insertMarkdown('*', '*')} className="fa fa-italic" />
+                <i onClick={() => this.insertMarkdown('* ')} className="fa fa-list-ul" />
+                <i onClick={() => this.insertMarkdown('1. ')} className="fa fa-list-ol" />
+                <i onClick={() => this.insertMarkdown('> ')} className="fa fa-quote-left" />
+                <i onClick={() => this.insertMarkdown('[', '](http://samepicofdavecoulier.tumblr.com)')} className="fa fa-link" />
+                <i onClick={() => this.insertMarkdown('![', '](http://cultofthepartyparrot.com/parrots/hd/parrot.gif)')} className="fa fa-file-image-o" />
+                <i onClick={() => this.insertMarkdown("<a href='https://google.com' class='article-cta-primary'>\n", "\n</a>")} className="fa fa-square" />
+                <i onClick={() => this.insertMarkdown("<a href='https://google.com' class='article-cta-secondary'>\n", "\n</a>")} className="fa fa-square-o" />
+              </div>
+              <textarea rows={4} type="text" id="markdown-content" value={this.state.body} onChange={this.handleBodyChange} />
+              <a target="_blank" href="http://commonmark.org/help/" className='markdown-cheatsheet'>Markdown Cheatsheet</a>
+            </div>
+
+            <div className="body-preview">
+              <label>Article Preview:</label>
+              <MarkdownParser className='markdown-preview' markdownText={this.state.body} />
+            </div>
+
+          </div>
 
           <input type="submit" value="Publish" onClick={(e) => { this.handleSubmitClick(e, true) }} />
           {this.renderSaveDraftButton()}

--- a/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
+++ b/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
@@ -7,6 +7,11 @@ import request from 'request';
 import moment from 'moment';
 
 export default class BlogPosts extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.renderBlogPostsByTopic = this.renderBlogPostsByTopic.bind(this)
+  }
 
   columns() {
     return ([
@@ -64,6 +69,28 @@ export default class BlogPosts extends React.Component {
     }
   }
 
+  renderBlogPostsByTopic() {
+    const tables = this.props.topics.map(t => {
+      const filteredBlogPosts = this.props.blogPosts.filter(bp => bp.topic === t)
+      if (filteredBlogPosts.length > 0) {
+        return <div>
+          <h1>{t}</h1>
+          <ReactTable
+            data={filteredBlogPosts}
+            columns={this.columns()}
+            showPagination={false}
+            showPaginationTop={false}
+            showPaginationBottom={false}
+            showPageSizeOptions={false}
+            defaultPageSize={filteredBlogPosts ? filteredBlogPosts.length : 0}
+          />
+        </div>
+      }
+    }
+    )
+    return tables
+  }
+
   render() {
     if (['new', 'edit'].includes(this.props.action)) {
       return <CreateOrEditBlogPost {...this.props} />;
@@ -76,17 +103,9 @@ export default class BlogPosts extends React.Component {
       <div className="cms-blog-posts">
         <a href="/cms/blog_posts/new" className="btn button-green">New Blog Post</a>
         <br /><br />
-        <ReactTable
-          data={this.props.blogPosts}
-          columns={this.columns()}
-          showPagination={false}
-          showPaginationTop={false}
-          showPaginationBottom={false}
-          showPageSizeOptions={false}
-          defaultPageSize={this.props.blogPosts ? this.props.blogPosts.length : 0}
-        />
+        {this.renderBlogPostsByTopic()}
       </div>
     );
-  },
+  }
 
 };

--- a/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
+++ b/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTable from 'react-table';
 import CreateOrEditBlogPost from '../components/cms/blog_posts/create_or_edit_blog_post.jsx';
+import BlogPostTable from '../components/cms/blog_posts/blog_post_table.jsx';
 import BlogPostIndex from '../components/blog_posts/blog_post_index.jsx';
 import BlogPost from '../components/blog_posts/blog_post.jsx';
 import request from 'request';
@@ -13,56 +14,6 @@ export default class BlogPosts extends React.Component {
     this.renderBlogPostsByTopic = this.renderBlogPostsByTopic.bind(this)
   }
 
-  columns() {
-    return ([
-      {
-        Header: '',
-        accessor: 'draft',
-        width: 75,
-        Cell: props => <span>{props.value ? 'DRAFT' : ''}</span>,
-      },
-      {
-        Header: 'Title',
-        accessor: 'title',
-      }, {
-        Header: 'Topic',
-        accessor: 'topic',
-      }, {
-        Header: 'Created',
-        accessor: 'created_at',
-        width: 115,
-        Cell: props => <span>{moment(props.value).format('MM-DD-YY')}</span>,
-      }, {
-        Header: 'Updated',
-        accessor: 'updated_at',
-        width: 115,
-        Cell: props => <span>{moment(props.value).format('MM-DD-YY')}</span>,
-      }, {
-        Header: 'Rating',
-        accessor: 'rating',
-        width: 75
-      }, {
-        Header: '',
-        accessor: 'id',
-        sortable: false,
-        width: 75,
-        Cell: props => <a className="button" href={`/cms/blog_posts/${props.value}/edit`}>Edit</a>,
-      }, {
-        Header: '',
-        accessor: 'slug',
-        sortable: false,
-        width: 75,
-        Cell: props => <a className="button" href={`/teacher_resources/${props.value}`}>Preview</a>,
-      }, {
-        Header: '',
-        accessor: 'id',
-        sortable: false,
-        width: 75,
-        Cell: props => <a className="button" onClick={this.confirmDelete} href={`/cms/blog_posts/${props.value}/delete`}>Delete</a>,
-      }
-    ]);
-  }
-
   confirmDelete(e) {
     if(window.prompt('To delete this post, please type DELETE.') !== 'DELETE') {
       e.preventDefault();
@@ -73,18 +24,10 @@ export default class BlogPosts extends React.Component {
     const tables = this.props.topics.map(t => {
       const filteredBlogPosts = this.props.blogPosts.filter(bp => bp.topic === t)
       if (filteredBlogPosts.length > 0) {
-        return <div>
-          <h1>{t}</h1>
-          <ReactTable
-            data={filteredBlogPosts}
-            columns={this.columns()}
-            showPagination={false}
-            showPaginationTop={false}
-            showPaginationBottom={false}
-            showPageSizeOptions={false}
-            defaultPageSize={filteredBlogPosts ? filteredBlogPosts.length : 0}
-          />
-        </div>
+        return <BlogPostTable
+          topic={t}
+          blogPosts={filteredBlogPosts}
+        />
       }
     }
     )

--- a/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
+++ b/client/app/bundles/HelloWorld/containers/BlogPosts.jsx
@@ -6,7 +6,7 @@ import BlogPost from '../components/blog_posts/blog_post.jsx';
 import request from 'request';
 import moment from 'moment';
 
-export default React.createClass({
+export default class BlogPosts extends React.Component {
 
   columns() {
     return ([
@@ -56,13 +56,13 @@ export default React.createClass({
         Cell: props => <a className="button" onClick={this.confirmDelete} href={`/cms/blog_posts/${props.value}/delete`}>Delete</a>,
       }
     ]);
-  },
+  }
 
   confirmDelete(e) {
     if(window.prompt('To delete this post, please type DELETE.') !== 'DELETE') {
       e.preventDefault();
     }
-  },
+  }
 
   render() {
     if (['new', 'edit'].includes(this.props.action)) {
@@ -89,4 +89,4 @@ export default React.createClass({
     );
   },
 
-});
+};

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -351,6 +351,7 @@ EmpiricalGrammar::Application.routes.draw do
     put '/unit_templates/update_order_numbers', to: 'unit_templates#update_order_numbers'
     resources :unit_templates, only: [:index, :create, :update, :destroy]
     resources :unit_template_categories, only: [:index, :create, :update, :destroy]
+    put '/blog_posts/update_order_numbers', to: 'blog_posts#update_order_numbers'
     resources :blog_posts
     get '/blog_posts/:id/delete', to: 'blog_posts#destroy'
     get '/blog_posts/:id/unpublish', to: 'blog_posts#unpublish'

--- a/db/migrate/20180227193833_add_published_at_to_blog_posts.rb
+++ b/db/migrate/20180227193833_add_published_at_to_blog_posts.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToBlogPosts < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :published_at, :datetime
+  end
+end

--- a/db/migrate/20180227215931_add_external_link_to_blog_posts.rb
+++ b/db/migrate/20180227215931_add_external_link_to_blog_posts.rb
@@ -1,0 +1,5 @@
+class AddExternalLinkToBlogPosts < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :external_link, :string
+  end
+end

--- a/db/migrate/20180228171538_add_center_images_to_blog_post.rb
+++ b/db/migrate/20180228171538_add_center_images_to_blog_post.rb
@@ -1,0 +1,5 @@
+class AddCenterImagesToBlogPost < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :center_images, :boolean
+  end
+end

--- a/db/migrate/20180301064334_add_order_number_to_blog_posts.rb
+++ b/db/migrate/20180301064334_add_order_number_to_blog_posts.rb
@@ -1,0 +1,5 @@
+class AddOrderNumberToBlogPosts < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :order_number, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -504,7 +504,11 @@ CREATE TABLE blog_posts (
     preview_card_content text NOT NULL,
     slug character varying,
     premium boolean DEFAULT false,
-    tsv tsvector
+    tsv tsvector,
+    published_at timestamp without time zone,
+    external_link character varying,
+    center_images boolean,
+    order_number integer
 );
 
 
@@ -4213,4 +4217,12 @@ INSERT INTO schema_migrations (version) VALUES ('20180222160256');
 INSERT INTO schema_migrations (version) VALUES ('20180222160302');
 
 INSERT INTO schema_migrations (version) VALUES ('20180222190628');
+
+INSERT INTO schema_migrations (version) VALUES ('20180227193833');
+
+INSERT INTO schema_migrations (version) VALUES ('20180227215931');
+
+INSERT INTO schema_migrations (version) VALUES ('20180228171538');
+
+INSERT INTO schema_migrations (version) VALUES ('20180301064334');
 


### PR DESCRIPTION
***run migrations***

Addresses issue #3873, #3884, #3886, #3888, #3890 

**Changes proposed in this pull request:**
- split blog posts cms index by topic
- allow dragging and dropping to change order of blog posts on cms index page
- add three options for card image size and update card editor on cms editing page
- add tabs to allow for toggling between body and body preview
- render entire body preview component
- add published_at column to blog_posts table and render on card if no author
- lots of small style changes
- add additional editing functionality for body (allow for different headers, preserve whitespace, etc)
- add ability to link cards to external pages
- add ability to center images in body

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes/no

**Have you updated the docs?** yes/no

**Have the tests been updated?** yes/no

**Reviewer:** @ddmck
