### PR TITLE
fix #4209 - school admin page updates

### DIFF
--- a/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -295,6 +295,9 @@
   }
 
   .tab-subnavigation-wrapper {
+    .active, a:hover {
+      text-decoration: none;
+    }
     .premium {
       border: 1px solid #eda41b;
       color: #875a12;

--- a/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -137,6 +137,7 @@
     }
     .warning {
       font-weight: bold;
+      margin: 0px;
     }
     .teacher-link {
       font-size: 14px;

--- a/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -57,7 +57,7 @@
     }
     .features-list {
       display: flex;
-      margin-top: 32px;
+      margin-top: 70px;
       .feature {
         width: 320px;
         &:first-of-type, &:nth-of-type(2) {

--- a/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -294,4 +294,22 @@
     }
   }
 
+  .tab-subnavigation-wrapper {
+    .premium {
+      border: 1px solid #eda41b;
+      color: #875a12;
+      .fa-star {
+        color: #eda41b;
+      }
+      &.active, &:hover {
+        text-decoration: none;
+        background: #eda41b;
+        color: white;
+        .fa-star {
+          color: white;
+        }
+      }
+    }
+  }
+
 }

--- a/app/views/teachers/shared/_scorebook_tabs.html.erb
+++ b/app/views/teachers/shared/_scorebook_tabs.html.erb
@@ -8,7 +8,7 @@
 
       <% if current_user.admin? %>
         <li class="admin-tab <%= 'active' if admin_page_should_be_active? %>">
-          <%= link_to 'School', teachers_admin_dashboard_path, role: 'tab' %>
+          <%= link_to 'School Dashboard', teachers_admin_dashboard_path, role: 'tab' %>
         </li>
       <% end %>
 

--- a/client/app/assets/styles/home.scss
+++ b/client/app/assets/styles/home.scss
@@ -67,11 +67,6 @@ p.feature-heading {
     }
   }
 
