### PR TITLE
Improve partial CircleCi caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: NPM install, should be short-cutted if cache is present
           command: |
-            cd services/QuillLMS/client
+            cd services/QuillLMS
             npm install
       - save_cache:
           key: bundle-cache-lms-v1-{{ checksum "services/QuillLMS/Gemfile.lock" }}
@@ -83,7 +83,7 @@ jobs:
             - npm-cache-lms-frontend-
           name: Install NPM dependencies
           command: |
-            cd services/QuillLMS/client
+            cd services/QuillLMS
             npm install
       - save_cache:
           key: npm-cache-lms-frontend-{{ .Branch }}-{{ checksum "services/QuillLMS/package.json" }}


### PR DESCRIPTION
WIP - not ready for review. Tests only run on PRs

## WHAT
Update the partial caching in Circle to speed up builds. Doing this by splitting by branch and `package.json`
## WHY
The npm installs are almost never hitting the cache key which is based on `package-lock.json` which causes all of the dependencies to be installed on every run (which is slow). This should speed up subsequent builds on each branch. 
## HOW
Making the cache keys it checks a little more generic to be off of `package.json` and a little more specific to include the git `branch` so that new dependencies are installed on each branch.
## Screenshots


## Have you added and/or updated tests?
All tests, all the time.

