### PR TITLE
do final data save to firebase before final review

### DIFF
--- a/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
+++ b/services/QuillProofreader/src/components/proofreaderActivities/container.tsx
@@ -52,7 +52,7 @@ interface PlayProofreaderContainerState {
   conceptResultsObjects?: ConceptResultObject[];
 }
 
-const FIREBASE_SAVE_INTERVAL = 15000 // 15 seconds
+const FIREBASE_SAVE_INTERVAL = 30000 // 30 seconds
 
 export class PlayProofreaderContainer extends React.Component<PlayProofreaderContainerProps, PlayProofreaderContainerState> {
     private interval: any


### PR DESCRIPTION
## WHAT
Save final session data to Firebase before the student enters the final review, not once it's completed.

## WHY
We're experiencing really long waits before the session data gets written to Firebase, causing a serious lag when the user gets to Grammar to start their next session. This will hopefully reduce the wait that they notice because it'll take a certain amount of time for them to get through the review, during which the data will hopefully get saved.

## HOW
I pulled the final firebase save out of the `finishReview` method and turned it into its own method that is a callback on the `setState` after the grading occurs.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A
