### PR TITLE
Make sure users are signed in when accessing the activity sessions fr…

### DIFF
--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -103,8 +103,9 @@ class ActivitySessionsController < ApplicationController
   end
 
   def authorize_student_belongs_to_classroom_unit!
+    return auth_failed if current_user.nil?
     @classroom_unit = ClassroomUnit.find params[:classroom_unit_id]
-    if current_user.classrooms.exclude?(@classroom_unit.classroom) then auth_failed end
+    if current_user.classrooms.exclude?(@classroom_unit.classroom) then auth_failed(hard: false) end
   end
 
 end

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -21,6 +21,8 @@ class SessionsController < ApplicationController
       sign_in(@user)
       if params[:redirect].present?
         redirect_to URI.parse(params[:redirect]).path
+      elsif session[:attempted_path]
+        redirect_to URI.parse(session.delete(:attempted_path)).path
       else
         redirect_to profile_path
       end
@@ -46,6 +48,8 @@ class SessionsController < ApplicationController
         render json: {redirect: url}
       elsif params[:redirect].present?
         render json: {redirect: URI.parse(params[:redirect]).path}
+      elsif session[:attempted_path]
+        render json: {redirect: URI.parse(session.delete(:attempted_path)).path}
       elsif @user.auditor? && @user.subscription&.school_subscription?
         render json: {redirect: '/subscriptions'}
       else

--- a/services/QuillLMS/lib/quill_authentication.rb
+++ b/services/QuillLMS/lib/quill_authentication.rb
@@ -79,10 +79,15 @@ module QuillAuthentication
     auth_failed
   end
 
-  def auth_failed
-    sign_out
-    session[:attempted_path] = request.fullpath
-    redirect_to(new_session_path, status: :see_other)
+  def auth_failed(hard: true)
+    if hard
+      sign_out
+      session[:attempted_path] = request.fullpath
+      redirect_to(new_session_path, status: :see_other)
+    else 
+      redirect_to(profile_path, notice: "404")
+    end
+    
   end
 
   def signed_out!


### PR DESCRIPTION
…om classroom unit controller

Addresses issue https://rpm.newrelic.com/accounts/770600/applications/3825541/traced_errors/8d85fb3d-b849-11e8-9588-0242ac110009_6753_13555?original_error_id=de6568a5-b870-11e8-9588-0242ac110009_0_6767

**Changes proposed in this pull request:**
- Ensure user is present before calling classrooms on current user
- prevent infinite sign out loop, show 404 if student is present but not in classroom unit.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes/no

**Have you updated the docs?** yes/no

**Have the tests been updated?** yes/no

**Reviewer:** @ddmck
