### PR TITLE
fix #4693 - adjust whitespace: pre-d text to wrap

### DIFF
--- a/services/QuillConnect/app/components/questions/response.jsx
+++ b/services/QuillConnect/app/components/questions/response.jsx
@@ -462,7 +462,7 @@ export default React.createClass({
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre' }}>{response.text}</span> {author}</p>
+                <p><span style={{ whiteSpace: 'preWrap' }}>{response.text}</span> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillDiagnostic/app/components/questions/response.jsx
+++ b/services/QuillDiagnostic/app/components/questions/response.jsx
@@ -462,7 +462,7 @@ export default React.createClass({
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre' }}>{response.text}</span> {author}</p>
+                <p><span style={{ whiteSpace: 'preWrap' }}>{response.text}</span> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillGrammar/src/components/questions/response.tsx
+++ b/services/QuillGrammar/src/components/questions/response.tsx
@@ -479,7 +479,7 @@ export default class Response extends React.Component<any, any> {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre' }}>{response.text}</span> {author}</p>
+                <p><span style={{ whiteSpace: 'preWrap' }}>{response.text}</span> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -71,7 +71,7 @@ export default React.createClass({
 			<tr key={attemptNum + answer}className={ScoreColor(averageScore)}>
 				<td>{`${NumberSuffix(attemptNum)} Submission`}</td>
 				<td />
-				<td><span style={{ whiteSpace: 'pre' }} >{answer}</span></td>
+				<td><span style={{ whiteSpace: 'preWrap' }} >{answer}</span></td>
 			</tr>
 		)
 	},

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.jsx
@@ -55,7 +55,7 @@ export default React.createClass({
 										<tr className={ScoreColor(data.score)}>
 											<td>Submission</td>
 											<td></td>
-											<td><span style={{ whiteSpace: 'pre' }}>{this.answer()}</span></td>
+											<td><span style={{ whiteSpace: 'preWrap' }}>{this.answer()}</span></td>
 										</tr>
 										{this.concepts()}
 	        				</tbody>


### PR DESCRIPTION
Addresses issue #4693

**Changes proposed in this pull request:**
- text that had `white-space: pre` set now has `white-space: pre-wrap` so it wraps appropriately.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="981" alt="screen shot 2018-10-18 at 2 20 57 pm" src="https://user-images.githubusercontent.com/18669014/47175477-309efb00-d2e1-11e8-8405-f361328e2362.png">


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
