### PR TITLE
Add a Rake task to import Firebase data to the server

### DIFF
--- a/services/QuillLMS/lib/tasks/firebase.rake
+++ b/services/QuillLMS/lib/tasks/firebase.rake
@@ -13,9 +13,10 @@ namespace :firebase do
     end
 
     klass = get_klass(RAILS_MODEL)
-    firebase_keys = fetch_firebase_data("#{FIREBASE_URL}.json?shallow=true")
+    firebase_shallow = fetch_firebase_data("#{FIREBASE_URL}.json?shallow=true")
+    firebase_keys = firebase_shallow.keys
     firebase_keys.each do |key|
-      copy_firebase_key(FIREBASE_URL, key)
+      copy_firebase_key(FIREBASE_URL, key, klass)
     end
   end
 
@@ -35,7 +36,7 @@ namespace :firebase do
       JSON.parse(resp.body)
     end
 
-    def copy_firebase_key(base_url, key)
+    def copy_firebase_key(base_url, key, klass)
       data = fetch_firebase_data("#{base_url}/#{key}.json")
       obj = klass.find_or_create_by(uid: key)
       if obj.valid?


### PR DESCRIPTION
## WHAT
Add a Rake task that can import arbitrary Firebase data into specified Rails models
## WHY
We'll need to populate our Rails models from Firebase somehow
## HOW
Does a `shallow=true` request to Firebase to get all of the keys at a parent object, then retrieves each of those keys individually in order to get the current Firebase state of the data.  Once that's done, the system attempts to retrieve any existing record with the UID so that it can update it.  If there is no existing record with that UID, a new instance is created and persisted.

This makes the script idempotent-ish.  Multiple runs with the same Firebase source data will result in no changes to the data in the LMS database.  However, any changes made to the Firebase data will be persisted to the LMS database on additional runs of this script.  (This allows us to easily update all of our LMS models via the same script we use for initial population.)

## Have you added and/or updated tests?
No test for Rake tasks
