### PR TITLE
fix #4315 - deleting a classroom activity now updates the front end correctly

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
@@ -17,6 +17,14 @@ export default React.createClass({
     };
   },
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.data.classroomActivities && (nextProps.data.classroomActivities.length === this.state.classroomActivities.length)) {
+      this.setState({classroomActivities: nextProps.data.classroomActivities})
+    } else if (nextProps.data.classroom_activities && (nextProps.data.classroom_activities.length === this.state.classroomActivities.length)) {
+      this.setState({classroomActivities: nextProps.data.classroom_activities})
+    }
+  },
+
   hideUnit() {
     const x = confirm('Are you sure you want to delete this Activity Pack? \n \nIt will delete all assignments given to students associated with this pack, even if those assignments have already been completed.');
     if (x) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/manage_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/manage_units.jsx
@@ -149,25 +149,28 @@ export default React.createClass({
     });
   },
 
-  hideClassroomActivity(ca_id, unit_id) {
-    let units,
-      x1;
-    units = this.state.units;
-    x1 = _.map(units, (unit) => {
-      if (this.getIdFromUnit(unit) === unit_id) {
-        if (unit.classroom_activities) {
-          unit.classroom_activities = _.reject(unit.classroom_activities, ca => ca.id === ca_id);
-        } else if (unit.classroomActivities) {
-          unit.classroomActivities = new Map(_.reject(Array.from(unit.classroomActivities), ca => ca[1].caId === ca_id)); // This is very bad code.
+  hideClassroomActivity(caId, unitId) {
+    request.put({
+      url: `${process.env.DEFAULT_URL}/teachers/classroom_activities/${caId}/hide`,
+      json: { authenticity_token: getAuthToken(), }, },
+      (error, httpStatus, body) => {
+        if (httpStatus && httpStatus.statusCode === 200) {
+          const units = this.state.units;
+          const modifiedUnits = _.map(units, (unit) => {
+            const modifiedUnit = unit
+            if (this.getIdFromUnit(modifiedUnit) === unitId) {
+              if (modifiedUnit.classroom_activities) {
+                modifiedUnit.classroom_activities = _.reject(modifiedUnit.classroom_activities, ca => ca.id === caId);
+              } else if (modifiedUnit.classroomActivities) {
+                modifiedUnit.classroomActivities = new Map(_.reject(Array.from(modifiedUnit.classroomActivities), ca => ca[1].caId === caId)); // This is very bad code.
+              }
+            }
+            return modifiedUnit;
+          });
+          this.setState({ units: modifiedUnits, });
         }
       }
-      return unit;
-    });
-    this.setState({ units: x1, });
-
-    request.put(`${process.env.DEFAULT_URL}/teachers/classroom_activities/${ca_id}/hide`, {
-      json: { authenticity_token: getAuthToken(), },
-    });
+    )
   },
 
   updateDueDate(ca_id, date) {


### PR DESCRIPTION
Addresses issue #4315

**Changes proposed in this pull request:**
- deleting an activity will now update the front end after a success response from the server

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
