### PR TITLE
Quill-LMS: Import underscore in module, rather than attempt UMD global

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Query, Mutation } from "react-apollo";
 import gql from "graphql-tag";
 import moment from 'moment'
+import _ from 'underscore';
 import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import { Concept } from '../interfaces/interfaces'


### PR DESCRIPTION
Addresses issue: #n/a

**Changes proposed in this pull request:**
Error reported (typescript@2.9.2):
```bash
ERROR in [at-loader] ./app/bundles/Staff/components/ArchivedConceptBox.tsx:83:10
    TS2686: '_' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** n/a - this was a report from the test suite

**Reviewer:** @emilia-friedberg / @anathomical
