### PR TITLE
Redirect to the correct URL on creation of questions

### DIFF
--- a/services/QuillConnect/app/actions/fillInBlank.ts
+++ b/services/QuillConnect/app/actions/fillInBlank.ts
@@ -96,7 +96,7 @@ function submitNewQuestion(content, response) {
       dispatch(submitResponse(response));
       dispatch(loadQuestion(response.questionUID));
       dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
-      const action = push(`/admin/questions/${response.questionUID}`);
+      const action = push(`/admin/fill-in-the-blanks/${response.questionUID}`);
       dispatch(action);
     }, (error) => {
       dispatch({ type: C.RECEIVE_NEW_FILL_IN_BLANK_QUESTION_RESPONSE, });

--- a/services/QuillConnect/app/actions/sentenceFragments.ts
+++ b/services/QuillConnect/app/actions/sentenceFragments.ts
@@ -113,7 +113,7 @@ function submitNewSentenceFragment(content, response) {
       dispatch(submitResponse(response));
       dispatch(loadSentenceFragment(response.questionUID));
       dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
-      const action = push(`/admin/questions/${response.questionUID}`);
+      const action = push(`/admin/sentence-fragments/${response.questionUID}`);
       dispatch(action);
     }, (error) => {
       dispatch({ type: C.RECEIVE_NEW_QUESTION_RESPONSE, });

--- a/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillConnect/app/components/fillInBlank/fillInBlankForm.jsx
@@ -75,7 +75,6 @@ class FillInBlankForm extends Component {
       cuesLabel: this.state.cuesLabel
     };
     this.props.action(data, this.state.newQuestionOptimalResponse);
-    window.location.href = window.location.origin + '/#/admin/fill-in-the-blanks/' + questionID;
   };
 
   toggleQuestionBlankAllowed = () => {


### PR DESCRIPTION
## WHAT
Fix:
1. A race condition that sometimes canceled creating new Fill in the Blank questions while trying to redirect to the (not-yet-existent) new question
1. Update the redirect when creating new Fill in the Blank (and sentence fragment) questions to be go to the right place
## WHY
New fill in the blank questions were sometimes not being created, and even when they were, users were ending up at the wrong URL making it look like it hadn't been created properly
## HOW
Just update the route URLs and delete an extraneous (and race-condition-y) redirect

## Have you added and/or updated tests?
No test coverage around redirects

## Have you deployed to Staging?
Yes