### PR TITLE
fix syntax error in recommendations email

### DIFF
--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -85,9 +85,11 @@ class UserMailer < ActionMailer::Base
     @group_less_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_under_ten_seconds_count") || 0
     @independent_more_than_ten_seconds = $redis.get("diagnostic_recommendations_over_ten_seconds_count") || 0
     @group_more_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_over_ten_seconds_count") || 0
-    @percentage_of_independent_less_than_ten_seconds = (@independent_less_than_ten_seconds.to_i/(@independent_more_than_ten_seconds.to_i + @independent_less_than_ten_seconds.to_i)) * 100
-    @percentage_of_group_less_than_ten_seconds = (@group_less_than_ten_seconds.to_i/(@group_more_than_ten_seconds.to_i + @group_less_than_ten_seconds.to_i)) * 100
-    mail to: ["Dev Tools <devtools@quill.org>", "Emilia Friedberg <emilia@quill.org>", "Thomas Robertson <thomasrobertson@quill.org"], subject: "Recommendations Assignment Report"
+    independent_total_recommendations = @independent_more_than_ten_seconds.to_i + @independent_less_than_ten_seconds.to_i
+    group_total_recommendations = @group_more_than_ten_seconds.to_i + @group_less_than_ten_seconds.to_i
+    @percentage_of_independent_less_than_ten_seconds = independent_total_recommendations > 0 ? (@independent_less_than_ten_seconds.to_i/@independent_total_recommendations) * 100 : 100
+    @percentage_of_group_less_than_ten_seconds = group_total_recommendations > 0 ? (@group_less_than_ten_seconds.to_i/group_total_recommendations) * 100 : 100
+    mail to: ["Dev Tools <devtools@quill.org>", "Emilia Friedberg <emilia@quill.org>", "Thomas Robertson <thomasrobertson@quill.org>"], subject: "Recommendations Assignment Report"
   end
 
 end

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -83,7 +83,6 @@ class AssignRecommendationsWorker
           raise "#{elapsed_time} seconds for user #{teacher_id} to assign #{lesson_text} recommendations"
         rescue => e
           NewRelic::Agent.notice_error(e)
-          errors.add(:long_assigning_time, "#{elapsed_time} seconds for user #{teacher_id} to assign #{lesson_text} recommendations")
         end
       else
         diagnostic_recommendations_under_ten_seconds_count = $redis.get("diagnostic_recommendations_under_ten_seconds_count")


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix syntax error in mail_to for recommendations assignment email

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
