### PR TITLE
Increase percentage of users using new sessions to 10%

### DIFF
--- a/services/QuillConnect/app/actions/sessions.js
+++ b/services/QuillConnect/app/actions/sessions.js
@@ -42,7 +42,7 @@ export default {
 
     // This is the whole number percentage of users who will be assigned
     // to the new session type.
-    const percentAssigned = 1;
+    const percentAssigned = 10;
     if (sessionID && simpleHash(sessionID) % 100 < percentAssigned) {
       const normalizedSession = normalizeSession(cleanedSession)
       // Let's start including an updated time on our sessions


### PR DESCRIPTION
## WHAT
Bumping from 1% to 10% of Connect sessions to use the new session format
## WHY
Things seem to be working fine at 1%.  We should increase the size of the experiment to collect more data.
## HOW
Update the value of the variable that controls percentage of sessions assigned to the test

## Have you added and/or updated tests?
No testing around assignment percentages
