### PR TITLE
fix #4658, fix #4656 - scope student classroom relationship to visibility

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -93,6 +93,7 @@ protected
       JOIN users AS teacher ON teacher.id = classrooms_teachers.user_id
       WHERE sc.student_id = #{current_user.id}
       AND classrooms.visible = true
+      AND students_classrooms.visible = true
       ORDER BY sc.created_at ASC").to_a
   end
 


### PR DESCRIPTION
Addresses issue #4658, #4656

**Changes proposed in this pull request:**
- limit classrooms returned by students classrooms query to only ones where the students_classroom record is visible

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
