### PR TITLE
Make sure images don't exceed the width of container in blog posts.

### DIFF
--- a/app/assets/stylesheets/pages/blog_posts.scss
+++ b/app/assets/stylesheets/pages/blog_posts.scss
@@ -306,6 +306,10 @@ a.all-blog-posts-back-button {
 #article-container {
   background: #ffffff;
 
+  div p img { 
+    max-width: 100%;
+  }
+
   article {
     margin: 0 auto;
     max-width: 945px;


### PR DESCRIPTION
Images _were_ too large in the blog posts, now they aren't.
