### PR TITLE
Display user validation errors in flash following failed google signup

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -59,16 +59,19 @@ class Auth::GoogleController < ApplicationController
   def save_teacher_from_google_signup
     return unless @user.new_record? && @user.teacher?
 
+    @js_file = 'session'
+
     if @user.save
       AccountCreationCallbacks.new(@user, request.remote_ip).trigger
       @user.subscribe_to_newsletter
       @teacherFromGoogleSignUp = true
-      @js_file = 'session'
 
       sign_in(@user)
-      render 'accounts/new'
     else
-      redirect_to new_account_path
+      @teacherFromGoogleSignUp = false
+      flash.now[:error] = @user.errors.full_messages.join(', ')
     end
+
+    render 'accounts/new'
   end
 end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- change one
- change two

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes/no

**Have you updated the docs?** yes/no

**Have the tests been updated?** yes/no

**Reviewer:** @ddmck
