### PR TITLE
hide archived questions for tool admins

### DIFF
--- a/services/QuillConnect/app/components/concepts/concept.jsx
+++ b/services/QuillConnect/app/components/concepts/concept.jsx
@@ -38,7 +38,8 @@ const Concept = React.createClass({
   renderQuestionsForConcept: function () {
     var questionsForConcept = this.questionsForConcept()
     var listItems = questionsForConcept.map((question) => {
-      return (<li key={question.key}><Link to={'/admin/questions/' + question.key}>{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>)
+      const archivedTag = question.flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
+      return (<li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{archivedTag}{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>)
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillConnect/app/components/concepts/concept.jsx
+++ b/services/QuillConnect/app/components/concepts/concept.jsx
@@ -31,8 +31,8 @@ const Concept = React.createClass({
   },
 
   questionsForConcept: function () {
-    var questionsCollection = hashToCollection(this.props.questions.data)
-    return _.where(questionsCollection, {conceptID: this.props.params.conceptID})
+    const questionsCollection = hashToCollection(this.props.questions.data)
+    return questionsCollection.filter(q => q.conceptID === this.props.params.conceptID && q.flag !== 'archived')
   },
 
   renderQuestionsForConcept: function () {

--- a/services/QuillDiagnostic/app/components/concepts/concept.jsx
+++ b/services/QuillDiagnostic/app/components/concepts/concept.jsx
@@ -31,8 +31,8 @@ const Concept = React.createClass({
   },
 
   questionsForConcept: function () {
-    var questionsCollection = hashToCollection(this.props.questions.data)
-    return _.where(questionsCollection, {conceptID: this.props.params.conceptID})
+    const questionsCollection = hashToCollection(this.props.questions.data)
+    return questionsCollection.filter(q => q.conceptID === this.props.params.conceptID && q.flag !== 'archived')
   },
 
   renderQuestionsForConcept: function () {

--- a/services/QuillDiagnostic/app/components/questions/responseRouteWrapper.jsx
+++ b/services/QuillDiagnostic/app/components/questions/responseRouteWrapper.jsx
@@ -24,7 +24,7 @@ const ResponseComponentWrapper = React.createClass({
 
   returnAppropriateDataset() {
     const { questionID, } = this.props.params;
-    const datasets = ['fillInBlank', 'sentenceFragments', 'diagnosticQuestions'];
+    const datasets = ['fillInBlank', 'sentenceFragments'];
     let theDatasetYouAreLookingFor = this.props.questions.data[questionID];
     let mode = 'questions';
     datasets.forEach((dataset) => {

--- a/services/QuillGrammar/src/components/concepts/concept.tsx
+++ b/services/QuillGrammar/src/components/concepts/concept.tsx
@@ -70,7 +70,8 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
   renderQuestionsForConcept() {
     const questionsForConcept = this.questionsForConcept()
     const listItems = questionsForConcept.map((question: Question) => {
-      return (<li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>)
+      const archivedTag = question.flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
+      return (<li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{archivedTag}{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>)
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillGrammar/src/components/concepts/concept.tsx
+++ b/services/QuillGrammar/src/components/concepts/concept.tsx
@@ -64,7 +64,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
 
   questionsForConcept() {
     const questionsCollection = hashToCollection(this.props.questions.data)
-    return _.where(questionsCollection, {concept_uid: this.props.match.params.conceptID})
+    return questionsCollection.filter(q => q.concept_uid === this.props.match.params.conceptID && q.flag !== 'archived')
   }
 
   renderQuestionsForConcept() {

--- a/services/QuillGrammar/src/components/lessons/lesson.tsx
+++ b/services/QuillGrammar/src/components/lessons/lesson.tsx
@@ -73,9 +73,10 @@ class Lesson extends React.Component<LessonProps> {
 
   renderQuestionsAsList(questionsForLesson) {
     return questionsForLesson.map((question: Question) => {
-      const { prompt, key, concept_uid} = question
+      const { prompt, key, concept_uid, flag, } = question
       const displayName = prompt || 'No question prompt';
-      return <p key={key}><Link to={`/admin/questions/${question.key}`}>{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></p>
+      const archivedTag = flag === 'archived' ? 'ARCHIVED - ' : ''
+      return <li key={key}><Link to={`/admin/questions/${key}`}><strong>{archivedTag}</strong>{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>
     })
   }
 
@@ -95,7 +96,7 @@ class Lesson extends React.Component<LessonProps> {
     } else if (lessonConcepts) {
       const questions = this.props.questions ? hashToCollection(this.props.questions.data) : []
       const conceptUids = Object.keys(data[lessonID].concepts)
-      questionsForLesson = questions.filter(q => conceptUids.includes(q.concept_uid))
+      questionsForLesson = questions.filter(q => conceptUids.includes(q.concept_uid) && q.flag !== 'archived')
       return this.renderQuestionsByConcept(questionsForLesson)
     }
     return (


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- hide archived questions on concept pages for grammar, connect, and diagnostic
- hide archived questions on grammar activity pages when the activity pulls questions by concept
- add archived tag to questions on grammar activity pages when the activity is explicitly assigned questions

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
