### PR TITLE
Change ‘master’ branch to ‘production’

### DIFF
--- a/services/QuillConnect/deploy.sh
+++ b/services/QuillConnect/deploy.sh
@@ -5,10 +5,10 @@ app_name="QuillConnect"
 # Set environment-specific values
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
-    if [ "$current_branch" != "master" ]
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     S3_DEPLOY_BUCKET=s3://aws-website-quillconnect-6sy4b

--- a/services/QuillDiagnostic/deploy.sh
+++ b/services/QuillDiagnostic/deploy.sh
@@ -5,10 +5,10 @@ app_name="QuillDiagnostic"
 
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
-    if [ "$current_branch" != "master" ]
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     S3_DEPLOY_BUCKET=s3://aws-website-quill-diagnostic

--- a/services/QuillGrammar/deploy.sh
+++ b/services/QuillGrammar/deploy.sh
@@ -5,10 +5,10 @@ app_name="QuillGrammar"
 # Set environment-specific values
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
-    if [ "$current_branch" != "master" ]
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     S3_DEPLOY_BUCKET=s3://aws-website-quill-grammar

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -9,9 +9,9 @@ case $1 in
     HEROKU_APP=empirical-grammar
     URL="https://www.quill.org/"
     NR_URL="https://rpm.newrelic.com/accounts/2639113/applications/548856875"
-    if [ ${current_branch} != "master" ]
+    if [ ${current_branch} != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     ;;

--- a/services/QuillLessons/deploy.sh
+++ b/services/QuillLessons/deploy.sh
@@ -8,10 +8,10 @@ app_name="QuillLessons"
 # Set environment-specific values
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
-    if [ "$current_branch" != "master" ]
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     export EMPIRICAL_BASE_URL=https://www.quill.org

--- a/services/QuillLessonsServer/deploy.sh
+++ b/services/QuillLessonsServer/deploy.sh
@@ -3,9 +3,9 @@ app_name="QuillLessonsServer"
 
 case $1 in
   prod)
-    if [ ${current_branch} != "master" ]
+    if [ ${current_branch} != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     DEPLOY_GIT_BRANCH=deploy-lessons-server-prod

--- a/services/QuillProofreader/deploy.sh
+++ b/services/QuillProofreader/deploy.sh
@@ -5,11 +5,11 @@ app_name="QuillProofreader"
 # Set environment-specific values
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
 
-    if [ "$current_branch" != "master" ]
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     S3_DEPLOY_BUCKET=s3://aws-website-quill-proofreader

--- a/services/comprehension/frontend/deploy.sh
+++ b/services/comprehension/frontend/deploy.sh
@@ -3,11 +3,11 @@
 # Set environment-specific values
 case $1 in
   prod)
-    # ENSURE THAT WE'RE ON MASTER FOR PRODUCTION DEPLOYS
+    # ENSURE THAT WE'RE ON production FOR PRODUCTION DEPLOYS
     current_branch=`git rev-parse --abbrev-ref HEAD`
-    if [ "$current_branch" != "master" ]
+    if [ "$current_branch" != "production" ]
     then
-      echo "You can not make a production deploy from a branch other than 'master'.  Don't forget to make sure you have the latest code pulled."
+      echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
     S3_DEPLOY_BUCKET=s3://aws-website-quill-comprehension


### PR DESCRIPTION
## WHAT
Let's change our deploy branch from `master` to `production`.
## WHY
Words matter. `master` has a lot of negative historical connotations. `production` is also more accurate.
## HOW
Change the deploy scripts. I'll create a `production` branch from `develop` when I deploy this.

## Have you added and/or updated tests?
No, just a deploy script change

## Have you deployed to Staging?
 NO - non-app change
