### PR TITLE
connect/bump-new-activity-session-rate

### DIFF
--- a/services/QuillConnect/app/actions/sessions.js
+++ b/services/QuillConnect/app/actions/sessions.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 
 const C = require('../constants').default;
 
-const NEW_SESSION_PERCENTAGE = 1;
+const NEW_SESSION_PERCENTAGE = 10;
 
 const sessionsRef = rootRef.child('savedSessions');
 const v4sessionsRef = v4rootRef.child('connectSessions');


### PR DESCRIPTION
## WHAT
Go from 1% of users on the new sessions to 10%
## WHY
So we keep ramping up traffic to ensure that this system works under load
## HOW
Just change the value of the constant that determines what percentage of users get assigned to the experiment

## Have you added and/or updated tests?
No tests around this functionality

## Have you deployed to Staging?
Not yet - deploying now!
