### PR TITLE
Fix/comprehension render markdown

### DIFF
--- a/services/QuillComprehension/app/javascript/src/components/activities/article.tsx
+++ b/services/QuillComprehension/app/javascript/src/components/activities/article.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react' 
+import * as React from 'react'
+import ReactMarkdown from 'react-markdown'
 
 function fontSizeToClass(fontSize:number):string  {
   switch (fontSize) {
-    case 1: 
+    case 1:
       return 'fs-sm'
-    case 2: 
+    case 2:
       return 'fs-md'
     case 3:
       return 'fs-lg'
@@ -20,8 +21,8 @@ const Article = ({activity_id, article, title, markAsRead, fontSize}): JSX.Eleme
       <h3 className="card-title">Read The Following Passage Carefully</h3>
     </div>
     <div className="card-body article-body">
-      <h2 className="mb3">{title}</h2>  
-      <p className={fontSizeToClass(fontSize)} onSelect={(e) => console.log(e)} dangerouslySetInnerHTML={{__html: article}}></p>
+      <h2 className="mb3">{title}</h2>
+      <ReactMarkdown className={fontSizeToClass(fontSize)} source={article} />
     </div>
     <div className="card-footer d-fl-r jc-sb">
       <div className="m-r-1 d-fl-r ai-c">When you have finished reading the passage, click done.</div>

--- a/services/QuillComprehension/app/javascript/src/components/activities/vocabulary_words.tsx
+++ b/services/QuillComprehension/app/javascript/src/components/activities/vocabulary_words.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import Modal from '../modals'
+import ReactMarkdown from 'react-markdown'
+
 export interface VocabularyWord {
   id:number
   text:string
@@ -9,7 +11,7 @@ export interface VocabularyWord {
 
 export interface Props {
   vocabWords: Array<VocabularyWord>
-} 
+}
 
 export interface State {
   readonly activeVocabWord: VocabularyWord|null
@@ -41,7 +43,7 @@ export default class VocabularyWords extends React.Component<Props, State> {
             <div className="card-header"><h3>{this.state.activeVocabWord.text}</h3></div>
             <div className="card-body">
               <p><strong>Definition</strong>: {this.state.activeVocabWord.description}</p>
-              <p><strong>Sample Sentence</strong>: <span dangerouslySetInnerHTML={{__html: this.state.activeVocabWord.example}}/></p>
+              <p><strong>Sample Sentence</strong>: <ReactMarkdown source={this.state.activeVocabWord.example} /></p>
             </div>
             <div className="card-footer"><button className="btn btn-primary" onClick={e => this.clearVocabWord()}>Done</button></div>
           </div>
@@ -49,7 +51,7 @@ export default class VocabularyWords extends React.Component<Props, State> {
       )
     }
   }
-  
+
   render() {
     return (
       <div className="d-fl-r ai-c">

--- a/services/QuillComprehension/app/javascript/src/styles/_ions.scss
+++ b/services/QuillComprehension/app/javascript/src/styles/_ions.scss
@@ -2,14 +2,14 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 //padding all
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pa#{$i - 1} { 
+  .pa#{$i - 1} {
     padding: $size;
   }
 }
 //padding horizontal
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .ph#{$i - 1} { 
+  .ph#{$i - 1} {
     padding-left: $size;
     padding-right: $size;
   }
@@ -17,7 +17,7 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 //padding vertical
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pv#{$i - 1} { 
+  .pv#{$i - 1} {
     padding-top: $size;
     padding-bottom: $size;
   }
@@ -25,28 +25,28 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 //padding top
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pt#{$i - 1} { 
+  .pt#{$i - 1} {
     padding-top: $size;
   }
 }
 //padding bottom
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pb#{$i - 1} { 
+  .pb#{$i - 1} {
     padding-bottom: $size;
   }
 }
 //padding left
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pl#{$i - 1} { 
+  .pl#{$i - 1} {
     padding-left: $size;
   }
 }
 //padding right
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .pr#{$i - 1} { 
+  .pr#{$i - 1} {
     padding-right: $size;
   }
 }
@@ -55,14 +55,14 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .ma#{$i - 1} { 
+  .ma#{$i - 1} {
     margin: $size;
   }
 }
 //margin horizontal
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .mh#{$i - 1} { 
+  .mh#{$i - 1} {
     margin-left: $size;
     margin-right: $size;
   }
