### PR TITLE
Remove outdated logic from question creation APIs in Connect

### DIFF
--- a/services/QuillConnect/app/actions/fillInBlank.ts
+++ b/services/QuillConnect/app/actions/fillInBlank.ts
@@ -10,7 +10,7 @@ declare global {
 
 import request from 'request';
 import _ from 'underscore';
-import { push, goBack } from 'react-router-redux';
+import { goBack } from 'react-router-redux';
 import pathwaysActions from './pathways';
 import { submitResponse } from './responses';
 import { Questions, Question, FocusPoint, IncorrectSequence } from '../interfaces/questions'
@@ -100,21 +100,16 @@ function submitNewQuestion(content, response, lessonID) {
       dispatch(submitResponse(response));
       dispatch(loadQuestion(response.questionUID));
       dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
-      if (lessonID) {
-        const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_FILL_IN_BLANK_TYPE}
-        dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
-        LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch(lessonActions.loadLesson(lessonID));
-          dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
-        }).catch( (error) => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
-        });
-      } else {
-        const action = push(`/admin/fill-in-the-blanks/${response.questionUID}`);
-        dispatch(action);
-      }
+      const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_FILL_IN_BLANK_TYPE}
+      dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
+      LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch(lessonActions.loadLesson(lessonID));
+        dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
+      }).catch( (error) => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
+      });
     }, (error) => {
       dispatch({ type: C.RECEIVE_NEW_FILL_IN_BLANK_QUESTION_RESPONSE, });
       dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });

--- a/services/QuillConnect/app/actions/questions.ts
+++ b/services/QuillConnect/app/actions/questions.ts
@@ -10,7 +10,6 @@ declare global {
 
 import request from 'request';
 import _ from 'underscore';
-import { push } from 'react-router-redux';
 import pathwaysActions from './pathways';
 import { submitResponse } from './responses';
 import { Questions, Question, FocusPoint, IncorrectSequence } from '../interfaces/questions'
@@ -97,21 +96,16 @@ function submitNewQuestion(content, response, lessonID) {
       dispatch(submitResponse(response));
       dispatch(loadQuestion(response.questionUID));
       dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
-      if (lessonID) {
-        const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_SENTENCE_COMBINING_TYPE}
-        dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
-        LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch(lessonActions.loadLesson(lessonID));
-          dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
-        }).catch( (error) => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
-        });
-      } else {
-        const action = push(`/admin/questions/${response.questionUID}`);
-        dispatch(action);
-      }
+      const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_SENTENCE_COMBINING_TYPE}
+      dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
+      LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch(lessonActions.loadLesson(lessonID));
+        dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
+      }).catch( (error) => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
+      });
     }, (error) => {
       dispatch({ type: C.RECEIVE_NEW_QUESTION_RESPONSE, });
       dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });

--- a/services/QuillConnect/app/actions/sentenceFragments.ts
+++ b/services/QuillConnect/app/actions/sentenceFragments.ts
@@ -115,21 +115,16 @@ function submitNewSentenceFragment(content, response, lessonID) {
       dispatch(submitResponse(response));
       dispatch(loadSentenceFragment(response.questionUID));
       dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
-      if (lessonID) {
-        const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_SENTENCE_FRAGMENTS_TYPE}
-        dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
-        LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch(lessonActions.loadLesson(lessonID));
-          dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
-        }).catch( (error) => {
-          dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
-          dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
-        });
-      } else {
-        const action = push(`/admin/sentence-fragments/${response.questionUID}`);
-        dispatch(action);
-      }
+      const lessonQuestion = {key: response.questionUID, questionType: C.INTERNAL_SENTENCE_FRAGMENTS_TYPE}
+      dispatch({ type: C.SUBMIT_LESSON_EDIT, cid: lessonID, });
+      LessonApi.addQuestion(TYPE_CONNECT_LESSON, lessonID, lessonQuestion).then( () => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch(lessonActions.loadLesson(lessonID));
+        dispatch({ type: C.DISPLAY_MESSAGE, message: 'Question successfully added to lesson!', });
+      }).catch( (error) => {
+        dispatch({ type: C.FINISH_LESSON_EDIT, cid: lessonID, });
+        dispatch({ type: C.DISPLAY_ERROR, error: `Add to lesson failed! ${error}`, });
+      });
     }, (error) => {
       dispatch({ type: C.RECEIVE_NEW_QUESTION_RESPONSE, });
       dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });


### PR DESCRIPTION
## WHAT
Now that I've removed all the front-end capabilities for creating questions anywhere EXCEPT inside of a lesson, we don't need this logic that checks whether or not a `lessonID` exists. Because it will always exist -- the function is now only called from `Lesson.jsx`

This is the LAST of 9 PRs rolling out the Activity creation workflow redesign for admin. Woo!

## WHY
Let's not have outdated code sitting around confusing people.

## HOW
Take out some outdated logic.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO, only removals

## Have you deployed to Staging?
Not yet - deploying now!
