### PR TITLE
give grammar attempts numbers so teachers can see individual answers

### DIFF
--- a/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
+++ b/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
@@ -1,47 +1,58 @@
 import { ConceptResult } from 'quill-marking-logic'
 import { hashToCollection } from 'quill-component-library/dist/componentLibrary';
 import * as _ from 'lodash'
-import { Question, FormattedConceptResult } from '../interfaces/questions'
+import { Question, FormattedConceptResult, ResponseAttempt } from '../interfaces/questions'
+
+const scoresForNAttempts = {
+  1: 1,
+  2: 0.5,
+};
 
 export function getConceptResultsForQuestion(question: Question): FormattedConceptResult[]|undefined {
   const prompt = question.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '');
   if (question.attempts) {
-    const answer = question.attempts[0].text;
-    let conceptResults: ConceptResult[]|never = [];
-    if (question.attempts[0]) {
-      const conceptResultObject = question.attempts[0].conceptResults || question.attempts[0].concept_results
-      conceptResults = hashToCollection(conceptResultObject) || [];
-    } else {
-      conceptResults = [];
-    }
-    conceptResults = Array.isArray(conceptResults) ? conceptResults : _.values(conceptResults)
-    if (conceptResults.length === 0) {
-      conceptResults = [{
-        conceptUID: question.concept_uid,
-        correct: false,
-      }];
-    } else if (!conceptResults.find(cr => cr.conceptUID === question.concept_uid )) {
-      conceptResults.push({
-        conceptUID: question.concept_uid,
-        correct: false,
-      })
-    }
-    const directions = question.instructions;
-    return conceptResults.map((conceptResult: ConceptResult) => {
-      return {
-        concept_uid: conceptResult.conceptUID,
-        question_type: 'sentence-writing',
-        metadata: {
-          correct: conceptResult.correct ? 1 : 0,
-          directions,
-          prompt,
-          answer,
-          question_uid:  question.uid
-        },
-      }});
+    return question.attempts.map((a, i) => getConceptResultsForAttempt(a, question, prompt, i)).flat(2)
   } else {
     return undefined
   }
+}
+
+function getConceptResultsForAttempt(attempt: ResponseAttempt, question: Question, prompt: string, index: Number):FormattedConceptResult[] {
+  const answer = attempt.text;
+  let conceptResults: ConceptResult[]|never = [];
+  if (attempt) {
+    const conceptResultObject = attempt.conceptResults || attempt.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
+  } else {
+    conceptResults = [];
+  }
+  conceptResults = Array.isArray(conceptResults) ? conceptResults : _.values(conceptResults)
+  if (conceptResults.length === 0) {
+    conceptResults = [{
+      conceptUID: question.concept_uid,
+      correct: false,
+    }];
+  } else if (!conceptResults.find(cr => cr.conceptUID === question.concept_uid )) {
+    conceptResults.push({
+      conceptUID: question.concept_uid,
+      correct: false,
+    })
+  }
+  const directions = question.instructions;
+  const attemptNumber = index + 1
+  return conceptResults.map((conceptResult: ConceptResult) => {
+    return {
+      concept_uid: conceptResult.conceptUID,
+      question_type: 'sentence-writing',
+      metadata: {
+        correct: conceptResult.correct ? 1 : 0,
+        directions,
+        prompt,
+        answer,
+        attemptNumber,
+        question_uid:  question.uid
+      },
+    }});
 }
 
 export function getNestedConceptResultsForAllQuestions(questions: Question[]) {
@@ -51,8 +62,13 @@ export function getNestedConceptResultsForAllQuestions(questions: Question[]) {
 export function embedQuestionNumbers(nestedConceptResultArray: FormattedConceptResult[][], startingNumber: number): FormattedConceptResult[][] {
   return nestedConceptResultArray.map((conceptResultArray, index) => {
     return conceptResultArray.map((conceptResult: FormattedConceptResult) => {
+      const lastAttempt = _.sortBy(conceptResultArray, (conceptResult) => {
+        return conceptResult.metadata.attemptNumber;
+      }).reverse()[0]
+      const maxAttemptNo = lastAttempt && lastAttempt.optimal ? lastAttempt.metadata.attemptNumber : undefined;
+      const questionScore = scoresForNAttempts[maxAttemptNo] || 0;
       conceptResult.metadata.questionNumber = startingNumber + index + 1;
-      conceptResult.metadata.questionScore = conceptResult.metadata.correct ? 1 : 0
+      conceptResult.metadata.questionScore = questionScore
       return conceptResult;
     })
   });

--- a/services/QuillGrammar/src/interfaces/questions.ts
+++ b/services/QuillGrammar/src/interfaces/questions.ts
@@ -1,6 +1,6 @@
 import { Response, ConceptResult } from 'quill-marking-logic'
 
-type ResponseAttempt = Response & { conceptResults: { [key: string]: ConceptResult } }
+export type ResponseAttempt = Response & { conceptResults: { [key: string]: ConceptResult } }
 
 export interface Questions {
   [key: string]: Question


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- we were not numbering the grammar attempts, so all concept results were being lumped together

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
