### PR TITLE
Optimize CMS Response endpoint DB queries. (#5438)

### DIFF
--- a/services/QuillCMS/db/migrate/20190915151918_add_response_count_index.rb
+++ b/services/QuillCMS/db/migrate/20190915151918_add_response_count_index.rb
@@ -1,0 +1,7 @@
+class AddResponseCountIndex < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :responses, :count, algorithm: :concurrently
+  end
+end

--- a/services/QuillCMS/db/migrate/20190915163835_add_response_text_index.rb
+++ b/services/QuillCMS/db/migrate/20190915163835_add_response_text_index.rb
@@ -1,0 +1,8 @@
+class AddResponseTextIndex < ActiveRecord::Migration[5.1]
+  # Need this setting to run index concurrently and not lock tables on large write.
+  disable_ddl_transaction!
+
+  def change
+    add_index :responses, :text, algorithm: :concurrently
+  end
+end

--- a/services/QuillCMS/db/schema.rb
+++ b/services/QuillCMS/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181126221244) do
+ActiveRecord::Schema.define(version: 20190915163835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,8 +32,10 @@ ActiveRecord::Schema.define(version: 20181126221244) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "spelling_error", default: false
+    t.index ["count"], name: "index_responses_on_count"
     t.index ["optimal"], name: "index_responses_on_optimal"
     t.index ["question_uid"], name: "index_responses_on_question_uid"
+    t.index ["text"], name: "index_responses_on_text"
     t.index ["uid"], name: "index_responses_on_uid"
   end
 

--- a/services/QuillCMS/lib/tasks/import_responses_from_csv.rake
+++ b/services/QuillCMS/lib/tasks/import_responses_from_csv.rake
@@ -1,19 +1,26 @@
 require 'csv'
 
 namespace :responses_csv do
-  task :import => :environment do
-    import_from_db_csv
+
+  # e.g. rake responses_csv:import['/Users/danieldrabik/code/data_files/responses.csv']
+  desc 'import a csv file of production response data into your local DB for testing'
+  task :import, [:file_path] => :environment do |task, args|
+    import_from_db_csv(args[:file_path])
   end
 
-  def import_from_db_csv 
-    File.open('../../../Desktop/responses.csv', 'r') do |file|
+  def import_from_db_csv(filepath_to_import)
+    File.open(filepath_to_import, 'r') do |file|
       csv = CSV.new(file)
       csv.shift
       sum = 0
       rows = []
-      columns = ["id","uid","parent_id","parent_uid","question_uid","author","text","feedback","count","first_attempt_count","child_count","optimal","weak","concept_results","created_at","updated_at"]
+      columns = ["uid","parent_id","parent_uid","question_uid","author","text","feedback","count","first_attempt_count","child_count","optimal","weak","concept_results","created_at","updated_at","spelling_error"]
       while row = csv.shift
-        rows.push row
+        # replace "NULL" with nil
+        # remove the first (id) column, since the auto-increment of the local DB should be used
+        cleaned_row = row.map {|value| value == "NULL" ? nil : value}.drop(1)
+
+        rows.push cleaned_row
 
         if rows.length == 1000
           begin

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -19,6 +19,63 @@ RSpec.describe ResponsesController, type: :controller do
     get_ids(array&.select { |r| r['parent_id'].nil?})
   end
 
+  describe '#create_or_increment' do
+    let(:q_response) { create(:response, question_uid: '123456', text: 'Reading is fundamental.') }
+
+    before do
+      allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
+      allow_any_instance_of(Response).to receive(:update_index_in_elastic_search)
+    end
+
+    it 'should return 200 for matching' do
+      post :create_or_increment, params: { response: {question_uid: q_response.question_uid, text: q_response.text}}
+
+      expect(response.status).to eq(201)
+    end
+
+    it 'should return 200 for non-matching' do
+      expect(AdminUpdates).to receive(:run)
+      post :create_or_increment, params: { response: {question_uid: q_response.question_uid, text: 'other text'}}
+
+      expect(response.status).to eq(201)
+    end
+  end
+
+  describe '#responses_for_question' do
+    let(:q_response) { create(:response, question_uid: '123456') }
+
+    before do
+      allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
+    end
+
+    it 'should return 200 for found' do
+      get :responses_for_question, params: { question_uid: q_response.question_uid}
+
+      expect(response.status).to eq(200)
+    end
+
+    it 'should return 200 for not-found' do
+      get :responses_for_question, params: { question_uid: 'adsfdsf'}
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#multiple_choice_options' do
+    let(:q_response) { create(:response, question_uid: '123456') }
+    let(:q_response_optimal) { create(:response, question_uid: '123456', optimal: true) }
+
+    before do
+      allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
+    end
+
+    it 'should return 200 for found' do
+      get :multiple_choice_options, params: { question_uid: q_response.question_uid}
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe 'POST #batch_responses_for_lesson' do
 
     it 'returns an object with question uids as keys and an array of responses as values' do

--- a/services/QuillCMS/spec/factories/response.rb
+++ b/services/QuillCMS/spec/factories/response.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :response, class: 'Response' do
-    id 1
     feedback 'Sample feedback'
   end
 end


### PR DESCRIPTION
* Add index to responses.count since it’s used on sorts

* Add migration for responses.text index

* Schema changes.

* Update import rake task and make it more flexible.

* Update controller with limits, add some tests.

* Remove responses_for_questions limit for now.

* Don’t assign ‘id’ in a factory (rely on auto increment)

* Make count index also concurrently.

## WHAT

## WHY

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

