### PR TITLE
bugfix/quilldiagnostic/fix-update-activity

### DIFF
--- a/services/QuillDiagnostic/app/actions/lessons.js
+++ b/services/QuillDiagnostic/app/actions/lessons.js
@@ -2,7 +2,7 @@ const C = require('../constants').default;
 import rootRef from '../libs/firebase';
 const	lessonsRef = rootRef.child('diagnostics');
 import { push } from 'react-router-redux';
-import {updateFlag, updateModelConceptUID} from './questions'
+import questionActions from './questions';
 
 	// called when the app starts. this means we immediately download all quotes, and
 	// then receive all quotes again as soon as anyone changes anything.
@@ -65,12 +65,12 @@ function updateQuestions(content, qids) {
   return function (dispatch) {
     if (content.flag) {
       qids.forEach(qid => {
-        dispatch(updateFlag(qid, content.flag))
+        dispatch(questionActions.updateFlag(qid, content.flag))
       })
     }
     if (content.modelConceptUID) {
       qids.forEach(qid => {
-        dispatch(updateModelConceptUID(qid, content.modelConceptUID))
+        dispatch(questionActions.updateModelConceptUID(qid, content.modelConceptUID))
       })
     }
   };


### PR DESCRIPTION
## WHAT
Update import references
## WHY
Not sure what happened, or why this wasn't working, but somehow the import was pulling in an object with a 'default' key that contained the actual exports, so it couldn't reference them out properly.  This meant that actually trying to execute the imported functions was failing.
## HOW
Made a minor tweak to the import referencing.

## Have you added and/or updated tests?
Tests all pass.
