### PR TITLE
change format for saving concept results for new optimal answers

### DIFF
--- a/services/QuillGrammar/src/actions/questions.ts
+++ b/services/QuillGrammar/src/actions/questions.ts
@@ -172,7 +172,7 @@ export const submitQuestionEdit = (qid: string, content: Question) => {
 export const saveOptimalResponse = (qid: string, conceptUid: string, answer: {text: string}) => {
   return (dispatch: Function) => {
     if (answer.text) {
-      const conceptResults = [{[conceptUid]: true}]
+      const conceptResults = [{ conceptUID: conceptUid, correct: true }]
       const formattedResponse = {
         optimal: true,
         count: 1,


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- when you create a new grammar question, the concept results for the new optimal answer get saved correctly

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
