### PR TITLE
make sure deleting demo account function actually works

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
@@ -2,6 +2,6 @@ module Demo::ReportDemoDestroyer
   def self.destroy_demo(name)
     email = name ? "hello+#{name}@quill.org" : "hello+demoteacher@quill.org"
     teacher  = User.find_by_email(email)
-    teacher.delete if teacher
+    teacher.destroy if teacher
   end
 end

--- a/services/QuillLMS/lib/report_demo_destroyer.rb
+++ b/services/QuillLMS/lib/report_demo_destroyer.rb
@@ -1,9 +1,0 @@
-module ReportDemoDestroyer
-  def self.destroy_demo(name)
-    email = name ? "hello+#{name}@quill.org" : "hello+demoteacher@quill.org"
-    teacher  = User.find_by_email(email)
-    SalesContact.where(user_id: teacher.id).destroy_all
-    Notification.where(user_id: teacher.id).destroy_all
-    teacher.destroy
-  end
-end


### PR DESCRIPTION
## WHAT
Update the `Demo::ReportDemoDestroyer` file to call `.destroy` instead of `.delete` on the demo teacher account, ensuring that the associated records get deleted and therefore that the deletion actually works. Also, delete a file with the same name that wasn't actually getting called anywhere and only served to confuse me.

## WHY
The worker that resets the demo account overnight was failing every time. This should fix that.

## HOW
Call `.destroy`, which will run callbacks (including `dependent: :destroy`), rather than `.delete`, which won't.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | I didn't deploy because staging is in use and this is small, but I did test the code via the rails console for the staging database.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
