### PR TITLE
can use teacher fix to delete activity session that has interaction logs

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -166,6 +166,7 @@ module TeacherFixes
   def self.delete_last_activity_session(user_id, activity_id)
     last_activity_session = get_all_completed_activity_sessions_for_a_given_user_and_activity(user_id, activity_id).order("activity_sessions.completed_at DESC").limit(1)[0]
     if last_activity_session
+      last_activity_session.activity_session_interaction_logs.delete_all
       last_activity_session.delete
     else
       raise 'This activity session does not exist'


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix issue with deleting activity session that has interaction logs via teacher fix

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
