### PR TITLE
Feature/quilllms/invalidate bad google sessions

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -147,6 +147,6 @@ class ApplicationController < ActionController::Base
     return if !current_user || !session
     # If the user is google authed, but doesn't have a valid refresh
     # token, then we need to invalidate their session
-    return reset_session if current_user.signed_up_with_google && !current_user.auth_credential&.refresh_token
+    return reset_session if current_user.google_id && !current_user.auth_credential&.refresh_token
   end
 end


### PR DESCRIPTION
## WHAT
Add a `before_action` to all controllers to find and invalidate sessions that need to be blown up.  In this case, sessions belonging to Google-authorized users who do not have a valid refresh token.
## WHY
We need to force those users to re-authorize with google so that we can get refresh tokens for them so that things like classroom sync will work.
## HOW
I was hoping to be able to blow up the user sessions, but it appears that we're configured for pure-cookie user sessions, so there's no way to access them directly from within our infrastructure.  This is something that we may want to reconsider as they are potentially unsafe (though they're encrypted, so not easy to hack).

## Have you added and/or updated tests?
Not totally sure how to test these sorts of global application controller functions.  Open to suggestions.