### PR TITLE
Remove percentage limiter for new question loads

### DIFF
--- a/services/QuillConnect/app/app.jsx
+++ b/services/QuillConnect/app/app.jsx
@@ -7,7 +7,6 @@ if (!window.Promise) {
 import BackOff from './utils/backOff';
 import React from 'react';
 import { render } from 'react-dom';
-import { applyFeatureToPercentage } from 'apply-feature';
 import createStore from './utils/configureStore';
 import { Provider } from 'react-redux';
 import { Router, Route, IndexRoute, } from 'react-router';
@@ -76,22 +75,10 @@ function extractLessonUIDFromLocation() {
   const matches = window.location.hash.match(playRegex);
   return (matches) ? matches[2] : null;
 }
-function extractSessionUIDFromLocation() {
-  const playRegex = /^#\/play\/(lesson|turk)\/.+\?.*student=(.+)(&|$)/;
-  const matches = window.location.hash.match(playRegex);
-  const sessionUid = (matches) ? matches[2] : null;
-  if (!sessionUid || sessionUid === 'null') return null;
-  return sessionUid;
-}
 
 const lessonUid = extractLessonUIDFromLocation();
-const sessionUid = extractSessionUIDFromLocation();
 
-// This is the whole number percentage of users who will be assigned
-// to the new session type.
-const percentAssigned = 10;
-
-if (lessonUid && applyFeatureToPercentage(sessionUid, percentAssigned)) {
+if (lessonUid) {
   setTimeout(() => {
     store.dispatch(conceptActions.startListeningToConcepts());
     store.dispatch(conceptsFeedbackActions.loadConceptsFeedback());


### PR DESCRIPTION
## WHAT
Turn off the code that limits the new question loading to only 10% of sessions
## WHY
We haven't gotten any reports about it causing problems, so we might as well roll it out to everyone
## HOW
Just remove the part of the conditional that limits rollout by percentage of sessions.

Note that we now technically no longer use the `apply-feature` module, and it could be removed from dependencies, but I figure we'll use it again in the future, so I'm going to leave it in.

## Have you added and/or updated tests?
No tests on the root `app.jsx` file