### PR TITLE
Simplify circle settings for new auto-scale plans.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,6 @@ jobs:
             cd services/QuillLMS
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
             bundle exec rspec -- ${TESTFILES}
-      - store_test_results:
-          path: ~/rspec
   lms_node_build:
     working_directory: ~/Empirical-Core
     docker:
@@ -439,20 +437,20 @@ workflows:
   build-test:
     jobs:
       - lms_rails_build
-  #     - connect_node_build
-  #     - lms_node_build
-  #     - marking_logic_node_build
-  #     - diagnostic_node_build
-  #     - lms_rails_build
-  #     - grammar_node_build
-  #     - cms_rails_build
-  #     - lessons_node_build
-  #     - proofreader_node_build
-  #     - spellchecker_node_build
-  #     - comprehension_rails_build
-  #     - comprehension_python_build
-  # lint-code:
-  #   jobs:
-  #     - node_lint
-  #     - rubocop_lint
-  #     - flake8_lint
+      - connect_node_build
+      - lms_node_build
+      - marking_logic_node_build
+      - diagnostic_node_build
+      - lms_rails_build
+      - grammar_node_build
+      - cms_rails_build
+      - lessons_node_build
+      - proofreader_node_build
+      - spellchecker_node_build
+      - comprehension_rails_build
+      - comprehension_python_build
+  lint-code:
+    jobs:
+      - node_lint
+      - rubocop_lint
+      - flake8_lint


### PR DESCRIPTION
## WHAT
Remove the ordering from the circleci config.
## WHY
CircleCi has (finally) enabled autoscaling pricing which will allow use to run all of our tests in parallel instead of two at a time on set boxes. So removing this optimization hack for running the long-running tests first.
## HOW
Remove the order.
## Screenshots
<img width="814" alt="Screen Shot 2019-12-10 at 4 43 19 PM" src="https://user-images.githubusercontent.com/1304933/70571866-9cd76080-1b6c-11ea-831f-19fc1da8d065.png">


## Have you added and/or updated tests?
Well, in a way, I've updated all of them.

