### PR TITLE
fix #4413 - order blog posts on topic page by order number

### DIFF
--- a/packages/quill-component-library/.gitignore
+++ b/packages/quill-component-library/.gitignore
@@ -1,0 +1,1 @@
+/.rpt2_cache

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -2,7 +2,7 @@ class BlogPostsController < ApplicationController
   before_action :set_announcement, only: [:index, :show, :show_topic]
 
   def index
-    @blog_posts = BlogPost.where(draft: false)
+    @blog_posts = BlogPost.where(draft: false).order('order_number')
     @topics = BlogPost::TOPICS
   end
 
@@ -45,7 +45,7 @@ class BlogPostsController < ApplicationController
         raise ActionController::RoutingError.new('Topic Not Found')
       end
       topic = params[:topic].gsub('-', ' ').titleize
-      @blog_posts = BlogPost.where(draft: false, topic: topic)
+      @blog_posts = BlogPost.where(draft: false, topic: topic).order('order_number')
       @title = topic
       return render 'index'
     end

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -346,11 +346,11 @@ class PagesController < ApplicationController
   end
 
   def press
-    @blog_posts = BlogPost.where(draft: false, topic: 'Press')
+    @blog_posts = BlogPost.where(draft: false, topic: 'Press').order('order_number')
   end
 
   def announcements
-    @blog_posts = BlogPost.where(draft: false, topic: 'Announcements')
+    @blog_posts = BlogPost.where(draft: false, topic: 'Announcements').order('order_number')
   end
 
   private


### PR DESCRIPTION
Addresses issue #4413

**Changes proposed in this pull request:**
- use order number (rather than popularity) to order blog posts on topic pages

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
