### PR TITLE
Remove recirect for turk diagnostics since we don't want them

### DIFF
--- a/services/QuillDiagnostic/app/components/turk/turkDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/turk/turkDiagnostic.jsx
@@ -108,7 +108,6 @@ const TurkDiagnostic = React.createClass({
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
           SessionActions.delete(this.state.sessionID);
-          document.location.href = process.env.EMPIRICAL_BASE_URL;
           this.setState({ saved: true, });
         } else {
           console.log('Save not successful');


### PR DESCRIPTION
## WHAT
Remove a redirect step from the Mechanical Turk-specific workflow
## WHY
Our other tools (Connect and so on) don't have this redirect, and just land users on the Turk completion page until they close the tab
## HOW
Removed a redirect that's likely part of a copy-paste job from the root workflow which does have a desired redirect at this spot.

## Screenshots
<img width="1087" alt="Screen Shot 2019-08-23 at 3 53 08 PM" src="https://user-images.githubusercontent.com/331565/63620059-55799400-c5be-11e9-9b4e-ad7dd9098b3b.png">
