### PR TITLE
fix #4791 - endless loading when teacher has no students

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -4,8 +4,12 @@ class Api::V1::ProgressReportsController < Api::ApiController
 
   def activities_scores_by_classroom_data
     classroom_ids = current_user.classrooms_i_teach.map(&:id)
-    data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids)
-    render json: { data: data }
+    if classroom_ids.length > 0
+      data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids)
+      render json: { data: data }
+    else
+      render json: { data: [] }
+    end
   end
 
   def real_time_data

--- a/services/QuillLMS/app/views/application/_sub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_sub_header.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <nav class="q-navbar-home">
-  <% if ['account/new', 'session', 'password_reset', 'sign-up'].any? { |str| current_path.include?(str)} %>
+  <% if ['account/new', '/session', 'password_reset', 'sign-up'].any? { |str| current_path.include?(str)} %>
     <div class="logo-only">
       <a href=<%= root_path %>>
         <img src="/images/quill_header_logo.svg" alt="Quill Logo">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -206,7 +206,7 @@ export default React.createClass({
 
     const allClassroomsClassroom = { name: 'All Classrooms', };
     const classrooms = [allClassroomsClassroom].concat(this.state.classrooms);
-    const classroomWithSelectedId = classrooms.find(classroom => classroom.id === Number(this.state.selectedClassroomId));
+    const classroomWithSelectedId = classrooms.find(classroom => classroom && classroom.id === Number(this.state.selectedClassroomId));
     const selectedClassroom = classroomWithSelectedId || allClassroomsClassroom;
 
     if (this.state.units.length === 0 && this.state.selectedClassroomId) {
@@ -221,7 +221,7 @@ export default React.createClass({
 				);
     } else if (this.state.units.length === 0) {
       content = <EmptyProgressReport missing="activities" />;
-    } else {
+    } else if {
       content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units} activityWithRecommendationsIds={this.state.activityWithRecommendationsIds} />;
     }
 
@@ -232,10 +232,10 @@ export default React.createClass({
         <div className="classroom-selector">
           <p>Select a classroom:</p>
           <ItemDropdown
-        items={classrooms}
-        callback={this.switchClassrooms}
-        selectedItem={selectedClassroom}
-      />
+            items={classrooms.filter(Boolean)}
+            callback={this.switchClassrooms}
+            selectedItem={selectedClassroom}
+          />
         </div>
         {content}
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -206,23 +206,31 @@ export default React.createClass({
 
     const allClassroomsClassroom = { name: 'All Classrooms', };
     const classrooms = [allClassroomsClassroom].concat(this.state.classrooms);
-    const classroomWithSelectedId = classrooms.find(classroom => classroom && classroom.id === Number(this.state.selectedClassroomId));
+    const classroomWithSelectedId = classrooms.find(classroom =>
+      classroom && classroom.id === Number(this.state.selectedClassroomId)
+    );
     const selectedClassroom = classroomWithSelectedId || allClassroomsClassroom;
 
-    if (this.state.units.length === 0 && this.state.selectedClassroomId) {
+    if (!this.state.classrooms || this.state.classrooms.filter(Boolean).length === 0) {
+      content = <EmptyProgressReport missing="classrooms" />;
+    } else if (this.state.units.length === 0 && this.state.selectedClassroomId) {
       content = (
         <EmptyProgressReport
           missing="activitiesForSelectedClassroom"
           onButtonClick={() => {
-        this.setState({ selectedClassroomId: null, loaded: false, });
-        this.getUnitsForCurrentClass();
-      }}
-        />
-				);
+            this.setState({ selectedClassroomId: null, loaded: false, });
+            this.getUnitsForCurrentClass();
+          }}
+        />);
     } else if (this.state.units.length === 0) {
       content = <EmptyProgressReport missing="activities" />;
-    } else if {
-      content = <Units report={Boolean(true)} activityReport={Boolean(true)} data={this.state.units} activityWithRecommendationsIds={this.state.activityWithRecommendationsIds} />;
+    } else {
+      content = (<Units
+        report={Boolean(true)}
+        activityReport={Boolean(true)}
+        data={this.state.units}
+        activityWithRecommendationsIds={this.state.activityWithRecommendationsIds}
+      />);
     }
 
     return (

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
@@ -122,7 +122,7 @@ export default React.createClass({
     const newCurrentPage = this.state.currentPage + 1;
     this.setState({ loading: true, currentPage: newCurrentPage, });
     if (!this.state.selectedClassroom) {
-      this.setState({ missing: 'classrooms', });
+      this.setState({ missing: 'classrooms', loading: false, });
       return;
     }
     $.ajax({


### PR DESCRIPTION
Addresses issue #4791

**Changes proposed in this pull request:**
- show empty state for activity summary, activity analysis, and activity scores pages rather than loading  spinner when a teacher has removed all of their classrooms

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
