### PR TITLE
fix #4279 - hide algorithm tags on responses that are not algorithmically graded

### DIFF
--- a/services/QuillConnect/app/components/questions/response.jsx
+++ b/services/QuillConnect/app/components/questions/response.jsx
@@ -442,7 +442,8 @@ export default React.createClass({
       icon = '⚠️';
     }
     const authorStyle = { marginLeft: '10px', };
-    const author = response.author ? <span style={authorStyle} className="tag is-dark">{response.author}</span> : undefined;
+    const showTag = response.author && (response.statusCode === 2 || response.statusCode === 3)
+    const author = showTag ? <span style={authorStyle} className="tag is-dark">{response.author}</span> : undefined;
     const checked = this.props.massEdit.selectedResponses.includes(response.id) ? 'checked' : '';
     return (
       <div style={{ display: 'flex', alignItems: 'center', }} className={bgColor}>


### PR DESCRIPTION
Addresses issue #4279

**Changes proposed in this pull request:**
- hide algorithm tags (on admin frontend, no database change) for human graded and ungraded responses

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?**  no

**Have the tests been updated?** no

**Reviewer:** @ddmck
