### PR TITLE
fix #5133 - update everywhere we save new questions to only save response if text

### DIFF
--- a/services/QuillConnect/app/actions/fillInBlank.js
+++ b/services/QuillConnect/app/actions/fillInBlank.js
@@ -58,9 +58,11 @@ const actions = {
         if (error) {
           dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
         } else {
-          response.questionUID = newRef.key;
-          response.gradeIndex = `human${newRef.key}`;
-          dispatch(submitResponse(response));
+          if (response.text) {
+            response.questionUID = newRef.key;
+            response.gradeIndex = `human${newRef.key}`;
+            dispatch(submitResponse(response));
+          }
           dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
           const action = push(`/admin/fill-in-the-blanks/${newRef.key}`);
           dispatch(action);

--- a/services/QuillConnect/app/actions/questions.js
+++ b/services/QuillConnect/app/actions/questions.js
@@ -63,9 +63,11 @@ function submitNewQuestion(content, response) {
       if (error) {
         dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
       } else {
-        response.questionUID = newRef.key;
-        response.gradeIndex = `human${newRef.key}`;
-        dispatch(submitResponse(response));
+        if (response.text) {
+          response.questionUID = newRef.key;
+          response.gradeIndex = `human${newRef.key}`;
+          dispatch(submitResponse(response));
+        }
         dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
         const action = push(`/admin/questions/${newRef.key}`);
         dispatch(action);

--- a/services/QuillConnect/app/actions/sentenceFragments.js
+++ b/services/QuillConnect/app/actions/sentenceFragments.js
@@ -105,9 +105,11 @@ function submitNewSentenceFragment(content, response) {
       if (error) {
         dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
       } else {
-        response.questionUID = newRef.key;
-        response.gradeIndex = `human${newRef.key}`;
-        dispatch(submitResponse(response));
+        if (response.text) {
+          response.questionUID = newRef.key;
+          response.gradeIndex = `human${newRef.key}`;
+          dispatch(submitResponse(response));
+        }
         const focusPoints = content.prompt.split(' ').map((w) => {
           const word = w.replace(/[^\w]|_/g, '')
           const caseModifiedWord = word.toLowerCase() !== word ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1)

--- a/services/QuillDiagnostic/app/actions/diagnosticQuestions.js
+++ b/services/QuillDiagnostic/app/actions/diagnosticQuestions.js
@@ -63,9 +63,11 @@ const actions = {
         if (error) {
           dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
         } else {
-          response.questionUID = newRef.key;
-          response.gradeIndex = `human${newRef.key}`;
-          dispatch(submitResponse(response));
+          if (response.text) {
+            response.questionUID = newRef.key;
+            response.gradeIndex = `human${newRef.key}`;
+            dispatch(submitResponse(response));
+          }
           dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
           const action = push(`/admin/diagnostic-questions/${newRef.key}`);
           dispatch(action);

--- a/services/QuillDiagnostic/app/actions/fillInBlank.js
+++ b/services/QuillDiagnostic/app/actions/fillInBlank.js
@@ -58,9 +58,11 @@ const actions = {
         if (error) {
           dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
         } else {
-          response.questionUID = newRef.key;
-          response.gradeIndex = `human${newRef.key}`;
-          dispatch(submitResponse(response));
+          if (response.text) {
+            response.questionUID = newRef.key;
+            response.gradeIndex = `human${newRef.key}`;
+            dispatch(submitResponse(response));
+          }
           dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
           const action = push(`/admin/fill-in-the-blanks/${newRef.key}`);
           dispatch(action);

--- a/services/QuillDiagnostic/app/actions/questions.js
+++ b/services/QuillDiagnostic/app/actions/questions.js
@@ -65,9 +65,11 @@ function submitNewQuestion(content, response) {
       if (error) {
         dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
       } else {
-        response.questionUID = newRef.key;
-        response.gradeIndex = `human${newRef.key}`;
-        dispatch(submitResponse(response));
+        if (response.text) {
+          response.questionUID = newRef.key;
+          response.gradeIndex = `human${newRef.key}`;
+          dispatch(submitResponse(response));
+        }
         dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
         const action = push(`/admin/questions/${newRef.key}`);
         dispatch(action);

--- a/services/QuillDiagnostic/app/actions/sentenceFragments.js
+++ b/services/QuillDiagnostic/app/actions/sentenceFragments.js
@@ -105,9 +105,11 @@ function submitNewSentenceFragment(content, response) {
       if (error) {
         dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
       } else {
-        response.questionUID = newRef.key;
-        response.gradeIndex = `human${newRef.key}`;
-        dispatch(submitResponse(response));
+        if (response.text) {
+          response.questionUID = newRef.key;
+          response.gradeIndex = `human${newRef.key}`;
+          dispatch(submitResponse(response));
+        }
         const focusPoints = content.prompt.split(' ').map((w) => {
           const word = w.replace(/[^\w]|_/g, '')
           const caseModifiedWord = word.toLowerCase() !== word ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1)


### PR DESCRIPTION
Addresses issue #5133

**Changes proposed in this pull request:**
- update everywhere we save new questions to only save response if text

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @anathomical 
