### PR TITLE
fix #4884 - cache district admin reports

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -20,22 +20,46 @@ class Api::V1::ProgressReportsController < Api::ApiController
 
   def district_activity_scores
     if current_user.admin?
-      data = ProgressReports::DistrictActivityScores.new(current_user.id).results
-      render json: { data: data }
+      serialized_district_activity_scores_json = $redis.get("SERIALIZED_DISTRICT_ACTIVITY_SCORES_FOR_#{current_user.id}")
+      if serialized_district_activity_scores_json
+        serialized_district_activity_scores = JSON.parse(serialized_district_activity_scores_json)
+      end
+      if serialized_district_activity_scores.nil?
+        FindDistrictActivityScoresWorker.perform_async(current_user.id)
+        render json: { id: current_user.id }
+      else
+        render json: { data: serialized_district_activity_scores }
+      end
     end
   end
 
   def district_concept_reports
     if current_user.admin?
-      data = ProgressReports::DistrictConceptReports.new(current_user.id).results
-      render json: { data: data }
+      serialized_district_concept_reports_json = $redis.get("SERIALIZED_DISTRICT_CONCEPT_REPORTS_FOR_#{current_user.id}")
+      if serialized_district_concept_reports_json
+        serialized_district_concept_reports = JSON.parse(serialized_district_concept_reports_json)
+      end
+      if serialized_district_concept_reports.nil?
+        FindDistrictConceptReportsWorker.perform_async(current_user.id)
+        render json: { id: current_user.id }
+      else
+        render json: { data: serialized_district_concept_reports }
+      end
     end
   end
 
   def district_standards_reports
     if current_user.admin?
-      data = ProgressReports::DistrictStandardsReports.new(current_user.id).results
-      render json: { data: data }
+      serialized_district_standards_reports_json = $redis.get("SERIALIZED_DISTRICT_STANDARDS_REPORTS_FOR_#{current_user.id}")
+      if serialized_district_standards_reports_json
+        serialized_district_standards_reports = JSON.parse(serialized_district_standards_reports_json)
+      end
+      if serialized_district_standards_reports.nil?
+        FindDistrictStandardsReportsWorker.perform_async(current_user.id)
+        render json: { id: current_user.id }
+      else
+        render json: { data: serialized_district_standards_reports }
+      end
     end
   end
 

--- a/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
@@ -1,0 +1,17 @@
+module PusherAdminUsersCompleted
+
+  def self.run(admin_id)
+    pusher_client = Pusher::Client.new(
+        app_id: ENV["PUSHER_APP_ID"],
+        key: ENV["PUSHER_KEY"],
+        secret: ENV["PUSHER_SECRET"],
+        encrypted: true
+    )
+    pusher_client.trigger(
+      admin_id.to_s,
+     "admin-users-found",
+     message: "Admin users found for #{admin_id}."
+   )
+  end
+
+end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
@@ -1,0 +1,17 @@
+module PusherDistrictActivityScoresCompleted
+
+  def self.run(admin_id)
+    pusher_client = Pusher::Client.new(
+        app_id: ENV["PUSHER_APP_ID"],
+        key: ENV["PUSHER_KEY"],
+        secret: ENV["PUSHER_SECRET"],
+        encrypted: true
+    )
+    pusher_client.trigger(
+      admin_id.to_s,
+     'district-activity-scores-found',
+     message: "District activity scores found for #{admin_id}."
+   )
+  end
+
+end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
@@ -1,0 +1,17 @@
+module PusherDistrictConceptReportsCompleted
+
+  def self.run(admin_id)
+    pusher_client = Pusher::Client.new(
+        app_id: ENV["PUSHER_APP_ID"],
+        key: ENV["PUSHER_KEY"],
+        secret: ENV["PUSHER_SECRET"],
+        encrypted: true
+    )
+    pusher_client.trigger(
+      admin_id.to_s,
+     'district-concept-reports-found',
+     message: "District concept reports found for #{admin_id}."
+   )
+  end
+
+end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
@@ -1,0 +1,17 @@
+module PusherDistrictStandardsReportsCompleted
+
+  def self.run(admin_id)
+    pusher_client = Pusher::Client.new(
+        app_id: ENV["PUSHER_APP_ID"],
+        key: ENV["PUSHER_KEY"],
+        secret: ENV["PUSHER_SECRET"],
+        encrypted: true
+    )
+    pusher_client.trigger(
+      admin_id.to_s,
+     'district-standards-reports-found',
+     message: "District standards reports found for #{admin_id}."
+   )
+  end
+
+end

