### PR TITLE
make sure google classroom announcements post for updated students

### DIFF
--- a/services/QuillLMS/app/services/google_integration/unit_announcement.rb
+++ b/services/QuillLMS/app/services/google_integration/unit_announcement.rb
@@ -16,8 +16,7 @@ class GoogleIntegration::UnitAnnouncement
   end
 
   def update_recipients(new_recipients)
-    recipients = new_recipients - classroom_unit.assigned_student_ids
-    make_request(recipients)
+    make_request(new_recipients)
   end
 
   private

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -34,8 +34,9 @@ module Units::Updater
       elsif (matching_cu.assigned_student_ids != classroom[:student_ids]) || matching_cu.assign_on_join != classroom[:assign_on_join]
         # then something changed and we should update
         google_unit_announcement = GoogleIntegration::UnitAnnouncement.new(matching_cu)
+        new_recipients = classroom[:student_ids] - matching_cu.assigned_student_ids
+        google_unit_announcement.update_recipients(new_recipients)
         matching_cu.update!(assign_on_join: classroom[:assign_on_join], assigned_student_ids: classroom[:student_ids], visible: true)
-        google_unit_announcement.update_recipients(classroom[:student_ids])
       elsif !matching_cu.visible
         matching_cu.update!(visible: true)
       end


### PR DESCRIPTION
## WHAT
Change the order in which we update the classroom unit and post a Google Classroom announcement for an updated classroom unit, in order to make sure the correct recipients are designated.

## WHY
I got a bug report that some of a teacher's classroom units were not posting to Google Classroom, and noticed that we had a lot of this error in NewRelic: https://rpm.newrelic.com/accounts/2639113/applications/548856875/traced_errors/2b5fd989-9b6f-11ea-9166-0242ac110008_5299_10864. After looking at the code, the best theory I could come up with is that updating the classroom unit prior to updating the recipients for the Google Classroom announcement will always result in an empty array for the `new_recipients` variable as previously written. I've updated this so that we pass the recipient array directly to that method, so that newly assigned students really do get the announcement after all. Then I tested that assigning and then updating the assigned students for a classroom unit resulted in the correct announcements, which it did.

## HOW
Don't update the classroom unit until after the call to post the google announcement has been made, and also pass the recipients to the `GoogleIntegration::UnitAnnouncement` class.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change