### PR TITLE
retrieve data for grammar and proofreader activities once

### DIFF
--- a/services/QuillGrammar/src/actions/grammarActivities.ts
+++ b/services/QuillGrammar/src/actions/grammarActivities.ts
@@ -18,9 +18,9 @@ export const startListeningToActivities = () => {
   }
 }
 
-export const startListeningToActivity = (activityUID: string) => {
+export const getActivity = (activityUID: string) => {
   return (dispatch: Function) => {
-    activitiesRef.child(activityUID).on('value', (snapshot: any) => {
+    activitiesRef.child(activityUID).once('value', (snapshot: any) => {
       const activity: GrammarActivity = snapshot.val()
       if (activity) {
         dispatch({ type: ActionTypes.RECEIVE_GRAMMAR_ACTIVITY_DATA, data: activity, });

--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -48,18 +48,18 @@ export const startListeningToFollowUpQuestionsForProofreaderSession = (proofread
           }
         })
         dispatch(saveProofreaderSessionToReducer(proofreaderSession))
-        dispatch(startListeningToQuestions(concepts))
+        dispatch(getQuestionsForConcepts(concepts))
       }
     })
   }
 }
 
 // typescript this
-export const startListeningToQuestions = (concepts: any) => {
+export const getQuestionsForConcepts = (concepts: any) => {
   return dispatch => {
 
     const conceptUIDs = Object.keys(concepts)
-    questionsRef.orderByChild('concept_uid').on('value', (snapshot) => {
+    questionsRef.orderByChild('concept_uid').once('value', (snapshot) => {
       const questions = snapshot.val()
       const questionsForConcepts = {}
       Object.keys(questions).map(q => {

--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -5,10 +5,10 @@ import * as request from 'request';
 import * as _ from 'lodash';
 import { Response } from 'quill-marking-logic'
 import getParameterByName from '../../helpers/getParameterByName';
-import { startListeningToActivity } from "../../actions/grammarActivities";
+import { getActivity } from "../../actions/grammarActivities";
 import {
   updateSessionOnFirebase,
-  startListeningToQuestions,
+  getQuestionsForConcepts,
   goToNextQuestion,
   checkAnswer,
   setSessionReducerToSavedSession,
@@ -63,7 +63,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       }
 
       if (activityUID) {
-        this.props.dispatch(startListeningToActivity(activityUID))
+        this.props.dispatch(getActivity(activityUID))
       }
 
       if (proofreaderSessionId) {
@@ -80,7 +80,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
     componentWillReceiveProps(nextProps: PlayGrammarContainerProps) {
       if (nextProps.grammarActivities.hasreceiveddata && !nextProps.session.hasreceiveddata && !nextProps.session.error) {
         const concepts = nextProps.grammarActivities.currentActivity.concepts
-        this.props.dispatch(startListeningToQuestions(concepts))
+        this.props.dispatch(getQuestionsForConcepts(concepts))
       }
 
       if (nextProps.session.hasreceiveddata && !nextProps.session.currentQuestion && nextProps.session.unansweredQuestions.length === 0 && nextProps.session.answeredQuestions.length > 0) {

--- a/services/QuillProofreader/src/actions/proofreaderActivities.ts
+++ b/services/QuillProofreader/src/actions/proofreaderActivities.ts
@@ -19,9 +19,9 @@ export const startListeningToActivities = () => {
   }
 }
 
-export const startListeningToActivity = (activityUID: string) => {
+export const getActivity = (activityUID: string) => {
   return (dispatch: Function) => {
-    activitiesRef.child(activityUID).on('value', (snapshot: any) => {
+    activitiesRef.child(activityUID).once('value', (snapshot: any) => {
       const activity: ProofreaderActivities = snapshot.val()
       if (activity) {
         dispatch({ type: ActionTypes.RECEIVE_PROOFREADER_ACTIVITY_DATA, data: activity, });

--- a/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
+++ b/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
@@ -8,7 +8,7 @@ import { stringNormalize } from 'quill-string-normalizer'
 const questionIconSrc = `${process.env.QUILL_CDN_URL}/images/icons/question_icon.svg`
 
 import getParameterByName from '../../helpers/getParameterByName';
-import { startListeningToActivity } from "../../actions/proofreaderActivities";
+import { getActivity } from "../../actions/proofreaderActivities";
 import { startListeningToConcepts } from "../../actions/concepts";
 import {
   updateConceptResultsOnFirebase,
@@ -85,7 +85,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       }
 
       if (activityUID) {
-        this.props.dispatch(startListeningToActivity(activityUID))
+        this.props.dispatch(getActivity(activityUID))
       }
 
     }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- we were listening for changes on the activity and questions when students loaded an activity, but this was sometimes reloading the activity. now we just get the data once.

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
