### PR TITLE
More test clean-up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Run LMS Frontend Tests
           command: |
             cd services/QuillLMS/client
-            FORCE_COLOR=true npm run jest --colors --runInBand app/
+            FORCE_COLOR=true npm run jest --colors --maxWorkers=1 app/
   cms_rails_build:
     working_directory: ~/Empirical-Core
     docker:


### PR DESCRIPTION
## WHAT
Trying to figure out why the lms_node tests occasionally run out of memory and fix it.
## WHY
There are only a couple of changes that occurred to the code since we had relatively consistently working CI.  `ts-jest` is one of them.  So working to see if that can be fixed.
## HOW
This'll probably be iterative.

## Have you added and/or updated tests?
Just trying to make existing tests work most of the time.
