### PR TITLE
disable Sentry error reporting for QuillConnect

### DIFF
--- a/services/QuillConnect/app/app.jsx
+++ b/services/QuillConnect/app/app.jsx
@@ -21,20 +21,22 @@ import levelActions from './actions/item-levels';
 import * as titleCardActions from './actions/titleCards.ts';
 import createHashHistory from 'history/lib/createHashHistory';
 import 'styles/style.scss';
-import Raven from 'raven-js';
+// import Raven from 'raven-js';
 import quillNormalizer from './libs/quillNormalizer';
 import SocketProvider from './components/socketProvider';
 
-if (process.env.NODE_ENV === 'production') {
-  Raven
-  .config(
-    'https://528794315c61463db7d5181ebc1d51b9@sentry.io/210579',
-    {
-      environment: process.env.NODE_ENV,
-    }
-  )
-  .install();
-}
+// TO-DO: re-enable Sentry errors for QuillConnect when errors have been reduced
+
+// if (process.env.NODE_ENV === 'production') {
+//   Raven
+//   .config(
+//     'https://528794315c61463db7d5181ebc1d51b9@sentry.io/210579',
+//     {
+//       environment: process.env.NODE_ENV,
+//     }
+//   )
+//   .install();
+// }
 
 BackOff();
 const hashhistory = createHashHistory({ queryKey: false, });


### PR DESCRIPTION
## WHAT
temporarily disabled Sentry error reporting for QuillConnect

## WHY
to make sure we don't unnecessarily hit our quota with potentially benign errors
## HOW
commented out Sentry config
## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
N/A
