### PR TITLE
Remove ConceptResult and ActivitySession from rails_admin

### DIFF
--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -136,4 +136,7 @@ RailsAdmin.config do |config|
         }
     end
   end
+
+  config.excluded_models << 'ActivitySession'
+  config.excluded_models << 'ConceptResult'
 end


### PR DESCRIPTION
## WHAT
Remove the `ConceptResult` and `ActivitySession` models from Rails admin
## WHY
These tables are huge, and loading them in admin results in extremely expensive DB calls.  We never need to admin these tables directly, anyway, so there's no advantage to allowing someone to accidentally click on them.
## HOW
`rails_admin` allows the simple blacklisting of models from its system, so I've added those models to the blacklist in the initializer.

## Have you added and/or updated tests?
This is a third-party gem, so we have no existing test coverage of it (and shouldn't need any).