### PR TITLE
log out admin users after 4 hours

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -146,7 +146,7 @@ class ApplicationController < ActionController::Base
     # Don't do anything if there's no authorized user or session
     return if !current_user || !session
     # if user is staff, logout if last_sign_in was more than 4 hours ago
-    if current_user && current_user.role == 'staff'
+    if current_user && current_user.role == 'staff' && current_user.last_sign_in
       time_diff = Time.now - current_user.last_sign_in
       time_diff = time_diff.round.abs
       hours = time_diff / 3600


### PR DESCRIPTION
## WHAT
Logging out staff members after 4 hours.

## WHY
This is a security best practice. It also helps present our application as secure to the College Board.

## HOW
Test if user last signed in more than 4 hours ago

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
NO