### PR TITLE
connect/use-lms-for-all-sessions

### DIFF
--- a/services/QuillConnect/app/actions/sessions.js
+++ b/services/QuillConnect/app/actions/sessions.js
@@ -7,8 +7,6 @@ import _ from 'lodash';
 
 const C = require('../constants').default;
 
-const NEW_SESSION_PERCENTAGE = 10;
-
 const sessionsRef = rootRef.child('savedSessions');
 const v4sessionsRef = v4rootRef.child('connectSessions');
 let allQuestions = {};
@@ -45,12 +43,7 @@ export default {
     const normalizedSession = normalizeSession(cleanedSession)
     // Let's start including an updated time on our sessions
     normalizedSession.updatedAt = new Date().getTime();
-    // If this session should go to the LMS
-    if (applyFeatureToPercentage(sessionID, NEW_SESSION_PERCENTAGE)) {
-      SessionApi.update(sessionID, normalizedSession);
-    } else {
-      v4sessionsRef.child(sessionID).set(normalizedSession);
-    }
+    SessionApi.update(sessionID, normalizedSession);
   },
 
   delete(sessionID) {


### PR DESCRIPTION
## WHAT
Use the LMS for 100% of session storage
## WHY
So we can finish shuttering our use of Firebase
## HOW
Remove the code that writes sessions to the LMS only sometimes so that it always happens

## Have you added and/or updated tests?
No tests on this code split

## Have you deployed to Staging?
Deploying now
