### PR TITLE
fix issue with backpack not scrolling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -1,6 +1,8 @@
 .style-guide-index {
   display: flex;
   font-family: adelle-sans, "Arial", sans-serif;
+  overflow: scroll;
+  height: 100%;
 }
 
 .style-guide {


### PR DESCRIPTION
## WHAT
Give the style guide index (backpack) some new CSS properties to make sure it's scrollable.

## WHY
For some reason I can't quite figure out, the backpack page stopped scrolling, rendering most of its content inaccessible. It doesn't appear to be happening elsewhere on the website, so my best guess is some peculiarity of the styles applied to it started conflicting with either a Chrome update or a package bump. In any case, we want to be able to see all of our glorious backpack, so I fixed it.

## HOW

## Screenshots
N/A

## Have you added and/or updated tests?
NO, just css

## Have you deployed to Staging?
NO - tiny change
