### PR TITLE
make "Add Response" button work for admins in Diagnostic

### DIFF
--- a/services/QuillDiagnostic/app/components/questions/question.jsx
+++ b/services/QuillDiagnostic/app/components/questions/question.jsx
@@ -69,7 +69,7 @@ class Question extends React.Component {
     this.setState({ uploadingNewOptimalResponses: true, });
   }
 
-  submitResponse = () => {
+  handleSubmitResponse = () => {
     const { params, dispatch, } = this.props
 
     const newResp = {
@@ -173,7 +173,7 @@ class Question extends React.Component {
               Optimal?
             </label>
           </p>
-          <button className="button is-primary" onClick={this.handleClickAddNewResponse} type="button">Add Response</button>
+          <button className="button is-primary" onClick={this.handleSubmitResponse} type="button">Add Response</button>
         </div>
       </Modal>
     );


### PR DESCRIPTION
## WHAT
The "Add Response" button was not working before, so I connected it to the right function call so it would work. Then I renamed that function as recommended by linting rules.

## WHY
So that Emma & Curriculum team can start adding new responses

## HOW
Hooking up the button to the right function call.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, couldn't find tests to update
