### PR TITLE
fix #5107  - handle teacher fix issue where teacher already has class in both accounts

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -109,7 +109,13 @@ class TeacherFixController < ApplicationController
     if account1 && account2
       if account1.role === 'teacher' && account2.role === 'teacher'
         Unit.unscoped.where(user_id: account1.id).update_all(user_id: account2.id)
-        ClassroomsTeacher.where(user_id: account1.id).update_all(user_id: account2.id)
+        ClassroomsTeacher.where(user_id: account1.id).each do |ct|
+          if ClassroomsTeacher.find_by(user_id: account2.id, classroom_id: ct.classroom_id)
+            ct.destroy
+          else
+            ct.update(user_id: account2.id)
+          end
+        end
         account1.delete_dashboard_caches
         account2.delete_dashboard_caches
         render json: {}, status: 200


### PR DESCRIPTION
Addresses issue #5107

**Changes proposed in this pull request:**
- handle case where teacher already has an association with a class in both teacher accounts they're trying to merge

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
