### PR TITLE
fix #5068 - make sure it is possible to assign additional students to unit

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ClassroomsWithStudentsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ClassroomsWithStudentsContainer.jsx
@@ -147,7 +147,7 @@ export default class ClassroomsWithStudentsContainer extends React.Component {
     let updated;
     if (classy.classroom_unit) {
       const ca = classy.classroom_unit;
-      if (ca.assign_on_join) {
+      if (ca.assign_on_join && classy.students.length === ca.assigned_student_ids.length) {
 				// if everyone in class was assigned, check to see if assignedStudentIds length is equal to number of students in class
 				// if it is, there hasn't been an update unless there are no students in the class
         const equalLengths = assignedStudentIds.length === classy.students.length;


### PR DESCRIPTION
Addresses issue #5068

**Changes proposed in this pull request:**
- makes sure it is possible to add additional students to unit even if assign_on_join is true

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
