### PR TITLE
fix  #4988 - don't show concept feedback for question unless answer is not optimal

### DIFF
--- a/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
+++ b/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponent.tsx
@@ -147,8 +147,8 @@ const PlaySentenceFragment = React.createClass<any, any>({
   renderConceptExplanation() {
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
-      if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+      if (latestAttempt && latestAttempt.response && !latestAttempt.response.optimal ) {
+        if (latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -156,7 +156,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
-        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+        } else if (latestAttempt.response.concept_results) {
           const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
           if (conceptID) {
             const data = this.props.conceptsFeedback.data[conceptID.conceptUID];

--- a/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
+++ b/services/QuillConnect/app/components/sentenceFragments/sentenceFragmentTemplateComponentML.tsx
@@ -154,8 +154,8 @@ const PlaySentenceFragment = React.createClass<any, any>({
   renderConceptExplanation() {
     if (!this.showNextQuestionButton()) {
       const latestAttempt:{response: Response}|undefined  = getLatestAttempt(this.props.question.attempts);
-      if (latestAttempt && latestAttempt.response) {
-        if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+      if (latestAttempt && latestAttempt.response && !latestAttempt.response.optimal) {
+        if (latestAttempt.response.conceptResults) {
             const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
             if (conceptID) {
               const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -163,7 +163,7 @@ const PlaySentenceFragment = React.createClass<any, any>({
                 return <ConceptExplanation {...data} />;
               }
             }
-        } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+        } else if (latestAttempt.response.concept_results) {
           const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
           if (conceptID) {
             const data = this.props.conceptsFeedback.data[conceptID.conceptUID];

--- a/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillConnect/app/components/studentLessons/fillInBlank.tsx
@@ -262,8 +262,8 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
 
   renderConceptExplanation() {
     const latestAttempt:{response: Response}|undefined = this.getLatestAttempt(this.props.question.attempts);
-    if (latestAttempt) {
-      if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+    if (latestAttempt && latestAttempt.response && !latestAttempt.response.optimal ) {
+      if (latestAttempt.response.conceptResults) {
           const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
           if (conceptID) {
             const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -271,7 +271,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
               return <ConceptExplanation {...data} />;
             }
           }
-      } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+      } else if (latestAttempt.response.concept_results) {
         const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
         if (conceptID) {
           const data = this.props.conceptsFeedback.data[conceptID.conceptUID];

--- a/services/QuillConnect/app/components/studentLessons/question.tsx
+++ b/services/QuillConnect/app/components/studentLessons/question.tsx
@@ -269,8 +269,8 @@ const playLessonQuestion = React.createClass<any, any>({
 
   renderConceptExplanation() {
     const latestAttempt:{response: Response}|undefined = getLatestAttempt(this.props.question.attempts);
-    if (latestAttempt) {
-      if (!latestAttempt.response.optimal && latestAttempt.response.conceptResults) {
+    if (latestAttempt && latestAttempt.response && !latestAttempt.response.optimal ) {
+      if (latestAttempt.response.conceptResults) {
           const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.conceptResults);
           if (conceptID) {
             const data = this.props.conceptsFeedback.data[conceptID.conceptUID];
@@ -278,7 +278,7 @@ const playLessonQuestion = React.createClass<any, any>({
               return <ConceptExplanation {...data} />;
             }
           }
-      } else if (latestAttempt.response && !latestAttempt.response.optimal && latestAttempt.response.concept_results) {
+      } else if (latestAttempt.response.concept_results) {
         const conceptID = this.getNegativeConceptResultForResponse(latestAttempt.response.concept_results);
         if (conceptID) {
           const data = this.props.conceptsFeedback.data[conceptID.conceptUID];


### PR DESCRIPTION
Addresses issue #4988

**Changes proposed in this pull request:**
- we were sometimes showing concept feedback when a student answered a question correctly; now we no longer are

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?**  no

**Reviewer:** @ddmck
