### PR TITLE
allow admin users to unmatch human graded responses

### DIFF
--- a/services/QuillConnect/app/components/questions/response.jsx
+++ b/services/QuillConnect/app/components/questions/response.jsx
@@ -59,6 +59,20 @@ export default React.createClass({
     };
   },
 
+  componentWillReceiveProps(nextProps: any) {
+    if (!_.isEqual(nextProps.response, this.props.response)) {
+      let conceptResults = {}
+      if (nextProps.response.concept_results) {
+        if (typeof nextProps.response.concept_results === 'string') {
+          conceptResults = JSON.parse(nextProps.response.concept_results)
+        } else {
+          conceptResults = nextProps.response.concept_results
+        }
+      }
+      this.setState({conceptResults})
+    }
+  },
+
   deleteResponse(rid) {
     if (window.confirm('Are you sure?')) {
       this.props.dispatch(deleteResponse(this.props.questionID, rid));
@@ -116,13 +130,15 @@ export default React.createClass({
   },
 
   unmatchResponse(rid) {
+    const { modelConceptUID, conceptID, } = this.props.question
+    const defaultConceptUID = modelConceptUID || conceptID
     const newResp = {
       weak: false,
       feedback: null,
       optimal: null,
       author: null,
       parent_id: null,
-      concept_results: null
+      concept_results: { [defaultConceptUID]: false, },
     }
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   },

--- a/services/QuillConnect/app/components/questions/response.jsx
+++ b/services/QuillConnect/app/components/questions/response.jsx
@@ -115,6 +115,18 @@ export default React.createClass({
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   },
 
+  unmatchResponse(rid) {
+    const newResp = {
+      weak: false,
+      feedback: null,
+      optimal: null,
+      author: null,
+      parent_id: null,
+      concept_results: null
+    }
+    this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
+  },
+
   getErrorsForAttempt(attempt) {
     return _.pick(attempt, ...C.ERROR_TYPES);
   },
@@ -420,6 +432,7 @@ export default React.createClass({
     if (isEditing) {
       buttons = [
         (<a className="card-footer-item" onClick={this.cancelResponseEdit.bind(null, response.key)} key="cancel" >Cancel</a>),
+        (<a className="card-footer-item" onClick={this.unmatchResponse.bind(null, response.key)} key="unmatch" >Unmatch</a>),
         (<a className="card-footer-item" onClick={this.incrementResponse.bind(null, response.key)} key="increment" >Increment</a>),
         (<a className="card-footer-item" onClick={this.updateResponse.bind(null, response.key)} key="update" >Update</a>)
       ];

--- a/services/QuillConnect/app/components/questions/responseComponent.jsx
+++ b/services/QuillConnect/app/components/questions/responseComponent.jsx
@@ -323,6 +323,7 @@ class ResponseComponent extends React.Component {
         concepts={this.props.concepts}
         conceptID={this.props.question.conceptID}
         massEdit={this.props.massEdit}
+        question={this.props.question}
       />);
     }
   }

--- a/services/QuillConnect/app/components/questions/responseList.jsx
+++ b/services/QuillConnect/app/components/questions/responseList.jsx
@@ -75,6 +75,7 @@ export default class ResponseList extends React.Component {
       concepts={this.props.concepts}
       conceptID={this.props.conceptID}
       massEdit={this.props.massEdit}
+      question={this.props.question}
     />
   }
 

--- a/services/QuillConnect/app/libs/grading/rematching.ts
+++ b/services/QuillConnect/app/libs/grading/rematching.ts
@@ -99,7 +99,7 @@ export function paginatedNonHumanResponses(matcher, matcherFields, qid, page, ca
 
   return request(
     {
-      uri: `https://cms.quill.org/questions/${qid}/responses/search`,
+      uri: `${process.env.QUILL_CMS}/questions/${qid}/responses/search`,
       method: 'POST',
       body: getResponseBody(page),
       json: true,
@@ -183,7 +183,7 @@ function updateResponse(rid, content) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content, false);
   return request({
     method: 'PUT',
-    uri: `https://cms.quill.org/responses/${rid}`,
+    uri: `${process.env.QUILL_CMS}/responses/${rid}`,
     body: { response: rubyConvertedResponse, },
     json: true,
   });
@@ -194,7 +194,7 @@ function determineDelta(response, newResponse) {
   const parentIDChanged = (newResponse.response.parent_id? Number(newResponse.response.parent_id) : null) !== response.parent_id;
   const authorChanged = newResponse.response.author !== response.author;
   const feedbackChanged = newResponse.response.feedback !== response.feedback;
-  const conceptResultsChanged = _.isEqual(convertResponsesArrayToHash(newResponse.response.concept_results), response.concept_results);
+  const conceptResultsChanged = !_.isEqual(convertResponsesArrayToHash(newResponse.response.concept_results), response.concept_results);
   const changed = parentIDChanged || authorChanged || feedbackChanged || conceptResultsChanged;
   // console.log(response.id, parentIDChanged, authorChanged, feedbackChanged, conceptResultsChanged);
   // console.log(response, newResponse.response);

--- a/services/QuillDiagnostic/app/components/questions/response.jsx
+++ b/services/QuillDiagnostic/app/components/questions/response.jsx
@@ -112,6 +112,18 @@ export default React.createClass({
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   },
 
+  unmatchResponse(rid) {
+    const newResp = {
+      weak: false,
+      feedback: null,
+      optimal: null,
+      author: null,
+      parent_id: null,
+      concept_results: null
+    }
+    this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
+  },
+
   getErrorsForAttempt(attempt) {
     return _.pick(attempt, ...C.ERROR_TYPES);
   },
@@ -416,6 +428,7 @@ export default React.createClass({
     if (isEditing) {
       buttons = [
         (<a className="card-footer-item" onClick={this.cancelResponseEdit.bind(null, response.key)} key="cancel" >Cancel</a>),
+        (<a className="card-footer-item" onClick={this.unmatchResponse.bind(null, response.key)} key="unmatch" >Unmatch</a>),
         (<a className="card-footer-item" onClick={this.incrementResponse.bind(null, response.key)} key="increment" >Increment</a>),
         (<a className="card-footer-item" onClick={this.updateResponse.bind(null, response.key)} key="update" >Update</a>)
       ];

--- a/services/QuillDiagnostic/app/components/questions/response.jsx
+++ b/services/QuillDiagnostic/app/components/questions/response.jsx
@@ -61,6 +61,21 @@ export default React.createClass({
     };
   },
 
+
+  componentWillReceiveProps(nextProps: any) {
+    if (!_.isEqual(nextProps.response, this.props.response)) {
+      let conceptResults = {}
+      if (nextProps.response.concept_results) {
+        if (typeof nextProps.response.concept_results === 'string') {
+          conceptResults = JSON.parse(nextProps.response.concept_results)
+        } else {
+          conceptResults = nextProps.response.concept_results
+        }
+      }
+      this.setState({conceptResults})
+    }
+  },
+
   deleteResponse(rid) {
     if (window.confirm('Are you sure?')) {
       this.props.dispatch(deleteResponse(this.props.questionID, rid));
@@ -113,13 +128,15 @@ export default React.createClass({
   },
 
   unmatchResponse(rid) {
+    const { modelConceptUID, conceptID, } = this.props.question
+    const defaultConceptUID = modelConceptUID || conceptID
     const newResp = {
       weak: false,
       feedback: null,
       optimal: null,
       author: null,
       parent_id: null,
-      concept_results: null
+      concept_results: { [defaultConceptUID]: false, },
     }
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   },

--- a/services/QuillDiagnostic/app/components/questions/responseComponent.jsx
+++ b/services/QuillDiagnostic/app/components/questions/responseComponent.jsx
@@ -328,6 +328,7 @@ class ResponseComponent extends React.Component {
         concepts={this.props.concepts}
         conceptID={this.props.question.conceptID}
         massEdit={this.props.massEdit}
+        question={this.props.question}
       />);
     }
   }

--- a/services/QuillDiagnostic/app/components/questions/responseList.jsx
+++ b/services/QuillDiagnostic/app/components/questions/responseList.jsx
@@ -75,6 +75,7 @@ export default class ResponseList extends React.Component {
       concepts={this.props.concepts}
       conceptID={this.props.conceptID}
       massEdit={this.props.massEdit}
+      question={this.props.question}
     />
   }
 

--- a/services/QuillDiagnostic/app/components/questions/responseRouteWrapper.jsx
+++ b/services/QuillDiagnostic/app/components/questions/responseRouteWrapper.jsx
@@ -24,7 +24,7 @@ const ResponseComponentWrapper = React.createClass({
 
   returnAppropriateDataset() {
     const { questionID, } = this.props.params;
-    const datasets = ['fillInBlank', 'sentenceFragments', 'diagnosticQuestions'];
+    const datasets = ['fillInBlank', 'sentenceFragments'];
     let theDatasetYouAreLookingFor = this.props.questions.data[questionID];
     let mode = 'questions';
     datasets.forEach((dataset) => {

--- a/services/QuillGrammar/src/components/questions/response.tsx
+++ b/services/QuillGrammar/src/components/questions/response.tsx
@@ -72,7 +72,20 @@ export default class Response extends React.Component<any, any> {
     this.toResponsePathways = this.toResponsePathways.bind(this)
     this.renderToResponsePathways = this.renderToResponsePathways.bind(this)
     this.renderFromResponsePathways = this.renderFromResponsePathways.bind(this)
+  }
 
+  componentWillReceiveProps(nextProps: any) {
+    if (!_.isEqual(nextProps.response, this.props.response)) {
+      let conceptResults = {}
+      if (nextProps.response.concept_results) {
+        if (typeof nextProps.response.concept_results === 'string') {
+          conceptResults = JSON.parse(nextProps.response.concept_results)
+        } else {
+          conceptResults = nextProps.response.concept_results
+        }
+      }
+      this.setState({conceptResults})
+    }
   }
 
   initialState() {
@@ -154,13 +167,15 @@ export default class Response extends React.Component<any, any> {
   }
 
   unmatchResponse(rid: string) {
+    const { modelConceptUID, concept_uid } = this.props.question
+    const defaultConceptUID = modelConceptUID || concept_uid
     const newResp = {
       weak: false,
       feedback: null,
       optimal: null,
       author: null,
       parent_id: null,
-      concept_results: {}
+      concept_results: {[defaultConceptUID]: false}
     }
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   }

--- a/services/QuillGrammar/src/components/questions/response.tsx
+++ b/services/QuillGrammar/src/components/questions/response.tsx
@@ -38,6 +38,7 @@ export default class Response extends React.Component<any, any> {
     this.viewToResponses = this.viewToResponses.bind(this)
     this.cancelToResponseView = this.cancelToResponseView.bind(this)
     this.updateResponse = this.updateResponse.bind(this)
+    this.unmatchResponse = this.unmatchResponse.bind(this)
     this.getErrorsForAttempt = this.getErrorsForAttempt.bind(this)
     this.markAsWeak = this.markAsWeak.bind(this)
     this.unmarkAsWeak = this.unmarkAsWeak.bind(this)
@@ -149,6 +150,18 @@ export default class Response extends React.Component<any, any> {
       parent_id: null,
       concept_results: Object.keys(this.state.conceptResults) && Object.keys(this.state.conceptResults).length ? this.state.conceptResults : null
     };
+    this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
+  }
+
+  unmatchResponse(rid: string) {
+    const newResp = {
+      weak: false,
+      feedback: null,
+      optimal: null,
+      author: null,
+      parent_id: null,
+      concept_results: {}
+    }
     this.props.dispatch(submitResponseEdit(rid, newResp, this.props.questionID));
   }
 
@@ -433,6 +446,7 @@ export default class Response extends React.Component<any, any> {
     if (isEditing) {
       buttons = [
         (<a className="card-footer-item" onClick={this.cancelResponseEdit.bind(null, response.key)} key="cancel" >Cancel</a>),
+        (<a className="card-footer-item" onClick={this.unmatchResponse.bind(null, response.key)} key="unmatch" >Unmatch</a>),
         (<a className="card-footer-item" onClick={this.incrementResponse.bind(null, response.key)} key="increment" >Increment</a>),
         (<a className="card-footer-item" onClick={this.updateResponse.bind(null, response.key)} key="update" >Update</a>)
       ];

--- a/services/QuillGrammar/src/components/questions/responseComponent.tsx
+++ b/services/QuillGrammar/src/components/questions/responseComponent.tsx
@@ -314,6 +314,7 @@ class ResponseComponent extends React.Component {
         concepts={this.props.concepts}
         conceptID={this.props.question.conceptID}
         massEdit={this.props.massEdit}
+        question={this.props.question}
       />);
     }
   }

--- a/services/QuillGrammar/src/components/questions/responseList.tsx
+++ b/services/QuillGrammar/src/components/questions/responseList.tsx
@@ -92,6 +92,7 @@ export default class ResponseList extends React.Component {
       massEdit={this.props.massEdit}
       states={this.props.states}
       state={this.props.states[this.props.questionID]}
+      question={this.props.question}
     />
   }
 

--- a/services/QuillGrammar/src/libs/grading/rematching.ts
+++ b/services/QuillGrammar/src/libs/grading/rematching.ts
@@ -84,7 +84,7 @@ export function paginatedNonHumanResponses(matcher: any, matcherFields: any, qid
 
   return request(
     {
-      uri: `https://cms.quill.org/questions/${qid}/responses/search`,
+      uri: `${process.env.QUILL_CMS}/questions/${qid}/responses/search`,
       method: 'POST',
       body: getResponseBody(page),
       json: true,
@@ -168,7 +168,7 @@ function updateResponse(rid: any, content: any) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
   return request({
     method: 'PUT',
-    uri: `https://cms.quill.org/responses/${rid}`,
+    uri: `${process.env.QUILL_CMS}/responses/${rid}`,
     body: { response: rubyConvertedResponse, },
     json: true,
   });
@@ -226,7 +226,7 @@ function getResponseBody(pageNumber: number) {
 }
 
 function getGradedResponses(questionID: string) {
-  return request(`https://cms.quill.org/questions/${questionID}/responses`);
+  return request(`${process.env.QUILL_CMS}/questions/${questionID}/responses`);
 }
 
 function formatGradedResponses(jsonString: string): {[key: string]: Response} {


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- allow admin users to unmatch human graded responses in grammar, connect, and diagnostic
- set an unmatched response to have the default concept results for that question

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
