### PR TITLE
Fix broken tests on develop

### DIFF
--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -18,14 +18,14 @@ describe Subscription, type: :model do
 
       it 'is a subscription with multiple users_subscriptions linked' do
         user_subscription_2
-        old_sub_attributes = subscription.attributes
+        old_sub_attributes = subscription.reload.attributes
         subscription.credit_user_and_de_activate
         expect(subscription.reload.attributes).to eq(old_sub_attributes)
       end
 
       it 'is a subscription with any school subscriptions linked' do
         school_subscription
-        old_sub_attributes = subscription.attributes
+        old_sub_attributes = subscription.reload.attributes
         subscription.credit_user_and_de_activate
         expect(subscription.reload.attributes).to eq(old_sub_attributes)
       end


### PR DESCRIPTION
One of the compared attributes hashes was coming from the database, whereas the other was coming from the object. This causes an issue when comparing updated_at and created_at because of the database's temporal fidelity on Travis.