### PR TITLE
Feature/new school creation updates salesmachine

### DIFF
--- a/app/controllers/cms/schools_controller.rb
+++ b/app/controllers/cms/schools_controller.rb
@@ -91,6 +91,7 @@ class Cms::SchoolsController < Cms::CmsController
   def create
     new_school = School.new(edit_or_add_school_params)
     if new_school.save
+      SyncSalesAccountWorker.perform_async(new_school.id)
       redirect_to cms_school_path(new_school.id)
     else
       render :new

--- a/app/services/sales_account_syncer.rb
+++ b/app/services/sales_account_syncer.rb
@@ -1,0 +1,17 @@
+class SalesAccountSyncer
+  def initialize(school_id, serializer = nil, client = nil)
+    @school_id  = school_id
+    @serializer = serializer || SerializeSalesAccount
+    @client     = client || SalesmachineClient
+  end
+
+  def sync
+    @client.batch([account_data])
+  end
+
+  private
+
+  def account_data
+    @serializer.new(@school_id).data
+  end
+end

--- a/app/services/sales_contact_syncer.rb
+++ b/app/services/sales_contact_syncer.rb
@@ -1,0 +1,26 @@
+class SalesContactSyncer
+  def initialize(teacher_id, serializer = nil, client = nil)
+    @teacher_id = teacher_id
+    @serializer = serializer || SerializeSalesContact
+    @client     = client || SalesmachineClient
+  end
+
+  def sync
+    if user && user.teacher?
+      @client.batch([account_data])
+      true
+    else
+      false
+    end
+  end
+
+  private
+
+  def account_data
+    @serializer.new(@teacher_id).data
+  end
+
+  def user
+    @user ||= User.find(@teacher_id)
+  end
+end

--- a/app/services/serialize_sales_contact.rb
+++ b/app/services/serialize_sales_contact.rb
@@ -15,7 +15,7 @@ class SerializeSalesContact
         signed_up: teacher.created_at.to_i,
         admin: teacher.admin?,
         premium_status: premium_status,
-        premium_expiry_date: premium_expiration_date,
+        premium_expiry_date: subscription_expiration_date,
         number_of_students: number_of_students,
         number_of_completed_activities: number_of_completed_activities,
         number_of_completed_activities_per_student: activities_per_student,
@@ -99,7 +99,7 @@ class SerializeSalesContact
     end
   end
 
-  def premium_expiration_date
+  def subscription_expiration_date
     if subscription.present?
       subscription.expiration
     else
@@ -108,7 +108,13 @@ class SerializeSalesContact
   end
 
   def subscription
-    teacher.subscription if teacher.subscription.present?
+    if teacher.subscription.present?
+      return teacher.subscription
+    end
+
+    if teacher.last_expired_subscription.present?
+      return teacher.last_expired_subscription
+    end
   end
 
   def account_uid

--- a/app/workers/sync_sales_account_worker.rb
+++ b/app/workers/sync_sales_account_worker.rb
@@ -1,0 +1,7 @@
+class SyncSalesAccountWorker
+  include Sidekiq::Worker
+
+  def perform(school_id)
+    SalesAccountSyncer.new(school_id).sync
+  end
+end

--- a/app/workers/sync_sales_accounts_worker.rb
+++ b/app/workers/sync_sales_accounts_worker.rb
@@ -1,4 +1,4 @@
-class SyncSalesAccountWorker
+class SyncSalesAccountsWorker
   include Sidekiq::Worker
 
   def perform(redis_key)
@@ -12,7 +12,7 @@ class SyncSalesAccountWorker
 
     if response.success?
       $redis.ltrim(redis_key, 100, -1)
-      SyncSalesAccountWorker.perform_async(redis_key)
+      SyncSalesAccountsWorker.perform_async(redis_key)
     else
       raise response.status.to_s
     end

--- a/app/workers/sync_sales_contact_worker.rb
+++ b/app/workers/sync_sales_contact_worker.rb
@@ -1,0 +1,7 @@
+class SyncSalesContactWorker
+  include Sidekiq::Worker
+
+  def perform(teacher_id)
+    SalesContactSyncer.new(teacher_id).sync
+  end
+end

--- a/app/workers/sync_sales_contacts_worker.rb
+++ b/app/workers/sync_sales_contacts_worker.rb
@@ -1,4 +1,4 @@
-class SyncSalesContactWorker
+class SyncSalesContactsWorker
   include Sidekiq::Worker
 
   def perform(redis_key)
