### PR TITLE
Add New Relic open links to deploy scripts

### DIFF
--- a/services/QuillCMS/deploy.sh
+++ b/services/QuillCMS/deploy.sh
@@ -13,3 +13,4 @@ case $1 in
 esac
 
 eb deploy ${EB_ENVIRONMENT_NAME}
+open "https://rpm.newrelic.com/accounts/770600/applications/74496669"

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -24,3 +24,4 @@ TEMP_DEPLOY_BRANCH=temp-for-deploy
  git push -f ${DEPLOY_GIT_REMOTE} ${TEMP_DEPLOY_BRANCH}:master)
 git checkout ${STARTING_BRANCH}
 git branch -D ${TEMP_DEPLOY_BRANCH}
+open "https://rpm.newrelic.com/accounts/770600/applications/3825541"


### PR DESCRIPTION
## WHAT
Add `open` commands to our deploy scripts so your browser automatically opens New Relic for monitoring when you complete a deployment of the LMS or CMS.
## WHY
It's helpful to be reminded that you need to monitor things, and where to do it, when you're doing a deploy
## HOW
Just use the `open` command at the end of the deploy script to launch a hard-coded link to application-specific New Relic pages in the user's default browser

## Have you added and/or updated tests?
No tests on deploy bash scripts.