### PR TITLE
Refactor Generate Username query for speed

### DIFF
--- a/services/QuillLMS/app/services/generate_username.rb
+++ b/services/QuillLMS/app/services/generate_username.rb
@@ -18,7 +18,7 @@ class GenerateUsername
     part1         = "#{first_name}.#{last_name}".downcase
     part1_pattern = "%#{part1}%"
     at_classcode  = at_classcode(classcode)
-    extant        = User.where("username ILIKE ?", part1_pattern)
+    extant        = User.where("username LIKE ?", part1_pattern)
 
     if extant.any?
       final = "#{part1}#{extant.length + 1}#{at_classcode}"


### PR DESCRIPTION
## WHAT
Changing the SQL query in `generate_username.rb` to search for only the lowercase string of an existing username. See [this card](https://www.notion.so/quill/Refactor-username-generation-in-the-LMS-because-it-s-pretty-expensive-92e3cebde8674345914e5b0d77600fea).

## WHY
The query takes too long ([according to dashboard here](https://data.heroku.com/datastores/5d3bc272-7412-4e15-9210-0f43a2f14f68#diagnose)). Also we don't need to be comparing to uppercased usernames, because our code automatically downcases all the generated usernames so they are downcased in the database. For cases where there is an uppercased username in our databse, this new code will simply generate a new lowercased name in the database, which is considered unique because PSQL uniqueness constraints are case sensitive.

## HOW
Changing the query fragment from using `ILIKE` (case insensitive) to using `LIKE` (case sensitive).

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, small change.
