### PR TITLE
Don't renew subscriptions that are attached to no users (#6569)

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -216,7 +216,7 @@ class Subscription < ActiveRecord::Base
 
   def self.update_todays_expired_recurring_subscriptions
     expired_today_or_previously_and_recurring.each do |s|
-      s.update_if_charge_succeeds
+      s.update_if_charge_succeeds unless s.users.empty?
     end
   end
 


### PR DESCRIPTION
For some reason we don't fully understand yet, some number of Subscription records are orphaned (not attached to any users or schools), which means they show up in none of our admin tools, but they still qualify for auto renewal if they're set up that way.  And there's no way to disable them from being that way since they've become inaccessible.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