@@ -12,7 +12,7 @@ class SyncSalesContactWorker
 
     if response.success?
       $redis.ltrim(redis_key, 100, -1)
-      SyncSalesContactWorker.perform_async(redis_key)
+      SyncSalesContactsWorker.perform_async(redis_key)
     else
       raise response.status.to_s
     end

--- a/app/workers/sync_sales_stages_worker.rb
+++ b/app/workers/sync_sales_stages_worker.rb
@@ -1,4 +1,4 @@
-class SyncSalesStageWorker
+class SyncSalesStagesWorker
   include Sidekiq::Worker
 
   def perform(redis_key)
@@ -22,7 +22,7 @@ class SyncSalesStageWorker
 
     if response.blank? || response.success?
       $redis.ltrim(redis_key, 100, -1)
-      SyncSalesStageWorker.perform_async(redis_key)
+      SyncSalesStagesWorker.perform_async(redis_key)
     else
       raise response.status.to_s
     end

--- a/lib/tasks/sync_salesmachine.rake
+++ b/lib/tasks/sync_salesmachine.rake
@@ -19,7 +19,7 @@ task :sync_salesmachine => :environment do
     $redis.lpush(SALES_STAGE_KEY, teacher.id)
   end
 
-  SyncSalesAccountWorker.perform_async(ACCOUNTS_KEY)
+  SyncSalesAccountsWorker.perform_async(ACCOUNTS_KEY)
   SyncSalesContactWorker.perform_async(CONTACTS_KEY)
   SyncSalesStageWorker.perform_async(SALES_STAGE_KEY)
 end

--- a/lib/tasks/sync_salesmachine.rake
+++ b/lib/tasks/sync_salesmachine.rake
@@ -20,6 +20,6 @@ task :sync_salesmachine => :environment do
   end
 
   SyncSalesAccountsWorker.perform_async(ACCOUNTS_KEY)
-  SyncSalesContactWorker.perform_async(CONTACTS_KEY)
+  SyncSalesContactsWorker.perform_async(CONTACTS_KEY)
   SyncSalesStageWorker.perform_async(SALES_STAGE_KEY)
 end

--- a/lib/tasks/sync_salesmachine.rake
+++ b/lib/tasks/sync_salesmachine.rake
@@ -21,5 +21,5 @@ task :sync_salesmachine => :environment do
 
   SyncSalesAccountsWorker.perform_async(ACCOUNTS_KEY)
   SyncSalesContactsWorker.perform_async(CONTACTS_KEY)
-  SyncSalesStageWorker.perform_async(SALES_STAGE_KEY)
+  SyncSalesStagesWorker.perform_async(SALES_STAGE_KEY)
 end

--- a/spec/services/sales_account_syncer_spec.rb
+++ b/spec/services/sales_account_syncer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'SalesAccountSyncer' do
+  before { Timecop.freeze }
+  after { Timecop.return }
+
+  it 'sends the serialized account data to salesmachine via a client' do
+    school              = create(:school)
+    serializer_instance = double('serializer_instance')
+    serializer          = double('serializer')
+    client              = double('client')
+    data                = double('data')
+
+    allow(serializer).to receive(:new).with(school.id) { serializer_instance }
+    allow(serializer_instance).to receive(:data) { data }
+    expect(client).to receive(:batch).with([data])
+
+    SalesAccountSyncer.new(school.id, serializer, client).sync
+  end
+end

--- a/spec/services/sales_contact_syncer_spec.rb
+++ b/spec/services/sales_contact_syncer_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'SalesContactSyncer' do
+  it 'syncs salesmachine with teacher data' do
+    user                = create(:user, role: 'teacher')
+    serializer_instance = double('serializer_instance')
+    serializer          = double('serializer')
+    client              = double('client')
+    data                = double('data')
+
+    allow(serializer).to receive(:new).with(user.id) { serializer_instance }
+    allow(serializer_instance).to receive(:data) { data }
+    expect(client).to receive(:batch).with([data])
+
+    SalesContactSyncer.new(user.id, serializer, client).sync
+  end
+
+  it 'only syncs if contact is a teacher' do
+    student = create(:user, role: 'student')
+    client  = double('client')
+
+    expect(client).to_not receive(:batch)
+
+    SalesContactSyncer.new(student.id, nil, client).sync
+  end
+end


### PR DESCRIPTION
Addresses issue

**Changes proposed in this pull request:**
- when an admin user creates a new school it will immediately push the school data to salesmachine 

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**no

**Have you updated the docs?**no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
