### PR TITLE
fix #4211 - checking and unchecking diagnostic recommendations

### DIFF
--- a/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -315,6 +315,11 @@ $lightgray: #cecece;
       font-size: 12px;
       color: #027360;
       cursor: pointer;
+      display: flex;
+      align-items: flex-end;
+      img {
+        margin-right: 5px;
+      }
     }
     .assigned-activity-pack-text {
       margin-left: 10px;

--- a/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -311,6 +311,11 @@ $lightgray: #cecece;
         margin-left: 44px;
       }
     }
+    .uncheck-recommendations, .check-recommendations {
+      font-size: 12px;
+      color: #027360;
+      cursor: pointer;
+    }
     .assigned-activity-pack-text {
       margin-left: 10px;
       p:nth-of-type(2) {

--- a/app/models/concerns/public_progress_reports.rb
+++ b/app/models/concerns/public_progress_reports.rb
@@ -252,7 +252,7 @@ module PublicProgressReports
         if !unit
           unit = Unit.find_by(user_id: teacher_id, name: UnitTemplate.find_by_id(rec[:activityPackId]).name)
         end
-        student_ids = ClassroomActivity.find_by(unit: unit, classroom: classroom).try(:assigned_student_ids)
+        student_ids = ClassroomActivity.find_by(unit: unit, classroom: classroom).try(:assigned_student_ids) || []
         return_value_for_recommendation(student_ids, rec)
       end
       recommended_lesson_activity_ids = LessonRecommendations.new.send("recs_#{diagnostic.id}_data").map {|r| r[:activityPackId]}

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__tests__/recommendations.test.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/__tests__/recommendations.test.jsx
@@ -60,15 +60,9 @@ describe('Recommendations Component', () => {
       />)
     wrapper.setState({recommendations, students, previouslyAssignedRecommendations})
     wrapper.instance().setSelections(previouslyAssignedRecommendations)
-    it('assigns state.selections to an array of activities, each with an array of student ids concatenated from state.previouslyAssignedRecommendations and state.recommendations', () => {
-      const selections = wrapper.state('recommendations').map((recommendation, i) => {
-				const prevAssigned = previouslyAssignedRecommendations[i]
-				const allStudents = _.uniq(recommendation.students.concat(prevAssigned.students))
-				return {
-					activity_pack_id: recommendation.activity_pack_id,
-					name: recommendation.name,
-					students: allStudents
-				}
+    it('assigns state.selections to an array of activities which is identical to the recommended activities', () => {
+      const selections = wrapper.state('recommendations').map(recommendation => {
+				return recommendation
 			})
       expect(_.isEqual(wrapper.state('selections'), selections)).toBe(true)
     })
@@ -80,15 +74,18 @@ describe('Recommendations Component', () => {
     />)
     wrapper.setState({recommendations, students, previouslyAssignedRecommendations, selections: recommendations})
     it ('returns an object with key selections and value array of objects with ids and classrooms', () => {
-      const selectionsArr = wrapper.state('selections').map(activityPack => ({
-        id: activityPack.activity_pack_id,
-        classrooms: [
-          {
-            id: params.classroomId,
-            student_ids: activityPack.students,
+      const selectionsArr = wrapper.state('selections').map((activityPack, index) => {
+        const students = _.uniq(activityPack.students.concat(wrapper.state('previouslyAssignedRecommendations')[index].students))
+          return {
+            id: activityPack.activity_pack_id,
+            classrooms: [
+              {
+                id: params.classroomId,
+                student_ids: students,
+              }
+            ]
           }
-        ]
-      }))
+        })
       const selectionsObj = {selections: selectionsArr}
       expect(_.isEqual(wrapper.instance().formatSelectionsForAssignment(), selectionsObj)).toBe(true)
     })

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
@@ -92,6 +92,18 @@ export default React.createClass({
     }
   },
 
+  unselectAllRecommendations() {
+    const newSelections = this.state.selections.map(selection => {
+      selection.students = []
+      return selection
+    })
+    this.setState({selections: newSelections})
+  },
+
+  selectAllRecommendations() {
+    this.setState({selections: this.state.recommendations})
+  },
+
   studentWasAssigned(student, previouslyAssignedRecommendation) {
     if (previouslyAssignedRecommendation && previouslyAssignedRecommendation.students) {
       return previouslyAssignedRecommendation.students.includes(student.id);
@@ -199,12 +211,24 @@ export default React.createClass({
     );
   },
 
+  renderCheckOrUncheckAllRecommendedActivityPacks() {
+    const hasSelectedActivities = this.state.selections.find(sel => _.compact(sel.students).length > 0)
+    if (hasSelectedActivities) {
+      return <p className="uncheck-recommendations" onClick={this.unselectAllRecommendations}><img src="https://assets.quill.org/images/icons/uncheckall-diagnostic.svg"/>Uncheck All</p>
+    } else {
+      return <p className="check-recommendations" onClick={this.selectAllRecommendations}><img src="https://assets.quill.org/images/icons/checkall-diagnostic.svg"/>Check All</p>
+    }
+  },
+
   renderTopBar() {
     return (
       <div className="recommendations-top-bar">
         <div className="recommendations-key">
           <div className="recommendations-key-icon" />
-          <p>Recommended Activity Packs</p>
+          <span className="recommended-activity-pack-text">
+            <p>Recommended Activity Packs</p>
+            {this.renderCheckOrUncheckAllRecommendedActivityPacks()}
+          </span>
           <div className="assigned-recommendations-key-icon"><i className="fa fa-check-circle" /></div>
           <span className="assigned-activity-pack-text">
             <p>Assigned Activity Packs</p>

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
@@ -101,7 +101,11 @@ export default React.createClass({
   },
 
   selectAllRecommendations() {
-    this.setState({selections: this.state.recommendations})
+    const newSelections = this.state.selections.map((selection, index) => {
+      selection.students = this.state.recommendations[index].students
+      return selection
+    })
+    this.setState({selections: newSelections})
   },
 
   studentWasAssigned(student, previouslyAssignedRecommendation) {

--- a/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
+++ b/client/app/bundles/HelloWorld/components/progress_reports/diagnostic_reports/recommendations.jsx
@@ -64,20 +64,23 @@ export default React.createClass({
       that.setState({
         previouslyAssignedRecommendations: data.previouslyAssignedRecommendations,
         previouslyAssignedLessonsRecommendations: data.previouslyAssignedLessonsRecommendations,
-      }, that.setSelections(data.previouslyAssignedRecommendations, assigned, data.previouslyAssignedLessonsRecommendations));
+      }, that.setSelections(assigned, data.previouslyAssignedLessonsRecommendations));
     }));
   },
 
-  setSelections(previouslyAssignedRecommendations, assigned, previouslyAssignedLessonsRecommendations) {
-    const selections = this.state.recommendations.map((recommendation, i) => {
-      const prevAssigned = previouslyAssignedRecommendations[i];
-      const allAssignedStudents = _.uniq(recommendation.students.concat(prevAssigned.students));
-      return {
-        activity_pack_id: recommendation.activity_pack_id,
-        name: recommendation.name,
-        students: allAssignedStudents,
-      };
-    });
+  setSelections(assigned, previouslyAssignedLessonsRecommendations) {
+    let selections
+    if (this.state.selections.length === 0) {
+      selections = this.state.recommendations.map((recommendation, i) => {
+        return {
+          activity_pack_id: recommendation.activity_pack_id,
+          name: recommendation.name,
+          students: recommendation.students,
+        };
+      });
+    } else {
+      selections = this.state.selections
+    }
     const lessonsRecommendations = this.state.lessonsRecommendations.map((recommendation) => {
       if (previouslyAssignedLessonsRecommendations.includes(recommendation.activity_pack_id)) {
         return Object.assign({}, recommendation, { status: 'assigned', });
@@ -153,15 +156,18 @@ export default React.createClass({
 
   formatSelectionsForAssignment() {
     const classroomId = this.props.params.classroomId;
-    const selectionsArr = this.state.selections.map(activityPack => ({
-      id: activityPack.activity_pack_id,
-      classrooms: [
-        {
-          id: classroomId,
-          student_ids: activityPack.students,
-        }
-      ],
-    }));
+    const selectionsArr = this.state.selections.map((activityPack, index) => {
+      const students = _.uniq(activityPack.students.concat(this.state.previouslyAssignedRecommendations[index].students))
+      return {
+        id: activityPack.activity_pack_id,
+        classrooms: [
+          {
+            id: classroomId,
+            student_ids: students,
+          }
+        ],
+      }
+    });
     return { selections: selectionsArr ,};
   },
 
@@ -218,9 +224,9 @@ export default React.createClass({
   renderCheckOrUncheckAllRecommendedActivityPacks() {
     const hasSelectedActivities = this.state.selections.find(sel => _.compact(sel.students).length > 0)
     if (hasSelectedActivities) {
-      return <p className="uncheck-recommendations" onClick={this.unselectAllRecommendations}><img src="https://assets.quill.org/images/icons/uncheckall-diagnostic.svg"/>Uncheck All</p>
+      return <p className="uncheck-recommendations" onClick={this.unselectAllRecommendations}><img src="https://assets.quill.org/images/icons/uncheckall-diagnostic.svg"/><span>Uncheck All</span></p>
     } else {
-      return <p className="check-recommendations" onClick={this.selectAllRecommendations}><img src="https://assets.quill.org/images/icons/checkall-diagnostic.svg"/>Check All</p>
+      return <p className="check-recommendations" onClick={this.selectAllRecommendations}><img src="https://assets.quill.org/images/icons/checkall-diagnostic.svg"/><span>Check All</span></p>
     }
   },
 


### PR DESCRIPTION
Addresses issue #4211

**Changes proposed in this pull request:**
- add option to uncheck activity packs when some are selected
- add option to check all recommended activity packs when none are selected
- concatenate previously assigned recommendations to currently selected ones when sending back to server, rather than when setting selections, to clean up logic

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="984" alt="screen shot 2018-05-09 at 5 12 13 pm" src="https://user-images.githubusercontent.com/18669014/39840062-2b2cc17a-53ac-11e8-94e5-5cdafb8e2278.png">
<img width="978" alt="screen shot 2018-05-09 at 5 12 02 pm" src="https://user-images.githubusercontent.com/18669014/39840071-32d38da0-53ac-11e8-9e2b-1c63c268e266.png">

**Has this branch been QA'd on staging?**no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
