### PR TITLE
fix #4843 - focus points and incorrect sequences not matching curly apostrophes

### DIFF
--- a/packages/quill-marking-logic/package-lock.json
+++ b/packages/quill-marking-logic/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/libs/matchers/focus_point_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/focus_point_match.ts
@@ -1,5 +1,6 @@
 import * as _ from 'underscore'
 import {getTopOptimalResponse} from '../sharedResponseFunctions'
+import {stringNormalize} from 'quill-string-normalizer'
 import {Response, FocusPoint, PartialResponse} from '../../interfaces'
 import {conceptResultTemplate} from '../helpers/concept_result_template'
 
@@ -16,7 +17,7 @@ export function focusPointMatch(responseString:string, focusPoints:Array<FocusPo
   // focusPts = [(Bob|||Katherine),(is|||was)]
   return _.find(focusPoints, (focusPoint) => {
     const options = focusPoint.text.split('|||');
-    const anyMatches = _.any(options, particle => focusPointMatchHelper(responseString, particle));
+    const anyMatches = _.any(options, particle => focusPointMatchHelper(stringNormalize(responseString), particle));
     return !anyMatches;
   }); // => null (1), (Bob|||Katherine) (2)
 

--- a/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
@@ -1,6 +1,7 @@
 import * as _ from 'underscore'
 import {getTopOptimalResponse} from '../sharedResponseFunctions'
 import {Response, IncorrectSequence, PartialResponse} from '../../interfaces'
+import {stringNormalize} from 'quill-string-normalizer'
 import {conceptResultTemplate} from '../helpers/concept_result_template'
 
 export function incorrectSequenceMatchHelper(responseString:string, incorrectSequenceParticle:string):boolean {
@@ -17,7 +18,7 @@ export function incorrectSequenceMatch(responseString: string, incorrectSequence
 }
 
 export function incorrectSequenceChecker(responseString: string, incorrectSequences:Array<IncorrectSequence>, responses:Array<Response>):PartialResponse|undefined {
-  const match = incorrectSequenceMatch(responseString, incorrectSequences);
+  const match = incorrectSequenceMatch(stringNormalize(responseString), incorrectSequences);
   if (match) {
     return incorrectSequenceResponseBuilder(match, responses)
   }

--- a/services/QuillConnect/package.json
+++ b/services/QuillConnect/package.json
@@ -132,7 +132,7 @@
     "promise-polyfill": "^6.0.2",
     "pusher-js": "^4.1.0",
     "quill-component-library": "^0.1.29",
-    "quill-marking-logic": "^0.7.6",
+    "quill-marking-logic": "^0.7.7",
     "raven-js": "^3.17.0",
     "react": "^15.6.2",
     "react-addons-css-transition-group": "^15.6.0",

--- a/services/QuillDiagnostic/package.json
+++ b/services/QuillDiagnostic/package.json
@@ -128,7 +128,7 @@
     "promise-polyfill": "^6.0.2",
     "pusher-js": "^4.1.0",
     "quill-component-library": "^0.1.29",
-    "quill-marking-logic": "^0.7.6",
+    "quill-marking-logic": "^0.7.7",
     "raven-js": "^3.17.0",
     "react": "15.6.2",
     "react-addons-css-transition-group": "^15.6.0",

--- a/services/QuillGrammar/package.json
+++ b/services/QuillGrammar/package.json
@@ -47,7 +47,7 @@
     "node-sass": "^4.9.3",
     "pusher-js": "^4.3.0",
     "quill-component-library": "^0.1.29",
-    "quill-marking-logic": "^0.7.6",
+    "quill-marking-logic": "^0.7.7",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",

--- a/services/QuillLessons/package.json
+++ b/services/QuillLessons/package.json
@@ -131,7 +131,7 @@
     "promise-polyfill": "^6.0.2",
     "pusher-js": "^4.1.0",
     "quill-component-library": "^0.1.29",
-    "quill-marking-logic": "^0.7.6",
+    "quill-marking-logic": "^0.7.7",
     "raven-js": "^3.17.0",
     "react": "15.6.2",
     "react-addons-css-transition-group": "^15.6.0",


### PR DESCRIPTION
Addresses issue #4843

**Changes proposed in this pull request:**
- update quill marking logic so focus point and incorrect sequence algorithms normalize the response string before attempting to match it

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
