### PR TITLE
show extra whitespaces in student submission on progress reports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import ScoreColor from '../../modules/score_color.js'
 import ConceptResultTableRow from './concept_result_table_row.tsx'
-import stripHtml from "string-strip-html";
 import Concept from '../../../../interfaces/concept.ts';
 import QuestionData from '../../../../interfaces/questionData.ts';
 
@@ -41,6 +40,7 @@ export class StudentReportBox extends React.Component<StudentReportBoxProps> {
   render() {
     const { boxNumber, questionData } = this.props;
     const { answer, concepts, directions, prompt, score } = questionData;
+    const formattedAnswer = answer ? answer.replace('&#x27;', "'") : ''
     return(
       <div className='individual-activity-report'>
         <div className="student-report-box">
@@ -50,10 +50,10 @@ export class StudentReportBox extends React.Component<StudentReportBoxProps> {
               <tbody>
                 {directions && this.renderDirections(directions)}
                 {prompt && this.renderPrompt(prompt)}
-                <tr className={score && ScoreColor(score)}>
+                <tr className={(score || score === 0) && ScoreColor(score)}>
                   <td>Submission</td>
                   <td />
-                  <td><span style={{ whiteSpace: 'pre-wrap' }}>{answer ? stripHtml(answer) : ''}</span></td>
+                  <td><span style={{ whiteSpace: 'pre-wrap' }}>{formattedAnswer}</span></td>
                 </tr>
                 {concepts && this.renderConcepts(concepts)}
               </tbody>


### PR DESCRIPTION
## WHAT
Stop using the `string-strip-html` library on student submissions in progress reports, and instead just replace the apostrophe hex code with an actual apostrophe. Also, fix a bug preventing the score color from rendering when the score for the question was 0.

## WHY
We had a bug reported where students were submitting the right answer and getting marked incorrect for it. This turned out to be because their answer had extra spaces in it, but the extras were being stripped by the library we were using to remove html and hex codes from the student submission. Since that library was added to solve this issue (https://www.notion.so/quill/Error-in-Reports-Apostrophe-not-rendered-correctly-622f53fec1014a4b9f158035dc9cdae5), and as far as I know we never actually decided to strip all html from student submissions, I just replaced that part of the logic. I actually think it's preferable to show any html that comes through in student submissions, because if it's in there, there's either something wrong with our code, which we should know about, or the student is entering it, which the teacher should know about.

## HOW
Remove call to strip html on student submission and replace it with a function that replaces hex code apostrophes with literal apostrophes.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change