### PR TITLE
fix #4924 - learn more button in lessons empty state

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
@@ -84,7 +84,7 @@ export default class ClassroomLessons extends React.Component {
         <p>With Quill Lessons, teachers can use Quill to lead whole-class lessons and to see and display student responses in real-time.</p>
         <div className="buttons">
           <a target="_blank" href="/teachers/classrooms/assign_activities/create-unit?tool=lessons" className="bg-quillgreen text-white">Assign Lessons</a>
-          <a target="_blank" href="/tool/lessons" className="bg-white text-quillgreen">Learn More</a>
+          <a target="_blank" href="/tools/lessons" className="bg-white text-quillgreen">Learn More</a>
         </div>
       </div>
       <img src={`${process.env.CDN_URL}/images/illustrations/empty_state_illustration_lessons.svg`} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/unit_template_assigned.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/unit_template_assigned.jsx
@@ -6,9 +6,10 @@ import UnitTemplateProfileShareButtons from './unit_templates_manager/unit_templ
 import LoadingIndicator from '../shared/loading_indicator'
 
 export default class UnitTemplateAssigned extends React.Component {
+  constructor(props) {
+    super(props)
 
-  getInitialState() {
-    return {
+    this.state = {
       loading: true,
       data: null,
       lastUnitId: ''
@@ -99,28 +100,25 @@ export default class UnitTemplateAssigned extends React.Component {
   }
 
   renderSharingContainer() {
-    const { name, id } = this.state.data
-    if (name && id) {
-      return <div className='sharing-container'>
-        <h2>
-          Share Quill With Your Colleagues
-        </h2>
-        <p className='nonprofit-copy'>
-          We’re a nonprofit providing free literacy activities. The more people <br></br>
-          who use Quill, the more free activities we can create.
-        </p>
-        <p className='social-copy'>
-          <i>{this.socialShareCopy()}</i>
-        </p>
-        <div className='container'>
-          <UnitTemplateProfileShareButtons text={this.socialShareCopy()} url={this.socialShareUrl()} />
-        </div>
+    return <div className='sharing-container'>
+      <h2>
+        Share Quill With Your Colleagues
+      </h2>
+      <p className='nonprofit-copy'>
+        We’re a nonprofit providing free literacy activities. The more people <br></br>
+        who use Quill, the more free activities we can create.
+      </p>
+      <p className='social-copy'>
+        <i>{this.socialShareCopy()}</i>
+      </p>
+      <div className='container'>
+        <UnitTemplateProfileShareButtons text={this.socialShareCopy()} url={this.socialShareUrl()} />
       </div>
-    }
+    </div>
   }
 
   render() {
-    if(this.state.loading) {
+    if (this.state.loading) {
       return(<LoadingIndicator />);
     }
 
@@ -139,7 +137,7 @@ export default class UnitTemplateAssigned extends React.Component {
         </div>
       </div>
     </div>
-    {this.renderSharingContainer}
+    {this.renderSharingContainer()}
     </div>
   );
   }


### PR DESCRIPTION
Addresses issue #4924

**Changes proposed in this pull request:**
- fix broken link from learn more button in lessons empty state

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
