### PR TITLE
Update tests to validate new copy

### DIFF
--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -116,7 +116,7 @@ describe UserMailer do
     it 'should set the subject, receiver and the sender' do
       expect(mail.subject).to eq("#{user.first_name}, you are now an admin on Quill!")
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["becca@quill.org"])
+      expect(mail.from).to eq(["hello@quill.org"])
     end
   end
 
@@ -126,7 +126,7 @@ describe UserMailer do
 
     it 'should set the subject, receiver and the sender' do
       expect(mail.subject).to eq("#{user.name} has purchased School Premium for a missing school")
-      expect(mail.to).to eq(["becca@quill.org", "amr@quill.org", "emilia@quill.org"])
+      expect(mail.to).to eq(["hello@quill.org", "emilia@quill.org"])
       expect(mail.from).to eq(['hello@quill.org'])
     end
   end


### PR DESCRIPTION
## WHAT
Update tests that validate sender addresses for certain transactional emails
## WHY
Maddy made some changes to email sender addresses, but the old tests validated the old values.  
## HOW
Just update the tests to match the copy

## Have you added and/or updated tests?
That's all this is.