### PR TITLE
Add script to multi-thread delete specified grammar sessions

### DIFF
--- a/scripts/firebase/2019-09-04_delete_completed_grammar_sessions.rb
+++ b/scripts/firebase/2019-09-04_delete_completed_grammar_sessions.rb
@@ -29,11 +29,7 @@ end
 def slice_session_keys(session_keys, slice_count)
   puts "Slicing #{session_keys.length} keys into #{slice_count} chunks..."
   chunk_size = session_keys.length / slice_count
-  session_key_slices = []
-  slice_count.times { |i|
-    session_key_slices << session_keys[(i * chunk_size), chunk_size]
-  }
-  session_key_slices
+  session_keys.each_slice(chunk_size).to_a
 end
 
 def get_deletion_url(session_key)


### PR DESCRIPTION
## WHAT
Add a light script to read a specified file of Grammar session keys that are safe to delete, and then delete them
## WHY
We want to do this in a script, and I figure I might as well commit it just in case anyone ever needs to retrace our steps or use parts of it for another mass deletion
## HOW
Read the input file, slice the data in that file into sub-arrays, and then send each array to a new thread which makes an HTTP call to delete the object in question.

## Have you added and/or updated tests?
This is quick and dirty, so no tests
