### PR TITLE
fix #4568 - make sure merging classrooms works when student in both classes

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/archived_classrooms_manager.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/archived_classrooms_manager.scss
@@ -54,8 +54,9 @@
     }
     td {
       width: 30%;
-      i, svg {
-        padding-right: 10px;
+      svg {
+        margin-right: 4px;
+        margin-bottom: 3px;
         font-size: 10px;
         vertical-align: middle;
       }

--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -129,7 +129,7 @@ module TeacherFixes
 
   def self.move_students_from_one_class_to_another(class_id_1, class_id_2)
     StudentsClassrooms.where(classroom_id: class_id_1).each do |sc|
-      if StudentsClassrooms.find_by(classroom_id: class_id_2, student_id: sc.student_id)
+      if StudentsClassrooms.unscoped.find_by(classroom_id: class_id_2, student_id: sc.student_id)
         sc.update(visible: false)
       else
         sc.update(classroom_id: class_id_2)

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ArchivedClassroomsManager.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ArchivedClassroomsManager.jsx
@@ -172,7 +172,7 @@ export default React.createClass({
     if (action == 'pending_coteachers') {
       return <td className="edit-or-remove" onClick={() => { this.removePendingCoteacher(coteacher_email); }}><i className="fa fa-times-circle" aria-hidden="true" />Remove</td>;
     }
-    return <td className="edit-or-remove"><a href={`/classrooms_teachers/${coteacher_id}/edit_coteacher_form`}><i className="fa fa-pencil" aria-hidden="true" />Edit</a></td>;
+    return <td className="edit-or-remove"><a href={`/classrooms_teachers/${coteacher_id}/edit_coteacher_form`}><i className="fa fa-pencil" />Edit</a></td>;
   },
 
   removePendingCoteacher(coteacher_email) {


### PR DESCRIPTION
Addresses issue #4568

**Changes proposed in this pull request:**
- make sure merging classrooms works when a student was in both classes and then removed from the first

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
