### PR TITLE
make it possible to edit a response in grammar again

### DIFF
--- a/services/QuillGrammar/src/components/questions/response.tsx
+++ b/services/QuillGrammar/src/components/questions/response.tsx
@@ -599,7 +599,7 @@ export default class Response extends React.Component<any, any> {
 
   render() {
     const { response, state, } = this.props;
-    const isEditing = (state === (`${ActionTypes.START_RESPONSE_EDIT}_${response.key}`));
+    const isEditing = (state === (`${ActionTypes.START_RESPONSE_EDIT}_${response.id}`));
     const isViewingChildResponses = (state === (`${ActionTypes.START_CHILD_RESPONSE_VIEW}_${response.key}`));
     const isViewingFromResponses = (state === (`${ActionTypes.START_FROM_RESPONSE_VIEW}_${response.key}`));
     const isViewingToResponses = (state === (`${ActionTypes.START_TO_RESPONSE_VIEW}_${response.key}`));

--- a/services/QuillGrammar/src/components/questions/responseComponent.tsx
+++ b/services/QuillGrammar/src/components/questions/responseComponent.tsx
@@ -116,6 +116,9 @@ class ResponseComponent extends React.Component {
   componentDidUpdate(prevProps) {
     if (!_.isEqual(this.props.filters.formattedFilterData, prevProps.filters.formattedFilterData)) {
       this.searchResponses();
+    } else if (this.props.states && this.props.states[this.props.questionID] === ActionTypes.SHOULD_RELOAD_RESPONSES && prevProps.states[prevProps.questionID] !== ActionTypes.SHOULD_RELOAD_RESPONSES) {
+      this.props.dispatch(questionActions.clearQuestionState(this.props.questionID));
+      this.searchResponses();
     }
   }
 

--- a/services/QuillGrammar/src/components/questions/responseList.tsx
+++ b/services/QuillGrammar/src/components/questions/responseList.tsx
@@ -28,12 +28,26 @@ export default class ResponseList extends React.Component {
 
   incorrectSequenceMatchHelper(responseString, sequenceParticle) {
     const matchList = sequenceParticle.split('&&');
-    return _.every(matchList, m => new RegExp(m).test(responseString));
+    return _.every(matchList, m => {
+      try {
+        return new RegExp(m).test(responseString)
+      } catch(e) {
+        console.log('e', e)
+        return false;
+      }
+    })
   }
 
   focusPointMatchHelper(responseString, sequenceParticle) {
     const matchList = sequenceParticle.split('&&');
-    return _.every(matchList, m => new RegExp(m, 'i').test(responseString));
+    return _.every(matchList, m => {
+      try {
+        return new RegExp(m).test(responseString)
+      } catch(e) {
+        console.log('e', e)
+        return false;
+      }
+    })
   }
 
   addAllResponsesToMassEdit() {
@@ -76,6 +90,8 @@ export default class ResponseList extends React.Component {
       concepts={this.props.concepts}
       conceptID={this.props.conceptID}
       massEdit={this.props.massEdit}
+      states={this.props.states}
+      state={this.props.states[this.props.questionID]}
     />
   }
 

--- a/services/QuillGrammar/src/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillGrammar/src/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -181,6 +181,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
             question={dataset}
             mode={mode}
             questionID={this.props.questionID}
+            states={this.props.questions.states}
           />
         </div>
       </div>

--- a/services/QuillGrammar/src/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillGrammar/src/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -253,7 +253,7 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
             selectedIncorrectSequences={this.state.itemText.split(/\|{3}(?!\|)/)}
             question={dataset}
             mode={mode}
-            states={this.props.states}
+            states={this.props.questions.states}
             questionID={this.props.questionID}
           />
         </div>


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix bug with editing responses from admin panel in grammar

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
