### PR TITLE
Clear google_id and auth credentials when user is soft deleted

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -347,7 +347,17 @@ class User < ActiveRecord::Base
   end
 
   def clear_data
-    self.update!(name: "Deleted User_#{self.id}", email: "deleted_user_#{self.id}@example.com", username: "deleted_user_#{self.id}")
+    ActiveRecord::Base.transaction do
+      update!(
+        name:      "Deleted User_#{self.id}",
+        email:     "deleted_user_#{self.id}@example.com",
+        username:  "deleted_user_#{self.id}",
+        google_id: nil
+      )
+      if auth_credential.present?
+        auth_credential.destroy!
+      end
+    end
   end
 
   def last_name= last_name

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -696,7 +696,8 @@ describe User, type: :model do
   end
 
   describe '#clear_data' do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, google_id: 'sergey_and_larry_were_here') }
+    let!(:auth_credential) { create(:auth_credential, user: user) }
     before(:each) { user.clear_data }
 
     it "changes the user's email to one that is not personally identiable" do
@@ -709,6 +710,14 @@ describe User, type: :model do
 
     it "changes the user's name to one that is not personally identiable" do
       expect(user.name).to eq("Deleted User_#{user.id}")
+    end
+
+    it "removes the google id" do
+      expect(user.google_id).to be nil
+    end
+
+    it "destroys associated auth credentials if present" do
+      expect(user.reload.auth_credential).to be nil
     end
   end
 


### PR DESCRIPTION
Addresses issue #4469

**Changes proposed in this pull request:**
- when a user is soft deleted, clear google id and auth credentials too

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
