### PR TITLE
lms/update-teacher-profile-copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_danger_zone.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_danger_zone.jsx
@@ -30,7 +30,7 @@ export default class TeacherDangerZone extends React.Component {
   render() {
     return (<div className="teacher-account-danger-zone user-account-section">
       {this.renderModal()}
-      <h1>Danger Zone</h1>
+      <h1>Danger zone</h1>
       <div className="quill-button outlined secondary medium" onClick={this.showDeleteAccountModal}>Delete my account</div>
       <p className="danger-zone-description">This will delete your user account, including all classes and reports.</p>
     </div>)


### PR DESCRIPTION
## WHAT
Make a minor tweak to copy on the Teacher Profile page, updating some copy to be sentence-case instead of title-case
## WHY
The other header copy on this page is sentence-case, so this update is for the sake of consistency
## HOW
Just a copy change

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on copy
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
