### PR TITLE
don't redirect diagnostic turkers

### DIFF
--- a/services/QuillDiagnostic/app/components/turk/turkDiagnostic.jsx
+++ b/services/QuillDiagnostic/app/components/turk/turkDiagnostic.jsx
@@ -133,7 +133,6 @@ const TurkDiagnostic = React.createClass({
         if (httpResponse.statusCode === 200) {
           console.log('Finished Saving');
           console.log(err, httpResponse, body);
-          document.location.href = `${process.env.EMPIRICAL_BASE_URL}/activity_sessions/${body.activity_session.uid}`;
           this.setState({ saved: true, });
         }
       }


### PR DESCRIPTION
## WHAT
Stop redirecting diagnostic turkers once their activity has saved.

## WHY
We want turkers to stay on the page where their code shows.

## HOW
Remove the line that does it.

## Screenshots

## Have you added and/or updated tests?
N/A
