### PR TITLE
fix css for student tooltip

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
@@ -204,7 +204,7 @@
       i, svg {
         position: absolute;
         color: #348fdf;
-        top: 51px;
+        top: 26px;
         right: 6px;
         font-size: 30px;
       }


### PR DESCRIPTION
## WHAT
Fix CSS for student tooltip.

## WHY
The caret for the tooltip had become detached from the text, probably as a result of the fontawesome update.

## HOW
Fix css.

## Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="986" alt="Screen Shot 2019-08-13 at 2 48 20 PM" src="https://user-images.githubusercontent.com/18669014/62968688-92cd6d00-bdd9-11e9-87a1-dfa4beab4a28.png">

## Have you added and/or updated tests?
N/A
