### PR TITLE
fix #4205 -add topic pages for teacher center topics

### DIFF
--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -5,7 +5,7 @@
 
   <header>
     <h1>Frequently Asked Questions</h1>
-    <h2>Everything you need to know about Quill's pedgagogy and use in the classroom</h2>
+    <h2>Everything you need to know about Quill's pedagogy and use in the classroom</h2>
     <p>Still have a question? <a href='https://support.quill.org'>Visit our support page</a></p>
   </header>
 

--- a/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
+++ b/client/app/bundles/HelloWorld/components/blog_posts/blog_post_index.jsx
@@ -18,6 +18,32 @@ export default class extends React.Component {
     this.setState({ articleFilter: filter });
   }
 
+  pageTitle() {
+    if (window.location.pathname.includes('topic')) {
+      return window.location.pathname.split('/')[3].split('-').map(topic => topic.charAt(0).toUpperCase() + topic.slice(1)).join(' ')
+    } else {
+      return 'Teacher Center'
+    }
+  }
+
+  pageSubtitle() {
+    switch (this.pageTitle()) {
+      case 'Teacher Stories':
+        return 'Read success stories about Quill in the class'
+      case 'Getting Started':
+        return 'Set up your classroom on Quill with guides, videos, and presentations'
+      case 'Writing Instruction Research':
+        return 'Read and download handpicked materials to teach writing'
+      case 'Support':
+        return 'The most common questions teachers ask about Quill'
+      case 'Webinars':
+        return 'Join online conferences to learn best practices for how to use Quill with your students'
+      case 'Teacher Center':
+      default:
+        return 'Everything you need to know about Quill’s pedagogy and use in the classroom'
+    }
+  }
+
   renderPreviewCards() {
     return this.props.blogPosts.map(article =>
       <PreviewCard
@@ -94,19 +120,18 @@ export default class extends React.Component {
   }
 
   renderNavAndSectionHeader() {
-    const currentPageIsTopicPage = window.location.pathname.includes('topic');
     const currentPageIsSearchPage = window.location.pathname.includes('search');
-    if (!currentPageIsTopicPage && !currentPageIsSearchPage) {
+    if (!currentPageIsSearchPage) {
       return (
         <span/>
       )
-    } else if (currentPageIsTopicPage) {
-      return (
-        <div className='topic-header'>
-          <h2>{window.location.pathname.split('/')[3].split('-').map(topic => topic.charAt(0).toUpperCase() + topic.slice(1)).join(' ')}</h2>
-        </div>
-      )
-    } else if (currentPageIsSearchPage) {
+    // } else if (currentPageIsTopicPage) {
+    //   return (
+    //     <div className='topic-header'>
+    //       <h2>{window.location.pathname.split('/')[3].split('-').map(topic => topic.charAt(0).toUpperCase() + topic.slice(1)).join(' ')}</h2>
+    //     </div>
+    //   )
+    } else {
       return (
         <nav>
           <ul>
@@ -116,6 +141,7 @@ export default class extends React.Component {
       )
     }
   }
+
 
   renderMostReadPost() {
     const mostReadArticle = this.state.blogPostsSortedByMostRead[0];
@@ -140,8 +166,8 @@ export default class extends React.Component {
       return (
         <div id="knowledge-center">
           <HeaderSection
-            title="Teacher Center"
-            subtitle="Everything you need to know about Quill’s pedgagogy and use in the classroom"
+            title={this.pageTitle()}
+            subtitle={this.pageSubtitle()}
             query={this.props.query}
             showCancelSearchButton={!!window.location.href.includes('search')}
           />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ EmpiricalGrammar::Application.routes.draw do
 
   resources :blog_posts, path: 'teacher-center', only: [:index, :show], param: :slug do
     collection do
+      get '/topic/press', to: redirect('/press')
+      get '/topic/announcements', to: redirect('/announcements')
       get '/topic/:topic', to: 'blog_posts#show_topic'
       get 'search', to: 'blog_posts#search'
     end


### PR DESCRIPTION
Addresses issue #4205

**Changes proposed in this pull request:**
- adds topic page with unique header for each teacher center topic

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
