### PR TITLE
fix #4809 - keep rendering cms pages that don't have new serialization implemented

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table.jsx
@@ -10,8 +10,12 @@ export default React.createClass({
   },
 
   furnishRows: function () {
-    var rows = this.props.data.resources.map((resource, index) => this.furnishRow(resource, index) );
-    return rows;
+    if (this.props.data.resources) {
+      var rows = this.props.data.resources.map((resource, index) => this.furnishRow(resource, index) );
+      return rows;
+    } else {
+      return []
+    }
   },
 
   furnishRow: function (resource, index) {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Cms.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Cms.jsx
@@ -52,58 +52,62 @@ export default React.createClass({
     // build map of included objects
     let includedObj = {};
     let x;
-    for (x = 0; x < data.included.length; x++) {
-      if (data.included[x].type == 'topics' || data.included[x].type == 'activities') {
-        includedObj[data.included[x].type + data.included[x].id] = data.included[x].attributes;
-      } else {
-        includedObj[data.included[x].type + data.included[x].id] = data.included[x];
+    if (data.included) {
+      for (x = 0; x < data.included.length; x++) {
+        if (data.included[x].type == 'topics' || data.included[x].type == 'activities') {
+          includedObj[data.included[x].type + data.included[x].id] = data.included[x].attributes;
+        } else {
+          includedObj[data.included[x].type + data.included[x].id] = data.included[x];
+        }
       }
-    }
-    // nest object under activities
+      // nest object under activities
 
-    // nest section and topic category on topic object 
-    let topicObj
-    for (x = 0; x < data.included.length; x++) {
-      if (data.included[x].type == 'topics') {
-        topicObj = data.included[x].attributes;
-        topicObj.section = includedObj[data.included[x].relationships.section.type + data.included[x].relationships.section.id];
-        topicObj.topic_category = includedObj[data.included[x].relationships.topic_category.type + data.included[x].relationships.topic_category.id];
-        includedObj[data.included[x].type + data.included[x].id] = topicObj;
-      } 
-    }
-    // nest topic on activities 
-    let actObj
-    for (x = 0; x < data.included.length; x++) {
-      if (data.included[x].type == 'activities') {
-        actObj = data.included[x].attributes;
-        actObj.topic = includedObj[data.included[x].relationships.topic.type + data.included[x].relationships.topic.id];
-        actObj.classification = includedObj[data.included[x].relationships.activity_classification.type + data.included[x].relationships.activity_classification.id];
-        includedObj[data.included[x].type + data.included[x].id] = actObj;
+      // nest section and topic category on topic object
+      let topicObj
+      for (x = 0; x < data.included.length; x++) {
+        if (data.included[x].type == 'topics') {
+          topicObj = data.included[x].attributes;
+          topicObj.section = includedObj[data.included[x].relationships.section.type + data.included[x].relationships.section.id];
+          topicObj.topic_category = includedObj[data.included[x].relationships.topic_category.type + data.included[x].relationships.topic_category.id];
+          includedObj[data.included[x].type + data.included[x].id] = topicObj;
+        }
       }
-    }
+      // nest topic on activities
+      let actObj
+      for (x = 0; x < data.included.length; x++) {
+        if (data.included[x].type == 'activities') {
+          actObj = data.included[x].attributes;
+          actObj.topic = includedObj[data.included[x].relationships.topic.type + data.included[x].relationships.topic.id];
+          actObj.classification = includedObj[data.included[x].relationships.activity_classification.type + data.included[x].relationships.activity_classification.id];
+          includedObj[data.included[x].type + data.included[x].id] = actObj;
+        }
+      }
 
-    let newData = [];
-    let newObj;
-    let i;
-    for (i = 0; i < data.data.length; i++) {
-      newObj = {
-        name:data.data[i].attributes.name,
-        unit_template_category: data.data[i].attributes.unit_template_category,
-        time: data.data[i].attributes.time,
-        grades:  data.data[i].attributes.grades,
-        author_id: data.data[i].attributes.author_id,
-        flag: data.data[i].attributes.flag,
-        order_number: data.data[i].attributes.order_number,
-        activity_info:  data.data[i].attributes.activity_info,
-        activities: data.data[i].relationships.activities.data.map(
-          function (rel) {
-            return includedObj[rel.type + rel.id] 
-          }
-        )
-      };
-      newData.push(newObj);
+      let newData = [];
+      let newObj;
+      let i;
+      for (i = 0; i < data.data.length; i++) {
+        newObj = {
+          name:data.data[i].attributes.name,
+          unit_template_category: data.data[i].attributes.unit_template_category,
+          time: data.data[i].attributes.time,
+          grades:  data.data[i].attributes.grades,
+          author_id: data.data[i].attributes.author_id,
+          flag: data.data[i].attributes.flag,
+          order_number: data.data[i].attributes.order_number,
+          activity_info:  data.data[i].attributes.activity_info,
+          activities: data.data[i].relationships.activities.data.map(
+            function (rel) {
+              return includedObj[rel.type + rel.id]
+            }
+          )
+        };
+        newData.push(newObj);
+      }
+      return newData;
+    } else {
+      return data[this.props.resourceNamePlural]
     }
-    return newData;
   },
 
   populateResources: function (resource) {
@@ -200,7 +204,7 @@ export default React.createClass({
   },
 
   isSortable: function () {
-    if(this.state[this.props.resourceNamePlural].length == 0) { return false }
+    if(this.state[this.props.resourceNamePlural] && this.state[this.props.resourceNamePlural].length == 0) { return false }
     const sortableResources = ['activity_classifications', 'unit_templates'];
     return sortableResources.includes(this.props.resourceNamePlural);
   },


### PR DESCRIPTION
Addresses issue #4809

**Changes proposed in this pull request:**
- preserve rendering functions for cms pages that have not been updated to use the new json serialization max implemented

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
