### PR TITLE
fix #4848 - fix move activity sessions teacher fix

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -103,8 +103,12 @@ module TeacherFixes
       new_unit_name = "#{user.name}'s Activities from #{classroom_1.name}"
       unit = Unit.create(user_id: classroom_2.owner.id, name: new_unit_name)
       classroom_units.each do |ca|
-        new_ca = ClassroomUnit.find_or_create_by(unit_id: unit.id, classroom_id: classroom_2_id, assigned_student_ids: [user_id])
-        ActivitySession.where(classroom_unit_id: ca.id, user_id: user_id).each { |as| as.update(classroom_unit_id: new_ca.id)}
+        new_cu = ClassroomUnit.find_or_create_by(unit_id: unit.id, classroom_id: classroom_2_id, assigned_student_ids: [user_id])
+
+        ActivitySession.where(classroom_unit_id: ca.id, user_id: user_id).each do |as|
+          as.update(classroom_unit_id: new_cu.id)
+          UnitActivity.find_or_create_by(unit_id: unit.id, activity_id: as.activity_id)
+        end
         hide_extra_activity_sessions(ca.id, user_id)
       end
     end


### PR DESCRIPTION
Addresses issue #4848

**Changes proposed in this pull request:**
- move activity sessions teacher fix was not recreating unit activities when a student was moved between two different teachers' classes, but now it is

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no
**Have the tests been updated?** no

**Reviewer:** @ddmck
