### PR TITLE
adds method validating that user does not already have a school sub

### DIFF
--- a/app/models/concerns/teacher.rb
+++ b/app/models/concerns/teacher.rb
@@ -293,7 +293,7 @@ module Teacher
     school = School.find(school_id)
     if school && school.subscription
       # then we let the user subscription handle everything else
-      UserSubscription.create_user_sub_from_school_sub(self.id, school.subscription.id)
+      UserSubscription.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(self.id, school.subscription.id)
     end
   end
 

--- a/app/models/school_subscription.rb
+++ b/app/models/school_subscription.rb
@@ -8,7 +8,7 @@ class SchoolSubscription < ActiveRecord::Base
   def update_schools_users
     if self.school && self.school.users
       self.school.users.each do |u|
-        UserSubscription.create_user_sub_from_school_sub(u.id, self.subscription_id)
+        UserSubscription.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(u.id, self.subscription_id)
       end
     end
   end

--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -4,10 +4,17 @@ class UserSubscription < ActiveRecord::Base
   belongs_to :subscription
   after_commit :send_premium_emails, on: :create
 
+  def self.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(user_id, subscription_id)
+      if !UserSubscription.where(user_id: user_id, subscription_id: subscription_id).exists?
+        # then the user does not have the school subscription yet
+        self.create_user_sub_from_school_sub(user_id, subscription_id)
+      end
+  end
+
   def self.create_user_sub_from_school_sub(user_id, subscription_id)
-      self.redeem_present_and_future_subscriptions_for_credit(user_id)
-      # create a new user sub pointing at the school
-      self.create(user_id: user_id, subscription_id: subscription_id)
+    self.redeem_present_and_future_subscriptions_for_credit(user_id)
+    # create a new user sub pointing at the school
+    self.create(user_id: user_id, subscription_id: subscription_id)
   end
 
   def send_premium_emails

--- a/spec/models/user_subscription_spec.rb
+++ b/spec/models/user_subscription_spec.rb
@@ -55,6 +55,25 @@ describe UserSubscription, type: :model do
     end
   end
 
+  context '#self.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub' do
+    let!(:user) { create(:user, email: 'test@quill.org') }
+    let!(:subscription) { create(:subscription) }
+    let!(:user_subscription) { create(:user_subscription, user: user, subscription: subscription) }
+    describe 'when the user does have the passed subscription' do
+      it "does call #self.create_user_sub_from_school_sub" do
+        expect(UserSubscription).not_to receive(:create_user_sub_from_school_sub)
+        UserSubscription.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(user.id, subscription.id)
+      end
+    end
+    describe 'when the user does have the passed subscription' do
+      it "does call #self.create_user_sub_from_school_sub" do
+        expect(UserSubscription).to receive(:create_user_sub_from_school_sub)
+        user_subscription.destroy
+        UserSubscription.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(user.id, subscription.id)
+      end
+    end
+  end
+
   context '#self.create_user_sub_from_school_sub' do
     it 'creates a new UserSubscription' do
       old_user_sub_count = user_1.user_subscriptions.count


### PR DESCRIPTION
**Changes proposed in this pull request:**
At some point, and perhaps currently, there was/is a bug stopping some users from receiving school premium when their school upgraded. This makes it safe to repeatedly run the methods that give users their school premium subscription with no worry of duplication or redundant crediting.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?**  no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
