### PR TITLE
Catch an edge case in classroom sync where user has no access_token

### DIFF
--- a/services/QuillLMS/app/services/google_integration/client.rb
+++ b/services/QuillLMS/app/services/google_integration/client.rb
@@ -2,6 +2,8 @@ require 'google/api_client'
 
 class GoogleIntegration::Client
 
+  class AccessTokenError < StandardError; end
+
   def initialize(user, api_client = nil, token_refresher = nil, api_version = nil, os_version = nil)
     @user            = user
     @api_client      = api_client      || Google::APIClient
@@ -11,6 +13,7 @@ class GoogleIntegration::Client
   end
 
   def create
+    raise AccessTokenError, "No access token found" if !access_token
     client.authorization.access_token = access_token
     client
   end

--- a/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
@@ -9,7 +9,8 @@ class RetrieveGoogleClassroomsWorker
     user = User.find(user_id)
     begin
       google_response = GoogleIntegration::Classroom::Main.pull_data(user)
-    rescue GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError => e
+    rescue GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError,
+           GoogleIntegration::Client::AccessTokenError => e
       NewRelic::Agent.add_custom_attributes({
         user_id: user_id
       })

--- a/services/QuillLMS/spec/workers/retrieve_google_classrooms_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/retrieve_google_classrooms_worker_spec.rb
@@ -16,5 +16,10 @@ describe RetrieveGoogleClassroomsWorker, type: :worker do
       expect(GoogleIntegration::Classroom::Main).to receive(:pull_data).with(user).and_raise(GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError)
       subject.perform(user.id)
     end
+
+    it 'should rescue GoogleIntegration::Client::AccessTokenError in the Google integration' do
+      expect(GoogleIntegration::Classroom::Main).to receive(:pull_data).with(user).and_raise(GoogleIntegration::Client::AccessTokenError)
+      subject.perform(user.id)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Catch an edge case in classroom sync where user has no access_token
## WHY
I have no idea how this happens.  It looks like the users that are failing don't even have an AuthCredential entry, which should be required for users logging in with Google.  Is it possible that someone can request a sync but not be logged in via Google?
## HOW
Just catch cases where the Google Integration client starts up with no `access_token` available and raise an error for them.  Then have the sync worker rescue that error to avoid retries.

## Have you added and/or updated tests?
Added a case to the worker spec to make sure it rescues the error.

