### PR TITLE
bugfix/quilllms/stop-500s-on-js-file-404s

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -57,7 +57,8 @@ class ApplicationController < ActionController::Base
       # falsely flags lack of content-type headers in responses to routes that end
       # in ".js" as a class of responses that need CORS protection and 500s when
       # attempting to serve a 404.  So we set the header to an empty value here.
-      format.all { render nothing: true, status: status, content_type: '' }
+      format.js { render nothing: true, status: status, content_type: '' }
+      format.all { render nothing: true, status: status }
     end
   end
 


### PR DESCRIPTION
## WHAT
Fix the false CORS bug when 404ing a JS file
## WHY
Sentry has recorded a fairly large number of errors that report as invalid Cross Origin requests.  We don't want users running into 500s if we can avoid it.
## HOW
It turns out that this particular issue has to do with the way that Rails CORS security works.  When our 404 response bubbled up to the CORS layer, the lack of a `Content-Type` header on the response, combined with the fact that the requested route ended in `.js` caused Rails to interpret it as a CORS violation.  By forcibly setting an empty `Content-Type` header for the 404 response (which isn't strictly correct in HTTP), we bypass the issue in the Rails CORS security code.

## Have you added and/or updated tests?
No test changes.
