### PR TITLE
fix #4321 - activity level model concepts

### DIFF
--- a/services/QuillConnect/app/actions/lessons.js
+++ b/services/QuillConnect/app/actions/lessons.js
@@ -2,7 +2,7 @@ const C = require('../constants').default;
 import rootRef from '../libs/firebase';
 const	lessonsRef = rootRef.child('lessons');
 import { push } from 'react-router-redux';
-import {updateFlag} from './questions'
+import {updateFlag, updateModelConceptUID} from './questions'
 
 	// called when the app starts. this means we immediately download all quotes, and
 	// then receive all quotes again as soon as anyone changes anything.
@@ -48,7 +48,7 @@ import {updateFlag} from './questions'
   function submitLessonEdit(cid, content, qids) {
     return function (dispatch, getState) {
       dispatch({ type: C.SUBMIT_LESSON_EDIT, cid, });
-      dispatch(updateQuestionFlags(content, qids))
+      dispatch(updateQuestions(content, qids))
       lessonsRef.child(cid).set(content, (error) => {
         dispatch({ type: C.FINISH_LESSON_EDIT, cid, });
         if (error) {
@@ -60,11 +60,16 @@ import {updateFlag} from './questions'
     };
   }
 
-  function updateQuestionFlags(content, qids) {
+  function updateQuestions(content, qids) {
     return function (dispatch) {
       if (content.flag) {
         qids.forEach(qid => {
           dispatch(updateFlag(qid, content.flag))
+        })
+      }
+      if (content.modelConceptUID) {
+        qids.forEach(qid => {
+          dispatch(updateModelConceptUID(qid, content.modelConceptUID))
         })
       }
     };
@@ -82,6 +87,8 @@ import {updateFlag} from './questions'
         if (error) {
           dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
         } else {
+          const qids = content.questions ? content.questions.map(q => q.key) : []
+          dispatch(updateQuestions(content, qids))
           dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
           const action = push(`/admin/lessons/${newRef.key}`);
           dispatch(action);
@@ -97,7 +104,7 @@ export default {
   cancelLessonEdit,
   deleteLesson,
   submitLessonEdit,
-  updateQuestionFlags,
+  updateQuestions,
   toggleNewLessonModal,
   submitNewLesson
 };

--- a/services/QuillConnect/app/actions/questions.js
+++ b/services/QuillConnect/app/actions/questions.js
@@ -122,6 +122,16 @@ function updateFlag(qid, flag) {
   }
 }
 
+function updateModelConceptUID(qid, modelConceptUID) {
+  return dispatch => {
+    questionsRef.child(`${qid}/modelConceptUID/`).set(modelConceptUID, (error) => {
+      if (error) {
+        alert(`Model concept update failed! ${error}`);
+      }
+    });
+  }
+}
+
 function submitNewIncorrectSequence(qid, data) {
   return (dispatch, getState) => {
     questionsRef.child(`${qid}/incorrectSequences`).push(data, (error) => {

--- a/services/QuillConnect/app/actions/questions.js
+++ b/services/QuillConnect/app/actions/questions.js
@@ -124,11 +124,15 @@ function updateFlag(qid, flag) {
 
 function updateModelConceptUID(qid, modelConceptUID) {
   return dispatch => {
-    questionsRef.child(`${qid}/modelConceptUID/`).set(modelConceptUID, (error) => {
-      if (error) {
-        alert(`Model concept update failed! ${error}`);
+    questionsRef.child(`${qid}/modelConceptUID/`).once('value', (snapshot) => {
+      if (!snapshot.val()) {
+        questionsRef.child(`${qid}/modelConceptUID/`).set(modelConceptUID, (error) => {
+          if (error) {
+            alert(`Model concept update failed! ${error}`);
+          }
+        });
       }
-    });
+    })
   }
 }
 
@@ -381,5 +385,6 @@ module.exports = {
   setStringFilter,
   incrementRequestCount,
   updateFlag,
-  getSuggestedSequences
+  getSuggestedSequences,
+  updateModelConceptUID
 };

--- a/services/QuillConnect/app/components/lessons/chooseModelContainer.jsx
+++ b/services/QuillConnect/app/components/lessons/chooseModelContainer.jsx
@@ -1,0 +1,50 @@
+import React, { Component } from 'react';
+import _ from 'underscore';
+import ConceptSelector from '../shared/conceptSelector.jsx';
+import ConceptExplanation from '../feedback/conceptExplanation.jsx';
+
+class ChooseModelContainer extends Component {
+  constructor() {
+    super();
+    this.selectConcept = this.selectConcept.bind(this);
+    this.removeModelConcept = this.removeModelConcept.bind(this);
+  }
+
+  removeModelConcept() {
+    this.props.updateModelConcept(null)
+  }
+
+  selectConcept(e) {
+    this.props.updateModelConcept(e.value)
+  }
+
+  renderButtons() {
+    return (
+      <p className="control">
+        <button
+          className="button is-outlined is-danger"
+          style={{marginLeft: 5}}
+          onClick={this.removeModelConcept}>
+          Remove
+        </button>
+      </p>
+    )
+  }
+
+  render() {
+    return (
+      <div className="box">
+        <h4 className="title">Choose Model</h4>
+        <div className="control">
+          <ConceptSelector onlyShowConceptsWithConceptFeedback currentConceptUID={this.props.modelConceptUID} handleSelectorChange={this.selectConcept} />
+          <ConceptExplanation {...this.props.conceptsFeedback.data[this.props.modelConceptUID]} />
+          {this.props.children}
+        </div>
+        {this.renderButtons()}
+      </div>
+    )
+  }
+
+}
+
+export default ChooseModelContainer;

--- a/services/QuillConnect/app/components/lessons/lesson.jsx
+++ b/services/QuillConnect/app/components/lessons/lesson.jsx
@@ -57,7 +57,7 @@ const Lesson = React.createClass({
   saveLessonEdits(vals) {
     const { data, } = this.props.lessons,
       { lessonID, } = this.props.params;
-    const qids = data[lessonID].questions ? data[lessonID].questions.map(q => q.key) : []
+    const qids = vals.questions ? vals.questions.map(q => q.key) : []
     this.props.dispatch(lessonActions.submitLessonEdit(lessonID, vals, qids));
   },
 

--- a/services/QuillConnect/app/components/lessons/lessonForm.jsx
+++ b/services/QuillConnect/app/components/lessons/lessonForm.jsx
@@ -17,15 +17,15 @@ const LessonForm = React.createClass({
       selectedQuestions: currentValues && currentValues.questions ? currentValues.questions : [],
       flag: currentValues ? currentValues.flag : 'alpha',
       questionType: 'questions',
-      modelConceptUID: null
+      modelConceptUID: currentValues ? currentValues.modelConceptUID : null
     };
   },
 
   submit() {
-    const { name, questions, landingPageHtml, flag, modelConceptUID } = this.state
+    const { name, selectedQuestions, landingPageHtml, flag, modelConceptUID, } = this.state
     this.props.submit({
       name,
-      questions,
+      questions: selectedQuestions,
       landingPageHtml,
       flag,
       modelConceptUID

--- a/services/QuillConnect/app/components/lessons/lessonForm.jsx
+++ b/services/QuillConnect/app/components/lessons/lessonForm.jsx
@@ -4,6 +4,7 @@ import { hashToCollection } from '../../libs/hashToCollection';
 import QuestionSelector from 'react-select-search';
 import SortableList from '../questions/sortableList/sortableList.jsx';
 import LandingPageEditor from './landingPageEditor.jsx';
+import ChooseModelContainer from './chooseModelContainer.jsx'
 import _ from 'underscore';
 
 const LessonForm = React.createClass({
@@ -16,15 +17,18 @@ const LessonForm = React.createClass({
       selectedQuestions: currentValues && currentValues.questions ? currentValues.questions : [],
       flag: currentValues ? currentValues.flag : 'alpha',
       questionType: 'questions',
+      modelConceptUID: null
     };
   },
 
   submit() {
+    const { name, questions, landingPageHtml, flag, modelConceptUID } = this.state
     this.props.submit({
-      name: this.state.name,
-      questions: this.state.selectedQuestions,
-      landingPageHtml: this.state.landingPageHtml,
-      flag: this.state.flag,
+      name,
+      questions,
+      landingPageHtml,
+      flag,
+      modelConceptUID
     });
   },
 
@@ -149,6 +153,11 @@ const LessonForm = React.createClass({
         <label className="label">All Questions</label>
         {this.renderSearchBox()}
         <br />
+        <ChooseModelContainer
+          updateModelConcept={modelConceptUID => this.setState({ modelConceptUID })}
+          modelConceptUID={this.state.modelConceptUID}
+          conceptsFeedback={this.props.conceptsFeedback}
+        />
         <p className="control">
           <button className={`button is-primary ${this.props.stateSpecificClass}`} onClick={this.submit}>Submit</button>
         </p>
@@ -162,6 +171,7 @@ function select(state) {
     questions: state.questions,
     concepts: state.concepts,
     sentenceFragments: state.sentenceFragments,
+    conceptsFeedback: state.conceptsFeedback
   };
 }
 

--- a/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
+++ b/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
@@ -72,7 +72,7 @@ class ChooseModelContainer extends Component {
     if (this.state.lessonModelConceptUID && this.state.lessonModelConceptUID !== this.state.modelConceptUID) {
       const concept = this.props.concepts.data['0'].find(c => c.uid === this.state.lessonModelConceptUID)
       if (concept) {
-        return <div style={{marginBottom: '10px'}}>
+        return <div style={{ marginBottom: '10px' }}>
           <p>The activity that this question belongs to has the following Model Concept:</p>
           <p><i>"{concept.displayName}"</i></p>
         </div>

--- a/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
+++ b/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
@@ -37,7 +37,7 @@ class ChooseModelContainer extends Component {
   }
 
   selectConcept(e) {
-    this.setState({modelConceptUID: e.value});
+    this.setState({ modelConceptUID: e.value });
   }
 
   renderButtons() {

--- a/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
+++ b/services/QuillConnect/app/components/questions/chooseModelContainer.jsx
@@ -6,19 +6,22 @@ import ConceptExplanation from '../feedback/conceptExplanation.jsx';
 import questionActions from '../../actions/questions.js';
 
 class ChooseModelContainer extends Component {
-  constructor() {
-    super();
-    this.state = {}
+  constructor(props) {
+    super(props);
+    const modelConceptUID = props.questions.data[props.params.questionID].modelConceptUID
+    const lessonUID = Object.keys(props.lessons.data).find((uid) => {
+      const lesson = props.lessons.data[uid]
+      return lesson.questions.find(q => q.key === props.params.questionID)
+    })
+    const lessonModelConceptUID = lessonUID && props.lessons.data[lessonUID] ? props.lessons.data[lessonUID].modelConceptUID : null
+    this.state = {
+      modelConceptUID,
+      lessonModelConceptUID
+    }
     this.setState = this.setState.bind(this);
     this.selectConcept = this.selectConcept.bind(this);
     this.saveModelConcept = this.saveModelConcept.bind(this);
     this.removeModelConcept = this.removeModelConcept.bind(this);
-  }
-
-  componentWillMount() {
-    this.setState({
-      modelConceptUID: this.props.questions.data[this.props.params.questionID].modelConceptUID
-    })
   }
 
   getModelConceptUID() {
@@ -65,10 +68,23 @@ class ChooseModelContainer extends Component {
     )
   }
 
+  renderLessonModelNote() {
+    if (this.state.lessonModelConceptUID && this.state.lessonModelConceptUID !== this.state.modelConceptUID) {
+      const concept = this.props.concepts.data['0'].find(c => c.uid === this.state.lessonModelConceptUID)
+      if (concept) {
+        return <div style={{marginBottom: '10px'}}>
+          <p>The activity that this question belongs to has the following Model Concept:</p>
+          <p><i>"{concept.displayName}"</i></p>
+        </div>
+      }
+    }
+  }
+
   render() {
     return(
       <div className="box">
         <h4 className="title">Choose Model</h4>
+        {this.renderLessonModelNote()}
         <div className="control">
           <ConceptSelector onlyShowConceptsWithConceptFeedback currentConceptUID={this.getModelConceptUID()} handleSelectorChange={this.selectConcept} />
           <ConceptExplanation {...this.props.conceptsFeedback.data[this.getModelConceptUID()]} />
@@ -83,8 +99,10 @@ class ChooseModelContainer extends Component {
 
 function select(props) {
   return {
+    lessons: props.lessons,
     questions: props.questions,
-    conceptsFeedback: props.conceptsFeedback
+    conceptsFeedback: props.conceptsFeedback,
+    concepts: props.concepts
   };
 }
 


### PR DESCRIPTION
Addresses issue #4321

**Changes proposed in this pull request:**
- add model concept uids to lessons
- automatically apply lesson model concept uid to any lesson questions without a model concept

In addition to selecting model concepts for individual questions, you can set the model concept at the activity level as well. When you add a model concept to an activity, the model concept will automatically be applied to all of the activity's questions that do not already have a model concept. This is also the case when a question without a model concept is added to an activity. If a question already has a model concept, it will not be overwritten automatically. Instead, you will see a note on the 'Edit Model Concept' section of the question's CMS page that gives the name of the model concept associated with the question's activity.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