@@ -70,7 +70,7 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 //margin vertical
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .mv#{$i - 1} { 
+  .mv#{$i - 1} {
     margin-top: $size;
     margin-bottom: $size;
   }
@@ -78,28 +78,28 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 //margin top
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .mt#{$i - 1} { 
+  .mt#{$i - 1} {
     margin-top: $size;
   }
 }
 //margin bottom
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .mb#{$i - 1} { 
+  .mb#{$i - 1} {
     margin-bottom: $size;
   }
 }
 //margin left
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .ml#{$i - 1} { 
+  .ml#{$i - 1} {
     margin-left: $size;
   }
 }
 //margin right
 @each $size in $spacingSizes {
   $i: index($spacingSizes, $size);
-  .mr#{$i - 1} { 
+  .mr#{$i - 1} {
     margin-right: $size;
   }
 }
@@ -128,12 +128,12 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
 .p-x-1 {
   padding-left: 1rem;
   padding-right: 1rem;
-} 
+}
 
 .p-y-1 {
   padding-top: 1rem;
   padding-bottom: 1rem;
-} 
+}
 
 // Margins
 .m-1 {
@@ -213,11 +213,17 @@ $spacingSizes: 0rem 0.25rem 0.5rem 1rem 2rem 4rem 8rem 16rem;
   white-space: nowrap !important;
 }
 
+
+// Sizes
 .mw-50 {
   max-width: 50vw;
 }
 
-// fonts 
+.mh-40 {
+  min-height: 40vh;
+}
+
+// fonts
 
 .fs-sm {
   font-size: 0.85rem;

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="form-group">
     <%= form.label :article, class: "form-label" %>
-    <%= form.text_area :article, class: "form-control" %>
+    <%= form.text_area :article, class: "form-control mh-40" %>
   </div>
 
   <div class="form-group">

--- a/services/QuillComprehension/package.json
+++ b/services/QuillComprehension/package.json
@@ -24,6 +24,7 @@
     "react-apollo": "^2.1.4",
     "react-dom": "^16.4.0",
     "react-feather": "^1.1.0",
+    "react-markdown": "^3.3.4",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "ts-loader": "3.5.0",

--- a/services/QuillComprehension/yarn.lock
+++ b/services/QuillComprehension/yarn.lock
@@ -1110,6 +1110,10 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
+bail@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
+
 balanced-match@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.1.0.tgz#b504bd05869b39259dd0c5efc35d843176dccc4a"
@@ -1485,6 +1489,18 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
+
+character-entities@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
+
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1603,6 +1619,10 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collapse-white-space@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2563,7 +2583,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -3379,6 +3399,17 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3393,7 +3424,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -3428,6 +3459,10 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3515,6 +3550,10 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
+
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -3567,7 +3606,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -3617,9 +3656,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4466,6 +4513,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -5114,6 +5165,17 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+
+parse-entities@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -6006,6 +6068,16 @@ react-feather@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-1.1.0.tgz#f0aa692497de952237ca1f3b118ebcb5427152e1"
 
+react-markdown@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.3.4.tgz#4002599ad133c649923a49aedc06b2f3af2016b6"
+  dependencies:
+    prop-types "^15.6.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
+
 react-redux@^5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
@@ -6183,6 +6255,26 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -6191,7 +6283,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -6200,6 +6292,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -6782,6 +6878,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+state-toggle@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7082,6 +7182,18 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
+
 "true-case-path@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.2.tgz#7ec91130924766c7f573be3020c34f8fdfd00d62"
@@ -7198,6 +7310,24 @@ uglifyjs-webpack-plugin@^1.2.5:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+unherit@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -7226,6 +7356,26 @@ unique-slug@^2.0.0:
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.1.tgz#c019ac9337a62486be58531bc27e7499ae7d55c7"
+  dependencies:
+    unist-util-is "^2.1.1"
 
 units-css@^0.4.0:
   version "0.4.0"
@@ -7336,6 +7486,25 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+
+vfile-message@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 viewport-dimensions@^0.2.0:
   version "0.2.0"
@@ -7572,11 +7741,15 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Addresses issue #4394 

**Changes proposed in this pull request:**
- Use [ReactMarkdown](https://github.com/rexxars/react-markdown) to render activity text
- Use ReactMarkdown to render vocabulary words' example sentences
- Increase default size for activity form article entry

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
