### PR TITLE
Comment out these questions health checks for now.

### DIFF
--- a/services/QuillCMS/app/controllers/stats_controller.rb
+++ b/services/QuillCMS/app/controllers/stats_controller.rb
@@ -1,12 +1,14 @@
 class StatsController < ApplicationController
 
   def question_health_index
-    question_health_index_helper('lessons', 'datadash')
+    # TODO - This query takes 327 seconds on average (almost 6 minutes) to run, commenting out for now
+    #question_health_index_helper('lessons', 'datadash')
     render json: :ok
   end
 
   def diagnostic_question_health_index
-    question_health_index_helper('diagnostics', 'diagnostic_datadash')
+    # TODO - This query takes 186 seconds on average (3 minutes) to run, commenting out for now
+    #question_health_index_helper('diagnostics', 'diagnostic_datadash')
     render json: :ok
   end
 


### PR DESCRIPTION
## WHAT
Remove health checks that are really insufficient queries. Disclaimer, I don't know the origin and reasons behind these checks.
## WHY
These only return an `:ok` response and update stats in a `datadash` firebase node, so I'm assuming these aren't mission critical. But they are putting intermittent intense load on the DB.
## HOW
Just commented out the intense queries for now.

## Have you added and/or updated tests?
No, this is a temp change.

