### PR TITLE
convert percentage to float for recommendations emails

### DIFF
--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -87,8 +87,8 @@ class UserMailer < ActionMailer::Base
     @group_more_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_over_ten_seconds_count") || 0
     independent_total_recommendations = @independent_more_than_ten_seconds.to_i + @independent_less_than_ten_seconds.to_i
     group_total_recommendations = @group_more_than_ten_seconds.to_i + @group_less_than_ten_seconds.to_i
-    @percentage_of_independent_less_than_ten_seconds = independent_total_recommendations > 0 ? (@independent_less_than_ten_seconds.to_i/independent_total_recommendations) * 100 : 100
-    @percentage_of_group_less_than_ten_seconds = group_total_recommendations > 0 ? (@group_less_than_ten_seconds.to_i/group_total_recommendations) * 100 : 100
+    @percentage_of_independent_less_than_ten_seconds = independent_total_recommendations > 0 ? (@independent_less_than_ten_seconds.to_f/independent_total_recommendations) * 100 : 100
+    @percentage_of_group_less_than_ten_seconds = group_total_recommendations > 0 ? (@group_less_than_ten_seconds.to_f/group_total_recommendations) * 100 : 100
     mail to: ["Dev Tools <devtools@quill.org>", "Emilia Friedberg <emilia@quill.org>", "Thomas Robertson <thomasrobertson@quill.org>"], subject: "Recommendations Assignment Report"
   end
 


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- change percentage to float for recommendations emails

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
