### PR TITLE
fix naming inconsistency on activity search and select

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/__tests__/activity_search_and_select.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/__tests__/activity_search_and_select.test.jsx
@@ -14,7 +14,7 @@ const commaUsageThirdGradeFilters = [
     "alias": "Filter By Category",
     "options": [
       {
-        "name": "All Categories",
+        "name": "All concepts",
         "id": "showAllId"
       }, {
         "id": 7,
@@ -36,7 +36,7 @@ const commaUsageThirdGradeFilters = [
     "alias": "Filter by Standard",
     "options": [
       {
-        "name": "All Sections",
+        "name": "All levels",
         "id": "showAllId"
       }, {
         "id": 9,
@@ -217,7 +217,7 @@ describe('ActivitySearchAndSelect component', () => {
         [
           {
             "id": "showAllId",
-            "name": "All Categories"
+            "name": "All concepts"
           }, {
             "id": 30,
             "name": "Diagnostics"
@@ -226,7 +226,7 @@ describe('ActivitySearchAndSelect component', () => {
         [
           {
             "id": "showAllId",
-            "name": "All Sections"
+            "name": "All levels"
           }, {
             "id": 35,
             "name": "Diagnostic"
@@ -252,7 +252,7 @@ describe('ActivitySearchAndSelect component', () => {
         "activity_category": [
           {
             "id": "showAllId",
-            "name": "All Categories"
+            "name": "All concepts"
           }, {
             "id": 30,
             "name": "Diagnostics"
@@ -269,7 +269,7 @@ describe('ActivitySearchAndSelect component', () => {
         "section": [
           {
             "id": "showAllId",
-            "name": "All Sections"
+            "name": "All levels"
           }, {
             "id": 35,
             "name": "Diagnostic"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/create_unit/activity_search/activity_search_and_select.jsx
@@ -119,9 +119,9 @@ export default class ActivitySearchAndSelect extends React.Component {
     });
     filterFields.forEach((field) => {
       if (field === 'activity_category') {
-        availableOptions[field].unshift({ name: 'All Categories', id: showAllId, });
+        availableOptions[field].unshift({ name: 'All concepts', id: showAllId, });
       } else if (field === 'section') {
-        availableOptions[field].unshift({ name: 'All Sections', id: showAllId, });
+        availableOptions[field].unshift({ name: 'All levels', id: showAllId, });
       }
     });
     return availableOptions;


### PR DESCRIPTION
## WHAT
Update names of dropdown options to reflect that we changed "Category" to "Concept" and "Section" to "Level" on the Explore All Activities page. 

## WHY
Tom pointed out that we had updated the dropdown's label but not its options, which was confusing.

## HOW
Just changed the label!

## Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="481" alt="Screen Shot 2019-09-17 at 9 50 28 AM" src="https://user-images.githubusercontent.com/18669014/65047824-1b877d80-d931-11e9-8725-6ffc2286983f.png">

## Have you added and/or updated tests?
YES