### PR TITLE
Quill-LMS: Fix missing module import in activity_scores_student_overview

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores_student_overview.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores_student_overview.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import StudentOverview from 'bundles/Teacher/components/progress_reports/student_overview';
+import StudentOverview from '../../Teacher/components/progress_reports/student_overview';
 import { Link } from 'react-router';
 
 


### PR DESCRIPTION
Addresses issue: #n/a

**Changes proposed in this pull request:**
Error reported:
```bash
  ERROR in [at-loader] ./app/bundles/admin_dashboard/components/activity_scores_student_overview.tsx:2:29
    TS2307: Cannot find module 'bundles/Teacher/components/progress_reports/student_overview'.
```

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @emilia-friedberg / @anathomical
