### PR TITLE
fix #4776 - give teacher dropdown a min width and make sure it displays nicely

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -76,6 +76,12 @@
     padding: 0px 12px;
     font-size: 14px;
     cursor: pointer;
+    min-width: 144px;
+    justify-content: space-between;
+    span {
+      display: flex;
+      align-items: center;
+    }
     img {
       margin-right: 12px;
     }

--- a/services/QuillLMS/app/views/application/_sub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_sub_header.html.erb
@@ -53,7 +53,7 @@
   		<%- elsif current_user.role == 'teacher' %>
   			<div class='navigation-vertical-rule hide-on-mobile nav-element'></div>
   			<div id="nav-user-dropdown" class="dropdown-closed hide-on-mobile nav-element <%= user_dropdown_class %>">
-  				<span onclick="toggleDropdown()" class='user-dropdown-button'><img class='user-dropdown-button-img' src=<%="#{user_dropdown_img}"%>></img><%="#{current_user.name}"%></span>
+  				<span onclick="toggleDropdown()" class='user-dropdown-button'><span><img class='user-dropdown-button-img' src=<%="#{user_dropdown_img}"%>></img><%="#{current_user.name}"%></span></span>
   				<div>
   					<i class="fa fa-caret-up"></i>
   					<%= link_to raw(


### PR DESCRIPTION
Addresses issue #4776

**Changes proposed in this pull request:**
- give teacher dropdown a min width and make sure it displays nicely 

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="228" alt="screen shot 2018-11-21 at 11 24 31 am" src="https://user-images.githubusercontent.com/18669014/48854623-5441df00-ed80-11e8-8dec-25936e0ebf77.png">


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
