### PR TITLE
make the css consistent between the landing page editor and the landing page

### DIFF
--- a/services/QuillConnect/app/styles/components/_landing-page-html.scss
+++ b/services/QuillConnect/app/styles/components/_landing-page-html.scss
@@ -1,12 +1,8 @@
-.landing-page-html {
+.landing-page-html, .landing-page-html-editor {
 
   h3 {
     font-size: 28px;
-    margin: 35px 0, 10px;
-
-    &:first-of-type {
-      margin-bottom: 20px;
-    }
+    margin-bottom: 20px;
   }
 
   p {
@@ -16,26 +12,4 @@
       margin-bottom: 2em;
     }
   }
-
-}
-
-.landing-page-html-editor {
-
-  h3 div span span {
-    font-size: 28px;
-    margin: 35px 0px 10px;
-
-    &:first-of-type {
-      margin-bottom: 20px;
-    }
-  }
-
-  p, div div span {
-    font-size: 22px;
-
-    &:last-of-type {
-      margin-bottom: 2em;
-    }
-  }
-
 }


### PR DESCRIPTION
## WHAT
Devin reported an issue where the CSS was inconsistent between the landing page editor and the actual landing page for Connect activities, so I fixed that.

## WHY
We want the landing page editor to accurately reflect how the landing page will display.

## HOW
Just adjust some css.

## Screenshots
<img width="1277" alt="Screen Shot 2020-06-26 at 11 01 10 AM" src="https://user-images.githubusercontent.com/18669014/85871412-5d850000-b79c-11ea-9bd2-f866bfc20d90.png">


## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change
