### PR TITLE
Feature/allow sortable unit activities

### DIFF
--- a/docs/models/unit_activity.md
+++ b/docs/models/unit_activity.md
@@ -1,0 +1,11 @@
+# Unit Activity
+
+## Columns
+
+### order_number
+Type: Integer
+Nullable: True
+
+This column was added to support manually-assigned sort orders of activities within a unit.  This allows teachers to drag and drop activities into different orders if they decide that they want students to encounter them in a specific order.
+
+Note that logic was also added to the Student API to respect this sort order when returning activities for students to undertake next.

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -114,6 +114,7 @@ protected
          COALESCE(cuas.completed, 'f') AS marked_complete,
          ua.activity_id,
          MAX(acts.updated_at) AS act_sesh_updated_at,
+         ua.order_number,
          ua.due_date,
          cu.created_at AS unit_activity_created_at,
          COALESCE(cuas.locked, 'f') AS locked,

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -136,7 +136,7 @@ protected
       AND ua.visible = true
       GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
 
-      ORDER BY pinned DESC, locked ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.order_number ASC, ua.id ASC").to_a
+      ORDER BY pinned DESC, locked ASC, ua.order_number ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.id ASC").to_a
     else
       @act_sesh_records = []
     end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -136,7 +136,7 @@ protected
       AND ua.visible = true
       GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
 
-      ORDER BY pinned DESC, locked ASC, ua.order_number ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.id ASC").to_a
+      ORDER BY pinned DESC, locked ASC, unit.created_at ASC, ua.order_number ASC, max_percentage DESC, ua.due_date ASC, ua.id ASC").to_a
     else
       @act_sesh_records = []
     end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -135,7 +135,7 @@ protected
       AND ua.visible = true
       GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
 
-      ORDER BY pinned DESC, locked ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.id ASC").to_a
+      ORDER BY pinned DESC, locked ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.order_number ASC, ua.id ASC").to_a
     else
       @act_sesh_records = []
     end

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -215,6 +215,7 @@ class Teachers::UnitsController < ApplicationController
          classrooms.name AS class_name,
          classrooms.id AS classroom_id,
          activities.activity_classification_id,
+         ua.order_number,
          cu.id AS classroom_unit_id,
          cu.unit_id AS unit_id,
          COALESCE(array_length(cu.assigned_student_ids, 1), 0) AS number_of_assigned_students,
@@ -249,7 +250,7 @@ class Teachers::UnitsController < ApplicationController
         #{lessons}
         GROUP BY units.name, units.created_at, cu.id, classrooms.name, classrooms.id, activities.name, activities.activity_classification_id, activities.id, activities.uid, unit_owner.name, unit_owner.id, ua.due_date, ua.created_at, unit_activity_id, state.completed, ua.id
         #{completed}
-        ORDER BY unit_activity_id
+        ORDER BY ua.order_number, unit_activity_id
         ").to_a
     else
       []

--- a/services/QuillLMS/app/services/units/creator.rb
+++ b/services/QuillLMS/app/services/units/creator.rb
@@ -42,11 +42,12 @@ module Units::Creator
     )
     # makes a permutation of each classroom with each activity to
     # create all necessary activity sessions
-    act_data = activities_data.uniq.map do |activity|
+    act_data = activities_data.uniq.map do |activity, index|
       {
         unit_id: unit.id,
         activity_id: activity[:id],
-        due_date: activity[:due_date]
+        due_date: activity[:due_date],
+        order_number: index + 1
       }
     end
     UnitActivity.create(act_data)

--- a/services/QuillLMS/app/services/units/creator.rb
+++ b/services/QuillLMS/app/services/units/creator.rb
@@ -42,7 +42,7 @@ module Units::Creator
     )
     # makes a permutation of each classroom with each activity to
     # create all necessary activity sessions
