### PR TITLE
removed module for cloud function deploy

### DIFF
--- a/services/comprehension/grammar-local-api/requirements.txt
+++ b/services/comprehension/grammar-local-api/requirements.txt
@@ -7,7 +7,6 @@ Click==7.0
 cymem==2.0.3
 Flask==1.1.1
 idna==2.8
-importlib-metadata==1.3.0
 itsdangerous==1.1.0
 Jinja2==2.10.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
## WHAT
the module `importlib-metadata` is not compatible with Google Cloudfunction, so I need to remove it in order to deploy successfully as a CloudFunction.

## WHY
to get the deploy up and working

## HOW
removing the module import from `requirements.txt`

## Screenshots


## Have you added and/or updated tests?

