### PR TITLE
fix broken links in tool admin page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -154,7 +154,7 @@ export class FocusPointsContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Focus Points</h1>
-          <a className="button is-outlined is-primary" href={`/#/admin/${questionTypeLink}/${questionID}/focus-points/new`} style={{ float: 'right', }}>Add Focus Point</a>
+          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${questionTypeLink}/${questionID}/focus-points/new`} style={{ float: 'right', }}>Add Focus Point</a>
           {this.renderfPButton()}
         </div>
         {this.renderFocusPointsList()}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -116,7 +116,7 @@ class IncorrectSequencesContainer extends Component {
           {this.renderConceptResults(val.conceptResults, key)}
         </div>
         <footer className="card-footer">
-          <a className="card-footer-item" href={`/#/admin/${path}/${questionID}/incorrect-sequences/${key}/edit`}>Edit</a>
+          <a className="card-footer-item" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/${key}/edit`}>Edit</a>
           <a className="card-footer-item" onClick={() => this.deleteSequence(key)}>Delete</a>
         </footer>
       </div>
@@ -144,7 +144,7 @@ class IncorrectSequencesContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`/#/admin/${path}/${questionID}/incorrect-sequences/new`} style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/new`} style={{ float: 'right', }}>Add Incorrect Sequence</a>
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -85,7 +85,7 @@ export class FocusPointsContainer extends React.Component {
               {this.renderConceptResults(fp.conceptResults, fp.key)}
             </div>
             <footer className="card-footer">
-              <a className="card-footer-item" href={`/#/admin/questions/${this.props.match.params.questionID}/focus-points/${fp.key}/edit`}>Edit</a>
+              <a className="card-footer-item" href={`/grammar/#/admin/questions/${this.props.match.params.questionID}/focus-points/${fp.key}/edit`}>Edit</a>
               <a className="card-footer-item" onClick={() => this.deleteFocusPoint(fp.key)}>Delete</a>
             </footer>
           </div>
@@ -127,7 +127,7 @@ export class FocusPointsContainer extends React.Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Focus Points</h1>
-          <a className="button is-outlined is-primary" href={`/#/admin/questions/${this.props.match.params.questionID}/focus-points/new`} style={{ float: 'right', }}>Add Focus Point</a>
+          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${this.props.match.params.questionID}/focus-points/new`} style={{ float: 'right', }}>Add Focus Point</a>
           {this.renderfPButton()}
         </div>
         {this.renderFocusPointsList()}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -90,7 +90,7 @@ class IncorrectSequencesContainer extends React.Component {
           {this.renderConceptResults(val.conceptResults, key)}
         </div>
         <footer className="card-footer">
-          <a className="card-footer-item" href={`/#/admin/questions/${match.params.questionID}/incorrect-sequences/${key}/edit`}>Edit</a>
+          <a className="card-footer-item" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/${key}/edit`}>Edit</a>
           <button className="card-footer-item" onClick={onClickDelete} type="button">Delete</button>
         </footer>
       </div>
@@ -112,7 +112,7 @@ class IncorrectSequencesContainer extends React.Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} style={{ float: 'right', }}>Add Incorrect Sequence</a>
         </div>
         {this.renderSequenceList()}
         {children}


### PR DESCRIPTION
## WHAT
Fix some links inside the admin panel that were broken when we migrated the front ends to the LMS.

## WHY
We want these links to work.

## HOW
Devin made a bug report pointing out one instance of this, so I fixed that and did a global search to see if there was anywhere else with the same pattern and fixed those instances as well.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
