### PR TITLE
redirect to profile, not results page, after diagnostic

### DIFF
--- a/services/QuillDiagnostic/app/components/diagnostics/studentDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/diagnostics/studentDiagnostic.jsx
@@ -108,7 +108,7 @@ const StudentDiagnostic = React.createClass({
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
           SessionActions.delete(this.state.sessionID);
-          document.location.href = `${process.env.EMPIRICAL_BASE_URL}/activity_sessions/${this.state.sessionID}`;
+          document.location.href = process.env.EMPIRICAL_BASE_URL
           this.setState({ saved: true, });
         } else {
           this.setState({

--- a/services/QuillDiagnostic/app/components/eslDiagnostic/studentDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/eslDiagnostic/studentDiagnostic.jsx
@@ -117,7 +117,7 @@ const StudentDiagnostic = React.createClass({
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
           SessionActions.delete(this.state.sessionID);
-          document.location.href = `${process.env.EMPIRICAL_BASE_URL}/activity_sessions/${this.state.sessionID}`;
+          document.location.href = process.env.EMPIRICAL_BASE_URL
           this.setState({ saved: true, });
         } else {
           this.setState({


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- redirect to profile, not results page, after diagnostic

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
