### PR TITLE
Get regex search working while I further investigate elasticsearch

### DIFF
--- a/services/QuillCMS/lib/modules/response_search.rb
+++ b/services/QuillCMS/lib/modules/response_search.rb
@@ -39,7 +39,7 @@ module ResponseSearch
     is_regex = user_input.first == '/' && user_input.last == '/'
     query = {
       query_string: {
-        default_field: is_regex ? 'text.keyword' : 'text',
+        default_field: is_regex ? 'sortable_text' : 'text',
         query: build_query_string(question_uid, query_filters, is_regex)
       }
     }

--- a/services/QuillCMS/spec/controllers/lib/response_search_spec.rb
+++ b/services/QuillCMS/spec/controllers/lib/response_search_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe ResponseSearch do
   end  
 
   describe '#get_query_values' do
-    it 'should search in field \'text.keyword\' if original query contains regex' do
+    it 'should search in field \'sortable_text\' if original query contains regex' do
       test_query_filters['text'] = '/test_regex/'
-      expect(ResponseSearch.get_query_values('000', test_query_filters)[:query_string][:default_field]).to eq('text.keyword')
+      expect(ResponseSearch.get_query_values('000', test_query_filters)[:query_string][:default_field]).to eq('sortable_text')
     end
 
     it 'should search in field \'text\' if original query does not contain regex' do


### PR DESCRIPTION
## WHAT
Regex search was originally broken because it was pointing to a field analyzed as `text` rather than `keyword`. I'm changing it to point to a `keyword` analyzed field. 
NOTE: this is still an imperfect fix because the `keyword` field does not support case sensitivity in searches, but I'm adding this now so Curriculum team can use this feature while I do my digging

## WHY
To have a working version of regex search live

## HOW
changing the field that elasticsearch searches in to be a `keyword` analyzed field, which supports regex searching

## Screenshots


## Have you added and/or updated tests?
YES
