### PR TITLE
fix issue with displaying the incorrect completed count on the activity analysis page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -182,9 +182,10 @@ export default class ActivityPacks extends React.Component {
       return new Promise(resolve => {
         request.get(`${process.env.DEFAULT_URL}/teachers/units/score_info_for_activity/${u.activity_id}?classroom_unit_id=${u.classroom_unit_id}`, (error, httpStatus, body) => {
           this.state.allUnits.forEach((stateUnit) => {
-            if (typeof stateUnit.classroomActivities.get(u.activity_id) != 'undefined' ) {
-              stateUnit.classroomActivities.get(u.activity_id).cumulativeScore = JSON.parse(body).cumulative_score;
-              stateUnit.classroomActivities.get(u.activity_id).completedCount = JSON.parse(body).completed_count;
+            const unitActivity = stateUnit.classroomActivities.get(u.activity_id)
+            if (typeof unitActivity != 'undefined' && Number(unitActivity.cuId) === Number(u.classroom_unit_id)) {
+              unitActivity.cumulativeScore = JSON.parse(body).cumulative_score;
+              unitActivity.completedCount = JSON.parse(body).completed_count;
             }
           })
           resolve()


### PR DESCRIPTION
## WHAT
Daniel reported an issue where we were displayed an incorrect "Completed" count on the Activity Analysis page. This turned out to be because, in the event that a teacher had two activity packs containing the same activity, the code wasn't identifying which instance of the activity that count was associated with, and would instead update all of them. This fixes that.

## WHY
We want to display accurate information on this page.

## HOW
Just make sure that the classroom unit identifier that the query to get the completed/cumulative data used is the same as the classroom unit for the activity that's being updated.  

## Screenshots
N/A

## Have you added and/or updated tests?
N/A

## Have you deployed to Staging?
NO - tiny change
