### PR TITLE
fix grammar library versions

### DIFF
--- a/services/QuillGrammar/package-lock.json
+++ b/services/QuillGrammar/package-lock.json
@@ -11945,9 +11945,9 @@
       "dev": true
     },
     "quill-component-library": {
-      "version": "0.1.59",
-      "resolved": "https://registry.npmjs.org/quill-component-library/-/quill-component-library-0.1.59.tgz",
-      "integrity": "sha512-ZuVRmyHrOa5pdRmZnEDnaHiPbqpq7zYkYZWhl00vLNY9HUEsAvPydVoyrrtVSJjUFnpxRDeaBnozhwGLwesv/g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/quill-component-library/-/quill-component-library-0.2.2.tgz",
+      "integrity": "sha512-aa+kPoRY67AyhI61FEERttk2ks36p8JQABM5HDedUIPz7lLpJ4ZIn+A9Rgv6cxjDP0jgf4X4J5V+q5sgKvDtyw==",
       "requires": {
         "@types/draft-js": "^0.10.5",
         "@types/lodash": "^4.14.110",
@@ -11965,6 +11965,7 @@
         "react-addons-css-transition-group": "^15.6.2",
         "react-select": "^2.4.2",
         "react-simple-pie-chart": "^0.5.0",
+        "reify": "^0.19.1",
         "rollup": "^0.60.7",
         "xlsx": "^0.14.2"
       },
@@ -13366,6 +13367,28 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
+      }
+    },
+    "reify": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.19.1.tgz",
+      "integrity": "sha512-Gt5EoUWsGqqfj8gB9rxIvToROBCnjtheYfL94gfEWYI3F8Uy128OiklYArJSK0JFDTdeLtiNTr4HB5fg7VKe5g==",
+      "requires": {
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
+        },
+        "acorn-dynamic-import": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+          "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+        }
       }
     },
     "relateurl": {

--- a/services/QuillGrammar/package.json
+++ b/services/QuillGrammar/package.json
@@ -47,7 +47,7 @@
     "net": "^1.0.2",
     "node-sass": "^4.12.0",
     "pusher-js": "^4.3.0",
-    "quill-component-library": "^0.1.29",
+    "quill-component-library": "^0.2.2",
     "quill-marking-logic": "^0.9.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
## WHAT
Update grammar packages to get focus point form working.

## WHY
The focus point form was erroring because grammar did not have the latest version of the quill component library installed.

## HOW
I updated that package, as well as lodash because it had security issues.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
No - no tests impacted.