### PR TITLE
don't show intercom message during signup

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -74,10 +74,12 @@ class ApplicationController < ActionController::Base
   end
 
   def should_load_intercom
+    current_path = request.env['PATH_INFO']
     user_is_logged_in_teacher = current_user && current_user.role == 'teacher'
     user_is_not_a_staff_member = session[:staff_id].nil?
     user_is_not_a_demo_account = current_user && /hello\+(.)*@quill.org/.match(current_user.email).nil?
-    @should_load_intercom = user_is_logged_in_teacher && user_is_not_a_staff_member && user_is_not_a_demo_account
+    not_on_sign_up = !current_path.include?('sign-up')
+    @should_load_intercom = user_is_logged_in_teacher && user_is_not_a_staff_member && user_is_not_a_demo_account && not_on_sign_up
   end
 
   protected


### PR DESCRIPTION
Addresses issue #
Notion: https://www.notion.so/quill/Change-the-Intercom-welcome-dashboard-to-show-up-on-the-teacher-s-dashboard-11834c95c4fa486b9d8a864c52593dba

**Changes proposed in this pull request:**
- don't show intercom message during signup

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
