### PR TITLE
fix #4753 - activity pack dropdown displays on activity summary page load

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
@@ -96,9 +96,14 @@ export default React.createClass({
       const selectedClassroom = this.state.classrooms.find(c => c.id === selectedClassroomId);
       if (selectedClassroom) {
         state.selectedClassroom = selectedClassroom;
+      } else {
+        state.selectedClassroom = this.props.allClassrooms[0]
       }
     } else {
       state.selectedClassroom = this.props.allClassrooms[0]
+    }
+    if (state.selectedClassroom) {
+      this.getUpdatedUnits(state.selectedClassroom.id)
     }
     if (dateFilterName) {
       const dateRangeFilterOption = this.DATE_RANGE_FILTER_OPTIONS.find(o => o.title === dateFilterName)


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix issue where activity pack options wouldn't load until teachers selected a class from the dropdown
- fix issue where staff members switching between teacher accounts would only see the loading spinner until they selected a class from the dropdown

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
