### PR TITLE
Release LEAP Cron

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -42,6 +42,7 @@ gem 'validates_email_format_of'
 gem 'responders'
 
 # UPLOADS
+gem "aws-sdk-s3", "~> 1.48"
 gem 'carrierwave', '~> 1.0'
 gem 'fog-aws'
 

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -58,6 +58,22 @@ GEM
     autoprefixer-rails (9.6.0)
       execjs
     awesome_print (1.8.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.221.0)
+    aws-sdk-core (3.68.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.48.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -253,6 +269,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -705,6 +722,7 @@ DEPENDENCIES
   ancestry
   atomic_arrays
   awesome_print
+  aws-sdk-s3 (~> 1.48)
   bcrypt
   better_errors
   binding_of_caller

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -386,6 +386,10 @@ class ActivitySession < ActiveRecord::Base
     # Dually, please do not add reload here, the db cost is not worth it
   end
 
+  def minutes_to_complete
+    ((self.completed_at - self.started_at)/60).round
+  end
+
   private
 
   def correctly_assigned

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -1,0 +1,26 @@
+class Cron
+  # Configured in Heroku Scheduler to run every 10 minutes
+  def self.interval_10_min
+
+  end
+
+  # Configured in Heroku Scheduler to run every hour on the XX:30 mark
+  def self.interval_1_hour
+
+  end
+
+  # Configured in Heroku Scheduler to run every day at 07:00UTC
+  # Which is 02:00 or 03:00 Eastern depending on Daylight Savings
+  def self.interval_1_day
+    run_saturday if now.wday == 6
+  end
+
+  def self.run_saturday
+    UploadLeapReportWorker.perform_async(29087)
+  end
+
+  def self.now
+    # We use UTC here to match the clock used for Heroku Scheduler
+    @t ||= Time.now.in_time_zone('UTC')
+  end
+end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -55,17 +55,50 @@ class School < ActiveRecord::Base
     data[ulocal.to_s.to_sym]
   end
 
-  private
+  def generate_leap_csv(activities_since = Time.parse("2010-01-01"), options = {})
+    CSV.generate(options) do |csv_file|
+      csv_file << %w(QuillID DistrictID StudentName StudentEmail TeacherName ClassroomName SchoolName Percentage Date ActivityName StandardName MinutesSpent)
 
-  def lower_grade_within_bounds
+      self.students.each do |student|
+        student.activity_sessions.where("completed_at >= ?", activities_since).each do |activity_session|
+          classroom = activity_session.classroom
+          teacher = User.joins(:classrooms_teachers).where(classrooms_teachers: {role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom_id: classroom.id}).first
+          csv_file << generate_leap_csv_row(student, teacher, classroom, activity_session)
+        end
+      end
+    end
+  end
+
+  def students
+    User.joins(student_in_classroom: {teachers: :school}).where(schools: {id: self.id}).uniq
+  end
+
+  private def generate_leap_csv_row(student, teacher, classroom, activity_session)
+    [
+      student.id,
+      student.third_party_user_ids.where(source: ThirdPartyUserId::SOURCES::LEAP).first&.id,
+      student.name,
+      student.email,
+      teacher.name,
+      classroom.name,
+      self.name,
+      activity_session.percentage,
+      activity_session.completed_at,
+      activity_session.activity.name,
+      activity_session.activity.topic.topic_category.name,
+      activity_session.minutes_to_complete
+    ]
+  end
+
+  private def lower_grade_within_bounds
     errors.add(:lower_grade, 'must be between 0 and 12') unless (0..12).include?(self.lower_grade.to_i)
   end
 
-  def upper_grade_within_bounds
+  private def upper_grade_within_bounds
     errors.add(:upper_grade, 'must be between 0 and 12') unless (0..12).include?(self.upper_grade.to_i)
   end
 
-  def lower_grade_greater_than_upper_grade
+  private def lower_grade_greater_than_upper_grade
     return true unless self.lower_grade && self.upper_grade
     errors.add(:lower_grade, 'must be less than or equal to upper grade') if self.lower_grade.to_i > self.upper_grade.to_i
   end

--- a/services/QuillLMS/app/models/third_party_user_id.rb
+++ b/services/QuillLMS/app/models/third_party_user_id.rb
@@ -1,0 +1,14 @@
+class ThirdPartyUserId < ActiveRecord::Base
+
+  module SOURCES
+    LEAP ||= "LEAP"
+  end
+
+  VALID_SOURCES = [SOURCES::LEAP].freeze
+
+  belongs_to :user
+
+  validates :user, presence: true
+  validates :source, presence: true, inclusion: {in: VALID_SOURCES}
+  validates :third_party_id, presence: true
+end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -34,10 +34,14 @@ class User < ActiveRecord::Base
   has_many :classrooms_i_teach, through: :classrooms_teachers, source: :classroom
   has_many :students_i_teach, through: :classrooms_i_teach, source: :students
 
+  has_many :students_classrooms, class_name: 'StudentsClassrooms', foreign_key: 'student_id'
+  has_many :student_in_classroom, through: :students_classrooms, source: :classroom
+
   has_and_belongs_to_many :districts
   has_one :ip_location
   has_many :user_milestones
   has_many :milestones, through: :user_milestones
+  has_many :third_party_user_ids
 
   has_many :blog_post_user_ratings
 

--- a/services/QuillLMS/app/workers/upload_leap_report_worker.rb
+++ b/services/QuillLMS/app/workers/upload_leap_report_worker.rb
@@ -1,0 +1,20 @@
+class UploadLeapReportWorker
+  include Sidekiq::Worker
+
+  LEAP_S3_BUCKET = 'quill-leap'
+  AWS_ACCESS_KEY_ID = ENV['AWS_UPLOADS_ACCESS_KEY_ID']
+  AWS_SECRET_ACCESS_KEY = ENV['AWS_UPLOADS_SECRET_ACCESS_KEY']
+
+  def perform(school_id)
+    school = School.find(school_id)
+    csv_data = school.generate_leap_csv
+
+    s3 = Aws::S3::Resource.new(
+      credentials: Aws::Credentials.new(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY),
+      region: 'us-east-1'
+    )
+    bucket = s3.bucket(LEAP_S3_BUCKET)
+    obj = bucket.object("Data/#{Time.now.strftime('%Y-%m-%d_%H-%M-%S')}.csv")
+    obj.put(body: csv_data, content_type: "text/csv")
+  end
+end

--- a/services/QuillLMS/db/migrate/20191008191026_create_third_party_user_ids.rb
+++ b/services/QuillLMS/db/migrate/20191008191026_create_third_party_user_ids.rb
@@ -1,0 +1,11 @@
+class CreateThirdPartyUserIds < ActiveRecord::Migration
+  def change
+    create_table :third_party_user_ids do |t|
+      t.references :user, index: true, foreign_key: true
+      t.string :source
+      t.string :third_party_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/cron.rake
+++ b/services/QuillLMS/lib/tasks/cron.rake
@@ -1,0 +1,17 @@
+namespace :cron do
+  desc "Process Cron's 10 minute interval logic"
+  task interval_10_minutes: :environment do
+    Cron.interval_10_minutes
+  end
+
+  desc "Process Cron's 1 hour interval logic"
+  task interval_1_hour: :environment do
+    Cron.interval_1_hour
+  end
+
+  desc "Process Cron's 1 day interval logic"
+  task interval_1_day: :environment do
+    Cron.interval_1_day
+  end
+
+end

--- a/services/QuillLMS/spec/factories/third_party_user_id.rb
+++ b/services/QuillLMS/spec/factories/third_party_user_id.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :third_party_user_id do
+    user            { create(:student) }
+    source          ThirdPartyUserId::VALID_SOURCES.sample
+    third_party_id  { rand(100000000) }
+  end
+end
+

--- a/services/QuillLMS/spec/models/third_party_user_id_spec.rb
+++ b/services/QuillLMS/spec/models/third_party_user_id_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "ThirdPartyUserId", type: :model do
+  let(:title_card) { create(:title_card) }
+  let(:third_party_user_id) { create(:third_party_user_id) }
+  let(:new_params) { {user: third_party_user_id.user, source: third_party_user_id.source, third_party_id: third_party_user_id.third_party_id} }
+
+  describe "#valid" do
+    it 'should be invalid if required params are not present' do
+      required_params = [:user, :third_party_id, :source]
+      required_params.each do |p|
+        expect(ThirdPartyUserId.new(new_params.except(p)).valid?).to eq(false)
+      end
+    end
+
+    it 'should be valid if required params are present' do
+      expect(ThirdPartyUserId.new(new_params).valid?).to eq(true)
+    end
+
+    it 'should only be valid if the ID source is one we already know' do
+      expect(ThirdPartyUserId.new(new_params.update({source: "unknown"})).valid?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
* Add a function to School model to generate a LEAP CSV

* Update the way we handle time calculation.

Also add the ability to generate a list of activity sessions completed since a specified Time rather than all of them ever

* Add a third-party user_id model for integrations

And use data stored there as part of the LEAP CSV generation code

* Add a rake task for shipping LEAP reports to S3

The code hasn't been tested but is probably close to code complete.  However, we still need to configure AWS accounts for this task and set credentials in ENV.

* Add a Rake task to generate and upload LEAP reports for specific schools

* Use constants for ThirdPartyUserId SOURCES to avoid typo errors

* Do not duplicate students if they are in multiple classrooms

Also do some clean up around approach and readability

* Add a Cron framework for better control of scheduled jobs

* Use a referenced constant rather than a string for where condition

* Remove old leap rake task since we're now using cron

* Update Cron timing to use UTC