### PR TITLE
Redirect to new_account_path if user created from google signup is in…

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -1,9 +1,9 @@
 class Auth::GoogleController < ApplicationController
-  before_action :follow_google_redirect,       only: :google
-  before_action :set_profile,                  only: :google
-  before_action :set_user,                     only: :google
-  before_action :check_if_email_matches,       only: :google
-  before_action :handle_google_teacher_signup, only: :google
+  before_action :follow_google_redirect,          only: :google
+  before_action :set_profile,                     only: :google
+  before_action :set_user,                        only: :google
+  before_action :check_if_email_matches,          only: :google
+  before_action :save_teacher_from_google_signup, only: :google
   before_action :save_student_from_google_signup, only: :google
 
   def google
@@ -49,12 +49,14 @@ class Auth::GoogleController < ApplicationController
   end
 
   def save_student_from_google_signup
-    if @user.new_record? && @user.student?
-      render 'accounts/new' unless @user.save
+    return unless @user.new_record? && @user.student?
+
+    unless @user.save
+      redirect_to new_account_path
     end
   end
 
-  def handle_google_teacher_signup
+  def save_teacher_from_google_signup
     return unless @user.new_record? && @user.teacher?
 
     if @user.save
@@ -64,8 +66,9 @@ class Auth::GoogleController < ApplicationController
       @js_file = 'session'
 
       sign_in(@user)
+      render 'accounts/new'
+    else
+      redirect_to new_account_path
     end
-
-    render 'accounts/new'
   end
 end


### PR DESCRIPTION
…valid

Addresses issue #4397

**Changes proposed in this pull request:**
- if user from google is invalid redirect to new_account page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
