### PR TITLE
clever integration school_admin fix

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/sign_up/sub_main.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/sub_main.rb
@@ -3,9 +3,14 @@ module CleverIntegration::SignUp::SubMain
   # we have to send district_success, district_failure, user_success, user_failure back to controller
 
   def self.run(auth_hash, requesters)
-    result = send(auth_hash[:info][:user_type],
-                  auth_hash,
-                  requesters)
+    case auth_hash[:info][:user_type]
+    when 'district'
+      result = self.district(auth_hash, requesters)
+    when 'student'
+      result = self.district(auth_hash, requesters)
+    else
+      result = self.teacher(auth_hash, requesters)
+    end
     result
   end
 
@@ -25,4 +30,5 @@ module CleverIntegration::SignUp::SubMain
     result = CleverIntegration::SignUp::Student.run(auth_hash)
     result
   end
+
 end


### PR DESCRIPTION
## WHAT
Add case statement to clever integration that should act as a catch-all for user types we don't currently handle.

## WHY
We had teachers reporting 500 errors on attempting to sign up for Quill with Clever.

## HOW
Case statement.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

