### PR TITLE
feature/quillcms/refactor-rematch-reference-responses

### DIFF
--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -17,11 +17,11 @@ class RematchResponseWorker
     "spelling_error",
   ].freeze
 
-  def perform(response_id, question_type, question_uid)
+  def perform(response_id, question_type, question_uid, reference_response_ids)
     response = Response.find_by(id: response_id)
     question = retrieve_question_from_firebase(question_uid, question_type)
     return unless question
-    reference_responses = get_human_graded_responses(question_uid).to_a
+    reference_responses = retrieve_reference_responses(reference_response_ids).to_a
     rematch_response(response, question_type, question, reference_responses)
   end
 
@@ -57,12 +57,6 @@ class RematchResponseWorker
     JSON.parse(resp.body)
   end
 
-  def get_human_graded_responses(question_uid)
-    Response.where(question_uid: question_uid)
-            .where.not(optimal: nil)
-            .where(parent_id: nil)
-  end
-
   def retrieve_question_from_firebase(question_uid, question_type)
     uri = URI(ENV['FIREBASE_URL'])
     path = get_firebase_path(question_uid, question_type)
@@ -83,4 +77,7 @@ class RematchResponseWorker
     end
   end
 
+  def retrieve_reference_responses(reference_response_ids)
+    Response.where(id: reference_response_ids)
+  end
 end

--- a/services/QuillCMS/app/workers/rematch_responses_for_question_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_responses_for_question_worker.rb
@@ -7,8 +7,9 @@ class RematchResponsesForQuestionWorker
 
   def perform(question_uid, question_type)
     responses_to_reprocess = get_ungraded_responses(question_uid) + get_machine_graded_responses(question_uid)
+    reference_response_ids = get_human_graded_responses(question_uid).map { |r| r.id }
     responses_to_reprocess.each do |response|
-      RematchResponseWorker.perform_async(response.id, question_type, question_uid)
+      RematchResponseWorker.perform_async(response.id, question_type, question_uid, reference_response_ids)
     end
   end
 
@@ -24,4 +25,10 @@ class RematchResponsesForQuestionWorker
             .where("responses.parent_id IS NOT NULL OR responses.parent_uid IS NOT NULL")
   end
 
+  def get_human_graded_responses(question_uid)
+    Response.where(question_uid: question_uid)
+            .where.not(optimal: nil)
+            .where(parent_id: nil)
+            .select(:id)
+  end
 end

--- a/services/QuillCMS/spec/workers/rematch_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/rematch_response_worker_spec.rb
@@ -115,15 +115,24 @@ describe RematchResponseWorker do
       "spelling_error":false
     }]
   }.stringify_keys
+  reference_responses = []
+  sample_payload["referenceResponses"].each_with_index do |r|
+    reference_responses.push(Response.create_with(r).find_or_create_by(id: r[:id]))
+  end
 
   describe '#perform' do
-    let(:response) { create(:response) }
+    let(:response) { Response.create(sample_payload['response']) }
     it 'should update the response based on the lambda payload' do
       stub_request(:post, /#{ENV['REMATCH_LAMBDA_URL']}/).
         to_return(status: 200, body: sample_lambda_response.to_json, headers: {})
 
-      expect(response).to receive(:update_index_in_elastic_search)
-      subject.rematch_response(response, sample_payload['type'], sample_payload['question'], sample_payload['reference_responses'])
+      reference_response_ids = reference_responses.map { |r| r.id }
+
+      expect(subject).to receive(:retrieve_question_from_firebase).with(sample_payload['question']['key'], sample_payload['type']).and_return(sample_payload['question'])
+      expect(subject).to receive(:retrieve_reference_responses).with(reference_response_ids).and_call_original
+      expect(subject).to receive(:rematch_response).with(response, sample_payload['type'], sample_payload['question'], reference_responses).and_call_original
+      subject.perform(response.id, sample_payload['type'], sample_payload['question']['key'], reference_response_ids)
+      response.reload
       expect(response.feedback).to eq(sample_lambda_response[:feedback])
     end
 

--- a/services/QuillCMS/spec/workers/rematch_responses_for_question_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/rematch_responses_for_question_worker_spec.rb
@@ -8,11 +8,13 @@ describe RematchResponsesForQuestionWorker do
     question_type = 'FAKE_TYPE'
     let(:response1) { create(:response) }
     let(:response2) { create(:response, id: 2) }
+    let(:reference_responses) { [response1.id, response2.id] }
     it 'should load rematch-eligible responses and enqueue them' do
       expect(subject).to receive(:get_ungraded_responses).with(question_uid).and_return([response1])
       expect(subject).to receive(:get_machine_graded_responses).with(question_uid).and_return([response2])
-      expect(RematchResponseWorker).to receive(:perform_async).with(response1.id, question_type, question_uid).ordered
-      expect(RematchResponseWorker).to receive(:perform_async).with(response2.id, question_type, question_uid).ordered
+      expect(subject).to receive(:get_human_graded_responses).and_return([response1, response2])
+      expect(RematchResponseWorker).to receive(:perform_async).with(response1.id, question_type, question_uid, reference_responses).ordered
+      expect(RematchResponseWorker).to receive(:perform_async).with(response2.id, question_type, question_uid, reference_responses).ordered
       subject.perform(question_uid, question_type)
     end
   end


### PR DESCRIPTION
## WHAT
Refactor the rematch all worker flow to do our most expensive query once and attach the results to the job requests
## WHY
For some reason the query to find reference responses is expensive(ish).  Enough so that running it thousands of times puts a lot of load on the db.
## HOW
We'll run the query to get reference responses once when we enqueue the various responses for rematching, and attach the IDs to the job payload.  Then we should be able to retrieve all of the reference responses efficiently by ID for each response we rematch.

## Have you added and/or updated tests?
Yes.  Which took me longer than I expected because, to be honest, the current tests are pretty crappy.  I should know, I wrote them myself.
