### PR TITLE
Fix/broken launch lessons route

### DIFF
--- a/app/controllers/teachers/classroom_activities_controller.rb
+++ b/app/controllers/teachers/classroom_activities_controller.rb
@@ -23,14 +23,18 @@ class Teachers::ClassroomActivitiesController < ApplicationController
   end
 
   def launch_lesson
-    if current_milestone && @classroom_activity.update(locked: false, pinned: true)
-      find_or_create_lesson_activity_sessions_for_classroom
-      PusherLessonLaunched.run(@classroom_activity.classroom)
-      redirect_to lesson_url(lesson) and return
-    elsif current_milestone
+    if lesson_tutorial_completed?
+      if @classroom_activity.update(locked: false, pinned: true)
+        find_or_create_lesson_activity_sessions_for_classroom
+        PusherLessonLaunched.run(@classroom_activity.classroom)
+        redirect_to lesson_url(lesson) and return
+      else
+        flash.now[:error] = "We cannot launch this lesson. If the problem persists, please contact support."
+        redirect_to :back
+      end
+    else
       redirect_to "#{ENV['DEFAULT_URL']}/tutorials/lessons?url=#{URI.escape(launch_lesson_url)}" and return
     end
-    flash.now[:error] = "We cannot launch this lesson. If the problem persists, please contact support."
   end
 
   def activity_from_classroom_activity
@@ -78,8 +82,8 @@ private
     "#{lesson.classification_form_url}teach/class-lessons/#{lesson.uid}/mark_lesson_as_completed?&classroom_activity_id=#{@classroom_activity.id}"
   end
 
-  def current_milestone
-    @user_milestone ||= UserMilestone.find_by(milestone_id: view_lessons_tutorial_milestone.id, user_id: current_user.id)
+  def lesson_tutorial_completed?
+    @tutorial_completed ||= UserMilestone.exists?(milestone_id: view_lessons_tutorial_milestone.id, user_id: current_user.id)
   end
 
   def launch_lesson_url

--- a/spec/controllers/teachers/classroom_activities_controller_spec.rb
+++ b/spec/controllers/teachers/classroom_activities_controller_spec.rb
@@ -27,9 +27,10 @@ describe Teachers::ClassroomActivitiesController, type: :controller do
     end
   end
 
-  describe '#launch_session' do
+  describe '#launch_lesson' do
     let!(:milestone) { create(:milestone, name: "View Lessons Tutorial") }
     let!(:activity) { create(:activity) }
+
 
     before do
       # stubbing custom validation on creation of activity session
@@ -67,15 +68,15 @@ describe Teachers::ClassroomActivitiesController, type: :controller do
 
     context 'when milestone exists and activity could not get updated' do
       let!(:user_milestone) { create(:user_milestone, milestone: milestone, user: teacher) }
-      let(:launch_lesson_url) {  "#{ENV['DEFAULT_URL']}/tutorials/lessons?url=/teachers/classroom_activities/#{classroom_activity.id}/launch_lesson/#{activity.uid}" }
 
       before do
         allow_any_instance_of(ClassroomActivity).to receive(:update) { false }
       end
 
-      it 'should redirecct to launch lesson ulr' do
+      it 'should redirect back to the referrer' do
+        request.env["HTTP_REFERER"] = '/'
         get :launch_lesson, id: classroom_activity.id, lesson_uid: activity.uid
-        expect(response).to redirect_to launch_lesson_url
+        expect(response).to redirect_to '/'
       end
     end
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
- refactors launch_lessons so that if there is a flash, it occurs after redirecting to back
- updates tests
- changes current_milestone method to lesson_tutorial_completed

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
