### PR TITLE
Small style tweak to reduce spacing between text and image

### DIFF
--- a/services/QuillLMS/client/app/assets/styles/schools-section.scss
+++ b/services/QuillLMS/client/app/assets/styles/schools-section.scss
@@ -516,7 +516,7 @@
   height: 608px;
   background-color: #e1f3f1;
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   align-items: center;
   flex-direction: row;
   .premium-text-container {


### PR DESCRIPTION
## WHAT
Small style tweak to reduce spacing between text and image
## WHY
Space-around was making the space between the items proportional to the total screen width, but we really only want to allow flexible spacing on the outside of the elements, not between them
## HOW
Change a single style rule for content justification in this section of the website
## Screenshots
OLD:
![Screenshot 2020-06-16 1805](https://user-images.githubusercontent.com/331565/84832904-1bb9c400-affc-11ea-9cfe-5d1e729d77c7.PNG)
NEW:
![Screenshot 2020-06-16 1806](https://user-images.githubusercontent.com/331565/84832913-1fe5e180-affc-11ea-9deb-36674efe4299.PNG)

## Have you added and/or updated tests?
No tests on styles

## Have you deployed to Staging?
YES
