### PR TITLE
fix #4050 - save scorebook selected classroom to local storage

### DIFF
--- a/client/app/bundles/HelloWorld/containers/Scorebook.jsx
+++ b/client/app/bundles/HelloWorld/containers/Scorebook.jsx
@@ -86,14 +86,26 @@ export default React.createClass({
   },
 
   setStateFromLocalStorage(callback) {
+    let state = {}
+    const storedSelectedClassroomId = window.localStorage.getItem('scorebookSelectedClassroomId')
     const storedDateFilterName = window.localStorage.getItem('scorebookDateFilterName')
     const dateFilterName = !storedDateFilterName || storedDateFilterName === 'null' ? null : storedDateFilterName
+    const selectedClassroomId = !storedSelectedClassroomId || storedSelectedClassroomId === 'null' ? null : storedSelectedClassroomId
+    if (selectedClassroomId) {
+      const selectedClassroom = this.state.classrooms.find(c => c.id === selectedClassroomId)
+      if (selectedClassroom) {
+        state.selectedClassroom = selectedClassroom
+      }
+    }
     if (dateFilterName) {
       const beginDate = this.DATE_RANGE_FILTER_OPTIONS.find(o => o.title === dateFilterName).beginDate
       window.localStorage.setItem('scorebookBeginDate', beginDate);
-      this.setState({beginDate, dateFilterName}, callback)
+      state.beginDate = beginDate
+      state.dateFilterName = dateFilterName
+      this.setState(state, callback)
     } else {
-      this.setState({beginDate: this.convertStoredDateToMoment(window.localStorage.getItem('scorebookBeginDate'))}, callback)
+      state.beginDate = this.convertStoredDateToMoment(window.localStorage.getItem('scorebookBeginDate'))
+      this.setState(state, callback)
     }
   },
 
@@ -203,6 +215,7 @@ export default React.createClass({
   },
 
   selectClassroom(option) {
+    window.localStorage.setItem('scorebookSelectedClassroomId', option.id)
     this.getUpdatedUnits(option.value);
     this.setState({
       scores: new Map(),


### PR DESCRIPTION
Addresses issue #4050

**Changes proposed in this pull request:**
- persist selected classroom in scorebook to local storage and use to set selected classroom on page load

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
