### PR TITLE
no grammar submissions before responses load

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/question.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/question.tsx
@@ -26,7 +26,7 @@ interface QuestionState {
   response: string;
   questionStatus: string;
   submittedEmptyString: boolean
-  responses: Response[]
+  responses: {[key:number]: Response}
 }
 
 export class QuestionComponent extends React.Component<QuestionProps, QuestionState> {
@@ -38,7 +38,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
         response: '',
         questionStatus: 'unanswered',
         submittedEmptyString: false,
-        responses: []
+        responses: {}
       }
 
       this.toggleExample = this.toggleExample.bind(this)
@@ -90,14 +90,16 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     }
 
     checkAnswer() {
-      const response = this.state.response
+      const { response, responses } = this.state
       const question = this.currentQuestion()
       const isFirstAttempt = !question.attempts || question.attempts.length === 0
-      if (this.state.response !== '') {
-        this.props.checkAnswer(response, question, this.state.responses, isFirstAttempt)
-        this.setState({submittedEmptyString: false})
-      } else {
-        this.setState({submittedEmptyString: true})
+      if (Object.keys(responses).length) {
+        if (response !== '') {
+          this.props.checkAnswer(response, question, responses, isFirstAttempt)
+          this.setState({submittedEmptyString: false})
+        } else {
+          this.setState({submittedEmptyString: true})
+        }
       }
     }
 
@@ -176,14 +178,16 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
       }
     }
 
-    renderCheckAnswerButton(): JSX.Element {
-      const { questionStatus } = this.state
-      if (questionStatus === 'unanswered') {
-        return <Button className="check-answer-button" onClick={this.checkAnswer}>Check Work</Button>
-      } else if (questionStatus === 'incorrectly answered') {
-        return <Button className="check-answer-button" onClick={this.checkAnswer}>Recheck Work</Button>
-      } else {
-        return <Button className="check-answer-button" onClick={this.goToNextQuestion}>Next Problem</Button>
+    renderCheckAnswerButton(): JSX.Element|void {
+      const { questionStatus, responses } = this.state
+      if (Object.keys(responses).length) {
+        if (questionStatus === 'unanswered') {
+          return <Button className="check-answer-button" onClick={this.checkAnswer}>Check Work</Button>
+        } else if (questionStatus === 'incorrectly answered') {
+          return <Button className="check-answer-button" onClick={this.checkAnswer}>Recheck Work</Button>
+        } else {
+          return <Button className="check-answer-button" onClick={this.goToNextQuestion}>Next Problem</Button>
+        }
       }
     }
 

--- a/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
+++ b/services/QuillGrammar/src/helpers/conceptResultsGenerator.ts
@@ -35,13 +35,8 @@ function getConceptResultsForAttempt(attempt: ResponseAttempt, question: Questio
   if (conceptResults.length === 0) {
     conceptResults = [{
       conceptUID: question.concept_uid,
-      correct: false,
+      correct: !!attempt.optimal
     }];
-  } else if (!conceptResults.find(cr => cr.conceptUID === question.concept_uid )) {
-    conceptResults.push({
-      conceptUID: question.concept_uid,
-      correct: false,
-    })
   }
   const directions = question.instructions;
   const attemptNumber = index + 1

--- a/services/QuillGrammar/src/styles/question.scss
+++ b/services/QuillGrammar/src/styles/question.scss
@@ -75,6 +75,10 @@
   .prompt {
     font-size: 22px;
     font-family: 'courier new';
+    -webkit-user-select: none; /* Safari */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Standard */
   }
 
   .input-field {


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- do not allow students to submit responses to grammar questions before we get the responses from the cms
- do not allow copy and pasting the prompt
- do not allow students to submit the same response twice

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
