### PR TITLE
Revert styling for navbar elements on focus

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -209,16 +209,6 @@ nav.q-navbar-home {
       &:not(.sign-up-button) {
         padding: 20px 0px;
       }
-      &:focus {
-        outline: dashed 2px #fff !important;
-        outline-offset: 2px;
-      }
-      a {
-        &:focus {
-          outline: dashed 2px #fff;
-          outline-offset: 2px;
-        }
-      }
     }
 
     .nav-element:not(.sign-up-button):hover {


### PR DESCRIPTION
## WHAT
revert to the previous styling for focus indicators for the navbar elements

## WHY
it was unattractive

## HOW
remove CSS

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
No-- small change
## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
No-- small change