### PR TITLE
fix #4662 - add sort indicators to rows in user table

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/table/react-table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/table/react-table.scss
@@ -7,6 +7,16 @@
     display: none;
   }
 
+  .rt-thead .rt-th {
+    &.-sort-asc {
+      box-shadow: inset 0 3px 0 0 rgba(0,0,0,0.6);
+    }
+
+    &.-sort-desc {
+      box-shadow: inset 0 -3px 0 0 rgba(0,0,0,0.6);
+    }
+  }
+
   &.progress-report, &.unit-template-profile-activities {
     border: none;
     max-width: 950px;


### PR DESCRIPTION
Addresses issue #4662

**Changes proposed in this pull request:**
- add indicators to make it easier to tell what order something is being sorted in on user manager

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2018-10-08 at 2 22 40 pm](https://user-images.githubusercontent.com/18669014/46626536-a77c0d00-cb05-11e8-803c-aca50ded16b1.png)


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
