### PR TITLE
Bug Fix: Units controller

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -140,7 +140,7 @@ class Teachers::UnitsController < ApplicationController
     )
 
     completed_count = completed.count
-    cumulative_score = completed.sum("percentage") * 100
+    cumulative_score = completed.sum(:percentage) * 100
 
     render json: {cumulative_score: cumulative_score, completed_count: completed_count}
   end

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -261,4 +261,39 @@ describe Teachers::UnitsController, type: :controller do
     end
   end
 
+  describe '#score_info' do
+    let!(:activity) {create(:activity)}
+    let!(:classroom_unit) {create(:classroom_unit, unit: unit, classroom: classroom, assigned_student_ids: [student.id])}
+    let!(:activity_session) {create(:activity_session,
+      activity: activity,
+      classroom_unit: classroom_unit,
+      is_final_score: true,
+      percentage: 0.17,
+      visible: true
+    )}
+
+    it 'no classroom_unit_id should return empty hash' do
+      get :score_info, activity_id: 1
+      json = JSON.parse(response.body)
+
+      expect(json['cumulative_score']).to eq 0
+      expect(json['completed_count']).to eq 0
+    end
+
+    it 'basic response' do
+      get :score_info, activity_id: activity.id, classroom_unit_id: classroom_unit.id
+      json = JSON.parse(response.body)
+
+      expect(json['cumulative_score']).to eq 17
+      expect(json['completed_count']).to eq 1
+    end
+
+    it 'not found response returns 0' do
+      get :score_info, activity_id: 999999, classroom_unit_id: 9999999
+      json = JSON.parse(response.body)
+
+      expect(json['cumulative_score']).to eq 0
+      expect(json['completed_count']).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Fixing a bug in the `teachers/units_controller.rb` and adding a spec test.

I ran the tests before and after the fix. The only difference I found was that the previous version was casting the numbers as strings (but then React was casting those strings back to numbers). So my new version just returns the numbers.

**Has this branch been QA'd on staging?** no

**Have the tests been updated?** yes

**Reviewer:** @emilia-friedberg/@anathomical
