### PR TITLE
Fix testing "Teachers::Page doesn't exist" error.

### DIFF
--- a/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
+++ b/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
@@ -1,4 +1,5 @@
 require_relative '../teachers'
+require_relative '../../page'
 
 module Teachers
   class ClassManagerPage < ::Page


### PR DESCRIPTION
## WHAT
We are getting intermittent test failures for `"Teachers::Page"` not existing. I'm loading that `Page` class explicitly and explicitly marking it as not being part of the module,

https://circleci.com/gh/empirical-org/Empirical-Core/10984
## WHY
To make the test suite consistent. I'm assuming this is intermittent because sometimes `Page` is loaded before and sometimes it is not based on the random order of the tests.
## HOW
Described above.
## Have you added and/or updated tests?
NO, this is fixing tests.

