### PR TITLE
Speed up spell-check google cloud function

### DIFF
--- a/services/comprehension/spelling-local-api/main.py
+++ b/services/comprehension/spelling-local-api/main.py
@@ -8,12 +8,14 @@ FEEDBACK_TYPE = 'spelling'
 POS_FEEDBACK = 'Correct spelling!'
 NEG_FEEDBACK = 'Try again. There may be a spelling mistake.'
 SYM_SPELL = SymSpell(max_dictionary_edit_distance=2, prefix_length=7)
-DICTIONARY_PATH = (pkg_resources
-                   .resource_filename("symspellpy",
-                                      "frequency_dictionary_en_82_765.txt"))
-BIGRAM_PATH = (pkg_resources
-               .resource_filename("symspellpy",
-                                  "frequency_bigramdictionary_en_243_342.txt"))
+DICTIONARY_PATH = pkg_resources.resource_filename(
+                           "symspellpy",
+                           "frequency_dictionary_en_82_765.txt"
+                  )
+BIGRAM_PATH = pkg_resources.resource_filename(
+                            "symspellpy",
+                            "frequency_bigramdictionary_en_243_342.txt"
+              )
 DICTIONARY = SYM_SPELL.load_dictionary(DICTIONARY_PATH,
                                        term_index=0,
                                        count_index=1)

--- a/services/comprehension/spelling-local-api/unit_tests.py
+++ b/services/comprehension/spelling-local-api/unit_tests.py
@@ -14,10 +14,10 @@ def app():
 class TestDictionariesLoading(TestCase):
 
     def test_dictionary_file(self):
-        assert main.DICTIONARY
+        self.assertIsNotNone(main.DICTIONARY)
 
     def test_bigram_file(self):
-        assert main.BIGRAM_DICTIONARY
+        self.assertIsNotNone(main.BIGRAM_DICTIONARY)
 
 
 class TestParameterChecks(TestCase):


### PR DESCRIPTION
## WHAT
We were previously loading these big dictionary files on each time the endpoint was called, which was super slow (5-10 seconds per call). I changed these to global variables so they would be loaded once and then preserved, speeding the function up to ~250 ms.

## WHY
5-10 seconds is way too slow for one endpoint.

## HOW
Switching the local variables to global so they get pre-loaded when the cloud function loads.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
YES
