### PR TITLE
fix bug in concept selector on grammar

### DIFF
--- a/services/QuillGrammar/src/components/shared/conceptSelector.tsx
+++ b/services/QuillGrammar/src/components/shared/conceptSelector.tsx
@@ -47,7 +47,7 @@ class ConceptSelector extends React.Component<ConceptSelectorProps> {
 
   placeholder() {
     const currentConcept = this.currentConcept()
-    if (this.props.currentConceptUID !== 'null' && this.props.currentConceptUID.length > 0 && currentConcept) {
+    if (this.props.currentConceptUID && this.props.currentConceptUID.length > 0 && currentConcept) {
       return currentConcept.displayName
     } else {
       return 'Please select a concept.'


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- get rid of bug in grammar concept selector that was preventing grammar activity editor from loading

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
