### PR TITLE
fix filter button styling

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/custom.scss
+++ b/services/QuillLMS/app/assets/stylesheets/custom.scss
@@ -149,7 +149,7 @@ section {
   border-bottom: 1px solid #cecece;
 }
 
-button:not(.select-mixin):not(.quill-button):not(.focus-on-light):not(.focus-on-dark) {
+button:not(.select-mixin):not(.quill-button):not(.focus-on-light):not(.focus-on-dark):not(.filter-button) {
   padding: 10px 25px;
   font-size: 14px;
   border-radius: 5px;
@@ -329,7 +329,7 @@ label.css-label {
   }
 }
 
-button:not(.select-mixin):not(.quill-button):not(.focus-on-light):not(.focus-on-dark) {
+button:not(.select-mixin):not(.quill-button):not(.focus-on-light):not(.focus-on-dark):not(.filter-button) {
   padding: 10px 25px;
   font-size: 14px;
   &:active {

--- a/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
@@ -77,6 +77,9 @@
         }
         .app-buttons {
           display: flex;
+          .filter-button:focus {
+            outline: none;
+          }
         }
         &.diagnostic-section, &.whole-class-section {
           margin-right: 16px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_search/activity_search_filters/filter_button.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_search/activity_search_filters/filter_button.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
     const { data, active, } = this.props
     const activeClassName = active ? 'active' : null;
     return (
-      <button className={`${activeClassName} ${data.key}`} onClick={() => this.handleClick()}>
+      <button className={`${activeClassName} ${data.key} filter-button`} onClick={this.handleClick}>
         <div className={`tool-${data.key}-gray`} />
         <div>
           <h4>{data.alias}</h4>


### PR DESCRIPTION
## WHAT
Fix filter button styling.

## WHY
I think when I added additional `:not` selectors to the generic button class (my least favorite css rule in our codebase), CSS's cascading rules prioritized that styling over the styling we had applied to these buttons, making them look a little funky. This fixes that.

## HOW
Add an actual class name to these buttons and exempt them from the default button styling.

## Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="981" alt="Screen Shot 2020-02-12 at 11 44 10 AM" src="https://user-images.githubusercontent.com/18669014/74359943-2c2e0980-4d92-11ea-837d-f00efba4908e.png">

## Have you added and/or updated tests?
N/A
