### PR TITLE
Update class-code generation to refuse specified terms

### DIFF
--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -1,4 +1,5 @@
 class Classroom < ActiveRecord::Base
+  CODE_DISALLOWED_TERMS = %w(nut)
   GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)
   validates_uniqueness_of :code
   validates_presence_of :name
@@ -106,11 +107,9 @@ class Classroom < ActiveRecord::Base
 
   def self.generate_unique_code
     code = NameGenerator.generate
-    if Classroom.unscoped.find_by_code(code)
-       generate_unique_code
-    else
-      code
-    end
+    return generate_unique_code if Classroom.unscoped.find_by_code(code)
+    return generate_unique_code if !(code.split('-') & CODE_DISALLOWED_TERMS).empty?
+    code
   end
 
   def hide_appropriate_classroom_units

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -190,6 +190,23 @@ describe Classroom, type: :model do
       classroom.update_attributes(name: 'Testy Westy')
       expect(classroom.code).to eq(old_code)
     end
+
+    it "checks to make sure the generated code is not already in use" do
+      used_code = NameGenerator.generate
+      new_code = NameGenerator.generate
+      create(:classroom, code: used_code)
+      expect(NameGenerator).to receive(:generate).and_return(used_code, new_code)
+      classroom.set_code
+      expect(classroom.code).to eq(new_code)
+    end
+
+    it "ensures that generated codes do not include disallowed terms" do
+      disallowed_term = Classroom::CODE_DISALLOWED_TERMS.first
+      allowed_term = 'allowed'
+      expect(NameGenerator).to receive(:generate).and_return(disallowed_term, allowed_term)
+      classroom.set_code
+      expect(classroom.code).to eq(allowed_term)
+    end
   end
 
 end


### PR DESCRIPTION
## WHAT
Update class-code generation to refuse specified terms
## WHY
While the name generator is pretty safe already, there are some terms in it that can generate funny-to-kids names like "nut-basket"
## HOW
Add a condition to see if any disallowed terms are part of a class code before finally setting it

## Have you added and/or updated tests?
Yes.  Added new test cases around invalid new class codes

## Have you deployed to Staging?
Yes.  Tested and working in staging.