### PR TITLE
make sure question results have prompt

### DIFF
--- a/services/QuillGrammar/src/components/lessons/lessonForm.tsx
+++ b/services/QuillGrammar/src/components/lessons/lessonForm.tsx
@@ -149,7 +149,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
     let options = hashToCollection(this.props.questions.data);
     let formatted
     if (options.length > 0) {
-        options = _.filter(options, option => option.flag !== "archived"); // filter out questions with no valid concept
+        options = _.filter(options, option => option.flag !== "archived" && option.prompt); // filter out questions with no valid concept
         formatted = options.map(opt => ({ name: opt.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, ''), value: opt.key, }));
       return (<QuestionSelector
         options={formatted} placeholder="Search for a question"


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- make sure question results have prompt (got error on lesson form load because apparently some grammar questions are missing one)

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
