### PR TITLE
Pass specified random seed from Spec to Faker

### DIFF
--- a/services/QuillLMS/bin/utils/spec_with_seed.sh
+++ b/services/QuillLMS/bin/utils/spec_with_seed.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ $# -ne 1 ]] ; then
+  echo 'You must provide a single argument to seed the test with.'
+  exit 0
+fi
+
+bundle exec rake spec SPEC_OPTS="--seed $1"

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -17,6 +17,8 @@
     "postinstall": "cd ./client && npm install",
     "gulp": "cd ./client && npm run gulp",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
+    "test:rails": "bundle exec rake spec",
+    "test:rails:seed": "./bin/utils/spec_with_seed.sh",
     "lint": "cd client && npm run lint",
     "install-react-on-rails": "cd client && npm run install-react-on-rails",
     "build:clean": "./bin/dev/clean_build_artifacts.sh",

--- a/services/QuillLMS/spec/spec_helper.rb
+++ b/services/QuillLMS/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 require 'simplecov-json'
 
 RSpec.configure do |config|
+  config.before(:all) { Faker::Config.random = Random.new(config.seed) }
   config.formatter = :progress
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## WHAT
Pass specified random seed from Spec to Faker
## WHY
We have some tests that are failing intermitently because of the data generated in our Factories by Faker, but we can't reproduce the errors to try to fix them.  I've configured Faker to use the same seed as Spec, so that if one is specified it gets passed through.
## HOW
A simple tweak to the spec helper allows us to pass the config value on to Faker.  I then did some work to provide a command-line tool to pass seeds to the `spec` rake task because that's no as obvious as it should be.

## Have you added and/or updated tests?
No change to test content, but this should let us more easily reproduce failures caused by Faker in the future.