### PR TITLE
Add a missing allowed submission parameter and fix a typo in another one

### DIFF
--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -64,9 +64,10 @@ protected
                                      :data,
                                      :activity_classification_id,
                                      :topic_id,
+                                     :flag,
                                      :flags,
                                      :repeatable,
                                      :follow_up_activity_id,
-                                     :suppirting_info)
+                                     :supporting_info)
   end
 end


### PR DESCRIPTION
## WHAT
Update the permitted attributes when updating activities through the confusingly-named LMS CMS
## WHY
This used to work, but I'm pretty sure we broke it during one of our security audits.  That's probably on me.
## HOW
It seems like some POST sources provide `flags` as an array, and some provide `flag` as a string, which Rails uses to magically set an array of just that string.  We accidentally ended up breaking the endpoints that did the latter, and this fixes that.

## Have you added and/or updated tests?
No test changes