### PR TITLE
fix path for prod connect aws bucket in deploy script

### DIFF
--- a/deprecated_independent_services/QuillConnect/deploy.sh
+++ b/deprecated_independent_services/QuillConnect/deploy.sh
@@ -13,7 +13,7 @@ case $1 in
       echo "You can not make a production deploy from a branch other than 'production'.  Don't forget to make sure you have the latest code pulled."
       exit 1
     fi
-    S3_DEPLOY_BUCKET=s3://aws-website-quill-connect
+    S3_DEPLOY_BUCKET=s3://aws-website-quillconnect-6sy4b
     ;;
   staging)
     S3_DEPLOY_BUCKET=s3://aws-website-quill-connect-staging


### PR DESCRIPTION
## WHAT
Fix the name of the bucket that hosts (hosted) the prod version of Connect.

## WHY
Mostly for historical reasons - we should never have to use this deploy script again but I still want it to be accurate.

## HOW
Just change the name.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | (Possible answers:  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
