### PR TITLE
Release 2020-04-22-2. Render /AP and /ap on page rather than redirect. (#6242)

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -8,7 +8,8 @@ EmpiricalGrammar::Application.routes.draw do
   end
 
   # temporary setup for AP landing page
-  get '/ap' => redirect('activities/packs/193')
+  get '/AP' => 'teachers/unit_templates#index', defaults: {id: 193}
+  get '/ap' => 'teachers/unit_templates#index', defaults: {id: 193}
 
   post "/graphql", to: "graphql#execute"
 


### PR DESCRIPTION
* Add caps route for AP.

* Don’t redirect, just render for AP links.

## WHAT

## WHY

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
