### PR TITLE
fix #4888 - don't pull questions with invalid data for grammar activities

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -63,7 +63,7 @@ export const getQuestionsForConcepts = (concepts: any) => {
       const questions = snapshot.val()
       const questionsForConcepts = {}
       Object.keys(questions).map(q => {
-        if (conceptUIDs.includes(questions[q].concept_uid)) {
+        if (conceptUIDs.includes(questions[q].concept_uid) && questions[q].prompt && questions[q].answers && questions[q].flag !== 'archived') {
           const question = questions[q]
           question.uid = q
           if (questionsForConcepts.hasOwnProperty(question.concept_uid)) {


### PR DESCRIPTION
Addresses issue #4888

**Changes proposed in this pull request:**
- check for prompt, answers, and non-archived flag before putting question in a grammar activity

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
