### PR TITLE
fix #4686 - scope classrooms_i_teach_with_lessons to visible everything

### DIFF
--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -84,7 +84,11 @@ class TeachersController < ApplicationController
        JOIN unit_activities ON unit_activities.unit_id = units.id
        JOIN activities ON activities.id = unit_activities.activity_id
        WHERE activities.activity_classification_id = 6
-            AND classrooms_teachers.user_id = #{current_user.id}"
+            AND classrooms_teachers.user_id = #{current_user.id}
+            AND classrooms.visible = true
+            AND classroom_units.visible = true
+            AND units.visible = true
+            AND unit_activities.visible = true"
     ).to_a
     render json: {classrooms: classrooms}
   end


### PR DESCRIPTION
Addresses issue #4686

**Changes proposed in this pull request:**
- scope classrooms_i_teach_with_lessons query for launch lessons page to only return visible classrooms, classroom units, units, and unit activities

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
