### PR TITLE
grammar student resuming completed session

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -26,10 +26,12 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
       if (session && Object.keys(session).length > 1 && !session.error) {
         questionsRef.orderByChild('concept_uid').once('value', (questionsSnapshot) => {
           const allQuestions = questionsSnapshot.val()
-          if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
-            const currentQuestion = allQuestions[session.currentQuestion.uid]
-            currentQuestion.uid = session.currentQuestion.uid
-            session.currentQuestion = currentQuestion
+          if (session.currentQuestion) {
+            if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
+              const currentQuestion = allQuestions[session.currentQuestion.uid]
+              currentQuestion.uid = session.currentQuestion.uid
+              session.currentQuestion = currentQuestion
+            }
           }
           if (session.unansweredQuestions) {
             session.unansweredQuestions = session.unansweredQuestions.map((q) => {


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- when students exit a session after completing it but before their data has saved to the lms, they were getting a forever loading screen, this is no longer occurring

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
