### PR TITLE
fix #4701 - fix issue with showing undefined message when cloning questions

### DIFF
--- a/services/QuillDiagnostic/app/actions/connectSentenceCombining.ts
+++ b/services/QuillDiagnostic/app/actions/connectSentenceCombining.ts
@@ -29,9 +29,6 @@ export function cloneConnectSentenceCombiningQuestion(uid: string) {
             json: { original_question_uid: uid, new_question_uid: diagnosticSentenceCombiningQuestion.key, }
           },
           (err, httpResponse, data) => {
-            // check again for number in state
-            // if equal to const set earlier, update the state
-            // otherwise, do nothing
             if (err) {
               dispatch({ type: C.ERROR_CLONING_CONNECT_SENTENCE_COMBINING_QUESTION })
             } else {

--- a/services/QuillDiagnostic/app/components/cloneConnect/cloneConnectQuestions.tsx
+++ b/services/QuillDiagnostic/app/components/cloneConnect/cloneConnectQuestions.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Question from './question.tsx'
+import Question from './question'
 import {
   cloneConnectSentenceCombiningQuestion
-} from '../../actions/connectSentenceCombining.ts'
+} from '../../actions/connectSentenceCombining'
 import {
   cloneConnectFillInBlankQuestion
-} from '../../actions/connectFillInBlank.ts'
+} from '../../actions/connectFillInBlank'
 import {
   cloneConnectSentenceFragment
-} from '../../actions/connectSentenceFragments.ts'
+} from '../../actions/connectSentenceFragments'
 
 class CloneConnectQuestions extends React.Component<any, any> {
   constructor(props) {
@@ -25,11 +25,13 @@ class CloneConnectQuestions extends React.Component<any, any> {
     } else if (connectFillInBlank.error !== this.props.connectFillInBlank.error) {
       window.alert(connectFillInBlank.error)
     } else if (connectFillInBlank.message !== this.props.connectFillInBlank.message) {
-      window.alert(connectSentenceFragments.message)
+      window.alert(connectFillInBlank.message)
     } else if (connectSentenceCombining.error !== this.props.connectSentenceCombining.error) {
+      debugger;
       window.alert(connectSentenceCombining.error)
     } else if (connectSentenceCombining.message !== this.props.connectSentenceCombining.message) {
-      window.alert(connectSentenceFragments.message)
+      debugger;
+      window.alert(connectSentenceCombining.message)
     }
   }
 


### PR DESCRIPTION
Addresses issue #4701

**Changes proposed in this pull request:**
- shows correct message when successfully cloning sentence combining or fill in blank question

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
