### PR TITLE
make sure students do not have to repeat question when resuming grammar activity

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -23,7 +23,7 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
   return dispatch => {
     sessionsRef.child(sessionID).once('value', (snapshot) => {
       const session = snapshot.val()
-      if (session && !session.error) {
+      if (session && Object.keys(session).length > 1 && !session.error) {
         questionsRef.orderByChild('concept_uid').once('value', (questionsSnapshot) => {
           const allQuestions = questionsSnapshot.val()
           if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {

--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -98,7 +98,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       }
 
       const sessionID = getParameterByName('student', window.location.href)
-      if (sessionID && !_.isEqual(nextProps.session, this.props.session)) {
+      if (sessionID && !_.isEqual(nextProps.session, this.props.session && !nextProps.session.pending)) {
         updateSessionOnFirebase(sessionID, nextProps.session)
       }
 

--- a/services/QuillGrammar/src/components/grammarActivities/question.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/question.tsx
@@ -37,7 +37,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
       this.state = {
         showExample: true,
         response: '',
-        questionStatus: 'unanswered',
+        questionStatus: this.getCurrentQuestionStatus(props.currentQuestion),
         submittedEmptyString: false,
         submittedSameResponseTwice: false,
         responses: {}
@@ -63,19 +63,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     componentWillReceiveProps(nextProps: QuestionProps) {
       const currentQuestion = nextProps.currentQuestion
       if (currentQuestion && currentQuestion.attempts && currentQuestion.attempts.length > 0) {
-        if (currentQuestion.attempts[1]) {
-          if (currentQuestion.attempts[1].optimal) {
-            this.setState({questionStatus: 'correctly answered'})
-          } else {
-            this.setState({questionStatus: 'final attempt'})
-          }
-        } else {
-          if (currentQuestion.attempts[0] && currentQuestion.attempts[0].optimal) {
-            this.setState({questionStatus: 'correctly answered'})
-          } else {
-            this.setState({questionStatus: 'incorrectly answered'})
-          }
-        }
+        this.setState({ questionStatus: this.getCurrentQuestionStatus(currentQuestion) })
       }
       if (this.props.currentQuestion.uid !== nextProps.currentQuestion.uid) {
         responseActions.getGradedResponsesWithCallback(
@@ -84,6 +72,26 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
             this.setState({ responses: data, });
           }
         );
+      }
+    }
+
+    getCurrentQuestionStatus(currentQuestion) {
+      if (currentQuestion.attempts && currentQuestion.attempts.length) {
+        if (currentQuestion.attempts[1]) {
+          if (currentQuestion.attempts[1].optimal) {
+            return 'correctly answered'
+          } else {
+            return 'final attempt'
+          }
+        } else {
+          if (currentQuestion.attempts[0] && currentQuestion.attempts[0].optimal) {
+            return 'correctly answered'
+          } else {
+            return 'incorrectly answered'
+          }
+        }
+      } else {
+        return 'unanswered'
       }
     }
 
@@ -111,7 +119,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
 
     goToNextQuestion() {
       this.props.goToNextQuestion()
-      this.setState({response: '', questionStatus: 'unanswered'})
+      this.setState({response: '', questionStatus: 'unanswered', responses: {}})
     }
 
     toggleExample() {


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix issue where students who didn't press 'next question' before saving and exiting would have to redo question

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
