### PR TITLE
Change the days for displaying the Live Q&A banner

### DIFF
--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -1,10 +1,9 @@
 <% current_time_on_east_coast = Time.now.in_time_zone('America/New_York') %>
 <% current_hour = current_time_on_east_coast.hour %>
-<% between_nine_and_ten = current_hour == 9 %>
 <% between_twelve_and_one = current_hour == 12 %>
-<% not_a_weekend = !current_time_on_east_coast.saturday? && !current_time_on_east_coast.sunday? %>
+<% monday_tuesday_or_thursday = current_time_on_east_coast.monday? || current_time_on_east_coast.thursday? || current_time_on_east_coast.tuesday? %>
 
-<% if (!current_user || current_user.teacher?) && (between_nine_and_ten || between_twelve_and_one) && not_a_weekend %>
+<% if (!current_user || current_user.teacher?) && (monday_tuesday_or_thursday && between_twelve_and_one) %>
   <div class="covid-banner" id="webinar-banner">
     <div class="content-container">
       <img alt="Video player with play symbol" class="banner-icon" src=<%= "#{ENV['CDN_URL']}/images/icons/live-stream.svg" %>>


### PR DESCRIPTION
## WHAT
Partnerships is changing their live Q&A schedule, so the Q&A banner display times should change accordingly.
They want the banner to be seen only 12pm-1pm on Mondays, Tuesdays, and Thursdays.

## WHY
Because Partnerships is no longer doing Q&As on the other times.

## HOW
Change the Time constraints for displaying the banner.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, tiny temporary change

## Have you deployed to Staging?
NO - tiny change