-    act_data = activities_data.uniq.map do |activity, index|
+    act_data = activities_data.uniq.map.with_index do |activity, index|
       {
         unit_id: unit.id,
         activity_id: activity[:id],

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -75,7 +75,7 @@ module Units::Updater
     classrooms_data.each do |classroom|
       self.matching_or_new_classroom_unit(classroom, extant_classroom_units, new_cus, hidden_cus_ids, unit_id)
     end
-    activities_data.each do |activity, index|
+    activities_data.each_with_index do |activity, index|
       order_number = index + 1
       self.matching_or_new_unit_activity(activity, extant_unit_activities, new_uas, hidden_ua_ids, unit_id, order_number)
     end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/sortableList.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/sortableList.jsx
@@ -6,7 +6,7 @@ const SortableListItem = sortable(ListItem);
 
 export default class SortableList extends React.Component {
 
-	constructor(props) {
+  constructor(props) {
     super(props)
 
     this.state = {
@@ -19,23 +19,23 @@ export default class SortableList extends React.Component {
     this.updateState = this.updateState.bind(this)
   }
 
-	componentWillReceiveProps(nextProps) {
-		if (nextProps.data !== this.state.data.items) {
-			this.setState({data: {items: nextProps.data}})
-		}
-	}
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.data !== this.state.data.items) {
+      this.setState({data: {items: nextProps.data}})
+    }
+  }
 
-	updateState(obj) {
-		this.setState(obj, this.props.sortCallback(this.state));
-	}
+  updateState(obj) {
+    this.setState(obj, this.props.sortCallback(this.state));
+  }
 
-	render() {
-		const childProps = {
-			className: 'myClass1'
-		};
-		const listItems = this.state.data.items.map(function(item, i) {
-			return (
-				<SortableListItem
+  render() {
+    const childProps = {
+      className: 'myClass1'
+    };
+    const listItems = this.state.data.items.map(function(item, i) {
+      return (
+        <SortableListItem
           key={i}
           updateState={this.updateState}
           items={this.state.data.items}
@@ -45,12 +45,12 @@ export default class SortableList extends React.Component {
           childProps={childProps}
           >
             {item}
-        </SortableListItem>
-			);
-		}, this);
+          </SortableListItem>
+      );
+    }, this);
 
-		return (
-			<div className="list">{listItems}</div>
-		);
-	}
+    return (
+      <div className="list">{listItems}</div>
+    );
+  }
 }

--- a/services/QuillLMS/db/migrate/20190128203336_add_order_number_to_unit_activities.rb
+++ b/services/QuillLMS/db/migrate/20190128203336_add_order_number_to_unit_activities.rb
@@ -1,0 +1,5 @@
+class AddOrderNumberToUnitActivities < ActiveRecord::Migration
+  def change
+    add_column :unit_activities, :order_number, :integer
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2,31 +2,18 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.3 (Ubuntu 10.3-1.pgdg16.04+1)
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 11.1
+-- Dumped by pg_dump version 11.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
@@ -70,13 +57,11 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
 
-SET search_path = public, pg_catalog;
-
 --
 -- Name: blog_posts_search_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION blog_posts_search_trigger() RETURNS trigger
+CREATE FUNCTION public.blog_posts_search_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
       begin
@@ -94,7 +79,7 @@ CREATE FUNCTION blog_posts_search_trigger() RETURNS trigger
 -- Name: old_timespent_teacher(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION old_timespent_teacher(teacher integer) RETURNS bigint
+CREATE FUNCTION public.old_timespent_teacher(teacher integer) RETURNS bigint
     LANGUAGE sql
     AS $$
         SELECT COALESCE(MAX(time_spent)::BIGINT, 0) FROM
@@ -132,7 +117,7 @@ CREATE FUNCTION old_timespent_teacher(teacher integer) RETURNS bigint
 -- Name: timespent_activity_session(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION timespent_activity_session(act_sess integer) RETURNS integer
+CREATE FUNCTION public.timespent_activity_session(act_sess integer) RETURNS integer
     LANGUAGE plpgsql
     AS $$
         DECLARE
@@ -195,7 +180,7 @@ CREATE FUNCTION timespent_activity_session(act_sess integer) RETURNS integer
 -- Name: timespent_question(integer, character varying); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION timespent_question(act_sess integer, question character varying) RETURNS integer
+CREATE FUNCTION public.timespent_question(act_sess integer, question character varying) RETURNS integer
     LANGUAGE plpgsql
     AS $$
         DECLARE
@@ -265,7 +250,7 @@ CREATE FUNCTION timespent_question(act_sess integer, question character varying)
 -- Name: timespent_student(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION timespent_student(student integer) RETURNS bigint
+CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     LANGUAGE sql
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
@@ -280,7 +265,7 @@ CREATE FUNCTION timespent_student(student integer) RETURNS bigint
 -- Name: timespent_student_for_teacher(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION timespent_student_for_teacher(student integer, teacher integer) RETURNS bigint
+CREATE FUNCTION public.timespent_student_for_teacher(student integer, teacher integer) RETURNS bigint
     LANGUAGE sql
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (SELECT activity_sessions.id AS activity_session_id, timespent_activity_session(activity_sessions.id) as time_spent FROM users
@@ -297,7 +282,7 @@ CREATE FUNCTION timespent_student_for_teacher(student integer, teacher integer) 
 -- Name: timespent_teacher(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION timespent_teacher(teacher integer) RETURNS bigint
+CREATE FUNCTION public.timespent_teacher(teacher integer) RETURNS bigint
     LANGUAGE sql
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (SELECT activity_sessions.id AS activity_session_id, timespent_activity_session(activity_sessions.id) as time_spent FROM users
@@ -317,12 +302,12 @@ SET default_with_oids = false;
 -- Name: activities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activities (
+CREATE TABLE public.activities (
     id integer NOT NULL,
     name character varying(255),
     description text,
     uid character varying(255) NOT NULL,
-    data hstore,
+    data public.hstore,
     activity_classification_id integer,
     topic_id integer,
     created_at timestamp without time zone,
@@ -338,7 +323,7 @@ CREATE TABLE activities (
 -- Name: activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activities_id_seq
+CREATE SEQUENCE public.activities_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -350,14 +335,14 @@ CREATE SEQUENCE activities_id_seq
 -- Name: activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activities_id_seq OWNED BY activities.id;
+ALTER SEQUENCE public.activities_id_seq OWNED BY public.activities.id;
 
 
 --
 -- Name: activities_unit_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activities_unit_templates (
+CREATE TABLE public.activities_unit_templates (
     unit_template_id integer NOT NULL,
     activity_id integer NOT NULL,
     id integer NOT NULL
@@ -368,7 +353,7 @@ CREATE TABLE activities_unit_templates (
 -- Name: activities_unit_templates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activities_unit_templates_id_seq
+CREATE SEQUENCE public.activities_unit_templates_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -381,14 +366,14 @@ CREATE SEQUENCE activities_unit_templates_id_seq
 -- Name: activities_unit_templates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activities_unit_templates_id_seq OWNED BY activities_unit_templates.id;
+ALTER SEQUENCE public.activities_unit_templates_id_seq OWNED BY public.activities_unit_templates.id;
 
 
 --
 -- Name: activity_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activity_categories (
+CREATE TABLE public.activity_categories (
     id integer NOT NULL,
     name character varying,
     order_number integer,
@@ -401,7 +386,7 @@ CREATE TABLE activity_categories (
 -- Name: activity_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activity_categories_id_seq
+CREATE SEQUENCE public.activity_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -413,14 +398,14 @@ CREATE SEQUENCE activity_categories_id_seq
 -- Name: activity_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activity_categories_id_seq OWNED BY activity_categories.id;
+ALTER SEQUENCE public.activity_categories_id_seq OWNED BY public.activity_categories.id;
 
 
 --
 -- Name: activity_category_activities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activity_category_activities (
+CREATE TABLE public.activity_category_activities (
     id integer NOT NULL,
     activity_category_id integer,
     activity_id integer,
@@ -434,7 +419,7 @@ CREATE TABLE activity_category_activities (
 -- Name: activity_category_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activity_category_activities_id_seq
+CREATE SEQUENCE public.activity_category_activities_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -446,14 +431,14 @@ CREATE SEQUENCE activity_category_activities_id_seq
 -- Name: activity_category_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activity_category_activities_id_seq OWNED BY activity_category_activities.id;
+ALTER SEQUENCE public.activity_category_activities_id_seq OWNED BY public.activity_category_activities.id;
 
 
 --
 -- Name: activity_classifications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activity_classifications (
+CREATE TABLE public.activity_classifications (
     id integer NOT NULL,
     name character varying(255),
     key character varying(255) NOT NULL,
@@ -474,7 +459,7 @@ CREATE TABLE activity_classifications (
 -- Name: activity_classifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activity_classifications_id_seq
+CREATE SEQUENCE public.activity_classifications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -486,14 +471,14 @@ CREATE SEQUENCE activity_classifications_id_seq
 -- Name: activity_classifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activity_classifications_id_seq OWNED BY activity_classifications.id;
+ALTER SEQUENCE public.activity_classifications_id_seq OWNED BY public.activity_classifications.id;
 
 
 --
 -- Name: activity_session_interaction_logs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activity_session_interaction_logs (
+CREATE TABLE public.activity_session_interaction_logs (
     id integer NOT NULL,
     date timestamp without time zone,
     meta jsonb,
@@ -505,7 +490,7 @@ CREATE TABLE activity_session_interaction_logs (
 -- Name: activity_session_interaction_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activity_session_interaction_logs_id_seq
+CREATE SEQUENCE public.activity_session_interaction_logs_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -518,14 +503,14 @@ CREATE SEQUENCE activity_session_interaction_logs_id_seq
 -- Name: activity_session_interaction_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activity_session_interaction_logs_id_seq OWNED BY activity_session_interaction_logs.id;
+ALTER SEQUENCE public.activity_session_interaction_logs_id_seq OWNED BY public.activity_session_interaction_logs.id;
 
 
 --
 -- Name: old_activity_sessions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE old_activity_sessions (
+CREATE TABLE public.old_activity_sessions (
     id integer NOT NULL,
     classroom_activity_id integer,
     activity_id integer,
@@ -536,7 +521,7 @@ CREATE TABLE old_activity_sessions (
     completed_at timestamp without time zone,
     uid character varying(255),
     temporary boolean DEFAULT false,
-    data hstore,
+    data public.hstore,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     started_at timestamp without time zone,
@@ -551,7 +536,7 @@ CREATE TABLE old_activity_sessions (
 -- Name: activity_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE activity_sessions_id_seq
+CREATE SEQUENCE public.activity_sessions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -563,15 +548,15 @@ CREATE SEQUENCE activity_sessions_id_seq
 -- Name: activity_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE activity_sessions_id_seq OWNED BY old_activity_sessions.id;
+ALTER SEQUENCE public.activity_sessions_id_seq OWNED BY public.old_activity_sessions.id;
 
 
 --
 -- Name: activity_sessions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE activity_sessions (
-    id integer DEFAULT nextval('activity_sessions_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.activity_sessions (
+    id integer DEFAULT nextval('public.activity_sessions_id_seq'::regclass) NOT NULL,
     classroom_activity_id integer,
     activity_id integer,
     user_id integer,
@@ -581,7 +566,7 @@ CREATE TABLE activity_sessions (
     completed_at timestamp without time zone,
     uid character varying(255),
     temporary boolean,
-    data hstore,
+    data public.hstore,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     started_at timestamp without time zone,
@@ -597,7 +582,7 @@ CREATE TABLE activity_sessions (
 -- Name: admin_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE admin_accounts (
+CREATE TABLE public.admin_accounts (
     id integer NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -609,7 +594,7 @@ CREATE TABLE admin_accounts (
 -- Name: admin_accounts_admins; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE admin_accounts_admins (
+CREATE TABLE public.admin_accounts_admins (
     id integer NOT NULL,
     admin_account_id integer,
     admin_id integer,
@@ -622,7 +607,7 @@ CREATE TABLE admin_accounts_admins (
 -- Name: admin_accounts_admins_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE admin_accounts_admins_id_seq
+CREATE SEQUENCE public.admin_accounts_admins_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -634,14 +619,14 @@ CREATE SEQUENCE admin_accounts_admins_id_seq
 -- Name: admin_accounts_admins_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE admin_accounts_admins_id_seq OWNED BY admin_accounts_admins.id;
+ALTER SEQUENCE public.admin_accounts_admins_id_seq OWNED BY public.admin_accounts_admins.id;
 
 
 --
 -- Name: admin_accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE admin_accounts_id_seq
+CREATE SEQUENCE public.admin_accounts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -653,14 +638,14 @@ CREATE SEQUENCE admin_accounts_id_seq
 -- Name: admin_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE admin_accounts_id_seq OWNED BY admin_accounts.id;
+ALTER SEQUENCE public.admin_accounts_id_seq OWNED BY public.admin_accounts.id;
 
 
 --
 -- Name: admin_accounts_teachers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE admin_accounts_teachers (
+CREATE TABLE public.admin_accounts_teachers (
     id integer NOT NULL,
     admin_account_id integer,
     teacher_id integer,
@@ -673,7 +658,7 @@ CREATE TABLE admin_accounts_teachers (
 -- Name: admin_accounts_teachers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE admin_accounts_teachers_id_seq
+CREATE SEQUENCE public.admin_accounts_teachers_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -685,14 +670,14 @@ CREATE SEQUENCE admin_accounts_teachers_id_seq
 -- Name: admin_accounts_teachers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE admin_accounts_teachers_id_seq OWNED BY admin_accounts_teachers.id;
+ALTER SEQUENCE public.admin_accounts_teachers_id_seq OWNED BY public.admin_accounts_teachers.id;
 
 
 --
 -- Name: announcements; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE announcements (
+CREATE TABLE public.announcements (
     id integer NOT NULL,
     announcement_type character varying,
     start timestamp without time zone,
@@ -706,7 +691,7 @@ CREATE TABLE announcements (
 -- Name: announcements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE announcements_id_seq
+CREATE SEQUENCE public.announcements_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -719,14 +704,14 @@ CREATE SEQUENCE announcements_id_seq
 -- Name: announcements_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE announcements_id_seq OWNED BY announcements.id;
+ALTER SEQUENCE public.announcements_id_seq OWNED BY public.announcements.id;
 
 
 --
 -- Name: auth_credentials; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE auth_credentials (
+CREATE TABLE public.auth_credentials (
     id integer NOT NULL,
     user_id integer NOT NULL,
     refresh_token character varying,
@@ -743,7 +728,7 @@ CREATE TABLE auth_credentials (
 -- Name: auth_credentials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE auth_credentials_id_seq
+CREATE SEQUENCE public.auth_credentials_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -756,14 +741,14 @@ CREATE SEQUENCE auth_credentials_id_seq
 -- Name: auth_credentials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE auth_credentials_id_seq OWNED BY auth_credentials.id;
+ALTER SEQUENCE public.auth_credentials_id_seq OWNED BY public.auth_credentials.id;
 
 
 --
 -- Name: authors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE authors (
+CREATE TABLE public.authors (
     id integer NOT NULL,
     name character varying(255),
     avatar text
@@ -774,7 +759,7 @@ CREATE TABLE authors (
 -- Name: authors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE authors_id_seq
+CREATE SEQUENCE public.authors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -786,14 +771,14 @@ CREATE SEQUENCE authors_id_seq
 -- Name: authors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE authors_id_seq OWNED BY authors.id;
+ALTER SEQUENCE public.authors_id_seq OWNED BY public.authors.id;
 
 
 --
 -- Name: blog_post_user_ratings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE blog_post_user_ratings (
+CREATE TABLE public.blog_post_user_ratings (
     id integer NOT NULL,
     blog_post_id integer,
     user_id integer,
@@ -807,7 +792,7 @@ CREATE TABLE blog_post_user_ratings (
 -- Name: blog_post_user_ratings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE blog_post_user_ratings_id_seq
+CREATE SEQUENCE public.blog_post_user_ratings_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -820,14 +805,14 @@ CREATE SEQUENCE blog_post_user_ratings_id_seq
 -- Name: blog_post_user_ratings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE blog_post_user_ratings_id_seq OWNED BY blog_post_user_ratings.id;
+ALTER SEQUENCE public.blog_post_user_ratings_id_seq OWNED BY public.blog_post_user_ratings.id;
 
 
 --
 -- Name: blog_posts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE blog_posts (
+CREATE TABLE public.blog_posts (
     id integer NOT NULL,
     title character varying NOT NULL,
     body text NOT NULL,
@@ -854,7 +839,7 @@ CREATE TABLE blog_posts (
 -- Name: blog_posts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE blog_posts_id_seq
+CREATE SEQUENCE public.blog_posts_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -867,14 +852,14 @@ CREATE SEQUENCE blog_posts_id_seq
 -- Name: blog_posts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE blog_posts_id_seq OWNED BY blog_posts.id;
+ALTER SEQUENCE public.blog_posts_id_seq OWNED BY public.blog_posts.id;
 
 
 --
 -- Name: categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE categories (
+CREATE TABLE public.categories (
     id integer NOT NULL,
     title text,
     created_at timestamp without time zone NOT NULL,
@@ -886,7 +871,7 @@ CREATE TABLE categories (
 -- Name: categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE categories_id_seq
+CREATE SEQUENCE public.categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -898,14 +883,14 @@ CREATE SEQUENCE categories_id_seq
 -- Name: categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
+ALTER SEQUENCE public.categories_id_seq OWNED BY public.categories.id;
 
 
 --
 -- Name: checkboxes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE checkboxes (
+CREATE TABLE public.checkboxes (
     id integer NOT NULL,
     user_id integer,
     objective_id integer,
@@ -919,7 +904,7 @@ CREATE TABLE checkboxes (
 -- Name: checkboxes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE checkboxes_id_seq
+CREATE SEQUENCE public.checkboxes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -931,14 +916,14 @@ CREATE SEQUENCE checkboxes_id_seq
 -- Name: checkboxes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE checkboxes_id_seq OWNED BY checkboxes.id;
+ALTER SEQUENCE public.checkboxes_id_seq OWNED BY public.checkboxes.id;
 
 
 --
 -- Name: classroom_activities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE classroom_activities (
+CREATE TABLE public.classroom_activities (
     id integer NOT NULL,
     classroom_id integer,
     activity_id integer,
@@ -959,7 +944,7 @@ CREATE TABLE classroom_activities (
 -- Name: classroom_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE classroom_activities_id_seq
+CREATE SEQUENCE public.classroom_activities_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -971,14 +956,14 @@ CREATE SEQUENCE classroom_activities_id_seq
 -- Name: classroom_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE classroom_activities_id_seq OWNED BY classroom_activities.id;
+ALTER SEQUENCE public.classroom_activities_id_seq OWNED BY public.classroom_activities.id;
 
 
 --
 -- Name: classroom_unit_activity_states; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE classroom_unit_activity_states (
+CREATE TABLE public.classroom_unit_activity_states (
     id integer NOT NULL,
     classroom_unit_id integer NOT NULL,
     unit_activity_id integer NOT NULL,
@@ -995,7 +980,7 @@ CREATE TABLE classroom_unit_activity_states (
 -- Name: classroom_unit_activity_states_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE classroom_unit_activity_states_id_seq
+CREATE SEQUENCE public.classroom_unit_activity_states_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1008,14 +993,14 @@ CREATE SEQUENCE classroom_unit_activity_states_id_seq
 -- Name: classroom_unit_activity_states_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE classroom_unit_activity_states_id_seq OWNED BY classroom_unit_activity_states.id;
+ALTER SEQUENCE public.classroom_unit_activity_states_id_seq OWNED BY public.classroom_unit_activity_states.id;
 
 
 --
 -- Name: classroom_units; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE classroom_units (
+CREATE TABLE public.classroom_units (
     id integer NOT NULL,
     classroom_id integer NOT NULL,
     unit_id integer NOT NULL,
@@ -1031,7 +1016,7 @@ CREATE TABLE classroom_units (
 -- Name: classroom_units_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE classroom_units_id_seq
+CREATE SEQUENCE public.classroom_units_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1044,14 +1029,14 @@ CREATE SEQUENCE classroom_units_id_seq
 -- Name: classroom_units_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE classroom_units_id_seq OWNED BY classroom_units.id;
+ALTER SEQUENCE public.classroom_units_id_seq OWNED BY public.classroom_units.id;
 
 
 --
 -- Name: classrooms; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE classrooms (
+CREATE TABLE public.classrooms (
     id integer NOT NULL,
     name character varying(255),
     code character varying(255),
@@ -1070,7 +1055,7 @@ CREATE TABLE classrooms (
 -- Name: classrooms_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE classrooms_id_seq
+CREATE SEQUENCE public.classrooms_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1082,14 +1067,14 @@ CREATE SEQUENCE classrooms_id_seq
 -- Name: classrooms_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE classrooms_id_seq OWNED BY classrooms.id;
+ALTER SEQUENCE public.classrooms_id_seq OWNED BY public.classrooms.id;
 
 
 --
 -- Name: classrooms_teachers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE classrooms_teachers (
+CREATE TABLE public.classrooms_teachers (
     id integer NOT NULL,
     user_id integer NOT NULL,
     classroom_id integer NOT NULL,
@@ -1104,7 +1089,7 @@ CREATE TABLE classrooms_teachers (
 -- Name: classrooms_teachers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE classrooms_teachers_id_seq
+CREATE SEQUENCE public.classrooms_teachers_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1116,14 +1101,14 @@ CREATE SEQUENCE classrooms_teachers_id_seq
 -- Name: classrooms_teachers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE classrooms_teachers_id_seq OWNED BY classrooms_teachers.id;
+ALTER SEQUENCE public.classrooms_teachers_id_seq OWNED BY public.classrooms_teachers.id;
 
 
 --
 -- Name: comments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE comments (
+CREATE TABLE public.comments (
     id integer NOT NULL,
     title character varying(255),
     body text,
@@ -1140,7 +1125,7 @@ CREATE TABLE comments (
 -- Name: comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE comments_id_seq
+CREATE SEQUENCE public.comments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1152,14 +1137,14 @@ CREATE SEQUENCE comments_id_seq
 -- Name: comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE comments_id_seq OWNED BY comments.id;
+ALTER SEQUENCE public.comments_id_seq OWNED BY public.comments.id;
 
 
 --
 -- Name: concept_results; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE concept_results (
+CREATE TABLE public.concept_results (
     id integer NOT NULL,
     activity_session_id integer,
     concept_id integer NOT NULL,
@@ -1173,7 +1158,7 @@ CREATE TABLE concept_results (
 -- Name: concept_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE concept_results_id_seq
+CREATE SEQUENCE public.concept_results_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1185,14 +1170,14 @@ CREATE SEQUENCE concept_results_id_seq
 -- Name: concept_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE concept_results_id_seq OWNED BY concept_results.id;
+ALTER SEQUENCE public.concept_results_id_seq OWNED BY public.concept_results.id;
 
 
 --
 -- Name: concepts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE concepts (
+CREATE TABLE public.concepts (
     id integer NOT NULL,
     name character varying(255),
     created_at timestamp without time zone,
@@ -1209,7 +1194,7 @@ CREATE TABLE concepts (
 -- Name: concepts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE concepts_id_seq
+CREATE SEQUENCE public.concepts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1221,14 +1206,14 @@ CREATE SEQUENCE concepts_id_seq
 -- Name: concepts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE concepts_id_seq OWNED BY concepts.id;
+ALTER SEQUENCE public.concepts_id_seq OWNED BY public.concepts.id;
 
 
 --
 -- Name: coteacher_classroom_invitations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE coteacher_classroom_invitations (
+CREATE TABLE public.coteacher_classroom_invitations (
     id integer NOT NULL,
     invitation_id integer NOT NULL,
     classroom_id integer NOT NULL,
@@ -1241,7 +1226,7 @@ CREATE TABLE coteacher_classroom_invitations (
 -- Name: coteacher_classroom_invitations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE coteacher_classroom_invitations_id_seq
+CREATE SEQUENCE public.coteacher_classroom_invitations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1253,14 +1238,14 @@ CREATE SEQUENCE coteacher_classroom_invitations_id_seq
 -- Name: coteacher_classroom_invitations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE coteacher_classroom_invitations_id_seq OWNED BY coteacher_classroom_invitations.id;
+ALTER SEQUENCE public.coteacher_classroom_invitations_id_seq OWNED BY public.coteacher_classroom_invitations.id;
 
 
 --
 -- Name: credit_transactions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE credit_transactions (
+CREATE TABLE public.credit_transactions (
     id integer NOT NULL,
     amount integer NOT NULL,
     user_id integer NOT NULL,
@@ -1275,7 +1260,7 @@ CREATE TABLE credit_transactions (
 -- Name: credit_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE credit_transactions_id_seq
+CREATE SEQUENCE public.credit_transactions_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1288,14 +1273,14 @@ CREATE SEQUENCE credit_transactions_id_seq
 -- Name: credit_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE credit_transactions_id_seq OWNED BY credit_transactions.id;
+ALTER SEQUENCE public.credit_transactions_id_seq OWNED BY public.credit_transactions.id;
 
 
 --
 -- Name: criteria; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE criteria (
+CREATE TABLE public.criteria (
     id integer NOT NULL,
     concept_id integer NOT NULL,
     count integer DEFAULT 0 NOT NULL,
@@ -1308,7 +1293,7 @@ CREATE TABLE criteria (
 -- Name: criteria_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE criteria_id_seq
+CREATE SEQUENCE public.criteria_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1321,14 +1306,14 @@ CREATE SEQUENCE criteria_id_seq
 -- Name: criteria_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE criteria_id_seq OWNED BY criteria.id;
+ALTER SEQUENCE public.criteria_id_seq OWNED BY public.criteria.id;
 
 
 --
 -- Name: csv_exports; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE csv_exports (
+CREATE TABLE public.csv_exports (
     id integer NOT NULL,
     export_type character varying(255),
     emailed_at timestamp without time zone,
@@ -1344,7 +1329,7 @@ CREATE TABLE csv_exports (
 -- Name: csv_exports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE csv_exports_id_seq
+CREATE SEQUENCE public.csv_exports_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1356,14 +1341,14 @@ CREATE SEQUENCE csv_exports_id_seq
 -- Name: csv_exports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE csv_exports_id_seq OWNED BY csv_exports.id;
+ALTER SEQUENCE public.csv_exports_id_seq OWNED BY public.csv_exports.id;
 
 
 --
 -- Name: districts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE districts (
+CREATE TABLE public.districts (
     id integer NOT NULL,
     clever_id character varying(255),
     name character varying(255),
@@ -1377,7 +1362,7 @@ CREATE TABLE districts (
 -- Name: districts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE districts_id_seq
+CREATE SEQUENCE public.districts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1389,14 +1374,14 @@ CREATE SEQUENCE districts_id_seq
 -- Name: districts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE districts_id_seq OWNED BY districts.id;
+ALTER SEQUENCE public.districts_id_seq OWNED BY public.districts.id;
 
 
 --
 -- Name: districts_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE districts_users (
+CREATE TABLE public.districts_users (
     district_id integer,
     user_id integer
 );
@@ -1406,7 +1391,7 @@ CREATE TABLE districts_users (
 -- Name: file_uploads; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE file_uploads (
+CREATE TABLE public.file_uploads (
     id integer NOT NULL,
     name character varying(255),
     file character varying(255),
@@ -1420,7 +1405,7 @@ CREATE TABLE file_uploads (
 -- Name: file_uploads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE file_uploads_id_seq
+CREATE SEQUENCE public.file_uploads_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1432,14 +1417,14 @@ CREATE SEQUENCE file_uploads_id_seq
 -- Name: file_uploads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE file_uploads_id_seq OWNED BY file_uploads.id;
+ALTER SEQUENCE public.file_uploads_id_seq OWNED BY public.file_uploads.id;
 
 
 --
 -- Name: firebase_apps; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE firebase_apps (
+CREATE TABLE public.firebase_apps (
     id integer NOT NULL,
     name character varying(255),
     secret character varying(255),
@@ -1453,7 +1438,7 @@ CREATE TABLE firebase_apps (
 -- Name: firebase_apps_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE firebase_apps_id_seq
+CREATE SEQUENCE public.firebase_apps_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1465,14 +1450,14 @@ CREATE SEQUENCE firebase_apps_id_seq
 -- Name: firebase_apps_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE firebase_apps_id_seq OWNED BY firebase_apps.id;
+ALTER SEQUENCE public.firebase_apps_id_seq OWNED BY public.firebase_apps.id;
 
 
 --
 -- Name: images; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE images (
+CREATE TABLE public.images (
     id integer NOT NULL,
     file character varying,
     created_at timestamp without time zone,
@@ -1484,7 +1469,7 @@ CREATE TABLE images (
 -- Name: images_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE images_id_seq
+CREATE SEQUENCE public.images_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1497,14 +1482,14 @@ CREATE SEQUENCE images_id_seq
 -- Name: images_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE images_id_seq OWNED BY images.id;
+ALTER SEQUENCE public.images_id_seq OWNED BY public.images.id;
 
 
 --
 -- Name: invitations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE invitations (
+CREATE TABLE public.invitations (
     id integer NOT NULL,
     invitee_email character varying NOT NULL,
     inviter_id integer NOT NULL,
@@ -1519,7 +1504,7 @@ CREATE TABLE invitations (
 -- Name: invitations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE invitations_id_seq
+CREATE SEQUENCE public.invitations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1531,14 +1516,14 @@ CREATE SEQUENCE invitations_id_seq
 -- Name: invitations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE invitations_id_seq OWNED BY invitations.id;
+ALTER SEQUENCE public.invitations_id_seq OWNED BY public.invitations.id;
 
 
 --
 -- Name: ip_locations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ip_locations (
+CREATE TABLE public.ip_locations (
     id integer NOT NULL,
     country character varying,
     city character varying,
@@ -1554,7 +1539,7 @@ CREATE TABLE ip_locations (
 -- Name: ip_locations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ip_locations_id_seq
+CREATE SEQUENCE public.ip_locations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1566,14 +1551,14 @@ CREATE SEQUENCE ip_locations_id_seq
 -- Name: ip_locations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ip_locations_id_seq OWNED BY ip_locations.id;
+ALTER SEQUENCE public.ip_locations_id_seq OWNED BY public.ip_locations.id;
 
 
 --
 -- Name: milestones; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE milestones (
+CREATE TABLE public.milestones (
     id integer NOT NULL,
     name character varying NOT NULL,
     created_at timestamp without time zone,
@@ -1585,7 +1570,7 @@ CREATE TABLE milestones (
 -- Name: milestones_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE milestones_id_seq
+CREATE SEQUENCE public.milestones_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1597,14 +1582,14 @@ CREATE SEQUENCE milestones_id_seq
 -- Name: milestones_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE milestones_id_seq OWNED BY milestones.id;
+ALTER SEQUENCE public.milestones_id_seq OWNED BY public.milestones.id;
 
 
 --
 -- Name: new_activity_sessions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE new_activity_sessions (
+CREATE TABLE public.new_activity_sessions (
     id integer NOT NULL,
     classroom_activity_id integer,
     activity_id integer,
@@ -1615,7 +1600,7 @@ CREATE TABLE new_activity_sessions (
     completed_at timestamp without time zone,
     uid character varying(255),
     temporary boolean,
-    data hstore,
+    data public.hstore,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     started_at timestamp without time zone,
@@ -1630,7 +1615,7 @@ CREATE TABLE new_activity_sessions (
 -- Name: newer_activity_sessions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE newer_activity_sessions (
+CREATE TABLE public.newer_activity_sessions (
     id integer,
     classroom_activity_id integer,
     activity_id integer,
@@ -1641,7 +1626,7 @@ CREATE TABLE newer_activity_sessions (
     completed_at timestamp without time zone,
     uid character varying(255),
     temporary boolean,
-    data hstore,
+    data public.hstore,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     started_at timestamp without time zone,
@@ -1656,7 +1641,7 @@ CREATE TABLE newer_activity_sessions (
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE notifications (
+CREATE TABLE public.notifications (
     id integer NOT NULL,
     text text NOT NULL,
     user_id integer NOT NULL,
@@ -1670,7 +1655,7 @@ CREATE TABLE notifications (
 -- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE notifications_id_seq
+CREATE SEQUENCE public.notifications_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1683,14 +1668,14 @@ CREATE SEQUENCE notifications_id_seq
 -- Name: notifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE notifications_id_seq OWNED BY notifications.id;
+ALTER SEQUENCE public.notifications_id_seq OWNED BY public.notifications.id;
 
 
 --
 -- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE oauth_access_grants (
+CREATE TABLE public.oauth_access_grants (
     id integer NOT NULL,
     resource_owner_id integer NOT NULL,
     application_id integer NOT NULL,
@@ -1707,7 +1692,7 @@ CREATE TABLE oauth_access_grants (
 -- Name: oauth_access_grants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE oauth_access_grants_id_seq
+CREATE SEQUENCE public.oauth_access_grants_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1719,14 +1704,14 @@ CREATE SEQUENCE oauth_access_grants_id_seq
 -- Name: oauth_access_grants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
+ALTER SEQUENCE public.oauth_access_grants_id_seq OWNED BY public.oauth_access_grants.id;
 
 
 --
 -- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE oauth_access_tokens (
+CREATE TABLE public.oauth_access_tokens (
     id integer NOT NULL,
     resource_owner_id integer,
     application_id integer,
@@ -1743,7 +1728,7 @@ CREATE TABLE oauth_access_tokens (
 -- Name: oauth_access_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE oauth_access_tokens_id_seq
+CREATE SEQUENCE public.oauth_access_tokens_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1755,14 +1740,14 @@ CREATE SEQUENCE oauth_access_tokens_id_seq
 -- Name: oauth_access_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
+ALTER SEQUENCE public.oauth_access_tokens_id_seq OWNED BY public.oauth_access_tokens.id;
 
 
 --
 -- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE oauth_applications (
+CREATE TABLE public.oauth_applications (
     id integer NOT NULL,
     name character varying(255) NOT NULL,
     uid character varying(255) NOT NULL,
@@ -1777,7 +1762,7 @@ CREATE TABLE oauth_applications (
 -- Name: oauth_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE oauth_applications_id_seq
+CREATE SEQUENCE public.oauth_applications_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1789,14 +1774,14 @@ CREATE SEQUENCE oauth_applications_id_seq
 -- Name: oauth_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
+ALTER SEQUENCE public.oauth_applications_id_seq OWNED BY public.oauth_applications.id;
 
 
 --
 -- Name: objectives; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE objectives (
+CREATE TABLE public.objectives (
     id integer NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
@@ -1813,7 +1798,7 @@ CREATE TABLE objectives (
 -- Name: objectives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE objectives_id_seq
+CREATE SEQUENCE public.objectives_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1825,14 +1810,14 @@ CREATE SEQUENCE objectives_id_seq
 -- Name: objectives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE objectives_id_seq OWNED BY objectives.id;
+ALTER SEQUENCE public.objectives_id_seq OWNED BY public.objectives.id;
 
 
 --
 -- Name: page_areas; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE page_areas (
+CREATE TABLE public.page_areas (
     id integer NOT NULL,
     name character varying(255),
     description character varying(255),
@@ -1846,7 +1831,7 @@ CREATE TABLE page_areas (
 -- Name: page_areas_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE page_areas_id_seq
+CREATE SEQUENCE public.page_areas_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1858,14 +1843,14 @@ CREATE SEQUENCE page_areas_id_seq
 -- Name: page_areas_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE page_areas_id_seq OWNED BY page_areas.id;
+ALTER SEQUENCE public.page_areas_id_seq OWNED BY public.page_areas.id;
 
 
 --
 -- Name: recommendations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE recommendations (
+CREATE TABLE public.recommendations (
     id integer NOT NULL,
     name character varying NOT NULL,
     activity_id integer NOT NULL,
@@ -1879,7 +1864,7 @@ CREATE TABLE recommendations (
 -- Name: recommendations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE recommendations_id_seq
+CREATE SEQUENCE public.recommendations_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1892,14 +1877,14 @@ CREATE SEQUENCE recommendations_id_seq
 -- Name: recommendations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE recommendations_id_seq OWNED BY recommendations.id;
+ALTER SEQUENCE public.recommendations_id_seq OWNED BY public.recommendations.id;
 
 
 --
 -- Name: referrals_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE referrals_users (
+CREATE TABLE public.referrals_users (
     id integer NOT NULL,
     user_id integer NOT NULL,
     referred_user_id integer NOT NULL,
@@ -1913,7 +1898,7 @@ CREATE TABLE referrals_users (
 -- Name: referrals_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE referrals_users_id_seq
+CREATE SEQUENCE public.referrals_users_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1926,14 +1911,14 @@ CREATE SEQUENCE referrals_users_id_seq
 -- Name: referrals_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE referrals_users_id_seq OWNED BY referrals_users.id;
+ALTER SEQUENCE public.referrals_users_id_seq OWNED BY public.referrals_users.id;
 
 
 --
 -- Name: referrer_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE referrer_users (
+CREATE TABLE public.referrer_users (
     id integer NOT NULL,
     user_id integer NOT NULL,
     referral_code character varying NOT NULL,
@@ -1946,7 +1931,7 @@ CREATE TABLE referrer_users (
 -- Name: referrer_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE referrer_users_id_seq
+CREATE SEQUENCE public.referrer_users_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1959,14 +1944,14 @@ CREATE SEQUENCE referrer_users_id_seq
 -- Name: referrer_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE referrer_users_id_seq OWNED BY referrer_users.id;
+ALTER SEQUENCE public.referrer_users_id_seq OWNED BY public.referrer_users.id;
 
 
 --
 -- Name: rules_misseds; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE rules_misseds (
+CREATE TABLE public.rules_misseds (
     id integer NOT NULL,
     rule_id integer,
     user_id integer,
@@ -1982,7 +1967,7 @@ CREATE TABLE rules_misseds (
 -- Name: rules_misseds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE rules_misseds_id_seq
+CREATE SEQUENCE public.rules_misseds_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1994,14 +1979,14 @@ CREATE SEQUENCE rules_misseds_id_seq
 -- Name: rules_misseds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE rules_misseds_id_seq OWNED BY rules_misseds.id;
+ALTER SEQUENCE public.rules_misseds_id_seq OWNED BY public.rules_misseds.id;
 
 
 --
 -- Name: sales_contacts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sales_contacts (
+CREATE TABLE public.sales_contacts (
     id integer NOT NULL,
     user_id integer NOT NULL,
     created_at timestamp without time zone,
@@ -2013,7 +1998,7 @@ CREATE TABLE sales_contacts (
 -- Name: sales_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sales_contacts_id_seq
+CREATE SEQUENCE public.sales_contacts_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2026,14 +2011,14 @@ CREATE SEQUENCE sales_contacts_id_seq
 -- Name: sales_contacts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sales_contacts_id_seq OWNED BY sales_contacts.id;
+ALTER SEQUENCE public.sales_contacts_id_seq OWNED BY public.sales_contacts.id;
 
 
 --
 -- Name: sales_stage_types; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sales_stage_types (
+CREATE TABLE public.sales_stage_types (
     id integer NOT NULL,
     description text,
     name text NOT NULL,
@@ -2048,7 +2033,7 @@ CREATE TABLE sales_stage_types (
 -- Name: sales_stage_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sales_stage_types_id_seq
+CREATE SEQUENCE public.sales_stage_types_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2061,14 +2046,14 @@ CREATE SEQUENCE sales_stage_types_id_seq
 -- Name: sales_stage_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sales_stage_types_id_seq OWNED BY sales_stage_types.id;
+ALTER SEQUENCE public.sales_stage_types_id_seq OWNED BY public.sales_stage_types.id;
 
 
 --
 -- Name: sales_stages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sales_stages (
+CREATE TABLE public.sales_stages (
     id integer NOT NULL,
     user_id integer,
     sales_stage_type_id integer NOT NULL,
@@ -2083,7 +2068,7 @@ CREATE TABLE sales_stages (
 -- Name: sales_stages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sales_stages_id_seq
+CREATE SEQUENCE public.sales_stages_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2096,14 +2081,14 @@ CREATE SEQUENCE sales_stages_id_seq
 -- Name: sales_stages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sales_stages_id_seq OWNED BY sales_stages.id;
+ALTER SEQUENCE public.sales_stages_id_seq OWNED BY public.sales_stages.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying(255) NOT NULL
 );
 
@@ -2112,7 +2097,7 @@ CREATE TABLE schema_migrations (
 -- Name: school_subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE school_subscriptions (
+CREATE TABLE public.school_subscriptions (
     id integer NOT NULL,
     school_id integer,
     subscription_id integer,
@@ -2125,7 +2110,7 @@ CREATE TABLE school_subscriptions (
 -- Name: school_subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE school_subscriptions_id_seq
+CREATE SEQUENCE public.school_subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2137,14 +2122,14 @@ CREATE SEQUENCE school_subscriptions_id_seq
 -- Name: school_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE school_subscriptions_id_seq OWNED BY school_subscriptions.id;
+ALTER SEQUENCE public.school_subscriptions_id_seq OWNED BY public.school_subscriptions.id;
 
 
 --
 -- Name: schools; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schools (
+CREATE TABLE public.schools (
     id integer NOT NULL,
     nces_id character varying(255),
     lea_id character varying(255),
@@ -2186,7 +2171,7 @@ CREATE TABLE schools (
 -- Name: schools_admins; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schools_admins (
+CREATE TABLE public.schools_admins (
     id integer NOT NULL,
     user_id integer,
     school_id integer,
@@ -2199,7 +2184,7 @@ CREATE TABLE schools_admins (
 -- Name: schools_admins_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE schools_admins_id_seq
+CREATE SEQUENCE public.schools_admins_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2211,14 +2196,14 @@ CREATE SEQUENCE schools_admins_id_seq
 -- Name: schools_admins_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE schools_admins_id_seq OWNED BY schools_admins.id;
+ALTER SEQUENCE public.schools_admins_id_seq OWNED BY public.schools_admins.id;
 
 
 --
 -- Name: schools_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE schools_id_seq
+CREATE SEQUENCE public.schools_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2230,14 +2215,14 @@ CREATE SEQUENCE schools_id_seq
 -- Name: schools_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE schools_id_seq OWNED BY schools.id;
+ALTER SEQUENCE public.schools_id_seq OWNED BY public.schools.id;
 
 
 --
 -- Name: schools_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schools_users (
+CREATE TABLE public.schools_users (
     school_id integer,
     user_id integer,
     id integer NOT NULL
@@ -2248,7 +2233,7 @@ CREATE TABLE schools_users (
 -- Name: schools_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE schools_users_id_seq
+CREATE SEQUENCE public.schools_users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2260,14 +2245,14 @@ CREATE SEQUENCE schools_users_id_seq
 -- Name: schools_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE schools_users_id_seq OWNED BY schools_users.id;
+ALTER SEQUENCE public.schools_users_id_seq OWNED BY public.schools_users.id;
 
 
 --
 -- Name: sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE sections (
+CREATE TABLE public.sections (
     id integer NOT NULL,
     name character varying(255),
     "position" integer,
@@ -2281,7 +2266,7 @@ CREATE TABLE sections (
 -- Name: sections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE sections_id_seq
+CREATE SEQUENCE public.sections_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2293,14 +2278,14 @@ CREATE SEQUENCE sections_id_seq
 -- Name: sections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE sections_id_seq OWNED BY sections.id;
+ALTER SEQUENCE public.sections_id_seq OWNED BY public.sections.id;
 
 
 --
 -- Name: students_classrooms; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE students_classrooms (
+CREATE TABLE public.students_classrooms (
     id integer NOT NULL,
     student_id integer,
     classroom_id integer,
@@ -2314,7 +2299,7 @@ CREATE TABLE students_classrooms (
 -- Name: students_classrooms_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE students_classrooms_id_seq
+CREATE SEQUENCE public.students_classrooms_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2326,14 +2311,14 @@ CREATE SEQUENCE students_classrooms_id_seq
 -- Name: students_classrooms_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE students_classrooms_id_seq OWNED BY students_classrooms.id;
+ALTER SEQUENCE public.students_classrooms_id_seq OWNED BY public.students_classrooms.id;
 
 
 --
 -- Name: subscription_types; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE subscription_types (
+CREATE TABLE public.subscription_types (
     id integer NOT NULL,
     name character varying NOT NULL,
     created_at timestamp without time zone,
@@ -2347,7 +2332,7 @@ CREATE TABLE subscription_types (
 -- Name: subscription_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE subscription_types_id_seq
+CREATE SEQUENCE public.subscription_types_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2360,14 +2345,14 @@ CREATE SEQUENCE subscription_types_id_seq
 -- Name: subscription_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE subscription_types_id_seq OWNED BY subscription_types.id;
+ALTER SEQUENCE public.subscription_types_id_seq OWNED BY public.subscription_types.id;
 
 
 --
 -- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE subscriptions (
+CREATE TABLE public.subscriptions (
     id integer NOT NULL,
     expiration date,
     created_at timestamp without time zone,
@@ -2388,7 +2373,7 @@ CREATE TABLE subscriptions (
 -- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE subscriptions_id_seq
+CREATE SEQUENCE public.subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2400,14 +2385,14 @@ CREATE SEQUENCE subscriptions_id_seq
 -- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
+ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
 
 
 --
 -- Name: topic_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE topic_categories (
+CREATE TABLE public.topic_categories (
     id integer NOT NULL,
     name character varying(255),
     created_at timestamp without time zone,
@@ -2420,7 +2405,7 @@ CREATE TABLE topic_categories (
 -- Name: topic_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE topic_categories_id_seq
+CREATE SEQUENCE public.topic_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2432,14 +2417,14 @@ CREATE SEQUENCE topic_categories_id_seq
 -- Name: topic_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE topic_categories_id_seq OWNED BY topic_categories.id;
+ALTER SEQUENCE public.topic_categories_id_seq OWNED BY public.topic_categories.id;
 
 
 --
 -- Name: topics; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE topics (
+CREATE TABLE public.topics (
     id integer NOT NULL,
     name character varying(255),
     section_id integer,
@@ -2454,7 +2439,7 @@ CREATE TABLE topics (
 -- Name: topics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE topics_id_seq
+CREATE SEQUENCE public.topics_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2466,21 +2451,22 @@ CREATE SEQUENCE topics_id_seq
 -- Name: topics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE topics_id_seq OWNED BY topics.id;
+ALTER SEQUENCE public.topics_id_seq OWNED BY public.topics.id;
 
 
 --
 -- Name: unit_activities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE unit_activities (
+CREATE TABLE public.unit_activities (
     id integer NOT NULL,
     unit_id integer NOT NULL,
     activity_id integer NOT NULL,
     visible boolean DEFAULT true,
     due_date timestamp without time zone,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    order_number integer
 );
 
 
@@ -2488,7 +2474,7 @@ CREATE TABLE unit_activities (
 -- Name: unit_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE unit_activities_id_seq
+CREATE SEQUENCE public.unit_activities_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2501,14 +2487,14 @@ CREATE SEQUENCE unit_activities_id_seq
 -- Name: unit_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE unit_activities_id_seq OWNED BY unit_activities.id;
+ALTER SEQUENCE public.unit_activities_id_seq OWNED BY public.unit_activities.id;
 
 
 --
 -- Name: unit_template_categories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE unit_template_categories (
+CREATE TABLE public.unit_template_categories (
     id integer NOT NULL,
     name character varying(255),
     primary_color character varying(255),
@@ -2520,7 +2506,7 @@ CREATE TABLE unit_template_categories (
 -- Name: unit_template_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE unit_template_categories_id_seq
+CREATE SEQUENCE public.unit_template_categories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2532,14 +2518,14 @@ CREATE SEQUENCE unit_template_categories_id_seq
 -- Name: unit_template_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE unit_template_categories_id_seq OWNED BY unit_template_categories.id;
+ALTER SEQUENCE public.unit_template_categories_id_seq OWNED BY public.unit_template_categories.id;
 
 
 --
 -- Name: unit_templates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE unit_templates (
+CREATE TABLE public.unit_templates (
     id integer NOT NULL,
     name character varying(255),
     unit_template_category_id integer,
@@ -2558,7 +2544,7 @@ CREATE TABLE unit_templates (
 -- Name: unit_templates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE unit_templates_id_seq
+CREATE SEQUENCE public.unit_templates_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2570,14 +2556,14 @@ CREATE SEQUENCE unit_templates_id_seq
 -- Name: unit_templates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE unit_templates_id_seq OWNED BY unit_templates.id;
+ALTER SEQUENCE public.unit_templates_id_seq OWNED BY public.unit_templates.id;
 
 
 --
 -- Name: units; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE units (
+CREATE TABLE public.units (
     id integer NOT NULL,
     name character varying(255),
     created_at timestamp without time zone,
@@ -2592,7 +2578,7 @@ CREATE TABLE units (
 -- Name: units_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE units_id_seq
+CREATE SEQUENCE public.units_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2604,14 +2590,14 @@ CREATE SEQUENCE units_id_seq
 -- Name: units_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE units_id_seq OWNED BY units.id;
+ALTER SEQUENCE public.units_id_seq OWNED BY public.units.id;
 
 
 --
 -- Name: user_milestones; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE user_milestones (
+CREATE TABLE public.user_milestones (
     id integer NOT NULL,
     user_id integer NOT NULL,
     milestone_id integer NOT NULL,
@@ -2624,7 +2610,7 @@ CREATE TABLE user_milestones (
 -- Name: user_milestones_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE user_milestones_id_seq
+CREATE SEQUENCE public.user_milestones_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2636,14 +2622,14 @@ CREATE SEQUENCE user_milestones_id_seq
 -- Name: user_milestones_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE user_milestones_id_seq OWNED BY user_milestones.id;
+ALTER SEQUENCE public.user_milestones_id_seq OWNED BY public.user_milestones.id;
 
 
 --
 -- Name: user_subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE user_subscriptions (
+CREATE TABLE public.user_subscriptions (
     id integer NOT NULL,
     user_id integer,
     subscription_id integer,
@@ -2656,7 +2642,7 @@ CREATE TABLE user_subscriptions (
 -- Name: user_subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE user_subscriptions_id_seq
+CREATE SEQUENCE public.user_subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2668,14 +2654,14 @@ CREATE SEQUENCE user_subscriptions_id_seq
 -- Name: user_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE user_subscriptions_id_seq OWNED BY user_subscriptions.id;
+ALTER SEQUENCE public.user_subscriptions_id_seq OWNED BY public.user_subscriptions.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id integer NOT NULL,
     name character varying(255),
     email character varying(255),
@@ -2706,7 +2692,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2718,14 +2704,14 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: zipcode_infos; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE zipcode_infos (
+CREATE TABLE public.zipcode_infos (
     id integer NOT NULL,
     zipcode text,
     zipcode_type text,
@@ -2746,7 +2732,7 @@ CREATE TABLE zipcode_infos (
 -- Name: zipcode_infos_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE zipcode_infos_id_seq
+CREATE SEQUENCE public.zipcode_infos_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -2759,483 +2745,483 @@ CREATE SEQUENCE zipcode_infos_id_seq
 -- Name: zipcode_infos_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE zipcode_infos_id_seq OWNED BY zipcode_infos.id;
+ALTER SEQUENCE public.zipcode_infos_id_seq OWNED BY public.zipcode_infos.id;
 
 
 --
 -- Name: activities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activities ALTER COLUMN id SET DEFAULT nextval('activities_id_seq'::regclass);
+ALTER TABLE ONLY public.activities ALTER COLUMN id SET DEFAULT nextval('public.activities_id_seq'::regclass);
 
 
 --
 -- Name: activities_unit_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activities_unit_templates ALTER COLUMN id SET DEFAULT nextval('activities_unit_templates_id_seq'::regclass);
+ALTER TABLE ONLY public.activities_unit_templates ALTER COLUMN id SET DEFAULT nextval('public.activities_unit_templates_id_seq'::regclass);
 
 
 --
 -- Name: activity_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_categories ALTER COLUMN id SET DEFAULT nextval('activity_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.activity_categories ALTER COLUMN id SET DEFAULT nextval('public.activity_categories_id_seq'::regclass);
 
 
 --
 -- Name: activity_category_activities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_category_activities ALTER COLUMN id SET DEFAULT nextval('activity_category_activities_id_seq'::regclass);
+ALTER TABLE ONLY public.activity_category_activities ALTER COLUMN id SET DEFAULT nextval('public.activity_category_activities_id_seq'::regclass);
 
 
 --
 -- Name: activity_classifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_classifications ALTER COLUMN id SET DEFAULT nextval('activity_classifications_id_seq'::regclass);
+ALTER TABLE ONLY public.activity_classifications ALTER COLUMN id SET DEFAULT nextval('public.activity_classifications_id_seq'::regclass);
 
 
 --
 -- Name: activity_session_interaction_logs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_session_interaction_logs ALTER COLUMN id SET DEFAULT nextval('activity_session_interaction_logs_id_seq'::regclass);
+ALTER TABLE ONLY public.activity_session_interaction_logs ALTER COLUMN id SET DEFAULT nextval('public.activity_session_interaction_logs_id_seq'::regclass);
 
 
 --
 -- Name: admin_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts ALTER COLUMN id SET DEFAULT nextval('admin_accounts_id_seq'::regclass);
+ALTER TABLE ONLY public.admin_accounts ALTER COLUMN id SET DEFAULT nextval('public.admin_accounts_id_seq'::regclass);
 
 
 --
 -- Name: admin_accounts_admins id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts_admins ALTER COLUMN id SET DEFAULT nextval('admin_accounts_admins_id_seq'::regclass);
+ALTER TABLE ONLY public.admin_accounts_admins ALTER COLUMN id SET DEFAULT nextval('public.admin_accounts_admins_id_seq'::regclass);
 
 
 --
 -- Name: admin_accounts_teachers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts_teachers ALTER COLUMN id SET DEFAULT nextval('admin_accounts_teachers_id_seq'::regclass);
+ALTER TABLE ONLY public.admin_accounts_teachers ALTER COLUMN id SET DEFAULT nextval('public.admin_accounts_teachers_id_seq'::regclass);
 
 
 --
 -- Name: announcements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY announcements ALTER COLUMN id SET DEFAULT nextval('announcements_id_seq'::regclass);
+ALTER TABLE ONLY public.announcements ALTER COLUMN id SET DEFAULT nextval('public.announcements_id_seq'::regclass);
 
 
 --
 -- Name: auth_credentials id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY auth_credentials ALTER COLUMN id SET DEFAULT nextval('auth_credentials_id_seq'::regclass);
+ALTER TABLE ONLY public.auth_credentials ALTER COLUMN id SET DEFAULT nextval('public.auth_credentials_id_seq'::regclass);
 
 
 --
 -- Name: authors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY authors ALTER COLUMN id SET DEFAULT nextval('authors_id_seq'::regclass);
+ALTER TABLE ONLY public.authors ALTER COLUMN id SET DEFAULT nextval('public.authors_id_seq'::regclass);
 
 
 --
 -- Name: blog_post_user_ratings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY blog_post_user_ratings ALTER COLUMN id SET DEFAULT nextval('blog_post_user_ratings_id_seq'::regclass);
+ALTER TABLE ONLY public.blog_post_user_ratings ALTER COLUMN id SET DEFAULT nextval('public.blog_post_user_ratings_id_seq'::regclass);
 
 
 --
 -- Name: blog_posts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY blog_posts ALTER COLUMN id SET DEFAULT nextval('blog_posts_id_seq'::regclass);
+ALTER TABLE ONLY public.blog_posts ALTER COLUMN id SET DEFAULT nextval('public.blog_posts_id_seq'::regclass);
 
 
 --
 -- Name: categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categories ALTER COLUMN id SET DEFAULT nextval('categories_id_seq'::regclass);
+ALTER TABLE ONLY public.categories ALTER COLUMN id SET DEFAULT nextval('public.categories_id_seq'::regclass);
 
 
 --
 -- Name: checkboxes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY checkboxes ALTER COLUMN id SET DEFAULT nextval('checkboxes_id_seq'::regclass);
+ALTER TABLE ONLY public.checkboxes ALTER COLUMN id SET DEFAULT nextval('public.checkboxes_id_seq'::regclass);
 
 
 --
 -- Name: classroom_activities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_activities ALTER COLUMN id SET DEFAULT nextval('classroom_activities_id_seq'::regclass);
+ALTER TABLE ONLY public.classroom_activities ALTER COLUMN id SET DEFAULT nextval('public.classroom_activities_id_seq'::regclass);
 
 
 --
 -- Name: classroom_unit_activity_states id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_unit_activity_states ALTER COLUMN id SET DEFAULT nextval('classroom_unit_activity_states_id_seq'::regclass);
+ALTER TABLE ONLY public.classroom_unit_activity_states ALTER COLUMN id SET DEFAULT nextval('public.classroom_unit_activity_states_id_seq'::regclass);
 
 
 --
 -- Name: classroom_units id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_units ALTER COLUMN id SET DEFAULT nextval('classroom_units_id_seq'::regclass);
+ALTER TABLE ONLY public.classroom_units ALTER COLUMN id SET DEFAULT nextval('public.classroom_units_id_seq'::regclass);
 
 
 --
 -- Name: classrooms id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classrooms ALTER COLUMN id SET DEFAULT nextval('classrooms_id_seq'::regclass);
+ALTER TABLE ONLY public.classrooms ALTER COLUMN id SET DEFAULT nextval('public.classrooms_id_seq'::regclass);
 
 
 --
 -- Name: classrooms_teachers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classrooms_teachers ALTER COLUMN id SET DEFAULT nextval('classrooms_teachers_id_seq'::regclass);
+ALTER TABLE ONLY public.classrooms_teachers ALTER COLUMN id SET DEFAULT nextval('public.classrooms_teachers_id_seq'::regclass);
 
 
 --
 -- Name: comments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq'::regclass);
+ALTER TABLE ONLY public.comments ALTER COLUMN id SET DEFAULT nextval('public.comments_id_seq'::regclass);
 
 
 --
 -- Name: concept_results id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY concept_results ALTER COLUMN id SET DEFAULT nextval('concept_results_id_seq'::regclass);
+ALTER TABLE ONLY public.concept_results ALTER COLUMN id SET DEFAULT nextval('public.concept_results_id_seq'::regclass);
 
 
 --
 -- Name: concepts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY concepts ALTER COLUMN id SET DEFAULT nextval('concepts_id_seq'::regclass);
+ALTER TABLE ONLY public.concepts ALTER COLUMN id SET DEFAULT nextval('public.concepts_id_seq'::regclass);
 
 
 --
 -- Name: coteacher_classroom_invitations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coteacher_classroom_invitations ALTER COLUMN id SET DEFAULT nextval('coteacher_classroom_invitations_id_seq'::regclass);
+ALTER TABLE ONLY public.coteacher_classroom_invitations ALTER COLUMN id SET DEFAULT nextval('public.coteacher_classroom_invitations_id_seq'::regclass);
 
 
 --
 -- Name: credit_transactions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY credit_transactions ALTER COLUMN id SET DEFAULT nextval('credit_transactions_id_seq'::regclass);
+ALTER TABLE ONLY public.credit_transactions ALTER COLUMN id SET DEFAULT nextval('public.credit_transactions_id_seq'::regclass);
 
 
 --
 -- Name: criteria id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY criteria ALTER COLUMN id SET DEFAULT nextval('criteria_id_seq'::regclass);
+ALTER TABLE ONLY public.criteria ALTER COLUMN id SET DEFAULT nextval('public.criteria_id_seq'::regclass);
 
 
 --
 -- Name: csv_exports id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY csv_exports ALTER COLUMN id SET DEFAULT nextval('csv_exports_id_seq'::regclass);
+ALTER TABLE ONLY public.csv_exports ALTER COLUMN id SET DEFAULT nextval('public.csv_exports_id_seq'::regclass);
 
 
 --
 -- Name: districts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY districts ALTER COLUMN id SET DEFAULT nextval('districts_id_seq'::regclass);
+ALTER TABLE ONLY public.districts ALTER COLUMN id SET DEFAULT nextval('public.districts_id_seq'::regclass);
 
 
 --
 -- Name: file_uploads id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY file_uploads ALTER COLUMN id SET DEFAULT nextval('file_uploads_id_seq'::regclass);
+ALTER TABLE ONLY public.file_uploads ALTER COLUMN id SET DEFAULT nextval('public.file_uploads_id_seq'::regclass);
 
 
 --
 -- Name: firebase_apps id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY firebase_apps ALTER COLUMN id SET DEFAULT nextval('firebase_apps_id_seq'::regclass);
+ALTER TABLE ONLY public.firebase_apps ALTER COLUMN id SET DEFAULT nextval('public.firebase_apps_id_seq'::regclass);
 
 
 --
 -- Name: images id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY images ALTER COLUMN id SET DEFAULT nextval('images_id_seq'::regclass);
+ALTER TABLE ONLY public.images ALTER COLUMN id SET DEFAULT nextval('public.images_id_seq'::regclass);
 
 
 --
 -- Name: invitations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invitations ALTER COLUMN id SET DEFAULT nextval('invitations_id_seq'::regclass);
+ALTER TABLE ONLY public.invitations ALTER COLUMN id SET DEFAULT nextval('public.invitations_id_seq'::regclass);
 
 
 --
 -- Name: ip_locations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ip_locations ALTER COLUMN id SET DEFAULT nextval('ip_locations_id_seq'::regclass);
+ALTER TABLE ONLY public.ip_locations ALTER COLUMN id SET DEFAULT nextval('public.ip_locations_id_seq'::regclass);
 
 
 --
 -- Name: milestones id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY milestones ALTER COLUMN id SET DEFAULT nextval('milestones_id_seq'::regclass);
+ALTER TABLE ONLY public.milestones ALTER COLUMN id SET DEFAULT nextval('public.milestones_id_seq'::regclass);
 
 
 --
 -- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications ALTER COLUMN id SET DEFAULT nextval('notifications_id_seq'::regclass);
+ALTER TABLE ONLY public.notifications ALTER COLUMN id SET DEFAULT nextval('public.notifications_id_seq'::regclass);
 
 
 --
 -- Name: oauth_access_grants id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_grants ALTER COLUMN id SET DEFAULT nextval('oauth_access_grants_id_seq'::regclass);
+ALTER TABLE ONLY public.oauth_access_grants ALTER COLUMN id SET DEFAULT nextval('public.oauth_access_grants_id_seq'::regclass);
 
 
 --
 -- Name: oauth_access_tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_tokens ALTER COLUMN id SET DEFAULT nextval('oauth_access_tokens_id_seq'::regclass);
+ALTER TABLE ONLY public.oauth_access_tokens ALTER COLUMN id SET DEFAULT nextval('public.oauth_access_tokens_id_seq'::regclass);
 
 
 --
 -- Name: oauth_applications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_applications ALTER COLUMN id SET DEFAULT nextval('oauth_applications_id_seq'::regclass);
+ALTER TABLE ONLY public.oauth_applications ALTER COLUMN id SET DEFAULT nextval('public.oauth_applications_id_seq'::regclass);
 
 
 --
 -- Name: objectives id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY objectives ALTER COLUMN id SET DEFAULT nextval('objectives_id_seq'::regclass);
+ALTER TABLE ONLY public.objectives ALTER COLUMN id SET DEFAULT nextval('public.objectives_id_seq'::regclass);
 
 
 --
 -- Name: old_activity_sessions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY old_activity_sessions ALTER COLUMN id SET DEFAULT nextval('activity_sessions_id_seq'::regclass);
+ALTER TABLE ONLY public.old_activity_sessions ALTER COLUMN id SET DEFAULT nextval('public.activity_sessions_id_seq'::regclass);
 
 
 --
 -- Name: page_areas id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY page_areas ALTER COLUMN id SET DEFAULT nextval('page_areas_id_seq'::regclass);
+ALTER TABLE ONLY public.page_areas ALTER COLUMN id SET DEFAULT nextval('public.page_areas_id_seq'::regclass);
 
 
 --
 -- Name: recommendations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY recommendations ALTER COLUMN id SET DEFAULT nextval('recommendations_id_seq'::regclass);
+ALTER TABLE ONLY public.recommendations ALTER COLUMN id SET DEFAULT nextval('public.recommendations_id_seq'::regclass);
 
 
 --
 -- Name: referrals_users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY referrals_users ALTER COLUMN id SET DEFAULT nextval('referrals_users_id_seq'::regclass);
+ALTER TABLE ONLY public.referrals_users ALTER COLUMN id SET DEFAULT nextval('public.referrals_users_id_seq'::regclass);
 
 
 --
 -- Name: referrer_users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY referrer_users ALTER COLUMN id SET DEFAULT nextval('referrer_users_id_seq'::regclass);
+ALTER TABLE ONLY public.referrer_users ALTER COLUMN id SET DEFAULT nextval('public.referrer_users_id_seq'::regclass);
 
 
 --
 -- Name: rules_misseds id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY rules_misseds ALTER COLUMN id SET DEFAULT nextval('rules_misseds_id_seq'::regclass);
+ALTER TABLE ONLY public.rules_misseds ALTER COLUMN id SET DEFAULT nextval('public.rules_misseds_id_seq'::regclass);
 
 
 --
 -- Name: sales_contacts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_contacts ALTER COLUMN id SET DEFAULT nextval('sales_contacts_id_seq'::regclass);
+ALTER TABLE ONLY public.sales_contacts ALTER COLUMN id SET DEFAULT nextval('public.sales_contacts_id_seq'::regclass);
 
 
 --
 -- Name: sales_stage_types id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stage_types ALTER COLUMN id SET DEFAULT nextval('sales_stage_types_id_seq'::regclass);
+ALTER TABLE ONLY public.sales_stage_types ALTER COLUMN id SET DEFAULT nextval('public.sales_stage_types_id_seq'::regclass);
 
 
 --
 -- Name: sales_stages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stages ALTER COLUMN id SET DEFAULT nextval('sales_stages_id_seq'::regclass);
+ALTER TABLE ONLY public.sales_stages ALTER COLUMN id SET DEFAULT nextval('public.sales_stages_id_seq'::regclass);
 
 
 --
 -- Name: school_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY school_subscriptions ALTER COLUMN id SET DEFAULT nextval('school_subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY public.school_subscriptions ALTER COLUMN id SET DEFAULT nextval('public.school_subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: schools id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools ALTER COLUMN id SET DEFAULT nextval('schools_id_seq'::regclass);
+ALTER TABLE ONLY public.schools ALTER COLUMN id SET DEFAULT nextval('public.schools_id_seq'::regclass);
 
 
 --
 -- Name: schools_admins id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools_admins ALTER COLUMN id SET DEFAULT nextval('schools_admins_id_seq'::regclass);
+ALTER TABLE ONLY public.schools_admins ALTER COLUMN id SET DEFAULT nextval('public.schools_admins_id_seq'::regclass);
 
 
 --
 -- Name: schools_users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools_users ALTER COLUMN id SET DEFAULT nextval('schools_users_id_seq'::regclass);
+ALTER TABLE ONLY public.schools_users ALTER COLUMN id SET DEFAULT nextval('public.schools_users_id_seq'::regclass);
 
 
 --
 -- Name: sections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections ALTER COLUMN id SET DEFAULT nextval('sections_id_seq'::regclass);
+ALTER TABLE ONLY public.sections ALTER COLUMN id SET DEFAULT nextval('public.sections_id_seq'::regclass);
 
 
 --
 -- Name: students_classrooms id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY students_classrooms ALTER COLUMN id SET DEFAULT nextval('students_classrooms_id_seq'::regclass);
+ALTER TABLE ONLY public.students_classrooms ALTER COLUMN id SET DEFAULT nextval('public.students_classrooms_id_seq'::regclass);
 
 
 --
 -- Name: subscription_types id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscription_types ALTER COLUMN id SET DEFAULT nextval('subscription_types_id_seq'::regclass);
+ALTER TABLE ONLY public.subscription_types ALTER COLUMN id SET DEFAULT nextval('public.subscription_types_id_seq'::regclass);
 
 
 --
 -- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('public.subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: topic_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY topic_categories ALTER COLUMN id SET DEFAULT nextval('topic_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.topic_categories ALTER COLUMN id SET DEFAULT nextval('public.topic_categories_id_seq'::regclass);
 
 
 --
 -- Name: topics id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY topics ALTER COLUMN id SET DEFAULT nextval('topics_id_seq'::regclass);
+ALTER TABLE ONLY public.topics ALTER COLUMN id SET DEFAULT nextval('public.topics_id_seq'::regclass);
 
 
 --
 -- Name: unit_activities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_activities ALTER COLUMN id SET DEFAULT nextval('unit_activities_id_seq'::regclass);
+ALTER TABLE ONLY public.unit_activities ALTER COLUMN id SET DEFAULT nextval('public.unit_activities_id_seq'::regclass);
 
 
 --
 -- Name: unit_template_categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_template_categories ALTER COLUMN id SET DEFAULT nextval('unit_template_categories_id_seq'::regclass);
+ALTER TABLE ONLY public.unit_template_categories ALTER COLUMN id SET DEFAULT nextval('public.unit_template_categories_id_seq'::regclass);
 
 
 --
 -- Name: unit_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_templates ALTER COLUMN id SET DEFAULT nextval('unit_templates_id_seq'::regclass);
+ALTER TABLE ONLY public.unit_templates ALTER COLUMN id SET DEFAULT nextval('public.unit_templates_id_seq'::regclass);
 
 
 --
 -- Name: units id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY units ALTER COLUMN id SET DEFAULT nextval('units_id_seq'::regclass);
+ALTER TABLE ONLY public.units ALTER COLUMN id SET DEFAULT nextval('public.units_id_seq'::regclass);
 
 
 --
 -- Name: user_milestones id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_milestones ALTER COLUMN id SET DEFAULT nextval('user_milestones_id_seq'::regclass);
+ALTER TABLE ONLY public.user_milestones ALTER COLUMN id SET DEFAULT nextval('public.user_milestones_id_seq'::regclass);
 
 
 --
 -- Name: user_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_subscriptions ALTER COLUMN id SET DEFAULT nextval('user_subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY public.user_subscriptions ALTER COLUMN id SET DEFAULT nextval('public.user_subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: zipcode_infos id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY zipcode_infos ALTER COLUMN id SET DEFAULT nextval('zipcode_infos_id_seq'::regclass);
+ALTER TABLE ONLY public.zipcode_infos ALTER COLUMN id SET DEFAULT nextval('public.zipcode_infos_id_seq'::regclass);
 
 
 --
 -- Name: activities activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activities
+ALTER TABLE ONLY public.activities
     ADD CONSTRAINT activities_pkey PRIMARY KEY (id);
 
 
@@ -3243,7 +3229,7 @@ ALTER TABLE ONLY activities
 -- Name: activities_unit_templates activities_unit_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activities_unit_templates
+ALTER TABLE ONLY public.activities_unit_templates
     ADD CONSTRAINT activities_unit_templates_pkey PRIMARY KEY (id);
 
 
@@ -3251,7 +3237,7 @@ ALTER TABLE ONLY activities_unit_templates
 -- Name: activity_categories activity_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_categories
+ALTER TABLE ONLY public.activity_categories
     ADD CONSTRAINT activity_categories_pkey PRIMARY KEY (id);
 
 
@@ -3259,7 +3245,7 @@ ALTER TABLE ONLY activity_categories
 -- Name: activity_category_activities activity_category_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_category_activities
+ALTER TABLE ONLY public.activity_category_activities
     ADD CONSTRAINT activity_category_activities_pkey PRIMARY KEY (id);
 
 
@@ -3267,7 +3253,7 @@ ALTER TABLE ONLY activity_category_activities
 -- Name: activity_classifications activity_classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_classifications
+ALTER TABLE ONLY public.activity_classifications
     ADD CONSTRAINT activity_classifications_pkey PRIMARY KEY (id);
 
 
@@ -3275,7 +3261,7 @@ ALTER TABLE ONLY activity_classifications
 -- Name: activity_session_interaction_logs activity_session_interaction_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_session_interaction_logs
+ALTER TABLE ONLY public.activity_session_interaction_logs
     ADD CONSTRAINT activity_session_interaction_logs_pkey PRIMARY KEY (id);
 
 
@@ -3283,7 +3269,7 @@ ALTER TABLE ONLY activity_session_interaction_logs
 -- Name: old_activity_sessions activity_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY old_activity_sessions
+ALTER TABLE ONLY public.old_activity_sessions
     ADD CONSTRAINT activity_sessions_pkey PRIMARY KEY (id);
 
 
@@ -3291,7 +3277,7 @@ ALTER TABLE ONLY old_activity_sessions
 -- Name: admin_accounts_admins admin_accounts_admins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts_admins
+ALTER TABLE ONLY public.admin_accounts_admins
     ADD CONSTRAINT admin_accounts_admins_pkey PRIMARY KEY (id);
 
 
@@ -3299,7 +3285,7 @@ ALTER TABLE ONLY admin_accounts_admins
 -- Name: admin_accounts admin_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts
+ALTER TABLE ONLY public.admin_accounts
     ADD CONSTRAINT admin_accounts_pkey PRIMARY KEY (id);
 
 
@@ -3307,7 +3293,7 @@ ALTER TABLE ONLY admin_accounts
 -- Name: admin_accounts_teachers admin_accounts_teachers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY admin_accounts_teachers
+ALTER TABLE ONLY public.admin_accounts_teachers
     ADD CONSTRAINT admin_accounts_teachers_pkey PRIMARY KEY (id);
 
 
@@ -3315,7 +3301,7 @@ ALTER TABLE ONLY admin_accounts_teachers
 -- Name: announcements announcements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY announcements
+ALTER TABLE ONLY public.announcements
     ADD CONSTRAINT announcements_pkey PRIMARY KEY (id);
 
 
@@ -3323,7 +3309,7 @@ ALTER TABLE ONLY announcements
 -- Name: auth_credentials auth_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY auth_credentials
+ALTER TABLE ONLY public.auth_credentials
     ADD CONSTRAINT auth_credentials_pkey PRIMARY KEY (id);
 
 
@@ -3331,7 +3317,7 @@ ALTER TABLE ONLY auth_credentials
 -- Name: authors authors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY authors
+ALTER TABLE ONLY public.authors
     ADD CONSTRAINT authors_pkey PRIMARY KEY (id);
 
 
@@ -3339,7 +3325,7 @@ ALTER TABLE ONLY authors
 -- Name: blog_post_user_ratings blog_post_user_ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY blog_post_user_ratings
+ALTER TABLE ONLY public.blog_post_user_ratings
     ADD CONSTRAINT blog_post_user_ratings_pkey PRIMARY KEY (id);
 
 
@@ -3347,7 +3333,7 @@ ALTER TABLE ONLY blog_post_user_ratings
 -- Name: blog_posts blog_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY blog_posts
+ALTER TABLE ONLY public.blog_posts
     ADD CONSTRAINT blog_posts_pkey PRIMARY KEY (id);
 
 
@@ -3355,7 +3341,7 @@ ALTER TABLE ONLY blog_posts
 -- Name: categories categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categories
+ALTER TABLE ONLY public.categories
     ADD CONSTRAINT categories_pkey PRIMARY KEY (id);
 
 
@@ -3363,7 +3349,7 @@ ALTER TABLE ONLY categories
 -- Name: checkboxes checkboxes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY checkboxes
+ALTER TABLE ONLY public.checkboxes
     ADD CONSTRAINT checkboxes_pkey PRIMARY KEY (id);
 
 
@@ -3371,7 +3357,7 @@ ALTER TABLE ONLY checkboxes
 -- Name: classroom_activities classroom_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_activities
+ALTER TABLE ONLY public.classroom_activities
     ADD CONSTRAINT classroom_activities_pkey PRIMARY KEY (id);
 
 
@@ -3379,7 +3365,7 @@ ALTER TABLE ONLY classroom_activities
 -- Name: classroom_unit_activity_states classroom_unit_activity_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_unit_activity_states
+ALTER TABLE ONLY public.classroom_unit_activity_states
     ADD CONSTRAINT classroom_unit_activity_states_pkey PRIMARY KEY (id);
 
 
@@ -3387,7 +3373,7 @@ ALTER TABLE ONLY classroom_unit_activity_states
 -- Name: classroom_units classroom_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_units
+ALTER TABLE ONLY public.classroom_units
     ADD CONSTRAINT classroom_units_pkey PRIMARY KEY (id);
 
 
@@ -3395,7 +3381,7 @@ ALTER TABLE ONLY classroom_units
 -- Name: classrooms classrooms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classrooms
+ALTER TABLE ONLY public.classrooms
     ADD CONSTRAINT classrooms_pkey PRIMARY KEY (id);
 
 
@@ -3403,7 +3389,7 @@ ALTER TABLE ONLY classrooms
 -- Name: classrooms_teachers classrooms_teachers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classrooms_teachers
+ALTER TABLE ONLY public.classrooms_teachers
     ADD CONSTRAINT classrooms_teachers_pkey PRIMARY KEY (id);
 
 
@@ -3411,7 +3397,7 @@ ALTER TABLE ONLY classrooms_teachers
 -- Name: comments comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY comments
+ALTER TABLE ONLY public.comments
     ADD CONSTRAINT comments_pkey PRIMARY KEY (id);
 
 
@@ -3419,7 +3405,7 @@ ALTER TABLE ONLY comments
 -- Name: concept_results concept_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY concept_results
+ALTER TABLE ONLY public.concept_results
     ADD CONSTRAINT concept_results_pkey PRIMARY KEY (id);
 
 
@@ -3427,7 +3413,7 @@ ALTER TABLE ONLY concept_results
 -- Name: concepts concepts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY concepts
+ALTER TABLE ONLY public.concepts
     ADD CONSTRAINT concepts_pkey PRIMARY KEY (id);
 
 
@@ -3435,7 +3421,7 @@ ALTER TABLE ONLY concepts
 -- Name: coteacher_classroom_invitations coteacher_classroom_invitations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coteacher_classroom_invitations
+ALTER TABLE ONLY public.coteacher_classroom_invitations
     ADD CONSTRAINT coteacher_classroom_invitations_pkey PRIMARY KEY (id);
 
 
@@ -3443,7 +3429,7 @@ ALTER TABLE ONLY coteacher_classroom_invitations
 -- Name: credit_transactions credit_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY credit_transactions
+ALTER TABLE ONLY public.credit_transactions
     ADD CONSTRAINT credit_transactions_pkey PRIMARY KEY (id);
 
 
@@ -3451,7 +3437,7 @@ ALTER TABLE ONLY credit_transactions
 -- Name: criteria criteria_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY criteria
+ALTER TABLE ONLY public.criteria
     ADD CONSTRAINT criteria_pkey PRIMARY KEY (id);
 
 
@@ -3459,7 +3445,7 @@ ALTER TABLE ONLY criteria
 -- Name: csv_exports csv_exports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY csv_exports
+ALTER TABLE ONLY public.csv_exports
     ADD CONSTRAINT csv_exports_pkey PRIMARY KEY (id);
 
 
@@ -3467,7 +3453,7 @@ ALTER TABLE ONLY csv_exports
 -- Name: districts districts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY districts
+ALTER TABLE ONLY public.districts
     ADD CONSTRAINT districts_pkey PRIMARY KEY (id);
 
 
@@ -3475,7 +3461,7 @@ ALTER TABLE ONLY districts
 -- Name: file_uploads file_uploads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY file_uploads
+ALTER TABLE ONLY public.file_uploads
     ADD CONSTRAINT file_uploads_pkey PRIMARY KEY (id);
 
 
@@ -3483,7 +3469,7 @@ ALTER TABLE ONLY file_uploads
 -- Name: firebase_apps firebase_apps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY firebase_apps
+ALTER TABLE ONLY public.firebase_apps
     ADD CONSTRAINT firebase_apps_pkey PRIMARY KEY (id);
 
 
@@ -3491,7 +3477,7 @@ ALTER TABLE ONLY firebase_apps
 -- Name: images images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY images
+ALTER TABLE ONLY public.images
     ADD CONSTRAINT images_pkey PRIMARY KEY (id);
 
 
@@ -3499,7 +3485,7 @@ ALTER TABLE ONLY images
 -- Name: invitations invitations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invitations
+ALTER TABLE ONLY public.invitations
     ADD CONSTRAINT invitations_pkey PRIMARY KEY (id);
 
 
@@ -3507,7 +3493,7 @@ ALTER TABLE ONLY invitations
 -- Name: ip_locations ip_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ip_locations
+ALTER TABLE ONLY public.ip_locations
     ADD CONSTRAINT ip_locations_pkey PRIMARY KEY (id);
 
 
@@ -3515,7 +3501,7 @@ ALTER TABLE ONLY ip_locations
 -- Name: milestones milestones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY milestones
+ALTER TABLE ONLY public.milestones
     ADD CONSTRAINT milestones_pkey PRIMARY KEY (id);
 
 
@@ -3523,7 +3509,7 @@ ALTER TABLE ONLY milestones
 -- Name: activity_sessions newest_activity_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_sessions
+ALTER TABLE ONLY public.activity_sessions
     ADD CONSTRAINT newest_activity_sessions_pkey PRIMARY KEY (id);
 
 
@@ -3531,7 +3517,7 @@ ALTER TABLE ONLY activity_sessions
 -- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications
+ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
 
 
@@ -3539,7 +3525,7 @@ ALTER TABLE ONLY notifications
 -- Name: oauth_access_grants oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_grants
+ALTER TABLE ONLY public.oauth_access_grants
     ADD CONSTRAINT oauth_access_grants_pkey PRIMARY KEY (id);
 
 
@@ -3547,7 +3533,7 @@ ALTER TABLE ONLY oauth_access_grants
 -- Name: oauth_access_tokens oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_access_tokens
+ALTER TABLE ONLY public.oauth_access_tokens
     ADD CONSTRAINT oauth_access_tokens_pkey PRIMARY KEY (id);
 
 
@@ -3555,7 +3541,7 @@ ALTER TABLE ONLY oauth_access_tokens
 -- Name: oauth_applications oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY oauth_applications
+ALTER TABLE ONLY public.oauth_applications
     ADD CONSTRAINT oauth_applications_pkey PRIMARY KEY (id);
 
 
@@ -3563,7 +3549,7 @@ ALTER TABLE ONLY oauth_applications
 -- Name: objectives objectives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY objectives
+ALTER TABLE ONLY public.objectives
     ADD CONSTRAINT objectives_pkey PRIMARY KEY (id);
 
 
@@ -3571,7 +3557,7 @@ ALTER TABLE ONLY objectives
 -- Name: page_areas page_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY page_areas
+ALTER TABLE ONLY public.page_areas
     ADD CONSTRAINT page_areas_pkey PRIMARY KEY (id);
 
 
@@ -3579,7 +3565,7 @@ ALTER TABLE ONLY page_areas
 -- Name: recommendations recommendations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY recommendations
+ALTER TABLE ONLY public.recommendations
     ADD CONSTRAINT recommendations_pkey PRIMARY KEY (id);
 
 
@@ -3587,7 +3573,7 @@ ALTER TABLE ONLY recommendations
 -- Name: referrals_users referrals_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY referrals_users
+ALTER TABLE ONLY public.referrals_users
     ADD CONSTRAINT referrals_users_pkey PRIMARY KEY (id);
 
 
@@ -3595,7 +3581,7 @@ ALTER TABLE ONLY referrals_users
 -- Name: referrer_users referrer_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY referrer_users
+ALTER TABLE ONLY public.referrer_users
     ADD CONSTRAINT referrer_users_pkey PRIMARY KEY (id);
 
 
@@ -3603,7 +3589,7 @@ ALTER TABLE ONLY referrer_users
 -- Name: rules_misseds rules_misseds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY rules_misseds
+ALTER TABLE ONLY public.rules_misseds
     ADD CONSTRAINT rules_misseds_pkey PRIMARY KEY (id);
 
 
@@ -3611,7 +3597,7 @@ ALTER TABLE ONLY rules_misseds
 -- Name: sales_contacts sales_contacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_contacts
+ALTER TABLE ONLY public.sales_contacts
     ADD CONSTRAINT sales_contacts_pkey PRIMARY KEY (id);
 
 
@@ -3619,7 +3605,7 @@ ALTER TABLE ONLY sales_contacts
 -- Name: sales_stage_types sales_stage_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stage_types
+ALTER TABLE ONLY public.sales_stage_types
     ADD CONSTRAINT sales_stage_types_pkey PRIMARY KEY (id);
 
 
@@ -3627,7 +3613,7 @@ ALTER TABLE ONLY sales_stage_types
 -- Name: sales_stages sales_stages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stages
+ALTER TABLE ONLY public.sales_stages
     ADD CONSTRAINT sales_stages_pkey PRIMARY KEY (id);
 
 
@@ -3635,7 +3621,7 @@ ALTER TABLE ONLY sales_stages
 -- Name: school_subscriptions school_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY school_subscriptions
+ALTER TABLE ONLY public.school_subscriptions
     ADD CONSTRAINT school_subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -3643,7 +3629,7 @@ ALTER TABLE ONLY school_subscriptions
 -- Name: schools_admins schools_admins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools_admins
+ALTER TABLE ONLY public.schools_admins
     ADD CONSTRAINT schools_admins_pkey PRIMARY KEY (id);
 
 
@@ -3651,7 +3637,7 @@ ALTER TABLE ONLY schools_admins
 -- Name: schools schools_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools
+ALTER TABLE ONLY public.schools
     ADD CONSTRAINT schools_pkey PRIMARY KEY (id);
 
 
@@ -3659,7 +3645,7 @@ ALTER TABLE ONLY schools
 -- Name: schools_users schools_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schools_users
+ALTER TABLE ONLY public.schools_users
     ADD CONSTRAINT schools_users_pkey PRIMARY KEY (id);
 
 
@@ -3667,7 +3653,7 @@ ALTER TABLE ONLY schools_users
 -- Name: sections sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sections
+ALTER TABLE ONLY public.sections
     ADD CONSTRAINT sections_pkey PRIMARY KEY (id);
 
 
@@ -3675,7 +3661,7 @@ ALTER TABLE ONLY sections
 -- Name: students_classrooms students_classrooms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY students_classrooms
+ALTER TABLE ONLY public.students_classrooms
     ADD CONSTRAINT students_classrooms_pkey PRIMARY KEY (id);
 
 
@@ -3683,7 +3669,7 @@ ALTER TABLE ONLY students_classrooms
 -- Name: subscription_types subscription_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscription_types
+ALTER TABLE ONLY public.subscription_types
     ADD CONSTRAINT subscription_types_pkey PRIMARY KEY (id);
 
 
@@ -3691,7 +3677,7 @@ ALTER TABLE ONLY subscription_types
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions
+ALTER TABLE ONLY public.subscriptions
     ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -3699,7 +3685,7 @@ ALTER TABLE ONLY subscriptions
 -- Name: topic_categories topic_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY topic_categories
+ALTER TABLE ONLY public.topic_categories
     ADD CONSTRAINT topic_categories_pkey PRIMARY KEY (id);
 
 
@@ -3707,7 +3693,7 @@ ALTER TABLE ONLY topic_categories
 -- Name: topics topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY topics
+ALTER TABLE ONLY public.topics
     ADD CONSTRAINT topics_pkey PRIMARY KEY (id);
 
 
@@ -3715,7 +3701,7 @@ ALTER TABLE ONLY topics
 -- Name: unit_activities unit_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_activities
+ALTER TABLE ONLY public.unit_activities
     ADD CONSTRAINT unit_activities_pkey PRIMARY KEY (id);
 
 
@@ -3723,7 +3709,7 @@ ALTER TABLE ONLY unit_activities
 -- Name: unit_template_categories unit_template_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_template_categories
+ALTER TABLE ONLY public.unit_template_categories
     ADD CONSTRAINT unit_template_categories_pkey PRIMARY KEY (id);
 
 
@@ -3731,7 +3717,7 @@ ALTER TABLE ONLY unit_template_categories
 -- Name: unit_templates unit_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_templates
+ALTER TABLE ONLY public.unit_templates
     ADD CONSTRAINT unit_templates_pkey PRIMARY KEY (id);
 
 
@@ -3739,7 +3725,7 @@ ALTER TABLE ONLY unit_templates
 -- Name: units units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY units
+ALTER TABLE ONLY public.units
     ADD CONSTRAINT units_pkey PRIMARY KEY (id);
 
 
@@ -3747,7 +3733,7 @@ ALTER TABLE ONLY units
 -- Name: user_milestones user_milestones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_milestones
+ALTER TABLE ONLY public.user_milestones
     ADD CONSTRAINT user_milestones_pkey PRIMARY KEY (id);
 
 
@@ -3755,7 +3741,7 @@ ALTER TABLE ONLY user_milestones
 -- Name: user_subscriptions user_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_subscriptions
+ALTER TABLE ONLY public.user_subscriptions
     ADD CONSTRAINT user_subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -3763,7 +3749,7 @@ ALTER TABLE ONLY user_subscriptions
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -3771,7 +3757,7 @@ ALTER TABLE ONLY users
 -- Name: zipcode_infos zipcode_infos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY zipcode_infos
+ALTER TABLE ONLY public.zipcode_infos
     ADD CONSTRAINT zipcode_infos_pkey PRIMARY KEY (id);
 
 
@@ -3800,7 +3786,7 @@ CREATE UNIQUE INDEX classroom_invitee_index ON public.coteacher_classroom_invita
 -- Name: email_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX email_idx ON public.users USING gin (email gin_trgm_ops);
+CREATE INDEX email_idx ON public.users USING gin (email public.gin_trgm_ops);
 
 
 --
@@ -4668,7 +4654,7 @@ CREATE UNIQUE INDEX index_zipcode_infos_on_zipcode ON public.zipcode_infos USING
 -- Name: name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX name_idx ON public.users USING gin (name gin_trgm_ops);
+CREATE INDEX name_idx ON public.users USING gin (name public.gin_trgm_ops);
 
 
 --
@@ -4780,7 +4766,7 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 -- Name: username_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX username_idx ON public.users USING gin (username gin_trgm_ops);
+CREATE INDEX username_idx ON public.users USING gin (username public.gin_trgm_ops);
 
 
 --
@@ -4878,159 +4864,159 @@ CREATE INDEX uta ON public.activities_unit_templates USING btree (unit_template_
 -- Name: blog_posts tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON public.blog_posts FOR EACH ROW EXECUTE PROCEDURE blog_posts_search_trigger();
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON public.blog_posts FOR EACH ROW EXECUTE PROCEDURE public.blog_posts_search_trigger();
 
 
 --
 -- Name: units fk_rails_0b3b28b65f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY units
-    ADD CONSTRAINT fk_rails_0b3b28b65f FOREIGN KEY (unit_template_id) REFERENCES unit_templates(id);
+ALTER TABLE ONLY public.units
+    ADD CONSTRAINT fk_rails_0b3b28b65f FOREIGN KEY (unit_template_id) REFERENCES public.unit_templates(id);
 
 
 --
 -- Name: activity_session_interaction_logs fk_rails_1ac1e7b3b5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY activity_session_interaction_logs
-    ADD CONSTRAINT fk_rails_1ac1e7b3b5 FOREIGN KEY (activity_session_id) REFERENCES activity_sessions(id);
+ALTER TABLE ONLY public.activity_session_interaction_logs
+    ADD CONSTRAINT fk_rails_1ac1e7b3b5 FOREIGN KEY (activity_session_id) REFERENCES public.activity_sessions(id);
 
 
 --
 -- Name: classroom_units fk_rails_3e1ff09783; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_units
-    ADD CONSTRAINT fk_rails_3e1ff09783 FOREIGN KEY (unit_id) REFERENCES units(id);
+ALTER TABLE ONLY public.classroom_units
+    ADD CONSTRAINT fk_rails_3e1ff09783 FOREIGN KEY (unit_id) REFERENCES public.units(id);
 
 
 --
 -- Name: sales_stages fk_rails_41082adef9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stages
-    ADD CONSTRAINT fk_rails_41082adef9 FOREIGN KEY (sales_contact_id) REFERENCES sales_contacts(id);
+ALTER TABLE ONLY public.sales_stages
+    ADD CONSTRAINT fk_rails_41082adef9 FOREIGN KEY (sales_contact_id) REFERENCES public.sales_contacts(id);
 
 
 --
 -- Name: classroom_unit_activity_states fk_rails_457a11a3eb; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_unit_activity_states
-    ADD CONSTRAINT fk_rails_457a11a3eb FOREIGN KEY (classroom_unit_id) REFERENCES classroom_units(id);
+ALTER TABLE ONLY public.classroom_unit_activity_states
+    ADD CONSTRAINT fk_rails_457a11a3eb FOREIGN KEY (classroom_unit_id) REFERENCES public.classroom_units(id);
 
 
 --
 -- Name: unit_activities fk_rails_48bcb0b8a0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_activities
-    ADD CONSTRAINT fk_rails_48bcb0b8a0 FOREIGN KEY (unit_id) REFERENCES units(id);
+ALTER TABLE ONLY public.unit_activities
+    ADD CONSTRAINT fk_rails_48bcb0b8a0 FOREIGN KEY (unit_id) REFERENCES public.units(id);
 
 
 --
 -- Name: criteria fk_rails_63b994bcda; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY criteria
-    ADD CONSTRAINT fk_rails_63b994bcda FOREIGN KEY (recommendation_id) REFERENCES recommendations(id);
+ALTER TABLE ONLY public.criteria
+    ADD CONSTRAINT fk_rails_63b994bcda FOREIGN KEY (recommendation_id) REFERENCES public.recommendations(id);
 
 
 --
 -- Name: recommendations fk_rails_6745e4bc86; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY recommendations
-    ADD CONSTRAINT fk_rails_6745e4bc86 FOREIGN KEY (unit_template_id) REFERENCES unit_templates(id);
+ALTER TABLE ONLY public.recommendations
+    ADD CONSTRAINT fk_rails_6745e4bc86 FOREIGN KEY (unit_template_id) REFERENCES public.unit_templates(id);
 
 
 --
 -- Name: classroom_units fk_rails_a3c514fc6d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_units
-    ADD CONSTRAINT fk_rails_a3c514fc6d FOREIGN KEY (classroom_id) REFERENCES classrooms(id);
+ALTER TABLE ONLY public.classroom_units
+    ADD CONSTRAINT fk_rails_a3c514fc6d FOREIGN KEY (classroom_id) REFERENCES public.classrooms(id);
 
 
 --
 -- Name: sales_stages fk_rails_a8025d2621; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stages
-    ADD CONSTRAINT fk_rails_a8025d2621 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.sales_stages
+    ADD CONSTRAINT fk_rails_a8025d2621 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: criteria fk_rails_ada79930c6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY criteria
-    ADD CONSTRAINT fk_rails_ada79930c6 FOREIGN KEY (concept_id) REFERENCES concepts(id);
+ALTER TABLE ONLY public.criteria
+    ADD CONSTRAINT fk_rails_ada79930c6 FOREIGN KEY (concept_id) REFERENCES public.concepts(id);
 
 
 --
 -- Name: notifications fk_rails_b080fb4855; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY notifications
-    ADD CONSTRAINT fk_rails_b080fb4855 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT fk_rails_b080fb4855 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: unit_activities fk_rails_b921d87b04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY unit_activities
-    ADD CONSTRAINT fk_rails_b921d87b04 FOREIGN KEY (activity_id) REFERENCES activities(id);
+ALTER TABLE ONLY public.unit_activities
+    ADD CONSTRAINT fk_rails_b921d87b04 FOREIGN KEY (activity_id) REFERENCES public.activities(id);
 
 
 --
 -- Name: classroom_unit_activity_states fk_rails_bab346c597; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY classroom_unit_activity_states
-    ADD CONSTRAINT fk_rails_bab346c597 FOREIGN KEY (unit_activity_id) REFERENCES unit_activities(id);
+ALTER TABLE ONLY public.classroom_unit_activity_states
+    ADD CONSTRAINT fk_rails_bab346c597 FOREIGN KEY (unit_activity_id) REFERENCES public.unit_activities(id);
 
 
 --
 -- Name: concept_results fk_rails_cebe4a6023; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY concept_results
-    ADD CONSTRAINT fk_rails_cebe4a6023 FOREIGN KEY (activity_classification_id) REFERENCES activity_classifications(id);
+ALTER TABLE ONLY public.concept_results
+    ADD CONSTRAINT fk_rails_cebe4a6023 FOREIGN KEY (activity_classification_id) REFERENCES public.activity_classifications(id);
 
 
 --
 -- Name: sales_contacts fk_rails_d6738e130a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_contacts
-    ADD CONSTRAINT fk_rails_d6738e130a FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.sales_contacts
+    ADD CONSTRAINT fk_rails_d6738e130a FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
 -- Name: recommendations fk_rails_dc326309ed; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY recommendations
-    ADD CONSTRAINT fk_rails_dc326309ed FOREIGN KEY (activity_id) REFERENCES activities(id);
+ALTER TABLE ONLY public.recommendations
+    ADD CONSTRAINT fk_rails_dc326309ed FOREIGN KEY (activity_id) REFERENCES public.activities(id);
 
 
 --
 -- Name: sales_stages fk_rails_e5da9d6c2d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY sales_stages
-    ADD CONSTRAINT fk_rails_e5da9d6c2d FOREIGN KEY (sales_stage_type_id) REFERENCES sales_stage_types(id);
+ALTER TABLE ONLY public.sales_stages
+    ADD CONSTRAINT fk_rails_e5da9d6c2d FOREIGN KEY (sales_stage_type_id) REFERENCES public.sales_stage_types(id);
 
 
 --
 -- Name: auth_credentials fk_rails_f92a275310; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY auth_credentials
-    ADD CONSTRAINT fk_rails_f92a275310 FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE ONLY public.auth_credentials
+    ADD CONSTRAINT fk_rails_f92a275310 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -5682,4 +5668,6 @@ INSERT INTO schema_migrations (version) VALUES ('20181105212102');
 INSERT INTO schema_migrations (version) VALUES ('20181203161708');
 
 INSERT INTO schema_migrations (version) VALUES ('20181214192858');
+
+INSERT INTO schema_migrations (version) VALUES ('20190128203336');
 

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -119,6 +119,7 @@ describe ProfilesController, type: :controller do
                 'activity_classification_id' => activity.activity_classification_id,
                 'unit_id' => unit.id,
                 'ua_id' => unit_activity.id,
+                'order_number' => unit_activity.order_number,
                 'unit_created_at' => unit.created_at,
                 'unit_name' => unit.name,
                 'ca_id' => classroom_unit.id,

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -161,9 +161,9 @@ describe ProfilesController, type: :controller do
           # This sort emulates the sort we are doing in the student_profile_data_sql method.
           sorted_scores = scores_array.sort { |a, b|
             [
-              b['pinned'], a['locked'], a['order_number'], b['max_percentage'] == nil ? 1.01 : b['max_percentage'], a['unit_created_at'], a['unit_activity_created_at']
+              b['pinned'], a['locked'], a['unit_created_at'], a['order_number'], b['max_percentage'] == nil ? 1.01 : b['max_percentage'], a['unit_activity_created_at']
             ] <=> [
-              a['pinned'], b['locked'], b['order_number'], a['max_percentage'] == nil ? 1.01 : a['max_percentage'], b['unit_created_at'], b['unit_activity_created_at']
+              a['pinned'], b['locked'], b['unit_created_at'], b['order_number'], a['max_percentage'] == nil ? 1.01 : a['max_percentage'], b['unit_activity_created_at']
             ]
           }
           expect(scores).to eq(sanitize_hash_array_for_comparison_with_sql(sorted_scores))


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- Update lesson-editing interface to let users sort activity order within the lesson and to save sorted order
- Update lesson API to return activities in their specified order for teacher viewing
- Update the student profile API to include specified activity order as part of order criteria for activities (sorting by pinned and locked first, but then by specified order)

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="1018" alt="screenshot_2_5_19__2_17_pm" src="https://user-images.githubusercontent.com/331565/52298462-fbcab880-2950-11e9-9d97-794955af5dd0.png">

**Has this branch been QA'd on staging?** yes

**Have you updated the docs?** yes

**Have the tests been updated?** yes

**Reviewer:** @ddmck
