### PR TITLE
check before calling flat on conceptResults

### DIFF
--- a/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
+++ b/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
@@ -10,8 +10,13 @@ const scoresForNAttempts = {
 
 export function getConceptResultsForQuestion(question: Question): FormattedConceptResult[]|undefined {
   const prompt = question.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '');
-  if (question.attempts) {
-    return question.attempts.map((a, i) => getConceptResultsForAttempt(a, question, prompt, i)).flat(2)
+  if (question.attempts && question.attempts.length) {
+    const conceptResults = question.attempts.map((a, i) => getConceptResultsForAttempt(a, question, prompt, i))
+    if (conceptResults && conceptResults.length) {
+      return conceptResults.flat(2)
+    } else {
+      return undefined
+    }
   } else {
     return undefined
   }
@@ -70,7 +75,7 @@ export function embedQuestionNumbers(nestedConceptResultArray: FormattedConceptR
 }
 
 export function getConceptResultsForAllQuestions(questions: Question[], startingNumber:number = 0): FormattedConceptResult[] {
-  const nested = getNestedConceptResultsForAllQuestions(questions);
+  const nested = getNestedConceptResultsForAllQuestions(questions).filter(Boolean);
   const withKeys = embedQuestionNumbers(nested, startingNumber);
   return [].concat.apply([], withKeys); // Flatten array
 }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- rewrite concept results generator in grammar to check before calling .flat on concept results array because some students were getting errors in their console around that

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
