### PR TITLE
add 'dead' and 'unidentified' to list of key values to ignore in proofreader

### DIFF
--- a/services/QuillProofreader/src/components/proofreaderActivities/passageEditor.tsx
+++ b/services/QuillProofreader/src/components/proofreaderActivities/passageEditor.tsx
@@ -310,7 +310,7 @@ class PassageEditor extends React.Component <PassageEditorProps, PassageEditorSt
       return false
     }
 
-    if (['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Backspace', 'Shift', 'MetaShift', 'Meta', 'Enter', 'CapsLock', 'Escape', 'Alt', 'Control'].includes(event.key)) { return }
+    if (['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Backspace', 'Shift', 'MetaShift', 'Meta', 'Enter', 'CapsLock', 'Escape', 'Alt', 'Control', 'Dead', 'Unidentified'].includes(event.key)) { return }
 
     if (!startInline && originalSelection.focus.offset === 0 && originalSelection.anchor.offset === 0) {
       const nextInline = change.moveEndForward(1).value.endInline


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add 'dead' and 'unidentified' to list of key values to ignore in proofreader

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
