### PR TITLE
check for units with same name when looking at previously assigned re…

### DIFF
--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -249,6 +249,9 @@ module PublicProgressReports
       assigned_recommendations = Recommendations.new.send("recs_for_#{diagnostic.id}").map do |rec|
         # one unit per teacher with this name.
         unit = Unit.find_by(user_id: teacher_id, unit_template_id: rec[:activityPackId])
+        if !unit
+          unit = Unit.find_by(user_id: teacher_id, name: UnitTemplate.find_by_id(rec[:activityPackId]).name)
+        end
         student_ids = ClassroomActivity.find_by(unit: unit, classroom: classroom).try(:assigned_student_ids)
         return_value_for_recommendation(student_ids, rec)
       end


### PR DESCRIPTION
…commendations


**Changes proposed in this pull request:**
- previously a recommendation would only show up as previously assigned if it had the 

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
