### PR TITLE
Put temp phone banner up for teachers.

### DIFF
--- a/services/QuillLMS/app/views/application/_notification_bar.html.erb
+++ b/services/QuillLMS/app/views/application/_notification_bar.html.erb
@@ -1,6 +1,6 @@
 <% current_path = request.env['PATH_INFO'] %>
 <div class="notification-bar google-issue">
   <p>
-    Quill is currently experiencing issues with our Lessons tool. It will be back up and running as quickly as possible. We&nbsp;apologize&nbsp;for&nbsp;the&nbsp;inconvenience!
+    Our temporary phone number is: ‪510-671-0222
   </p>
 </div>

--- a/services/QuillLMS/app/views/layouts/application.html.erb
+++ b/services/QuillLMS/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <% if ENV['UPGRADE'] && ENV['UPGRADE_END_TIME'] && Time.now < Time.parse(ENV['UPGRADE_END_TIME'])%>
       <%= render partial: 'application/upgraded_bar' %>
     <% else %>
-      <!-- <%= render partial: 'application/notification_bar' %> -->
+      <%= render partial: 'application/notification_bar' %>
     <% end %>
     <div id='application_nav_bar'>
       <%= render partial: 'header', media: 'all', 'data-turbolinks-track' => true %>


### PR DESCRIPTION
## WHAT
Putting a banner up with our temp phone number at Peter's request.
## WHY
We are moving offices so we don't have a permanent number yet, but school is starting.
## HOW
Uncommented existing code.
## Screenshots

<img width="797" alt="Screen Shot 2019-09-02 at 6 40 37 PM" src="https://user-images.githubusercontent.com/1304933/64135027-5d9db480-cdb2-11e9-9511-b3d63793b908.png">
<img width="1629" alt="Screen Shot 2019-09-02 at 6 42 08 PM" src="https://user-images.githubusercontent.com/1304933/64135030-6098a500-cdb2-11e9-8a84-75f505f85d28.png">


## Have you added and/or updated tests?
NO.

