### PR TITLE
lms/fix-duplicate-diagnostic-instructions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/sentenceCombining.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/sentenceCombining.jsx
@@ -66,7 +66,7 @@ class ELLSentenceCombining extends React.Component {
     const { instructions } = question;
     const textKey = translationMap[question.key];
     let text = instructions ? instructions : translations.english[textKey];
-    if(!language) {
+    if(!language || language == ENGLISH) {
       return <p dangerouslySetInnerHTML={{ __html: text, }} />;
     } else if (language && diagnosticID === 'ell') {
       const textClass = rightToLeftLanguages.includes(language) ? 'right-to-left' : '';


### PR DESCRIPTION
## WHAT
Add a condition to not show "translated" instructions in English

## WHY
The system already displays the English instructions, so if the selected language is English, unlike with other languages, we don't need to display the text again in the selected language.

## HOW
There was already a condition for suppressing translations if no language was selected at all, we just modified that logic to include cases where the selected language is English, since we want the same behavior in that case, too.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around this behavior
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
