### PR TITLE
program webinar banners to stop showing after specified dates

### DIFF
--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -4,8 +4,9 @@
 <% between_two_and_three = current_hour == 14 %>
 <% monday_tuesday_or_thursday = current_time_on_east_coast.monday? || current_time_on_east_coast.thursday? || current_time_on_east_coast.tuesday? %>
 <% still_doing_live_q_and_a = current_time_on_east_coast < Date.parse("19/05/2020") %>
+<% still_doing_webinars = current_time_on_east_coast < Date.parse("29/05/2020") %>
 
-<% if (!current_user || current_user.teacher?) %>
+<% if (still_doing_webinars && (!current_user || current_user.teacher?)) %>
   <% if (between_twelve_and_one && monday_tuesday_or_thursday && still_doing_live_q_and_a) %>
     <div class="covid-banner" id="webinar-banner">
       <div class="content-container">


### PR DESCRIPTION
## WHAT
Stop showing the live Q&A banner after 5/18; stop showing all webinar banners after 5/28.

## WHY
These dates are when the content team plans to stop having the webinars, and we don't want people to attempt to join a session that isn't happening. We should go back and remove this code at some point, but in the meanwhile it's less stressful to have it stop showing programmatically than have to delete it in a narrow window of time.

## HOW
Just check the current date (on the east coast) and make sure it's less than the day after the last day we plan to have the webinars.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
N/A