### PR TITLE
lms/tweak-sidekiq-config

### DIFF
--- a/services/QuillLMS/config/sidekiq.yml
+++ b/services/QuillLMS/config/sidekiq.yml
@@ -1,9 +1,9 @@
 ---
-:concurrency: 5
+:concurrency: 4
 staging:
-  :concurrency: 5
+  :concurrency: 4
 production:
-  :concurrency: 5
+  :concurrency: 4
 :queues:
   - critical
   - default


### PR DESCRIPTION
## WHAT
Reduce Sidekiq concurrency in the hopes that doesn't overrun db connections
## WHY
When our overnight jobs run, we're generating a number of errors indicating that we're out of connections in the DB connection pool.  These look like they generally retry successfully, but we should be able to run our Sidekiq jobs without generating avoidable errors.
## HOW
From what I can tell in the docs, Sidekiq uses the default ActiveRecord connection pool (the size of which is set in `config/database.yml` under the `pool` config.  This defaults to 5.  In theory, that should work perfectly with the current Sidekiq `concurrency` configuration of 5.  However, we're getting errors, which suggests that there's some weird mismatch.  My current guess is that Sidekiq may not fully wait for a thread to relinquish its db connection before starting a new job.  I'm proposing that we reduce Sidekiq concurrency by 1 to provide a small buffer to see if that resolves the issue.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around config changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
