### PR TITLE
fix #4754 - coteachers launch lessons page

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -2,8 +2,8 @@ class Teachers::ClassroomManagerController < ApplicationController
   respond_to :json, :html
   before_filter :teacher_or_public_activity_packs
   # WARNING: these filter methods check against classroom_id, not id.
-  before_filter :authorize_owner!, except: [:scores, :scorebook]
-  before_filter :authorize_teacher!, only: [:scores, :scorebook]
+  before_filter :authorize_owner!, except: [:scores, :scorebook, :lesson_planner]
+  before_filter :authorize_teacher!, only: [:scores, :scorebook, :lesson_planner]
   include ScorebookHelper
 
   def lesson_planner

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
@@ -92,7 +92,7 @@ export default class ClassroomLessons extends React.Component {
   }
 
   switchClassrooms(classroom) {
-    window.location.href = (`${process.env.DEFAULT_URL}/teachers/classrooms/activity_planner/lessons/${classroom.id}`);
+    this.props.router.push(`${process.env.DEFAULT_URL}/teachers/classrooms/activity_planner/lessons/${classroom.id}`);
     this.setState({ selectedClassroomId: `${classroom.id}`, }, () => this.getLessonsForCurrentClass());
   }
 


### PR DESCRIPTION
Addresses issue #4754

**Changes proposed in this pull request:**
- allow coteachers to go to launch lessons page of cotaught classroom
- go back to using react router to switch between classes on launch lessons page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
