### PR TITLE
Send no back-end events to Salesmachine under any circumstances

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -98,7 +98,7 @@ class SegmentAnalytics
     integrations = {
      all: true,
      Intercom: should_send_data,
-     Salesmachine: should_send_data
+     Salesmachine: false
     }
     integrations
   end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -38,13 +38,13 @@ describe 'SegmentAnalytics' do
     let(:teacher) { create(:teacher) }
     let(:student) { create(:student) }
 
-    it 'sends events to the Salesmachine integration when user is a teacher' do
+    it 'never sends events to Intercom but not Salesmachine, even if the user is a teacher' do
       analytics.track(teacher, {})
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:integrations]).to eq({
         all: true,
-        Salesmachine: true,
+        Salesmachine: false,
         Intercom: true
       })
     end


### PR DESCRIPTION
## WHAT
Stop sending back-end events to Salesmachine
## WHY
We're still over our rate-limit for Salesmachine events, and after discussion with Peter and Jeremy we don't need these events in Salesmachine, so we're going to stop sending them
## HOW
We were sending events to Salesmachine if the user was a teacher, but now we're just never sending to Salesmachine

## Have you added and/or updated tests?
Updated the tests with the new conditions
