### PR TITLE
handle lack of rule description better on grammar

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -15,6 +15,7 @@ import {
   startListeningToFollowUpQuestionsForProofreaderSession
 } from "../../actions/session";
 import { startListeningToConceptsFeedback } from '../../actions/conceptsFeedback'
+import { startListeningToConcepts } from '../../actions/concepts'
 import { getConceptResultsForAllQuestions, calculateScoreForLesson } from '../../helpers/conceptResultsGenerator'
 import { SessionState } from '../../reducers/sessionReducer'
 import { GrammarActivityState } from '../../reducers/grammarActivitiesReducer'
@@ -73,6 +74,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
 
     componentDidMount() {
       this.props.dispatch(startListeningToConceptsFeedback());
+      this.props.dispatch(startListeningToConcepts());
     }
 
     componentWillReceiveProps(nextProps: PlayGrammarContainerProps) {

--- a/services/QuillGrammar/src/components/grammarActivities/question.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/question.tsx
@@ -42,6 +42,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
       }
 
       this.toggleExample = this.toggleExample.bind(this)
+      this.example = this.example.bind(this)
       this.updateResponse = this.updateResponse.bind(this)
       this.checkAnswer = this.checkAnswer.bind(this)
       this.goToNextQuestion = this.goToNextQuestion.bind(this)
@@ -128,7 +129,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     }
 
     getConcept() {
-      return this.props.concepts.data[0].find((c: any) => c.uid === this.currentQuestion().concept_uid)
+      return this.props.concepts && this.props.concepts.data && this.props.concepts.data[0] ? this.props.concepts.data[0].find((c: any) => c.uid === this.currentQuestion().concept_uid) : null
     }
 
     onPressEnter = (e: any) => {
@@ -143,13 +144,16 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
       }
     }
 
-    renderExample(): JSX.Element|undefined {
-      let example
+    example(): JSX.Element|string|void {
       if (this.currentQuestion().rule_description && this.currentQuestion().rule_description.length && this.currentQuestion().rule_description !== "<br/>") {
-        example = this.currentQuestion().rule_description
+        return this.currentQuestion().rule_description
       } else if (this.getConcept() && this.getConcept().description) {
-        example = this.getConcept().description
+        return this.getConcept().description
       }
+    }
+
+    renderExample(): JSX.Element|undefined {
+      const example = this.example()
       if (example) {
         let componentClasses = 'example-container'
         if (this.state.showExample) {
@@ -161,6 +165,14 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
 
       } else {
         return undefined
+      }
+    }
+
+    renderExampleButton(): JSX.Element|void {
+      if (this.example()) {
+        return <Row type="flex" align="middle" justify="start">
+          <Button className="example-button" onClick={this.toggleExample}>{this.state.showExample ? 'Hide Example' : 'Show Example'}</Button>
+        </Row>
       }
     }
 
@@ -195,9 +207,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
             </div>
         </div>
       </Row>
-      <Row type="flex" align="middle" justify="start">
-        <Button className="example-button" onClick={this.toggleExample}>{this.state.showExample ? 'Hide Example' : 'Show Example'}</Button>
-      </Row>
+      {this.renderExampleButton()}
       {this.renderExample()}
       <Row type="flex" align="middle" justify="start">
         <img style={{ height: '22px', marginRight: '10px' }} src={questionIconSrc} />


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- get concepts on immediate load of grammar question
- don't show button if there is neither a rule description for the question nor a description for the concept

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
