### PR TITLE
fix teacher's class page student list cut-off

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -317,6 +317,14 @@
         cursor: pointer;
       }
     }
+    .data-table-row {
+      .data-table-row-section {
+        button {
+          min-width: 30px;
+          background-color: white;
+        }
+      }
+    }
     .data-table-row:last-of-type {
       border-bottom: none;
     }


### PR DESCRIPTION
## WHAT
fix the student list in the class table from having a scroll

## WHY
there is no need for the scroll unless the window is resized

## HOW
added css

## Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="929" alt="Screen Shot 2020-02-14 at 1 07 50 PM" src="https://user-images.githubusercontent.com/25959584/74547537-07b96500-4f2b-11ea-9a08-85ac07039578.png">

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
N/A