### PR TITLE
implement disabled reset button state

### DIFF
--- a/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
+++ b/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
@@ -644,8 +644,13 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
     }
 
     renderResetButton(): JSX.Element|void {
-      if (!this.state.reviewing) {
-        return <button className="reset-button" onClick={this.openResetModal}><img src={refreshIconSrc} /> Reset</button>
+      const { reviewing, edits, } = this.state
+      if (!reviewing) {
+        if (edits.length) {
+          return <button className="reset-button" onClick={this.openResetModal}><img src={refreshIconSrc} /> Reset</button>
+        } else {
+          return <button className="reset-button disabled"><img src={refreshIconSrc} /> Reset</button>
+        }
       }
     }
 

--- a/services/QuillProofreader/src/styles/passage.scss
+++ b/services/QuillProofreader/src/styles/passage.scss
@@ -153,6 +153,7 @@
       &.disabled {
         border: solid 1px #bdbdbd;
         color: #878787;
+        cursor: default;
         img {
           filter: invert(.5);
         }

--- a/services/QuillProofreader/src/styles/passage.scss
+++ b/services/QuillProofreader/src/styles/passage.scss
@@ -150,6 +150,13 @@
       align-items: flex-start;
       justify-content: space-between;
       color: #000000;
+      &.disabled {
+        border: solid 1px #bdbdbd;
+        color: #878787;
+        img {
+          filter: invert(.5);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses issue #
Notion: https://www.notion.so/quill/Implement-a-disabled-state-of-the-reset-button-in-Quill-Proofreader-7f0d52a3fe5e42649b0f1a4f1c40caac

**Changes proposed in this pull request:**
- give reset button a disabled state on proofreader

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
