### PR TITLE
fix bug preventing teachers from removing activities from existing packs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/activities_unit.jsx
@@ -8,9 +8,11 @@ import AddClassroomActivityRow from './add_classroom_activity_row.jsx';
 import { Snackbar, defaultSnackbarTimeout } from 'quill-component-library/dist/componentLibrary';
 import * as api from '../../modules/call_api';
 
-export default React.createClass({
-  getInitialState() {
-    return {
+export default class ActivitiesUnit extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
       edit: false,
       unitName: (this.props.data.unitName || this.props.data.unit.name),
       savedUnitName: (this.props.data.unitName || this.props.data.unit.name),
@@ -21,31 +23,31 @@ export default React.createClass({
       snackbarVisible: false,
       snackbarFadeTimer: null,
       allowSorting: this.props.allowSorting || false,
-    };
-  },
+    }
+  }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps = (nextProps) => {
     if (nextProps.data.classroomActivities && (nextProps.data.classroomActivities.length === this.state.classroomActivities.length)) {
       this.setState({ classroomActivities: nextProps.data.classroomActivities, });
     } else if (nextProps.data.classroom_activities && (nextProps.data.classroom_activities.length === this.state.classroomActivities.length)) {
       this.setState({ classroomActivities: nextProps.data.classroom_activities, });
     }
-  },
+  }
 
-  ownedByCurrentUser() {
+  ownedByCurrentUser = () => {
     const firstCa = this.state.classroomActivities.values().next().value;
     return firstCa.ownedByCurrentUser;
-  },
+  }
 
 
-  hideUnit() {
+  hideUnit = () => {
     const x = confirm('Are you sure you want to delete this Activity Pack? \n \nIt will delete all assignments given to students associated with this pack, even if those assignments have already been completed.');
     if (x) {
       this.props.hideUnit(this.getUnitId());
     }
-  },
+  }
 
-  assignedToSection() {
+  assignedToSection = () => {
     const dclassy = this.props.data.classrooms;
     // ensure classrooms is always an array as sometimes it is passed a set
     // and we need to do a number of things with it that are better with an array
@@ -57,9 +59,9 @@ export default React.createClass({
         {classroomList}
       </ul>
     </div>);
-  },
+  }
 
-  classroomList(classrooms) {
+  classroomList = (classrooms) => {
     if (classrooms.length >= 4 && !this.state.showAllClassrooms) {
       const classroomsArray = classrooms.slice(0, 3).map((c, i) => <li key={i}>{c.name} <span>({c.assignedStudentCount}/{c.totalStudentCount} {Pluralize('student', c.totalStudentCount)})</span></li>)
       classroomsArray.push(<li className="see-all" onClick={() => this.setState({showAllClassrooms: true})}>Show all {classrooms.length} classes <i className="fa fa-icon fa-chevron-down"/></li>)
@@ -67,13 +69,13 @@ export default React.createClass({
     }
       return classrooms.map((c, i) => <li key={i}>{c.name} <span>({c.assignedStudentCount}/{c.totalStudentCount} {Pluralize('student', c.totalStudentCount)})</span></li>)
 
-  },
+  }
 
-  editUnit() {
+  editUnit = () => {
     this.props.editUnit(this.getUnitId());
-  },
+  }
 
-  deleteOrLockedInfo() {
+  deleteOrLockedInfo = () => {
     const firstCa = this.state.classroomActivities.values().next().value;
     const ownedByCurrentUser = this.ownedByCurrentUser();
     if (!this.props.report && !this.props.lesson && ownedByCurrentUser) {
@@ -89,9 +91,9 @@ export default React.createClass({
           {this.renderTooltip()}
         </span>);
     }
-  },
+  }
 
-  editName() {
+  editName = () => {
     if (this.ownedByCurrentUser()) {
       let text,
         classy,
@@ -106,17 +108,17 @@ export default React.createClass({
       }
       return <span style={inlineStyle} className={classy} onClick={this.changeToEdit}>{text}</span>;
     }
-  },
+  }
 
-  submitName() {
+  submitName = () => {
     return <span className="edit-unit" onClick={this.handleSubmit}>Submit</span>;
-  },
+  }
 
-  toggleTooltip() {
+  toggleTooltip = () => {
     this.setState({ showTooltip: !this.state.showTooltip ,});
-  },
+  }
 
-  renderTooltip() {
+  renderTooltip = () => {
     const visible = this.state.showTooltip ? 'visible' : 'invisible';
     const ownerName = this.state.classroomActivities.values().next().value.ownerName;
     return (<div className={`tooltip ${visible}`}>
@@ -124,21 +126,21 @@ export default React.createClass({
       <p>Since {ownerName} created this activity pack, you are unable to edit this activity pack. You can ask the creator to edit it.</p>
       <p>If you would like to assign additional practice activities, you can create a new pack for your students.</p>
     </div>);
-  },
+  }
 
-  changeToEdit() {
+  changeToEdit = () => {
     this.setState({ edit: true, });
-  },
+  }
 
-  handleNameChange(e) {
+  handleNameChange = (e) => {
     this.setState({ unitName: e.target.value, });
-  },
+  }
 
-  editUnitName() {
+  editUnitName = () => {
     return <input type="text" onChange={this.handleNameChange} value={this.state.unitName} />;
-  },
+  }
 
-  editStudentsLink() {
+  editStudentsLink = () => {
     const ownedByCurrentUser = this.ownedByCurrentUser()
     const { report, lesson, } = this.props
     if (!ownedByCurrentUser || report || lesson) {
@@ -146,9 +148,9 @@ export default React.createClass({
     } else {
       return <a className="edit-unit edit-students" href={`/teachers/classrooms/activity_planner/units/${this.getUnitId()}/students/edit`}>Edit Classes & Students</a>
     }
-  },
+  }
 
-  handleSubmit() {
+  handleSubmit = () => {
     const that = this;
     api.changeActivityPackName(that.props.data.unitId, that.state.unitName,
                                () => that.setState({edit: false,
@@ -157,17 +159,17 @@ export default React.createClass({
                                (response) => that.setState({errors: response.body.errors,
                                                             edit: false,
                                                             unitName: that.state.savedUnitName}));
-  },
+  }
 
-  showUnitName() {
+  showUnitName = () => {
     return <span className="h-pointer">{this.state.unitName}</span>;
-  },
+  }
 
-  showOrEditName() {
+  showOrEditName = () => {
     return this.state.edit ? this.editUnitName() : this.showUnitName();
-  },
+  }
 
-  nameActionLink() {
+  nameActionLink = () => {
     if (this.state.edit) {
       return this.submitName();
     } else if (this.props.report || this.props.lesson) {
@@ -176,36 +178,36 @@ export default React.createClass({
     return this.editName();
 
     // return this.state.edit ? this.submitName() : this.editName()
-  },
+  }
 
-  getUnitId() {
+  getUnitId = () => {
     return this.props.data.unitId || this.props.data.unit.id;
-  },
+  }
 
-  addClassroomActivityRow() {
+  addClassroomActivityRow = () => {
     if (this.state.classroomActivities.values().next().value.ownedByCurrentUser) {
       return this.props.report || this.props.lesson ? null : <AddClassroomActivityRow unitId={this.getUnitId()} unitName={this.props.data.unitName || this.props.data.unit.name} />;
     }
-  },
+  }
 
-  saveSortOrder() {
+  saveSortOrder = () => {
     this.updateActivitiesApi(this.props.data.unitId, this.state.activityOrder, this.displaySaveSnackbar);
-  },
+  }
 
-  displaySaveSnackbar() {
+  displaySaveSnackbar = () => {
     if (this.state.snackbarFadeTimer) {
       clearTimeout(this.state.snackbarFadeTimer);
     }
     this.setState({snackbarVisible: true, snackbarFadeTimer: setTimeout(() => {
       this.setState({snackbarVisible: false});
     }, defaultSnackbarTimeout)});
-  },
+  }
 
-  updateActivitiesApi(unitId, activityIds, successHandler, errorHandler) {
+  updateActivitiesApi = (unitId, activityIds, successHandler, errorHandler) => {
     api.changeActivityPackOrder(unitId, activityIds, successHandler, errorHandler);
-  },
+  }
 
-  updateAllDueDates(date) {
+  updateAllDueDates = (date) => {
     const newClassroomActivities = new Map(this.state.classroomActivities);
     const uaIds = [];
     this.state.classroomActivities.forEach((v, k) => {
@@ -216,9 +218,9 @@ export default React.createClass({
     });
     this.setState({ classroomActivities: newClassroomActivities, });
     this.props.updateMultipleDueDates(uaIds, date);
-  },
+  }
 
-  numberOfStudentsAssignedToUnit() {
+  numberOfStudentsAssignedToUnit = () => {
     const dclassy = this.props.data.classrooms;
     // ensure classrooms is always an array as sometimes it is passed as a set
     const classrooms = Array.isArray(dclassy) ? dclassy : [...dclassy];
@@ -227,7 +229,7 @@ export default React.createClass({
       numberOfStudentsAssignedToUnit += Number(c.assignedStudentCount);
     });
     return numberOfStudentsAssignedToUnit;
-  },
+  }
 
   updateSortOrder(sortableListState) {
     // There are data states in which this update call is triggered with no items in the
@@ -243,39 +245,41 @@ export default React.createClass({
         sortableListState.draggingIndex === null) {
       this.setState({activityOrder: newSortOrder}, this.saveSortOrder);
     }
-  },
+  }
 
-  renderClassroomActivities() {
+  renderClassroomActivities = () => {
     const classroomActivitiesArr = [];
     let i = 0;
     for (let key of this.state.activityOrder) {
-      let ca = this.state.classroomActivities.get(key);
-      classroomActivitiesArr.push(
-        <ClassroomActivity
-          key={`${this.props.data.unitId}-${key}`}
-          report={this.props.report}
-          activityReport={this.props.activityReport}
-          lesson={this.props.lesson}
-          updateDueDate={this.props.updateDueDate}
-          hideUnitActivity={this.props.hideUnitActivity}
-          unitId={this.props.data.unitId}
-          data={ca}
-          updateAllDueDates={this.updateAllDueDates}
-          isFirst={i === 0}
-          numberOfStudentsAssignedToUnit={this.numberOfStudentsAssignedToUnit()}
-          activityWithRecommendationsIds={this.props.activityWithRecommendationsIds}
-        />
-      );
-      i++;
+      const ca = this.state.classroomActivities.get(key);
+      if (ca) {
+        classroomActivitiesArr.push(
+          <ClassroomActivity
+            key={`${this.props.data.unitId}-${key}`}
+            report={this.props.report}
+            activityReport={this.props.activityReport}
+            lesson={this.props.lesson}
+            updateDueDate={this.props.updateDueDate}
+            hideUnitActivity={this.props.hideUnitActivity}
+            unitId={this.props.data.unitId}
+            data={ca}
+            updateAllDueDates={this.updateAllDueDates}
+            isFirst={i === 0}
+            numberOfStudentsAssignedToUnit={this.numberOfStudentsAssignedToUnit()}
+            activityWithRecommendationsIds={this.props.activityWithRecommendationsIds}
+          />
+        );
+        i++;
+      }
     }
     if (this.state.allowSorting) {
       return <SortableList data={classroomActivitiesArr} sortCallback={this.updateSortOrder} />
     } else {
       return classroomActivitiesArr;
     }
-  },
+  }
 
-  render() {
+  render = () => {
     if (this.state.classroomActivities.size === 0) {
       return null;
     }
@@ -307,5 +311,5 @@ export default React.createClass({
       <Snackbar text="Activity order saved" visible={this.state.snackbarVisible} />
       </div>
     );
-  },
-});
+  }
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/classroom_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/lesson_planner/manage_units/classroom_activity.jsx
@@ -12,98 +12,99 @@ const styles = {
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  endRow: {
+  endRow:{
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
     maxWidth: '240px',
   },
-  lessonEndRow: {
+  lessonEndRow:{
     display: 'flex',
     width: '100%',
     maxWidth: '390px',
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
-  reportEndRow: {
+  reportEndRow:{
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
     marginRight: '15px',
-  },
-};
+  }
+}
 
-export default React.createClass({
+export default class ClassroomActivity extends React.Component {
+  constructor(props) {
+    super(props)
 
-  getInitialState() {
-    return {
+    this.state = {
       startDate: this.dueDate() ? moment(this.dueDate()) : undefined,
       showModal: false,
       showCustomizeTooltip: false,
       showLessonPlanTooltip: false,
-    };
-  },
+    }
+  }
 
-  componentWillReceiveProps(nextProps) {
-    const newDueDate = nextProps.data.dueDate;
+  componentWillReceiveProps = (nextProps) => {
+    const newDueDate = nextProps.data ? nextProps.data.dueDate : null
     const formattedNewDueDate = newDueDate ? moment(newDueDate) : undefined;
     if (formattedNewDueDate !== this.state.startDate) {
       this.setState({ startDate: formattedNewDueDate, });
     }
-  },
+  }
 
-  hideUnitActivity() {
+  hideUnitActivity = () => {
     const x = confirm('Are you sure you want to delete this assignment?');
     if (x) {
       this.props.hideUnitActivity(this.uaId(), this.unitId());
     }
-  },
+  }
 
-  handleChange(date) {
+  handleChange = (date) => {
     this.setState({ startDate: date, });
     this.props.updateDueDate(this.uaId(), date.format());
-  },
+  }
 
-  toggleCustomizeTooltip() {
+  toggleCustomizeTooltip = () => {
     this.setState({ showCustomizeTooltip: !this.state.showCustomizeTooltip, });
-  },
+  }
 
-  toggleLessonPlanTooltip() {
+  toggleLessonPlanTooltip = () => {
     this.setState({ showLessonPlanTooltip: !this.state.showLessonPlanTooltip, });
-  },
+  }
 
-  renderCustomizedEditionsTag() {
+  renderCustomizedEditionsTag = () => {
     if (window.location.pathname.includes('lessons')) {
       if (this.props.data.hasEditions) {
         return <div className="customized-editions-tag">Customized</div>;
       }
     }
-  },
+  }
 
-  renderCustomizeTooltip() {
+  renderCustomizeTooltip = () => {
     if (this.state.showCustomizeTooltip) {
       return (<div className="customize-tooltip">
         <i className="fa fa-caret-up" />
         Customize
       </div>);
     }
-  },
+  }
 
-  renderLessonPlanTooltip() {
+  renderLessonPlanTooltip = () => {
     if (this.state.showLessonPlanTooltip) {
       return (<div className="lesson-plan-tooltip">
         <i className="fa fa-caret-up" />
         Download Lesson Plan
       </div>);
     }
-  },
+  }
 
-  goToRecommendations() {
+  goToRecommendations = () => {
     const link = `/teachers/progress_reports/diagnostic_reports#/u/${this.unitId()}/a/${this.activityId()}/c/${this.classroomId()}/recommendations`;
     window.location = link;
-  },
+  }
 
-  buttonForRecommendations() {
+  buttonForRecommendations = () => {
     const activityWithRecommendationIds = this.props.activityWithRecommendationsIds;
     if (activityWithRecommendationIds && activityWithRecommendationIds.includes(this.activityId()) && window.location.pathname.includes('diagnostic_reports')) {
       return (
@@ -112,9 +113,9 @@ export default React.createClass({
         </div>
       );
     }
-  },
+  }
 
-  renderLessonsAction() {
+  renderLessonsAction = () => {
     if (window.location.pathname.includes('lessons')) {
       if (this.props.data.completed === 't') {
         return <p className="lesson-completed"><i className="fa fa-icon fa-check-circle" />Lesson Complete</p>;
@@ -124,9 +125,9 @@ export default React.createClass({
         return <a className="mark-completed" target="_blank" href={href}>Mark As Complete</a>;
       }
     }
-  },
+  }
 
-  lessonFinalCell() {
+  lessonFinalCell = () => {
     return (<div className="lessons-end-row">
       {this.lessonCompletedOrLaunch()}
       <a
@@ -149,19 +150,19 @@ export default React.createClass({
         {this.renderLessonPlanTooltip()}
       </a>
     </div>);
-  },
+  }
 
-  urlForReport() {
+  urlForReport = () => {
     $.get(`/teachers/progress_reports/report_from_unit_and_activity/u/${this.unitId()}/a/${this.activityId()}`)
       .success(data => window.location = data.url)
       .fail(() => alert('This report is not yet available. Please check back when at least one of your students has completed this activity.'));
-  },
+  }
 
-  anonymousPath() {
+  anonymousPath = () => {
     return `${process.env.DEFAULT_URL}/activity_sessions/anonymous?activity_id=${this.activityId()}`;
-  },
+  }
 
-  calculateAverageScore() {
+  calculateAverageScore = () => {
     const averageScore = this.props.data.cumulativeScore / this.props.data.completedCount;
     if (isNaN(averageScore)) {
       return '—';
@@ -169,9 +170,9 @@ export default React.createClass({
       return `${averageScore.toPrecision(2)}%`;
     }
     return `${averageScore}%`;
-  },
+  }
 
-  finalCell() {
+  finalCell = () => {
     if (this.props.activityReport) {
       return [
         <span key="number-of-students" className="number-of-students">{this.renderPieChart()} {this.props.data.completedCount} of {this.props.numberOfStudentsAssignedToUnit} {Pluralize('student', this.props.numberOfStudentsAssignedToUnit)}</span>,
@@ -191,9 +192,9 @@ export default React.createClass({
       </span>);
     }
     return this.state.startDate ? <div className="due-date-input">{this.state.startDate.format('l')}</div> : null;
-  },
+  }
 
-  renderPieChart() {
+  renderPieChart = () => {
     const rawPercent = this.props.data.completedCount / this.props.numberOfStudentsAssignedToUnit;
     const percent = rawPercent > 100 ? 100 : Math.round(rawPercent * 100) / 100;
     const largeArcFlag = percent > 0.5 ? 1 : 0;
@@ -203,41 +204,41 @@ export default React.createClass({
         <path d={pathData} fill="#348fdf" />
       </svg>
     );
-  },
+  }
 
-  classroomUnitId() {
+  classroomUnitId = () => {
     return this.props.data.cuId || this.props.data.classroom_unit_id;
-  },
+  }
 
-  uaId() {
+  uaId = () => {
     return this.props.data.uaId || this.props.data.ua_id;
-  },
+  }
 
-  unitId() {
+  unitId = () => {
     return this.props.unitId || this.props.data.unit_id;
-  },
+  }
 
-  dueDate() {
+  dueDate = () => {
     return this.props.data.due_date || this.props.data.dueDate;
-  },
+  }
 
-  activityId() {
+  activityId = () => {
     return this.props.data.activityId || this.props.data.activityUid || this.props.data.activity.uid;
-  },
+  }
 
-  activityName() {
+  activityName = () => {
     return this.props.data.name || this.props.data.activity.name;
-  },
+  }
 
-  classification() {
+  classification = () => {
     return this.props.data.activityClassificationId;
-  },
+  }
 
-  classroomId() {
+  classroomId = () => {
     return this.props.data.classroomId || this.props.data.classroom_id;
-  },
+  }
 
-  icon() {
+  icon = () => {
     const classification = this.classification();
     if (classification) {
       // then we're coming from the index and have an id
@@ -246,9 +247,9 @@ export default React.createClass({
     // it is stupid that we are passing this in some of this components use create_activity_sessions
     //  but don't have time to deprecate it right now
     return this.props.data.activity && this.props.data.activity.classification ? this.props.data.activity.classification.green_image_class : '';
-  },
+  }
 
-  lessonCompletedOrLaunch() {
+  lessonCompletedOrLaunch = () => {
     if (this.props.data.completed === 't') {
       return <a className="report-link" target="_blank" href={`/teachers/progress_reports/report_from_classroom_unit_and_activity/${this.classroomUnitId()}/a/${this.activityId()}`}>View Report</a>;
     }
@@ -259,34 +260,34 @@ export default React.createClass({
       return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} className="resume-lesson">Resume Lesson</a>;
     }
     return <a href={`${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`} id="launch-lesson">Launch Lesson</a>;
-  },
+  }
 
-  noStudentsWarning() {
+  noStudentsWarning = () => {
     if (window.confirm("You have no students in this class. Quill Lessons is a collaborative tool for teachers and students to work together. If you'd like to launch this lesson anyway, click OK below. Otherwise, click Cancel.")) {
       window.location.href = `${process.env.DEFAULT_URL}/teachers/classroom_units/${this.classroomUnitId()}/launch_lesson/${this.activityId()}`;
     }
-  },
+  }
 
-  isLesson() {
+  isLesson = () => {
     return this.props.lesson || this.classification() === 6;
-  },
+  }
 
-  deleteRow() {
+  deleteRow = () => {
     if (!this.props.report && !(this.isLesson())) {
       const style = !this.props.data.ownedByCurrentUser ? { visibility: 'hidden', } : null;
       return <div className="pull-right" style={style}><img className="delete-classroom-activity h-pointer" onClick={this.hideUnitActivity} src="/images/x.svg" /></div>;
     }
-  },
+  }
 
-  openModal() {
+  openModal = () => {
     this.setState({ showModal: true, });
-  },
+  }
 
-  closeModal() {
+  closeModal = () => {
     this.setState({ showModal: false, });
-  },
+  }
 
-  renderModal() {
+  renderModal = () => {
     if (this.state.showModal) {
       return (<PreviewOrLaunchModal
         lessonID={this.activityId()}
@@ -295,9 +296,9 @@ export default React.createClass({
         completed={this.props.data.completed}
       />);
     }
-  },
+  }
 
-  render() {
+  render = () => {
     let link,
       endRow;
     if (this.props.report) {
@@ -330,5 +331,5 @@ export default React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+};


### PR DESCRIPTION
## WHAT
Don't show unit activities that have been removed from the unit

## WHY
When a unit activity got removed, the component wouldn't re-render properly because it was still looking for the activity that got taken out. This fixes that.

## HOW
I made sure to only try to render the component if the activity was still in the list, and I also refactored two components to use ES6 while I was in here.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
No
