### PR TITLE
fix #4616 - correctly order levels for activity search

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_filters/activity_search_filter.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_filters/activity_search_filter.jsx
@@ -49,7 +49,7 @@ export default React.createClass({
       options.sort(function(a, b) {
         let textA = a.name.toUpperCase();
         let textB = b.name.toUpperCase();
-        return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+        return textA.localeCompare(textB, 'en', { numeric: true, })
       });
     }
     // ensure that the show all option is always on the top


### PR DESCRIPTION
Addresses issue #4616

**Changes proposed in this pull request:**
- correctly order levels for activity search

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="251" alt="screen shot 2018-10-18 at 3 11 51 pm" src="https://user-images.githubusercontent.com/18669014/47178095-2fbd9780-d2e8-11e8-95c1-86b25e2ab048.png">


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
