### PR TITLE
add image link to blogposts so we can customize image on social media

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -17,6 +17,7 @@ class BlogPostsController < ApplicationController
     @most_recent_posts = BlogPost.where("draft = false AND id != #{@blog_post.id}").order('updated_at DESC').limit(3)
     @title = @blog_post.title
     @description = @blog_post.subtitle || @title
+    @image_link = @blog_post.image_link
   end
 
   def search

--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -62,7 +62,8 @@ class Cms::BlogPostsController < Cms::CmsController
                     :premium,
                     :external_link,
                     :published_at,
-                    :center_images
+                    :center_images,
+                    :image_link
                   )
   end
 

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -15,7 +15,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:type"               content="website" />
   <meta property="og:title"              content= "<%= @title || "Free tools to make your students better writers." %>" />
-  <meta property="og:image"              content=<%= image_url('share/facebook.png') %> />
+  <meta property="og:image"              content=<%=@image_link || image_url('share/facebook.png') %> />
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -27,6 +27,7 @@ export default class extends React.Component {
       id: p ? p.id : null,
       title: p ? p.title : '',
       subtitle: p ? p.subtitle : '',
+      imageLink: p ? p.image_link : '',
       body: p ? p.body : '',
       author_id: p ? p.author_id : 11 /* Quill Staff */,
       topic: p ? p.topic : 'Webinars',
@@ -52,6 +53,7 @@ export default class extends React.Component {
 
     this.handleTitleChange = this.handleTitleChange.bind(this)
     this.handleSubtitleChange = this.handleSubtitleChange.bind(this)
+    this.handleImageLinkChange = this.handleImageLinkChange.bind(this)
     this.handleBodyChange = this.handleBodyChange.bind(this)
     this.handleSubmitClick = this.handleSubmitClick.bind(this)
     this.handleTopicChange = this.handleTopicChange.bind(this)
@@ -138,6 +140,19 @@ export default class extends React.Component {
     });
   }
 
+  handleImageLinkChange(e) {
+    const targetValue = e.target.value;
+    let state = { imageLink: targetValue };
+    if(!this.state.previewCardHasAlreadyBeenManuallyEdited) {
+      state['blogPostPreviewImage'] = targetValue;
+    }
+    this.setState(state, () => {
+      if(!this.state.previewCardHasAlreadyBeenManuallyEdited) {
+        this.updatePreviewCardFromBlogPostPreview();
+      }
+    });
+  }
+
   handleBodyChange(e) {
     this.setState({body: e.target.value})
     const container = document.getElementById('markdown-content');
@@ -187,6 +202,7 @@ export default class extends React.Component {
         blog_post: {
           title: this.state.title,
           subtitle: this.state.subtitle,
+          image_link: this.state.imageLink,
           body: this.state.body,
           topic: this.state.topic,
           author_id: this.state.author_id,
@@ -575,6 +591,9 @@ export default class extends React.Component {
 
           <label>SEO Meta Description:</label>
           <input type="text" value={this.state.subtitle} onChange={this.handleSubtitleChange} />
+
+          <label>SEO Meta Image:</label>
+          <input type="text" value={this.state.imageLink} onChange={this.handleImageLinkChange} />
 
           <div className='short-fields'>
             <div>

--- a/services/QuillLMS/db/migrate/20181018195753_add_image_link_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20181018195753_add_image_link_to_blog_posts.rb
@@ -1,0 +1,5 @@
+class AddImageLinkToBlogPosts < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :image_link, :string
+  end
+end


### PR DESCRIPTION
Addresses issue #

*** has a migration ***

**Changes proposed in this pull request:**
- this adds an image_link attribute to blog posts so that we can set images in the meta tag to display on social media.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
