### PR TITLE
Handle weird accept params for `home_new`

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -29,6 +29,7 @@ class PagesController < ApplicationController
     if check_should_clear_segment_identity
       set_just_logged_out_flag
     end
+    self.formats = ['html']
   end
 
   def develop

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -49,6 +49,16 @@ describe PagesController do
       end
     end
 
+    context 'when user is not signed in, weird format' do
+      it 'should render page' do
+        headers = { Accept: "RandomGobbledyguck"}
+        request.headers.merge! headers
+        get :home_new
+
+        expect(response).to render_template 'pages/home_new'
+      end
+    end
+
     context 'when a user has just signed out' do
       before do
         allow(controller).to receive(:check_should_clear_segment_identity) { true }


### PR DESCRIPTION
## WHAT
Fixing a sentry error for a weird `format` coming in to the new homepage:
https://sentry.io/organizations/quillorg/issues/1063852280/?project=1474913&query=is%3Aunresolved
## WHY
We are getting a lot of errors for this is sentry and I'm not sure the root cause. My guess is that there is a link that is somehow sending this format (but I can't find one) or it's a bot/scraper of some kind.
## HOW
General bug fix: Create a failing test, fix that test. The old `home` action, hardcodes `format` to `html`, which makes me think this issue isn't new. I just copied that patch to the new action for `home_new`.

## Have you added and/or updated tests?
YES

