### PR TITLE
change app to tool in tooltips

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
@@ -27,7 +27,7 @@ export default React.createClass({
       data-html="true"
       data-toggle="tooltip"
       data-placement="top"
-      title={`<h1>${this.props.data.name}</h1><p>App: ${this.props.data.activity_classification.alias}</p><p>${this.props.data.section.name}</p><p>${this.props.data.topic_name}</p><p>${this.props.data.description}</p>`}
+      title={`<h1>${this.props.data.name}</h1><p>Tool: ${this.props.data.activity_classification.alias}</p><p>${this.props.data.section.name}</p><p>${this.props.data.topic_name}</p><p>${this.props.data.description}</p>`}
     />)
     : <span />;
     return (

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/stage2/activity_due_date.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/stage2/activity_due_date.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
     return (
       <tr>
         <td style={{paddingLeft: '45px'}} className={this.props.activity.activity_classification ? `icon-${this.props.activity.activity_classification.id}-green-no-border` : ''}>
-          <div ref="activateTooltip" className='activate-tooltip' data-html="true" data-toggle="tooltip" data-placement="top" title={`<h1>${this.props.activity.name}</h1><p>App: ${this.props.activity.activity_classification.alias}</p><p>${this.props.activity.section.name}</p><p>${this.props.activity.description}</p>`} />
+          <div ref="activateTooltip" className='activate-tooltip' data-html="true" data-toggle="tooltip" data-placement="top" title={`<h1>${this.props.activity.name}</h1><p>Tool: ${this.props.activity.activity_classification.alias}</p><p>${this.props.activity.section.name}</p><p>${this.props.activity.description}</p>`} />
         </td>
         <td onMouseEnter={this.tooltipTrigger} onMouseLeave={this.tooltipTriggerStop} className="tooltip-trigger activity_name">{this.props.activity.name}</td>
         <td>


### PR DESCRIPTION
Notion: https://www.notion.so/quill/Change-text-from-app-to-tool-in-the-tooltips-2f8fe62d650c4234b97763118a237bea

**Changes proposed in this pull request:**
- Change "App" to "Tool" in tooltips to make language consistent

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
