### PR TITLE
Roll back changes to lesson controller to make it pull from Lessons again

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
@@ -2,31 +2,25 @@ class Api::V1::LessonsController < Api::ApiController
   before_action :staff_only, only: [:destroy]
   before_action :lesson_type, only: [:index, :create]
   before_action :lesson_by_uid, except: [:index, :create]
-  LESSON_TYPE_TO_KEY = {
-    "connect_lesson": "connect",
-    "diagnostic_lesson": "diagnostic",
-    "grammar_activity": "sentence",
-    "proofreader_passage": "passage"
-  }
 
   def index
-    all_lessons = Activity.where(classification: @classification).reduce({}) { |agg, q| agg.update({q.uid => q.data_as_json}) }
+    all_lessons = Lesson.where(lesson_type: @lesson_type).reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
     render(json: all_lessons)
   end
 
   def show
-    render(json: @lesson.data_as_json)
+    render(json: @lesson.as_json)
   end
 
   def create
     uid = SecureRandom.uuid
-    @lesson = Activity.create!(uid: uid, classification: @classification, data: valid_params)
-    render(json: {@lesson.uid => @lesson.data_as_json})
+    @lesson = Lesson.create!(uid: uid, lesson_type: @lesson_type, data: valid_params)
+    render(json: {@lesson.uid => @lesson.as_json})
   end
 
   def update
     @lesson.update!({data: valid_params})
-    render(json: @lesson.data_as_json)
+    render(json: @lesson.as_json)
   end
 
   def destroy
@@ -36,20 +30,18 @@ class Api::V1::LessonsController < Api::ApiController
 
   def add_question
     if @lesson.add_question(params[:question])
-      render(json: @lesson.data_as_json)
+      render(json: @lesson.as_json)
     else
       render :json => { :errors => @lesson.errors.full_messages }, :status => 404
     end
   end
 
   private def lesson_type
-    lesson_type = params[:lesson_type]
-    classification_key = LESSON_TYPE_TO_KEY[lesson_type.to_sym]
-    @classification = ActivityClassification.find_by_key(classification_key)
+    @lesson_type = params[:lesson_type]
   end
 
   private def lesson_by_uid
-    @lesson = Activity.find_by!(uid: params[:id])
+    @lesson = Lesson.find_by!(uid: params[:id])
   end
 
   private def valid_params

--- a/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
@@ -2,25 +2,25 @@ require 'json'
 require 'rails_helper'
 
 describe Api::V1::LessonsController, type: :controller do
-  let!(:activity) { create(:connect_activity) }
+  let!(:lesson) { create(:lesson) }
   let!(:question) { create(:question) }
 
   describe "#index" do
     it "should return a list of Lessons" do
-      get :index, lesson_type: "connect_lesson"
+      get :index, lesson_type: lesson.lesson_type
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should include the response from the db" do
-      get :index, lesson_type: "connect_lesson"
-      expect(JSON.parse(response.body).keys.first).to eq(activity.uid)
+      get :index, lesson_type: lesson.lesson_type
+      expect(JSON.parse(response.body).keys.first).to eq(lesson.uid)
     end
   end
 
   describe "#show" do
     it "should return the specified lesson" do
-      get :show, id: activity.uid
-      expect(JSON.parse(response.body)).to eq(activity.data)
+      get :show, id: lesson.uid
+      expect(JSON.parse(response.body)).to eq(lesson.data)
     end
 
     it "should return a 404 if the requested Lesson is not found" do
@@ -35,18 +35,18 @@ describe Api::V1::LessonsController, type: :controller do
       uuid = SecureRandom.uuid
       data = {foo: "bar"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
-      pre_create_count = Activity.count
-      post :create, lesson_type: "connect_lesson", lesson: data
-      expect(Activity.count).to eq(pre_create_count + 1)
+      pre_create_count = Lesson.count
+      post :create, lesson_type: lesson.lesson_type, lesson: data
+      expect(Lesson.count).to eq(pre_create_count + 1)
     end
   end
 
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, id: activity.uid, lesson: data
-      activity.reload
-      expect(activity.data).to eq(data)
+      put :update, id: lesson.uid, lesson: data
+      lesson.reload
+      expect(lesson.data).to eq(data)
     end
 
     it "should return a 404 if the requested Lesson is not found" do
@@ -62,8 +62,8 @@ describe Api::V1::LessonsController, type: :controller do
 
     it "should destroy the existing record if the current user is staff" do
       allow(controller).to receive(:current_user).and_return(staff)
-      delete :destroy, id: activity.uid
-      expect(Activity.where(uid: activity.uid).count).to eq(0)
+      delete :destroy, id: lesson.uid
+      expect(Lesson.where(uid: lesson.uid).count).to eq(0)
     end
 
     it "should return a 404 if the requested Lesson is not found if the current user is staff" do
@@ -75,7 +75,7 @@ describe Api::V1::LessonsController, type: :controller do
 
     it "should return a 403 if the current user is not staff" do
       allow(controller).to receive(:current_user).and_return(teacher)
-      delete :destroy, id: activity.uid
+      delete :destroy, id: lesson.uid
       expect(response.status).to eq(403)
       expect(response.body).to include("You are not authorized to access this resource")
     end
@@ -84,14 +84,14 @@ describe Api::V1::LessonsController, type: :controller do
   describe "#add_question" do
     it "should add a question to the existing record" do
       data = {"key" => question.uid, "questionType" => "questions"}
-      put :add_question, id: activity.uid, question: data
-      activity.reload
-      expect(activity.data["questions"]).to include(data)
+      put :add_question, id: lesson.uid, question: data
+      lesson.reload
+      expect(lesson.data["questions"]).to include(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
       data = {"question" => {"key" => "notarealID", "questionType" => "question"}}
-      put :add_question, id: activity.uid, question: data
+      put :add_question, id: lesson.uid, question: data
       expect(response.status).to eq(404)
       expect(response.body).to include("does not exist")
     end


### PR DESCRIPTION
## WHAT
My migration from Lessons to Activity failed. We still do not know exactly how to resolve the failure. In the meantime, users are unable to access Activities because I have hooked up `lessons_controller` to the `Activity` model which lacks the data it needs.

So I'm rolling back my changes so that we have users seeing their Activities in the meantime.

## WHY
Parts of the site are unusable until we fix `lessons_controller`

## HOW
Rolling back `lessons_controller`



## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
YES

## Have you deployed to Staging?
Not yet - deploying now!
