### PR TITLE
Quill-LMS: Fix property 'content' does not exist on type 'HTMLElement'

### DIFF
--- a/services/QuillLMS/client/app/modules/apollo.ts
+++ b/services/QuillLMS/client/app/modules/apollo.ts
@@ -13,7 +13,7 @@ const authMiddleware = new ApolloLink((operation, forward) => {
   // add the authorization to the headers
   operation.setContext({
     headers: {
-      'x-csrf-token': document.getElementsByName('csrf-token')[0] ? document.getElementsByName('csrf-token')[0].content : 0
+      'x-csrf-token': document.getElementsByName('csrf-token')[0] ? document.getElementsByName('csrf-token')[0].getAttribute('content') : 0
     } 
   });
 


### PR DESCRIPTION
Addresses issue: #n/a

**Changes proposed in this pull request:**
`document.getElementsByName()` returns a HTMLElement object, which does not have a property 'content'. [0]

TypeScript is typesafe, so where returned object HTMLElement does not have a property, any attempted access to it will be invalid. Reported by `tslint` and `typescript@2.9.2`.

There are two potential solutions:

 - Utilize the generic `.getAttribute('content')`; or

 - Cast to the specific subtype (e.g. HTMLMetaElement) [1]  which does have a property 'content'.

tslint error:
```bash
  ERROR in [at-loader] ./app/modules/apollo.ts:16:113
    TS2339: Property 'content' does not exist on type 'HTMLElement'.
```
[0] https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
[1] https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** n/a

**Have the tests been updated?** n/a - This was reported by the testsuite
```bash
$ cd empirical-core/services/QuillLMS
$ npm run test
```

**Reviewer:** @emilia-friedberg / @anathomical
