### PR TITLE
fix #4918 - don't impose limit on school results when user has entered zip or prefix

### DIFF
--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -4,10 +4,10 @@ class SchoolsController < ApplicationController
 
   def index
     @radius = params[:radius].presence || 5
-    @limit = params[:limit].presence || 10
     @lat, @lng = params[:lat],params[:lng]
     @search = params[:search]
     @prefix,@zipcode = get_prefix_and_zipcode(@search)
+    @limit = @prefix || @zipcode ? nil : params[:limit].presence || 10
     @schools = []
 
     school_ids = []


### PR DESCRIPTION
Addresses issue #4918

**Changes proposed in this pull request:**
- set limit to nil when user has entered either their zipcode or input for the name of their school

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
