### PR TITLE
fix #4770 - allow students to move on from fill in blank after optimal response

### DIFF
--- a/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
@@ -314,8 +314,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
   showNextQuestionButton() {
     const { question, } = this.props;
     const latestAttempt = this.getLatestAttempt();
-    const readyForNext =
-      question.attempts ? question.attempts.length > 4 : false || (latestAttempt && latestAttempt.response.optimal);
+    const readyForNext = question.attempts.length > 4 || (latestAttempt && latestAttempt.response.optimal);
     if (readyForNext) {
       return true;
     } else {

--- a/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
@@ -314,7 +314,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
   showNextQuestionButton() {
     const { question, } = this.props;
     const latestAttempt = this.getLatestAttempt();
-    const readyForNext = question.attempts.length > 4 || (latestAttempt && latestAttempt.response.optimal);
+    const readyForNext = (question.attempts && question.attempts.length > 4) || (latestAttempt && latestAttempt.response.optimal);
     if (readyForNext) {
       return true;
     } else {


### PR DESCRIPTION
Addresses issue #4770

**Changes proposed in this pull request:**
- stop preventing students from moving on before four submissions for fill in blank question

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
