### PR TITLE
add validation and rake task for handling duplicate Activity results in assignment flow

### DIFF
--- a/services/QuillLMS/app/models/activity_category_activity.rb
+++ b/services/QuillLMS/app/models/activity_category_activity.rb
@@ -4,7 +4,7 @@ class ActivityCategoryActivity < ActiveRecord::Base
 
   after_commit :clear_activity_search_cache
   
-  validates :activity_category, uniqueness: { scope: :activity }
+  validates :activity_category_id, uniqueness: { scope: :activity_id }
 
   def clear_activity_search_cache
     Activity.clear_activity_search_cache

--- a/services/QuillLMS/lib/tasks/remove_order_number_duplicates.rake
+++ b/services/QuillLMS/lib/tasks/remove_order_number_duplicates.rake
@@ -10,5 +10,5 @@ namespace :remove_order_number_duplicates do
         ids_check[ids] = true
       end
     end
- end
+  end
 end

--- a/services/QuillLMS/spec/models/activity_category_activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_category_activity_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe ActivityCategoryActivity, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should validate_uniqueness_of(:activity_category_id).scoped_to(:activity_id) }
 end

--- a/services/QuillLMS/spec/queries/activity_search_spec.rb
+++ b/services/QuillLMS/spec/queries/activity_search_spec.rb
@@ -6,7 +6,7 @@ describe ActivitySearch do
     let!(:topic) { create(:topic) }
     let!(:section) { create(:section) }
     let!(:activity) { create(:activity, activity_categories: [], flags: %w{beta production}, activity_classification_id: activity_classification.id, topic: topic, section: section) }
-    let!(:activity_category) { create(:activity_category, activities: [activity]) }
+    let!(:activity_category) { create(:activity_category) }
     let!(:activity_category_activity) { create(:activity_category_activity, activity_category: activity_category, activity: activity) }
 
     it 'should get the correct attributes based on the flag given' do


### PR DESCRIPTION
## WHAT
add validation and rake task for handling duplicate Activity results in assignment flow

## WHY
we're seeing some activities show up twice

## HOW
add validation to check for uniqueness of `activity_category_id` on `ActivityClassficationActivity` records and rake task to remove duplicate records

## Screenshots
(If applicable. Also, please censor any sensitive data)

## Have you added and/or updated tests?
(The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Not yet

## Have you deployed to Staging?
(Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Not yet-- will after importing some data