### PR TITLE
Remove the ability to reset individual student answers on Lesson slides

### DIFF
--- a/services/QuillLessons/CHANGELOG.md
+++ b/services/QuillLessons/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Released on: TBD
+### Removed
+- Removed the ability to reset a single, specific student's answer in a Lesson slide
+
+## Prior to 2019-03-25
+### Added
+- So much stuff
+### Removed
+- So much stuff
+### Changed
+- So much stuff
+### Fixed
+- So much stuff

--- a/services/QuillLessons/app/components/classroomLessons/shared/scriptComponent.tsx
+++ b/services/QuillLessons/app/components/classroomLessons/shared/scriptComponent.tsx
@@ -360,7 +360,6 @@ class ScriptContainer extends React.Component<ScriptContainerProps, ScriptContai
       'time': 'Time',
       'displayed': 'Select to Display',
       'order': 1,
-      'retry': 'Have Student Retry',
     }
     const headers: Array<JSX.Element> = []
     for (let key in fields) {
@@ -468,7 +467,6 @@ class ScriptContainer extends React.Component<ScriptContainerProps, ScriptContai
           </label>
         </td>
         <td><span className={`answer-number-container ${studentNumberClassName}`}>{studentNumber}</span></td>
-        <td className="retry-question-cell"><i className="fa fa-refresh student-retry-question" onClick={() => this.retryQuestionForStudent(studentKey)}/></td>
       </tr>
 
   }


### PR DESCRIPTION
This is a temporary measure while we get this code to actually work, at which point we'd like to re-introduce it.