### PR TITLE
replace .flat call with _.flatten

### DIFF
--- a/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
+++ b/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
@@ -13,7 +13,7 @@ export function getConceptResultsForQuestion(question: Question): FormattedConce
   if (question.attempts && question.attempts.length) {
     const conceptResults = question.attempts.map((a, i) => getConceptResultsForAttempt(a, question, prompt, i))
     if (conceptResults && conceptResults.length) {
-      return conceptResults.flat(2)
+      return _.flatten(conceptResults)
     } else {
       return undefined
     }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- replace .flat call with _.flatten because .flat is not supported on all browsers

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
