### PR TITLE
only delete cache when updated question is human graded

### DIFF
--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -48,8 +48,11 @@ class ResponsesController < ApplicationController
   # PATCH/PUT /responses/1
   def update
     new_vals = transformed_new_vals(response_params)
-    if @response.update(new_vals)
-      Rails.cache.delete("questions/#{@response.question_uid}/responses")
+    updated_response = @response.update(new_vals)
+    if updated_response
+      if updated_response.optimal != nil
+        Rails.cache.delete("questions/#{@response.question_uid}/responses")
+      end
       render json: @response
     else
       render json: @response.errors, status: :unprocessable_entity


### PR DESCRIPTION
this will only delete the cache when an updated question is human graded, which should speed up the rematching script.