### PR TITLE
Remove Facebook tracking pixel

### DIFF
--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -38,18 +38,4 @@
   }}();
   </script>
   <!-- end Segment.io -->
-  <!-- Facebook Pixel -->
-  <script>
-  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-  document,'script','https://connect.facebook.net/en_US/fbevents.js');
-
-  fbq('init', '508162756033212');
-  fbq('track', "PageView");</script>
-  <noscript><img height="1" width="1" style="display:none"
-  src="https://www.facebook.com/tr?id=508162756033212&ev=PageView&noscript=1"
-  /></noscript>
-  <!-- End Facebook Pixel -->
 <% end %>


### PR DESCRIPTION
## WHAT
Remove Facebook tracking pixel from LMS header
## WHY
We don't make use of the data, so there's no use sharing it with facebook
## HOW
Remove the code block that sets up the Facebook pixel

## Have you added and/or updated tests?
No test coverage on our headers