### PR TITLE
Allow submission of new responses in Connect admin

### DIFF
--- a/services/QuillConnect/app/components/questions/question.jsx
+++ b/services/QuillConnect/app/components/questions/question.jsx
@@ -173,7 +173,7 @@ class Question extends React.Component {
               Optimal?
             </label>
           </p>
-          <button className="button is-primary" onClick={this.handleClickAddNewResponse} type="button">Add Response</button>
+          <button className="button is-primary" onClick={this.submitResponse} type="button">Add Response</button>
         </div>
       </Modal>
     );


### PR DESCRIPTION
## WHAT
Change the function that's used onClick when trying to submit new responses in Connect admin
## WHY
A refactor accidentally set the wrong function here, and it stopped submitting new responses to the CMS
## HOW
Just change the function called

## Have you added and/or updated tests?
Sadly insufficient tests on Connect, so nowhere to put a new test for this case