### PR TITLE
- add access control credentials header to finish lesson method

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
   end
 
   def finish_lesson
+    response.headers['Access-Control-Allow-Credentials'] = 'true'
     activity = Activity.find_by_id_or_uid(params[:activity_id])
     classroom_unit = ClassroomUnit.find(params[:classroom_unit_id])
 


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add access control credentials header to finish lesson method

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** yes/no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
