### PR TITLE
fix issue with submitting responses early and replaying sessions

### DIFF
--- a/services/QuillConnect/app/components/studentLessons/finished.jsx
+++ b/services/QuillConnect/app/components/studentLessons/finished.jsx
@@ -33,15 +33,29 @@ export default React.createClass({
   },
 
   renderErrorState() {
+    let header
+    let message
+    if (this.props.error === "Activity Session Already Completed") {
+      header = "This Activity Session Has Already Been Completed"
+      message = (<p>
+        The activity session with this unique identifier has already been&nbsp;completed.<br />
+        In order to redo this activity, you must return to your dashboard and click "Replay Activity".<br />
+        If you believe that you have received this message in error, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+        </p>)
+    } else {
+      header = "We Couldn't Save Your Lesson."
+      message = (<p>Your results could not be saved. <br />
+        Make sure you are connected to the internet.<br />
+        You can attempt to save again using the button below.<br />
+        If the issue persists, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+      </p>)
+    }
     return (
       <div className="landing-page">
-        <h1>We Couldn't Save Your Lesson.</h1>
-        <p>
-          Your results could not be saved. <br />Make sure you are connected to the internet.<br />
-          You can attempt to save again using the button below.<br />
-          If the issue persists, ask your teacher to contact Quill.<br />
-          Please provide the following URL to help us solve the problem.
-        </p>
+        <h1>{header}</h1>
+        {message}
         <p><code style={{ fontSize: 14, }}>
           {window.location.href}
         </code></p>

--- a/services/QuillConnect/app/components/studentLessons/finished.jsx
+++ b/services/QuillConnect/app/components/studentLessons/finished.jsx
@@ -44,7 +44,7 @@ export default React.createClass({
         Please provide the following URL to help us solve the problem.
         </p>)
     } else {
-      header = "We Couldn't Save Your Lesson."
+      header = "We Couldn't Save Your Activity Session."
       message = (<p>Your results could not be saved. <br />
         Make sure you are connected to the internet.<br />
         You can attempt to save again using the button below.<br />

--- a/services/QuillConnect/app/components/studentLessons/lesson.jsx
+++ b/services/QuillConnect/app/components/studentLessons/lesson.jsx
@@ -111,7 +111,7 @@ const Lesson = React.createClass({
         } else {
           this.setState({
             saved: false,
-            error: true,
+            error: body.meta.message,
           });
         }
       }

--- a/services/QuillConnect/app/components/studentLessons/question.tsx
+++ b/services/QuillConnect/app/components/studentLessons/question.tsx
@@ -175,7 +175,7 @@ const playLessonQuestion = React.createClass<any, any>({
   },
 
   checkAnswer(e) {
-    if (this.state.editing) {
+    if (this.state.editing && this.getResponses() && Object.keys(this.getResponses()).length) {
       this.removePrefilledUnderscores();
       const response = getResponse(this.getQuestion(), this.state.response, this.getResponses());
       this.updateResponseResource(response);
@@ -189,7 +189,7 @@ const playLessonQuestion = React.createClass<any, any>({
   },
 
   toggleDisabled() {
-    if (this.state.editing) {
+    if (this.state.editing && this.getResponses() && Object.keys(this.getResponses()).length) {
       return '';
     }
     return 'is-disabled';

--- a/services/QuillDiagnostic/app/components/diagnostics/finishedDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/diagnostics/finishedDiagnostic.jsx
@@ -22,23 +22,41 @@ export default React.createClass({
     }
   },
 
+  renderErrorState() {
+    let header
+    let message
+    if (this.props.error === "Activity Session Already Completed") {
+      header = "This Activity Session Has Already Been Completed"
+      message = (<p>
+        The activity session with this unique identifier has already been&nbsp;completed.<br />
+        In order to redo this activity, you must return to your dashboard and click "Replay Activity".<br />
+        If you believe that you have received this message in error, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+        </p>)
+    } else {
+      header = "We Couldn't Save Your Activity Session."
+      message = (<p>Your results could not be saved. <br />
+        Make sure you are connected to the internet.<br />
+        You can attempt to save again using the button below.<br />
+        If the issue persists, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+      </p>)
+    }
+    return (
+      <div className="landing-page">
+        <h1>{header}</h1>
+        {message}
+        <p><code style={{ fontSize: 14, }}>
+          {window.location.href}
+        </code></p>
+        <button className="button is-info is-large" onClick={this.props.saveToLMS}>Retry</button>
+      </div>
+    );
+  },
+
   render() {
     if (this.props.error) {
-      return (
-        <div className="landing-page">
-          <h1>We Couldn't Save Your Lesson.</h1>
-          <p>
-            Your results could not be saved. <br />Make sure you are connected to the internet.<br />
-            You can attempt to save again using the button below.<br />
-            If the issue persists, ask your teacher to contact Quill.<br />
-            Please provide the following URL to help us solve the problem.
-          </p>
-          <p><code style={{ fontSize: 14, }}>
-            {window.location.href}
-          </code></p>
-          <button className="button is-info is-large" onClick={this.props.saveToLMS}>Retry</button>
-        </div>
-      );
+      return this.renderErrorState()
     } else {
       return (
         <div className="landing-page">

--- a/services/QuillDiagnostic/app/components/diagnostics/sentenceCombining.jsx
+++ b/services/QuillDiagnostic/app/components/diagnostics/sentenceCombining.jsx
@@ -114,7 +114,7 @@ const PlayDiagnosticQuestion = React.createClass({
   },
 
   checkAnswer(e) {
-    if (this.state.editing) {
+    if (this.state.editing && this.state.responses) {
       this.removePrefilledUnderscores();
       const response = getResponse(this.getQuestion(), this.state.response, this.getResponses(), this.props.marking || 'diagnostic');
       this.updateResponseResource(response);

--- a/services/QuillDiagnostic/app/components/diagnostics/studentDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/diagnostics/studentDiagnostic.jsx
@@ -108,11 +108,13 @@ const StudentDiagnostic = React.createClass({
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
           SessionActions.delete(this.state.sessionID);
-          document.location.href = process.env.EMPIRICAL_BASE_URL;
+          document.location.href = `${process.env.EMPIRICAL_BASE_URL}/activity_sessions/${this.state.sessionID}`;
           this.setState({ saved: true, });
         } else {
-          console.log('Save not successful');
-          this.setState({ saved: false, error: true, });
+          this.setState({
+            saved: false,
+            error: body.meta.message,
+          });
         }
       }
     );

--- a/services/QuillDiagnostic/app/components/eslDiagnostic/finishedDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/eslDiagnostic/finishedDiagnostic.jsx
@@ -33,23 +33,41 @@ export default React.createClass({
     }
   },
 
+  renderErrorState() {
+    let header
+    let message
+    if (this.props.error === "Activity Session Already Completed") {
+      header = "This Activity Session Has Already Been Completed"
+      message = (<p>
+        The activity session with this unique identifier has already been&nbsp;completed.<br />
+        In order to redo this activity, you must return to your dashboard and click "Replay Activity".<br />
+        If you believe that you have received this message in error, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+        </p>)
+    } else {
+      header = "We Couldn't Save Your Activity Session."
+      message = (<p>Your results could not be saved. <br />
+        Make sure you are connected to the internet.<br />
+        You can attempt to save again using the button below.<br />
+        If the issue persists, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+      </p>)
+    }
+    return (
+      <div className="landing-page">
+        <h1>{header}</h1>
+        {message}
+        <p><code style={{ fontSize: 14, }}>
+          {window.location.href}
+        </code></p>
+        <button className="button is-info is-large" onClick={this.props.saveToLMS}>Retry</button>
+      </div>
+    );
+  },
+
   render() {
     if (this.props.error) {
-      return (
-        <div className="landing-page">
-          <h1>We Couldn't Save Your Lesson.</h1>
-          <p>
-            Your results could not be saved. <br />Make sure you are connected to the internet.<br />
-            You can attempt to save again using the button below.<br />
-            If the issue persists, ask your teacher to contact Quill.<br />
-            Please provide the following URL to help us solve the problem.
-          </p>
-          <p><code style={{ fontSize: 14, }}>
-            {window.location.href}
-          </code></p>
-          <button className="button is-info is-large" onClick={this.props.saveToLMS}>Retry</button>
-        </div>
-      );
+      return this.renderErrorState()
     } else {
       return (
         <div className="landing-page">

--- a/services/QuillDiagnostic/app/components/eslDiagnostic/sentenceCombining.jsx
+++ b/services/QuillDiagnostic/app/components/eslDiagnostic/sentenceCombining.jsx
@@ -123,7 +123,7 @@ const PlayDiagnosticQuestion = React.createClass({
   },
 
   checkAnswer(e) {
-    if (this.state.editing) {
+    if (this.state.editing && this.state.responses) {
       this.removePrefilledUnderscores();
       const response = getResponse(this.getQuestion(), this.state.response, this.getResponses(), this.props.marking || 'diagnostic');
       this.updateResponseResource(response);
@@ -211,10 +211,14 @@ const PlayDiagnosticQuestion = React.createClass({
   render() {
     let button;
     const fullPageInstructions = this.props.language === 'arabic' ? { maxWidth: 800, width: '100%', } : { display: 'block', };
-    if (this.props.question.attempts.length > 0) {
-      button = <button className="button student-submit" onClick={this.nextQuestion}>{this.getSubmitButtonText()}</button>;
+    if (this.state.responses && Object.keys(this.state.responses).length) {
+      if (this.props.question.attempts.length > 0) {
+        button = <button className="button student-submit" onClick={this.nextQuestion}>{this.getSubmitButtonText()}</button>;
+      } else {
+        button = <button className="button student-submit" onClick={this.checkAnswer}>{this.getSubmitButtonText()}</button>;
+      }
     } else {
-      button = <button className="button student-submit" onClick={this.checkAnswer}>{this.getSubmitButtonText()}</button>;
+      button = <button className="button student-submit is-disabled">{this.getSubmitButtonText()}</button>;
     }
     if (this.props.question) {
       const instructions = (this.props.question.instructions && this.props.question.instructions !== '') ? this.props.question.instructions : 'Combine the sentences into one sentence. Combinar las frases en una frase.';

--- a/services/QuillDiagnostic/app/components/eslDiagnostic/sentenceFragment.jsx
+++ b/services/QuillDiagnostic/app/components/eslDiagnostic/sentenceFragment.jsx
@@ -166,7 +166,12 @@ const PlaySentenceFragment = React.createClass({
 
   renderPlaySentenceFragmentMode(fragment) {
     // HARDCODED
-    const button = <button className="button student-submit" onClick={this.checkAnswer}>{this.getSubmitButtonText()}</button>;
+    let button
+    if (this.state.responses) {
+      button = <button className="button student-submit" onClick={this.checkAnswer}>{this.getSubmitButtonText()}</button>;
+    } else {
+      button = <button className="button student-submit is-disabled">{this.getSubmitButtonText()}</button>;
+    }
 
     if (!this.choosingSentenceOrFragment()) {
       const component = (

--- a/services/QuillDiagnostic/app/components/eslDiagnostic/studentDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/eslDiagnostic/studentDiagnostic.jsx
@@ -93,12 +93,11 @@ const StudentDiagnostic = React.createClass({
     this.setState({ error: false, });
     const results = getConceptResultsForAllQuestions(this.props.playDiagnostic.answeredQuestions);
 
-    const { diagnosticID, } = this.props.params;
     const sessionID = this.state.sessionID;
     if (sessionID) {
       this.finishActivitySession(sessionID, results, 1);
     } else {
-      this.createAnonActivitySession(diagnosticID, results, 1);
+      this.createAnonActivitySession('ell', results, 1);
     }
   },
 
@@ -118,11 +117,13 @@ const StudentDiagnostic = React.createClass({
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
           SessionActions.delete(this.state.sessionID);
-          document.location.href = process.env.EMPIRICAL_BASE_URL;
+          document.location.href = `${process.env.EMPIRICAL_BASE_URL}/activity_sessions/${this.state.sessionID}`;
           this.setState({ saved: true, });
         } else {
-          console.log('Save not successful');
-          this.setState({ saved: false, error: true, });
+          this.setState({
+            saved: false,
+            error: body.meta.message,
+          });
         }
       }
     );

--- a/services/QuillDiagnostic/app/components/fillInBlank/playFillInTheBlankQuestion.tsx
+++ b/services/QuillDiagnostic/app/components/fillInBlank/playFillInTheBlankQuestion.tsx
@@ -269,7 +269,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
   }
 
   checkAnswer() {
-    if (!this.state.inputErrors.size) {
+    if (!this.state.inputErrors.size && this.state.responses) {
       if (!this.state.blankAllowed) {
         if (this.state.inputVals.filter(Boolean).length !== this.state.inputVals.length) {
           this.state.inputVals.forEach((val, i) => this.validateInput(i))

--- a/services/QuillDiagnostic/app/components/studentLessons/finished.jsx
+++ b/services/QuillDiagnostic/app/components/studentLessons/finished.jsx
@@ -33,15 +33,29 @@ export default React.createClass({
   },
 
   renderErrorState() {
+    let header
+    let message
+    if (this.props.error === "Activity Session Already Completed") {
+      header = "This Activity Session Has Already Been Completed"
+      message = (<p>
+        The activity session with this unique identifier has already been&nbsp;completed.<br />
+        In order to redo this activity, you must return to your dashboard and click "Replay Activity".<br />
+        If you believe that you have received this message in error, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+        </p>)
+    } else {
+      header = "We Couldn't Save Your Activity Session."
+      message = (<p>Your results could not be saved. <br />
+        Make sure you are connected to the internet.<br />
+        You can attempt to save again using the button below.<br />
+        If the issue persists, ask your teacher to contact Quill.<br />
+        Please provide the following URL to help us solve the problem.
+      </p>)
+    }
     return (
       <div className="landing-page">
-        <h1>We Couldn't Save Your Lesson.</h1>
-        <p>
-          Your results could not be saved. <br />Make sure you are connected to the internet.<br />
-          You can attempt to save again using the button below.<br />
-          If the issue persists, ask your teacher to contact Quill.<br />
-          Please provide the following URL to help us solve the problem.
-        </p>
+        <h1>{header}</h1>
+        {message}
         <p><code style={{ fontSize: 14, }}>
           {window.location.href}
         </code></p>

--- a/services/QuillDiagnostic/app/components/studentLessons/lesson.jsx
+++ b/services/QuillDiagnostic/app/components/studentLessons/lesson.jsx
@@ -119,7 +119,7 @@ const Lesson = React.createClass({
         } else {
           this.setState({
             saved: false,
-            error: true,
+            error: body.meta.message,
           });
         }
       }

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -14,7 +14,13 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   def update
     # FIXME: ignore id because it's related to inconsistency between
     # naming - id in app and uid here
-    if @activity_session.update(activity_session_params.except(:id, :concept_results))
+    if @activity_session.completed_at
+      render json: @activity_session, meta: {
+        status: :failed,
+        message: "Activity Session Already Completed",
+        errors: "This activity session has already been completed."
+      }, status: :unprocessable_entity
+    elsif @activity_session.update(activity_session_params.except(:id, :concept_results))
       NotifyOfCompletedActivity.new(@activity_session).call if @activity_session.classroom_unit_id
 
       if @concept_results


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- fix issue with replaying completed sessions that caused confusing score reports
- fix issue with submitting responses in connect and diagnostic before responses were loaded

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?**  no

**Reviewer:** @ddmck
