### PR TITLE
Lms/migrate comprehension regex (#6494)

### DIFF
--- a/services/QuillLMS/db/migrate/20200629191908_create_comprehension_rule_sets.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200629191908_create_comprehension_rule_sets.comprehension.rb
@@ -1,0 +1,16 @@
+# This migration comes from comprehension (originally 20200625222938)
+class CreateComprehensionRuleSets < ActiveRecord::Migration
+  def change
+    create_table :comprehension_rule_sets do |t|
+      t.integer :activity_id
+      t.integer :prompt_id
+      t.string :name
+      t.string :feedback
+      t.integer :priority
+
+      t.timestamps null: false
+    end
+    add_index :comprehension_rule_sets, :activity_id
+    add_index :comprehension_rule_sets, :prompt_id
+  end
+end

--- a/services/QuillLMS/db/migrate/20200629191909_create_comprehension_rules.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200629191909_create_comprehension_rules.comprehension.rb
@@ -1,0 +1,13 @@
+# This migration comes from comprehension (originally 20200626160522)
+class CreateComprehensionRules < ActiveRecord::Migration
+  def change
+    create_table :comprehension_rules do |t|
+      t.integer :rule_set_id
+      t.string :regex_text
+      t.boolean :case_sensitive
+
+      t.timestamps null: false
+    end
+    add_index :comprehension_rules, :rule_set_id
+  end
+end

--- a/services/QuillLMS/db/migrate/20200706135059_create_comprehension_prompts_rule_sets_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200706135059_create_comprehension_prompts_rule_sets_table.comprehension.rb
@@ -1,0 +1,11 @@
+# This migration comes from comprehension (originally 20200626181312)
+class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration
+  def change
+    create_table :comprehension_prompts_rule_sets do |t|
+      t.integer :prompt_id
+      t.integer :rule_set_id
+    end
+    add_index :comprehension_prompts_rule_sets, :prompt_id
+    add_index :comprehension_prompts_rule_sets, :rule_set_id
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -6305,7 +6305,7 @@ INSERT INTO schema_migrations (version) VALUES ('20200629191908');
 
 INSERT INTO schema_migrations (version) VALUES ('20200629191909');
 
-INSERT INTO schema_migrations (version) VALUES ('20200629191910');
-
 INSERT INTO schema_migrations (version) VALUES ('20200702140252');
+
+INSERT INTO schema_migrations (version) VALUES ('20200706135059');
 

--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rule_sets_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rule_sets_controller.rb
@@ -1,0 +1,63 @@
+module Comprehension
+  class RuleSetsController < ApplicationController
+    before_action :set_activity
+    before_action :set_rule_set, only: [:show, :update, :destroy]
+
+    # GET /rule_sets.json
+    def index
+      @rule_sets = @activity.rule_sets
+
+      render json: @rule_sets
+    end
+
+    # GET /rule_sets/1.json
+    def show
+      render json: @rule_set
+    end
+
+    # POST /rule_sets.json
+    def create
+      @rule_set = @activity.rule_sets.build(rule_set_params)
+
+      if @rule_set.save
+        render json: @rule_set, status: :created
+      else
+        render json: @rule_set.errors, status: :unprocessable_entity
+      end
+    end
+
+
+    # PATCH/PUT /rule_sets/1.json
+    def update
+      if @rule_set.update(rule_set_params)
+        head :no_content
+      else
+        render json: @rule_set.errors, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /rule_sets/1.json
+    def destroy
+      @rule_set.destroy
+      head :no_content
+    end
+
+    private def set_activity
+      @activity = Comprehension::Activity.find(params[:activity_id])
+    end
+
+    private def set_rule_set
+      @rule_set = @activity.rule_sets.find(params[:id])
+    end
+
+    private def rule_set_params
+      params.require(:rule_set).permit(
+        :name,
+        :feedback,
+        :priority,
+        prompt_ids: [],
+        rules_attributes: [:id, :regex_text, :case_sensitive]
+      )
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
@@ -1,0 +1,58 @@
+module Comprehension
+  class RulesController < ApplicationController
+    before_action :set_rule_set
+    before_action :set_rule, only: [:show, :update, :destroy]
+
+    # GET /rules.json
+    def index
+      @rules = @rule_set.rules
+
+      render json: @rules
+    end
+
+    # GET /rules/1.json
+    def show
+      render json: @rule
+    end
+
+    # POST /rules.json
+    def create
+      @rule = @rule_set.rules.build(rule_params)
+
+      if @rule.save
+        render json: @rule, status: :created
+      else
+        render json: @rule.errors, status: :unprocessable_entity
+      end
+    end
+
+
+    # PATCH/PUT /rules/1.json
+    def update
+      if @rule.update(rule_params)
+        head :no_content
+      else
+        render json: @rule.errors, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /rules/1.json
+    def destroy
+      @rule.destroy
+      head :no_content
+    end
+
+    private
+      def set_rule_set
+        @rule_set = RuleSet.find(params[:rule_set_id])
+      end
+
+      def set_rule
+        @rule = @rule_set.rules.find(params[:id])
+      end
+
+      def rule_params
+        params.require(:rule).permit(:regex_text, :case_sensitive)
+      end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -10,6 +10,7 @@ module Comprehension
 
     has_many :passages, inverse_of: :activity, dependent: :destroy
     has_many :prompts, inverse_of: :activity, dependent: :destroy
+    has_many :rule_sets, inverse_of: :activity, dependent: :destroy
     has_many :turking_rounds, inverse_of: :activity
     belongs_to :parent_activity, class_name: Comprehension.parent_activity_class
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
@@ -8,6 +8,8 @@ module Comprehension
     MAX_MAX_ATTEMPTS = 6
 
     belongs_to :activity, inverse_of: :passages
+    has_many :prompts_rule_sets
+    has_many :rule_sets, through: :prompts_rule_sets, inverse_of: :prompts
 
     before_validation :downcase_conjunction
     before_validation :set_max_attempts, on: :create

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompts_rule_set.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompts_rule_set.rb
@@ -1,0 +1,7 @@
+module Comprehension
+  class PromptsRuleSet < ActiveRecord::Base
+    belongs_to :prompt
+    belongs_to :rule_set
+  end
+end
+

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -1,0 +1,28 @@
+module Comprehension
+  class Rule < ActiveRecord::Base
+    DEFAULT_CASE_SENSITIVITY = true
+    MAX_REGEX_TEXT_LENGTH = 200
+    CASE_SENSITIVE_ALLOWED_VALUES = [true, false]
+
+    belongs_to :rule_set, inverse_of: :rules
+
+    before_validation :set_default_case_sensitivity, on: :create
+
+    validates_presence_of :rule_set
+    validates :regex_text, presence: true, length: {maximum: MAX_REGEX_TEXT_LENGTH}
+    validates :case_sensitive, inclusion: CASE_SENSITIVE_ALLOWED_VALUES
+
+    def serializable_hash(options = nil)
+      options ||= {}
+
+      super(options.reverse_merge(
+        only: [:id, :rule_set_id, :regex_text, :case_sensitive]
+      ))
+    end
+
+    private def set_default_case_sensitivity
+      return if case_sensitive.in? CASE_SENSITIVE_ALLOWED_VALUES
+      self.case_sensitive = DEFAULT_CASE_SENSITIVITY
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule_set.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule_set.rb
@@ -1,0 +1,31 @@
+module Comprehension
+  class RuleSet < ActiveRecord::Base
+    MAX_NAME_LENGTH = 100
+    MAX_FEEDBACK_LENGTH = 500
+    MIN_PRIORITY = 0
+
+    belongs_to :activity, inverse_of: :rule_sets
+    has_many :prompts_rule_sets
+    has_many :prompts, through: :prompts_rule_sets, inverse_of: :rule_sets
+    has_many :rules, inverse_of: :rule_set, dependent: :destroy
+
+    accepts_nested_attributes_for :rules, reject_if: proc { |r| r['regex_text'].blank? }
+
+    validates_presence_of :activity
+    validates :name, presence: true, length: {maximum: MAX_NAME_LENGTH}
+    validates :feedback, presence: true, length: {maximum: MAX_FEEDBACK_LENGTH}
+    validates :priority, uniqueness: { scope: :activity_id },
+      numericality: { only_integer: true, greater_than_or_equal_to: MIN_PRIORITY }
+
+    def serializable_hash(options = nil)
+      options ||= {}
+      super(options.reverse_merge(
+        only: [:id, :activity_id, :name, :feedback, :priority],
+        include: {
+          rules: {},
+          prompts: { only: [:id, :conjunction] }
+        }
+      ))
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/config/routes.rb
+++ b/services/QuillLMS/engines/comprehension/config/routes.rb
@@ -1,4 +1,11 @@
 Comprehension::Engine.routes.draw do
-  resources :activities, only: [:index, :show, :create, :update, :destroy]
+  resources :activities, only: [:index, :show, :create, :update, :destroy] do
+    resources :rule_sets, only: [:index, :show, :create, :update, :destroy]
+  end
+
+  resources :rule_sets, only: [] do
+    resources :rules, only: [:index, :show, :create, :update, :destroy]
+  end
+
   resources :turking_rounds, only: [:index, :show, :create, :update, :destroy]
 end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200625222938_create_comprehension_rule_sets.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200625222938_create_comprehension_rule_sets.rb
@@ -1,0 +1,15 @@
+class CreateComprehensionRuleSets < ActiveRecord::Migration
+  def change
+    create_table :comprehension_rule_sets do |t|
+      t.integer :activity_id
+      t.integer :prompt_id
+      t.string :name, limit: 100
+      t.text :feedback
+      t.integer :priority, limit: 2
+
+      t.timestamps null: false
+    end
+    add_index :comprehension_rule_sets, :activity_id
+    add_index :comprehension_rule_sets, :prompt_id
+  end
+end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200626160522_create_comprehension_rules.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200626160522_create_comprehension_rules.rb
@@ -1,0 +1,12 @@
+class CreateComprehensionRules < ActiveRecord::Migration
+  def change
+    create_table :comprehension_rules do |t|
+      t.integer :rule_set_id
+      t.string :regex_text, limit: 200
+      t.boolean :case_sensitive
+
+      t.timestamps null: false
+    end
+    add_index :comprehension_rules, :rule_set_id
+  end
+end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200626181312_create_comprehension_prompts_rule_sets_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200626181312_create_comprehension_prompts_rule_sets_table.rb
@@ -1,0 +1,10 @@
+class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration
+  def change
+    create_table :comprehension_prompts_rule_sets do |t|
+      t.integer :prompt_id
+      t.integer :rule_set_id
+    end
+    add_index :comprehension_prompts_rule_sets, :prompt_id
+    add_index :comprehension_prompts_rule_sets, :rule_set_id
+  end
+end

--- a/services/QuillLMS/engines/comprehension/lib/generators/quill_scaffold_controller/templates/quill_api_controller.rb
+++ b/services/QuillLMS/engines/comprehension/lib/generators/quill_scaffold_controller/templates/quill_api_controller.rb
@@ -19,7 +19,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= namespace %>::<%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %>
+      render json: <%= "@#{singular_table_name}" %>, status: :created
     else
       render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
     end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rule_sets_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rule_sets_controller_test.rb
@@ -1,0 +1,169 @@
+require 'test_helper'
+
+module Comprehension
+  class RuleSetsControllerTest < ActionController::TestCase
+    setup do
+      @routes = Engine.routes
+    end
+
+    context "index" do
+      should "return successfully - no rule_set" do
+        activity = create(:comprehension_activity)
+        get :index, activity_id: activity.id
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_response :success
+        assert_equal Array, parsed_response.class
+        assert parsed_response.empty?
+      end
+
+      context 'with rule_sets' do
+        setup do
+          @rule_set = create(:comprehension_rule_set)
+        end
+
+        should "return successfully" do
+          get :index, activity_id: @rule_set.activity_id
+
+          parsed_response = JSON.parse(response.body)
+
+          assert_response :success
+          assert_equal Array, parsed_response.class
+          refute parsed_response.empty?
+      
+          assert_equal @rule_set.activity_id, parsed_response.first['activity_id']
+          assert_equal @rule_set.prompts, parsed_response.first['prompts']
+          assert_equal @rule_set.name, parsed_response.first['name']
+          assert_equal @rule_set.feedback, parsed_response.first['feedback']
+          assert_equal @rule_set.priority, parsed_response.first['priority']
+        end
+      end
+    end
+
+    context "create" do
+      setup do
+        @activity = create(:comprehension_activity)
+        @rule_set = build(:comprehension_rule_set, activity: @activity)
+      end
+
+      should "create a valid record and return it as json" do
+        post :create, activity_id: @activity.id, rule_set: { feedback: @rule_set.feedback, name: @rule_set.name, priority: @rule_set.priority, prompts: @rule_set.prompts }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 201, response.code.to_i
+	assert_equal @activity.id, parsed_response['activity_id']
+        assert_equal @rule_set.prompts, parsed_response['prompts']
+        assert_equal @rule_set.name, parsed_response['name']
+        assert_equal @rule_set.feedback, parsed_response['feedback']
+        assert_equal @rule_set.priority, parsed_response['priority']
+        assert_equal 1, RuleSet.count
+      end
+
+      should "not create an invalid record and return errors as json" do
+        post :create, activity_id: @rule_set.activity_id, rule_set: { feedback: 'x' * 501, name: 'x' * 101, priority: 1.5 }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 422, response.code.to_i
+        assert parsed_response['name'].include?("is too long (maximum is 100 characters)")
+        assert parsed_response['feedback'].include?("is too long (maximum is 500 characters)")
+        assert parsed_response['priority'].include?("must be an integer")
+        assert_equal 0, RuleSet.count
+      end
+    end
+
+    context "show" do
+      setup do
+        @rule_set = create(:comprehension_rule_set)
+        @rule = create(:comprehension_rule, rule_set: @rule_set)
+      end
+
+      should "return json if found" do
+        get :show, activity_id: @rule_set.activity_id, id: @rule_set.id
+
+        assert_equal 200, response.code.to_i
+
+        parsed_response = JSON.parse(response.body)
+    
+        assert_equal @rule_set.prompts, parsed_response['prompts']
+        assert_equal @rule_set.name, parsed_response['name']
+        assert_equal @rule_set.feedback, parsed_response['feedback']
+        assert_equal @rule_set.priority, parsed_response['priority']
+
+        rule_response = parsed_response['rules'].first
+
+        assert_equal @rule.id, rule_response['id']
+        assert_equal @rule.regex_text, rule_response['regex_text']
+        assert_equal @rule.case_sensitive, rule_response['case_sensitive']
+      end
+
+      should "raise if not found (to be handled by parent app)" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, activity_id: @rule_set.activity_id, id: 99999
+        end
+      end
+    end
+
+    context "update" do
+      setup do
+        @prompt = create(:comprehension_prompt)
+        @rule_set = create(:comprehension_rule_set, activity: @prompt.activity)
+        @rule = create(:comprehension_rule, rule_set: @rule_set)
+      end
+
+      should "update record if valid, return nothing" do
+        patch :update, activity_id: @rule_set.activity_id, id: @rule_set.id, rule_set: { feedback: 'Updated feedback', name: 'Updated name', priority: 100, prompt_ids: [@prompt.id] }
+
+        assert_equal "", response.body
+        assert_equal 204, response.code.to_i
+
+        @rule_set.reload
+    
+        assert_equal [@prompt], @rule_set.prompts
+        assert_equal "Updated name", @rule_set.name
+        assert_equal "Updated feedback", @rule_set.feedback
+        assert_equal 100, @rule_set.priority
+      end
+
+      should "update rule if valid, return nothing" do
+        patch :update, activity_id: @rule_set.activity_id, id: @rule_set.id, rule_set: { rules_attributes: [{id: @rule.id, regex_text: 'Some updated text', case_sensitive: true}] }
+
+        assert_equal "", response.body
+        assert_equal 204, response.code.to_i
+
+        @rule.reload
+
+        assert_equal 'Some updated text', @rule.regex_text
+        assert_equal true, @rule.case_sensitive
+      end
+
+      should "not update record and return errors as json" do
+        patch :update, activity_id: @rule_set.activity_id, id: @rule_set.id, rule_set: { feedback: 'x' * 501, name: 'x' * 101, priority: 1.5, prompts: @rule_set.prompts }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 422, response.code.to_i
+        assert parsed_response['name'].include?("is too long (maximum is 100 characters)")
+        assert parsed_response['feedback'].include?("is too long (maximum is 500 characters)")
+        assert parsed_response['priority'].include?("must be an integer")
+      end
+    end
+
+    context 'destroy' do
+      setup do
+        @rule_set = create(:comprehension_rule_set)
+      end
+
+      should "destroy record at id" do
+        delete :destroy, activity_id: @rule_set.activity_id, id: @rule_set.id
+
+        assert_equal "", response.body
+        assert_equal 204, response.code.to_i
+        assert @rule_set.id # still in test memory
+        assert_nil RuleSet.find_by_id(@rule_set.id) # not in DB.
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+module Comprehension
+  class RulesControllerTest < ActionController::TestCase
+    setup do
+      @routes = Engine.routes
+    end
+
+    context "index" do
+      should "return successfully - no rule" do
+        rule_set = create(:comprehension_rule_set)
+        activity = rule_set.activity
+        get :index, activity_id: activity.id, rule_set_id: rule_set.id
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_response :success
+        assert_equal Array, parsed_response.class
+        assert parsed_response.empty?
+      end
+
+      context 'with rules' do
+        setup do
+          @rule = create(:comprehension_rule)
+          @rule_set = @rule.rule_set
+          @activity = @rule_set.activity
+        end
+
+        should "return successfully" do
+          get :index, activity_id: @activity.id, rule_set_id: @rule_set.id
+
+          parsed_response = JSON.parse(response.body)
+
+          assert_response :success
+          assert_equal Array, parsed_response.class
+          refute parsed_response.empty?
+      
+          assert_equal @rule.rule_set_id, parsed_response.first['rule_set_id']
+          assert_equal @rule.regex_text, parsed_response.first['regex_text']
+          assert_equal @rule.case_sensitive, parsed_response.first['case_sensitive']
+        end
+      end
+    end
+
+    context "create" do
+      setup do
+        @rule = build(:comprehension_rule)
+        @rule_set = create(:comprehension_rule_set)
+        @activity = @rule_set.activity
+      end
+
+      should "create a valid record and return it as json" do
+        post :create, activity_id: @activity.id, rule_set_id: @rule_set.id, rule: { case_sensitive: @rule.case_sensitive, regex_text: @rule.regex_text, rule_set_id: @rule.rule_set_id }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 201, response.code.to_i
+        assert_equal @rule_set.id, parsed_response['rule_set_id']
+        assert_equal @rule.regex_text, parsed_response['regex_text']
+        assert_equal @rule.case_sensitive, parsed_response['case_sensitive']
+        assert_equal 1, Rule.count
+      end
+
+      should "not create an invalid record and return errors as json" do
+        post :create, activity_id: @activity.id, rule_set_id: @rule_set.id, rule: { regex_text: 'x' * 201 }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 422, response.code.to_i
+        assert parsed_response['regex_text'].include?("is too long (maximum is 200 characters)")
+        assert_equal 0, Rule.count
+      end
+    end
+
+    context "show" do
+      setup do
+        @rule = create(:comprehension_rule)
+        @rule_set = @rule.rule_set
+        @activity = @rule_set.activity
+      end
+
+      should "return json if found" do
+        get :show, activity_id: @activity.id, rule_set_id: @rule_set.id, id: @rule.id
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 200, response.code.to_i
+        assert_equal @rule.rule_set_id, parsed_response['rule_set_id']
+        assert_equal @rule.regex_text, parsed_response['regex_text']
+        assert_equal @rule.case_sensitive, parsed_response['case_sensitive']
+      end
+
+      should "raise if not found (to be handled by parent app)" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, activity_id: @activity.id, rule_set_id: @rule_set.id, id: 99999
+        end
+      end
+    end
+
+    context "update" do
+      setup do
+        @rule = create(:comprehension_rule)
+        @rule_set = @rule.rule_set
+        @activity = @rule_set.activity
+      end
+
+      should "update record if valid, return nothing" do
+        patch :update, activity_id: @activity.id, rule_set_id: @rule_set.id, id: @rule.id, rule: { case_sensitive: false, regex_text: 'Updated text' }
+
+        assert_equal "", response.body
+        assert_equal 204, response.code.to_i
+
+        @rule.reload
+    
+        assert_equal 'Updated text', @rule.regex_text
+        assert_equal false, @rule.case_sensitive
+      end
+
+      should "not update record and return errors as json" do
+        patch :update, activity_id: @activity.id, rule_set_id: @rule_set.id, id: @rule.id, rule: { case_sensitive: nil, regex_text: 'x' * 201 }
+
+        parsed_response = JSON.parse(response.body)
+
+        assert_equal 422, response.code.to_i
+        assert parsed_response['regex_text'].include?("is too long (maximum is 200 characters)")
+        assert parsed_response['case_sensitive'].include?("is not included in the list")
+      end
+    end
+
+    context 'destroy' do
+      setup do
+        @rule = create(:comprehension_rule)
+        @rule_set = @rule.rule_set
+        @activity = @rule_set.activity
+      end
+
+      should "destroy record at id" do
+        delete :destroy, activity_id: @activity.id, rule_set_id: @rule_set.id, id: @rule.id
+
+        assert_equal "", response.body
+        assert_equal 204, response.code.to_i
+        assert @rule.id # still in test memory
+        assert_nil Rule.find_by_id(@rule.id) # not in DB.
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -48,6 +48,37 @@ ActiveRecord::Schema.define(version: 20200630161345) do
 
   add_index "comprehension_prompts", ["activity_id"], name: "index_comprehension_prompts_on_activity_id", using: :btree
 
+  create_table "comprehension_prompts_rule_sets", force: :cascade do |t|
+    t.integer "prompt_id"
+    t.integer "rule_set_id"
+  end
+
+  add_index "comprehension_prompts_rule_sets", ["prompt_id"], name: "index_comprehension_prompts_rule_sets_on_prompt_id", using: :btree
+  add_index "comprehension_prompts_rule_sets", ["rule_set_id"], name: "index_comprehension_prompts_rule_sets_on_rule_set_id", using: :btree
+
+  create_table "comprehension_rule_sets", force: :cascade do |t|
+    t.integer  "activity_id"
+    t.integer  "prompt_id"
+    t.string   "name",        limit: 100
+    t.text     "feedback"
+    t.integer  "priority",    limit: 2
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "comprehension_rule_sets", ["activity_id"], name: "index_comprehension_rule_sets_on_activity_id", using: :btree
+  add_index "comprehension_rule_sets", ["prompt_id"], name: "index_comprehension_rule_sets_on_prompt_id", using: :btree
+
+  create_table "comprehension_rules", force: :cascade do |t|
+    t.integer  "rule_set_id"
+    t.string   "regex_text",     limit: 200
+    t.boolean  "case_sensitive"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "comprehension_rules", ["rule_set_id"], name: "index_comprehension_rules_on_rule_set_id", using: :btree
+
   create_table "comprehension_turking_rounds", force: :cascade do |t|
     t.integer  "activity_id"
     t.uuid     "uuid"

--- a/services/QuillLMS/engines/comprehension/test/factories/comprehension/rule_sets.rb
+++ b/services/QuillLMS/engines/comprehension/test/factories/comprehension/rule_sets.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :comprehension_rule_set, class: 'Comprehension::RuleSet' do
+    association :activity, factory: :comprehension_activity
+    name { "MyString" }
+    feedback { "MyString" }
+    priority { 1 }
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/factories/comprehension/rules.rb
+++ b/services/QuillLMS/engines/comprehension/test/factories/comprehension/rules.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comprehension_rule, class: 'Comprehension::Rule' do
+    association :rule_set, factory: :comprehension_rule_set
+    regex_text { "MyString" }
+    case_sensitive { false }
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/activity_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/activity_test.rb
@@ -7,6 +7,7 @@ module Comprehension
     context 'associations' do
       should have_many(:passages).dependent(:destroy)
       should have_many(:prompts).dependent(:destroy)
+      should have_many(:rule_sets).dependent(:destroy)
     end
 
     context 'validations' do
@@ -61,7 +62,7 @@ module Comprehension
         @passage = create(:comprehension_passage, activity: @activity)
 
         @activity.destroy
-        refute Passage.exists?(@passage)
+        refute Passage.exists?(@passage.id)
       end
 
       should 'destroy dependent prompts' do
@@ -69,7 +70,7 @@ module Comprehension
         @prompt = create(:comprehension_prompt, activity: @activity)
 
         @activity.destroy
-        refute Prompt.exists?(@prompt)
+        refute Prompt.exists?(@prompt.id)
       end
     end
 

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
@@ -4,6 +4,8 @@ module Comprehension
   class PromptTest < ActiveSupport::TestCase
     context 'relations' do
       should belong_to(:activity)
+      should have_many(:prompts_rule_sets)
+      should have_many(:rule_sets).through(:prompts_rule_sets)
     end
 
     context 'validations' do

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/prompts_rule_set_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/prompts_rule_set_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+module Comprehension
+  class PromptsRuleSetTest < ActiveSupport::TestCase
+    context 'relations' do
+      should belong_to(:prompt)
+      should belong_to(:rule_set)
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_set_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_set_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+module Comprehension
+  class RuleSetTest < ActiveSupport::TestCase
+
+    context 'relationships' do
+      should belong_to(:activity)
+      should have_many(:prompts_rule_sets)
+      should have_many(:prompts).through(:prompts_rule_sets)
+      should have_many(:rules).dependent(:destroy)
+    end
+
+    context 'validations' do
+      should validate_presence_of(:activity)
+      should validate_presence_of(:name)
+      should validate_length_of(:name).is_at_most(100)
+      should validate_presence_of(:feedback)
+      should validate_length_of(:feedback).is_at_most(500)
+      should validate_uniqueness_of(:priority)
+        .scoped_to(:activity_id)
+      should validate_numericality_of(:priority)
+        .only_integer
+        .is_greater_than_or_equal_to(0)
+    end
+
+    context 'serializable_hash' do
+      setup do
+        @activity = create(:comprehension_activity, title: "First Activity", target_level: 8, scored_level: "4th grade")
+        @prompt = create(:comprehension_prompt, activity: @activity, text: "it is good.", conjunction: "because", max_attempts_feedback: "good work!.")
+        @rule_set = create(:comprehension_rule_set, activity: @activity, prompts: [@prompt], name: 'Test Rule Set', feedback: 'Feedback' * 10, priority: 0)
+        @rule = create(:comprehension_rule, rule_set: @rule_set, regex_text: 'test', case_sensitive: true)
+      end
+
+      should 'fill out hash with all fields' do
+        json_hash = @rule_set.as_json
+
+        assert_equal json_hash['id'], @rule_set.id
+        assert_equal json_hash['activity_id'], @activity.id
+        assert_equal json_hash['name'], @rule_set.name
+        assert_equal json_hash['feedback'], @rule_set.feedback
+        assert_equal json_hash['priority'], @rule_set.priority
+
+        prompt_hash = json_hash['prompts'].first
+
+        assert_equal prompt_hash['id'], @prompt.id
+
+        rule_hash = json_hash['rules'].first
+
+        assert_equal rule_hash['id'], @rule.id
+        assert_equal rule_hash['regex_text'], @rule.regex_text
+        assert_equal rule_hash['case_sensitive'], @rule.case_sensitive
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Comprehension
+  class RuleTest < ActiveSupport::TestCase
+
+    context 'relationships' do
+      should belong_to(:rule_set)
+    end
+
+    context 'validations' do
+      should validate_presence_of(:rule_set)
+      should validate_presence_of(:regex_text)
+      should validate_length_of(:regex_text).is_at_most(200)
+    end
+
+    context 'custom validations' do
+      setup do
+        @rule_set = create(:comprehension_rule_set, name: 'Test Rule Set', feedback: 'Feedback' * 10, priority: 0)
+        @rule = Rule.create(rule_set: @rule_set, regex_text: 'test regex')
+      end
+
+      should 'provide a default value for "case_sensitive"' do
+        assert @rule.case_sensitive
+      end
+
+      should 'not override a "case_sensitive" with the default if one is provided' do
+        rule = Rule.create(rule_set: @rule_set, regex_text: 'test regex', case_sensitive: false)
+        assert rule.valid?
+        refute rule.case_sensitive
+      end
+
+      should 'validate the presence of "case_sensitive"' do
+        @rule.case_sensitive = nil
+        refute @rule.valid?
+      end
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/import_comprehension.rake
+++ b/services/QuillLMS/lib/tasks/import_comprehension.rake
@@ -12,20 +12,31 @@ namespace :import_comprehension do
     all_activities = JSON.parse(response.body)
     all_activities.each do |a|
       activities_url = "#{base_url}/api/activities/#{a['id']}.json"
+      regex_rules_url = "#{base_url}/api/activities/#{a['id']}/rulesets.json"
       response = HTTParty.get(activities_url)
       source_activity = JSON.parse(response.body)
+      response = HTTParty.get(regex_rules_url)
+      source_regex_rules = JSON.parse(response.body) | []
       activity = Comprehension::Activity.create(
         title: source_activity['title'],
         target_level: source_activity['target_reading_level'] || 12,
         passages: source_activity['passages'].map { |p| Comprehension::Passage.new(text: p['text']) },
-        prompts: source_activity['prompts'].map { |p|
+        prompts: source_activity['prompts'].map do |p|
           Comprehension::Prompt.new(
             max_attempts: p['max_attempts'],
             max_attempts_feedback: p['max_attempts_feedback'],
             text: p['text'].split[0..-2].join(' '),
             conjunction: p['text'].split[-1]
           )
-        }
+        end,
+        rule_sets: source_regex_rules.each_with_index.map do |r, i|
+          Comprehension::RuleSet.new(
+            name: r['name'][0,100],
+            feedback: r['name'],
+            priority: i,
+            rules: r['rules'].map { |rule| Comprehension::Rule.new(regex_text: rule['regex_text'], case_sensitive: rule['case_sensitive']) }
+          )
+        end
       )
     end
   end


### PR DESCRIPTION
* Set up models for Regex

This is all relations and validations along with tests

* Remove 'location' option from render call in create actions in template

We're not using this redirect, and for newer Rails users, it may not be intuitive how to update this value to work properly.

* Add controller and tests for RuleSet interaction

* Add Rule controller and tests

Also do some small tweaks to Rule validation

* Make sure to install migrations in the main app

* Somehow accidentally committed this file back, so removing it

* Fix linting errors

* Modify import code to include regex rules

* Make a minor tweak to Comprehension import

So that prompt text gets set properly

* More updates based on PR feedback

- Refactor nested resource controllers to be more Rails-y
- Use 'has_many through' for many-to-many relationships

* Update tests based on deprecation warnings

* Tweak routing rules to simplify them slightly

* Make tweak to migration name so it works properly

Not sure how this didn't come up before, but some how it didn't

## WHAT

## WHY

## HOW

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)

## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
