### PR TITLE
Render AP routes on page, Support both caps and non-caps.

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -8,8 +8,8 @@ EmpiricalGrammar::Application.routes.draw do
   end
 
   # temporary setup for AP landing page
-  get '/AP' => redirect('activities/packs/193')
-  get '/ap' => redirect('activities/packs/193')
+  get '/AP' => 'teachers/unit_templates#index', defaults: {id: 193}
+  get '/ap' => 'teachers/unit_templates#index', defaults: {id: 193}
 
   post "/graphql", to: "graphql#execute"
 


### PR DESCRIPTION
## WHAT
Support caps in the ap url and render on page instead of redirect.
## WHY
They asked for it.
## HOW
Magic.

## Have you added and/or updated tests?
No.

## Have you deployed to Staging?
NO - tiny change
