### PR TITLE
Fix string param being compared to integer

### DIFF
--- a/app/controllers/teachers/classroom_manager_controller.rb
+++ b/app/controllers/teachers/classroom_manager_controller.rb
@@ -121,7 +121,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
 
   def students_list
-    @classroom = current_user.classrooms_i_teach.find {|classroom| classroom.id == params[:id]}
+    @classroom = current_user.classrooms_i_teach.find {|classroom| classroom.id == params[:id]&.to_i}
     last_name = "substring(users.name, '(?=\s).*')"
     render json: {students: @classroom.students.order("#{last_name} asc, users.name asc")}
   end


### PR DESCRIPTION
Classroom ID param is a string, but being compared to an integer from the classrooms table, causing teachers to fail authorization for classroom management.
