### PR TITLE
avoid null error in grammar

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/question.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/question.tsx
@@ -255,7 +255,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     const question = this.currentQuestion()
     const latestAttempt: Response | undefined = this.getLatestAttempt(question.attempts)
 
-    if (question.attempts.length === ALLOWED_ATTEMPTS && !latestAttempt.optimal) { return }
+    if ((question.attempts && question.attempts.length === ALLOWED_ATTEMPTS) && (latestAttempt && !latestAttempt.optimal)) { return }
     const disabled = [CORRECTLY_ANSWERED, FINAL_ATTEMPT].includes(questionStatus) ? 'disabled' : null
     return (<Row align="middle" justify="start" type="flex">
       <ContentEditable


### PR DESCRIPTION
## WHAT
Fix error caused by calling `.length` on null in Grammar.

## WHY
This fixes an edge case where the `.attempts` array hasn't populated yet on page reload in Grammar, causing the page to throw an error.

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A