### PR TITLE
fix #4208 - send teacher to premium report when they sign up for free trial

### DIFF
--- a/client/app/bundles/HelloWorld/components/dashboard/premium_mini.jsx
+++ b/client/app/bundles/HelloWorld/components/dashboard/premium_mini.jsx
@@ -5,7 +5,7 @@ export default React.createClass({
 
   beginTrial() {
     $.post('/subscriptions', { subscription: { account_type: 'Teacher Trial', }, })
-      .success(() => { window.location.assign('/'); });
+      .success(() => { window.location.assign('/teachers/progress_reports/activities_scores_by_classroom'); });
   },
 
   miniBuilder() {

--- a/client/app/bundles/HelloWorld/components/premium/premium_minis/teacher_pricing_mini.jsx
+++ b/client/app/bundles/HelloWorld/components/premium/premium_minis/teacher_pricing_mini.jsx
@@ -30,7 +30,7 @@ export default React.createClass({
           authenticity_token: $('meta[name=csrf-token]').attr('content'),
         },
       }).success(() => {
-        window.location.assign('/teachers/classrooms/scorebook');
+        window.location.assign('/teachers/progress_reports/activities_scores_by_classroom');
       });
     }
   },


### PR DESCRIPTION
Addresses issue #4208

**Changes proposed in this pull request:**
- redirect teacher to activity scores pages when they sign up for a free trial

**Has this branch been QA'd on staging?**no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
