### PR TITLE
fix no user error in Google Classrooms course requester

### DIFF
--- a/services/QuillLMS/app/services/google_integration/classroom/main.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/main.rb
@@ -13,7 +13,7 @@ module GoogleIntegration::Classroom::Main
   private
 
   def self.parse_courses(user, client)
-    raw_course_response = GoogleIntegration::Classroom::Requesters::Courses.run(client)
+    raw_course_response = GoogleIntegration::Classroom::Requesters::Courses.run(client, user)
     course_response = JSON.parse(raw_course_response.body, symbolize_names: true)
     if course_response.dig(:error, :status) == 'UNAUTHENTICATED'
       'UNAUTHENTICATED'

--- a/services/QuillLMS/app/services/google_integration/classroom/requesters/courses.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/requesters/courses.rb
@@ -1,6 +1,6 @@
 module GoogleIntegration::Classroom::Requesters::Courses
 
-  def self.run(client)
+  def self.run(client, user)
     service = client.discovered_api('classroom', 'v1')
     google_api_call = client.execute(api_method: service.courses.list, parameters: { teacherId: user.google_id })
     google_api_call


### PR DESCRIPTION
## WHAT
Fix error where we were calling `.google_id` on an object that didn't exist.

## WHY
I missed this in testing because the user I was testing must have had cached classrooms.

## HOW
Just pass the user object into the method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
