### PR TITLE
fix #4338 - lack of time zone no longer prevents teachers from updating account

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
@@ -90,7 +90,7 @@ export default React.createClass({
       email: this.state.email,
       role: this.state.role,
       password: this.state.password,
-      time_zone: this.state.time_zone.name,
+      time_zone: this.state.time_zone ? this.state.time_zone.name : null,
       school_id: ((this.state.selectedSchool == null)
         ? null
         : this.state.selectedSchool.id),


### PR DESCRIPTION
Addresses issue #4338

**Changes proposed in this pull request:**
- fix bug on teacher account page where teachers could not update their account without a timezone

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
