### PR TITLE
batch reindex updated responses

### DIFF
--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -173,8 +173,8 @@ class ResponsesController < ApplicationController
   end
 
   def reindex_responses_updated_today_for_given_question
-    responses = Response.where("question_uid = ? AND updated_at >= ?", params[:question_uid], Time.zone.now.beginning_of_day)
-    responses.each { |response| response.update_index_in_elastic_search }
+    question_uid = params[:question_uid]
+    Response.__elasticsearch__.import query: -> { where("question_uid = ? AND updated_at >= ?", question_uid, Time.zone.now.beginning_of_day) }
   end
 
   private


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- use elasticsearch's import to batch reindex responses rather than doing each one individually

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
