### PR TITLE
An interim database.yml config to set up Makara config

### DIFF
--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -1,0 +1,54 @@
+default: &default
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+
+development_env: &development_env
+  adapter: postgresql
+  encoding: unicode
+  database: emp_gr_development
+  host:     localhost
+  port: 5432
+
+test_env: &test_env
+  <<: *development_env
+  database: emp_gr_test
+
+leader_db_env: &leader_db_env
+  database: <%= ENV['LEADER_DB_NAME'] %>
+  user: <%= ENV['LEADER_DB_USERNAME'] %>
+  password: <%= ENV['LEADER_DB_PASSWORD'] %>
+  host: <%= ENV['LEADER_DB_HOSTNAME'] %>
+  port: <%= ENV['LEADER_DB_PORT'] %>
+
+follower_db_env: &follower_db_env
+  database: <%= ENV['FOLLOWER_DB_NAME'] %>
+  user: <%= ENV['FOLLOWER_DB_USERNAME'] %>
+  password: <%= ENV['FOLLOWER_DB_PASSWORD'] %>
+  host: <%= ENV['FOLLOWER_DB_HOSTNAME'] %>
+  port: <%= ENV['FOLLOWER_DB_PORT'] %>
+
+development: &development
+  <<: *default
+  adapter: postgresql
+  <<: *leader_db_env
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  adapter: postgresql
+  <<: *test_env
+
+staging: &staging
+  <<: *default
+  adapter: postgresql
+  <<: *leader_db_env
+
+sprint:
+  <<: *staging
+
+production:
+  <<: *default
+  adapter: postgresql
+  <<: *leader_db_env


### PR DESCRIPTION
## WHAT
An interim database config that will allow us to seamlessly change our ENV variables in a way that will allow us to merge the code that we're (temporarily) reverting here, and deploy it.

## WHY
We currently have an ENV variable for `DATABASE_URL` in PROD, which overrides anything in `database.yml`.  That means that any new code, on deploy, will be incompatible with Makara-specific code changes.
## HOW
By adding a `database.yml` file that supports the same behavior that the current `DATABASE_URL` generates, we can deploy this code, remove that ENV variable, and thus free us to deploy any `database.yml` code we want.  This should allow us to get the Makara code into place.

## Have you added and/or updated tests?
Local testing to ensure that this works as intended.  Deployed to staging for testing as well, where everything seems to be working fine.
