### PR TITLE
fix #5017 - make sure lesson name becomes ellipsis when it is too long to fit

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
@@ -433,6 +433,10 @@
     height: 52px;
     .lesson-name {
       cursor: pointer;
+      width: 410px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/dashboard.scss
@@ -437,6 +437,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      text-align: left;
     }
   }
 }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- make sure too-long lessons titles are cut off and replaced with ellipsis

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
<img width="689" alt="screen shot 2019-02-19 at 11 13 53 am" src="https://user-images.githubusercontent.com/18669014/53030241-6fcc8c80-3438-11e9-83d6-c01945e5fc7b.png">


**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
