### PR TITLE
fix test for generate_leap_csv

### DIFF
--- a/services/QuillLMS/spec/workers/upload_leap_report_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/upload_leap_report_worker_spec.rb
@@ -21,7 +21,7 @@ describe UploadLeapReportWorker, type: :worker do
       expected_start_date = Date.parse('2014-08-01')
       run_on_date = Date.parse('2015-01-10')
       expect(Date).to receive(:today).and_return(run_on_date)
-      expect_any_instance_of(School).to receive(:generate_leap_csv).with(activities_since: expected_start_date)
+      expect_any_instance_of(School).to receive(:generate_leap_csv).with(expected_start_date)
       expect(worker).to receive(:upload_data_to_s3)
       worker.perform(school.id)
     end
@@ -30,7 +30,7 @@ describe UploadLeapReportWorker, type: :worker do
       expected_start_date = Date.parse('2014-08-01')
       run_on_date = Date.parse('2014-09-10')
       expect(Date).to receive(:today).and_return(run_on_date)
-      expect_any_instance_of(School).to receive(:generate_leap_csv).with(activities_since: expected_start_date)
+      expect_any_instance_of(School).to receive(:generate_leap_csv).with(expected_start_date)
       expect(worker).to receive(:upload_data_to_s3)
       worker.perform(school.id)
     end


### PR DESCRIPTION
## WHAT
Fixing test that only requires expected_start_date

## WHY
Test was failing.

## HOW
Updated the assertion to only check for expected_start_date

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
YES
