### PR TITLE
redirect old diagnostic links to new assignment flow

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -610,9 +610,9 @@ EmpiricalGrammar::Application.routes.draw do
 
   get 'lessons' => 'pages#activities' # so that old links still work
   get 'about' => 'pages#activities' # so that old links still work
-  get 'diagnostic/:activityId' =>'activities#diagnostic' # placeholder til we find where this goes
-  get 'diagnostic/:activityId/stage/:stage' => 'activities#diagnostic'
-  get 'diagnostic/:activityId/success' => 'activities#diagnostic'
+  get 'diagnostic/:activityId' => redirect('/assign/diagnostic')
+  get 'diagnostic/:activityId/stage/:stage' => redirect('/assign/diagnostic')
+  get 'diagnostic/:activityId/success' => redirect('/assign/diagnostic')
   get 'customize/:id' => 'activities#customize_lesson'
   get 'preview_lesson/:lesson_id' => 'activities#preview_lesson'
   get 'activities/:id/supporting_info' => 'activities#supporting_info'


### PR DESCRIPTION
## WHAT
Redirect old diagnostic assignment links to the new diagnostic flow.

## WHY
We are getting a significant number of Sentry errors about there being no template for 'pages/diagnostic'. This is because we removed that when we redid the assignment flow, but evidently some users have the old link saved. This will redirect them to the appropriate place in the assignment flow.

## HOW
Just add a redirect.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A