### PR TITLE
alert user if they try to purchase school premium sans school #3214

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -340,6 +340,7 @@ class PagesController < ApplicationController
   def premium
     @user_is_eligible_for_new_subscription= current_user&.eligible_for_new_subscription?
     @user_is_eligible_for_trial = current_user&.subscriptions&.none?
+    @user_has_school = !!current_user&.school
     @user_belongs_to_school_that_has_paid = current_user&.school ? Subscription.school_or_user_has_ever_paid?(current_user&.school) : false
     @last_four = current_user&.last_four
   end

--- a/app/views/pages/shared/_premium_main.html.slim
+++ b/app/views/pages/shared/_premium_main.html.slim
@@ -3,7 +3,7 @@
 | ">
 
 #first-preview-section
-  = react_component('PremiumPricingGuideApp', props: {lastFour: @last_four, userIsEligibleForNewSubscription: @user_is_eligible_for_new_subscription, userIsEligibleForTrial: @user_is_eligible_for_trial, userBelongsToSchoolThatHasPaid: @user_belongs_to_school_that_has_paid})
+  = react_component('PremiumPricingGuideApp', props: {lastFour: @last_four, userHasSchool: @user_has_school, userIsEligibleForNewSubscription: @user_is_eligible_for_new_subscription, userIsEligibleForTrial: @user_is_eligible_for_trial, userBelongsToSchoolThatHasPaid: @user_belongs_to_school_that_has_paid})
 .preview-section#second-preview-section
   .title Save Time Grading
   .copy

--- a/client/app/bundles/HelloWorld/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/client/app/bundles/HelloWorld/components/premium/premium_minis/school_pricing_mini.jsx
@@ -11,6 +11,8 @@ export default React.createClass({
     }
     if (!this.props.userIsSignedIn) {
       onClickEvent = () => alert('You must be logged in to activate Premium.');
+    } else if (!this.props.userHasSchool) {
+      onClickEvent = () => alert('You must add a school before buying School Premium. You can do so by visiting Quill.org/teachers/my_account');
     } else if (!this.props.userIsEligibleForNewSubscription) {
       onClickEvent = () => alert('You have an active subscription and cannot buy premium now. You may buy a new Premium subscription when your current subscription expires.');
     }

--- a/cypress/integration/premium_page.js
+++ b/cypress/integration/premium_page.js
@@ -90,7 +90,7 @@ describe('Premium Page', () => {
       before(() => {
         cy.cleanDatabase()
         cy.factoryBotCreate({
-          factory: 'teacher',
+          factory: 'teacher_with_school',
           password: 'password',
           username: 'teacher',
           stripe_customer_id: 'cus_CN6VaNY6yd8R5M'
@@ -187,7 +187,7 @@ describe('Premium Page', () => {
         before(() => {
           cy.cleanDatabase()
           cy.factoryBotCreate({
-            factory: 'teacher',
+            factory: 'teacher_with_school',
             password: 'password',
             username: 'teacher',
             id: 1

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,6 +22,12 @@ FactoryBot.define do
           create(:classrooms_teacher, user_id: teacher.id)
         end
       end
+      factory :teacher_with_school do
+        after(:create) do |teacher|
+          school = create(:school)
+          school.users.push(teacher)
+        end
+      end
 
       factory :co_teacher_with_one_classroom do
         after(:create) do |teacher|


### PR DESCRIPTION
Addresses issue #4215

**Changes proposed in this pull request:**
Users are alerted if they try to purchase school premium but don't have a school. Previously this just returned a 500. 

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
