### PR TITLE
Cache Questions.all query in Redis for index action

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
@@ -1,9 +1,16 @@
 class Api::V1::QuestionsController < Api::ApiController
   before_filter :get_question_by_uid, except: [:index, :create, :valid_params]
 
+  ALL_QUESTIONS_CACHE_KEY = 'ALL_QUESTIONS'
+  ALL_QUESTIONS_CACHE_EXPIRY = 600
+
   def index
-    all_questions = Question.all.reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
-    render(json: all_questions)
+    all_questions = $redis.get(ALL_QUESTIONS_CACHE_KEY)
+    if !all_questions
+      all_questions = Question.all.reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+      $redis.set(ALL_QUESTIONS_CACHE_KEY, all_questions, {ex: ALL_QUESTIONS_CACHE_EXPIRY})
+    end
+    render(json: all_questions.as_json)
   end
 
   def show

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -6,8 +6,23 @@ describe Api::V1::QuestionsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Questions" do
+      expect($redis).to receive(:get).and_return(nil)
       get :index
       expect(JSON.parse(response.body).keys.length).to eq(1)
+    end
+
+    it "should set cache if it is empty" do
+      expect($redis).to receive(:get).and_return(nil)
+      expect($redis).to receive(:set)
+      get :index
+    end
+
+    it "should not set cache if there is a cache hit" do
+      mock_cached_data = "CACHED DATA"
+      expect($redis).to receive(:get).and_return(mock_cached_data)
+      expect($redis).not_to receive(:set)
+      get :index
+      expect(response.body).to eq(mock_cached_data)
     end
 
     it "should include the response from the db" do


### PR DESCRIPTION
## WHAT
Cache the results of `Question.all` in the `QuestionController.index` action
## WHY
The database query pulls so much data that it takes 2,000ms just in SQL most of the time, and this is putting a lot of strain on the DB (slowing down all other queries).
## HOW
Cache the results of the query in Redis, and on subsequent calls see if that data is still there, preferring to send Redis data over re-running the SQL query.

## Have you added and/or updated tests?
Tests updated to pass with new caching logic, and new tests added to ensure caching behavior is working
