### PR TITLE
fix #3933 - activity category ordering

### DIFF
--- a/app/models/activity_category_activity.rb
+++ b/app/models/activity_category_activity.rb
@@ -1,4 +1,10 @@
 class ActivityCategoryActivity < ActiveRecord::Base
   belongs_to :activity_category
   belongs_to :activity
+
+  after_commit :clear_activity_search_cache
+
+  def clear_activity_search_cache
+    Activity.clear_activity_search_cache
+  end
 end

--- a/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
+++ b/client/app/bundles/HelloWorld/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
@@ -250,6 +250,8 @@ export default React.createClass({
           selectedActivities={this.props.selectedActivities}
           toggleActivitySelection={this.props.toggleActivitySelection}
           unitName={this.props.unitName}
+          sortable={this.props.sortable}
+          sortCallback={this.props.sortCallback}
         />
       </section>
     );


### PR DESCRIPTION
Addresses issue #3933

**Changes proposed in this pull request:**
- activities within activity categories are drag and droppable once again
- clear activity search cache when activity category activity order number changes

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