--- a/services/QuillLMS/app/workers/find_admin_users_worker.rb
+++ b/services/QuillLMS/app/workers/find_admin_users_worker.rb
@@ -1,0 +1,12 @@
+class FindAdminUsersWorker
+  include Sidekiq::Worker
+
+  def perform(admin_id)
+    user = User.find(admin_id)
+    serialized_admin_users_cache_life = 60*60*25
+    serialized_admin_users = UserAdminSerializer.new(user, root: false).to_json
+    $redis.set("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users)
+    $redis.expire("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users_cache_life)
+    PusherAdminUsersCompleted.run(admin_id)
+  end
+end

--- a/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
@@ -1,0 +1,11 @@
+class FindDistrictActivityScoresWorker
+  include Sidekiq::Worker
+
+  def perform(admin_id)
+    serialized_district_activity_scores_cache_life = 60*60*25
+    serialized_district_activity_scores = ProgressReports::DistrictActivityScores.new(admin_id).results.to_json
+    $redis.set("SERIALIZED_DISTRICT_ACTIVITY_SCORES_FOR_#{admin_id}", serialized_district_activity_scores)
+    $redis.expire("SERIALIZED_DISTRICT_ACTIVITY_SCORES_FOR_#{admin_id}", serialized_district_activity_scores_cache_life)
+    PusherDistrictActivityScoresCompleted.run(admin_id)
+  end
+end

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -1,0 +1,11 @@
+class FindDistrictConceptReportsWorker
+  include Sidekiq::Worker
+
+  def perform(admin_id)
+    serialized_district_concept_reports_cache_life = 60*60*25
+    serialized_district_concept_reports = ProgressReports::DistrictConceptReports.new(admin_id).results.to_json
+    $redis.set("SERIALIZED_DISTRICT_CONCEPT_REPORTS_FOR_#{admin_id}", serialized_district_concept_reports)
+    $redis.expire("SERIALIZED_DISTRICT_CONCEPT_REPORTS_FOR_#{admin_id}", serialized_district_concept_reports_cache_life)
+    PusherDistrictConceptReportsCompleted.run(admin_id)
+  end
+end

--- a/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
@@ -1,0 +1,11 @@
+class FindDistrictStandardsReportsWorker
+  include Sidekiq::Worker
+
+  def perform(admin_id)
+    serialized_district_standards_reports_cache_life = 60*60*25
+    serialized_district_standards_reports = ProgressReports::DistrictStandardsReports.new(admin_id).results.to_json
+    $redis.set("SERIALIZED_DISTRICT_STANDARDS_REPORTS_FOR_#{admin_id}", serialized_district_standards_reports)
+    $redis.expire("SERIALIZED_DISTRICT_STANDARDS_REPORTS_FOR_#{admin_id}", serialized_district_standards_reports_cache_life)
+    PusherDistrictStandardsReportsCompleted.run(admin_id)
+  end
+end

--- a/services/QuillLMS/client/app/actions/district_activity_scores.js
+++ b/services/QuillLMS/client/app/actions/district_activity_scores.js
@@ -1,6 +1,7 @@
 import request from 'request';
+import Pusher from 'pusher-js';
 
-export const recieveDistrictActivityScores = (body) => {
+export const receiveDistrictActivityScores = (body) => {
   return { type: 'RECIEVE_DISTRICT_ACTIVITY_SCORES', body, };
 };
 
@@ -16,13 +17,31 @@ export const switchTeacher = (teacher) => {
   return { type: 'SWITCH_TEACHER', teacher, };
 }
 
+export const initializePusherForDistrictActivityScores = (adminId) => {
+  return (dispatch) => {
+    if (process.env.RAILS_ENV === 'development') {
+      Pusher.logToConsole = true;
+    }
+    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, });
+    const channel = pusher.subscribe(adminId);
+    channel.bind('district-activity-scores-found', () => {
+      dispatch(getDistrictActivityScores())
+    });
+  }
+}
+
 export const getDistrictActivityScores = () => {
   return (dispatch) => {
     request.get({
       url: `${process.env.DEFAULT_URL}/api/v1/progress_reports/district_activity_scores`
     },
     (e, r, body) => {
-      dispatch(recieveDistrictActivityScores(body))
+      const parsedBody = JSON.parse(body)
+      if (parsedBody.id) {
+        dispatch(initializePusherForDistrictActivityScores(String(parsedBody.id)))
+      } else {
+        dispatch(receiveDistrictActivityScores(parsedBody))
+      }
     });
   }
 };

--- a/services/QuillLMS/client/app/actions/district_concept_reports.js
+++ b/services/QuillLMS/client/app/actions/district_concept_reports.js
@@ -1,4 +1,5 @@
 import request from 'request';
+import Pusher from 'pusher-js';
 
 export const recieveDistrictConceptReports = (body) => {
   return { type: 'RECIEVE_DISTRICT_CONCEPT_REPORTS', body, };
@@ -16,13 +17,31 @@ export const switchTeacher = (teacher) => {
   return { type: 'SWITCH_TEACHER', teacher, };
 }
 
+export const initializePusherForDistrictConceptReports = (adminId) => {
+  return (dispatch) => {
+    if (process.env.RAILS_ENV === 'development') {
+      Pusher.logToConsole = true;
+    }
+    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, });
+    const channel = pusher.subscribe(adminId);
+    channel.bind('district-concept-reports-found', () => {
+      dispatch(getDistrictConceptReports())
+    });
+  }
+}
+
 export const getDistrictConceptReports = () => {
   return (dispatch) => {
     request.get({
       url: `${process.env.DEFAULT_URL}/api/v1/progress_reports/district_concept_reports`
     },
     (e, r, body) => {
-      dispatch(recieveDistrictConceptReports(body))
+      const parsedBody = JSON.parse(body)
+      if (parsedBody.id) {
+        dispatch(initializePusherForDistrictConceptReports(String(parsedBody.id)))
+      } else {
+        dispatch(recieveDistrictConceptReports(parsedBody))
+      }
     });
   }
 };

