### PR TITLE
use roles constant instead of querying for possible user roles

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -271,7 +271,7 @@ protected
   def set_search_inputs
     @text_search_inputs = ['user_name', 'user_username', 'user_email', 'user_ip', 'school_name']
     @school_premium_types = Subscription.account_types
-    @user_role_types = User.select('DISTINCT role').map { |r| r.role }
+    @user_role_types = User::ROLES
     @all_search_inputs = @text_search_inputs + ['user_premium_status', 'user_role', 'page', 'user_flag']
   end
 


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- use roles constant from user model file rather than querying for unique roles for user manager 

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
