### PR TITLE
add link to find and replace guide

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/containers/ConceptsFindAndReplace.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/containers/ConceptsFindAndReplace.tsx
@@ -68,7 +68,10 @@ class ConceptsFindAndReplace extends React.Component<ConceptsFindAndReplaceProps
             if (loading) return <p>Loading...</p>;
             if (error) return <p>Error :(</p>;
 
-            return <ConceptReplaceForm showSuccessBanner={this.showSuccessBanner} concepts={data.concepts}/>
+            return <div className="find-and-replace-container">
+              <a className="find-and-replace-guide" href="https://www.notion.so/quill/Concept-Manager-Guide-08b52d41f62f47e59856b14c91b4a95a" target="_blank">Guide For Find & Replace</a>
+              <ConceptReplaceForm showSuccessBanner={this.showSuccessBanner} concepts={data.concepts}/>
+            </div>
           }}
         </Query>
       </div>

--- a/services/QuillLMS/client/app/bundles/Staff/styles/concept_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/concept_manager.scss
@@ -555,3 +555,11 @@
     margin-bottom: 32px;
   }
 }
+
+.find-and-replace-guide {
+  color: #189a6b;
+  font-size: 20px;
+  margin: 30px 30px 0px;
+  font-weight: 600;
+  display: inline-block;
+}


### PR DESCRIPTION
## WHAT
Add link to find and replace guide on find and replace page

## WHY
To make it easier for interns and staff to understand the action they're taking

## HOW

## Screenshots
<img width="823" alt="Screen Shot 2019-09-30 at 10 44 26 AM" src="https://user-images.githubusercontent.com/18669014/65906721-08dd6180-e391-11e9-877f-024183f45ee6.png">


## Have you added and/or updated tests?
N/A
