### PR TITLE
reset tag counts for a response label

### DIFF
--- a/services/QuillComprehension/app/controllers/responses_controller.rb
+++ b/services/QuillComprehension/app/controllers/responses_controller.rb
@@ -1,5 +1,5 @@
 class ResponsesController < ApplicationController
-  before_action :set_response, only: [:show, :edit, :update, :destroy]
+  before_action :set_response, only: [:show, :edit, :update, :destroy, :reset_tags]
   before_action :set_question, only: [:index, :create, :new]
   # GET /responses
   # GET /responses.json
@@ -63,10 +63,14 @@ class ResponsesController < ApplicationController
     end
   end
 
-  # Should be:
   # POST /responses/1/reset_tags
+  # POST /responses/1/reset_tags.json
   def reset_tags
-    Response.find(params[:id]).reset_tags(params[:response_label_name])
+    @response.reset_tags(params[:response_label_name])
+    respond_to do |format|
+      format.html { redirect_to @response, notice: 'Response tags were successfully reset.' }
+      format.json { head :no_content }
+    end
   end
 
   private

--- a/services/QuillComprehension/app/controllers/responses_controller.rb
+++ b/services/QuillComprehension/app/controllers/responses_controller.rb
@@ -1,6 +1,6 @@
 class ResponsesController < ApplicationController
   before_action :set_response, only: [:show, :edit, :update, :destroy]
-  before_action :set_question, only: [:index, :create, :new] 
+  before_action :set_question, only: [:index, :create, :new]
   # GET /responses
   # GET /responses.json
   def index
@@ -61,6 +61,12 @@ class ResponsesController < ApplicationController
       format.html { redirect_to question_responses_url(@response.question_id), notice: 'Response was successfully destroyed.' }
       format.json { head :no_content }
     end
+  end
+
+  # Should be:
+  # POST /responses/1/reset_tags
+  def reset_tags
+    Response.find(params[:id]).reset_tags(params[:response_label_name])
   end
 
   private

--- a/services/QuillComprehension/app/models/response.rb
+++ b/services/QuillComprehension/app/models/response.rb
@@ -38,7 +38,7 @@ class Response < ApplicationRecord
     mapped.to_h
   end
 
-  def reset_metric(response_label_name)
+  def reset_tags(response_label_name)
     label_id = ResponseLabel.find_by_name!(response_label_name).id
     tags = ResponseLabelTag.where(response: self).where(response_label_id: label_id)
     tags.destroy_all

--- a/services/QuillComprehension/app/models/response.rb
+++ b/services/QuillComprehension/app/models/response.rb
@@ -37,4 +37,11 @@ class Response < ApplicationRecord
     end
     mapped.to_h
   end
+
+  def reset_metric(response_label_name)
+    label_id = ResponseLabel.find_by_name!(response_label_name).id
+    tags = ResponseLabelTag.where(response: self).where(response_label_id: label_id)
+    tags.destroy_all
+  end
+
 end

--- a/services/QuillComprehension/app/views/responses/show.html.erb
+++ b/services/QuillComprehension/app/views/responses/show.html.erb
@@ -9,18 +9,14 @@
     <%= @response.text %>
   </p>
 
-  <ul>
-    <% @response.metrics.each do |k, v| %>
-      <li><%= "#{k}: #{v}"%></li>
-    <% end %>
-  </ul>
-
+  <h4>All Metrics</h4>
   <ul>
     <% @response.all_metrics.each do |k, v| %>
       <li><%= "#{k}: #{v}"%></li>
     <% end %>
   </ul>
 
+  <h4>Latest Tags</h4>
   <ul>
     <% @response.latest_metrics.each do |k, v| %>
       <li><%= "#{k}: #{v}"%></li>

--- a/services/QuillComprehension/app/views/responses/show.html.erb
+++ b/services/QuillComprehension/app/views/responses/show.html.erb
@@ -12,7 +12,7 @@
   <h4>All Metrics</h4>
   <ul>
     <% @response.all_metrics.each do |k, v| %>
