### PR TITLE
add nullchecks to district admin reports queries

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/district_activity_scores.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_activity_scores.rb
@@ -6,7 +6,11 @@ class ProgressReports::DistrictActivityScores
   end
 
   def results
-    ActiveRecord::Base.connection.execute(query).to_a
+    if classroom_ids_for_admin.length > 0
+      ActiveRecord::Base.connection.execute(query).to_a
+    else
+      []
+    end
   end
 
   private

--- a/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
@@ -39,7 +39,7 @@ class ProgressReports::DistrictConceptReports
         JOIN concept_results ON concept_results.activity_session_id =
           activity_sessions.id
         WHERE schools_admins.user_id = #{admin_id}
-        GROUP BY students.id, teachers.name, classrooms.name, schools.name
+        GROUP BY student_id, teacher_name, classroom_name, school_name
     )
     SELECT
       school_name,

--- a/services/QuillLMS/app/serializers/user_admin_serializer.rb
+++ b/services/QuillLMS/app/serializers/user_admin_serializer.rb
@@ -4,8 +4,12 @@ class UserAdminSerializer < ActiveModel::Serializer
 
   def teachers
     teacher_ids = User.find(object.id).admins_teachers
-    teachers_data = TeachersData.run(teacher_ids)
-    teachers_data.map{|t| Admin::TeacherSerializer.new(t, root: false) }
+    if teacher_ids
+      teachers_data = TeachersData.run(teacher_ids)
+      teachers_data.map{|t| Admin::TeacherSerializer.new(t, root: false) }
+    else
+      []
+    end
   end
 
   def valid_subscription

--- a/services/QuillLMS/app/workers/find_admin_users_worker.rb
+++ b/services/QuillLMS/app/workers/find_admin_users_worker.rb
@@ -2,11 +2,13 @@ class FindAdminUsersWorker
   include Sidekiq::Worker
 
   def perform(admin_id)
-    user = User.find(admin_id)
-    serialized_admin_users_cache_life = 60*60*25
-    serialized_admin_users = UserAdminSerializer.new(user, root: false).to_json
-    $redis.set("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users)
-    $redis.expire("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users_cache_life)
-    PusherAdminUsersCompleted.run(admin_id)
+    user = User.find_by_id(admin_id)
+    if user
+      serialized_admin_users_cache_life = 60*60*25
+      serialized_admin_users = UserAdminSerializer.new(user, root: false).to_json
+      $redis.set("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users)
+      $redis.expire("SERIALIZED_ADMIN_USERS_FOR_#{admin_id}", serialized_admin_users_cache_life)
+      PusherAdminUsersCompleted.run(admin_id)
+    end
   end
 end

--- a/services/QuillLMS/lib/tasks/reset_admin_caches.rake
+++ b/services/QuillLMS/lib/tasks/reset_admin_caches.rake
@@ -2,10 +2,12 @@ namespace :admin_caches do
   desc 'reset caches for district admin reports'
   task :reset => :environment do
     SchoolsAdmins.all.each do |sa|
-      FindAdminUsersWorker.perform_async(sa.user_id)
-      FindDistrictConceptReportsWorker.perform_async(sa.user_id)
-      FindDistrictStandardsReportsWorker.perform_async(sa.user_id)
-      FindDistrictActivityScoresWorker.perform_async(sa.user_id)
+      if sa.user
+        FindAdminUsersWorker.perform_async(sa.user_id)
+        FindDistrictConceptReportsWorker.perform_async(sa.user_id)
+        FindDistrictStandardsReportsWorker.perform_async(sa.user_id)
+        FindDistrictActivityScoresWorker.perform_async(sa.user_id)
+      end
     end
   end
 end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add nullchecks to district admin reports queries so we don't get background worker errors

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?**  no

**Reviewer:** @ddmck
