### PR TITLE
Test out auto-deploys on sprint.

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -32,13 +32,22 @@ esac
 read -r -p "Deploy branch '$current_branch' to '$1' environment? [y/N]" response
 if [[ "$response" =~ ^([y])$ ]]
 then
-    # Slack deploy start
-    sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
-    git push -f ${DEPLOY_GIT_REMOTE} ${current_branch}:master -v
-    open $URL
-    open $NR_URL
-    # Slack deploy finish
-    sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch true
+    # test out different deploy pattern on sprint
+    if [[ $1 = "sprint" ]]
+    then
+        sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
+        git push origin -f ${current_branch}:deploy-lms-sprint
+        open "https://dashboard.heroku.com/apps/quill-lms-sprint/activity"
+        echo "Deploy screen opened in your browser, you can monitor from there."
+    else
+        # Slack deploy start
+        sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
+        git push -f ${DEPLOY_GIT_REMOTE} ${current_branch}:master -v
+        open $URL
+        open $NR_URL
+        # Slack deploy finish
+        sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch true
+    fi
 else
     echo "Ok, we won't deploy. Have a good day!"
 fi


### PR DESCRIPTION
## WHAT
Try out auto-deploys on `quill-lms-sprint`. Heroku can 'auto-deploy' when you push to a specified branch. Experimenting with this to see if it speeds up our deploy time for the `git push`.
## WHY
Our current deploy does a `git push --force` to heroku's copy of our repo. Theoretically, this should be very fast since the diffs are small, but many (most?) times it's pushing the 300MB+ whole repo which takes several minutes. If we force push to our own repo, theoretically, that shouldn't happen.

The downsides are that the deploy log output is no longer on the command line (I open a web browser, which isn't even to the exact page, since we don't have the deploy id). And the deploy hooks are slightly different. So trying this out on sprint to see if it's an improvement overall before expanding.

Note, there are other Heroku tools that could speed this up, namely Heroku pipelines, which would allows us to deploy to staging and 'promote' to production with re-deploying. I'm putting it on a future card to look at that.
## HOW
Just force push to our own branch. I 
## Screenshots
![Screen Shot 2020-05-15 at 12 20 39 PM](https://user-images.githubusercontent.com/1304933/82075873-f52a0580-96aa-11ea-9918-6d4878c0f637.png)
![Screen Shot 2020-05-15 at 12 26 17 PM](https://user-images.githubusercontent.com/1304933/82075874-f5c29c00-96aa-11ea-97e2-7557239b2e1a.png)
![Screen Shot 2020-05-15 at 12 26 45 PM](https://user-images.githubusercontent.com/1304933/82075876-f5c29c00-96aa-11ea-911f-38ff86e654ee.png)
![Screen Shot 2020-05-15 at 12 26 24 PM](https://user-images.githubusercontent.com/1304933/82075875-f5c29c00-96aa-11ea-97ef-9c5456f79ae0.png)



## Have you added and/or updated tests?
No, not app change.

## Have you deployed to Staging?
Did a test deploy to `sprint`.
