### PR TITLE
fix #4326 - customize joining words label

### DIFF
--- a/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
+++ b/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
@@ -87,7 +87,7 @@ const diagnosticQuestionForm = React.createClass({
         <p className="control">
           <textarea className="input" type="text" ref="instructions" defaultValue={this.state.instructions} onChange={this.handleInstructionsChange}></textarea>
         </p>
-        <label className="label">Cues Label (default is "Joining Words")</label>
+        <label className="label">Cues Label (default is "joining words" for multiple cues and "joining word" for single cues)</label>
         <p className="control">
           <input className="input" type="text" onChange={this.handleCuesLabelChange} defaultValue={this.props.question.cuesLabel}></input>
         </p>

--- a/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
+++ b/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
@@ -41,7 +41,7 @@ const diagnosticQuestionForm = React.createClass({
       conceptID: this.state.concept,
       instructions: this.state.instructions,
       flag: this.state.flag,
-      cuesLabel: this.refs.cuesLabel.value
+      cuesLabel: this.state.cuesLabel
     })
   },
 

--- a/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
+++ b/services/QuillConnect/app/components/diagnosticQuestions/diagnosticQuestionForm.jsx
@@ -17,6 +17,7 @@ const diagnosticQuestionForm = React.createClass({
         prefilledText: '',
         cues: '',
         flag: 'alpha',
+        cuesLabel: ''
       }
     }
     return {
@@ -27,6 +28,7 @@ const diagnosticQuestionForm = React.createClass({
       prefilledText: question.prefilledText? question.prefilledText : '',
       cues: question.cues? question.cues : '',
       flag: question.flag ? question.flag : 'alpha',
+      cuesLabel: question.cuesLabel ? question.cuesLabel : ''
     }
   },
 
@@ -39,6 +41,7 @@ const diagnosticQuestionForm = React.createClass({
       conceptID: this.state.concept,
       instructions: this.state.instructions,
       flag: this.state.flag,
+      cuesLabel: this.refs.cuesLabel.value
     })
   },
 
@@ -70,6 +73,10 @@ const diagnosticQuestionForm = React.createClass({
     this.setState({ flag: e.target.value, });
   },
 
+  handleCuesLabelChange: function(e) {
+    this.setState({ cuesLabel: e.target.value, });
+  },
+
   render: function () {
     return (
       <div className="box">
@@ -79,6 +86,10 @@ const diagnosticQuestionForm = React.createClass({
         <label className="label">Instructions for student</label>
         <p className="control">
           <textarea className="input" type="text" ref="instructions" defaultValue={this.state.instructions} onChange={this.handleInstructionsChange}></textarea>
+        </p>
+        <label className="label">Cues Label (default is "Joining Words")</label>
+        <p className="control">
+          <input className="input" type="text" onChange={this.handleCuesLabelChange} defaultValue={this.props.question.cuesLabel}></input>
         </p>
         <label className="label">Cues (separated by commas, no spaces eg "however,therefore,hence")</label>
         <p className="control">

--- a/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
@@ -17,6 +17,7 @@ class FillInBlankForm extends Component {
       newQuestionOptimalResponse: '',
       itemLevel: 'Select Item Level',
       flag: 'alpha',
+      cuesLabel: ''
     };
     this.toggleQuestionBlankAllowed = this.toggleQuestionBlankAllowed.bind(this);
     this.handlePromptChange = this.handlePromptChange.bind(this);
@@ -57,6 +58,10 @@ class FillInBlankForm extends Component {
     this.setState({ flag: e.target.value, });
   }
 
+  handleCuesLabelChange(e) {
+    this.setState({ cuesLabel: e.target.value, });
+  }
+
   itemLevelToOptions() {
     return hashToCollection(this.props.itemLevels.data).map((level) => {
       return (
@@ -78,6 +83,7 @@ class FillInBlankForm extends Component {
       instructions: this.state.instructions,
       conceptID: this.state.conceptID,
       flag: this.state.flag ? this.state.flag : 'alpha',
+      cuesLabel: this.state.cuesLabel
     };
     this.props.action(data, this.state.newQuestionOptimalResponse);
   }
@@ -91,6 +97,7 @@ class FillInBlankForm extends Component {
       itemLevel: 'Select Item Level',
       conceptID: null,
       flag: 'alpha',
+      cuesLabel: ''
     });
   }
 
@@ -127,6 +134,10 @@ class FillInBlankForm extends Component {
         <label className="label">Instructions for student</label>
         <p className="control">
           <textarea className="input" type="text" value={this.state.instructions} onChange={this.handleInstructionsChange}></textarea>
+        </p>
+        <label className="label">Cues Label (default is "Joining Words")</label>
+        <p className="control">
+          <input className="input" type="text" value={this.state.cuesLabel} onChange={this.handleCuesLabelChange}></input>
         </p>
         <label className="label">Cues (separated by commas, no spaces eg "however,therefore,hence")</label>
         <p className="control">

--- a/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
@@ -136,7 +136,7 @@ class FillInBlankForm extends Component {
         <p className="control">
           <textarea className="input" type="text" value={this.state.instructions} onChange={this.handleInstructionsChange}></textarea>
         </p>
-        <label className="label">Cues Label (default is "Joining Words")</label>
+        <label className="label">Cues Label (default is "joining words" for multiple cues and "joining word" for single cues)</label>
         <p className="control">
           <input className="input" type="text" value={this.state.cuesLabel} onChange={this.handleCuesLabelChange}></input>
         </p>

--- a/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
@@ -27,6 +27,7 @@ class FillInBlankForm extends Component {
     this.handleItemLevelChange = this.handleItemLevelChange.bind(this);
     this.handleSelectorChange = this.handleSelectorChange.bind(this);
     this.handleFlagChange = this.handleFlagChange.bind(this);
+    this.handleCuesLabelChange = this.handleCuesLabelChange.bind(this);
     this.submit = this.submit.bind(this);
   }
 

--- a/services/QuillConnect/app/components/fillInBlank/playFillInTheBlankQuestion.tsx
+++ b/services/QuillConnect/app/components/fillInBlank/playFillInTheBlankQuestion.tsx
@@ -286,6 +286,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
 
   customText() {
     // HARDCODED
+    // this code should be deprecated once cuesLabels are launched and the 
     let text = translations.english['add word bank cue'];
     text = `${text}${this.state.blankAllowed ? ' or leave blank' : ''}`;
     if (this.props.language && this.props.language !== 'english') {

--- a/services/QuillConnect/app/components/questions/questionForm.jsx
+++ b/services/QuillConnect/app/components/questions/questionForm.jsx
@@ -78,7 +78,7 @@ export default React.createClass({
           <p className="control">
             <textarea className="input" type="text" ref="instructions" defaultValue={this.props.question.instructions} onChange={this.handleInstructionsChange}></textarea>
           </p>
-          <label className="label">Cues Label (default is "Joining Words")</label>
+          <label className="label">Cues Label (default is "joining words" for multiple cues and "joining word" for single cues)</label>
           <p className="control">
             <input className="input" type="text" onChange={this.handleCuesLabelChange} defaultValue={this.props.question.cuesLabel}></input>
           </p>

--- a/services/QuillConnect/app/components/questions/questionForm.jsx
+++ b/services/QuillConnect/app/components/questions/questionForm.jsx
@@ -13,6 +13,7 @@ export default React.createClass({
       concept: this.props.question.conceptID,
       instructions: this.props.question.instructions ? this.props.question.instructions : "",
       flag: this.props.question.flag ? this.props.question.flag : "alpha",
+      cuesLabel: this.props.cuesLabel ? this.props.cuesLabel : ''
     }
   },
 
@@ -25,7 +26,8 @@ export default React.createClass({
       itemLevel: this.state.itemLevel,
       conceptID: this.state.concept,
       instructions: this.state.instructions,
-      flag: this.state.flag
+      flag: this.state.flag,
+      cuesLabel: this.refs.cuesLabel.value
     })
   },
 
@@ -61,6 +63,10 @@ export default React.createClass({
     this.setState({ flag: e.target.value, });
   },
 
+  handleCuesLabelChange: function(e) {
+    this.setState({ cuesLabel: e.target.value, });
+  },
+
   render: function () {
     if(this.props.concepts.hasreceiveddata) {
       return (
@@ -71,6 +77,10 @@ export default React.createClass({
           <label className="label">Instructions for student</label>
           <p className="control">
             <textarea className="input" type="text" ref="instructions" defaultValue={this.props.question.instructions} onChange={this.handleInstructionsChange}></textarea>
+          </p>
+          <label className="label">Cues Label (default is "Joining Words")</label>
+          <p className="control">
+            <input className="input" type="text" onChange={this.handleCuesLabelChange} defaultValue={this.props.question.cuesLabel}></input>
           </p>
           <label className="label">Cues (separated by commas, no spaces eg "however,therefore,hence")</label>
           <p className="control">

--- a/services/QuillConnect/app/components/questions/questionForm.jsx
+++ b/services/QuillConnect/app/components/questions/questionForm.jsx
@@ -27,7 +27,7 @@ export default React.createClass({
       conceptID: this.state.concept,
       instructions: this.state.instructions,
       flag: this.state.flag,
-      cuesLabel: this.refs.cuesLabel.value
+      cuesLabel: this.state.cuesLabel
     })
   },
 

--- a/services/QuillConnect/app/components/renderForQuestions/cues.jsx
+++ b/services/QuillConnect/app/components/renderForQuestions/cues.jsx
@@ -7,7 +7,9 @@ import translations from '../../libs/translations/index.js';
 export default React.createClass({
 
   getJoiningWordsText() {
-    if (this.props.getQuestion().cues && this.props.getQuestion().cues.length === 1) {
+    if (this.props.getQuestion().cues && this.props.getQuestion().cuesLabel) {
+      return this.props.getQuestion().cuesLabel
+    } else if (this.props.getQuestion().cues && this.props.getQuestion().cues.length === 1) {
       let text = translations.english['joining word cues single'];
       if (this.props.language && this.props.language !== 'english') {
         text += ` / ${translations[this.props.language]['joining word cues single']}`;

--- a/services/QuillConnect/app/styles/components/_language-choices.scss
+++ b/services/QuillConnect/app/styles/components/_language-choices.scss
@@ -43,7 +43,7 @@
     height: 72px;
     border: solid 1px #c0c0c0;
     background-color: white;
-    padding: 0 33px;
+    padding: 0 32px;
     text-align: center;
     display: flex;
     align-items: center;


### PR DESCRIPTION
Addresses issue #4326

**Changes proposed in this pull request:**
- staff can now add their own labels to cues that will replace "joining words" or "joining word"
- this is present for sentence combining, fill in the blank, or diagnostic questions (sentence fragments do not currently support cues at all)

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
