### PR TITLE
Quill-LMS: Fix thenBy.js TypeScript support

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptsTable.tsx
@@ -29,14 +29,14 @@ function columns(selectConcept) {
       dataIndex: 'grandparentConceptName',
       key: 'grandparentConceptName',
       render: (text, record:ConceptRow) => (<div onClick={() => selectConcept(record.grandparentConceptId, 2)}>{text}</div>),
-      sorter: firstBy('grandparentConceptName').thenBy('parentConceptName').thenBy('conceptName'),
+      sorter: firstBy<ConceptRow>('grandparentConceptName').thenBy('parentConceptName').thenBy('conceptName'),
     },
     {
       title: 'Level 1',
       dataIndex: 'parentConceptName',
       key: 'parentConceptName',
       render: (text, record:ConceptRow) => (<div onClick={() => selectConcept(record.parentConceptId, 1)}>{text}</div>),
-      sorter: firstBy('parentConceptName').thenBy('conceptName'),
+      sorter: firstBy<ConceptRow>('parentConceptName').thenBy('conceptName'),
     },
     {
       title: 'Level 0',


### PR DESCRIPTION
Addresses issue: #n/a

**Changes proposed in this pull request:**
Provide a type to the first call to `.firstBy()` in order to support TypeScript.

Errors reported by TypeScript@2.9.2:
```bash
ERROR in [at-loader] ./app/bundles/Staff/components/ConceptsTable.tsx:32:56
    TS2345: Argument of type '"parentConceptName"' is not assignable to parameter of type '"grandparentConceptName" | ((v1: { grandparentConceptName: any; }, v2?: { grandparentConceptName:...'.

ERROR in [at-loader] ./app/bundles/Staff/components/ConceptsTable.tsx:39:51
    TS2345: Argument of type '"conceptName"' is not assignable to parameter of type '"parentConceptName" | ((v1: { parentConceptName: any; }, v2?: { parentConceptName: any; }) => any)'.
```
Link:
 https://github.com/Teun/thenBy.js/issues/26#issuecomment-394497141

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** n/a - reported by test suite
```bash
$ cd services/QuillLMS
$ npm run test
```
**Reviewer:** @emilia-friedberg / @anathomical
