### PR TITLE
Make frontend deploys only post ‘FINISHED’ message.

### DIFF
--- a/scripts/post_slack_deploy.sh
+++ b/scripts/post_slack_deploy.sh
@@ -7,7 +7,7 @@
 username=$(git config user.name)
 if $4; then status='FINISHED'; else status='STARTED'; fi
 
-message=":ship: *$1 $2 Deploy* \`$status\`. *_$3_* branch, deployed by: $username"
+message=":ship: *$1 $2 Deploy* \`$status\`. branch: *_$3_*, deployed by: $username"
 webhook=$(heroku config:get SLACK_API_WEBHOOK --app empirical-grammar)
 
 curl -X POST -H 'Content-type: application/json' --data "{'text':'$message'}" $webhook

--- a/services/QuillConnect/deploy.sh
+++ b/services/QuillConnect/deploy.sh
@@ -25,9 +25,6 @@ case $1 in
     exit 1
 esac
 
-# Slack deploy start
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-
 # Upload build to S3 bucket
 aws s3 sync ./dist ${S3_DEPLOY_BUCKET} --profile peter-aws
 

--- a/services/QuillDiagnostic/deploy.sh
+++ b/services/QuillDiagnostic/deploy.sh
@@ -23,9 +23,6 @@ case $1 in
     exit 1
 esac
 
-# Slack deploy start
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-
 
 # Execute a new build
 # Upload build to S3 bucket

--- a/services/QuillGrammar/deploy.sh
+++ b/services/QuillGrammar/deploy.sh
@@ -23,9 +23,6 @@ case $1 in
     exit 1
 esac
 
-# Slack deploy start
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-
 # Upload build to S3 bucket
 aws s3 sync ./dist ${S3_DEPLOY_BUCKET} --profile peter-aws
 

--- a/services/QuillLessons/deploy.sh
+++ b/services/QuillLessons/deploy.sh
@@ -38,9 +38,6 @@ then
   rm -rf ./dist
 fi
 
-# Slack deploy start
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-
 # Execute a new build
 npm run build
 

--- a/services/QuillProofreader/deploy.sh
+++ b/services/QuillProofreader/deploy.sh
@@ -24,9 +24,6 @@ case $1 in
     exit 1
 esac
 
-# Slack deploy start
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-
 # Upload build to S3 bucket
 aws s3 sync ./dist ${S3_DEPLOY_BUCKET} --profile peter-aws
 


### PR DESCRIPTION
## WHAT
Don't slack deploy 'started' for frontend apps.
## WHY
The deploys happen so quickly, it's a bit unnecessary and chatty.
## HOW
Remove line

## Have you added and/or updated tests?
NO, command line script

## Have you deployed to Staging?
 NO - non-app change
