### PR TITLE
organize students by last name; add account type to login pdf

### DIFF
--- a/services/QuillLMS/app/pdfs/login_pdf.rb
+++ b/services/QuillLMS/app/pdfs/login_pdf.rb
@@ -44,10 +44,10 @@ class LoginPdf < Prawn::Document
   end
 
   def render_cover_page_table
-    header = [["<b><font size='12'>Name</font></b>", "<b><font size='12'>Username</font></b>", "<b><font size='12'> Default Password</font></b>"]]
+    header = [["<b><font size='12'>Name</font></b>", "<b><font size='12'>Account Type</font></b>", "<b><font size='12'>Username</font></b>", "<b><font size='12'> Default Password</font></b>"]]
     body = []
-    @classroom.students.each do |student|
-      body << [student.name, username_or_email_value_for_student(student), render_password_for_student(student)]
+    @classroom.students.sort_by { |s| s.name.split(' ')[1]}.each do |student|
+      body << [student.name, student.account_type, username_or_email_value_for_student(student), render_password_for_student(student)]
     end
     table(header, cell_style: {
       inline_format: true,
@@ -55,13 +55,13 @@ class LoginPdf < Prawn::Document
       background_color: 'EFEFEF',
       borders: [:top],
       border_color: 'DDDDDD'
-    }, column_widths: [182, 242, 140])
+    }, column_widths: [140, 140, 140, 140])
     table(body, cell_style: {
       padding: 10,
       size: 10,
       border_color: 'DDDDDD',
       borders: [:top, :bottom]
-    }, column_widths: [182, 242, 140])
+    }, column_widths: [140, 140, 140, 140])
   end
 
   def render_section_for_one_student(student)


### PR DESCRIPTION
Notion: https://www.notion.so/quill/Student-Login-PDF-Sort-Students-by-Last-Name-Include-Login-Account-Type-9cdaf5212c7445b68c0453060958ed3c

**Changes proposed in this pull request:**
- organize students by last name on login pdf
- add account type to login pdf

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
