### PR TITLE
fix #4924 - fix broken link on lessons empty state page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/classroom_lessons.jsx
@@ -84,7 +84,7 @@ export default class ClassroomLessons extends React.Component {
         <p>With Quill Lessons, teachers can use Quill to lead whole-class lessons and to see and display student responses in real-time.</p>
         <div className="buttons">
           <a target="_blank" href="/teachers/classrooms/assign_activities/create-unit?tool=lessons" className="bg-quillgreen text-white">Assign Lessons</a>
-          <a target="_blank" href="/tool/lessons" className="bg-white text-quillgreen">Learn More</a>
+          <a target="_blank" href="/tools/lessons" className="bg-white text-quillgreen">Learn More</a>
         </div>
       </div>
       <img src={`${process.env.CDN_URL}/images/illustrations/empty_state_illustration_lessons.svg`} />


### PR DESCRIPTION
Addresses issue #4924 

**Changes proposed in this pull request:**
- fix  broken link on lessons empty state page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
