### PR TITLE
fix issue with previewing lessons

### DIFF
--- a/services/QuillLessons/app/components/classroomLessons/teach/container.tsx
+++ b/services/QuillLessons/app/components/classroomLessons/teach/container.tsx
@@ -67,21 +67,7 @@ class TeachClassroomLessonContainer extends React.Component<any, any> {
       });
       registerTeacherPresence(classroomSessionId);
     } else {
-      const { lessonID, editionID } = match.params;
-      const classroomUnitId = createPreviewSession(lessonID, editionID)
-      const modalQSValue = getParameterByName('modal')
-      const modalQS = modalQSValue ? `&modal=${modalQSValue}` : ''
-      if (classroomUnitId) {
-        const route = `/teach/class-lessons/${lessonID}?&classroom_unit_id=${classroomUnitId}${modalQS}`;
-        history.push(route)
-        const classroomSessionId = classroomUnitId.concat(lessonID)
-        this.setState({ classroomSessionId, })
-
-        startLesson(classroomUnitId, classroomSessionId, () => {
-          dispatch(startListeningToSessionForTeacher(activityId, classroomUnitId, classroomSessionId));
-        });
-        registerTeacherPresence(classroomSessionId);
-      }
+      this.setupPreviewSession()
     }
     if (classroomLesson.hasreceiveddata) {
       dispatch(clearClassroomLessonFromStore());
@@ -127,6 +113,24 @@ class TeachClassroomLessonContainer extends React.Component<any, any> {
       }
       user_ids.push(props.customize.user_id)
       this.props.dispatch(getEditionMetadataForUserIds(user_ids, lessonId))
+    }
+  }
+
+  setupPreviewSession = () => {
+    const { match, history, dispatch, } = this.props
+    const { lessonID, editionID } = match.params;
+    const classroomUnitId = createPreviewSession(lessonID, editionID)
+    const modalQSValue = getParameterByName('modal')
+    const modalQS = modalQSValue ? `&modal=${modalQSValue}` : ''
+    if (classroomUnitId) {
+      const route = `/teach/class-lessons/${lessonID}?&classroom_unit_id=${classroomUnitId}${modalQS}`;
+      history.push(route)
+      const classroomSessionId = classroomUnitId.concat(lessonID)
+      this.setState({ classroomSessionId, })
+      startLesson(classroomUnitId, classroomSessionId, () => {
+        dispatch(startListeningToSessionForTeacher(lessonID, classroomUnitId, classroomSessionId));
+      });
+      registerTeacherPresence(classroomSessionId);
     }
   }
 


### PR DESCRIPTION
## WHAT
Fix issue with previewing lessons not properly setting up a classroom session.

## WHY
So people don't need to reload their page to get preview lesson sessions to work.

## HOW
Make sure we call the same functions that are called earlier in the set up when the `classroom_unit_id` already exists.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
Not yet - deploying now!