### PR TITLE
fix #5116 - don't look for specific unit template without an id

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -7,9 +7,11 @@ class Teachers::UnitTemplatesController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        unit_template = UnitTemplate.find(params[:id])
-        if unit_template&.image_link
-          @image_link = unit_template.image_link
+        if params[:id]
+          unit_template = UnitTemplate.find(params[:id])
+          if unit_template&.image_link
+            @image_link = unit_template.image_link
+          end
         end
         redirect_to "/teachers/classrooms/assign_activities/featured-activity-packs/#{params[:id]}" if @is_teacher
       end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- don't look for specific unit template without an id param

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
