### PR TITLE
fix #4939 - add more general error handling for usernames and emails on signup

### DIFF
--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -41,6 +41,12 @@ class AccountsController < ApplicationController
         errors['email'] = ['That email is taken. Try another.']
       elsif @user.errors['email']&.include?('does not appear to be a valid e-mail address')
         errors['email'] = ['Enter a valid email']
+      elsif @user.errors['username']&.include?('cannot contain spaces')
+        errors['username'] = ['That username is not valid because it has a space. Try another.']
+      elsif @user.errors['username']
+        errors['username'] = ['That username is invalid. Try another.']
+      else @user.errors['email']
+        errors['email'] = ['That email is invalid. Try another.']
       end
       render json: {errors: errors}, status: 422
     end


### PR DESCRIPTION
Addresses issue #4939

**Changes proposed in this pull request:**
- add more general error handling for usernames and emails on signup, including the specific case of students not getting an error when they try to put spaces in their usernames

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
