### PR TITLE
fix #4299 - add where clause to limit teacher subscriptions to the most recent one

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -192,7 +192,9 @@ protected
   end
 
   def where_query_string_builder
-    conditions = ["users.role != 'temporary'"]
+    not_temporary = "users.role != 'temporary'"
+    most_recent_subscription = "user_subscriptions.created_at = (SELECT MAX(user_subscriptions.created_at) FROM user_subscriptions WHERE user_subscriptions.user_id = users.id)"
+    conditions = [not_temporary, most_recent_subscription]
     @all_search_inputs.each do |param|
       param_value = user_query_params[param]
       if param_value && !param_value.empty?


### PR DESCRIPTION
Addresses issue #4299
**Changes proposed in this pull request:**
- add where clause to limit teacher subscriptions to the most recent one

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
