### PR TITLE
assigning hidden featured activity packs

### DIFF
--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -6,13 +6,14 @@ class UnitTemplate < ActiveRecord::Base
   has_many :recommendations, dependent: :destroy
   serialize :grades, Array
 
-  validates :flag,                  inclusion: { in: %w(archived alpha beta production),
+  validates :flag,                  inclusion: { in: %w(archived alpha beta production private),
                                     message: "%{value} is not a valid flag" }, :allow_nil => true
 
 
   scope :production, -> {where("unit_templates.flag IN('production') OR unit_templates.flag IS null")}
   scope :beta_user, -> { where("unit_templates.flag IN('production','beta') OR unit_templates.flag IS null")}
   scope :alpha_user, -> { where("unit_templates.flag IN('production','beta','alpha') OR unit_templates.flag IS null")}
+  scope :private_user, -> { where("unit_templates.flag IN('private', 'production','beta','alpha') OR unit_templates.flag IS null")}
   around_save :delete_relevant_caches
 
 
@@ -39,7 +40,9 @@ class UnitTemplate < ActiveRecord::Base
   # end
 
   def self.user_scope(user_flag)
-    if user_flag == 'alpha'
+    if user_flag == 'private'
+      UnitTemplate.private_user
+    elsif user_flag == 'alpha'
       UnitTemplate.alpha_user
     elsif user_flag == 'beta'
       UnitTemplate.beta_user

--- a/services/QuillLMS/app/queries/activity_search.rb
+++ b/services/QuillLMS/app/queries/activity_search.rb
@@ -3,6 +3,8 @@ class ActivitySearch
   # sort = hash with 'field' and 'asc_or_desc' (?) as keys
   def self.search(flag)
     case flag
+    when 'private'
+      flags = "'private', 'alpha', 'beta', 'production'"
     when 'alpha'
       flags = "'alpha', 'beta', 'production'"
     when 'beta'

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
       { name: 'grades', value: [], fromServer: true, },
       { name: 'unit_template_categories', value: [], fromServer: true, cmsController: true, },
       { name: 'authors', value: [], fromServer: true, cmsController: true, },
-      { name: 'flag', value: ['production', 'alpha', 'beta', 'archived'], fromServer: false, cmsController: true, },
+      { name: 'flag', value: ['production', 'alpha', 'beta', 'archived', 'private'], fromServer: false, cmsController: true, },
       { name: 'order_number', value: _.range(1, 30), fromServer: false, }
     ];
     return this.modelOptions;


### PR DESCRIPTION
Addresses issue #
Notion: https://www.notion.so/quill/Add-ability-for-a-pack-to-be-made-private-from-Activity-Pack-Editor-page-7776ac3e52624a2ca86004d360eb008e
Notion: https://www.notion.so/quill/Add-ability-for-a-pack-to-be-made-private-from-Activity-Pack-Editor-page-7776ac3e52624a2ca86004d360eb008e

**Changes proposed in this pull request:**
- make it possible to see private activity packs from cms pages in activity search
- make it possible to set activity pack to have private flag from cms

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
