### PR TITLE
college board card on lms teacher dashboard

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
@@ -81,17 +81,6 @@
         margin-left: -8px;
         margin-right: 32px;
       }
-      .new-tag {
-        border-radius: 3px;
-        background-color: #eb5757;
-        color: white;
-        margin-left: 4px;
-        padding: 0px 4px;
-        font-size: 12px;
-        font-weight: bold;
-        letter-spacing: 0.4px;
-        text-align: center;
-      }
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/college_board_mini.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/college_board_mini.scss
@@ -1,0 +1,17 @@
+.college-board-mini {
+  .mini_content {
+    padding: 11px 16px;
+  }
+  p {
+    margin-top: 11px;
+  }
+  a {
+    height: 40px;
+    border-radius: 6px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 20px;
+  }
+}

--- a/services/QuillLMS/app/assets/stylesheets/shared/new_tag.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/new_tag.scss
@@ -1,0 +1,11 @@
+.new-tag {
+  border-radius: 3px;
+  background-color: #eb5757;
+  color: white;
+  margin-left: 4px;
+  padding: 0px 4px;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.4px;
+  text-align: center;
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/college_board_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/college_board_mini.test.jsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CollegeBoardMini component should render 1`] = `
+<CollegeBoardMini>
+  <div
+    className="mini_container results-overview-mini-container col-md-4 col-sm-5 text-center college-board-mini"
+  >
+    <div
+      className="mini_content"
+    >
+      <h3>
+        AP and Pre-AP Activities 
+        <span
+          className="new-tag"
+        >
+          NEW
+        </span>
+      </h3>
+      <p>
+        The College Board has partnered with Quill to provide free and open source activities for high school students.
+      </p>
+      <p>
+        These activities cover key writing skills needed for AP exams, as well as activities based on Pre-AP texts.
+      </p>
+      <a
+        className="bg-quillgreen text-white"
+        href="/assign/college-board"
+      >
+        Explore the Activities
+      </a>
+    </div>
+  </div>
+</CollegeBoardMini>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/college_board_mini.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/college_board_mini.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import CollegeBoardMini from '../college_board_mini';
+
+describe('CollegeBoardMini component', () => {
+
+  it('should render', () => {
+    expect(mount(<CollegeBoardMini />)).toMatchSnapshot();
+  });
+
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_overview.jsx
@@ -8,6 +8,7 @@ import NewTools from './new_tools_mini.jsx';
 import PremiumPromo from './premium_promo.jsx';
 import LessonsList from './lessons_list.jsx';
 import DiagnosticMini from './diagnostic_mini.jsx';
+import CollegeBoardMini from './college_board_mini.tsx';
 
 export default class ClassOverview extends React.Component {
   constructor(props) {
@@ -55,12 +56,15 @@ export default class ClassOverview extends React.Component {
     return <DiagnosticMini />;
   };
 
+  collegeBoardMini = () => <CollegeBoardMini />;
+
   render() {
     return (
       <div className="row">
         {this.teacherGuide()}
         {this.diagnosticMini()}
         {this.lessonsList()}
+        {this.collegeBoardMini()}
         {this.hasPremium()}
         {this.overviewMinis()}
         <NotificationFeed notifications={this.props.notifications} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/college_board_mini.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/college_board_mini.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+const CollegeBoardMini = () => (
+  <div className="mini_container results-overview-mini-container col-md-4 col-sm-5 text-center college-board-mini">
+    <div className="mini_content">
+      <h3>AP and Pre-AP Activities <span className="new-tag">NEW</span></h3>
+      <p>The College Board has partnered with Quill to provide free and open source activities for high school students.</p>
+      <p>These activities cover key writing skills needed for AP exams, as well as activities based on Pre-AP texts.</p>
+      <a className="bg-quillgreen text-white" href="/assign/college-board">Explore the Activities</a>
+    </div>
+  </div>
+)
+
+export default CollegeBoardMini


### PR DESCRIPTION
## WHAT
Add a card to the teacher dashboard that links to the new College Board section of the assignment flow.

## WHY
To make it easier for teachers to find this content.

## HOW
Basically just duplicated the existing HTML structure/class names for other minis. I don't love how this part of the site works right now but since the style is out of date with our other pages, I imagine we'll be redoing it at some point in the not too distant future so I didn't want to spend too much time updating it now.

### Screenshots
<img width="257" alt="Screen Shot 2020-07-28 at 9 14 10 AM" src="https://user-images.githubusercontent.com/18669014/88670492-206d9f80-d0b3-11ea-96de-0525686b99f5.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
