### PR TITLE
add &nbsp; to the list of replaced characters for Connect text editor, and prevent paste

### DIFF
--- a/services/QuillConnect/app/components/renderForQuestions/renderTextEditor.jsx
+++ b/services/QuillConnect/app/components/renderForQuestions/renderTextEditor.jsx
@@ -19,6 +19,13 @@ export default class RenderTextEditor extends React.Component {
     }
   }
 
+  componentDidMount() {
+    window.addEventListener('paste', (e) => {
+      e.preventDefault()
+      return false
+    }, true);
+  }
+
   componentWillReceiveProps(nextProps) {
     const { latestAttempt, getResponse, } = this.props
     if (nextProps.latestAttempt !== latestAttempt) {
@@ -116,7 +123,7 @@ export default class RenderTextEditor extends React.Component {
     const { disabled, onChange, } = this.props
     if (disabled) { return }
 
-    const stripHTML = e.target.value.replace(/<\/?[^>]+(>|$)/g, '')
+    const stripHTML = e.target.value.replace(/<\/?[^>]+(>|$)/g, '').replace(/&nbsp;/g, ' ')
     onChange(stripHTML, this.answerBox);
   }
 


### PR DESCRIPTION
## WHAT
In addition to filtering out HTML from submitted student responses, we were having some responses submit with "&nbsp;" as part of the response string, so I'm replacing those with regular spaces. Also, because the only way I could replicate this was by pasting a space in the text editor (though I'm pretty sure this is actually some kind of browser issue), I disabled pasting on the page. This is a feature I think we had previously and then got wiped out in some long-ago rewrite.

## WHY
See above.

## HOW
Just add a regex to check for instances of `&nbsp;` and replace them with a `' '`.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A