### PR TITLE
fix issue with refreshing grammar activities in the middle of a session

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -31,17 +31,22 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
             currentQuestion.uid = session.currentQuestion.uid
             session.currentQuestion = currentQuestion
           }
-          session.unansweredQuestions = session.unansweredQuestions.map((q) => {
-            if (q.prompt && q.answers && q.uid) {
-              return q
-            } else {
-              const question = allQuestions[q.uid]
-              question.uid = q.uid
-              return question
-            }
-          })
+          if (session.unansweredQuestions) {
+            session.unansweredQuestions = session.unansweredQuestions.map((q) => {
+              if (q.prompt && q.answers && q.uid) {
+                return q
+              } else {
+                const question = allQuestions[q.uid]
+                question.uid = q.uid
+                return question
+              }
+            })
+          }
           dispatch(setSessionReducer(session))
         })
+      } else {
+        console.log('there is no session')
+        dispatch(setSessionPending(false))
       }
     })
   }
@@ -75,7 +80,7 @@ export const startListeningToFollowUpQuestionsForProofreaderSession = (proofread
 // typescript this
 export const getQuestionsForConcepts = (concepts: any) => {
   return dispatch => {
-    dispatch({ type: ActionTypes.SET_SESSION_PENDING, pending: true })
+    dispatch(setSessionPending(true))
     const conceptUIDs = Object.keys(concepts)
     questionsRef.orderByChild('concept_uid').once('value', (snapshot) => {
       const questions = snapshot.val()
@@ -105,7 +110,7 @@ export const getQuestionsForConcepts = (concepts: any) => {
       } else {
         dispatch({ type: ActionTypes.NO_QUESTIONS_FOUND_FOR_SESSION})
       }
-      dispatch({ type: ActionTypes.SET_SESSION_PENDING, pending: false })
+      dispatch(setSessionPending(false))
     });
 
   }
@@ -113,7 +118,7 @@ export const getQuestionsForConcepts = (concepts: any) => {
 
 export const getQuestions = (questions: any) => {
   return dispatch => {
-    dispatch({ type: ActionTypes.SET_SESSION_PENDING, pending: true })
+    dispatch(setSessionPending(true))
     questionsRef.once('value', (snapshot) => {
       const allQuestions = snapshot.val()
       const arrayOfQuestions = questions.map(q => {
@@ -126,7 +131,7 @@ export const getQuestions = (questions: any) => {
       } else {
         dispatch({ type: ActionTypes.NO_QUESTIONS_FOUND_FOR_SESSION})
       }
-      dispatch({ type: ActionTypes.SET_SESSION_PENDING, pending: false })
+      dispatch(setSessionPending(false))
     })
   }
 }
@@ -166,5 +171,11 @@ export const setSessionReducer = (session: SessionState) => {
 export const saveProofreaderSessionToReducer = (proofreaderSession) => {
   return dispatch => {
     dispatch({ type: ActionTypes.SET_PROOFREADER_SESSION_TO_REDUCER, data: proofreaderSession})
+  }
+}
+
+export const setSessionPending = (pendingStatus: boolean) => {
+  return dispatch => {
+    dispatch({ type: ActionTypes.SET_SESSION_PENDING, pending: pendingStatus })
   }
 }

--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -13,7 +13,8 @@ import {
   goToNextQuestion,
   checkAnswer,
   setSessionReducerToSavedSession,
-  startListeningToFollowUpQuestionsForProofreaderSession
+  startListeningToFollowUpQuestionsForProofreaderSession,
+  setSessionPending
 } from "../../actions/session";
 import { startListeningToConceptsFeedback } from '../../actions/conceptsFeedback'
 import { startListeningToConcepts } from '../../actions/concepts'
@@ -61,6 +62,8 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       const proofreaderSessionId = getParameterByName('proofreaderSessionId', window.location.href)
       if (sessionID) {
         this.props.dispatch(setSessionReducerToSavedSession(sessionID))
+      } else {
+        this.props.dispatch(setSessionPending(false))
       }
 
       if (activityUID) {

--- a/services/QuillGrammar/src/reducers/sessionReducer.ts
+++ b/services/QuillGrammar/src/reducers/sessionReducer.ts
@@ -15,13 +15,13 @@ export interface SessionState {
 type SessionAction = Action & { data: any, attempts: any, response: any, session: any }
 
 export default (
-    currentState: SessionState = {hasreceiveddata: false, answeredQuestions: [], unansweredQuestions: [], currentQuestion: null, pending: false},
+    currentState: SessionState = {hasreceiveddata: false, answeredQuestions: [], unansweredQuestions: [], currentQuestion: null, pending: true},
     action: SessionAction,
 ): SessionState => {
     let currentQuestion: Question|{}
     switch (action.type) {
         case ActionTypes.SET_SESSION:
-            return Object.assign({}, currentState, action.session)
+            return Object.assign({}, currentState, action.session, { pending: false, hasreceiveddata: true })
         case ActionTypes.RECEIVE_QUESTION_DATA:
             currentQuestion = action.data.splice(0, 1)[0]
             return Object.assign({}, currentState, { unansweredQuestions: action.data, currentQuestion, hasreceiveddata: true});
@@ -43,8 +43,6 @@ export default (
             return Object.assign({}, currentState, {currentQuestion})
         case ActionTypes.SET_PROOFREADER_SESSION_TO_REDUCER:
             return Object.assign({}, currentState, {proofreaderSession: action.data})
-        case ActionTypes.SET_SESSION_PENDING:
-            return Object.assign({}, currentState, {pending: action.pending})
         case ActionTypes.SET_SESSION_PENDING:
             return Object.assign({}, currentState, {pending: action.pending})
         default:


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix issue where refreshing a grammar activity could sometimes cause grammar to get responses for the wrong question

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
