### PR TITLE
update careers page w/ product manager role

### DIFF
--- a/services/QuillLMS/app/views/pages/careers.html.erb
+++ b/services/QuillLMS/app/views/pages/careers.html.erb
@@ -82,9 +82,9 @@
             <h3>Product</h3>
           </div>
           <div class="positions">
-            <a target="_blank" href="https://angel.co/company/quill-org/jobs/583873-quill-org-technical-project-manager">
+            <a target="_blank" href="https://angel.co/company/quill-org/jobs/738265-quill-org-product-manager-nonprofit-edtech-startup">
               <div class="position">
-                <div>Technical Project Manager</div>
+                <div>Product Manager</div>
                 <img class="icon-img" src=<%= "#{expand_icon_url}" %> width=24 height=24 />
               </div>
             </a>


### PR DESCRIPTION
## WHAT
updated the careers page to have the most recent listing for Product Manager

## WHY
we want people to see the current job listing!

## HOW
changed the HTML tag and links

## Screenshots
<img width="926" alt="Screen Shot 2020-02-26 at 10 39 52 AM" src="https://user-images.githubusercontent.com/57366100/75360909-73cd8e80-5884-11ea-84be-d62df8723e3b.png">

## Have you added and/or updated tests?
NO
