### PR TITLE
fix #5111 - make sure we're only adding responses with text to popular answer array

### DIFF
--- a/services/QuillConnect/app/components/renderForQuestions/renderEndState.jsx
+++ b/services/QuillConnect/app/components/renderForQuestions/renderEndState.jsx
@@ -61,7 +61,7 @@ const EndState = React.createClass({
   renderTopThreeResponses() {
     let responses = this.props.responses;
     responses = hashToCollection(responses);
-    responses = responses.filter(response => response.optimal).sort((a, b) => b.count - a.count);
+    responses = responses.filter(response => response.optimal && response.text.length).sort((a, b) => b.count - a.count);
     const responsesToRender = _.first(responses, 3);
     const sum = _.reduce(responsesToRender, (memo, response) => memo + response.count, 0);
     let attemptKey;


### PR DESCRIPTION
Addresses issue #5111

**Changes proposed in this pull request:**
- only add responses with text to popular answer array

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
