### PR TITLE
Fix  #4017 Scope finding reports to visible classroom activities.

### DIFF
--- a/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -44,6 +44,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
         LEFT JOIN activity_sessions ON classroom_activities.id = activity_sessions.classroom_activity_id
         WHERE classroom_activities.unit_id = #{ActiveRecord::Base.sanitize(unit_id)}
           AND classroom_activities.activity_id = #{ActiveRecord::Base.sanitize(activity_id)}
+          AND classroom_activities.visible = TRUE
           AND activity_sessions.is_final_score = TRUE
         ORDER BY activity_sessions.updated_at DESC
         LIMIT 1;").to_a


### PR DESCRIPTION
Prevents loading of archived classroom activities for diagnostic reports.

Fixes  https://github.com/empirical-org/Empirical-Core/issues/4017