### PR TITLE
lms/stop-renewing-orphaned-subscriptions

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -216,7 +216,7 @@ class Subscription < ActiveRecord::Base
 
   def self.update_todays_expired_recurring_subscriptions
     expired_today_or_previously_and_recurring.each do |s|
-      s.update_if_charge_succeeds
+      s.update_if_charge_succeeds unless s.users.empty?
     end
   end
 


### PR DESCRIPTION
## WHAT
Don't renew subscriptions that are attached to no users
## WHY
For some reason we don't fully understand yet, some number of Subscription records are orphaned (not attached to any users or schools), which means they show up in none of our admin tools, but they still qualify for auto renewal if they're set up that way.  And there's no way to disable them from being that way since they've become inaccessible.
## HOW
- Just add a clause to the code that renews subscriptions to skip renewal on any subscription that isn't actually attached to users

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  The tests that are supposed to cover subscription renewals are commented out with a "TODO: Figure out why these don't work", and this needs to get merged and deployed today before more renewals run overnight
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
