### PR TITLE
Fix serialization bug in caching logic

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
@@ -21,10 +21,10 @@ class Api::V1::QuestionsController < Api::ApiController
   def show
     @question = $redis.get(get_question_cache_key(params[:id]))
     if !@question
-      @question = Question.find_by!(uid: params[:id])
-      $redis.set(get_question_cache_key(@question.uid), @question, {ex: QUESTION_CACHE_KEY_EXPIRY})
+      @question = Question.find_by!(uid: params[:id]).to_json
+      $redis.set(get_question_cache_key(params[:id]), @question, {ex: QUESTION_CACHE_KEY_EXPIRY})
     end
-    render_question
+    render(json: @question)
   end
 
   def create


### PR DESCRIPTION
## WHAT
Fix a bug in serialization
## WHY
The `$redis` module does not handle serialization of objects automatically, so we have to be explicit
## HOW
Make sure the set the redis value to the json form of the data