### PR TITLE
Add a separate School Closure Premium type for schools

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -301,7 +301,7 @@ class Subscription < ActiveRecord::Base
       if attributes[:account_type]&.downcase == 'teacher trial'
         PremiumAnalyticsWorker.perform_async(school_or_user_id, attributes[:account_type])
         attributes = attributes.merge(Subscription.set_trial_expiration_and_start_date)
-      elsif attributes[:account_type] == COVID_19_SUBSCRIPTION_TYPE
+      elsif [COVID_19_SUBSCRIPTION_TYPE, COVID_19_SCHOOL_SUBSCRIPTION_TYPE].include?(attributes[:account_type])
         attributes = attributes.merge(Subscription.set_covid_expiration_and_start_date)
         extend_current_subscription_for_covid_19(school_or_user)
       else


### PR DESCRIPTION
## WHAT
Add a separate School Closure Premium type for schools
## WHY
The current approach displays individual School Closure Premium as a "School" class of Premium in the Teacher Dashboard "My Subscriptions" page.  This also creates a new subscription type that can be assigned to Schools to upgrade them if necessary and keep a differentiation between School and Teacher premium.
## HOW
Remove the existing Closure Premium type from the list of School Premium Types, create a new Closure Premium type explicitly for schools, add that new type to the list of School Premium Types

## Screenshots
<img width="1035" alt="Screen Shot 2020-03-19 at 5 53 52 PM" src="https://user-images.githubusercontent.com/331565/77118472-a7768100-6a0a-11ea-90fd-4910336fe922.png">

## Have you added and/or updated tests?
Small tweak to include new subscription type in tests