### PR TITLE
fix small bug with cursor location immediately after response submission

### DIFF
--- a/services/comprehension/frontend/src/components/studentView/editorContainer.tsx
+++ b/services/comprehension/frontend/src/components/studentView/editorContainer.tsx
@@ -4,7 +4,7 @@ import ContentEditable from 'react-contenteditable'
 const clearSrc =  `${process.env.QUILL_CDN_URL}/images/icons/clear.svg`
 
 interface EditorContainerProps {
-  unsubmittableResponses: Array<string>;
+  promptText: string;
   stripHtml: (string: string) => string;
   html: string;
   disabled: boolean;
@@ -24,11 +24,11 @@ export default class EditorContainer extends React.Component<EditorContainerProp
 
   shouldComponentUpdate(nextProps: EditorContainerProps) {
     // this prevents some weird cursor stuff from happening in the text editor
-    const { unsubmittableResponses, stripHtml, html, disabled } = nextProps
+    const { promptText, stripHtml, html, disabled } = nextProps
     if (disabled) return true
 
     // this prevents some weird cursor stuff from happening in the text editor
-    const firstEditHasAlreadyBeenMade = !unsubmittableResponses.includes(stripHtml(html))
+    const firstEditHasAlreadyBeenMade = promptText !== stripHtml(html)
     if (firstEditHasAlreadyBeenMade) return false
 
     return true

--- a/services/comprehension/frontend/src/components/studentView/promptStep.tsx
+++ b/services/comprehension/frontend/src/components/studentView/promptStep.tsx
@@ -30,6 +30,8 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     super(props)
 
     this.state = { html: this.formattedPrompt() };
+
+    this.editor = React.createRef()
   }
 
   lastSubmittedResponse = () => {
@@ -45,7 +47,8 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
   stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>/g, '').replace('&nbsp;', ' ')
 
   formattedPrompt = () => {
-    const { text, } = this.props.prompt
+    const { prompt, } = this.props
+    const { text, } = prompt
     return `<p>${this.allButLastWord(text)} <u>${this.lastWord(text)}</u>&nbsp;</p>`
   }
 
@@ -53,7 +56,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
 
   lastWord = (str: string) => str.substring(str.lastIndexOf(' ') + 1)
 
-  handleTextChange = (e) => {
+  onTextChange = (e) => {
     const { html, } = this.state
     const { value, } = e.target
     const text = value.replace(/<p>|<\/p>|<br>/g, '')
@@ -74,6 +77,8 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     this.setState({ html }, () => this.editor.innerHTML = html)
   }
 
+  setEditorRef = (node: JSX.Element) => this.editor = node
+
   renderButton = () => {
     const { prompt, submitResponse, submittedResponses, completeStep, everyOtherStepCompleted, } = this.props
     const { html, } = this.state
@@ -88,7 +93,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
       className = 'disabled'
       onClick = () => {}
     }
-    return <button className={className} onClick={onClick}>{buttonCopy}</button>
+    return <button className={className} onClick={onClick} type="button">{buttonCopy}</button>
   }
 
   renderFeedbackSection = () => {
@@ -126,6 +131,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
   }
 
   renderEditorContainer = () => {
+    const { html, } = this.state
     const { submittedResponses, prompt, } = this.props
     const lastSubmittedResponse = this.lastSubmittedResponse()
     let className = 'editor'
@@ -143,17 +149,19 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     return (<EditorContainer
       className={className}
       disabled={disabled}
-      handleTextChange={this.handleTextChange}
-      html={this.state.html}
-      innerRef={(node: JSX.Element) => this.editor = node}
+      handleTextChange={this.onTextChange}
+      html={html}
+      innerRef={this.setEditorRef}
+      promptText={prompt.text}
       resetText={this.resetText}
       stripHtml={this.stripHtml}
-      unsubmittableResponses={this.unsubmittableResponses()}
     />)
   }
 
   renderActiveContent = () => {
-    if (!this.props.active) return
+    const { active, } = this.props
+    if (!active) return
+
     return (<div className="active-content-container">
       {this.renderEditorContainer()}
       {this.renderButton()}


### PR DESCRIPTION
## WHAT
Fix a bug where the cursor location couldn't be manually changed immediately after a response submission in Comprehension.

## WHY
We want users to be able to use their mouse normally.

## HOW
Limit the cases where the interior Editor component will maintain its own DOM state to only after the very first edit has been made.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A
