### PR TITLE
Connect: Filter for null values in Incorrect Sequence sorting

### DIFF
--- a/services/QuillConnect/app/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillConnect/app/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -38,7 +38,12 @@ class IncorrectSequencesContainer extends Component {
   }
 
   getSequences = () => {
-    return this.getQuestion().incorrectSequences.filter(incorrectSequence => incorrectSequence);
+    const sequences = this.getQuestion().incorrectSequences;
+    if(sequences.length) {
+      return sequences.filter(incorrectSequence => incorrectSequence);
+    } else {
+      return sequences;
+    }
   }
 
   deleteConceptResult = (conceptResultKey, sequenceKey) => {


### PR DESCRIPTION
## WHAT
fix bug where incorrect sequences on Connect prompt cannot be re-ordered

## WHY
so that curriculum can re-order incorrect sequences

## HOW
added a filter for the incorrect sequences and the sorting callback to weed out null values

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
no-- no tests exist for this file

## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Not yet - deploying now!