### PR TITLE
Bug/reports speedup fix #4587

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import ClassroomActivity from './classroom_activity';
 import Pluralize from 'pluralize';
 import AddClassroomActivityRow from './add_classroom_activity_row.jsx';
-import moment from 'moment'
+import moment from 'moment';
 
 export default React.createClass({
   getInitialState() {
@@ -13,15 +13,15 @@ export default React.createClass({
       savedUnitName: (this.props.data.unitName || this.props.data.unit.name),
       error: false,
       showTooltip: false,
-      classroomActivities: (this.props.data.classroomActivities || this.props.data.classroom_activities)
+      classroomActivities: (this.props.data.classroomActivities || this.props.data.classroom_activities),
     };
   },
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.data.classroomActivities && (nextProps.data.classroomActivities.length === this.state.classroomActivities.length)) {
-      this.setState({classroomActivities: nextProps.data.classroomActivities})
+      this.setState({ classroomActivities: nextProps.data.classroomActivities, });
     } else if (nextProps.data.classroom_activities && (nextProps.data.classroom_activities.length === this.state.classroomActivities.length)) {
-      this.setState({classroomActivities: nextProps.data.classroom_activities})
+      this.setState({ classroomActivities: nextProps.data.classroom_activities, });
     }
   },
 
@@ -37,7 +37,7 @@ export default React.createClass({
     // ensure classrooms is always an array as sometimes it is passed a set
     // and we need to do a number of things with it that are better with an array
     const classrooms = Array.isArray(dclassy) ? dclassy : [...dclassy];
-    const classroomList = this.classroomList(classrooms)
+    const classroomList = this.classroomList(classrooms);
     return (<div className="assigned-to">
       <span className="heading">Assigned to {classrooms.length} {Pluralize('class', classrooms.length)}:</span>
       <ul>
@@ -51,9 +51,9 @@ export default React.createClass({
       const classroomsArray = classrooms.slice(0, 3).map((c, i) => <li key={i}>{c.name} <span>({c.assignedStudentCount}/{c.totalStudentCount} {Pluralize('student', c.totalStudentCount)})</span></li>)
       classroomsArray.push(<li className="see-all" onClick={() => this.setState({showAllClassrooms: true})}>Show all {classrooms.length} classes <i className="fa fa-icon fa-chevron-down"/></li>)
       return classroomsArray
-    } else {
+    } 
       return classrooms.map((c, i) => <li key={i}>{c.name} <span>({c.assignedStudentCount}/{c.totalStudentCount} {Pluralize('student', c.totalStudentCount)})</span></li>)
-    }
+    
   },
 
   editUnit() {
@@ -61,12 +61,12 @@ export default React.createClass({
   },
 
   deleteOrLockedInfo() {
-    const firstCa = this.state.classroomActivities.values().next().value
-    const ownedByCurrentUser = firstCa.ownedByCurrentUser
+    const firstCa = this.state.classroomActivities.values().next().value;
+    const ownedByCurrentUser = firstCa.ownedByCurrentUser;
     if (!this.props.report && !this.props.lesson && ownedByCurrentUser) {
       return <span className="delete-unit" onClick={this.hideUnit}>Delete Activity Pack</span>;
     } else if (!ownedByCurrentUser) {
-      return <span
+      return (<span
         className='locked-unit'
         onMouseEnter={this.toggleTooltip}
         onMouseLeave={this.toggleTooltip}
@@ -74,12 +74,12 @@ export default React.createClass({
           <img src="https://assets.quill.org/images/icons/lock-activity-pack-icon.svg"/>
           Created By {firstCa.ownerName}
           {this.renderTooltip()}
-        </span>
+        </span>);
     }
   },
 
   editName() {
-    if(this.state.classroomActivities.values().next().value.ownedByCurrentUser) {
+    if (this.state.classroomActivities.values().next().value.ownedByCurrentUser) {
       let text,
         classy,
         inlineStyle;
@@ -104,17 +104,17 @@ export default React.createClass({
   },
 
   toggleTooltip() {
-    this.setState({showTooltip: !this.state.showTooltip})
+    this.setState({ showTooltip: !this.state.showTooltip ,});
   },
 
   renderTooltip() {
-  const visible = this.state.showTooltip ? 'visible' : 'invisible'
-    const ownerName = this.state.classroomActivities.values().next().value.ownerName
-    return <div className={`tooltip ${visible}`}>
+    const visible = this.state.showTooltip ? 'visible' : 'invisible';
+    const ownerName = this.state.classroomActivities.values().next().value.ownerName;
+    return (<div className={`tooltip ${visible}`}>
       <i className="fa fa-caret-up"/>
       <p>Since {ownerName} created this activity pack, you are unable to edit this activity pack. You can ask the creator to edit it.</p>
       <p>If you would like to assign additional practice activities, you can create a new pack for your students.</p>
-    </div>
+    </div>);
   },
 
   changeToEdit() {
@@ -178,22 +178,22 @@ export default React.createClass({
   },
 
   addClassroomActivityRow() {
-    if(this.state.classroomActivities.values().next().value.ownedByCurrentUser) {
+    if (this.state.classroomActivities.values().next().value.ownedByCurrentUser) {
       return this.props.report || this.props.lesson ? null : <AddClassroomActivityRow unitId={this.getUnitId()} unitName={this.props.data.unitName || this.props.data.unit.name} />;
     }
   },
 
   updateAllDueDates(date) {
-    const newClassroomActivities = new Map(this.state.classroomActivities)
-    const uaIds = []
+    const newClassroomActivities = new Map(this.state.classroomActivities);
+    const uaIds = [];
     this.state.classroomActivities.forEach((v, k) => {
-      uaIds.push(v.uaId)
-      const classroomActivity = newClassroomActivities.get(k)
-      classroomActivity.dueDate = moment(date)
-      newClassroomActivities.set(k, classroomActivity)
-    })
-    this.setState({classroomActivities: newClassroomActivities})
-    this.props.updateMultipleDueDates(uaIds, date)
+      uaIds.push(v.uaId);
+      const classroomActivity = newClassroomActivities.get(k);
+      classroomActivity.dueDate = moment(date);
+      newClassroomActivities.set(k, classroomActivity);
+    });
+    this.setState({ classroomActivities: newClassroomActivities, });
+    this.props.updateMultipleDueDates(uaIds, date);
   },
 
   numberOfStudentsAssignedToUnit() {
@@ -201,7 +201,7 @@ export default React.createClass({
     // ensure classrooms is always an array as sometimes it is passed as a set
     const classrooms = Array.isArray(dclassy) ? dclassy : [...dclassy];
     let numberOfStudentsAssignedToUnit = 0;
-    classrooms.forEach(c => {
+    classrooms.forEach((c) => {
       numberOfStudentsAssignedToUnit += Number(c.assignedStudentCount);
     });
     return numberOfStudentsAssignedToUnit;
@@ -209,8 +209,8 @@ export default React.createClass({
 
   renderClassroomActivities() {
     const classroomActivitiesArr = [];
-      let i = 0
-      for (const [key, ca] of this.state.classroomActivities) {
+    let i = 0;
+    for (const [key, ca] of this.state.classroomActivities) {
         classroomActivitiesArr.push(
           <ClassroomActivity
             key={`${this.props.data.unitId}-${key}`}
@@ -224,10 +224,11 @@ export default React.createClass({
             updateAllDueDates={this.updateAllDueDates}
             isFirst={i === 0}
             numberOfStudentsAssignedToUnit={this.numberOfStudentsAssignedToUnit()}
+            activityWithRecommendationsIds={this.props.activityWithRecommendationsIds}
           />
         );
-      i += 1
-    }
+        i += 1;
+      }
     return classroomActivitiesArr;
   },
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_units.jsx
@@ -6,17 +6,18 @@ export default React.createClass({
 
   render() {
     const units = _.map(this.props.data, function (data) {
-  			return (<Unit
-    key={data.unitId}
-    hideUnitActivity={this.props.hideUnitActivity}
-    hideUnit={this.props.hideUnit}
-    report={this.props.report}
-    activityReport={this.props.activityReport}
-    lesson={this.props.lesson}
-    updateDueDate={this.props.updateDueDate}
-    data={data}
-    updateMultipleDueDates={this.props.updateMultipleDueDates}
-  			/>);
+      return (<Unit
+        key={data.unitId}
+        hideUnitActivity={this.props.hideUnitActivity}
+        hideUnit={this.props.hideUnit}
+        report={this.props.report}
+        activityReport={this.props.activityReport}
+        lesson={this.props.lesson}
+        updateDueDate={this.props.updateDueDate}
+        data={data}
+        updateMultipleDueDates={this.props.updateMultipleDueDates}
+        activityWithRecommendationsIds={this.props.activityWithRecommendationsIds}
+      />);
     }, this);
     return (
       <span>{units}</span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/classroom_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/classroom_activity.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import moment from 'moment'
-import DatePicker from 'react-datepicker'
+import React from 'react';
+import moment from 'moment';
+import DatePicker from 'react-datepicker';
 import Pluralize from 'pluralize';
-import activityFromClassificationId from '../../modules/activity_from_classification_id.js'
+import activityFromClassificationId from '../../modules/activity_from_classification_id.js';
 
-import PreviewOrLaunchModal from '../../shared/preview_or_launch_modal'
+import PreviewOrLaunchModal from '../../shared/preview_or_launch_modal';
 
 const styles = {
   row: {
@@ -31,7 +31,7 @@ const styles = {
     alignItems: 'center',
     marginRight: '15px',
   },
-}
+};
 
 export default React.createClass({
 
@@ -41,271 +41,249 @@ export default React.createClass({
       showModal: false,
       showCustomizeTooltip: false,
       showLessonPlanTooltip: false,
-      diagnosticIds: []
-    }
-  },
-
-  componentDidMount() {
-    fetch(`${process.env.DEFAULT_URL}/teachers/progress_reports/activity_with_recommendations_ids`, {
-      method: 'GET',
-      mode: 'cors',
-      credentials: 'include'
-    }).then((response) => {
-      if (!response.ok) {
-        throw Error(response.statusText);
-      }
-      return response.json();
-    }).then((response) => {
-      this.setState({ activityWithRecommendationsIds: response.activityWithRecommendationsIds })
-    }).catch((error) => {
-      console.log('error', error)
-    })
+    };
   },
 
   componentWillReceiveProps(nextProps) {
-    const newDueDate = nextProps.data.dueDate
-    const formattedNewDueDate = newDueDate ? moment(newDueDate) : undefined
+    const newDueDate = nextProps.data.dueDate;
+    const formattedNewDueDate = newDueDate ? moment(newDueDate) : undefined;
     if (formattedNewDueDate !== this.state.startDate) {
-      this.setState({startDate: formattedNewDueDate})
+      this.setState({ startDate: formattedNewDueDate, });
     }
   },
 
   hideUnitActivity() {
-    const x = confirm('Are you sure you want to delete this assignment?')
+    const x = confirm('Are you sure you want to delete this assignment?');
     if (x) {
-      this.props.hideUnitActivity(this.uaId(), this.unitId())
+      this.props.hideUnitActivity(this.uaId(), this.unitId());
     }
   },
 
   handleChange(date) {
-    this.setState({ startDate: date, })
-    this.props.updateDueDate(this.uaId(), date.format())
+    this.setState({ startDate: date, });
+    this.props.updateDueDate(this.uaId(), date.format());
   },
 
   toggleCustomizeTooltip() {
-    this.setState({showCustomizeTooltip: !this.state.showCustomizeTooltip})
+    this.setState({ showCustomizeTooltip: !this.state.showCustomizeTooltip, });
   },
 
   toggleLessonPlanTooltip() {
-    this.setState({showLessonPlanTooltip: !this.state.showLessonPlanTooltip})
+    this.setState({ showLessonPlanTooltip: !this.state.showLessonPlanTooltip, });
   },
 
   renderCustomizedEditionsTag() {
     if (window.location.pathname.includes('lessons')) {
       if (this.props.data.hasEditions) {
-        return <div className="customized-editions-tag">Customized</div>
+        return <div className="customized-editions-tag">Customized</div>;
       }
     }
   },
 
   renderCustomizeTooltip() {
     if (this.state.showCustomizeTooltip) {
-      return <div className="customize-tooltip">
-        <i className="fa fa-caret-up"/>
+      return (<div className="customize-tooltip">
+        <i className="fa fa-caret-up" />
         Customize
-      </div>
+      </div>);
     }
   },
 
   renderLessonPlanTooltip() {
     if (this.state.showLessonPlanTooltip) {
-      return <div className="lesson-plan-tooltip">
-        <i className="fa fa-caret-up"/>
+      return (<div className="lesson-plan-tooltip">
+        <i className="fa fa-caret-up" />
         Download Lesson Plan
-      </div>
+      </div>);
     }
   },
 
   goToRecommendations() {
-    const link = `/teachers/progress_reports/diagnostic_reports#/u/${this.unitId()}/a/${this.activityId()}/c/${this.classroomId()}/recommendations`
-    window.location = link
+    const link = `/teachers/progress_reports/diagnostic_reports#/u/${this.unitId()}/a/${this.activityId()}/c/${this.classroomId()}/recommendations`;
+    window.location = link;
   },
 
   buttonForRecommendations() {
-    const activityWithRecommendationIds = this.state.activityWithRecommendationsIds
+    const activityWithRecommendationIds = this.props.activityWithRecommendationsIds;
     if (activityWithRecommendationIds && activityWithRecommendationIds.includes(this.activityId()) && window.location.pathname.includes('diagnostic_reports')) {
       return (
         <div onClick={this.goToRecommendations} className="recommendations-button">
           Recommendations
         </div>
-      )
+      );
     }
   },
 
   renderLessonsAction() {
     if (window.location.pathname.includes('lessons')) {
       if (this.props.data.completed === 't') {
-        return <p className="lesson-completed"><i className="fa fa-icon fa-check-circle" />Lesson Complete</p>
+        return <p className="lesson-completed"><i className="fa fa-icon fa-check-circle" />Lesson Complete</p>;
       } else if (this.props.data.started) {
-        let href = `/teachers/classroom_units/${this.classroomUnitId()}/mark_lesson_as_completed/${this.activityId()}`;
+        const href = `/teachers/classroom_units/${this.classroomUnitId()}/mark_lesson_as_completed/${this.activityId()}`;
 
-        return <a className="mark-completed" target="_blank" href={href}>Mark As Complete</a>
+        return <a className="mark-completed" target="_blank" href={href}>Mark As Complete</a>;
       }
     }
   },
 
   lessonFinalCell() {
-  return <div className="lessons-end-row">
-    {this.lessonCompletedOrLaunch()}
-    <a
-      className="customize-lesson"
-      href={`/customize/${this.props.data.activityUid}`}
-      onMouseEnter={this.toggleCustomizeTooltip}
-      onMouseLeave={this.toggleCustomizeTooltip}
-    >
-      <i className="fa fa-icon fa-magic"/>
-      {this.renderCustomizeTooltip()}
-    </a>
-    <a
-      className="supporting-info"
-      target="_blank"
-      href={`/activities/${this.activityId()}/supporting_info`}
-      onMouseEnter={this.toggleLessonPlanTooltip}
-      onMouseLeave={this.toggleLessonPlanTooltip}
-    >
-      <img src="https://assets.quill.org/images/icons/download-lesson-plan-green-icon.svg"/>
-      {this.renderLessonPlanTooltip()}
-    </a>
-  </div>
-},
+    return (<div className="lessons-end-row">
+      {this.lessonCompletedOrLaunch()}
+      <a
+        className="customize-lesson"
+        href={`/customize/${this.props.data.activityUid}`}
+        onMouseEnter={this.toggleCustomizeTooltip}
+        onMouseLeave={this.toggleCustomizeTooltip}
+      >
+        <i className="fa fa-icon fa-magic" />
+        {this.renderCustomizeTooltip()}
+      </a>
+      <a
+        className="supporting-info"
+        target="_blank"
+        href={`/activities/${this.activityId()}/supporting_info`}
+        onMouseEnter={this.toggleLessonPlanTooltip}
+        onMouseLeave={this.toggleLessonPlanTooltip}
+      >
+        <img src="https://assets.quill.org/images/icons/download-lesson-plan-green-icon.svg" />
+        {this.renderLessonPlanTooltip()}
+      </a>
+    </div>);
+  },
 
   urlForReport() {
     $.get(`/teachers/progress_reports/report_from_unit_and_activity/u/${this.unitId()}/a/${this.activityId()}`)
-      .success((data) => window.location = data.url)
-      .fail(() => alert('This report is not yet available. Please check back when at least one of your students has completed this activity.'))
+      .success(data => window.location = data.url)
+      .fail(() => alert('This report is not yet available. Please check back when at least one of your students has completed this activity.'));
   },
 
   anonymousPath() {
-    return `${process.env.DEFAULT_URL}/activity_sessions/anonymous?activity_id=${this.activityId()}`
+    return `${process.env.DEFAULT_URL}/activity_sessions/anonymous?activity_id=${this.activityId()}`;
   },
 
   calculateAverageScore() {
     const averageScore = this.props.data.cumulativeScore / this.props.data.completedCount;
-    if(isNaN(averageScore)) {
+    if (isNaN(averageScore)) {
       return '—';
-    } else if(Math.round(averageScore).toString().length === 2) {
+    } else if (Math.round(averageScore).toString().length === 2) {
       return `${averageScore.toPrecision(2)}%`;
-    } else {
-      return `${averageScore}%`;
     }
+    return `${averageScore}%`;
   },
 
   finalCell() {
     if (this.props.activityReport) {
       return [
-        <span key='number-of-students' className='number-of-students'>{this.renderPieChart()} {this.props.data.completedCount} of {this.props.numberOfStudentsAssignedToUnit} {Pluralize('student', this.props.numberOfStudentsAssignedToUnit)}</span>,
-        <span key='average-score' className='average-score'>{this.calculateAverageScore()}</span>,
-        <img key='chevron-right' className='chevron-right' src="https://assets.quill.org/images/icons/chevron-dark-green.svg" />
-      ]
+        <span key="number-of-students" className="number-of-students">{this.renderPieChart()} {this.props.data.completedCount} of {this.props.numberOfStudentsAssignedToUnit} {Pluralize('student', this.props.numberOfStudentsAssignedToUnit)}</span>,
+        <span key="average-score" className="average-score">{this.calculateAverageScore()}</span>,
+        <img key="chevron-right" className="chevron-right" src="https://assets.quill.org/images/icons/chevron-dark-green.svg" />
+      ];
     } else if (this.props.report) {
-      return [<a key="this.props.data.activity.anonymous_path" href={this.anonymousPath()} target="_blank">Preview</a>, <a key={`report-url-${this.classroomUnitId()}`} onClick={this.urlForReport}>View Report</a>]
+      return [<a key="this.props.data.activity.anonymous_path" href={this.anonymousPath()} target="_blank">Preview</a>, <a key={`report-url-${this.classroomUnitId()}`} onClick={this.urlForReport}>View Report</a>];
     } else if (this.isLesson()) {
-       return this.lessonFinalCell()
+      return this.lessonFinalCell();
     }
     if (this.props.data.ownedByCurrentUser) {
-      const startDate = this.state.startDate
-      return <span className="due-date-field">
+      const startDate = this.state.startDate;
+      return (<span className="due-date-field">
         <DatePicker className="due-date-input" onChange={this.handleChange} selected={startDate} placeholderText={startDate ? startDate.format('l') : 'Due Date (Optional)'} />
         {startDate && this.props.isFirst ? <span className="apply-to-all" onClick={() => this.props.updateAllDueDates(startDate)}>Apply to All</span> : null}
-      </span>
-    } else {
-      return this.state.startDate ? <div className='due-date-input'>{this.state.startDate.format('l')}</div> : null
+      </span>);
     }
+    return this.state.startDate ? <div className="due-date-input">{this.state.startDate.format('l')}</div> : null;
   },
 
   renderPieChart() {
     const rawPercent = this.props.data.completedCount / this.props.numberOfStudentsAssignedToUnit;
     const percent = rawPercent > 100 ? 100 : Math.round(rawPercent * 100) / 100;
-    const largeArcFlag = percent > .5 ? 1 : 0;
-    const pathData = `M 1 0 A 1 1 0 ${largeArcFlag} 1 ${Math.cos(2 * Math.PI * percent)} ${Math.sin(2 * Math.PI * percent)} L 0 0`
+    const largeArcFlag = percent > 0.5 ? 1 : 0;
+    const pathData = `M 1 0 A 1 1 0 ${largeArcFlag} 1 ${Math.cos(2 * Math.PI * percent)} ${Math.sin(2 * Math.PI * percent)} L 0 0`;
     return (
-      <svg viewBox='-1 -1 2 2' className='activity-analysis-pie-chart'>
-        <path d={pathData} fill='#348fdf'></path>
+      <svg viewBox="-1 -1 2 2" className="activity-analysis-pie-chart">
+        <path d={pathData} fill="#348fdf" />
       </svg>
-    )
+    );
   },
 
   classroomUnitId() {
-    return this.props.data.cuId || this.props.data.classroom_unit_id
+    return this.props.data.cuId || this.props.data.classroom_unit_id;
   },
 
   uaId() {
-    return this.props.data.uaId || this.props.data.ua_id
+    return this.props.data.uaId || this.props.data.ua_id;
   },
 
   unitId() {
-    return this.props.unitId || this.props.data.unit_id
+    return this.props.unitId || this.props.data.unit_id;
   },
 
   dueDate() {
-    return this.props.data.due_date || this.props.data.dueDate
+    return this.props.data.due_date || this.props.data.dueDate;
   },
 
   activityId() {
-    return this.props.data.activityId || this.props.data.activityUid || this.props.data.activity.uid
+    return this.props.data.activityId || this.props.data.activityUid || this.props.data.activity.uid;
   },
 
   activityName() {
-    return this.props.data.name || this.props.data.activity.name
+    return this.props.data.name || this.props.data.activity.name;
   },
 
   classification() {
-    return this.props.data.activityClassificationId
+    return this.props.data.activityClassificationId;
   },
 
   classroomId() {
-    return this.props.data.classroomId || this.props.data.classroom_id
+    return this.props.data.classroomId || this.props.data.classroom_id;
   },
 
   icon() {
-    const classification = this.classification()
+    const classification = this.classification();
     if (classification) {
       // then we're coming from the index and have an id
-      return `icon-${activityFromClassificationId(classification)}-green-no-border`
+      return `icon-${activityFromClassificationId(classification)}-green-no-border`;
     }
     // it is stupid that we are passing this in some of this components use create_activity_sessions
     //  but don't have time to deprecate it right now
-    return this.props.data.activity && this.props.data.activity.classification ? this.props.data.activity.classification.green_image_class : ''
+    return this.props.data.activity && this.props.data.activity.classification ? this.props.data.activity.classification.green_image_class : '';
   },
 
   lessonCompletedOrLaunch() {
     if (this.props.data.completed === 't') {
-      return <a className="report-link" target="_blank" href={`/teachers/progress_reports/report_from_classroom_unit_and_activity/${this.classroomUnitId()}/a/${this.activityId()}`}>View Report</a>
+      return <a className="report-link" target="_blank" href={`/teachers/progress_reports/report_from_classroom_unit_and_activity/${this.classroomUnitId()}/a/${this.activityId()}`}>View Report</a>;
     }
     if (this.props.data.studentCount === 0) {
-      return <a onClick={this.noStudentsWarning} id="launch-lesson">{this.props.data.started ? 'Resume Lesson' : 'Launch Lesson'}</a>
-    } else {
-      if (this.props.data.started) {
-        return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} className="resume-lesson">Resume Lesson</a>
-      } else {
-        return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} id="launch-lesson">Launch Lesson</a>
-      }
+      return <a onClick={this.noStudentsWarning} id="launch-lesson">{this.props.data.started ? 'Resume Lesson' : 'Launch Lesson'}</a>;
     }
+    if (this.props.data.started) {
+      return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} className="resume-lesson">Resume Lesson</a>;
+    }
+    return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} id="launch-lesson">Launch Lesson</a>;
   },
 
   noStudentsWarning() {
     if (window.confirm("You have no students in this class. Quill Lessons is a collaborative tool for teachers and students to work together. If you'd like to launch this lesson anyway, click OK below. Otherwise, click Cancel.")) {
-      window.location.href = `${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`
+      window.location.href = `${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`;
     }
   },
 
   isLesson() {
-    return this.props.lesson || this.classification() === 6
+    return this.props.lesson || this.classification() === 6;
   },
 
   deleteRow() {
     if (!this.props.report && !(this.isLesson())) {
-      const style = !this.props.data.ownedByCurrentUser ? {visibility: 'hidden'} : null
-      return <div className="pull-right" style={style}><img className="delete-classroom-activity h-pointer" onClick={this.hideUnitActivity} src="/images/x.svg" /></div>
+      const style = !this.props.data.ownedByCurrentUser ? { visibility: 'hidden', } : null;
+      return <div className="pull-right" style={style}><img className="delete-classroom-activity h-pointer" onClick={this.hideUnitActivity} src="/images/x.svg" /></div>;
     }
   },
 
   openModal() {
-    this.setState({ showModal: true, })
+    this.setState({ showModal: true, });
   },
 
   closeModal() {
-    this.setState({ showModal: false, })
+    this.setState({ showModal: false, });
   },
 
   renderModal() {
@@ -315,25 +293,25 @@ export default React.createClass({
         classroomUnitId={this.classroomUnitId()}
         closeModal={this.closeModal}
         completed={this.props.data.completed}
-      />)
+      />);
     }
   },
 
   render() {
     let link,
-      endRow
+      endRow;
     if (this.props.report) {
-      link = <a onClick={this.urlForReport} target="_new">{this.activityName()}</a>
-      endRow = Object.assign({}, styles.reportEndRow, {width: this.props.activityReport ? '350px' : '150px'})
+      link = <a onClick={this.urlForReport} target="_new">{this.activityName()}</a>;
+      endRow = Object.assign({}, styles.reportEndRow, { width: this.props.activityReport ? '350px' : '150px', });
     } else if (this.isLesson()) {
-      link = <span onClick={this.openModal}>{this.activityName()}</span>
-      endRow = styles.lessonEndRow
+      link = <span onClick={this.openModal}>{this.activityName()}</span>;
+      endRow = styles.lessonEndRow;
     } else {
-      link = <a href={this.anonymousPath()} target="_new">{this.activityName()}</a>
-      endRow = styles.endRow
+      link = <a href={this.anonymousPath()} target="_new">{this.activityName()}</a>;
+      endRow = styles.endRow;
     }
     return (
-      <div className="row activity" style={this.props.activityReport ? Object.assign({}, styles.row, {cursor: 'pointer'}) : styles.row} onClick={this.props.activityReport ? this.urlForReport : null}>
+      <div className="row activity" style={this.props.activityReport ? Object.assign({}, styles.row, { cursor: 'pointer', }) : styles.row} onClick={this.props.activityReport ? this.urlForReport : null}>
         <div className="starting-row">
           <div className="cell">
             <div className={`pull-left icon-wrapper ${this.icon()}`} />
@@ -351,6 +329,6 @@ export default React.createClass({
           {this.deleteRow()}
         </div>
       </div>
-    )
+    );
   },
-})
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/manage_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/manage_units.jsx
@@ -20,10 +20,12 @@ export default React.createClass({
       loaded: false,
       classrooms: this.getClassrooms(),
       selectedClassroomId: getParameterByName('classroom_id'),
+      activityWithRecommendationsIds: [],
     };
   },
 
   componentDidMount() {
+    this.getRecommendationIds();
     window.onpopstate = () => {
       this.setState({ loaded: false, selectedClassroomId: getParameterByName('classroom_id'), });
       this.getUnitsForCurrentClass();
@@ -34,6 +36,23 @@ export default React.createClass({
     request.get(`${process.env.DEFAULT_URL}/teachers/classrooms/classrooms_i_teach`, (error, httpStatus, body) => {
       const classrooms = JSON.parse(body).classrooms;
       this.handleClassrooms(classrooms);
+    });
+  },
+
+  getRecommendationIds() {
+    fetch(`${process.env.DEFAULT_URL}/teachers/progress_reports/activity_with_recommendations_ids`, {
+      method: 'GET',
+      mode: 'cors',
+      credentials: 'include',
+    }).then((response) => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      }
+      return response.json();
+    }).then((response) => {
+      this.setState({ activityWithRecommendationsIds: response.activityWithRecommendationsIds, });
+    }).catch((error) => {
+      console.log('error', error);
     });
   },
 
@@ -90,7 +109,7 @@ export default React.createClass({
       dueDate: u.due_date,
       ownedByCurrentUser: u.owned_by_current_user === 't',
       ownerName: u.owner_name,
-      uaId: u.unit_activity_id
+      uaId: u.unit_activity_id,
     });
     return caObj;
   },
@@ -121,7 +140,7 @@ export default React.createClass({
             dueDate: u.due_date,
             ownedByCurrentUser: u.owned_by_current_user === 't',
             ownerName: u.owner_name,
-            uaId: u.unit_activity_id
+            uaId: u.unit_activity_id,
           });
       }
     });
@@ -159,7 +178,7 @@ export default React.createClass({
         if (httpStatus && httpStatus.statusCode === 200) {
           const units = this.state.units;
           const modifiedUnits = _.map(units, (unit) => {
-            const modifiedUnit = unit
+            const modifiedUnit = unit;
             if (this.getIdFromUnit(modifiedUnit) === unitId) {
               if (modifiedUnit.classroom_activities) {
                 modifiedUnit.classroom_activities = _.reject(modifiedUnit.classroom_activities, ca => ca.ua_id === uaId);
@@ -172,7 +191,7 @@ export default React.createClass({
           this.setState({ units: modifiedUnits, });
         }
       }
-    )
+    );
   },
 
   updateDueDate(ua_id, date) {
@@ -214,6 +233,7 @@ export default React.createClass({
         hideUnit={this.hideUnit}
         data={this.state.units}
         updateMultipleDueDates={this.updateMultipleDueDates}
+        activityWithRecommendationsIds={this.state.activityWithRecommendationsIds}
       />);
     }
     const allClassroomsClassroom = { name: allClassroomKey, id: allClassroomKey, };

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/unit.jsx
@@ -36,17 +36,17 @@ export default React.createClass({
   },
 
   deleteOrLockedInfo() {
-    const firstCa = this.props.data.classroomActivities.values().next().value
-    const ownedByCurrentUser = firstCa.ownedByCurrentUser
+    const firstCa = this.props.data.classroomActivities.values().next().value;
+    const ownedByCurrentUser = firstCa.ownedByCurrentUser;
     if (!this.props.report && !this.props.lesson && ownedByCurrentUser) {
       return <span className="delete-unit" onClick={this.hideUnit}>Delete</span>;
     } else if (!ownedByCurrentUser) {
-      return <span className='locked-unit'>  <img src="https://assets.quill.org/images/icons/lock-activity-pack-icon.svg"/>Created By {firstCa.ownerName}</span>
+      return <span className="locked-unit">   <img src="https://assets.quill.org/images/icons/lock-activity-pack-icon.svg"  />Created By {firstCa.ownerName}</span>;
     }
   },
 
   editName() {
-    if(this.props.data.classroomActivities.values().next().value.ownedByCurrentUser) {
+    if (this.props.data.classroomActivities.values().next().value.ownedByCurrentUser) {
       let text,
         classy,
         inlineStyle;
@@ -137,7 +137,7 @@ export default React.createClass({
   },
 
   addClassroomActivityRow() {
-    if(this.props.data.classroomActivities.values().next().value.ownedByCurrentUser) {
+    if (this.props.data.classroomActivities.values().next().value.ownedByCurrentUser) {
       return this.props.report || this.props.lesson ? null : <AddClassroomActivityRow unitId={this.getUnitId()} unitName={this.props.data.unitName || this.props.data.unit.name} />;
     }
   },
@@ -155,6 +155,7 @@ export default React.createClass({
             hideClassroomActivity={this.props.hideClassroomActivity}
             unitId={this.props.data.unit.id}
             data={ca}
+            activityWithRecommendationsIds={this.state.activityWithRecommendationsIds}
           />
         );
       });
@@ -169,6 +170,7 @@ export default React.createClass({
             hideClassroomActivity={this.props.hideClassroomActivity}
             unitId={this.props.data.unitId}
             data={ca}
+            activityWithRecommendationsIds={this.state.activityWithRecommendationsIds}
           />
         );
       }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -1,82 +1,73 @@
-import React from 'react'
+import React from 'react';
 import request from 'request';
-import Units from '../../lesson_planner/manage_units/activities_units.jsx'
-import LoadingSpinner from '../../shared/loading_indicator.jsx'
-import EmptyProgressReport from '../../shared/EmptyProgressReport.jsx'
+import Units from '../../lesson_planner/manage_units/activities_units.jsx';
+import LoadingSpinner from '../../shared/loading_indicator.jsx';
+import EmptyProgressReport from '../../shared/EmptyProgressReport.jsx';
 import ItemDropdown from '../../general_components/dropdown_selectors/item_dropdown';
 import getParameterByName from '../../modules/get_parameter_by_name';
 
-'use strict'
+'use strict';
 
 export default React.createClass({
 
-	getInitialState: function() {
-		return {
-			allUnits: [],
-			units: [],
-			loaded: false,
-			selectedClassroomId: getParameterByName('classroom_id'),
-		}
-	},
+  getInitialState() {
+    return {
+      allUnits: [],
+      units: [],
+      loaded: false,
+      selectedClassroomId: getParameterByName('classroom_id'),
+    };
+  },
 
-	componentWillMount() {
-		document.getElementsByClassName('diagnostic-tab')[0].classList.remove('active');
-		document.getElementsByClassName('activity-analysis-tab')[0].classList.add('active');
-	},
+  componentWillMount() {
+    document.getElementsByClassName('diagnostic-tab')[0].classList.remove('active');
+    document.getElementsByClassName('activity-analysis-tab')[0].classList.add('active');
+  },
 
-	componentDidMount: function() {
-		this.getClassrooms();
-		request.get({
-			url: `${process.env.DEFAULT_URL}/teachers/units`,
-			data: { report: true }
-		}, (error, httpStatus, body) => {
-			if(error) {
-				alert('Unable to download your reports at this time.');
-			} else {
-				this.setAllUnits(JSON.parse(body));
-			}
-		});
-		window.onpopstate = () => {
-			this.setState({ loaded: false, selectedClassroomId: getParameterByName('classroom_id') });
-			this.getUnitsForCurrentClass();
-		};
-	},
+  componentDidMount() {
+    this.getClassrooms();
+    this.getUnits();
+    window.onpopstate = () => {
+      this.setState({ loaded: false, selectedClassroomId: getParameterByName('classroom_id'), });
+      this.getUnitsForCurrentClass();
+    };
+  },
 
-	getClassrooms() {
-		request.get(`${process.env.DEFAULT_URL}/teachers/classrooms/classrooms_i_teach`, (error, httpStatus, body) => {
-			const classrooms = JSON.parse(body).classrooms;
-			console.log('classrooms', classrooms.length)
-			if(classrooms.length > 0) {
-				this.setState({ classrooms }, () => this.getUnits());
-			} else {
-				this.setState({ empty: true, loaded: true, });
-			}
+  getClassrooms() {
+    request.get(`${process.env.DEFAULT_URL}/teachers/classrooms/classrooms_i_teach`, (error, httpStatus, body) => {
+      const classrooms = JSON.parse(body).classrooms;
+      console.log('classrooms', classrooms.length);
+      if (classrooms.length > 0) {
+        this.setState({ classrooms, }, () => this.getUnits());
+      } else {
+        this.setState({ empty: true, loaded: true, });
+      }
   	});
-	},
+  },
 
-	getUnits() {
-		request.get(`${process.env.DEFAULT_URL}/teachers/units`, (error, httpStatus, body) => {
-			this.setAllUnits(JSON.parse(body));
-		});
-	},
+  getUnits() {
+    request.get(`${process.env.DEFAULT_URL}/teachers/units?report=true`, (error, httpStatus, body) => {
+      this.setAllUnits(JSON.parse(body));
+    });
+  },
 
-	getUnitsForCurrentClass() {
-		if(this.state.selectedClassroomId) {
-			const selectedClassroom = this.state.classrooms.find(c => c.id === Number(this.state.selectedClassroomId));
-			const unitsInCurrentClassroom = this.state.allUnits.filter(unit=>unit.classrooms.find(classroom=>selectedClassroom.name === classroom.name))
-			this.setState({ units: unitsInCurrentClassroom, loaded: true });
-		} else {
-			this.setState({ units: this.state.allUnits, loaded: true })
-		}
-	},
+  getUnitsForCurrentClass() {
+    if (this.state.selectedClassroomId) {
+      const selectedClassroom = this.state.classrooms.find(c => c.id === Number(this.state.selectedClassroomId));
+      const unitsInCurrentClassroom = this.state.allUnits.filter(unit => unit.classrooms.find(classroom => selectedClassroom.name === classroom.name));
+      this.setState({ units: unitsInCurrentClassroom, loaded: true, });
+    } else {
+      this.setState({ units: this.state.allUnits, loaded: true, });
+    }
+  },
 
-	setAllUnits(data) {
-		this.setState({ allUnits: this.parseUnits(data)}, this.getUnitsForCurrentClass);
-	},
+  setAllUnits(data) {
+    this.setState({ allUnits: this.parseUnits(data), }, this.getUnitsForCurrentClass);
+  },
 
-	generateNewCaUnit(u) {
-		const assignedStudentCount = this.assignedStudentCount(u);
-		const classroom = {name: u.class_name, totalStudentCount: u.class_size, assignedStudentCount: assignedStudentCount}
+  generateNewCaUnit(u) {
+    const assignedStudentCount = this.assignedStudentCount(u);
+    const classroom = { name: u.class_name, totalStudentCount: u.class_size, assignedStudentCount, };
     const caObj = {
       classrooms: [classroom],
       classroomActivities: new Map(),
@@ -91,69 +82,70 @@ export default React.createClass({
       uaId: u.unit_activity_id,
       cuId: u.classroom_unit_id,
       activityClassificationId: u.activity_classification_id,
-			classroomId: u.classroom_id,
-			ownedByCurrentUser: u.owned_by_current_user === 't',
-			ownerName: u.owner_name,
+      classroomId: u.classroom_id,
+      ownedByCurrentUser: u.owned_by_current_user === 't',
+      ownerName: u.owner_name,
       dueDate: u.due_date,
-			numberOfAssignedStudents: assignedStudentCount,
-			completedCount: u.completed_count,
-			cumulativeScore: u.classroom_cumulative_score
-		});
+      numberOfAssignedStudents: assignedStudentCount,
+      completedCount: u.completed_count,
+      cumulativeScore: u.classroom_cumulative_score,
+    });
     return caObj;
   },
 
   parseUnits(data) {
     const parsedUnits = {};
     data.forEach((u) => {
-			const assignedStudentCount = this.assignedStudentCount(u);
+      const assignedStudentCount = this.assignedStudentCount(u);
       if (!parsedUnits[u.unit_id]) {
         // if this unit doesn't exist yet, go create it with the info from the first ca
         parsedUnits[u.unit_id] = this.generateNewCaUnit(u);
       } else {
         const caUnit = parsedUnits[u.unit_id];
-				if (caUnit.classrooms.findIndex(c => c.name === u.class_name) === -1) {
+        if (caUnit.classrooms.findIndex(c => c.name === u.class_name) === -1) {
           // add the info and student count from the classroom if it hasn't already been done
-          const classroom = {name: u.class_name, totalStudentCount: u.class_size, assignedStudentCount: assignedStudentCount}
+          const classroom = { name: u.class_name, totalStudentCount: u.class_size, assignedStudentCount, };
           caUnit.classrooms.push(classroom);
         }
         // if the activity info already exists, add to the completed count
 				// otherwise, add the activity info if it doesn't already exist
-				let completedCount, cumulativeScore;
-				if(caUnit.classroomActivities.has(u.activity_id)) {
-					completedCount = Number(caUnit.classroomActivities.get(u.activity_id).completedCount) + Number(u.completed_count)
-					cumulativeScore = Number(caUnit.classroomActivities.get(u.activity_id).cumulativeScore) + Number(u.classroom_cumulative_score)
-				} else {
-					cumulativeScore = Number(u.classroom_cumulative_score)
-					completedCount = Number(u.completed_count)
-				}
-				caUnit.classroomActivities.set(u.activity_id, this.classroomActivityData(u, assignedStudentCount, completedCount, cumulativeScore));
+        let completedCount,
+          cumulativeScore;
+        if (caUnit.classroomActivities.has(u.activity_id)) {
+          completedCount = Number(caUnit.classroomActivities.get(u.activity_id).completedCount) + Number(u.completed_count);
+          cumulativeScore = Number(caUnit.classroomActivities.get(u.activity_id).cumulativeScore) + Number(u.classroom_cumulative_score);
+        } else {
+          cumulativeScore = Number(u.classroom_cumulative_score);
+          completedCount = Number(u.completed_count);
+        }
+        caUnit.classroomActivities.set(u.activity_id, this.classroomActivityData(u, assignedStudentCount, completedCount, cumulativeScore));
       }
     });
     return this.orderUnits(parsedUnits);
   },
 
-	classroomActivityData(u, assignedStudentCount, completedCount, cumulativeScore) {
-		return {
-			name: u.activity_name,
-			uaId: u.unit_activity_id,
+  classroomActivityData(u, assignedStudentCount, completedCount, cumulativeScore) {
+    return {
+      name: u.activity_name,
+      uaId: u.unit_activity_id,
       cuId: u.classroom_unit_id,
-			activityId: u.activity_id,
-			created_at: u.unit_activity_created_at,
-			activityClassificationId: u.activity_classification_id,
-			classroomId: u.classroom_id,
-			ownedByCurrentUser: u.owned_by_current_user === 't',
-			ownerName: u.owner_name,
-			createdAt: u.ca_created_at,
-			dueDate: u.due_date,
-			numberOfAssignedStudents: assignedStudentCount,
-			cumulativeScore: cumulativeScore,
-			completedCount: completedCount
-		}
-	},
+      activityId: u.activity_id,
+      created_at: u.unit_activity_created_at,
+      activityClassificationId: u.activity_classification_id,
+      classroomId: u.classroom_id,
+      ownedByCurrentUser: u.owned_by_current_user === 't',
+      ownerName: u.owner_name,
+      createdAt: u.ca_created_at,
+      dueDate: u.due_date,
+      numberOfAssignedStudents: assignedStudentCount,
+      cumulativeScore,
+      completedCount,
+    };
+  },
 
-	assignedStudentCount(u) {
-		return u.number_of_assigned_students ? u.number_of_assigned_students : u.class_size;
-	},
+  assignedStudentCount(u) {
+    return u.number_of_assigned_students ? u.number_of_assigned_students : u.class_size;
+  },
 
   orderUnits(units) {
     const unitsArr = [];
@@ -161,66 +153,62 @@ export default React.createClass({
     return unitsArr;
   },
 
-	switchClassrooms(classroom) {
-		const path = '/teachers/progress_reports/diagnostic_reports/#/activity_packs'
+  switchClassrooms(classroom) {
+    const path = '/teachers/progress_reports/diagnostic_reports/#/activity_packs';
    	window.history.pushState({}, '', classroom.id ? `${path}?classroom_id=${classroom.id}` : path);
  		this.setState({ selectedClassroomId: classroom.id, }, () => this.getUnitsForCurrentClass());
   },
 
-	stateBasedComponent: function() {
-		if(!this.state.loaded) {
-			return <LoadingSpinner />;
-		} else {
-			let content;
+  stateBasedComponent() {
+    if (!this.state.loaded) {
+      return <LoadingSpinner />;
+    }
+    let content;
 
-			const allClassroomsClassroom = { name: 'All Classrooms' }
-			const classrooms = [allClassroomsClassroom].concat(this.state.classrooms);
-			const classroomWithSelectedId = classrooms.find(classroom => classroom.id === Number(this.state.selectedClassroomId));
-			const selectedClassroom = classroomWithSelectedId ? classroomWithSelectedId : allClassroomsClassroom;
+    const allClassroomsClassroom = { name: 'All Classrooms', };
+    const classrooms = [allClassroomsClassroom].concat(this.state.classrooms);
+    const classroomWithSelectedId = classrooms.find(classroom => classroom.id === Number(this.state.selectedClassroomId));
+    const selectedClassroom = classroomWithSelectedId || allClassroomsClassroom;
 
-			if(this.state.units.length === 0 && this.state.selectedClassroomId) {
-				content = (
-					<EmptyProgressReport
-						missing='activitiesForSelectedClassroom'
-						onButtonClick={() => {
-							this.setState({ selectedClassroomId: null, loaded: false });
-							this.getUnitsForCurrentClass();
-						}}
-					/>
+    if (this.state.units.length === 0 && this.state.selectedClassroomId) {
+      content = (
+    <EmptyProgressReport
+    missing="activitiesForSelectedClassroom"
+    onButtonClick={() => {
+    this.setState({ selectedClassroomId: null, loaded: false, });
+    this.getUnitsForCurrentClass();
+  }}
+  />
 				);
-			} else if(this.state.units.length === 0) {
-				content = <EmptyProgressReport missing='activities' />
-			} else {
-				content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units}/>
-			}
+    } else if (this.state.units.length === 0) {
+  content = <EmptyProgressReport missing="activities" />;
+} else {
+  content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units} />;
+}
 
-			return (
-				<div className='activity-analysis'>
-					<h1>Activity Analysis</h1>
-					<p>Open an activity analysis to view students' responses, the overall results on each question, and the concepts students need to practice.</p>
-					<div className="classroom-selector">
-						<p>Select a classroom:</p>
-						<ItemDropdown
-							items={classrooms}
-							callback={this.switchClassrooms}
-							selectedItem={selectedClassroom}
-						/>
-					</div>
-					{content}
-				</div>
-			)
+    return (
+      <div className="activity-analysis">
+    <h1>Activity Analysis</h1>
+    <p>Open an activity analysis to view students' responses, the overall results on each question, and the concepts students need to practice.</p>
+    <div className="classroom-selector">
+    <p>Select a classroom:</p>
+    <ItemDropdown
+    items={classrooms}
+    callback={this.switchClassrooms}
+    selectedItem={selectedClassroom}
+  />
+  </div>
+    {content}
+  </div>
+    );
+  },
 
-		}
-
-	},
-
-	render: function() {
-		return (
-			<div className="container manage-units">
-				{this.stateBasedComponent()}
-			</div>
-		);
-
-	}
+  render() {
+    return (
+      <div className="container manage-units">
+        {this.stateBasedComponent()}
+      </div>
+    );
+  },
 
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -16,6 +16,7 @@ export default React.createClass({
       units: [],
       loaded: false,
       selectedClassroomId: getParameterByName('classroom_id'),
+      activityWithRecommendationsIds: [],
     };
   },
 
@@ -27,10 +28,28 @@ export default React.createClass({
   componentDidMount() {
     this.getClassrooms();
     this.getUnits();
+    this.getRecommendationIds();
     window.onpopstate = () => {
       this.setState({ loaded: false, selectedClassroomId: getParameterByName('classroom_id'), });
       this.getUnitsForCurrentClass();
     };
+  },
+
+  getRecommendationIds() {
+    fetch(`${process.env.DEFAULT_URL}/teachers/progress_reports/activity_with_recommendations_ids`, {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'include',
+  }).then((response) => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      }
+      return response.json();
+    }).then((response) => {
+      this.setState({ activityWithRecommendationsIds: response.activityWithRecommendationsIds, });
+    }).catch((error) => {
+      console.log('error', error);
+    });
   },
 
   getClassrooms() {
@@ -172,34 +191,34 @@ export default React.createClass({
 
     if (this.state.units.length === 0 && this.state.selectedClassroomId) {
       content = (
-    <EmptyProgressReport
-    missing="activitiesForSelectedClassroom"
-    onButtonClick={() => {
-    this.setState({ selectedClassroomId: null, loaded: false, });
-    this.getUnitsForCurrentClass();
-  }}
-  />
+        <EmptyProgressReport
+          missing="activitiesForSelectedClassroom"
+          onButtonClick={() => {
+        this.setState({ selectedClassroomId: null, loaded: false, });
+        this.getUnitsForCurrentClass();
+      }}
+        />
 				);
     } else if (this.state.units.length === 0) {
-  content = <EmptyProgressReport missing="activities" />;
-} else {
-  content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units} />;
-}
+      content = <EmptyProgressReport missing="activities" />;
+    } else {
+      content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units} activityWithRecommendationsIds={this.state.activityWithRecommendationsIds} />;
+    }
 
     return (
       <div className="activity-analysis">
-    <h1>Activity Analysis</h1>
-    <p>Open an activity analysis to view students' responses, the overall results on each question, and the concepts students need to practice.</p>
-    <div className="classroom-selector">
-    <p>Select a classroom:</p>
-    <ItemDropdown
-    items={classrooms}
-    callback={this.switchClassrooms}
-    selectedItem={selectedClassroom}
-  />
-  </div>
-    {content}
-  </div>
+        <h1>Activity Analysis</h1>
+        <p>Open an activity analysis to view students' responses, the overall results on each question, and the concepts students need to practice.</p>
+        <div className="classroom-selector">
+          <p>Select a classroom:</p>
+          <ItemDropdown
+        items={classrooms}
+        callback={this.switchClassrooms}
+        selectedItem={selectedClassroom}
+      />
+        </div>
+        {content}
+      </div>
     );
   },
 


### PR DESCRIPTION
Fixes https://github.com/empirical-org/Empirical-Core/issues/4587

**Changes proposed in this pull request:**
- Pass report=true properly to the units controller
- only query scores if report true
- only load recommendation IDs once per page load instead of once per classroom activity.
- Correctly show recommendation button on activities with recommendations



**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
