### PR TITLE
Tweak CircleCI caching logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,16 +89,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - npm-cache-lms-v3-{{ checksum "services/QuillLMS/client/package.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
-            - npm-cache-lms-v3-{{ checksum "services/QuillLMS/client/package.json" }}-
-            - npm-cache-lms-v3-
+            - npm-cache-lms-v3-{{ checksum "services/QuillLMS/client/package.json" }}
       - run:
           name: Install NPM dependencies
           command: |
             cd services/QuillLMS
             npm install
       - save_cache:
-          key: npm-cache-lms-v3-{{ checksum "services/QuillLMS/client/package-lock.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
+          key: npm-cache-lms-v3-{{ checksum "services/QuillLMS/client/package-lock.json" }}
           paths:
             - services/QuillLMS/client/node_modules
       - run:


### PR DESCRIPTION
## WHAT
Change the cache loading rules in CircleCI
## WHY
The old rules were loading a particularly old unbounded cache that was somehow breaking calls to `npm install`
## HOW
Removed the older cache loads and focused on a specific more "proper" cache load instead

## Have you added and/or updated tests?
No test changes, just want them to run

## Have you deployed to Staging?
No.  No actual code is changing.  I'm hoping that CI passes when I create this PR, though.