### PR TITLE
Tentative Parallel tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,9 +134,6 @@ gem 'rack-heartbeat'
 # INTEGRATIONS
 gem 'clever-ruby', '~> 0.13.2'
 
-gem "factory_bot", require: false
-gem "factory_bot_rails", require: false
-
 group :production, :staging do
   gem 'rails_12factor'
   gem 'lograge' # for making logs more dense
@@ -177,10 +174,14 @@ group :test, :development do
   gem 'rspec-retry'
   gem 'rspec-redis_helper'
   gem 'brakeman'
+  gem 'zeus-parallel_tests'
+  gem 'parallel_tests'
 end
 
 group :test, :development, :cypress do
   gem 'faker'
+  gem "factory_bot"
+  gem "factory_bot_rails"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,9 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+    parallel (1.12.1)
+    parallel_tests (2.21.3)
+      parallel
     parslet (1.8.1)
     pdf-core (0.7.0)
     pdf-inspector (1.3.0)
@@ -671,6 +674,11 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.0.0)
       nokogiri (~> 1.8)
+    zeus (0.15.14)
+      method_source (>= 0.6.7)
+    zeus-parallel_tests (0.3.2)
+      parallel_tests (>= 0.11.3)
+      zeus (>= 0.13.0)
 
 PLATFORMS
   ruby
@@ -730,6 +738,7 @@ DEPENDENCIES
   omniauth-clever
   omniauth-google-oauth2
   paperclip
+  parallel_tests
   parslet
   pdf-core
   pdf-inspector
@@ -803,6 +812,7 @@ DEPENDENCIES
   vcr
   webmock
   webpacker (~> 3.0.0)
+  zeus-parallel_tests
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -1,0 +1,7 @@
+require 'zeus/parallel_tests'
+
+class CustomPlan < Zeus::ParallelTests::Rails
+  # Your custom methods go here
+end
+
+Zeus.plan = CustomPlan.new

--- a/zeus.json
+++ b/zeus.json
@@ -1,0 +1,26 @@
+{
+  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+
+  "plan": {
+    "boot": {
+      "default_bundle": {
+        "development_environment": {
+          "prerake": {"rake": []},
+          "runner": ["r"],
+          "console": ["c"],
+          "server": ["s"],
+          "generate": ["g"],
+          "destroy": ["d"],
+          "dbconsole": [],
+          "parallel_rspec": []
+        },
+        "test_environment": {
+          "test_helper": {
+            "test": ["rspec"],
+            "parallel_rspec_worker": []
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The tests are slow. This PR proposes installing Zeus and Parallel Tests to speed up the test suite considerably.

On my 4 core 8 thread MacBook Pro running:
4 test processes the suite completes in 218 seconds (3:38)
6 processes the suite completes in 205 seconds (3:25)
8 processes I received a segmentation fault in some of the processes. This could be due to some recursive code in a test [this stackoverflow issue relates to better_errors, ours seems to relate to Faker](https://stackoverflow.com/questions/17178107/ruby-segmentation-fault-on-rspec)
```
versions/2.3.1/lib/ruby/gems/2.3.0/gems/faker-1.8.7/lib/faker.rb:200: .0/gems/parallel-1.12.1/lib/parallel/processor_count.rb
[BUG] Segmentation fault at 0x00000000000000
```

You will need to add `TEST_ENV_NUMBER=6` to your .env file.

See: 
https://infinum.co/the-capsized-eight/run-faster-ruby-on-rails-tests
https://github.com/sevos/zeus-parallel_tests
https://github.com/grosser/parallel_tests follow the commands in here for the tasks that will set up the db for parallelism.

I have been running 
```
bundle exec zeus start
```
then in a new tab
```
bundle exec zeus rake parallel:spec[6]
```

**Reviewer:** @ddmck
