### PR TITLE
Integrate Quill text editor into Comprehension

### DIFF
--- a/services/QuillComprehension/app/controllers/activities_controller.rb
+++ b/services/QuillComprehension/app/controllers/activities_controller.rb
@@ -20,6 +20,7 @@ class ActivitiesController < ApplicationController
 
   # GET /activities/1/edit
   def edit
+    @page_js_bundle = 'text_editor'
   end
 
   # POST /activities

--- a/services/QuillComprehension/app/controllers/activities_controller.rb
+++ b/services/QuillComprehension/app/controllers/activities_controller.rb
@@ -16,11 +16,13 @@ class ActivitiesController < ApplicationController
   def new
     @activity = Activity.new
     @page_js_bundle = 'text_editor'
+    @page_style_bundle = 'text_editor'
   end
 
   # GET /activities/1/edit
   def edit
     @page_js_bundle = 'text_editor'
+    @page_style_bundle = 'text_editor'
   end
 
   # POST /activities

--- a/services/QuillComprehension/app/controllers/activities_controller.rb
+++ b/services/QuillComprehension/app/controllers/activities_controller.rb
@@ -15,6 +15,7 @@ class ActivitiesController < ApplicationController
   # GET /activities/new
   def new
     @activity = Activity.new
+    @page_js_bundle = 'text_editor'
   end
 
   # GET /activities/1/edit
@@ -64,7 +65,7 @@ class ActivitiesController < ApplicationController
   def play
     @page_js_bundle = 'play_activity'
   end
-    
+
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/services/QuillComprehension/app/controllers/vocabulary_words_controller.rb
+++ b/services/QuillComprehension/app/controllers/vocabulary_words_controller.rb
@@ -16,11 +16,13 @@ class VocabularyWordsController < ApplicationController
   def new
     @vocabulary_word = VocabularyWord.new
     @page_js_bundle = 'text_editor'
+    @page_style_bundle = 'text_editor'
   end
 
   # GET /vocabulary_words/1/edit
   def edit
     @page_js_bundle = 'text_editor'
+    @page_style_bundle = 'text_editor'
   end
 
   # POST /vocabulary_words

--- a/services/QuillComprehension/app/controllers/vocabulary_words_controller.rb
+++ b/services/QuillComprehension/app/controllers/vocabulary_words_controller.rb
@@ -15,10 +15,12 @@ class VocabularyWordsController < ApplicationController
   # GET /vocabulary_words/new
   def new
     @vocabulary_word = VocabularyWord.new
+    @page_js_bundle = 'text_editor'
   end
 
   # GET /vocabulary_words/1/edit
   def edit
+    @page_js_bundle = 'text_editor'
   end
 
   # POST /vocabulary_words

--- a/services/QuillComprehension/app/javascript/packs/text_editor.js
+++ b/services/QuillComprehension/app/javascript/packs/text_editor.js
@@ -17,7 +17,7 @@ class TextEditor extends React.Component {
   }
 
   render() {
-    return <ReactQuill value={this.state.text} onChange={this.handleChange} />
+    return <ReactQuill value={this.state.text} onChange={this.handleChange} theme="snow"/>
   }
 
 }

