### PR TITLE
devops/quillgrammar/update-deletion-script-to-delete-live-keys

### DIFF
--- a/scripts/firebase/2019-09-04_delete_completed_grammar_sessions.rb
+++ b/scripts/firebase/2019-09-04_delete_completed_grammar_sessions.rb
@@ -39,7 +39,7 @@ def get_deletion_url(session_key)
 end
 
 def get_grammar_session_keys
-  url = "#{BASE_URL}#{GRAMMAR_SESSION_PATH}.json?shallow=true&timeout=30"
+  url = "#{BASE_URL}#{GRAMMAR_SESSION_PATH}.json?shallow=true&timeout=30s"
   puts "Retrieving undeleted Grammar session keys..."
   response = HTTParty.get(url)
   grammar_session_keys_object = JSON.parse(response.body)


### PR DESCRIPTION
  The list of keys that SHOULD be deleted is constant, though, so we can pull a list of all keys still live and intersect it with the list of keys that should be deleted to get a list of all keys that STILL need to be deleted.

## WHAT
Update the script to determine which keys still need to be deleted
## WHY
We were pulling from a static list of keys, but we weren't tracking whether those keys had been deleted or not, so subsequent runs of the script could waste time re-"deleting" keys that were already gone.  This change determines which keys are still left on Firebase and attempts to delete only them.
## HOW
We load the static file that contains all the Grammar session IDs that we marked for deletion based on LMS data, then we intersect that list with a list of all Grammar session IDs still in Firebase (which we pull live).  We queue all items in that intersection for thread-based deletion.

## Have you added and/or updated tests?
Still no tests on this script
