### PR TITLE
fix styling issues with timezone dropdown on my account page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
@@ -30,6 +30,10 @@
       }
     }
   }
+  .dropdown-menu {
+    max-height: 300px;
+    overflow: scroll;
+  }
   .dropdown-toggle.btn.btn-default {
     width: 300px;
   }

--- a/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
@@ -30,6 +30,9 @@
       }
     }
   }
+  .dropdown-toggle.btn.btn-default {
+    width: 300px;
+  }
   .error {
 
   }

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -135,7 +135,7 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def my_account
-    @time_zones = [{name: 'Select Time Zone', id: 'Select Time Zone'}].concat(TZInfo::Timezone.all_country_zone_identifiers.sort.map{|tz| {name: tz, id: tz}})
+    @time_zones = [{name: 'Select Time Zone', id: 'Select Time Zone'}].concat(TZInfo::Timezone.all_country_zone_identifiers.sort.map{|tz| {name: tz.gsub('_', ' '), id: tz}})
   end
 
   def my_account_data

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ActiveRecord::Base
   end
 
   def utc_offset
-    if self.time_zone
+    if self.time_zone && self.time_zone.length > 0
       tz = TZInfo::Timezone.get(time_zone)
       tz.period_for_utc(Time.new.utc).utc_total_offset
     else

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
@@ -62,7 +62,7 @@ export default React.createClass({
       role: data.role,
       googleId: data.google_id,
       signedUpWithGoogle: data.signed_up_with_google,
-      time_zone: data.time_zone,
+      time_zone: data.time_zone ? data.time_zone.replace(/_/g, ' ') : data.time_zone,
       selectedSchool: schoolData,
       originalSelectedSchoolId,
       schoolOptionsDoNotApply: (originalSelectedSchoolId == null),
@@ -90,7 +90,7 @@ export default React.createClass({
       email: this.state.email,
       role: this.state.role,
       password: this.state.password,
-      time_zone: this.state.time_zone ? this.state.time_zone.name : null,
+      time_zone: this.state.time_zone ? this.state.time_zone.name.replace(/ /g, '_') : null,
       school_id: ((this.state.selectedSchool == null)
         ? null
         : this.state.selectedSchool.id),

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
@@ -90,7 +90,7 @@ export default React.createClass({
       email: this.state.email,
       role: this.state.role,
       password: this.state.password,
-      time_zone: this.state.time_zone ? this.state.time_zone.name.replace(/ /g, '_') : null,
+      time_zone: this.state.time_zone && this.state.time_zone.name !== 'Select Time Zone' ? this.state.time_zone.name.replace(/ /g, '_') : null,
       school_id: ((this.state.selectedSchool == null)
         ? null
         : this.state.selectedSchool.id),


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- give dropdown enough width to not cut off timezones
- add max height and scroll to dropdown
- render time zone names with spaces rather than underscores

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2018-07-30 at 12 20 37 pm](https://user-images.githubusercontent.com/18669014/43409831-031cb654-93f3-11e8-90d8-0409fb1ef458.png)


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
