### PR TITLE
Deploy - Use force push since Heroku’s history is different

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -25,7 +25,7 @@ esac
 read -r -p "Deploy branch '$CURRENT_BRANCH' to '$1' environment? [Y/n]" response
 if [[ "$response" =~ ^([Y])$ ]]
 then
-    git push ${DEPLOY_GIT_REMOTE} ${CURRENT_BRANCH}:master -v
+    git push -f ${DEPLOY_GIT_REMOTE} ${CURRENT_BRANCH}:master -v
     open "https://rpm.newrelic.com/accounts/2639113/applications/548856875"
 else
     echo "Ok, we won't deploy. Have a good day!"


### PR DESCRIPTION
## WHAT
Use force push to deploy to heroku.
## WHY
Heroku is rejecting the pushes for the different histories. So we either have to pull the heroku history into a branch `git pull quill-lms-staging master` or do a force push to ignore the history comparison.
## HOW
Pass `-f` flag. Our previous deploy process used this. I just thought we could get away with not using it. I was incorrect.


## Have you added and/or updated tests?
No, command line script.

