### PR TITLE
Release 2020-05-07

### DIFF
--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -10475,9 +10475,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "jquery-ujs": {
       "version": "1.2.2",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -45,7 +45,7 @@
     "history": "^2.0.1",
     "imports-loader": "^0.6.5",
     "isomorphic-fetch": "^2.2.1",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.0",
     "jquery-ujs": "^1.2.1",
     "lazysizes": "^5.2.0-beta1",
     "loader-utils": "^0.2.13",


### PR DESCRIPTION
Bump jquery from 3.4.1 to 3.5.0 in /services/QuillLMS/client