### PR TITLE
make sure grammar activities only pull questions with the flag of the activity or broader

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -83,11 +83,11 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
 
     componentWillReceiveProps(nextProps: PlayGrammarContainerProps) {
       if (nextProps.grammarActivities.hasreceiveddata && !nextProps.session.hasreceiveddata && !nextProps.session.pending && !nextProps.session.error) {
-        const { questions, concepts } = nextProps.grammarActivities.currentActivity
+        const { questions, concepts, flag } = nextProps.grammarActivities.currentActivity
         if (questions) {
           this.props.dispatch(getQuestions(questions))
         } else {
-          this.props.dispatch(getQuestionsForConcepts(concepts))
+          this.props.dispatch(getQuestionsForConcepts(concepts, flag))
         }
       }
 


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- when grammar activities are assigned concepts, only pull questions from those concepts when the flag matches or is broader than the flag of the activity (ie, beta activities can have beta and production questions, but production activities can only have production questions)
- when grammar activities are assigned questions, filter out archived questions

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @ddmck
