### PR TITLE
fix issue with blog posts controller

### DIFF
--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -1,11 +1,9 @@
 class Cms::BlogPostsController < Cms::CmsController
   before_action :set_blog_post, only: [:update, :destroy, :edit, :show, :unpublish]
-  before_action :authors, :topics, only: [:edit, :new]
+  before_action :authors, :topics, only: [:index, :edit, :new]
 
   def index
     @blog_posts_name_and_id = BlogPost.all.map{|bp| bp.attributes.merge({'rating' => bp.average_rating})}
-    @topics = BlogPost::TOPICS
-    @student_topics = BlogPost::STUDENT_TOPICS
     #cms/blog_posts/index.html.erb
   end
 
@@ -74,7 +72,7 @@ class Cms::BlogPostsController < Cms::CmsController
   end
 
   def topics
-    @topics = BlogPost::TEACHER_TOPICS
+    @topics = BlogPost::TOPICS
     @student_topics = BlogPost::STUDENT_TOPICS
   end
 end


### PR DESCRIPTION
## WHAT
Make sure admins can create and edit blog posts with "Press releases" and "In the news" blog post types

## WHY
A little while ago, we updated the site so that the aforementioned blog post types did not appear on the Teacher Center pages. When we did so, we inadvertently made it so that admins couldn't create a blog post with either of those types. This fixes that.

## HOW
Just switched the constant to which `@types` refers in the cms blog posts controller.

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
NO

## Have you deployed to Staging?
NO - tiny change
