### PR TITLE
fix #5096 - grammar activities with archived questions

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -102,11 +102,11 @@ export const getQuestionsForConcepts = (concepts: any) => {
       const arrayOfQuestions = []
       Object.keys(questionsForConcepts).forEach(conceptUID => {
         const shuffledQuestionArray = shuffle(questionsForConcepts[conceptUID])
-        const numberOfQuestions = concepts[conceptUID].quantity
+        const numberOfQuestions = shuffledQuestionArray.length >= concepts[conceptUID].quantity ? concepts[conceptUID].quantity : shuffledQuestionArray.length
         arrayOfQuestions.push(shuffledQuestionArray.slice(0, numberOfQuestions))
       })
 
-      const flattenedArrayOfQuestions = _.flatten(arrayOfQuestions)
+      const flattenedArrayOfQuestions = shuffle(_.flatten(arrayOfQuestions))
       if (flattenedArrayOfQuestions.length > 0) {
         dispatch({ type: ActionTypes.RECEIVE_QUESTION_DATA, data: flattenedArrayOfQuestions, });
       } else {

--- a/services/QuillGrammar/src/components/lessons/lesson.tsx
+++ b/services/QuillGrammar/src/components/lessons/lesson.tsx
@@ -47,9 +47,10 @@ class Lesson extends React.Component<LessonProps> {
   renderQuestionsByConcept(questionsForLesson) {
     const conceptIds: {[key: string]: JSX.Element[]} = {}
     questionsForLesson.forEach((question: Question) => {
-      const { prompt, key, concept_uid} = question
+      const { prompt, key, concept_uid, flag } = question
       const displayName = prompt || 'No question prompt';
-      const questionLink = <li key={key}><Link to={`/admin/questions/${question.key}`}>{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>
+      const archivedTag = flag === 'archived' ? 'ARCHIVED - ' : ''
+      const questionLink = <li key={key}><Link to={`/admin/questions/${question.key}`}><strong>{archivedTag}</strong>{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>
       if (conceptIds[concept_uid]) {
         conceptIds[concept_uid].push(questionLink)
       } else {


### PR DESCRIPTION
Addresses issue #5096

**Changes proposed in this pull request:**
- make sure we don't cause an error if there are fewer questions for a given concept than an activity specifies
- show 'archived' tag on the link to the question from the activity page

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