--- a/services/QuillLMS/client/app/actions/district_standards_reports.js
+++ b/services/QuillLMS/client/app/actions/district_standards_reports.js
@@ -1,4 +1,5 @@
 import request from 'request';
+import Pusher from 'pusher-js';
 
 export const recieveDistrictStandardsReports = (body) => {
   return { type: 'RECIEVE_DISTRICT_STANDARDS_REPORTS', body, };
@@ -16,13 +17,31 @@ export const switchTeacher = (teacher) => {
   return { type: 'SWITCH_TEACHER', teacher, };
 }
 
+export const initializePusherForDistrictStandardsReports = (adminId) => {
+  return (dispatch) => {
+    if (process.env.RAILS_ENV === 'development') {
+      Pusher.logToConsole = true;
+    }
+    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, });
+    const channel = pusher.subscribe(adminId);
+    channel.bind('district-standards-reports-found', () => {
+      dispatch(getDistrictStandardsReports())
+    });
+  }
+}
+
 export const getDistrictStandardsReports = () => {
   return (dispatch) => {
     request.get({
       url: `${process.env.DEFAULT_URL}/api/v1/progress_reports/district_standards_reports`
     },
     (e, r, body) => {
-      dispatch(recieveDistrictStandardsReports(body))
+      const parsedBody = JSON.parse(body)
+      if (parsedBody.id) {
+        dispatch(initializePusherForDistrictStandardsReports(String(parsedBody.id)))
+      } else {
+        dispatch(recieveDistrictStandardsReports(parsedBody))
+      }
     });
   }
 };

--- a/services/QuillLMS/client/app/reducers/district_activity_scores.js
+++ b/services/QuillLMS/client/app/reducers/district_activity_scores.js
@@ -33,7 +33,7 @@ export default function districtActivityScores(state = initialState, action) {
       return updateObject(state, {
         loading: false,
         errors: action.body.errors,
-        classroomsData: JSON.parse(action.body).data,
+        classroomsData: action.body.data,
       });
     default:
       return state;

--- a/services/QuillLMS/client/app/reducers/district_concept_reports.js
+++ b/services/QuillLMS/client/app/reducers/district_concept_reports.js
@@ -33,7 +33,7 @@ export default function districtConceptReports(state = initialState, action) {
       return updateObject(state, {
         loading: false,
         errors: action.body.errors,
-        conceptReportsData: JSON.parse(action.body).data,
+        conceptReportsData: action.body.data,
       });
     default:
       return state;

--- a/services/QuillLMS/client/app/reducers/district_standards_reports.js
+++ b/services/QuillLMS/client/app/reducers/district_standards_reports.js
@@ -34,7 +34,7 @@ export default function districtStandardsReports(state = initialState, action) {
       return updateObject(state, {
         loading: false,
         errors: action.body.errors,
-        standardsReportsData: JSON.parse(action.body).data,
+        standardsReportsData: action.body.data,
       });
     default:
       return state;

--- a/services/QuillLMS/lib/tasks/reset_admin_caches.rake
+++ b/services/QuillLMS/lib/tasks/reset_admin_caches.rake
@@ -1,0 +1,11 @@
+namespace :admin_caches do
+  desc 'reset caches for district admin reports'
+  task :reset => :environment do
+    SchoolsAdmins.all.each do |sa|
+      FindAdminUsersWorker.perform_async(sa.user_id)
+      FindDistrictConceptReportsWorker.perform_async(sa.user_id)
+      FindDistrictStandardsReportsWorker.perform_async(sa.user_id)
+      FindDistrictActivityScoresWorker.perform_async(sa.user_id)
+    end
+  end
+end


### PR DESCRIPTION
Addresses issue #4884

**when we deploy this we will also want to add `rake admin_caches:reset` to the heroku scheduler**

**Changes proposed in this pull request:**
- add caching for admin reports pages
- add rake task to reset caches (will schedule to run every 24 hours)

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
