### PR TITLE
update cors policy (#6073)

### DIFF
--- a/services/QuillCMS/config/environments/production.rb
+++ b/services/QuillCMS/config/environments/production.rb
@@ -85,8 +85,11 @@ Rails.application.configure do
   # Allow cross site origin in the following contexts
   config.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins 'https://connect.quill.org', 'https://quillconnect.firebaseapp.com', 'localhost:8080'
-      resource '*', :headers => :any, :methods => [:get, :post, :put, :options, :delete]
+      origins '*'
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head]
     end
   end
 

--- a/services/QuillGrammar/src/components/grammarActivities/question.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/question.tsx
@@ -77,7 +77,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
 
   previousResponses = () => {
     const question = this.currentQuestion()
-    return question.attempts.map(a => a.text)
+    return question.attempts ? question.attempts.map(a => a.text) : []
   }
 
   getCurrentQuestionStatus(currentQuestion) {


### PR DESCRIPTION
* dummy change

* dependabot; removing nbsp spaces from connect responses; add isEll flag (#5863)

* Bump rack from 1.6.11 to 1.6.12 in /services/QuillLMS

Bumps [rack](https://github.com/rack/rack) from 1.6.11 to 1.6.12.
- [Release notes](https://github.com/rack/rack/releases)
- [Changelog](https://github.com/rack/rack/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rack/rack/compare/1.6.11...1.6.12)

Signed-off-by: dependabot[bot] <support@github.com>

* Jest testing for Diagnostic Container (#5819)

* setup test framework for diagnostic container

* add test files

* add tests for prop dependent rendering

* add component function tests

* update tests for standard diagnostic

* reconcile lock file

* remove empty file

* small variable updates

* Add isELL flag for Diagnostic activities; convert associated files into Typescript (#5846)

* various refactoring; add testing for updated components; fix eslint errors; remove deprecated eslint rule

* typescript updates

* add more interfaces and typescript reducers; update tests

* add lesson interface; fix eslint errors; update function names; update tests

* add &nbsp; to the list of replaced characters, and prevent paste (#5862)

Co-authored-by: hequill <55706216+hequill@users.noreply.github.com>
Co-authored-by: Eric Adams <erictayloradams@gmail.com>

* fix clever sign up link (#5870)

* dummy change

* fix clever sign up link

* fix null error

* update cors policy

Co-authored-by: hequill <55706216+hequill@users.noreply.github.com>
Co-authored-by: Eric Adams <erictayloradams@gmail.com>
Co-authored-by: cissyxyu <57366100+cissyxyu@users.noreply.github.com>
Co-authored-by: Anathomical <thomas.robertson@quill.org>
Co-authored-by: dandrabik <dandrabik@users.noreply.github.com>

## WHAT

## WHY

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

