### PR TITLE
Redirect student to saved Proofreader session if they saved their session

### DIFF
--- a/services/QuillProofreader/src/actions/session.ts
+++ b/services/QuillProofreader/src/actions/session.ts
@@ -34,7 +34,7 @@ export const setSessionReducerToSavedSession = (sessionID: string, initialLoad?:
       const session = snapshot.val()
       if (session && !session.error) {
         if (session.conceptResults && initialLoad) {
-          window.location.href = `${process.env.QUILL_GRAMMAR_URL}/play/sw?proofreaderSessionId=${sessionID}`
+          window.location.href = `${window.location.origin}/#/play/sw?proofreaderSessionId=${sessionID}`
         } else {
           dispatch(setSessionReducer(session.passage))
         }


### PR DESCRIPTION
## WHAT
If a student has saved a Proofreader session and wants to resume it, they should go back to their saved session. 
Right now we have their session reloading into a grammar Activity, probably because of a typo copying from another method where we redirect them into Quill Grammar.

## WHY
We don't want students to get redirected into the wrong Activity.

## HOW
Changing the redirect link in QuillProofreader saved sessions.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, tiny change

## Have you deployed to Staging?
Not yet - deploying now!
