### PR TITLE
make sure that we have good data in resumed session

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -23,7 +23,24 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
     sessionsRef.child(sessionID).once('value', (snapshot) => {
       const session = snapshot.val()
       if (session && !session.error) {
-        dispatch(setSessionReducer(session))
+        questionsRef.orderByChild('concept_uid').once('value', (questionsSnapshot) => {
+          const allQuestions = questionsSnapshot.val()
+          if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
+            const currentQuestion = allQuestions[session.currentQuestion.uid]
+            currentQuestion.uid = session.currentQuestion.uid
+            session.currentQuestion = currentQuestion
+          }
+          session.unansweredQuestions = session.unansweredQuestions.map((q) => {
+            if (q.prompt && q.answers && q.uid) {
+              return q
+            } else {
+              const question = allQuestions[q.uid]
+              question.uid = q.uid
+              return question
+            }
+          })
+          dispatch(setSessionReducer(session))
+        })
       }
     })
   }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- when resuming a grammar session, make sure that the full question data is there

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
