### PR TITLE
typeahead supports zipcode search

### DIFF
--- a/services/QuillLMS/app/views/schools/index.json.jbuilder
+++ b/services/QuillLMS/app/views/schools/index.json.jbuilder
@@ -20,7 +20,9 @@ json.ignore_nil! false
 json.meta do
   json.lat @lat
   json.lng @lng
+  json.search @search
   json.prefix @prefix
+  json.zipcode @zipcode
   json.radius @radius
   json.limit @limit
   json.request_time DateTime.now.to_s


### PR DESCRIPTION
emilia, this adds zipcode to search. one change -- rather than specifying `prefix`, specify `search` as a query param.

**/schools.json?lat=41.505493&lng=-81.681290&search=our%20lady&radius=5&limit=10**

or 

**/schools.json?search=our%20lady%2044102&radius=5&limit=10**

or 

**/schools.json?search=44102**