### PR TITLE
Remove "github issues" icon from footer

### DIFF
--- a/services/QuillLMS/app/views/pages/shared/_footer.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_footer.html.erb
@@ -88,7 +88,6 @@
       <a target="_blank" href="https://www.youtube.com/channel/UCG9mgvktG6vxp7XoYEJTiaw/videos?flow=list&view=0&sort=dd&live_view=500"><i class="fab fa-youtube" aria-hidden="true"></i></a>
       <a target="_blank" href="https://facebook.com/quill.org"><i class="fab fa-facebook" aria-hidden="true"></i></a>
       <a target="_blank" href="http://instagram.com/quill_org/"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-      <a target="_blank" href="https://github.com/empirical-org/Empirical-Core/issues"><i class="fab fa-github-alt" aria-hidden="true"></i></a>
     </div>
     <form action="/teacher-center/search">
       <div class="input">


### PR DESCRIPTION
## WHAT
Because Quill doesn't use Github Issues to track things on our site anymore, we want to remove the icon and link from our website's footer.

## WHY
To keep the main LMS page up to date.

## HOW
Removing the icon and link from `_footer.html.erb`

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, tiny change

## Have you deployed to Staging?
Not yet - deploying now!
