### PR TITLE
Bug fix for comprehension RuleSets -- select DISTINCT to avoid duplicates

### DIFF
--- a/services/comprehension/main-api/comprehension/views/api.py
+++ b/services/comprehension/main-api/comprehension/views/api.py
@@ -41,7 +41,8 @@ class RuleViewSet(viewsets.ModelViewSet):
         activities_pk = self.kwargs['activities_pk']
         get_object_or_404(Activity, pk=activities_pk)
         return (Rule.objects
-                    .filter(rule_set__prompts__activities__pk=activities_pk))
+                    .filter(rule_set__prompts__activities__pk=activities_pk)
+                    .distinct())
 
 
 class RuleSetViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## WHAT
Add a `distinct()` filter to the select clause for `Rule` in comprehension. Because the clause contains `join` statements, it was returning duplicate rows and those were getting sent to the serializer, causing weird stuff to happen.

_We only want to select one of each Rule object when we select rules!_

## WHY
This way, there won't be confusing duplicate rows in later querysets and in return objects to the user.

## HOW
Use a `distinct` filter statement.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
