### PR TITLE
make white background on activities page extend to bottom

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
@@ -45,6 +45,7 @@
 
 .assign-a-new-activity-container {
   background-color: white;
+  height: 100%;
 }
 
 .assign-a-new-activity {


### PR DESCRIPTION
## WHAT
Make white background on activities page extend to the bottom of the page.

## WHY
I noticed that on larger screen sizes, there was a little strip of gray between where the white-background of the page itself ended and the footer starts (since the footer is pinned to the very bottom of the screen). This will make sure that strip doesn't exist.

## HOW
Just give the container a height of 100%.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A