### PR TITLE
only push non null vals in grammar and concept rows to firebase

### DIFF
--- a/services/QuillGrammar/src/actions/questionAndConceptMap.ts
+++ b/services/QuillGrammar/src/actions/questionAndConceptMap.ts
@@ -51,7 +51,7 @@ export function updateData() {
       questionRow.noActivities = !(explicitlyAssignedActivities.length || implicitlyAssignedActivities.length)
       questionRow.explicitlyAssignedActivities = explicitlyAssignedActivities
       questionRow.implicitlyAssignedActivities = implicitlyAssignedActivities
-      return questionRow
+      return removeNullAndUndefinedValues(questionRow)
     })
 
     const groupedConcepts = _.groupBy(questionRows, 'concept_uid')
@@ -74,10 +74,10 @@ export function updateData() {
       const uniqueImplicitlyAssignedActivities = uniqueImplicitlyAssignedActivityLinks.map(link => implicitlyAssignedActivities.find(act => act.link === link))
       conceptRow.explicitlyAssignedActivities = uniqueExplicitlyAssignedActivities
       conceptRow.implicitlyAssignedActivities = uniqueImplicitlyAssignedActivities
-      return conceptRow
+      return removeNullAndUndefinedValues(conceptRow)
     })
-    grammarQuestionsAndConceptsRef.child('questionRows').set(_.pickBy(questionRows))
-    grammarQuestionsAndConceptsRef.child('conceptRows').set(_.pickBy(conceptRows))
+    grammarQuestionsAndConceptsRef.child('questionRows').set(questionRows)
+    grammarQuestionsAndConceptsRef.child('conceptRows').set(conceptRows)
   }
 }
 
@@ -90,4 +90,13 @@ export function checkTimeout() {
       }
     })
   };
+}
+
+function removeNullAndUndefinedValues(obj: any) {
+  Object.keys(obj).forEach((key: any) => {
+    if ([undefined, null].includes(obj[key])) {
+      delete obj[key]
+    }
+  })
+  return obj
 }


### PR DESCRIPTION
Addresses issue #

**Changes proposed in this pull request:**
- only push non null vals in grammar and concept rows to firebase

**If this is a visual change please attach screencaps of the new branch, making sure to censor user data**

**Has this branch been QA'd on staging?** no

**Have you updated the docs?** no

**Have the tests been updated?** no

**Reviewer:** @dandrabik /@anathomical
