### PR TITLE
Bugfix for "Create Activity" button not working

### DIFF
--- a/services/QuillDiagnostic/app/components/lessons/lessonForm.tsx
+++ b/services/QuillDiagnostic/app/components/lessons/lessonForm.tsx
@@ -28,11 +28,11 @@ export interface LessonFormProps {
   sentenceFragments: SentenceFragmentsReducerState,
   stateSpecificClass?: string
   submit(object: {
-    name: string, 
-    questions: Array<Object>, 
-    landingPageHtml: string, 
-    flag: string, 
-    modelConceptUID: string, 
+    name: string,
+    questions: Array<Object>,
+    landingPageHtml: string,
+    flag: string,
+    modelConceptUID: string,
     isELL: boolean
   }): void,
   titleCards: TitleCardsReducerState,
@@ -57,7 +57,7 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
   constructor(props) {
     super(props)
 
-    const { flag, introURL, isELL, landingPageHtml, modelConceptUID, name, questions } = props.currentValues || ''; // eslint-disable-line react/destructuring-assignment
+    const { flag, introURL, isELL, landingPageHtml, modelConceptUID, name, questions } = props.currentValues || {}; // eslint-disable-line react/destructuring-assignment
 
     this.state = {
       flag: flag || 'alpha',
@@ -162,8 +162,8 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
           return ({ name: opt.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, ''), value: opt.key, });
         });
       } else {
-        formatted = options.map((opt: { key: string, title: string }) => { 
-          return { name: opt.title, value: opt.key } 
+        formatted = options.map((opt: { key: string, title: string }) => {
+          return { name: opt.title, value: opt.key }
         });
       }
       return (<QuestionSelector


### PR DESCRIPTION
## WHAT
The "Create Activity" button in Diagnostic was not working, because it was trying to access keys in a prop value that was undefined. I addressed this edge case by giving it a default value of empty string.

## WHY
Emma needs this!!! She needs to build a bunch of Diagnostic activities today.

## HOW
Giving it an empty string as default value so it doesn't error out.

## Screenshots
<img width="718" alt="Screen Shot 2020-02-19 at 12 35 48 PM" src="https://user-images.githubusercontent.com/57366100/74859102-63616500-5314-11ea-84e0-c1de0f16f0cd.png">

## Have you added and/or updated tests?
NO
