### PR TITLE
Custom user agent to prevent new line causing bugs

### DIFF
--- a/services/QuillLMS/app/services/google_integration/client.rb
+++ b/services/QuillLMS/app/services/google_integration/client.rb
@@ -24,6 +24,18 @@ class GoogleIntegration::Client
   end
 
   def client
-    @client ||= @api_client.new(application_name: 'quill')
+    @client ||= @api_client.new(application_name: 'quill', user_agent: user_agent)
+  end
+
+  # Builds a custom user agent to prevent Google::APIClient to
+  # use an invalid auto-generated one
+  # @see https://github.com/google/google-api-ruby-client/blob/15853007bf1fc8ad000bb35dafdd3ca6bfa8ae26/lib/google/api_client.rb#L112
+  def user_agent
+    [
+      "quill/0.0.0",
+      "google-api-ruby-client/#{Google::APIClient::VERSION::STRING}",
+      Google::APIClient::ENV::OS_VERSION,
+      '(gzip)'
+    ].join(' ').delete("\n")
   end
 end


### PR DESCRIPTION
Ruby 2.5 does not support \n in headers, this updates the Google User Agent to prevent having one in the request to Google Classroom.