### PR TITLE
Release 2020-01-16

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :should_load_intercom
   before_action :set_raven_context
   before_action :confirm_valid_session
-  before_action :stick_to_leader_db
+  # before_action :stick_to_leader_db
 
   def admin!
     return if current_user.try(:admin?)

--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -29,75 +29,26 @@ follower_db_env: &follower_db_env
 
 development: &development
   <<: *default
-  adapter: postgresql_makara
-  makara:
-    id: postgres_development_db
-    disable_blacklist: true
-    sticky: true
-    master_ttl: 60
-    connections:
-      - role: master
-        name: leader
-        <<: *development_env
-      - role: slave
-        name: replica
-        <<: *development_env
+  adapter: postgresql
+  <<: *leader_db_env
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  adapter: postgresql_makara
-  makara:
-    id: postgres_development_db
-    disable_blacklist: true
-    sticky: true
-    master_ttl: 60
-    connections:
-      - role: master
-        name: leader
-        <<: *test_env
-      - role: slave
-        name: replica
-        <<: *test_env
+  adapter: postgresql
+  <<: *test_env
 
 staging: &staging
   <<: *default
-  adapter: postgresql_makara
-  makara:
-    id: postgres_staging_db
-    disable_blacklist: true
-    sticky: true
-    master_ttl: 60
-    connections:
-      - role: master
-        name: leader
-        <<: *leader_db_env
-      - role: slave
-        name: replica
-        <<: *follower_db_env
+  adapter: postgresql
+  <<: *leader_db_env
 
 sprint:
   <<: *staging
 
 production:
   <<: *default
-  adapter: postgresql_makara
-  makara:
-    id: postgres_production_db
-    disable_blacklist: true
-    sticky: true
-    master_ttl: 60
-    connections:
-      - role: master
-        name: leader
-        <<: *leader_db_env
-      - role: slave
-        name: dummy_replica
-        weight: <%= 100 - ENV['MAKARA_REPLICA_READ_PERCENTAGE'].to_i %>
-        <<: *leader_db_env
-      - role: slave
-        name: replica
-        weight: <%= ENV['MAKARA_REPLICA_READ_PERCENTAGE'].to_i %>
-        <<: *follower_db_env
+  adapter: postgresql
+  <<: *leader_db_env

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -5,8 +5,8 @@ class StickToLeaderDbSidekiqMiddleware
   end
 end
 
-Sidekiq.configure_server do |config|
-  config.server_middleware do |chain|
-    chain.add(StickToLeaderDbSidekiqMiddleware)
-  end
-end
+#Sidekiq.configure_server do |config|
+#  config.server_middleware do |chain|
+#    chain.add(StickToLeaderDbSidekiqMiddleware)
+#  end
+#end

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -29,11 +29,11 @@ describe PagesController do
   # end
 
   describe '#home_new' do
-    it 'should stick to the leader db' do
-      expect(controller).to receive(:stick_to_leader_db).and_call_original
-      expect(ActiveRecord::Base.connection).to receive(:stick_to_master!).at_least(:once)
-      get :home_new
-    end
+    #it 'should stick to the leader db' do
+    #  expect(controller).to receive(:stick_to_leader_db).and_call_original
+    #  expect(ActiveRecord::Base.connection).to receive(:stick_to_master!).at_least(:once)
+    #  get :home_new
+    #end
 
     context 'when user is signed in' do
       before do


### PR DESCRIPTION
- Log out Google users without a refresh token
- Disable Makara to see if it's the source of our db connection issues in prod