### PR TITLE
fix failing test on develop

### DIFF
--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -9,9 +9,10 @@ describe BlogPostsController, type: :controller do
     let(:blog_posts) { create_list(:blog_post, 3) }
     let(:draft_post) { create(:blog_post, :draft) }
 
-    it 'should return all non-draft blog posts' do
+    it 'should return all non-draft blog posts where the topic is a teacher topic' do
       get :index
-      expect(assigns(:blog_posts)).to match_array(blog_posts)
+      teacher_blog_posts = blog_posts.select { |bp| BlogPost::TEACHER_TOPICS.include?(bp.topic) }
+      expect(assigns(:blog_posts)).to match_array(teacher_blog_posts)
     end
 
     it 'should never return a draft' do


### PR DESCRIPTION
## WHAT
Fix test that has started intermittently failing on develop.

## WHY
I changed the return value of a controller function to return a filtered list of blog posts, but didn't update this, so it was sometimes generating blog posts that weren't included on the filtered list and failing. Now it will always pass.

## HOW
Match return value against a filtered array, rather than the whole generated array.

## Screenshots
N/A

## Have you added and/or updated tests?
YES

## Have you deployed to Staging?
No, test change