### PR TITLE
Add sessionID to Proofreader session objects so we can index them

### DIFF
--- a/services/QuillProofreader/src/actions/session.ts
+++ b/services/QuillProofreader/src/actions/session.ts
@@ -15,6 +15,7 @@ export const updateSessionOnFirebase = (sessionID: string, passage: Array<Array<
 export const updateConceptResultsOnFirebase = (sessionID: string|null, activityUID: string, conceptResults: ConceptResultObject[]) => {
   const sessionObj = { conceptResults, activityUID, anonymous: !sessionID }
   if (sessionID) {
+    sessionObj.sessionID = sessionID;
     sessionsRef.child(sessionID).set(sessionObj)
     return sessionID
   } else {


### PR DESCRIPTION
## WHAT
Add the `sessionID` value to the Proofreader session object so that it can be read as a value, not just as the key the object is stored in
## WHY
Firebase doesn't allow indexes to be created on keys, only on values, so if we want to create an explicit index for the `sessionID`, we'll need to save it as a value to do so.  We think this *might* improve read performance on Proofreader sessions, and it's an easy enough thing to try that we might as well find out.
## HOW
If we're using a pre-defined `sessionID` (passed into Proofreader by the LMS), then go ahead and save that value to the session object before we persist it.

## Have you added and/or updated tests?
No new tests
