### PR TITLE
Add padding to Activity Analysis table rows

### DIFF
--- a/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
+++ b/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
@@ -8,13 +8,13 @@ class GenerateConceptsInUseArrayWorker
     concepts_in_use << headers
     $redis.set("CONCEPTS_IN_USE", concepts_in_use.to_json)
     $redis.set("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET", Time.now)
-    sc_questions = Question.where(question_type: 'connect_sentence_combining').reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+    sc_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/questions.json").parsed_response
     $redis.set('SC_QUESTIONS', sc_questions.to_json)
     fib_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/fillInBlankQuestions.json").parsed_response
     $redis.set('FIB_QUESTIONS', fib_questions.to_json)
     sf_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/sentenceFragments.json").parsed_response
     $redis.set('SF_QUESTIONS', sf_questions.to_json)
-    d_questions = Question.where(question_type: 'diagnostic_sentence_combining').reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+    d_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/diagnostic_questions.json").parsed_response
     $redis.set('D_QUESTIONS', d_questions.to_json)
     d_fib_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/diagnostic_fillInBlankQuestions.json").parsed_response
     $redis.set('D_FIB_QUESTIONS', d_fib_questions.to_json)


### PR DESCRIPTION
## WHAT
Add slightly more padding to Activity Analysis table rows so that multiple lines of text can be read more easily.

## WHY
Easier use, visibility.

## HOW
Adding padding to the appropriate class of table data.

## Screenshots
![Screen Shot 2019-12-16 at 12 52 47 PM](https://user-images.githubusercontent.com/57366100/70932272-55871f00-2007-11ea-9f7a-6576e6aa4f5c.png)


## Have you added and/or updated tests?
NO, test not needed.
