### PR TITLE
fix #5028 - fix issue with mismatched instructions on admin page

### DIFF
--- a/services/QuillConnect/app/components/questions/question.jsx
+++ b/services/QuillConnect/app/components/questions/question.jsx
@@ -196,7 +196,7 @@ const Question = React.createClass({
       let instructionText = 'Combine the sentences into one sentence.'
       if (instructions) {
         instructionText = instructions
-      } else if (cues) {
+      } else if (cues && cues.length > 0 && cues[0] !== "") {
         if (cues.length === 1) {
           instructionText = "Combine the sentences into one sentence. Use the joining word."
         } else {


### PR DESCRIPTION
Addresses issue #5028

**Changes proposed in this pull request:**
- make admin instructions and student-facing instructions match

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
