### PR TITLE
update references to school premium to make price clearer

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/premium_promo.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/premium_promo.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`PremiumPromo component should render 1`] = `
         className="pricing"
       >
         <h2>
-          $900*
+          $1800
         </h2>
         <span>
           per school
@@ -51,7 +51,7 @@ exports[`PremiumPromo component should render 1`] = `
         <span
           className="special-price"
         >
-          *special price
+          50% off the first year
         </span>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/premium_promo.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/premium_promo.jsx
@@ -28,10 +28,10 @@ export default React.createClass({
           </div>
           <div className="fake-border" />
           <div className="pricing">
-            <h2>$900*</h2>
+            <h2>$1800</h2>
             <span>per school</span>
             <br />
-            <span className="special-price">*special price</span>
+            <span className="special-price">50% off the first year</span>
           </div>
         </div>
         <a href="https://support.quill.org/quill-premium" target="_blank" className="q-button text-white">Learn More About Premium</a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -30,14 +30,10 @@ export default React.createClass({
         </header>
         <section className="pricing-info">
           <div className="premium-rates">
-            <img className="red-line" src="/images/red-line-premium.svg" alt="red-line" />
             <h3>
-              <span className="four-fifty">
-            $900
-          </span>
               <span>
-            $1800
-          </span>
+                $1800
+              </span>
             </h3>
             <h4>per year</h4>
           </div>


### PR DESCRIPTION
## WHAT
Update references to school premium on premium page and teacher dashboard to make price clearer.

## WHY
Teachers were confused about what school premium actually costs. This should make it clearer.

## HOW
Just updated the HTML.

## Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="363" alt="Screen Shot 2019-08-08 at 3 15 07 PM" src="https://user-images.githubusercontent.com/18669014/62731173-92a32b00-b9ef-11e9-9009-9d15723f9b4a.png">
<img width="285" alt="Screen Shot 2019-08-08 at 3 11 36 PM" src="https://user-images.githubusercontent.com/18669014/62731174-92a32b00-b9ef-11e9-8ce2-f28f714c6ae6.png">

## Have you added and/or updated tests?
Yes
