### PR TITLE
filter undefined activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -84,7 +84,7 @@ export default class CreateUnit extends React.Component {
       const { activities, } = body
       const activityIdsArray = this.props.params.activityIdsArray || window.localStorage.getItem(ACTIVITY_IDS_ARRAY)
       const activityIdsArrayAsArray = activityIdsArray.split(',')
-      const selectedActivities = activityIdsArrayAsArray.map(id => activities.find(act => String(act.id) === id))
+      const selectedActivities = activityIdsArrayAsArray.map(id => activities.find(act => String(act.id) === id)).filter(Boolean)
       this.setState({ activities: activities, selectedActivities: selectedActivities, })
     })
   }


### PR DESCRIPTION
## WHAT
Filter undefined activities from the selectedActivities array so the front end doesn't error.

## WHY
Some of our unit templates apparently contain archived activities, which result in teachers being unable to assign those packs. This will filter those activities from the array on the frontend, making it so that teachers can assign the rest of the ones in the pack.

## HOW
`.filter(Boolean)` will filter for truthy values.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A