### PR TITLE
fix #4314 - due dates factor into the next activity now

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -126,7 +126,7 @@ protected
     GROUP BY ca.id, activity.name, activity.description, acts.activity_id,
             unit.name, unit.id, unit.created_at, unit_name, activity.repeatable,
             activity.activity_classification_id, activity.repeatable
-    ORDER BY pinned DESC, locked ASC, max_percentage DESC, unit.created_at ASC, ca.created_at ASC").to_a
+    ORDER BY pinned DESC, locked ASC, max_percentage DESC, ca.due_date ASC, unit.created_at ASC, ca.created_at ASC").to_a
   end
 
   def next_activity_session


### PR DESCRIPTION
Addresses issue #4314 

**Changes proposed in this pull request:**
- due dates are being used in sql query that helps find the next activity

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
