### PR TITLE
rename recommendations_for_classroom method

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -24,7 +24,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     end
 
     def recommendations_for_classroom
-        render json: recommendations_for_classroom(params[:unit_id], params[:classroom_id], params[:activity_id])
+        render json: generate_recommendations_for_classroom(params[:unit_id], params[:classroom_id], params[:activity_id])
     end
 
     def lesson_recommendations_for_classroom

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -230,7 +230,7 @@ module PublicProgressReports
       end
     end
 
-    def recommendations_for_classroom(unit_id, classroom_id, activity_id)
+    def generate_recommendations_for_classroom(unit_id, classroom_id, activity_id)
       classroom_unit = ClassroomUnit.find_by(classroom_id: classroom_id, unit_id: unit_id)
       classroom = Classroom.find(classroom_id)
       diagnostic = Activity.find(activity_id)


### PR DESCRIPTION
## WHAT
Rename `recommendations_for_classroom` method.

## WHY
One already exists, causing an error.

## HOW
Rename it `generate_recommendations_for_classroom` to avoid linting rule.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO
