### PR TITLE
set inspectletIgnore class on password field on login

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -121,7 +121,7 @@ class LoginFormApp extends React.Component {
                   value={password}
                   handleChange={this.handlePasswordChange}
                   type={this.togglePass()}
-                  className="password"
+                  className="password inspectletIgnore"
                   error={errors.password}
                   timesSubmitted={timesSubmitted}
                 />


### PR DESCRIPTION
Addresses issue #
Notion: https://www.notion.so/quill/Hide-people-s-passwords-from-Inspectlet-047f9543288c4d7ca6331bb2fcfb346f

**Changes proposed in this pull request:**
- add inspectletIgnore class to password input field

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
