### PR TITLE
fix #5074 - hide archived activities on my activities, scorebook, and student dash

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -133,6 +133,7 @@ protected
       AND cu.visible = true
       AND unit.visible = true
       AND ua.visible = true
+      AND 'archived' != ANY(activity.flags)
       GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
 
       ORDER BY pinned DESC, locked ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.id ASC").to_a

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -199,9 +199,11 @@ class Teachers::UnitsController < ApplicationController
     # returns an empty array if teach_own_or_coteach_classrooms_array is empty
     teach_own_or_coteach_classrooms_array = current_user.send("classrooms_i_#{teach_own_or_coteach}").map(&:id)
     if teach_own_or_coteach_classrooms_array.any?
-      scores, completed = ''
+      scores, completed, archived_activities = ''
       if report
         completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0"
+      else
+        archived_activities = "AND 'archived' != ANY(activities.flags)"
       end
       if lessons
         lessons = "AND activities.activity_classification_id = 6"
@@ -246,6 +248,7 @@ class Teachers::UnitsController < ApplicationController
         AND units.visible = true
         AND cu.visible = true
         AND ua.visible = true
+        #{archived_activities}
         #{lessons}
         GROUP BY units.name, units.created_at, cu.id, classrooms.name, classrooms.id, activities.name, activities.activity_classification_id, activities.id, activities.uid, unit_owner.name, unit_owner.id, ua.due_date, ua.created_at, unit_activity_id, state.completed, ua.id
         #{completed}

--- a/services/QuillLMS/app/queries/profile/mobile/activity_sessions_by_unit.rb
+++ b/services/QuillLMS/app/queries/profile/mobile/activity_sessions_by_unit.rb
@@ -43,6 +43,7 @@ class Profile::Mobile::ActivitySessionsByUnit
     AND cu.visible = true
     AND unit.visible = true
     AND ua.visible = true
+    AND 'archived' != ANY(activity.flags)
     GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
     ORDER BY pinned DESC, locked ASC, max_percentage DESC, ua.due_date ASC, unit.created_at ASC, ua.id ASC").to_a
   end

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -39,6 +39,7 @@ class Scorebook::Query
      AND unit_activities.visible
      AND cu.visible
      AND sc.visible
+     AND 'archived' != ANY(activity.flags)
      #{last_unit}
      #{self.date_conditional_string(begin_date, end_date, offset)}
      GROUP BY


### PR DESCRIPTION
Addresses issue #5074

**Changes proposed in this pull request:**
- hide archived assigned activities on my activities, the visual overview, and the student dashboard, so that students do not attempt to play activities that have no questions

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
