### PR TITLE
change limit on scorebook query to 10000

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -1,6 +1,6 @@
 # SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS act_id
 class Scorebook::Query
-  SCORES_PER_PAGE = 200
+  SCORES_PER_PAGE = 10000
 
   def self.run(classroom_id, current_page=1, unit_id=nil, begin_date=nil, end_date=nil, offset=0)
     first_unit = self.units(unit_id) ? self.units(unit_id).first : nil


### PR DESCRIPTION
## WHAT
Change limit on scorebook query to 200 to 10000

## WHY
Users with over 200 sessions on their activity summary pages are only seeing that initial 200 load. No code on the `Scorebook` component has been updated in the last year, so it is unclear when this broke, as the code itself does not appear to be performing the function we would expect (repeated calls to the API to get all of the data).

## HOW
I updated the constant responsible for determining batch size to 10000, since this seemed like a number high enough that it should a) load all the relevant data for the vast, vast majority (all?) of our users, or else enough that viewing an unfiltered view of the page would be basically useless anyway.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
NO - none impacted.
