### PR TITLE
Quill-LMS: Fix module import in activity_scores_table

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores_table.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores_table.tsx
@@ -3,7 +3,7 @@ import ReactTable from 'react-table';
 import EmptyStateForReport from '../../Teacher/components/progress_reports/empty_state_for_report';
 import * as moment from 'moment';
 import 'react-table/react-table.css';
-import { sortByLastName, sortFromSQLTimeStamp } from 'modules/sortingMethods';
+import { sortByLastName, sortFromSQLTimeStamp } from '../../../modules/sortingMethods';
 import { Link } from 'react-router';
 
 interface ActivityScoresTableProps {


### PR DESCRIPTION
Addresses issue: #n/a

**Changes proposed in this pull request:**
Error reported (typescript@2.9.2):
```bash
ERROR in [at-loader] ./app/bundles/admin_dashboard/components/activity_scores_table.tsx:6:54
    TS2307: Cannot find module 'modules/sortingMethods'.
```

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** n/a - reported by test suite

**Reviewer:** @emilia-friedberg / @anathomical
