### PR TITLE
update recommendations background worker

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -134,6 +134,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     private
     def create_or_update_selected_packs
         if params[:whole_class]
+          $redis.set("user_id:#{current_user.id}_lesson_diagnostic_recommendations_start_time", Time.now)
           return render json: {}, status: 401 unless current_user.classrooms_i_teach.map(&:id).include?(params[:classroom_id].to_i)
           UnitTemplate.assign_to_whole_class(params[:classroom_id], params[:unit_template_id])
         else
@@ -141,6 +142,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
             ut[:classrooms][0][:student_ids]&.compact&.any?
           end
           if selections_with_students.any?
+            $redis.set("user_id:#{current_user.id}_diagnostic_recommendations_start_time", Time.now)
             number_of_selections = selections_with_students.length
             selections_with_students.each_with_index do |value, index|
                 last = (number_of_selections - 1) == index

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -80,4 +80,14 @@ class UserMailer < ActionMailer::Base
     mail to: ["Becca Garrison <becca@quill.org>", "Amr Thameen <amr@quill.org>", "Emilia Friedberg <emilia@quill.org>"], subject: "#{user.name} has purchased School Premium for a missing school"
   end
 
+  def recommendations_assignment_report_email
+    @independent_less_than_ten_seconds = $redis.get("diagnostic_recommendations_under_ten_seconds_count") || 0
+    @group_less_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_under_ten_seconds_count") || 0
+    @independent_more_than_ten_seconds = $redis.get("diagnostic_recommendations_over_ten_seconds_count") || 0
+    @group_more_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_over_ten_seconds_count") || 0
+    @percentage_of_independent_less_than_ten_seconds = (@independent_less_than_ten_seconds.to_i/(@independent_more_than_ten_seconds.to_i + @independent_less_than_ten_seconds.to_i)) * 100
+    @percentage_of_group_less_than_ten_seconds = (@group_less_than_ten_seconds.to_i/(@group_more_than_ten_seconds.to_i + @group_less_than_ten_seconds.to_i)) * 100
+    mail to: ["Dev Tools <devtools@quill.org>", "Emilia Friedberg <emilia@quill.org>", "Thomas Robertson <thomasrobertson@quill.org"], subject: "Recommendations Assignment Report"
+  end
+
 end

--- a/services/QuillLMS/app/views/user_mailer/recommendations_assignment_report_email.html.erb
+++ b/services/QuillLMS/app/views/user_mailer/recommendations_assignment_report_email.html.erb
@@ -1,0 +1,9 @@
+<h1>Independent Activity Recommendations</h1>
+<p>Assigned in fewer than ten seconds: <%=@independent_less_than_ten_seconds%></p>
+<p>Assigned in more than ten seconds: <%=@independent_more_than_ten_seconds%></p>
+<p>Percentage completed in fewer than ten seconds: <%=@percentage_of_independent_less_than_ten_seconds%>%</p>
+
+<h1>Group Activity Recommendations</h1>
+<p>Assigned in fewer than ten seconds: <%=@group_less_than_ten_seconds%></p>
+<p>Assigned in more than ten seconds: <%=@group_more_than_ten_seconds%></p>
+<p>Percentage completed in fewer than ten seconds: <%=@percentage_of_group_less_than_ten_seconds%>%</p>

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -18,7 +18,10 @@ class AssignRecommendationsWorker
     unit ||= nil
     assign_unit_to_one_class(unit, classroom_id, classroom_data, unit_template_id, teacher.id)
     track_recommendation_assignment(teacher)
-    PusherRecommendationCompleted.run(classroom, unit_template_id, lesson) if last
+    if last
+      handle_error_tracking_for_diagnostic_recommendation_assignment_time(teacher.id, lesson)
+      PusherRecommendationCompleted.run(classroom, unit_template_id, lesson)
+    end
   end
 
   def assign_unit_to_one_class(unit, classroom_id, classroom_data, unit_template_id, teacher_id)
@@ -61,6 +64,43 @@ class AssignRecommendationsWorker
       Unit.unscoped.where(name: UnitTemplate.find(unit_template_id).name, user_id: teacher_id)
     else
       units
+    end
+  end
+
+  def handle_error_tracking_for_diagnostic_recommendation_assignment_time(teacher_id, lesson)
+    if lesson
+      start_time = $redis.get("user_id:#{teacher_id}_lesson_diagnostic_recommendations_start_time")
+    else
+      start_time = $redis.get("user_id:#{teacher_id}_diagnostic_recommendations_start_time")
+    end
+    if start_time
+      elapsed_time = Time.now - start_time.to_time
+      if elapsed_time > 10
+        diagnostic_recommendations_over_ten_seconds_count = $redis.get("diagnostic_recommendations_over_ten_seconds_count")
+        if diagnostic_recommendations_over_ten_seconds_count
+          $redis.set("diagnostic_recommendations_over_ten_seconds_count", diagnostic_recommendations_over_ten_seconds_count.to_i + 1)
+        else
+          $redis.set("diagnostic_recommendations_over_ten_seconds_count", 1)
+        end
+        begin
+          raise "#{elapsed_time} for #{teacher_id} to assign recommendations"
+        rescue => e
+          NewRelic::Agent.notice_error(e)
+          errors.add(:long_assigning_time, "#{elapsed_time} for #{teacher_id} to assign recommendations")
+        end
+      else
+        diagnostic_recommendations_under_ten_seconds_count = $redis.get("diagnostic_recommendations_under_ten_seconds_count")
+        if diagnostic_recommendations_under_ten_seconds_count
+          $redis.set("diagnostic_recommendations_under_ten_seconds_count", diagnostic_recommendations_under_ten_seconds_count.to_i + 1)
+        else
+          $redis.set("diagnostic_recommendations_under_ten_seconds_count", 1)
+        end
+      end
+      if lesson
+        $redis.del("user_id:#{teacher_id}_lesson_diagnostic_recommendations_start_time")
+      else
+        $redis.del("user_id:#{teacher_id}_diagnostic_recommendations_start_time")
+      end
     end
   end
 end

--- a/services/QuillLMS/config/sidekiq.yml
+++ b/services/QuillLMS/config/sidekiq.yml
@@ -5,6 +5,6 @@ staging:
 production:
   :concurrency: 5
 :queues:
-  - [critical, 10] 
-  - [default, 2]
-  - [low, 1]
+  - critical
+  - default
+  - low

--- a/services/QuillLMS/lib/tasks/email_recommendations_assignment_report.rake
+++ b/services/QuillLMS/lib/tasks/email_recommendations_assignment_report.rake
@@ -1,0 +1,6 @@
+namespace :recommendation_assignments_report do
+  desc 'email dev team recommendations assignment report'
+  task :email => :environment do
+    UserMailer.recommendations_assignment_report_email.deliver_now!
+  end
+end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- go back to previous queuing system for background workers to ensure recommendation assignment will happen first
- track elapsed time between the controller action that calls the recommendation background worker and it completing
- send new relic error if it takes more than ten seconds for the above process to occur
- track number of times it completes in more than and fewer than ten seconds in redis
- add rake task for email to @anathomical, @emilia-friedberg, and dev-tools with report on current numbers  

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
