### PR TITLE
only pull grammar and connect questions with appropriate flags for activities

### DIFF
--- a/services/QuillConnect/app/components/lessons/lesson.jsx
+++ b/services/QuillConnect/app/components/lessons/lesson.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import _ from 'underscore';
 import lessonActions from '../../actions/lessons';
-import flagArray from '../../libs/flagArray'
+import { permittedFlag } from '../../libs/flagArray'
 import { Modal } from 'quill-component-library/dist/componentLibrary';
 import C from '../../constants.js';
 import EditLessonForm from './lessonForm.jsx';
@@ -15,10 +15,10 @@ String.prototype.toKebab = function () {
 const Lesson = React.createClass({
 
   lesson() {
-    const { data, } = this.props.lessons,
-      { lessonID, } = this.props.params;
+    const { data, } = this.props.lessons
+    const { lessonID, } = this.props.params;
     return data[lessonID]
-  }
+  },
 
   questionsForLesson() {
     if (this.lesson().questions) {
@@ -40,7 +40,7 @@ const Lesson = React.createClass({
         const { questionType, title, prompt, key, flag } = question
         const displayName = (questionType === 'titleCards' ? title : prompt) || 'No question prompt';
         const questionTypeLink = questionType === 'fillInBlank' ? 'fill-in-the-blanks' : questionType.toKebab()
-        const flagTag = flagArray(lessonFlag).includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
+        const flagTag = permittedFlag(lessonFlag, flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
         return (
           <li key={key}>
             <Link to={`/admin/${questionTypeLink || 'questions'}/${key}`}>

--- a/services/QuillConnect/app/components/lessons/lesson.jsx
+++ b/services/QuillConnect/app/components/lessons/lesson.jsx
@@ -41,7 +41,13 @@ const Lesson = React.createClass({
         const displayName = (questionType === 'titleCards' ? title : prompt) || 'No question prompt';
         const questionTypeLink = questionType === 'fillInBlank' ? 'fill-in-the-blanks' : questionType.toKebab()
         const flagTag = flagArray(lessonFlag).includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
-        return (<li key={key}><Link to={`/admin/${questionTypeLink || 'questions'}/${key}`}>{flagTag}{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>);
+        return (
+          <li key={key}>
+            <Link to={`/admin/${questionTypeLink || 'questions'}/${key}`}>
+              {flagTag}
+              {displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}
+            </Link>
+          </li>);
       });
       return (
         <ul>{listItems}</ul>

--- a/services/QuillConnect/app/components/studentLessons/lesson.jsx
+++ b/services/QuillConnect/app/components/studentLessons/lesson.jsx
@@ -15,6 +15,7 @@ import _ from 'underscore';
 import { getConceptResultsForAllQuestions, calculateScoreForLesson } from '../../libs/conceptResults/lesson';
 import Finished from './finished.jsx';
 import { getParameterByName } from '../../libs/getParameterByName';
+import flagArray from '../../libs/flagArray'
 
 const request = require('request');
 
@@ -147,10 +148,12 @@ const Lesson = React.createClass({
   },
 
   questionsForLesson() {
-    const { data, } = this.props.lessons,
-      { lessonID, } = this.props.params;
-    const filteredQuestions = data[lessonID].questions.filter(ques =>
-       this.props[ques.questionType].data[ques.key]
+    const { data, } = this.props.lessons
+    const { lessonID, } = this.props.params;
+    const filteredQuestions = data[lessonID].questions.filter(ques => {
+      const question = this.props[ques.questionType].data[ques.key]
+      return question && flagArray(data[lessonID].flag).includes(question.flag)
+    }
     );
     // this is a quickfix for missing questions -- if we leave this in here
     // long term, we should return an array through a forloop to

--- a/services/QuillConnect/app/components/studentLessons/lesson.jsx
+++ b/services/QuillConnect/app/components/studentLessons/lesson.jsx
@@ -15,7 +15,7 @@ import _ from 'underscore';
 import { getConceptResultsForAllQuestions, calculateScoreForLesson } from '../../libs/conceptResults/lesson';
 import Finished from './finished.jsx';
 import { getParameterByName } from '../../libs/getParameterByName';
-import flagArray from '../../libs/flagArray'
+import { permittedFlag } from '../../libs/flagArray'
 
 const request = require('request');
 
@@ -150,9 +150,9 @@ const Lesson = React.createClass({
   questionsForLesson() {
     const { data, } = this.props.lessons
     const { lessonID, } = this.props.params;
-    const filteredQuestions = data[lessonID].questions.filter(ques => {
+    const filteredQuestions = data[lessonID].questions.filter((ques) => {
       const question = this.props[ques.questionType].data[ques.key]
-      return question && flagArray(data[lessonID].flag).includes(question.flag)
+      return question && permittedFlag(data[lessonID].flag, question.flag)
     }
     );
     // this is a quickfix for missing questions -- if we leave this in here

--- a/services/QuillConnect/app/libs/flagArray.js
+++ b/services/QuillConnect/app/libs/flagArray.js
@@ -1,0 +1,11 @@
+export default (flag) => {
+  let flagArray = ['production']
+  if (flag === 'alpha') {
+    flagArray = ['alpha', 'beta', 'production']
+  } else if (flag === 'beta') {
+    flagArray = ['beta', 'production']
+  } else if (flag === 'archived') {
+    flagArray = ['archived', 'alpha', 'beta', 'production']
+  }
+  return flagArray
+}

--- a/services/QuillConnect/app/libs/flagArray.js
+++ b/services/QuillConnect/app/libs/flagArray.js
@@ -1,4 +1,4 @@
-export default (flag) => {
+export const flagArray = (flag) => {
   let flagArray = ['production']
   if (flag === 'alpha') {
     flagArray = ['alpha', 'beta', 'production']
@@ -8,4 +8,10 @@ export default (flag) => {
     flagArray = ['archived', 'alpha', 'beta', 'production']
   }
   return flagArray
+}
+
+export const permittedFlag = (activityFlag, questionFlag) => {
+  const notNullActivityFlag = activityFlag || 'production'
+  const notNullQuestionFlag = questionFlag || 'production'
+  return flagArray(notNullActivityFlag).includes(notNullQuestionFlag)
 }

--- a/services/QuillGrammar/src/actions/session.ts
+++ b/services/QuillGrammar/src/actions/session.ts
@@ -9,7 +9,7 @@ import { SessionState } from '../reducers/sessionReducer'
 import { checkGrammarQuestion, Response } from 'quill-marking-logic'
 import { hashToCollection } from '../helpers/hashToCollection'
 import { shuffle } from '../helpers/shuffle';
-import flagArray from '../helpers/flagArray'
+import { permittedFlag } from '../helpers/flagArray'
 import _ from 'lodash';
 
 export const updateSessionOnFirebase = (sessionID: string, session: SessionState) => {
@@ -89,7 +89,7 @@ export const getQuestionsForConcepts = (concepts: any, flag: string) => {
       const questions = snapshot.val()
       const questionsForConcepts = {}
       Object.keys(questions).map(q => {
-        if (conceptUIDs.includes(questions[q].concept_uid) && questions[q].prompt && questions[q].answers && flagArray(flag).includes(questions[q].flag)) {
+        if (conceptUIDs.includes(questions[q].concept_uid) && questions[q].prompt && questions[q].answers && permittedFlag(flag, questions[q].flag)) {
           const question = questions[q]
           question.uid = q
           if (questionsForConcepts.hasOwnProperty(question.concept_uid)) {
@@ -134,7 +134,7 @@ export const getQuestions = (questions: any, flag: string) => {
         question.uid = q.key
         return question
       })
-      const arrayOfQuestionsFilteredByFlag = arrayOfQuestions.filter(q => flagArray(flag).includes(q.flag))
+      const arrayOfQuestionsFilteredByFlag = arrayOfQuestions.filter(q => permittedFlag(flag, q.flag))
       if (arrayOfQuestionsFilteredByFlag.length > 0) {
         dispatch({ type: ActionTypes.RECEIVE_QUESTION_DATA, data: arrayOfQuestionsFilteredByFlag, });
       } else {

--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -85,7 +85,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       if (nextProps.grammarActivities.hasreceiveddata && !nextProps.session.hasreceiveddata && !nextProps.session.pending && !nextProps.session.error) {
         const { questions, concepts, flag } = nextProps.grammarActivities.currentActivity
         if (questions) {
-          this.props.dispatch(getQuestions(questions))
+          this.props.dispatch(getQuestions(questions, flag))
         } else {
           this.props.dispatch(getQuestionsForConcepts(concepts, flag))
         }

--- a/services/QuillGrammar/src/components/lessons/lesson.tsx
+++ b/services/QuillGrammar/src/components/lessons/lesson.tsx
@@ -55,7 +55,13 @@ class Lesson extends React.Component<LessonProps> {
       const { prompt, key, concept_uid, flag } = question
       const displayName = prompt || 'No question prompt';
       const flagTag = flag && this.permittedFlags().includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
-      const questionLink = <li key={key}><Link to={`/admin/questions/${question.key}`}>{flagTag}{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>
+      const questionLink = (
+        <li key={key}>
+          <Link to={`/admin/questions/${question.key}`}>
+            {flagTag}
+            {displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}
+          </Link>
+        </li>)
       if (conceptIds[concept_uid]) {
         conceptIds[concept_uid].push(questionLink)
       } else {
@@ -81,7 +87,13 @@ class Lesson extends React.Component<LessonProps> {
       const { prompt, key, concept_uid, flag, } = question
       const displayName = prompt || 'No question prompt';
       const flagTag = flag && this.permittedFlags().includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
-      return <li key={key}><Link to={`/admin/questions/${key}`}>{flagTag}{displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}</Link></li>
+      return (
+        <li key={key}>
+          <Link to={`/admin/questions/${key}`}>
+            {flagTag}
+            {displayName.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '')}
+          </Link>
+        </li>)
     })
   }
 

--- a/services/QuillGrammar/src/components/lessons/lesson.tsx
+++ b/services/QuillGrammar/src/components/lessons/lesson.tsx
@@ -10,7 +10,7 @@ import { GrammarActivityState } from '../../reducers/grammarActivitiesReducer'
 import { ConceptReducerState } from '../../reducers/conceptsReducer'
 import { GrammarActivity } from '../../interfaces/grammarActivities'
 import { Match } from '../../interfaces/match'
-import flagArray from '../../helpers/flagArray'
+import { permittedFlag } from '../../helpers/flagArray'
 
 String.prototype.toKebab = function() {
   return this.replace(/([A-Z])/g, char => `-${char.toLowerCase()}`);
@@ -36,17 +36,14 @@ class Lesson extends React.Component<LessonProps> {
     this.renderEditLessonForm = this.renderEditLessonForm.bind(this)
   }
 
-  lesson(): GrammarActivity|void {
+  lesson(): GrammarActivity|{} {
     const { data, } = this.props.lessons
     const lessonID: string|undefined = this.props.match.params.lessonID;
     if (lessonID) {
       return data[lessonID]
+    } else {
+      return {}
     }
-  }
-
-  permittedFlags():Array<string> {
-    const lessonFlag = this.lesson() ? this.lesson().flag : 'production'
-    return flagArray(lessonFlag)
   }
 
   renderQuestionsByConcept(questionsForLesson) {
@@ -54,7 +51,7 @@ class Lesson extends React.Component<LessonProps> {
     questionsForLesson.forEach((question: Question) => {
       const { prompt, key, concept_uid, flag } = question
       const displayName = prompt || 'No question prompt';
-      const flagTag = flag && this.permittedFlags().includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
+      const flagTag = flag && permittedFlag(this.lesson().flag, flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
       const questionLink = (
         <li key={key}>
           <Link to={`/admin/questions/${question.key}`}>
@@ -86,7 +83,7 @@ class Lesson extends React.Component<LessonProps> {
     return questionsForLesson.map((question: Question) => {
       const { prompt, key, concept_uid, flag, } = question
       const displayName = prompt || 'No question prompt';
-      const flagTag = flag && this.permittedFlags().includes(flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
+      const flagTag = flag && permittedFlag(this.lesson().flag, flag) ? '' : <strong>{flag.toUpperCase()} - </strong>
       return (
         <li key={key}>
           <Link to={`/admin/questions/${key}`}>
@@ -111,7 +108,7 @@ class Lesson extends React.Component<LessonProps> {
     } else if (lessonConcepts) {
       const questions = this.props.questions ? hashToCollection(this.props.questions.data) : []
       const conceptUids = Object.keys(this.lesson().concepts)
-      questionsForLesson = questions.filter(q => conceptUids.includes(q.concept_uid) && this.permittedFlags().includes(q.flag))
+      questionsForLesson = questions.filter(q => conceptUids.includes(q.concept_uid) && permittedFlag(this.lesson().flag, q.flag))
       return this.renderQuestionsByConcept(questionsForLesson)
     }
     return (

--- a/services/QuillGrammar/src/helpers/flagArray.ts
+++ b/services/QuillGrammar/src/helpers/flagArray.ts
@@ -1,0 +1,11 @@
+export default (flag: string): Array<string|undefined> => {
+  let flagArray = ['production']
+  if (flag === 'alpha') {
+    flagArray = ['alpha', 'beta', 'production']
+  } else if (flag === 'beta') {
+    flagArray = ['beta', 'production']
+  } else if (flag === 'archived') {
+    flagArray = ['archived', 'alpha', 'beta', 'production']
+  }
+  return flagArray
+}

--- a/services/QuillGrammar/src/helpers/flagArray.ts
+++ b/services/QuillGrammar/src/helpers/flagArray.ts
@@ -1,4 +1,4 @@
-export default (flag: string): Array<string|undefined> => {
+export const flagArray = (flag: string): Array<string|undefined> => {
   let flagArray = ['production']
   if (flag === 'alpha') {
     flagArray = ['alpha', 'beta', 'production']
@@ -8,4 +8,10 @@ export default (flag: string): Array<string|undefined> => {
     flagArray = ['archived', 'alpha', 'beta', 'production']
   }
   return flagArray
+}
+
+export const permittedFlag = (activityFlag: string|undefined, questionFlag: string|undefined):Boolean => {
+  const notNullActivityFlag = activityFlag || 'production'
+  const notNullQuestionFlag = questionFlag || 'production'
+  return flagArray(notNullActivityFlag).includes(notNullQuestionFlag)
 }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- don't include questions with wrong flags (ex: an alpha question for a beta or production activity) in grammar or connect activities, even when the question is assigned to the activity
- highlight questions with mismatched flags on the activity page so they can be corrected or removed

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
