### PR TITLE
fix #4994 - clear private activity search cache when an activity is committed

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -119,7 +119,7 @@ class Activity < ActiveRecord::Base
   end
 
   def self.clear_activity_search_cache
-    %w(production_ beta_ alpha_).push('').each do |flag|
+    %w(private_ production_ beta_ alpha_).push('').each do |flag|
       $redis.del("default_#{flag}activity_search")
     end
   end


### PR DESCRIPTION
Addresses issue #4994

**Changes proposed in this pull request:**
- add the private flag to list of activity search caches we clear on activity commit

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
