### PR TITLE
fix diagnostic incorrect sequence grading

### DIFF
--- a/services/QuillConnect/app/libs/conceptResults/fillInTheBlanks.js
+++ b/services/QuillConnect/app/libs/conceptResults/fillInTheBlanks.js
@@ -6,7 +6,8 @@ export function getConceptResultsForFillInTheBlanks(question) {
   const answer = question.attempts[0].submitted;
   let conceptResults = [];
   if (question.attempts[0].response) {
-    conceptResults = hashToCollection(question.attempts[0].response.conceptResults) || [];
+    const conceptResultObject = question.attempts[0].response.conceptResults || question.attempts[0].response.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
   } else {
     conceptResults = [];
   }

--- a/services/QuillConnect/app/libs/conceptResults/sentenceCombining.js
+++ b/services/QuillConnect/app/libs/conceptResults/sentenceCombining.js
@@ -6,7 +6,8 @@ export function getConceptResultsForSentenceCombining(question) {
   const answer = question.attempts[0].submitted;
   let conceptResults = [];
   if (question.attempts[0].response) {
-    conceptResults = hashToCollection(question.attempts[0].response.conceptResults) || [];
+    const conceptResultObject = question.attempts[0].response.conceptResults || question.attempts[0].response.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
   } else {
     conceptResults = [];
   }

--- a/services/QuillDiagnostic/app/libs/conceptResults/fillInTheBlanks.js
+++ b/services/QuillDiagnostic/app/libs/conceptResults/fillInTheBlanks.js
@@ -6,7 +6,8 @@ export function getConceptResultsForFillInTheBlanks(question) {
   const answer = question.attempts[0].response.text;
   let conceptResults = [];
   if (question.attempts[0].response) {
-    conceptResults = hashToCollection(question.attempts[0].response.conceptResults) || [];
+    const conceptResultObject = question.attempts[0].response.conceptResults || question.attempts[0].response.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
   } else {
     conceptResults = [];
   }

--- a/services/QuillDiagnostic/app/libs/conceptResults/sentenceCombining.js
+++ b/services/QuillDiagnostic/app/libs/conceptResults/sentenceCombining.js
@@ -6,7 +6,8 @@ export function getConceptResultsForSentenceCombining(question) {
   const answer = question.attempts[0].response.text;
   let conceptResults = [];
   if (question.attempts[0].response) {
-    conceptResults = hashToCollection(question.attempts[0].response.conceptResults) || [];
+    const conceptResultObject = question.attempts[0].response.conceptResults || question.attempts[0].response.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
   } else {
     conceptResults = [];
   }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- concept result formatter will recognize response's concept_results as well as conceptResults (appears to be primarily an inconsistency affecting incorrect sequences)

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?**  no

**Have the tests been updated?** no

**Reviewer:** @ddmck
