### PR TITLE
docs: Reflect change to Ruby 2.5.1

### DIFF
--- a/docs/misc/setting_up.md
+++ b/docs/misc/setting_up.md
@@ -13,7 +13,7 @@ Empirical-Core is our web app for managing students, assigning activities, and v
 
 QuillLMS is the Learning Management System that powers Quill.org. It is part of Empirical-Core Here's how to get QuillLMS running on your system:
 
-1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or another Ruby version manager of your choice). You need to have Ruby version 2.3.1 installed in order to use Empirical Core. The best way to make sure you have version 2.3.1 is to follow the README and wiki of the Ruby version manager that you download.
+1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or another Ruby version manager of your choice). You need to have Ruby version 2.5.1 installed in order to use Empirical Core. The best way to make sure you have version 2.5.1 is to follow the README and wiki of the Ruby version manager that you download.
 
     If you decide to use rbenv, then [homebrew](http://brew.sh/) has a really great and easy-to-use setup and install process:
 

--- a/services/QuillLMS/README.md
+++ b/services/QuillLMS/README.md
@@ -16,7 +16,7 @@ QuillLMS is the Learning Management System that powers Quill.org, a free writing
 
 QuillLMS is the Learning Management System that powers Quill.org. It is part of Empirical-Core Here's how to get QuillLMS running on your system:
 
-1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or another Ruby version manager of your choice). You need to have Ruby version 2.3.1 installed in order to use Empirical Core. The best way to make sure you have version 2.3.1 is to follow the README and wiki of the Ruby version manager that you download.
+1. Download and install [rbenv](https://github.com/sstephenson/rbenv) (or another Ruby version manager of your choice). You need to have Ruby version 2.5.1 installed in order to use Empirical Core. The best way to make sure you have version 2.5.1 is to follow the README and wiki of the Ruby version manager that you download.
 
     If you decide to use rbenv, then [homebrew](http://brew.sh/) has a really great and easy-to-use setup and install process:
 


### PR DESCRIPTION

Addresses issue: n/a

Hi @emilia-friedberg, I noticed this small documentation inconsistency when refreshing my dev environment back in Sydney.

**Changes proposed in this pull request:**
Ensure development environment setup documentation matches the specified Ruby 2.5.1 version, which is required by:
 - services/QuillLMS
 - services/QuillComprehension

Fixes: fef6b541c ("Upgrade to Ruby 2.5.1 and Rails 4.2.10")
Fixes: 2d3b68aa6 ("Init Comprehension")

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** yes (this is the only change in this patch)

**Have the tests been updated?** n/a

**Reviewer:** @emilia-friedberg