-  #q-and-a {
-    .expand-or-collapse {
-      margin: auto;
-    }
-  }
 }
 
 a {

--- a/client/app/assets/styles/tool-section.scss
+++ b/client/app/assets/styles/tool-section.scss
@@ -1090,6 +1090,7 @@ $tool-grey: #f8f9f9;
     font-weight: 600;
     cursor: pointer;
     margin-left: 10px;
+    margin-top: 1.3em;
   }
   .support-link {
     color: #ffffff;

--- a/client/app/bundles/HelloWorld/components/modules/questionsAndAnswers/admin.jsx
+++ b/client/app/bundles/HelloWorld/components/modules/questionsAndAnswers/admin.jsx
@@ -6,19 +6,19 @@ const admin = () => [
     answer: <p>After upgrading to Quill School Premium, you’ll receive an email from our team with next steps, which include setting up your professional development session.</p>
   },
   {
-    question: 'Arranging the Session',
+    question: 'How can I arrange the Professional Development session?',
     answer: [<p>In order to set up that session, you will set up an initial 15-minute call between your PD coordinator and our School Partnerships team to discuss tailoring the session school goals and writing curriculum, which tools you’d like to highlight, and when you’d like the session to happen. You can do this by signing up at <a href="http://beccaquill.youcanbook.me">beccaquill.youcanbook.me</a>.</p>,
             <p>Teachers will be asked to set up their Quill accounts prior to the session, so they can jump right into exploring Quill!</p>
     ]
   },
   {
-    question: 'Session Structure',
+    question: 'What is the Professional Development session structure like?',
     answer: [
             <p>The personalized session will last 45 to 75 minutes, and will involve a review of chosen tools as they relate to the school’s focus, and (time allowing) a conversation surrounding how teachers can effectively integrate Quill into their classroom. In the session, teachers will establish a direct line of communication with the School Partnerships team.</p>
             ]
   },
   {
-    question: 'Session Access',
+    question: 'How will I access the Professional Development session?',
     answer: [<p>Sessions outside of New York City will be held remotely via Google Hangouts, and will be recorded via Hangouts on Air to provide teachers with continued access to the information. Teachers will receive a follow up email with a reminder of resources and a link to the session recording.</p>]
   },
   {

--- a/client/app/bundles/admin_dashboard/components/premium_features.tsx
+++ b/client/app/bundles/admin_dashboard/components/premium_features.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 
 const PremiumFeatures = () =>
 <div id="features">
-  <h2>School dashboard</h2>
-  <p>Quill Premium for Schools provides you with:</p>
   <div className="features-list">
     <div className="feature">
       <img src="https://assets.quill.org/images/icons/student_icon_admin.svg"/>

--- a/client/app/bundles/admin_dashboard/components/subnav_tabs.tsx
+++ b/client/app/bundles/admin_dashboard/components/subnav_tabs.tsx
@@ -1,35 +1,59 @@
 import * as React from 'react';
 import { Link } from 'react-router';
 
-const SubnavTabs = () => {
-  return(
-    <div className="tab-subnavigation-wrapper class-subnav">
-      <div className="container">
-        <ul>
-          <li>
-            <Link to="/teachers/admin_dashboard">
-              Admin Dashboard
-            </Link>
-          </li>
-          <li>
-            <Link to="/teachers/admin_dashboard/district_activity_scores">
-              Activity Scores
-            </Link>
-          </li>
-          <li>
-            <Link to="/teachers/admin_dashboard/district_concept_reports">
-              Concept Reports
-            </Link>
-          </li>
-          <li>
-            <Link to="/teachers/admin_dashboard/district_standards_reports">
-             Standards Reports
-            </Link>
-          </li>
-        </ul>
-      </div>
-    </div>
-  );
-};
+export default class AdminSubnav extends React.Component<any, any> {
+  constructor(props) {
+    super(props)
 
-export default SubnavTabs;
+    this.state = this.getStateFromProps(props)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(this.getStateFromProps(nextProps))
+  }
+
+  getStateFromProps(props) {
+    const state = {activityScores: '', conceptReports: '', standardsReports: '', overview: ''}
+    if (props.path.pathname.includes('/district_activity_scores')) {
+      state.activityScores = 'active'
+    } else if (props.path.pathname.includes('/district_concept_reports')) {
+      state.conceptReports = 'active'
+    } else if (props.path.pathname.includes('/district_standards_reports')) {
+      state.standardsReports = 'active'
+    } else if (props.path.pathname.includes('admin_dashboard')) {
+      state.overview = 'active'
+    }
+    return state
+  }
+
+  render() {
+    return(
+      <div className="tab-subnavigation-wrapper class-subnav">
+        <div className="container">
+          <ul>
+            <li>
+              <Link className={this.state.overview} to="/teachers/admin_dashboard">
+              Overview
+            </Link>
+          </li>
+          <li>
+            <Link className={this.state.activityScores} to="/teachers/admin_dashboard/district_activity_scores">
+            Activity Scores
+          </Link>
+        </li>
+        <li>
+          <Link className={this.state.conceptReports} to="/teachers/admin_dashboard/district_concept_reports">
+          Concept Reports
+        </Link>
+      </li>
+      <li>
+        <Link className={this.state.standardsReports} to="/teachers/admin_dashboard/district_standards_reports">
+        Standards Reports
+      </Link>
+    </li>
+  </ul>
+</div>
+</div>
+);
+  }
+};

--- a/client/app/bundles/admin_dashboard/components/subnav_tabs.tsx
+++ b/client/app/bundles/admin_dashboard/components/subnav_tabs.tsx
@@ -37,18 +37,18 @@ export default class AdminSubnav extends React.Component<any, any> {
             </Link>
           </li>
           <li>
-            <Link className={this.state.activityScores} to="/teachers/admin_dashboard/district_activity_scores">
-            Activity Scores
+            <Link className={`premium ${this.state.activityScores}`} to="/teachers/admin_dashboard/district_activity_scores">
+            Activity Scores <i className="fa fa-star"/>
           </Link>
         </li>
         <li>
-          <Link className={this.state.conceptReports} to="/teachers/admin_dashboard/district_concept_reports">
-          Concept Reports
+          <Link className={`premium ${this.state.conceptReports}`} to="/teachers/admin_dashboard/district_concept_reports">
+          Concept Reports <i className="fa fa-star"/>
         </Link>
       </li>
       <li>
-        <Link className={this.state.standardsReports} to="/teachers/admin_dashboard/district_standards_reports">
-        Standards Reports
+        <Link className={`premium ${this.state.standardsReports}`} to="/teachers/admin_dashboard/district_standards_reports">
+        Standards Reports <i className="fa fa-star"/>
       </Link>
     </li>
   </ul>

--- a/client/app/bundles/admin_dashboard/containers/AdminDashboardContainer.jsx
+++ b/client/app/bundles/admin_dashboard/containers/AdminDashboardContainer.jsx
@@ -4,7 +4,7 @@ import SubnavTabs from '../components/subnav_tabs.tsx';
 const AdminDashboardContainer = (props) => (
     <div className="tab-content">
       <div className="tab-pane active" id="class-manager">
-        <SubnavTabs />
+        <SubnavTabs path={props.location}/>
         <div id="admin-dashboard">
           {props.children}
         </div>


### PR DESCRIPTION
Addresses issue #4209

**Changes proposed in this pull request:**
- copy updates
- tabs on school admin dashboard are now active and premium ones have premium styling
- expand/collapse button styling for q&a

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

<img width="998" alt="screen shot 2018-05-09 at 1 08 11 pm" src="https://user-images.githubusercontent.com/18669014/39828726-11be7322-538a-11e8-88d4-b09b13802783.png">

<img width="915" alt="screen shot 2018-05-09 at 1 03 58 pm" src="https://user-images.githubusercontent.com/18669014/39828651-cbc942b6-5389-11e8-9c54-03c376a08d11.png">

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
