### PR TITLE
Add low level npm configs for Lessons tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           name: Run QuillLessons Tests
           command: |
             cd services/QuillLessons
-            FORCE_COLOR=true npm run jest --colors --runInBand app/
+            npm run jest app/
   grammar_node_build:
     working_directory: ~/Empirical-Core
     docker:

--- a/services/QuillLessons/package.json
+++ b/services/QuillLessons/package.json
@@ -17,7 +17,7 @@
     "deploy:lessons": "./deploy_lessons.sh",
     "deploy:staging": "./staging.sh",
     "test:singular": "mocha $FILE --watch --reporter dot",
-    "jest": "jest",
+    "jest": "node --expose-gc ./node_modules/.bin/jest --maxWorkers=2 --logHeapUsage",
     "jest:u": "jest --updateSnapshot",
     "jest:watch": "jest:watch",
     "jest:coverage": "jest:coverage"


### PR DESCRIPTION
## WHAT
Fixing tests on Lessons which keep running out of memory.
## WHY
It's nice when tests finish.
## HOW
Use garbage collection for the tests and manually set worker number. I made this update the the LMS frontend and Connect previously to fix this issue. I should have made this change then. All `jest` tests in the repo now use this setting.
`node --expose-gc ./node_modules/.bin/jest --maxWorkers=2 --logHeapUsage"`
## Screenshots
That's a little better
![Screen Shot 2020-06-25 at 10 46 57 AM](https://user-images.githubusercontent.com/1304933/85742417-39102180-b6d1-11ea-8c7e-b8ad5ba1241c.png)


## Have you added and/or updated tests?
In a very meta way.

## Have you deployed to Staging?
NO - non-app change
