### PR TITLE
Fix symbol-vs-string hash key mismatch

### DIFF
--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -7,7 +7,7 @@ class CreateOrIncrementResponseWorker
     if !response
       response = Response.new(indifferent_vals)
       if !response.text.blank? && response.save!
-        #AdminUpdates.run(response.question_uid)
+        AdminUpdates.run(response.question_uid)
       end
     else
       increment_counts(response, indifferent_vals)


### PR DESCRIPTION
## WHAT
Make has key access indifferent in sidekiq worker
## WHY
Key type coercion was working before, but the Monday deploy seems to have broken it.
## HOW
Make the input hash key-type indifferent before accessing it

## Have you added and/or updated tests?
No updates.