### PR TITLE
Lms/add cb lifetime premium

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -26,7 +26,8 @@ class Subscription < ActiveRecord::Base
                          'School Paid',
                          'Teacher Paid',
                          'Purchase Missing School',
-                         'Premium Credit']
+                         'Premium Credit',
+                         CB_LIFETIME_SUBSCRIPTION_TYPE]
 
   OFFICIAL_FREE_TYPES = ['School NYC Free',
                          'School Research',


### PR DESCRIPTION
## WHAT
Add a new special individual teacher subscription type that can only be assigned through the admin panel with a really long expiration date to make it a "lifetime" subscription
## WHY
As part of our agreement with the College Board, teachers with a specific status are entitled to lifetime Quill subscriptions, and this supports that
## HOW
Just added a new subscription type and some code to set its default expiration 50 years in the future

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  There's no test coverage around the various subscription types
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