--- a/services/QuillComprehension/app/javascript/packs/text_editor.js
+++ b/services/QuillComprehension/app/javascript/packs/text_editor.js
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import ReactQuill from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
 
 class TextEditor extends React.Component {
 

--- a/services/QuillComprehension/app/javascript/packs/text_editor.js
+++ b/services/QuillComprehension/app/javascript/packs/text_editor.js
@@ -1,33 +1,35 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import ReactQuill from 'react-quill'
-import 'react-quill/dist/quill.snow.css'
-
 
 class TextEditor extends React.Component {
 
   constructor(props) {
     super(props)
-    this.state = {text: ''}
+    this.state = {text: this.props.text}
     this.handleChange = this.handleChange.bind(this)
   }
 
   handleChange(value) {
     this.setState({ text: value })
-    //TODO: Fix this hardcoding of component name
-    document.getElementById('activity_article').value = this.state.text
+    document.getElementById(this.props.fieldName).value = this.state.text
   }
 
   render() {
-    return <ReactQuill value={this.state.text} onChange={this.handleChange} theme="snow"/>
+    return <ReactQuill value={this.state.text} onChange={this.handleChange} />
   }
 
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const form_editor = document.getElementById('quill-react-text-editor')
-  ReactDOM.render(
-    <TextEditor />,
-    form_editor,
-  )
+  var formGroups = document.getElementsByClassName("quill-editor")
+  for (var i = 0; i < formGroups.length; i++) {
+    var origForm = formGroups[i].getElementsByClassName("form-control")[0]
+    var quillEditor = document.createElement("div")
+    formGroups[i].appendChild(quillEditor)
+    ReactDOM.render(
+      <TextEditor fieldName={origForm.id} text={origForm.value}/>,
+      quillEditor
+    )
+  }
 })

--- a/services/QuillComprehension/app/javascript/packs/text_editor.js
+++ b/services/QuillComprehension/app/javascript/packs/text_editor.js
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import ReactQuill from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
+
+
+class TextEditor extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {text: ''}
+    this.handleChange = this.handleChange.bind(this)
+  }
+
+  handleChange(value) {
+    this.setState({ text: value })
+    //TODO: Fix this hardcoding of component name
+    document.getElementById('activity_article').value = this.state.text
+  }
+
+  render() {
+    return <ReactQuill value={this.state.text} onChange={this.handleChange} theme="snow"/>
+  }
+
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form_editor = document.getElementById('quill-react-text-editor')
+  ReactDOM.render(
+    <TextEditor />,
+    form_editor,
+  )
+})

--- a/services/QuillComprehension/app/javascript/packs/text_editor.js
+++ b/services/QuillComprehension/app/javascript/packs/text_editor.js
@@ -22,14 +22,14 @@ class TextEditor extends React.Component {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  var formGroups = document.getElementsByClassName("quill-editor")
+  var formGroups = document.getElementsByClassName("text-editor")
   for (var i = 0; i < formGroups.length; i++) {
-    var origForm = formGroups[i].getElementsByClassName("form-control")[0]
-    var quillEditor = document.createElement("div")
-    formGroups[i].appendChild(quillEditor)
+    var oldInput = formGroups[i].getElementsByClassName("form-control")[0]
+    var newInput = document.createElement("div")
+    formGroups[i].appendChild(newInput)
     ReactDOM.render(
-      <TextEditor fieldName={origForm.id} text={origForm.value}/>,
-      quillEditor
+      <TextEditor fieldName={oldInput.id} text={oldInput.value}/>,
+      newInput
     )
   }
 })

--- a/services/QuillComprehension/app/javascript/src/components/activities/article.tsx
+++ b/services/QuillComprehension/app/javascript/src/components/activities/article.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import ReactMarkdown from 'react-markdown'
 
 function fontSizeToClass(fontSize:number):string  {
   switch (fontSize) {
@@ -22,7 +21,7 @@ const Article = ({activity_id, article, title, markAsRead, fontSize}): JSX.Eleme
     </div>
     <div className="card-body article-body">
       <h2 className="mb3">{title}</h2>
-      <ReactMarkdown className={fontSizeToClass(fontSize)} source={article} />
+      <p className={fontSizeToClass(fontSize)} onSelect={(e) => console.log(e)} dangerouslySetInnerHTML={{__html: article}}></p>
     </div>
     <div className="card-footer d-fl-r jc-sb">
       <div className="m-r-1 d-fl-r ai-c">When you have finished reading the passage, click done.</div>

--- a/services/QuillComprehension/app/javascript/src/components/activities/vocabulary_words.tsx
+++ b/services/QuillComprehension/app/javascript/src/components/activities/vocabulary_words.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Modal from '../modals'
-import ReactMarkdown from 'react-markdown'
 
 export interface VocabularyWord {
   id:number
@@ -42,8 +41,8 @@ export default class VocabularyWords extends React.Component<Props, State> {
           <div className="card mw-50">
             <div className="card-header"><h3>{this.state.activeVocabWord.text}</h3></div>
             <div className="card-body">
-              <p><strong>Definition</strong>: <ReactMarkdown source={this.state.activeVocabWord.description}/></p>
-              <p><strong>Sample Sentence</strong>: <ReactMarkdown source={this.state.activeVocabWord.example}/></p>
+              <p><strong>Definition</strong>: <span dangerouslySetInnerHTML={{__html: this.state.activeVocabWord.description}}/></p>
+              <p><strong>Sample Sentence</strong>: <span dangerouslySetInnerHTML={{__html: this.state.activeVocabWord.example}}/></p>
             </div>
             <div className="card-footer"><button className="btn btn-primary" onClick={e => this.clearVocabWord()}>Done</button></div>
           </div>

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -1,3 +1,6 @@
+<link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css">
+<!-- TODO: Change the style import from CDN to Javscript import -->
+
 <%= form_with(model: activity, local: true) do |form| %>
   <% if activity.errors.any? %>
     <div id="error_explanation">
@@ -18,8 +21,10 @@
 
   <div class="form-group">
     <%= form.label :article, class: "form-label" %>
-    <%= form.text_area :article, class: "form-control mh-40" %>
+    <%= form.text_field :article, class: "form-control" %>
   </div>
+
+  <div id="quill-react-text-editor"></div>
 
   <div class="form-group">
     <%= form.label :description, class: "form-label" %>

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -19,16 +19,14 @@
     <%= form.text_field :title, class: "form-control" %>
   </div>
 
-  <div class="form-group">
+  <div class="form-group quill-editor">
     <%= form.label :article, class: "form-label" %>
-    <%= form.text_field :article, class: "form-control" %>
+    <%= form.hidden_field :article, class: "form-control"%>
   </div>
 
-  <div id="quill-react-text-editor"></div>
-
-  <div class="form-group">
+  <div class="form-group quill-editor">
     <%= form.label :description, class: "form-label" %>
-    <%= form.text_area :description, class: "form-control" %>
+    <%= form.hidden_field :description, class: "form-control" %>
   </div>
 
   <div class="actions">

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -19,12 +19,12 @@
     <%= form.text_field :title, class: "form-control" %>
   </div>
 
-  <div class="form-group quill-editor">
+  <div class="form-group text-editor">
     <%= form.label :article, class: "form-label" %>
     <%= form.hidden_field :article, class: "form-control"%>
   </div>
 
-  <div class="form-group quill-editor">
+  <div class="form-group text-editor">
     <%= form.label :description, class: "form-label" %>
     <%= form.hidden_field :description, class: "form-control" %>
   </div>

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -1,6 +1,3 @@
-<link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css">
-<!-- TODO: Change the style import from CDN to Javscript import -->
-
 <%= form_with(model: activity, local: true) do |form| %>
   <% if activity.errors.any? %>
     <div id="error_explanation">

--- a/services/QuillComprehension/app/views/activities/_form.html.erb
+++ b/services/QuillComprehension/app/views/activities/_form.html.erb
@@ -24,9 +24,9 @@
     <%= form.hidden_field :article, class: "form-control"%>
   </div>
 
-  <div class="form-group text-editor">
+  <div class="form-group">
     <%= form.label :description, class: "form-label" %>
-    <%= form.hidden_field :description, class: "form-control" %>
+    <%= form.text_field :description, class: "form-control" %>
   </div>
 
   <div class="actions">

--- a/services/QuillComprehension/app/views/vocabulary_words/_form.html.erb
+++ b/services/QuillComprehension/app/views/vocabulary_words/_form.html.erb
@@ -1,6 +1,3 @@
-<link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css">
-<!-- TODO: Change the style import from CDN to Javscript import -->
-
 <%= form_with(model: vocabulary_word, local: true, url: (@vocabulary_word.new_record? ? [@activity, @vocabulary_word]: @vocabulary_word)) do |form| %>
   <% if vocabulary_word.errors.any? %>
     <div id="error_explanation">

--- a/services/QuillComprehension/app/views/vocabulary_words/_form.html.erb
+++ b/services/QuillComprehension/app/views/vocabulary_words/_form.html.erb
@@ -1,3 +1,6 @@
+<link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css">
+<!-- TODO: Change the style import from CDN to Javscript import -->
+
 <%= form_with(model: vocabulary_word, local: true, url: (@vocabulary_word.new_record? ? [@activity, @vocabulary_word]: @vocabulary_word)) do |form| %>
   <% if vocabulary_word.errors.any? %>
     <div id="error_explanation">
@@ -21,14 +24,14 @@
     <%= form.text_area :text, class: "form-control" %>
   </div>
 
-  <div class="form-group">
+  <div class="form-group text-editor">
     <%= form.label :description, class: "form-label" %>
-    <%= form.text_area :description, class: "form-control" %>
+    <%= form.hidden_field :description, class: "form-control" %>
   </div>
 
-  <div class="form-group">
+  <div class="form-group text-editor">
     <%= form.label :example, class: "form-label" %>
-    <%= form.text_area :example, class: "form-control" %>
+    <%= form.hidden_field :example, class: "form-control" %>
   </div>
 
   <div class="form-group">

--- a/services/QuillComprehension/package.json
+++ b/services/QuillComprehension/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^16.4.0",
     "react-feather": "^1.1.0",
     "react-markdown": "^3.3.4",
+    "react-quill": "^1.3.1",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "ts-loader": "3.5.0",

--- a/services/QuillComprehension/package.json
+++ b/services/QuillComprehension/package.json
@@ -24,7 +24,6 @@
     "react-apollo": "^2.1.4",
     "react-dom": "^16.4.0",
     "react-feather": "^1.1.0",
-    "react-markdown": "^3.3.4",
     "react-quill": "^1.3.1",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",

--- a/services/QuillComprehension/yarn.lock
+++ b/services/QuillComprehension/yarn.lock
@@ -61,6 +61,12 @@
   version "10.3.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
 
+"@types/quill@*":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.7.tgz#8fcf89632f79b2b04c12c6c38a4a495c7f198705"
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/ramda@^0.25.32":
   version "0.25.33"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.33.tgz#a134fde6da3be303a1bdefd9155d8365bb7b14ec"
@@ -1606,6 +1612,10 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1885,6 +1895,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.0:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -2446,6 +2464,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -2587,6 +2609,10 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2631,6 +2657,10 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -2661,7 +2691,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
+fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -5156,6 +5186,10 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+
 parse-asn1@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
@@ -5895,6 +5929,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -5998,6 +6039,25 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
+quill-delta@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.2.tgz#76eed0163b8b09a076fba6ade29307c42b40b8d8"
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.1"
+    fast-diff "1.1.2"
+
+quill@^1.2.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.6.tgz#99f4de1fee85925a0d7d4163b6d8328f23317a4d"
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.1"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
@@ -6055,6 +6115,10 @@ react-apollo@^2.1.4:
     lodash "4.17.10"
     prop-types "^15.6.0"
 
+react-dom-factories@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
+
 react-dom@^16.4.0:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
@@ -6077,6 +6141,18 @@ react-markdown@^3.3.4:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
+
+react-quill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-1.3.1.tgz#9fd2003f20a0f3bb6c9e55631add7658f5f967a4"
+  dependencies:
+    "@types/quill" "*"
+    "@types/react" "*"
+    create-react-class "^15.6.0"
+    lodash "^4.17.4"
+    prop-types "^15.5.10"
+    quill "^1.2.6"
+    react-dom-factories "^1.0.0"
 
 react-redux@^5.0.7:
   version "5.0.7"

--- a/services/QuillComprehension/yarn.lock
+++ b/services/QuillComprehension/yarn.lock
@@ -1116,10 +1116,6 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
-bail@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
-
 balanced-match@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.1.0.tgz#b504bd05869b39259dd0c5efc35d843176dccc4a"
@@ -1495,18 +1491,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-character-entities-legacy@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
-
-character-entities@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
-
-character-reference-invalid@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
-
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1629,10 +1613,6 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-
-collapse-white-space@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2605,13 +2585,13 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
 extend@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
+extend@~3.0.0, extend@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -3429,17 +3409,6 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-alphabetical@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
-
-is-alphanumerical@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
-  dependencies:
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3454,7 +3423,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.4, is-buffer@^1.1.5:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -3489,10 +3458,6 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-
-is-decimal@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3580,10 +3545,6 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-hexadecimal@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
-
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -3636,7 +3597,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -3686,17 +3647,9 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-whitespace-character@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
-
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
-
-is-word-character@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4543,10 +4496,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-escapes@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
-
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -5199,17 +5148,6 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
-
-parse-entities@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
-  dependencies:
-    character-entities "^1.0.0"
-    character-entities-legacy "^1.0.0"
-    character-reference-invalid "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-hexadecimal "^1.0.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -6132,16 +6070,6 @@ react-feather@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-1.1.0.tgz#f0aa692497de952237ca1f3b118ebcb5427152e1"
 
-react-markdown@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.3.4.tgz#4002599ad133c649923a49aedc06b2f3af2016b6"
-  dependencies:
-    prop-types "^15.6.1"
-    remark-parse "^5.0.0"
-    unified "^6.1.5"
-    unist-util-visit "^1.3.0"
-    xtend "^4.0.1"
-
 react-quill@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-1.3.1.tgz#9fd2003f20a0f3bb6c9e55631add7658f5f967a4"
@@ -6331,26 +6259,6 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-remark-parse@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
-  dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -6359,7 +6267,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -6368,10 +6276,6 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
-
-replace-ext@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -6954,10 +6858,6 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
-state-toggle@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7258,18 +7158,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trim-trailing-lines@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
-
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-
-trough@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
-
 "true-case-path@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.2.tgz#7ec91130924766c7f573be3020c34f8fdfd00d62"
@@ -7386,24 +7274,6 @@ uglifyjs-webpack-plugin@^1.2.5:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
-unherit@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
-  dependencies:
-    inherits "^2.0.1"
-    xtend "^4.0.1"
-
-unified@^6.1.5:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^1.1.0"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -7432,26 +7302,6 @@ unique-slug@^2.0.0:
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
   dependencies:
     imurmurhash "^0.1.4"
-
-unist-util-is@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
-
-unist-util-remove-position@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
-  dependencies:
-    unist-util-visit "^1.1.0"
-
-unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
-
-unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.1.tgz#c019ac9337a62486be58531bc27e7499ae7d55c7"
-  dependencies:
-    unist-util-is "^2.1.1"
 
 units-css@^0.4.0:
   version "0.4.0"
@@ -7562,25 +7412,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vfile-location@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
-
-vfile-message@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
-  dependencies:
-    unist-util-stringify-position "^1.1.1"
-
-vfile@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
-  dependencies:
-    is-buffer "^1.1.4"
-    replace-ext "1.0.0"
-    unist-util-stringify-position "^1.0.0"
-    vfile-message "^1.0.0"
 
 viewport-dimensions@^0.2.0:
   version "0.2.0"
@@ -7817,15 +7648,11 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
-x-is-string@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Addresses issue NA

**Changes proposed in this pull request:**
- Use [React-Quill ](https://github.com/zenoamaro/react-quill) text editor to edit vocabulary_word and activities in QuillComprehension

![screen shot 2018-07-23 at 11 14 47 am](https://user-images.githubusercontent.com/30219972/43085706-a71bf4c0-8e69-11e8-855a-56389fdd1e5b.png)

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
