### PR TITLE
avoid null error in transition from proofreader to grammar

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/intro.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/intro.tsx
@@ -29,7 +29,7 @@ export default class Intro extends React.Component<IntroProps, IntroState> {
 
   handleNextClick = () => {
     const { activity, startActivity, } = this.props
-    if (activity.landingPageHtml && this.landingPageHtmlHasText()) {
+    if (activity && activity.landingPageHtml && this.landingPageHtmlHasText()) {
       this.setState({ showLandingPage: true, });
     } else {
       startActivity();


### PR DESCRIPTION
## WHAT
Add null check for `activity` in landing page code for Grammar.

## WHY
When we generate a mini Grammar activity for students after their Proofreader session is completed, there is no actual activity in the Redux store, and therefore we were getting an error when the student tried to move on from the intro page. This will fix that.

## HOW
Just null check.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
N/A