### PR TITLE
call find_by on user, not teacher in lesson cache worker

### DIFF
--- a/services/QuillLMS/app/workers/set_teacher_lesson_cache.rb
+++ b/services/QuillLMS/app/workers/set_teacher_lesson_cache.rb
@@ -3,7 +3,7 @@ class SetTeacherLessonCache
   sidekiq_options queue: 'critical'
 
   def perform(teacher_id)
-    @user = Teacher.find_by(id: teacher_id)
+    @user = User.find_by(id: teacher_id)
     @user.set_lessons_cache if @user
   end
 


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
-call find_by on user, not teacher

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
