### PR TITLE
put peg back on team page

### DIFF
--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -176,6 +176,12 @@ module PagesHelper
 						desc: "Daniel Scibienski is the founder of ELL Consulting.  He has been involved in English language education for over 14 years as a teacher, trainer, and program administrator."
 					},
 					{
+						img: 'thumb-peg.jpg',
+						name: 'Peg Tyre',
+						title: "Advisory Board Member",
+						desc: "Peg Tyre is a longtime education journalist and the best-selling author of two books on education. She is also director of strategy for The Edwin Gould Foundation, which invests in organizations that get low-income students to and through college. Tyre is currently at work on a book about literacy."
+					},
+					{
 						img: 'thumb-emily.jpg',
 						name: 'Emily Dalton Smith',
 						title: 'Advisory Board Member',

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -170,12 +170,6 @@ module PagesHelper
 				team: 'Education Advisory Board',
 				members: [
 					{
-						img: 'thumb-daniel.jpg',
-						name: 'Daniel Scibienski',
-						title: "Advisory Board Member",
-						desc: "Daniel Scibienski is the founder of ELL Consulting.  He has been involved in English language education for over 14 years as a teacher, trainer, and program administrator."
-					},
-					{
 						img: 'thumb-peg.jpg',
 						name: 'Peg Tyre',
 						title: "Advisory Board Member",
@@ -192,12 +186,6 @@ module PagesHelper
 						name: 'John Silberstein',
 						title: 'Advisory Board Member',
 						desc: "After beginning his career as a real estate lawyer at Skadden Arps, John Silberstein pursued an entrepreneurial path in real estate and technology. John then taught middle school English at The Dalton School in New York City and The Rivers School in Weston, MA. John is currently on the Board of Snap Interactive, a publicly traded social media company and is on the Advisory Board of Will Power Labs, which makes Meal Enders, a dietary lozenge."
-					},
-					{
-						img: 'thumb-deborah.jpg',
-						name: 'Deborah Chang',
-						title: 'Advisory Board Member',
-						desc: "Deborah Chang is an educator and an entrepreneur. She co-founded Nexus Works, a community of people working with purpose and is also a community organizer of #NYCEDU, an organization that curates, coaches, and connects community organizers."
 					}
 				]
 			},


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add Peg back to team page under Education Advisory Board

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
