### PR TITLE
Add cache invalidation when saving a Question object

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -3,6 +3,8 @@ class Question < ActiveRecord::Base
   validates :data, presence: true
   validate :data_must_be_hash
 
+  after_save :expire_all_questions_cache
+
   def as_json(options=nil)
     data
   end
@@ -59,10 +61,8 @@ class Question < ActiveRecord::Base
     save
   end
 
-  def save
-    valid = super
+  private def expire_all_questions_cache
     $redis.del(Api::V1::QuestionsController::ALL_QUESTIONS_CACHE_KEY)
-    valid
   end
 
   private def new_uuid

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe Question, type: :model do
     end
   end
 
-  describe '#save' do
-    it 'should invalidate the ALL_QUESTIONS cache' do
+  describe '#after_save' do
+    it 'should execute invalidate_all_questions_cache to invalidate the ALL_QUESTIONS cache' do
       key = Api::V1::QuestionsController::ALL_QUESTIONS_CACHE_KEY
       $redis.set(key, 'Dummy data')
       question.data = {foo: "bar"}


### PR DESCRIPTION
## WHAT
Invalidate the ALL_QUESTIONS cache when individual Question objects are saved
## WHY
Right now when an admin edits a question, the ALL_QUESTIONS cache immediately becomes stale and when the admin refreshes a page, they don't see their changes reflected in the UI
## HOW
When a Question is saved, delete the value in Redis at the cache key

## Have you added and/or updated tests?
Added a test case to guarantee that the cache key gets cleared when save is called.
