### PR TITLE
Allow saving of mobile app activity sessions with classroom_activity_id

### DIFF
--- a/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/app/controllers/api/v1/activity_sessions_controller.rb
@@ -102,6 +102,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
                   :state,
                   :question_type,
                   :completed_at,
+                  :classroom_activity_id,
                   :activity_uid,
                   :activity_id,
                   :anonymous,


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Activity Sessions can now be created with a classroom_activity_id

**Has this branch been QA'd on staging?** yes

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
