### PR TITLE
fix cms users search glitch

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -100,7 +100,7 @@ export default class CmsUserIndex extends React.Component {
   };
 
   search = (e) => {
-    e.preventDefault();
+    e ? e.preventDefault() : null;
     this.setState({loading: true})
     const link = `${process.env.DEFAULT_URL}/cms/users/search`
     const data = new FormData();


### PR DESCRIPTION
## WHAT
Fix issue where you couldn't load past the first page of results for the CMS user search.

## WHY
We want this to work.

## HOW
We were calling `.preventDefault()` on an argument which wasn't always defined. Now we null check first.

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change