### PR TITLE
fix #4808 - fix buttons on minis

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/__tests__/__snapshots__/new_account_stage1.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/__tests__/__snapshots__/new_account_stage1.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`NewAccountStage1 component should render  1`] = `
 <BrowserRouter>
   <div
-    className="container account-form"
     id="sign-up"
   >
     <Route

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/champion_invitation_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/champion_invitation_mini.test.jsx.snap
@@ -83,9 +83,8 @@ exports[`ChampionInvitationMini component should render 1`] = `
         className="button button-white beta"
         style={
           Object {
-            "marginTop": "15px",
+            "margin": "15px auto 0px",
             "maxWidth": "233px",
-            "paddingBottom": "13px",
             "width": "100%",
           }
         }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/coteaching_announcement_mini_test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/coteaching_announcement_mini_test.jsx.snap
@@ -83,9 +83,8 @@ exports[`CoteachingAnnouncementMini component should render 1`] = `
         className="button button-white beta"
         style={
           Object {
-            "marginTop": "15px",
+            "margin": "15px auto 0px",
             "maxWidth": "233px",
-            "paddingBottom": "13px",
             "width": "100%",
           }
         }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/my_resources.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/my_resources.test.jsx
@@ -3,9 +3,9 @@ import { shallow } from 'enzyme';
 
 import MyResources from '../my_resources';
 
-import VideoMini from '../video_mini'
-import TeacherResourcesMini from '../teacher_resources_mini'
-import GoogleClassroomMini from '../google_classroom_mini'
+import TeacherResourcesMini from '../teacher_resources_mini';
+import TeacherBestPracticesMini from '../teacher_best_practices_mini';
+import ChampionInvitationMini from '../champion_invitation_mini';
 
 describe('MyResources component', () => {
 
@@ -16,9 +16,9 @@ describe('MyResources component', () => {
 
   it('should render VideoMini, TeacherResourcesMini, and GoogleClassroomMini', () => {
     const wrapper = shallow(<MyResources />);
-    expect(wrapper.find(VideoMini).exists()).toBe(true);
     expect(wrapper.find(TeacherResourcesMini).exists()).toBe(true);
-    expect(wrapper.find(GoogleClassroomMini).exists()).toBe(true);
+    expect(wrapper.find(TeacherBestPracticesMini).exists()).toBe(true);
+    expect(wrapper.find(ChampionInvitationMini).exists()).toBe(true);
   });
 
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/champion_invitation_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/champion_invitation_mini.jsx
@@ -16,7 +16,7 @@ class ChampionInvitationMini extends React.Component {
           <p style={{ padding: '0px 15px', lineHeight: '1.57', fontFamily: 'lucida-grande, adelle-sans, helvetica', }}>
             With the new Quill Referral Program, you can earn rewards for helping fellow educators discover Quill.
           </p>
-          <a style={{ display: 'block', marginBottom: '12px', }} href="/referrals"><button style={{ maxWidth: '233px', width: '100%', paddingBottom: '13px', marginTop: '15px', }} className="button button-white beta">Earn Rewards</button></a>
+          <a style={{ display: 'block', marginBottom: '12px', }} href="/referrals"><button style={{ maxWidth: '233px', width: '100%', margin: '15px auto 0px', }} className="button button-white beta">Earn Rewards</button></a>
           <a style={{ color: '#027360', }} target="_blank" href="/referrals_toc">Learn more about the Referral Program ></a>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/coteaching_announcement_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/coteaching_announcement_mini.jsx
@@ -16,7 +16,8 @@ export default React.createClass({
         <p style={{ padding: '0px 15px', lineHeight: '1.57', fontFamily: 'lucida-grande, adelle-sans, helvetica', }}>
         You can now invite co-teachers to your classes. Co-teachers can manage classes, assign activities and view reports.
       </p>
-        <a style={{ display: 'block', marginBottom: '12px', }} href="/teachers/classrooms#invite-coteachers"><button style={{ maxWidth: '233px', width: '100%', paddingBottom: '13px', marginTop: '15px', }} className="button button-white beta">Invite Co-Teachers</button></a>
+        <a style={{ display: 'block', marginBottom: '12px', }} href="/teachers/classrooms#invite-coteachers">
+          <button style={{ maxWidth: '233px', width: '100%', margin: '15px auto 0px', }} className="button button-white beta">Invite Co-Teachers</button></a>
         <a style={{ color: '#027360', }} target="_blank" href="http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher">Learn more about co-teaching ></a>
       </div>
     );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/__tests__/classroom_activity.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/__tests__/classroom_activity.test.jsx
@@ -17,7 +17,7 @@ describe('ClassroomActivity component', () => {
                 scorebook_icon_class: '',
               },
             },
-              activityId: 412, }}  
+              activityId: 412, }}
         />
       );
     expect(wrapper.find('.recommendations-button')).toHaveLength(0);
@@ -33,25 +33,10 @@ describe('ClassroomActivity component', () => {
                 scorebook_icon_class: '',
               },
           },
-            activityId: 413 ,}}  
+            activityId: 413 ,}}
         />
       );
     expect(wrapper.find('.recommendations-button')).toHaveLength(0);
-  });
-
-  it('should render Recommendations div if data.activityId is diagnostic id and it is on the activity analysis page', () => {
-    window.location.pathname = '/teachers/progress_reports/diagnostic_reports/';
-    const wrapper = shallow(
-      <ClassroomActivity
-        data={{ activity:
-        { anonymous_path: '',
-          classification: { scorebook_icon_class: '', },
-        },
-          activityId: 413 ,}}  
-      />
-    );
-    wrapper.setState({ activityWithRecommendationsIds: [413], });
-    expect(wrapper.find('.recommendations-button')).toHaveLength(1);
   });
 
   it('should render the Lessons End Row div if it is not a report and it gets the lesson prop', () => {


### PR DESCRIPTION
Addresses issue #4808

**Changes proposed in this pull request:**
- change in-line button styling for cards on dashboard that had gone wonky

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="334" alt="screen shot 2018-11-21 at 10 37 19 am" src="https://user-images.githubusercontent.com/18669014/48851611-7dab3c80-ed79-11e8-9ed3-5055618e2327.png">
<img width="327" alt="screen shot 2018-11-21 at 10 37 12 am" src="https://user-images.githubusercontent.com/18669014/48851617-81d75a00-ed79-11e8-8805-a79b890b6edf.png">


**Has this branch been QA'd on staging?**no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @ddmck
