### PR TITLE
fix #5150 - fix google classroom support page links

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/google_classroom/google_classroom_sync/SyncSuccessModal.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/google_classroom/google_classroom_sync/SyncSuccessModal.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
                   <h1 className='q-h2'><i className="fa fa-check" aria-hidden="true"></i>Great! You've synced {`${syncedCount} ${pluralize('class', syncedCount)}`}</h1>
                   <h3 className='subheader'>It may take up to <strong>5 minutes</strong> to import your students.</h3>
                   <p>
-                    Please have your students log in using their Google accounts. If you have any questions, you can check <a href='www.support.quill.org'>support.quill.org</a>
+                    Please have your students log in using their Google accounts. If you have any questions, you can check <a href='https://support.quill.org'>support.quill.org</a>
                   </p>
                     <a className="q-button cta-button bg-quillgreen text-white back-to-profile" href='/'>
                       Got It!

--- a/services/QuillLMS/client/app/bundles/Teacher/components/google_classroom/google_classroom_sync/__tests__/__snapshots__/SyncSuccessModal.js.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/google_classroom/google_classroom_sync/__tests__/__snapshots__/SyncSuccessModal.js.snap
@@ -51,22 +51,22 @@ exports[`the SyncSuccessModal component should render 1`] = `
         aria-hidden="true"
         className="fa fa-check"
       />
-      Great! You've synced 
+      Great! You've synced
       5 classes
     </h1>
     <h3
       className="subheader"
     >
-      It may take up to 
+      It may take up to
       <strong>
         5 minutes
       </strong>
        to import your students.
     </h3>
     <p>
-      Please have your students log in using their Google accounts. If you have any questions, you can check 
+      Please have your students log in using their Google accounts. If you have any questions, you can check
       <a
-        href="www.support.quill.org"
+        href="https://support.quill.org"
       >
         support.quill.org
       </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/GoogleSync.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/GoogleSync.jsx
@@ -121,7 +121,7 @@ export default class extends React.Component{
     return (
       <div className='google-sync no-classrooms'>
         <h2>It seems that you don't have any Google Classrooms.</h2>
-        <p>If you believe this is an error, please contact us at <a href="www.support.quill.org">www.support.quill.org</a></p>
+        <p>If you believe this is an error, please contact us at <a href="https://support.quill.org">support.quill.org</a></p>
         <p>Otherwise, you can join Google Classroom or add classrooms <a href="https://classroom.google.com/h">here.</a></p>
       </div>)
   }


### PR DESCRIPTION
Addresses issue #5150

**Changes proposed in this pull request:**
- update links to support.quill.org from google classroom pages to be "https://support.quill.org" rather than "www.support.quill.org"

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** yes

**Reviewer:** @anathomical
