### PR TITLE
fix #4937 - don't show diagnostic scores for students removed from class

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -122,7 +122,7 @@ module PublicProgressReports
       }
       classroom_unit.assigned_student_ids.each do |student_id|
         student = User.find_by(id: student_id)
-        if student
+        if student && student.classroom_ids.include?(classroom.id)
           final_activity_session = ActivitySession.find_by(user_id: student_id, is_final_score: true, classroom_unit_id: cu_id, activity_id: activity_id)
           if final_activity_session
             scores[:students].push(formatted_score_obj(final_activity_session, activity, student))


### PR DESCRIPTION
Addresses issue #4937

**Changes proposed in this pull request:**
- don't show diagnostic scores for students removed from class

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
