### PR TITLE
handle case where highlights is null

### DIFF
--- a/services/comprehension/frontend/src/components/studentView/container.tsx
+++ b/services/comprehension/frontend/src/components/studentView/container.tsx
@@ -178,6 +178,9 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     if (!(submittedResponsesForActivePrompt && submittedResponsesForActivePrompt.length)) { return passagesWithPTags }
 
     const lastSubmittedResponse = submittedResponsesForActivePrompt[submittedResponsesForActivePrompt.length - 1]
+
+    if (!lastSubmittedResponse.highlight) { return passagesWithPTags }
+
     const passageHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === "passage")
 
     passageHighlights.forEach(hl => {

--- a/services/comprehension/frontend/src/components/studentView/promptStep.tsx
+++ b/services/comprehension/frontend/src/components/studentView/promptStep.tsx
@@ -159,7 +159,6 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     let buttonCopy = submittedResponses.length ? 'Get new feedback' : 'Get feedback'
     let className = 'quill-button'
     let onClick = () => this.handleGetFeedbackClick(entry, prompt.prompt_id, prompt.text)
-    if (submittedResponses.length) { debugger; }
     if (submittedResponses.length === prompt.max_attempts || this.lastSubmittedResponse().optimal) {
       onClick = this.completeStep
       buttonCopy = everyOtherStepCompleted ? 'Done' : 'Start next sentence'


### PR DESCRIPTION
## WHAT
Handle case where highlights is null for a response and remove debugger

## WHY
It seems like our endpoint sometimes passes back null instead of an empty array for highlights, and we don't want to call `.filter` on null.

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A