### PR TITLE
fix referral typo

### DIFF
--- a/services/QuillLMS/app/views/referrals/index.html.erb
+++ b/services/QuillLMS/app/views/referrals/index.html.erb
@@ -28,7 +28,7 @@
         <span class='offset'>1</span>
       </span>
       <h2>Invite Teachers</h2>
-      <p>Share your referral link with teachers who have not yet signed up for Quill yet.</p>
+      <p>Share your referral link with teachers who have not signed up for Quill yet.</p>
     </div>
     <div class='step'>
       <span class='circle-icon'>
@@ -55,8 +55,8 @@
     <% if @unredeemed_credits > 0 %>
       Redeem at <%= link_to "My Subscriptions", subscriptions_path %>.
     <% end %>
-    
-    
+
+
     </p>
 
   </div>


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- copy on referral page said "Share your referral link with teachers who have not yet signed up for Quill yet," removed first yet

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?**  no

**Have the tests been updated?** no

**Reviewer:** @ddmck
