### PR TITLE
Copy changes for COVID-related Premium copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/premium_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/premium_mini.test.jsx.snap
@@ -11,14 +11,14 @@ exports[`PremiumMini component should render 1`] = `
       className="premium-container "
     >
       <h4>
-        Try Premium for Free
+        Activate free Quill Premium
       </h4>
       <button
         className="btn btn-orange"
         onClick={[Function]}
         type="button"
       >
-        Get Premium Free for 30 days
+        Get Premium Free until 7/31/2020
       </button>
       <p
         className="credit-card"
@@ -26,10 +26,10 @@ exports[`PremiumMini component should render 1`] = `
         No credit card required.
       </p>
       <p>
-        Unlock your Premium trial to save time grading and gain actionable insights.
+        Due to school closures, we're offering Quill Premium free for the rest of the school year.
       </p>
       <a
-        href="https://support.quill.org/quill-premium"
+        href="/subscriptions/activate_covid_subscription"
         target="_blank"
       >
         Learn more about Premium

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/premium_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/premium_mini.jsx
@@ -18,7 +18,7 @@ export default class PremiumMini extends React.Component {
         <h4>Activate free Quill Premium</h4>
         <button className="btn btn-orange" onClick={this.handleBeginTrialClick} type="button">Get Premium Free until 7/31/2020</button>
         <p className="credit-card">No credit card required.</p>
-        <p>Due to school closures, we're offering Quill Premium free for the rest of the school year.</p>
+        <p>Due to school closures, we&apos;re offering Quill Premium free for the rest of the school year.</p>
         {supportLink}
       </div>
     );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
   //   })
   // },
 
-  activateSubscription() {
+  handleActivateSubscription() {
     window.location.href = '/subscriptions/activate_covid_subscription'
   },
 
@@ -33,7 +33,7 @@ export default React.createClass({
         </div>
         <div className="col-md-3 col-xs-12 pull-right">
           <div className="premium-button-box text-center">
-            <button className="btn-orange" onClick={this.activateSubscription} type="button">Get Premium Free</button>
+            <button className="btn-orange" onClick={this.handleActivateSubscription} type="button">Get Premium Free</button>
             <br />
             <span>No credit card required</span>
           </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_status.jsx
@@ -4,7 +4,7 @@ import pluralize from 'pluralize';
 
 const quillBasicCopy = (
   <span>
-    Quill Basic provides access to all of Quill's content. To access Quill Premium, you can purchase an individual teacher subscription or a school subscription. We are currently offering Quill Premium for free for the rest of the 2019/20 school year. Activate <a href="/subscriptions/activate_covid_subscription">here</a>.
+    Quill Basic provides access to all of Quill&apos;s content. To access Quill Premium, you can purchase an individual teacher subscription or a school subscription. We are currently offering Quill Premium for free for the rest of the 2019/20 school year. Activate <a href="/subscriptions/activate_covid_subscription">here</a>.
   </span>);
 
 const schoolPremiumCopy = (


### PR DESCRIPTION
## WHAT
A bunch of copy changes that update all our premium flyers, banners, etc. with the new free premium policy and links. See this [card here](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=6d046a7464bf4a358b21f07d5583d427).

## WHY
So our website copy reflects consistent, updated content on our new Premium policy.

## HOW
Copy changes inside html elements, added one button click redirect.

## Screenshots
<img width="285" alt="Screen Shot 2020-03-31 at 1 00 13 PM" src="https://user-images.githubusercontent.com/57366100/78054612-56db1e00-7350-11ea-9894-24c03490ea05.png">
<img width="941" alt="Screen Shot 2020-03-31 at 1 00 27 PM" src="https://user-images.githubusercontent.com/57366100/78054621-59d60e80-7350-11ea-8166-4d5cbe71c360.png">
<img width="919" alt="Screen Shot 2020-03-31 at 1 00 52 PM" src="https://user-images.githubusercontent.com/57366100/78055521-aa9a3700-7351-11ea-97e3-66a882c344e9.png">


## Have you added and/or updated tests?
YEP.

## Have you deployed to Staging?
Not yet - deploying now!
