### PR TITLE
Change auth logic around launch act session from classroom unit

### DIFF
--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -103,8 +103,9 @@ class ActivitySessionsController < ApplicationController
   end
 
   def authorize_student_belongs_to_classroom_unit!
+    return auth_failed if current_user.nil?
     @classroom_unit = ClassroomUnit.find params[:classroom_unit_id]
-    if current_user.classrooms.exclude?(@classroom_unit.classroom) then auth_failed end
+    if current_user.classrooms.exclude?(@classroom_unit.classroom) then auth_failed(hard: false) end
   end
 
 end

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -21,6 +21,8 @@ class SessionsController < ApplicationController
       sign_in(@user)
       if params[:redirect].present?
         redirect_to URI.parse(params[:redirect]).path
+      elsif session[:attempted_path]
+        redirect_to URI.parse(session.delete(:attempted_path)).path
       else
         redirect_to profile_path
       end
@@ -46,6 +48,8 @@ class SessionsController < ApplicationController
         render json: {redirect: url}
       elsif params[:redirect].present?
         render json: {redirect: URI.parse(params[:redirect]).path}
+      elsif session[:attempted_path]
+        render json: {redirect: URI.parse(session.delete(:attempted_path)).path}
       elsif @user.auditor? && @user.subscription&.school_subscription?
         render json: {redirect: '/subscriptions'}
       else

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.slim
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.slim
@@ -40,29 +40,37 @@
         .preview-question
           | What do I get with a Premium Membership?
         .preview-answer
-          | With Quill Premium, teachers can access Quill Progress Reports, which allow teachers to easily view and download their data. Quill Progress Reports show teachers how students are progressing on the Common Core and which concepts they need help with. Schools may also upload their rosters via CSV.
+          | With Quill Premium, teachers can access Quill Progress Reports, which allow teachers to easily view and download their data. Quill Progress Reports show teachers how students are progressing on the Common Core and which concepts they need help with. With Quill Premium for Schools, teachers and administrators can access a school-wide dashboard that shows student progress and standards mastered across the entire school.
 
       .preview-question-and-answer
         .preview-question
           | How does payment work on a Premium Membership?
         .preview-answer
-          | Quill Premium is provided on an annual license based on the school year. You may pay via credit card or check. Credit cards will be billed annually for Teacher and School Premium. If you pay with a check, you can request an invoice to renew your subscription.
+          | Quill Premium is provided on an annual license based on the school year. You may pay via credit card or check. Credit cards will be billed annually for Teacher and School Premium. If you pay with a check, Quill will issue an invoice to renew your subscription.
 
     .preview-questions-column
       .preview-question-and-answer.preview-question-and-answer-with-margin
         .preview-question
           | How much does Quill Premium cost?
         .preview-answer
-          | Quill Premium is provided as a teacher license, school license, or district license. The teacher license covers all of the students for one teacher and costs $80 per year. The school license is a site-wide license that covers all teachers and students in the school, and costs $900 per year. &nbsp;
+          | Quill Premium is provided as a teacher license, school license, or district license. The teacher license covers all of the students for one teacher and costs $80 per year. The school license is a site-wide license that covers all teachers and students in the school, and costs $1,800 per year, with a 50% discount for the first year. &nbsp;
           | For districts, we provide custom pricing, on-site training, and district dashboards. &nbsp;
           = link_to 'Contact us', 'https://quillpremium.wufoo.com/forms/quill-premium-quote/', target: '_blank'
           | &nbsp;to receive a demo.
+          
+      .preview-question-and-answer.preview-question-and-answer-with-margin
+        .preview-question
+          | Do you accept purchase orders?
+        .preview-answer
+          | Yes, we accept purchase orders. You may email a purchase order to sales@quill.org. You can access our W-9 by 
+          = link_to 'clicking this link', 'http://bit.ly/quill-w9-2018', target: '_new' 
+          | &nbsp; and you can reach out with questions at 646-442-1095. &nbsp;
 
       .preview-question-and-answer.preview-question-and-answer-with-margin
         .preview-question
           | Do you offer financial aid?
         .preview-answer
-          | Yes, we provide Quill Premium for free to schools that have a demonstrated financial need. This funding is provided to select partners thanks to the support of the Bill & Melinda Gates Foundation. Please&nbsp;
+          | Yes, we provide Quill Premium for free to schools that have a demonstrated financial need. This funding is provided to select partners thanks to the support of our funders. Please&nbsp;
           = link_to 'contact us', 'https://quillpremium.wufoo.com/forms/quill-premium-quote/', target: '_new'
           |  &nbsp;to apply.
 
@@ -70,7 +78,7 @@
         .preview-question
           | Have more questions?
         .preview-answer
-          | You can call us at 646-442-1095 or visit our
+          | You can call us at 646-442-1095 or visit our 
           = link_to 'Support Center.', 'http://support.quill.org', target: '_new'
 
   .preview-questions-view-all

--- a/services/QuillLMS/lib/quill_authentication.rb
+++ b/services/QuillLMS/lib/quill_authentication.rb
@@ -79,10 +79,15 @@ module QuillAuthentication
     auth_failed
   end
 
-  def auth_failed
-    sign_out
-    session[:attempted_path] = request.fullpath
-    redirect_to(new_session_path, status: :see_other)
+  def auth_failed(hard: true)
+    if hard
+      sign_out
+      session[:attempted_path] = request.fullpath
+      redirect_to(new_session_path, status: :see_other)
+    else 
+      redirect_to(profile_path, notice: "404")
+    end
+    
   end
 
   def signed_out!


### PR DESCRIPTION
It now makes sure that the student is logged in first
If they are logged in but not authed they are kicked back to the profile to prevent an infinite loop.