### PR TITLE
redirect student if they've been removed from a class

### DIFF
--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -2,6 +2,7 @@ class StudentsController < ApplicationController
   include QuillAuthentication
 
   before_filter :authorize!, except: [:student_demo, :join_classroom]
+  before_action :redirect_to_profile, only: [:index]
 
   def index
     @current_user = current_user
@@ -10,12 +11,6 @@ class StudentsController < ApplicationController
     if params["joined"] == 'success' && classroom_id
       classroom = Classroom.find(classroom_id)
       flash.now["join-class-notification"] = "You have joined #{classroom.name} 🎉🎊"
-    end
-
-    if classroom_id && (Classroom.find_by(id: classroom_id).nil? || StudentsClassrooms.find_by(student_id: @current_user.id, classroom_id: classroom_id).nil?)
-      flash[:error] = 'Oops! You are no longer part of that classroom. Your teacher may have archived the class or removed you.'
-      flash.keep(:error)
-      redirect_to '/profile'
     end
   end
 
@@ -79,6 +74,16 @@ class StudentsController < ApplicationController
 
   def authorize!
     auth_failed unless current_user
+  end
+
+  def redirect_to_profile
+    @current_user = current_user
+    classroom_id = params["classroom"]
+    if classroom_id && (Classroom.find_by(id: classroom_id).nil? || StudentsClassrooms.find_by(student_id: @current_user.id, classroom_id: classroom_id).nil?)
+      flash[:error] = 'Oops! You do not belong to that classroom. Your teacher may have archived the class or removed you.'
+      flash.keep(:error)
+      redirect_to '/profile'
+    end
   end
 
 end


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- if a student has been removed from a class or the class has been archived, they get redirected to their `/profile` link with a flash error saying "Oops! You are no longer part of that classroom. Your teacher may have archived the class or removed you."

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**
![Screen Shot 2019-04-30 at 10 27 13 AM](https://user-images.githubusercontent.com/18669014/56975583-1c18a680-6b3f-11e9-8146-70295d1d99c1.png)

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @dandrabik/@anathomical
