### PR TITLE
rewrite regex route logic to make lms react load on safari

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/index.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/index.jsx
@@ -133,33 +133,33 @@ class DiagnosticReports extends React.Component {
 		// we don't want to render a navbar for the activity packs, not_completed, or diagnostics
 		if (['/activity_packs', '/not_completed', '/diagnostics'].indexOf(this.props.location.pathname) !== -1) {
 			return (
-        <div>{this.props.children}</div>
+  <div>{this.props.children}</div>
 			)
 		} else if (this.state.loading) {
 			return <LoadingSpinner />
 		} else {
 			return (
-        <div className='individual-activity-reports'>
-          <NavBar
-            buttonGroupCallback={this.changeReport}
-            classrooms={this.state.classrooms}
-            dropdownCallback={this.changeClassroom}
-            key={'key'}
-            params={params}
-            selectedActivity={this.state.selectedActivity}
-            selectedStudentId={params.studentId}
-            showStudentDropdown={this.showStudentDropdown()}
-            studentDropdownCallback={this.changeStudent}
-            students={this.state.students}
-          />
-          {this.props.children}
-          <Switch>
-            <Route component={routerProps => <StudentReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/student_report/:studentId' />
-            <Route component={routerProps => <Recommendations params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/recommendations' />
-            <Route component={routerProps => <QuestionReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/questions' />
-            <Route component={routerProps => <ClassReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/students' />
-          </Switch>
-        </div>
+  <div className='individual-activity-reports'>
+    <NavBar
+      buttonGroupCallback={this.changeReport}
+      classrooms={this.state.classrooms}
+      dropdownCallback={this.changeClassroom}
+      key={'key'}
+      params={params}
+      selectedActivity={this.state.selectedActivity}
+      selectedStudentId={params.studentId}
+      showStudentDropdown={this.showStudentDropdown()}
+      studentDropdownCallback={this.changeStudent}
+      students={this.state.students}
+    />
+    {this.props.children}
+    <Switch>
+      <Route component={routerProps => <StudentReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/student_report/:studentId' />
+      <Route component={routerProps => <Recommendations params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/recommendations' />
+      <Route component={routerProps => <QuestionReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/questions' />
+      <Route component={routerProps => <ClassReport params={params} {...routerProps} />} path='/u/:unitId/a/:activityId/c/:classroomId/students' />
+    </Switch>
+  </div>
 			);
 		}
 	}


### PR DESCRIPTION
## WHAT
Rewrite regex lookbehinds to just use normal regex and then remove part we don't want.

## WHY
Regex lookbehinds do not work on Safari, causing none of our React code to render.

## HOW

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
Small fix