### PR TITLE
fix focus point issue and null check error in concept workers

### DIFF
--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -45,7 +45,7 @@ class ConceptReplacementConnectWorker
   end
 
   def replace_focus_points_or_incorrect_sequences_for_question(fp_or_is, original_concept_uid, new_concept_uid)
-    if fp_or_is.any { |k, v| v['conceptResults'] && v['conceptResults'].any { |cr| cr['conceptUID'] == original_concept_uid} }
+    if fp_or_is.any? { |k, v| v['conceptResults'] && v['conceptResults'].any { |cr| cr['conceptUID'] == original_concept_uid} }
       new_fp_or_is = fp_or_is.dup
       fp_or_is.each do |k, v|
         v['conceptResults'].each do |crkey, cr|

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -4,7 +4,7 @@ class ConceptReplacementGrammarWorker
   def perform(original_concept_uid, new_concept_uid)
     activities = HTTParty.get("#{ENV['FIREBASE_DATABASE_URL']}/v3/grammarActivities.json").parsed_response
     activities.each do |key, act|
-      if act['concepts'].keys.include?(original_concept_uid)
+      if act['concepts'] && acts['concepts'].keys.include?(original_concept_uid)
         new_concepts = act['concepts'].dup
         new_concepts[new_concept_uid] = new_concepts[original_concept_uid]
         new_concepts.delete(original_concept_uid)


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix typo in focus point replacement
- check that grammar activity has concepts before calling .keys on it

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
