### PR TITLE
fix bug with editing grammar activities

### DIFF
--- a/services/QuillGrammar/src/components/grammarActivities/container.tsx
+++ b/services/QuillGrammar/src/components/grammarActivities/container.tsx
@@ -85,9 +85,9 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
 
     componentWillReceiveProps(nextProps: PlayGrammarContainerProps) {
       const { dispatch, session, } = this.props
-      if (nextProps.grammarActivities.hasreceiveddata && !nextProps.session.hasreceiveddata && !nextProps.session.pending && !nextProps.session.error) {
+      if (nextProps.grammarActivities.hasreceiveddata && nextProps.grammarActivities.currentActivity && !nextProps.session.hasreceiveddata && !nextProps.session.pending && !nextProps.session.error) {
         const { questions, concepts, flag } = nextProps.grammarActivities.currentActivity
-        if (questions) {
+        if (questions && questions.length) {
           dispatch(getQuestions(questions, flag))
         } else {
           dispatch(getQuestionsForConcepts(concepts, flag))

--- a/services/QuillGrammar/src/components/lessons/lesson.tsx
+++ b/services/QuillGrammar/src/components/lessons/lesson.tsx
@@ -95,12 +95,12 @@ class Lesson extends React.Component<LessonProps> {
   }
 
   renderQuestionsForLesson(): JSX.Element[]|JSX.Element {
-    const lessonQuestions = this.lesson()? this.lesson().questions : null
-    const lessonConcepts = this.lesson()? this.lesson().concepts : null
+    const lessonQuestions = this.lesson() ? this.lesson().questions : null
+    const lessonConcepts = this.lesson() ? this.lesson().concepts : null
     let questionsForLesson
     const { questions } = this.props
     if (questions.hasreceiveddata) {
-      if (lessonQuestions) {
+      if (lessonQuestions && lessonQuestions.length) {
         questionsForLesson = lessonQuestions.map(q => {
           const question = questions.data[q.key]
           question.key = q.key
@@ -108,8 +108,8 @@ class Lesson extends React.Component<LessonProps> {
         })
         return this.renderQuestionsAsList(questionsForLesson)
       } else if (lessonConcepts) {
-        const questionsData = this.props.questions ? hashToCollection(questions.data) : []
-        const conceptUids = Object.keys(this.lesson().concepts)
+        const questionsData = questions ? hashToCollection(questions.data) : []
+        const conceptUids = Object.keys(lessonConcepts)
         questionsForLesson = questionsData.filter(q => conceptUids.includes(q.concept_uid) && permittedFlag(this.lesson().flag, q.flag))
         return this.renderQuestionsByConcept(questionsForLesson)
       }


### PR DESCRIPTION
## WHAT
Check that the array of a grammar activity's associated questions is not empty when determining whether to use that or the associated concepts to generate the content for the activity.

## WHY
I think when grammar activities were on Firebase, there was no such thing as an empty array value for a grammar activity's questions attribute: there was either a populated array or null. Now, though, when you update a grammar activity but don't add any questions, it saves an empty array as the value, so then when you try to play the activity it doesn't load any questions at all, instead of picking questions associated with the activity's concept. This fixes that.

## HOW
Check to make sure that the activity's questions array has content when determining whether to use the `.questions` or `.concepts` value to get content for the activity. I also fixed another bug that I noticed while I was at it (trying to extract data from `nextProps.grammarActivities.currentActivity` when it was sometimes undefined).

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
No - very small change.