### PR TITLE
fix #4077 - add styling back in for dropdowns who have become ugly

### DIFF
--- a/app/assets/stylesheets/shared/dropdown_select.scss
+++ b/app/assets/stylesheets/shared/dropdown_select.scss
@@ -26,3 +26,16 @@
       letter-spacing: 1px;
     }
 }
+
+.dropdown-toggle.btn.btn-default {
+  font-weight: normal;
+  border-radius: 6px;
+  color: #000000;
+  padding: 0px 14px;
+  height: 40px;
+  min-width: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: solid 1px #cecece;
+}


### PR DESCRIPTION
Addresses issue #4077

**Changes proposed in this pull request:**
- add style rule for dropdowns that seem to have lost their styling

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="1022" alt="screen shot 2018-04-04 at 1 00 30 pm" src="https://user-images.githubusercontent.com/18669014/38322418-58826e5a-3808-11e8-950a-d53e008f6094.png">


**Has this branch been QA'd on staging?** no

**Have you updated the docs?**  no

**Have the tests been updated?**  no

**Reviewer:** @ddmck