-      <li><%= "#{k}: #{v}"%></li>
+      <li><%= "#{k}: #{v}"%> <%= button_to "Reset", action: "reset_tags", response_label_name: k%> </li>
     <% end %>
   </ul>
 

--- a/services/QuillComprehension/config/routes.rb
+++ b/services/QuillComprehension/config/routes.rb
@@ -3,14 +3,15 @@ Rails.application.routes.draw do
   resources :activities, shallow: true do
     resources :question_sets
     resources :vocabulary_words
-
     get 'play', on: :member
   end
   resources :question_sets, only: [], shallow: true do
     resources :questions
   end
   resources :questions, only: [], shallow: true do
-    resources :responses
+    resources :responses do
+      post 'reset_tags', on: :member
+    end
   end
 
 
@@ -21,7 +22,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/', to: 'pages#index'
-
-  post 'responses/:id/reset_tags', to: 'responses#reset_tags'
 
 end

--- a/services/QuillComprehension/config/routes.rb
+++ b/services/QuillComprehension/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :question_sets
     resources :vocabulary_words
 
-    get 'play', on: :member    
+    get 'play', on: :member
   end
   resources :question_sets, only: [], shallow: true do
     resources :questions
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   resources :questions, only: [], shallow: true do
     resources :responses
   end
-  
-  
+
+
   if Rails.env.development?
     mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
   end
@@ -21,5 +21,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/', to: 'pages#index'
+
+  post 'responses/:id/reset_tags', to: 'responses#reset_tags'
 
 end

--- a/services/QuillComprehension/spec/models/response_spec.rb
+++ b/services/QuillComprehension/spec/models/response_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Response, type: :model do
   it "can reset its tags for a response label" do
     create(:response_label_tag, response: response, response_label: correct_response_label)
     create(:response_label_tag, response: response, response_label: factual_response_label, score: -1)
-    response.reset_metric("correct")
+    response.reset_tags("correct")
     expect(response.all_metrics).to eq({
       "correct": 0,
       "factual": -1

--- a/services/QuillComprehension/spec/models/response_spec.rb
+++ b/services/QuillComprehension/spec/models/response_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Response, type: :model do
     expect(question.activity).to be(activity)
   end
 
-  it "can calculate one of it metrics" do 
+  it "can calculate one of it metrics" do
     rlt1 = create(:response_label_tag, response: response, response_label: correct_response_label)
     expect(response.metric("correct")).to eq(1)
     rlt2 = create(:response_label_tag, response: response, response_label: correct_response_label, score: -1)
     expect(response.metric("correct")).to eq(0)
   end
 
-  it "can calculate one of it metrics 2" do 
+  it "can calculate one of it metrics 2" do
     rlt2 = create(:response_label_tag, response: response, response_label: correct_response_label, score: -1)
     expect(response.metric("correct")).to eq(-1)
   end
@@ -82,7 +82,6 @@ RSpec.describe Response, type: :model do
     })
   end
 
-
   it "can calculate its latest metrics with multiple tags" do
     create(:response_label_tag, response: response, response_label: correct_response_label)
     create(:response_label_tag, response: response, response_label: correct_response_label, score: -1)
@@ -91,6 +90,16 @@ RSpec.describe Response, type: :model do
     expect(response.latest_metrics).to eq({
       "correct": -1,
       "factual": 1
+    })
+  end
+
+  it "can reset its tags for a response label" do
+    create(:response_label_tag, response: response, response_label: correct_response_label)
+    create(:response_label_tag, response: response, response_label: factual_response_label, score: -1)
+    response.reset_metric("correct")
+    expect(response.all_metrics).to eq({
+      "correct": 0,
+      "factual": -1
     })
   end
 


### PR DESCRIPTION
Addresses issue NA

**Changes proposed in this pull request:**
- Add button to reset the counts of tags for a given response and response label
- Mild changes to response analytics view

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
