### PR TITLE
allow custom meta tags for unit templates

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -7,6 +7,10 @@ class Teachers::UnitTemplatesController < ApplicationController
   def index
     respond_to do |format|
       format.html do
+        unit_template = UnitTemplate.find(params[:id])
+        if unit_template&.image_link
+          @image_link = unit_template.image_link
+        end
         redirect_to "/teachers/classrooms/assign_activities/featured-activity-packs/#{params[:id]}" if @is_teacher
       end
       format.json do

--- a/services/QuillLMS/db/migrate/20190312193928_add_image_link_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20190312193928_add_image_link_to_unit_templates.rb
@@ -1,0 +1,5 @@
+class AddImageLinkToUnitTemplates < ActiveRecord::Migration
+  def change
+    add_column :unit_templates, :image_link, :string
+  end
+end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- add image_link attribute to unit templates
- set @image_link variable to be the image link of the unit template when one exists, so that it is set as the og:image meta tag when shared

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
