### PR TITLE
Fix a bug in purchasing premium for teachers

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -51,7 +51,11 @@ export default class PremiumPricingMinisRow extends React.Component {
   }
 
   renderPurchaseModal() {
-    const { showPurchaseModal, } = this.state
+    const {
+      showPurchaseModal,
+      subscriptionType
+    } = this.state
+    const { lastFour, } = this.props
     if (!showPurchaseModal) { return }
     return (<PurchaseModal
       hideModal={this.hidePurchaseModal}


### PR DESCRIPTION
## WHAT
Make sure to extract values from `state` and `props` if we're going to reference them.
## WHY
So that the code doesn't choke when it tries to load the modal.
## HOW
Just extract values into `const`s
## Have you added and/or updated tests?
NO

## Have you deployed to Staging?
Not yet - deploying now!
