### PR TITLE
add rake task to handle duplicate clever accounts

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -149,6 +149,8 @@ Layout/DefEndAlignment:
 
 Layout/HeredocIndentation:
   Enabled: true
+  Exclude:
+    - QuillLMS/lib/tasks/merge_duplicate_clever_accounts.rake
 
 Layout/SpaceInLambdaLiteral:
   Enabled: true

--- a/services/QuillLMS/lib/tasks/merge_duplicate_clever_accounts.rake
+++ b/services/QuillLMS/lib/tasks/merge_duplicate_clever_accounts.rake
@@ -2,32 +2,32 @@ namespace :duplicate_clever_accounts do
   task :merge => :environment do
 
     sql = <<~SQL.squish
-SELECT
-a.id AS a_id,
-b.id AS b_id,
-a.name AS a_name,
-b.name AS b_name,
-a.count AS a_activity_sessions_count,
-b.count AS b_activity_sessions_count,
-a.email AS a_email,
-b.email AS b_email,
-a.clever_id AS a_clever_id,
-b.clever_id AS b_clever_id,
-a.username AS a_username,
-b.username AS b_username FROM (
-SELECT users.id, name, email, clever_id, username, activity_sessions.count FROM users
-LEFT JOIN activity_sessions ON activity_sessions.user_id = users.id AND activity_sessions.state = 'finished'
-WHERE clever_id IS NOT NULL AND clever_id != '' AND role = 'student'
-GROUP BY users.id, name, email, clever_id, username
-) as a
-INNER JOIN(
-SELECT users.id, name, email, clever_id, username, activity_sessions.count FROM users
-LEFT JOIN activity_sessions ON activity_sessions.user_id = users.id AND activity_sessions.state = 'finished'
-WHERE clever_id IS NOT NULL AND clever_id != '' AND role = 'student'
-GROUP BY users.id, name, email, clever_id, username
-) as b
-ON a.clever_id = b.clever_id
-WHERE CASE WHEN a.count = b.count THEN a.id > b.id ELSE a.count > b.count END
+      SELECT
+      a.id AS a_id,
+      b.id AS b_id,
+      a.name AS a_name,
+      b.name AS b_name,
+      a.count AS a_activity_sessions_count,
+      b.count AS b_activity_sessions_count,
+      a.email AS a_email,
+      b.email AS b_email,
+      a.clever_id AS a_clever_id,
+      b.clever_id AS b_clever_id,
+      a.username AS a_username,
+      b.username AS b_username FROM (
+      SELECT users.id, name, email, clever_id, username, activity_sessions.count FROM users
+      LEFT JOIN activity_sessions ON activity_sessions.user_id = users.id AND activity_sessions.state = 'finished'
+      WHERE clever_id IS NOT NULL AND clever_id != '' AND role = 'student'
+      GROUP BY users.id, name, email, clever_id, username
+      ) as a
+      INNER JOIN(
+      SELECT users.id, name, email, clever_id, username, activity_sessions.count FROM users
+      LEFT JOIN activity_sessions ON activity_sessions.user_id = users.id AND activity_sessions.state = 'finished'
+      WHERE clever_id IS NOT NULL AND clever_id != '' AND role = 'student'
+      GROUP BY users.id, name, email, clever_id, username
+      ) as b
+      ON a.clever_id = b.clever_id
+      WHERE CASE WHEN a.count = b.count THEN a.id > b.id ELSE a.count > b.count END
     SQL
 
     duplicated_student_records = ActiveRecord::Base.connection.execute(sql).to_a


### PR DESCRIPTION
## WHAT
Add a rake task to find and merge duplicate student Clever accounts.

## WHY
We've been having issues at two of our premium schools with teachers who have used multiple methods of having their students create their accounts, then switched to Clever, resulting in duplicate Clever accounts for the same student. I want to add a uniqueness restriction to clever ids, but we still need to fix the problem at hand. It's also easier to add a uniqueness restriction when there are fewer accounts already violating it.

## HOW
FInd accounts that share a clever id and mark account A as the one that the student has completed more activities in (the primary account). Then transfer all data from the secondary account to the primary account and delete the secondary account. I tested this on staging and checked a bunch of accounts and all seems to have gone smoothly.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A