### PR TITLE
make authors index respond to both json and html requests

### DIFF
--- a/app/controllers/cms/authors_controller.rb
+++ b/app/controllers/cms/authors_controller.rb
@@ -1,7 +1,12 @@
 class Cms::AuthorsController < Cms::CmsController
   def index
     @authors = Author.all
-    render json: @authors
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: @authors
+      end
+    end
   end
 
   def new


### PR DESCRIPTION
Addresses issue #3934

**Changes proposed in this pull request:**
-make authors index respond to both json and html requests

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
