### PR TITLE
fix #5101 - proofreader modals

### DIFF
--- a/services/QuillGrammar/src/styles/question.scss
+++ b/services/QuillGrammar/src/styles/question.scss
@@ -62,10 +62,15 @@
 
   .instructions {
     margin: 1em 0;
+    max-width: 80%;
   }
 
   .top-section, .question-section {
     padding: 20px 30px;
+  }
+
+  .top-section {
+    background-color: #ededed;
   }
 
   .question-section {

--- a/services/QuillProofreader/src/components/proofreaderActivities/edit.tsx
+++ b/services/QuillProofreader/src/components/proofreaderActivities/edit.tsx
@@ -31,9 +31,25 @@ export default class Edit extends React.Component<EditProps, {offset: string}> {
   componentDidMount() {
     const { id } = this.props
     const element = document.getElementById(id)
-    console.log('window.innerWidth', window.innerWidth)
-    console.log('element.offsetLeft', element? element.offsetLeft : '')
-    const offset = element && ((window.innerWidth - element.offsetLeft) < 340) ? 'offset' : ''
+    let tooltipWidth = 340
+    if (window.innerWidth <= 900) {
+      tooltipWidth = 230
+    } else if (window.innerWidth <= 400) {
+      tooltipWidth = 185
+    }
+    let remainingWidth
+    let offset = ''
+    if (element) {
+      // the following line handles the case where the element is split across two lines, because its offsetWidth will be roughly the width of the entire text area
+      if (window.innerWidth - 200 < element.offsetWidth) {
+        // if that's the case, we want to calculate the remaining width without reference to the element itself
+        remainingWidth = window.innerWidth - element.offsetLeft - tooltipWidth
+      } else {
+        // otherwise, since the tooltip begins where the element does, we can include the element's width as part of the space needed for the tooltip
+        remainingWidth = (window.innerWidth - element.offsetLeft - tooltipWidth) + element.offsetWidth
+      }
+      offset = remainingWidth < tooltipWidth ? 'offset' : ''
+    }
     this.setState({ offset })
   }
 

--- a/services/QuillProofreader/src/styles/edit.scss
+++ b/services/QuillProofreader/src/styles/edit.scss
@@ -52,7 +52,7 @@
     &.offset {
       left: -130px;
       @media (max-width: 600px) {
-        left: 0px;
+        left: -50px;
       }
     }
 
@@ -141,6 +141,9 @@
       .button-section {
         justify-content: flex-start;
       }
+    }
+    @media (max-width: 400px) {
+      width: 185px;
     }
   }
 }

--- a/services/QuillProofreader/src/styles/edit.scss
+++ b/services/QuillProofreader/src/styles/edit.scss
@@ -51,6 +51,9 @@
     font-family: "Monospaced Number", "Chinese Quote", -apple-system, system-ui, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
     &.offset {
       left: -130px;
+      @media (max-width: 600px) {
+        left: 0px;
+      }
     }
 
     .top-section {

--- a/services/QuillProofreader/src/styles/modal.scss
+++ b/services/QuillProofreader/src/styles/modal.scss
@@ -22,6 +22,9 @@
   .reset-modal {
     width: 560px;
     height: 214px;
+    @media (max-width: 600px) {
+      width: 90%;
+    }
   }
 
   .reset-modal, .early-submit-modal, .review-modal {


### PR DESCRIPTION
Addresses issue #5101

**Changes proposed in this pull request:**
- update modal sizes for proofreader so they still look nice on different mobile devices

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
