### PR TITLE
make sure coteacher options show

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_teacher_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_teacher_section.tsx
@@ -159,7 +159,8 @@ export default class ClassroomTeacherSection extends React.Component<ClassroomTe
 
   actionsForTeacherRow(teacher) {
     const { isOwnedByCurrentUser, classroom, user, } = this.props
-    const { role, id } = teacher
+    const { classroom_relation, id } = teacher
+    const role = this.formatRole(classroom_relation)
     if (!classroom.visible || role !== CoteacherDisplayName) {
       return null
     } else if (isOwnedByCurrentUser) {


### PR DESCRIPTION
## WHAT
Fix error that was always causing the `actionsForTeacherRow` method to return null.

## WHY
We want teachers to be able to see the actions!

## HOW
Base logic on formatted classroom relation.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A
