### PR TITLE
add favicon to all five apps

### DIFF
--- a/services/QuillConnect/app/index.html.ejs
+++ b/services/QuillConnect/app/index.html.ejs
@@ -1,6 +1,7 @@
 <!DOCTYPE html/>
 <html lang="en">
   <head>
+    <link rel="shortcut icon" href="https://assets.quill.org/images/shared/favicon.ico" type="image/x-icon">
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-42943443-4"></script>
     <script>

--- a/services/QuillDiagnostic/app/index.html.ejs
+++ b/services/QuillDiagnostic/app/index.html.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
+    <link rel="shortcut icon" href="https://assets.quill.org/images/shared/favicon.ico" type="image/x-icon">
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-42943443-4"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/services/QuillGrammar/src/index.html
+++ b/services/QuillGrammar/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <link rel="shortcut icon" href="https://assets.quill.org/images/shared/favicon.ico" type="image/x-icon">
         <meta charset="UTF-8" />
         <title>Quill Grammar</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/services/QuillLessons/app/index.html.ejs
+++ b/services/QuillLessons/app/index.html.ejs
@@ -1,6 +1,7 @@
 <!DOCTYPE html/>
 <html lang="en">
   <head>
+    <link rel="shortcut icon" href="https://assets.quill.org/images/shared/favicon.ico" type="image/x-icon">
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-42943443-4"></script>
     <script>

--- a/services/QuillProofreader/src/index.html
+++ b/services/QuillProofreader/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <link rel="shortcut icon" href="https://assets.quill.org/images/shared/favicon.ico" type="image/x-icon">
         <meta charset="UTF-8" />
         <title>Quill Proofreader</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add link to the favicon on the Quill CDN to the <head> section of all five apps

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?**  no

**Have you updated the docs?**  no

**Have the tests been updated?** no

**Reviewer:** @anathomical
