### PR TITLE
add link to status page to error and maintenance pages

### DIFF
--- a/packages/quill-cdn/assets/html/404.html
+++ b/packages/quill-cdn/assets/html/404.html
@@ -23,6 +23,7 @@
         </div>
 
         <p class="helpful-links">Here are some helpful links:</p>
+        <a target="_blank" href="https://quillorg.statuspage.io/">Status Page</a>
         <a target="_blank" href="https://www.quill.org/tools/connect">Quill Connect</a>
         <a target="_blank" href="https://www.quill.org/activities/packs">Resources</a>
         <a target="_blank" href="https://d1yxac6hjodhgc.cloudfront.net/wp-content/uploads/2017/04/Quill-Getting-Started-Guide-for-Teachers1.pdf">Getting Started Guide For Teachers</a>

--- a/packages/quill-cdn/assets/html/heroku_timeout.html
+++ b/packages/quill-cdn/assets/html/heroku_timeout.html
@@ -17,7 +17,7 @@
 
         <button onclick="refreshPage()">Refresh Page</button>
 
-        <p class="contact-us">If you keep seeing this page or if you need help, you can call us at <span class="contact-info">646-442-1095</span> or email us at <span class="contact-info">hello@quill.org</span></p>
+        <p class="contact-us">If you keep seeing this page, please check our <a class="contact-info" href="https://quillorg.statuspage.io/">status page</a> for planned maintenance events or outages. If you need help, you can call us at <span class="contact-info">510-671-0222</span> or email us at <span class="contact-info">hello@quill.org</span></p>
       </div>
 
       <div class="illustration">

--- a/packages/quill-cdn/assets/html/upgrading.html
+++ b/packages/quill-cdn/assets/html/upgrading.html
@@ -11,7 +11,7 @@
       <div class="text">
         <h1>Quill is being upgraded!</h1>
 
-        <p class="return-time">We'll be back up in 15 - 30 minutes.</p>
+        <p class="return-time">Please check our <a class="contact-info" href="https://quillorg.statuspage.io/">status page</a> for updates.</p>
 
         <p><span class="dont-worry">Don't worry!</span> Quill always saves student progress. Once Quill is back online, students should resume an activity to complete and save it.</p>
 


### PR DESCRIPTION
## WHAT
Link to our new status page (https://quillorg.statuspage.io/) from our maintenance, timeout, and 404 pages.

## WHY
It's good to have some status page hosted by someone other than us in the event of a site-wide outage, and it's also nice to be able to update incidents in one place.

## HOW
I set up our statuspage.io site and then added links to it from our existing error and maintenance pages. We could also link to it in a notification banner in the event of an incident that is not sitewide, as we have historically. 

## Screenshots
![Screen Shot 2019-11-04 at 1 08 31 PM](https://user-images.githubusercontent.com/18669014/68146095-39bb3400-ff05-11e9-8779-150494eb5e4c.png)
![Screen Shot 2019-11-04 at 1 07 47 PM](https://user-images.githubusercontent.com/18669014/68146096-39bb3400-ff05-11e9-8360-e85d907395f6.png)
![Screen Shot 2019-11-04 at 1 07 34 PM](https://user-images.githubusercontent.com/18669014/68146097-3a53ca80-ff05-11e9-889b-d62464d1d29a.png)


## Have you added and/or updated tests?
NO
