### PR TITLE
fix #4479  - remove premium promo

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -29,6 +29,19 @@ export default React.createClass({
     );
   },
 
+  premiumPromo() {
+    const today = new Date()
+    const marchFirst = new Date(today.getFullYear(), 2, 1)
+    const julyFifteenth = new Date(today.getFullYear(), 6, 15)
+    if (today > marchFirst && today < julyFifteenth) {
+      return <div className="premium-notification-box-container">
+        <NotificationBox>
+          <span><strong>Upgrade now and get the rest of the school year free.</strong><br/> First time subscribers' subscriptions will be extended through July 31st, {today.getFullYear()}.</span>
+        </NotificationBox>
+      </div>
+    }
+  },
+
   render() {
     return (
       <div className="container" id="premium-pricing-guide">
@@ -36,11 +49,7 @@ export default React.createClass({
           <h1>Pricing Guide</h1>
           <p>Save time grading and gain actionable insights with Quill Premium.</p>
         </div>
-        <div className="premium-notification-box-container">
-          <NotificationBox>
-            <span><strong>Upgrade now and get the rest of the school year free.</strong><br/> First time subscribers' subscriptions will be extended through July 31st, 2019.</span>
-          </NotificationBox>
-        </div>
+        {this.premiumPromo()}
         <PremiumPricingMinisRow {...this.props} />
         <DistrictPricingBox />
         <PremiumFlyer />

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['PremiumPricingGuide container should render 1'] = `
+exports[`PremiumPricingGuide container should render 1`] = `
 <div
   className="container"
   id="premium-pricing-guide"
@@ -14,19 +14,6 @@ exports['PremiumPricingGuide container should render 1'] = `
     <p>
       Save time grading and gain actionable insights with Quill Premium.
     </p>
-  </div>
-  <div
-    className="premium-notification-box-container"
-  >
-    <_class>
-      <span>
-        <strong>
-          Upgrade now and get the rest of the school year free.
-        </strong>
-        <br />
-         First time subscribers' subscriptions will be extended through July 31st, 2019.
-      </span>
-    </_class>
   </div>
   <_class />
   <_class />


### PR DESCRIPTION
Addresses issue #4479

**Changes proposed in this pull request:**
- update premium promo on premium page to only show between March 1st and July 15th of every year

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
