### PR TITLE
fix #5102 - handle proofreader activity with no questions for follow-up concepts

### DIFF
--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -81,7 +81,7 @@ export const startListeningToFollowUpQuestionsForProofreaderSession = (proofread
 
 // typescript this
 export const getQuestionsForConcepts = (concepts: any) => {
-  return dispatch => {
+  return (dispatch, getState) => {
     dispatch(setSessionPending(true))
     const conceptUIDs = Object.keys(concepts)
     questionsRef.orderByChild('concept_uid').once('value', (snapshot) => {
@@ -110,7 +110,12 @@ export const getQuestionsForConcepts = (concepts: any) => {
       if (flattenedArrayOfQuestions.length > 0) {
         dispatch({ type: ActionTypes.RECEIVE_QUESTION_DATA, data: flattenedArrayOfQuestions, });
       } else {
-        dispatch({ type: ActionTypes.NO_QUESTIONS_FOUND_FOR_SESSION})
+        // we should only show no questions error if it is not a proofreader follow-up
+        if (getState().session.proofreaderSession) {
+          dispatch({ type: ActionTypes.RECEIVE_QUESTION_DATA, data: [] });
+        } else {
+          dispatch({ type: ActionTypes.NO_QUESTIONS_FOUND_FOR_SESSION})
+        }
       }
       dispatch(setSessionPending(false))
     });

--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -93,6 +93,9 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
 
       if (nextProps.session.hasreceiveddata && !nextProps.session.currentQuestion && nextProps.session.unansweredQuestions.length === 0 && nextProps.session.answeredQuestions.length > 0) {
         this.saveToLMS(nextProps.session)
+        // handles case where proofreader has no follow-up questions
+      } else if (nextProps.session.hasreceiveddata && !nextProps.session.currentQuestion && nextProps.session.unansweredQuestions.length === 0 && nextProps.session.proofreaderSession) {
+        this.saveToLMS(nextProps.session)
       } else if (nextProps.session.hasreceiveddata && !nextProps.session.currentQuestion) {
         this.props.dispatch(goToNextQuestion())
       }
@@ -119,11 +122,15 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         const proofreaderConceptResults = proofreaderSession.conceptResults
         const numberOfGrammarQuestions = answeredQuestions.length
         const numberOfProofreaderQuestions = proofreaderConceptResults.length
-        results = getConceptResultsForAllQuestions(answeredQuestions, numberOfProofreaderQuestions);
-        const proofreaderAndGrammarResults = proofreaderConceptResults.concat(results)
         const correctProofreaderQuestions = proofreaderConceptResults.filter(cr => cr.metadata.correct === 1)
         const proofreaderScore = correctProofreaderQuestions.length / numberOfProofreaderQuestions
-        const totalScore = ((proofreaderScore * numberOfProofreaderQuestions) + (score * numberOfGrammarQuestions)) / (numberOfGrammarQuestions + numberOfProofreaderQuestions)
+        let proofreaderAndGrammarResults = proofreaderConceptResults
+        let totalScore = proofreaderScore
+        if (numberOfGrammarQuestions) {
+          results = getConceptResultsForAllQuestions(answeredQuestions, numberOfProofreaderQuestions);
+          proofreaderAndGrammarResults = proofreaderConceptResults.concat(results)
+          totalScore = ((proofreaderScore * numberOfProofreaderQuestions) + (score * numberOfGrammarQuestions)) / (numberOfGrammarQuestions + numberOfProofreaderQuestions)
+        }
         if (proofreaderSession.anonymous) {
           const proofreaderActivityUID = proofreaderSession.activityUID
           this.createAnonActivitySession(proofreaderActivityUID, proofreaderAndGrammarResults, totalScore)


### PR DESCRIPTION
Addresses issue #5102

**Changes proposed in this pull request:**
- handle the case where there are no unarchived grammar questions for the concepts a student got wrong on proofreader, making them stuck with a "no questions found" screen

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
