### PR TITLE
fix #4278 - add quill style guide link on lesson and edition cover page

### DIFF
--- a/services/QuillLessons/app/components/classroomLessons/admin/show.tsx
+++ b/services/QuillLessons/app/components/classroomLessons/admin/show.tsx
@@ -149,7 +149,10 @@ class ShowClassroomLesson extends Component<any, any> {
       return (
         <div className="admin-classroom-lessons-container">
           <div className="lesson-header">
-            <h5 className="title is-4">Lesson: {this.classroomLesson().title}</h5>
+            <div className="top-line">
+              <h5 className="title is-4">Lesson: {this.classroomLesson().title}</h5>
+              <a href="https://docs.google.com/document/d/1oc3IlB4pDPUFcFLl4eHItPinC9GEKvblkifIKStMSmQ/edit">Quill Lessons Style Guide</a>
+            </div>
             <h5 className="title is-5">{this.renderPercentage()}</h5>
             <EditLessonDetails classroomLesson={this.classroomLesson()} save={this.saveLessonDetails} deleteLesson={this.deleteLesson} />
           </div>

--- a/services/QuillLessons/app/components/classroomLessons/admin/showAdminEdition.tsx
+++ b/services/QuillLessons/app/components/classroomLessons/admin/showAdminEdition.tsx
@@ -141,7 +141,10 @@ class ShowAdminEdition extends Component<any, any> {
       return (
         <div className="admin-classroom-lessons-container">
           <div className="lesson-header">
-            <h4 className="title is-4">Lesson: <a href={`/#/admin/classroom-lessons/${this.props.params.classroomLessonID}`}>{this.classroomLesson().title} </a> </h4>
+            <div className="top-line">
+              <h5 className="title is-4">Lesson: {this.classroomLesson().title}</h5>
+              <a href="https://docs.google.com/document/d/1oc3IlB4pDPUFcFLl4eHItPinC9GEKvblkifIKStMSmQ/edit">Quill Lessons Style Guide</a>
+            </div>
             <h4 className="title is-4">Edition: {this.edition().name} <a target="_blank" href={`/#/teach/class-lessons/${this.props.params.classroomLessonID}/preview/${this.props.params.editionID}`}>Preview</a> </h4>
             <EditEditionDetails edition={this.edition()} save={this.saveEditionDetails} deleteEdition={this.deleteEdition} />
           </div>

--- a/services/QuillLessons/app/styles/components/classroom_lessons/_admin.scss
+++ b/services/QuillLessons/app/styles/components/classroom_lessons/_admin.scss
@@ -12,6 +12,11 @@
     border-bottom: 1px solid #e3e3e3;
   }
 
+  .top-line {
+    display: flex;
+    justify-content: space-between;
+  }
+
   ul.classroom-lessons-index {
     width: 650px;
     li {


### PR DESCRIPTION
Addresses issue #4278

**Changes proposed in this pull request:**
- add quill style guide link on lesson and edition cover page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
