### PR TITLE
use snake cased value instead of camel cased value for first attempt count

### DIFF
--- a/services/QuillConnect/app/components/questions/response.jsx
+++ b/services/QuillConnect/app/components/questions/response.jsx
@@ -500,7 +500,7 @@ export default React.createClass({
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">
-                  <span>{ icon } { response.firstAttemptCount ? response.firstAttemptCount : 0 }</span>
+                  <span>{ icon } { response.first_attempt_count ? response.first_attempt_count : 0 }</span>
                 </figure>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>

--- a/services/QuillDiagnostic/app/components/questions/response.jsx
+++ b/services/QuillDiagnostic/app/components/questions/response.jsx
@@ -496,7 +496,7 @@ export default React.createClass({
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">
-                  <span>{ icon } { response.firstAttemptCount ? response.firstAttemptCount : 0 }</span>
+                  <span>{ icon } { response.first_attempt_count ? response.first_attempt_count : 0 }</span>
                 </figure>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>

--- a/services/QuillGrammar/src/components/questions/response.tsx
+++ b/services/QuillGrammar/src/components/questions/response.tsx
@@ -512,7 +512,7 @@ export default class Response extends React.Component<any, any> {
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">
-                  <span>{ icon } { response.firstAttemptCount ? response.firstAttemptCount : 0 }</span>
+                  <span>{ icon } { response.first_attempt_count ? response.first_attempt_count : 0 }</span>
                 </figure>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>


### PR DESCRIPTION
## WHAT
Use snake cased value instead of camel cased value for first attempt count.

## WHY
Emma reported a bug where all the first attempt counts in the response tables for the apps were recorded as 0. This turned out to be because they were all using `firstAttemptCount` instead of `first_attempt_count`. I believe this feature broke when the responses were migrated to the CMS.

## HOW
Switched the attribute name!

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A
