### PR TITLE
render published_at if field; nullcheck updated_at

### DIFF
--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post.jsx
@@ -60,7 +60,7 @@ export default class BlogPost extends React.Component {
         <article>
           <a className='back-to-topic' href={`/teacher_resources/topic/${this.state.backLink}`}><i className='fa fa-chevron-left'></i>Back to {this.props.blogPost.topic}</a>
           <BlogPostContent
-            updatedAt={this.props.blogPost.updated_at}
+            updatedAt={this.props.blogPost.published_at ? this.props.blogPost.published_at : this.props.blogPost.updated_at}
             title={this.props.blogPost.title}
             body={this.props.blogPost.body}
             author={this.props.author}

--- a/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/client/app/bundles/HelloWorld/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -453,7 +453,14 @@ export default class extends React.Component {
   }
 
   renderArticleMarkdownOrPreview() {
-    let content, toolbarLeft, mdLink
+    let content, toolbarLeft, mdLink, dateDisplayed
+    if (this.state.publishedAt) {
+      dateDisplayed = this.state.publishedAt
+    } else if (this.props.postToEdit) {
+      dateDisplayed = this.props.postToEdit.updated_at
+    } else {
+      dateDisplayed = moment()
+    }
     if (this.state.showArticlePreview) {
       toolbarLeft = <div/>
       content = <div id="article-container">
@@ -461,7 +468,7 @@ export default class extends React.Component {
           <BlogPostContent
             body={this.state.body}
             title={this.state.title}
-            updatedAt={this.props.postToEdit.updated_at}
+            updatedAt={dateDisplayed}
             author={this.props.authors.find(a => a.id == this.state.author_id)}
             displayPaywall={false}
             centerImages={this.state.centerImages}


### PR DESCRIPTION
**Changes proposed in this pull request:**
- render published_at if field exists on blog post page
- nullcheck updated_at so unsaved articles can be previewed

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes/no

**Have you updated the docs?** yes/no

**Have the tests been updated?** yes/no

**Reviewer:** @ddmck
