### PR TITLE
turn notification bar into env variable

### DIFF
--- a/services/QuillLMS/app/views/application/_notification_bar.html.erb
+++ b/services/QuillLMS/app/views/application/_notification_bar.html.erb
@@ -1,5 +1,5 @@
 <% current_path = request.env['PATH_INFO'] %>
-<% if ENV['NOTIFICATION_BAR_TEXT'] %>
+<% if ENV['SHOW_NOTIFICATION_BAR'] %>
   <div class="notification-bar google-issue">
     <p>
       <%= ENV['NOTIFICATION_BAR_TEXT'] %>


### PR DESCRIPTION
## WHAT
Use a 'NOTIFICATION_BAR_TEXT' env variable to determine whether or not to show notification bar and what the text is.

## WHY
When we have a major issue, we like to show notification bars to alert users, but it takes a long time to deploy a change to the LMS. This will make it faster and easier to put the banner up and take it down.

## HOW
Use an if-statement to determine whether or not to show the notification bar and what will render inside of it.

## Screenshots
<img width="1051" alt="Screen Shot 2019-09-13 at 8 55 59 AM" src="https://user-images.githubusercontent.com/18669014/64864174-8456b900-d604-11e9-81d3-58b724693386.png">

## Have you added and/or updated tests?
NO