### PR TITLE
remove units from activity view in rails admin

### DIFF
--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -142,7 +142,7 @@ RailsAdmin.config do |config|
 
   config.model Activity do
     edit do
-      exclude_fields :classroom_units, :classrooms, :unit_activities
+      exclude_fields :classroom_units, :classrooms, :unit_activities, :units
     end
   end
 


### PR DESCRIPTION
## WHAT
Remove units from the activity editor in the rails admin.

## WHY
Rachel reported that the Rails Admin CMS is frequently timing out when she tries to make edits to activities. My guess is that this is due to the fact that it is pulling the units associated with an activity when you load the page, which is quite a large query. I'm hoping removing them solves the issue.

## HOW
Just update the rails admin config file.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change
