### PR TITLE
Do not allow title in the notifications card to grow

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
@@ -140,6 +140,7 @@
 
       ul {
         overflow-y: scroll;
+        flex-grow: 1;
       }
     }
 


### PR DESCRIPTION
Notifications title and content were both flex boxes and took up too much space, now only the content can grow.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
