### PR TITLE
Restrict salesmachine events on the front end

### DIFF
--- a/services/QuillLMS/client/app/modules/analytics/index.ts
+++ b/services/QuillLMS/client/app/modules/analytics/index.ts
@@ -43,8 +43,8 @@ class SegmentAnalytics {
 
     const eventProperties = Object.assign(this.formatCustomProperties(properties), this.getDefaultProperties());
     const integrations = {
-      Salesmachine:false,
-      Intercom:false
+      Salesmachine: false,
+      Intercom: false
     }
     const options = { integrations }
 


### PR DESCRIPTION
## WHAT
We currently send some data to Segment through the `track` method in the Segment API. However, we send this data without limiting the destinations it should reach, which means that we send all of it to Salesmachine and Intercom. This PR adds a parameter to our `track` API call to force it to block Salesmachine and Intercom from the destinations that will receive this data.

## WHY
We need to block these events from reaching Salesmachine because they are unnecessary and causing us to hit Salesmachine's API rate limit.

## HOW
Adding the `options` argument to our API call, as per instructions on the Segment API docs.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, we don't have tests written for the API call
