### PR TITLE
move tooltip over activity name instead of tool icon

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_results/activity_search_result.jsx
@@ -21,28 +21,28 @@ export default React.createClass({
     const selectedClass = this.props.selected ? 'selected' : '';
     const toolTip = this.props.data.activity_classification
 
-    ? (<div
-      ref="activateTooltip"
-      className={`icon-${this.props.data.activity_classification.id}-green-no-border`}
-      data-html="true"
-      data-toggle="tooltip"
-      data-placement="top"
-      title={`<h1>${this.props.data.name}</h1><p>Tool: ${this.props.data.activity_classification.alias}</p><p>${this.props.data.section.name}</p><p>${this.props.data.topic_name}</p><p>${this.props.data.description}</p>`}
-    />)
+    ? (<td className="activity_name">
+        <a
+          className="activity_link"
+          href={this.props.data.anonymous_path}
+          target="_new"
+          ref="activateTooltip"
+          data-html="true"
+          data-toggle="tooltip"
+          data-placement="top"
+          title={`<h1>${this.props.data.name}</h1><p>Tool: ${this.props.data.activity_classification.alias}</p><p>${this.props.data.section.name}</p><p>${this.props.data.topic_name}</p><p>${this.props.data.description}</p>`}
+        >
+          {this.props.data.name}
+        </a>
+    </td>)
     : <span />;
     return (
       <tr onMouseEnter={this.tooltipTrigger} onMouseLeave={this.tooltipTriggerStop} className={`tooltip-trigger ${selectedClass}`}>
         <td>{this.props.data.activity_category ? this.props.data.activity_category.name : ''}</td>
         <td>
-          {toolTip}
+          <div className={`icon-${this.props.data.activity_classification.id}-green-no-border`} />
         </td>
-        <td className="activity_name">
-          <a className="activity_link" href={this.props.data.anonymous_path} target="_new">
-            {this.props.data.name}
-          </a>
-        </td>
-
-
+        {toolTip}
         <td>
           <input type="checkbox" checked={this.props.selected} onChange={this.callToggleActivitySelection} id={`activity_${this.props.data.id}`} data-model-id={this.props.data.id} className="css-checkbox" />
           <label htmlFor={`activity_${this.props.data.id}`} id={`activity_${this.props.data.id}`} className="css-label" />


### PR DESCRIPTION
Addresses issue #
Notion: https://www.notion.so/quill/Move-the-tool-tip-from-displaying-over-tools-to-over-activity-names-in-the-create-custom-activity-packs-table-3f5a6a7324b7416b9f75fde64f131e41

**Changes proposed in this pull request:**
- move tooltip so it displays over activity name instead of over tool icon

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![screen shot 2018-12-14 at 12 26 45 pm](https://user-images.githubusercontent.com/18669014/50017965-ca122280-ff9b-11e8-8c52-ae2433a098d8.png)


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
