### PR TITLE
fix activity assign header

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`AssignANewActivity component should render 1`] = `
         text="Explore our library of diagnostic assessments and learning activities to find the best materials for your students."
       />
       <AssignmentStep
-        header="Choose Assignment Type"
+        header="Assign to Classes"
         number="3"
         text="Assign these activities to either the whole class or individual students."
       />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
@@ -33,7 +33,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned }) => (<div className="
         text="Explore our library of diagnostic assessments and learning activities to find the best materials for your students."
       />
       <AssignmentStep
-        header="Choose Assignment Type"
+        header="Assign to Classes"
         number="3"
         text="Assign these activities to either the whole class or individual students."
       />


### PR DESCRIPTION
## WHAT
Fix the third header on the Assign Activities page to say "Assign to Classes"
## WHY
It's currently a repeated header
## HOW
Change text label
## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Yes
