### PR TITLE
fix order of concept results checker so the correct feedback displayed

### DIFF
--- a/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
+++ b/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
@@ -148,15 +148,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
       if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-          if (conceptID) {
-            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-            if (data) {
-              return <ConceptExplanation {...data} />;
-            }
-          }
-        } else if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -164,6 +156,14 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
+        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
+          if (conceptID) {
+            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+            if (data) {
+              return <ConceptExplanation {...data} />;
+            }
+          }
         } else if (this.getQuestion() && this.getQuestion().modelConceptUID) {
           const dataF = this.props.conceptsFeedback.data[this.getQuestion().modelConceptUID];
           if (dataF) {

--- a/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
+++ b/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
@@ -155,15 +155,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined  = getLatestAttempt(this.props.question.attempts);
       if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-          if (conceptID) {
-            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-            if (data) {
-              return <ConceptExplanation {...data} />;
-            }
-          }
-        } else if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -171,6 +163,14 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
+        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
+          if (conceptID) {
+            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+            if (data) {
+              return <ConceptExplanation {...data} />;
+            }
+          }
         } else if (this.getQuestion() && this.getQuestion().modelConceptUID) {
           const dataF = this.props.conceptsFeedback.data[this.getQuestion().modelConceptUID];
           if (dataF) {

--- a/services/QuillConnect/app/components/studentLessons/question.tsx
+++ b/services/QuillConnect/app/components/studentLessons/question.tsx
@@ -270,16 +270,16 @@ const playLessonQuestion = React.createClass<any, any>({
   renderConceptExplanation() {
     const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
     if (latestAttempt) {
-      if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-        const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-        if (conceptID) {
-          const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-          if (data) {
-            return <ConceptExplanation {...data} />;
+      if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
+          if (conceptID) {
+            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+            if (data) {
+              return <ConceptExplanation {...data} />;
+            }
           }
-        }
-      } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
-        const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
+      } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+        const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
         if (conceptID) {
           const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
           if (data) {

--- a/services/QuillDiagnostic/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
+++ b/services/QuillDiagnostic/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
@@ -149,15 +149,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
       if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-          if (conceptID) {
-            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-            if (data) {
-              return <ConceptExplanation {...data} />;
-            }
-          }
-        } else if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -165,6 +157,14 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
+        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
+          if (conceptID) {
+            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+            if (data) {
+              return <ConceptExplanation {...data} />;
+            }
+          }
         } else if (this.getQuestion() && this.getQuestion().modelConceptUID) {
           const dataF = this.props.conceptsFeedback.data[this.getQuestion().modelConceptUID];
           if (dataF) {

--- a/services/QuillDiagnostic/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
+++ b/services/QuillDiagnostic/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
@@ -155,15 +155,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined  = getLatestAttempt(this.props.question.attempts);
       if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-          if (conceptID) {
-            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-            if (data) {
-              return <ConceptExplanation {...data} />;
-            }
-          }
-        } else if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -171,6 +163,14 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
+        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+          const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
+          if (conceptID) {
+            const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+            if (data) {
+              return <ConceptExplanation {...data} />;
+            }
+          }
         } else if (this.getQuestion() && this.getQuestion().modelConceptUID) {
           const dataF = this.props.conceptsFeedback.data[this.getQuestion().modelConceptUID];
           if (dataF) {

--- a/services/QuillDiagnostic/app/components/studentLessons/question.tsx
+++ b/services/QuillDiagnostic/app/components/studentLessons/question.tsx
@@ -269,15 +269,7 @@ const playLessonQuestion = React.createClass<any, any>({
   renderConceptExplanation() {
     const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
     if (latestAttempt) {
-      if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
-        const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
-        if (conceptID) {
-          const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
-          if (data) {
-            return <ConceptExplanation {...data} />;
-          }
-        }
-      } else if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+      if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
           const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
           if (conceptID) {
             const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -285,6 +277,14 @@ const playLessonQuestion = React.createClass<any, any>({
               return <ConceptExplanation {...data} />;
             }
           }
+      } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+        const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
+        if (conceptID) {
+          const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
+          if (data) {
+            return <ConceptExplanation {...data} />;
+          }
+        }
       } else if (this.getQuestion() && this.getQuestion().modelConceptUID) {
         const dataF = this.props.conceptsFeedback.data[this.getQuestion().modelConceptUID];
         if (dataF) {


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- we were checking concept_results before conceptResults, which will sometimes only give us the generic question's concept result

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
