### PR TITLE
fix  #4189 - add descriptions and links to icons in scorebook

### DIFF
--- a/app/assets/stylesheets/pages/scorebook_page.scss
+++ b/app/assets/stylesheets/pages/scorebook_page.scss
@@ -31,8 +31,24 @@
 
 	.app-legend {
 		padding-top: 25px;
+		.icon {
+			cursor: pointer;
+		}
 		.title {
 			color: #717171;
+			margin-bottom: 6px;
+		}
+		.description {
+			color: #888888;
+		}
+		.icon-puzzle-embossed, .icon-flag-embossed, .icon-connect-embossed, .icon-lessons-embossed, .icon-diagnostic-embossed {
+			background-position: top;
+		}
+		.icon-wrapper {
+			margin-bottom: 3px;
+		}
+		.icons-description-wrapper {
+			margin-left: 5px;
 		}
 	}
 

--- a/client/app/bundles/HelloWorld/components/scorebook/__tests__/__snapshots__/app_legend.test.jsx.snap
+++ b/client/app/bundles/HelloWorld/components/scorebook/__tests__/__snapshots__/app_legend.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`AppLegend component should render 1`] = `
   >
     <div
       className="icon"
+      onClick={[Function]}
     >
       <div
         className="icon-wrapper icon-diagnostic-embossed"
@@ -21,10 +22,16 @@ exports[`AppLegend component should render 1`] = `
         >
           Quill Diagnostic
         </p>
+        <p
+          className="description"
+        >
+          Identify Learning Gaps
+        </p>
       </div>
     </div>
     <div
       className="icon"
+      onClick={[Function]}
     >
       <div
         className="icon-wrapper icon-lessons-embossed"
@@ -37,10 +44,16 @@ exports[`AppLegend component should render 1`] = `
         >
           Quill Lessons
         </p>
+        <p
+          className="description"
+        >
+          Shared Group Lessons
+        </p>
       </div>
     </div>
     <div
       className="icon"
+      onClick={[Function]}
     >
       <div
         className="icon-wrapper icon-connect-embossed"
@@ -53,10 +66,16 @@ exports[`AppLegend component should render 1`] = `
         >
           Quill Connect
         </p>
+        <p
+          className="description"
+        >
+          Combine Sentences
+        </p>
       </div>
     </div>
     <div
       className="icon"
+      onClick={[Function]}
     >
       <div
         className="icon-wrapper icon-flag-embossed"
@@ -69,10 +88,16 @@ exports[`AppLegend component should render 1`] = `
         >
           Quill Proofreader
         </p>
+        <p
+          className="description"
+        >
+          Practice Mechanics
+        </p>
       </div>
     </div>
     <div
       className="icon"
+      onClick={[Function]}
     >
       <div
         className="icon-wrapper icon-puzzle-embossed"
@@ -84,6 +109,11 @@ exports[`AppLegend component should render 1`] = `
           className="title"
         >
           Quill Grammar
+        </p>
+        <p
+          className="description"
+        >
+          Fix Errors In Passages
         </p>
       </div>
     </div>

--- a/client/app/bundles/HelloWorld/components/scorebook/app_legend.jsx
+++ b/client/app/bundles/HelloWorld/components/scorebook/app_legend.jsx
@@ -6,34 +6,39 @@ export default React.createClass({
     return (
       <div className="icons-wrapper icon-legend app-legend">
         <div className="icons">
-          <div className="icon">
+          <div className="icon" onClick={() => window.location.href = "/tools/diagnostic"}>
             <div className="icon-wrapper icon-diagnostic-embossed"/>
             <div className="icons-description-wrapper">
               <p className="title">Quill Diagnostic</p>
+              <p className="description">Identify Learning Gaps</p>
             </div>
           </div>
-          <div className="icon">
+          <div className="icon" onClick={() => window.location.href = "/tools/lessons"}>
             <div className="icon-wrapper icon-lessons-embossed"/>
             <div className="icons-description-wrapper">
               <p className="title">Quill Lessons</p>
+              <p className="description">Shared Group Lessons</p>
             </div>
           </div>
-          <div className="icon">
+          <div className="icon" onClick={() => window.location.href = "/tools/connect"}>
             <div className="icon-wrapper icon-connect-embossed"/>
             <div className="icons-description-wrapper">
               <p className="title">Quill Connect</p>
+              <p className="description">Combine Sentences</p>
             </div>
           </div>
-            <div className="icon">
+          <div className="icon" onClick={() => window.location.href = "/tools/grammar"}>
               <div className="icon-wrapper icon-flag-embossed"/>
               <div className="icons-description-wrapper">
                 <p className="title">Quill Proofreader</p>
+                <p className="description">Practice Mechanics</p>
               </div>
             </div>
-            <div className="icon">
+            <div className="icon" onClick={() => window.location.href = "/tools/proofreader"}>
               <div className="icon-wrapper icon-puzzle-embossed"/>
               <div className="icons-description-wrapper">
                 <p className="title">Quill Grammar</p>
+                <p className="description">Fix Errors In Passages</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Addresses issue #4189

**Changes proposed in this pull request:**
- add descriptions to scorebook activity icons
- scorebook activities are links to their tools pages

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2018-05-08 at 12 28 51 pm](https://user-images.githubusercontent.com/18669014/39769942-9f4043a8-52bb-11e8-99dc-9f389b0c4c7d.png)


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
