### PR TITLE
fix #4520 - fix issue with not showing correct data on scorebook

### DIFF
--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -13,7 +13,7 @@ class GradesController < ApplicationController
   private
 
   def tooltip_params
-    params.permit(:classroom_unit_id, :user_id, :completed)
+    params.permit(:classroom_unit_id, :user_id, :completed, :activity_id)
   end
 
   def tooltip_query
@@ -33,7 +33,9 @@ class GradesController < ApplicationController
         JOIN unit_activities ON activities.id = unit_activities.activity_id AND unit_activities.unit_id = classroom_units.unit_id
         WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.sanitize(tooltip_params[:classroom_unit_id].to_i)}
         AND activity_sessions.user_id = #{ActiveRecord::Base.sanitize(tooltip_params[:user_id].to_i)}
+        AND activity_sessions.activity_id = #{ActiveRecord::Base.sanitize(tooltip_params[:activity_id].to_i)}
         AND activity_sessions.is_final_score IS true
+        AND activity_sessions.visible
         ").to_a
     end
   end
@@ -46,7 +48,9 @@ class GradesController < ApplicationController
       FROM activity_sessions
       WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.sanitize(tooltip_params[:classroom_unit_id].to_i)}
       AND activity_sessions.user_id = #{ActiveRecord::Base.sanitize(tooltip_params[:user_id].to_i)}
-      And activity_sessions.percentage IS NOT NULL
+      AND activity_sessions.activity_id = #{ActiveRecord::Base.sanitize(tooltip_params[:activity_id].to_i)}
+      AND activity_sessions.percentage IS NOT NULL
+      AND activity_sessions.visible
       ORDER BY activity_sessions.completed_at
       ").to_a
   end

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -31,7 +31,7 @@ class Scorebook::Query
            acts.classroom_unit_id = cu.id
            AND acts.user_id = students.id
            AND acts.activity_id = activity.id
-           AND acts.visible = true
+           AND acts.visible
            )
      LEFT JOIN classroom_unit_activity_states AS cuas ON cuas.unit_activity_id = unit_activities.id AND cuas.classroom_unit_id = cu.id
      WHERE cu.classroom_id = #{classroom_id}
@@ -43,7 +43,7 @@ class Scorebook::Query
      #{self.date_conditional_string(begin_date, end_date, offset)}
      GROUP BY
       students.id,
-       students.name, cu.id, activity.activity_classification_id, activity.name, activity.description, cuas.completed, activity.id, acts.id
+       students.name, cu.id, activity.activity_classification_id, activity.name, activity.description, cuas.completed, activity.id
      ORDER BY split_part( students.name, ' ' , 2),
        CASE WHEN SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
        MIN(acts.completed_at),

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -24,7 +24,7 @@ export default class ActivityIconWithTooltip extends React.Component {
   getConceptResultInfo() {
     const that = this;
     request.get({
-      url: `${process.env.DEFAULT_URL}/grades/tooltip/classroom_unit_id/${this.props.data.cuId}/user_id/${this.props.data.userId}/completed/${!!this.props.data.percentage}`,
+      url: `${process.env.DEFAULT_URL}/grades/tooltip/classroom_unit_id/${this.props.data.cuId}/user_id/${this.props.data.userId}/activity_id/${this.activityId()}/completed/${!!this.props.data.percentage}`,
     }, (error, httpStatus, body) => {
       const parsedBody = JSON.parse(body);
       that.loadTooltipTitle(parsedBody);

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -119,7 +119,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   resources :grades, only: [:index]
 
-  get 'grades/tooltip/classroom_unit_id/:classroom_unit_id/user_id/:user_id/completed/:completed' => 'grades#tooltip'
+  get 'grades/tooltip/classroom_unit_id/:classroom_unit_id/user_id/:user_id/activity_id/:activity_id/completed/:completed' => 'grades#tooltip'
 
   get :current_user_json, controller: 'teachers', action: 'current_user_json'
 


### PR DESCRIPTION
Addresses issue #4520

**Changes proposed in this pull request:**
- scores for tooltips are now organized by activity id so we don't pull all of the classroom unit's activity sessions in
- activity sessions are grouped correctly for scorebook percentage

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
