### PR TITLE
update copy for tooltips to include last resort class code

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
@@ -71,14 +71,14 @@ export default class Classroom extends React.Component<ClassroomProps, Classroom
     const { code, google_classroom_id, clever_id, } = classroom
     if (google_classroom_id) {
       return (<Tooltip
-        tooltipText="Add students by syncing with Google Classroom. No class code needed!"
+        tooltipText={`Add students by syncing with Google Classroom. Experiencing sync issues? You can add students with the class code '${code}'`}
         tooltipTriggerText="Class code: N/A"
       />)
     }
 
     if (clever_id) {
       return (<Tooltip
-        tooltipText="Add students here by adding students to Clever. No class code needed!"
+        tooltipText={`Add students through Clever. Experiencing sync issues? You can add students with the class code '${code}'`}
         tooltipTriggerText="Class code: N/A"
       />)
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_mini.jsx
@@ -43,14 +43,14 @@ export default class ClassMini extends React.Component {
     const { code, google_classroom_id, clever_id, } = classObj
     if (google_classroom_id) {
       return (<Tooltip
-        tooltipText="Add students by syncing with Google Classroom. No class code needed!"
+        tooltipText={`Add students by syncing with Google Classroom. Experiencing sync issues? You can add students with the class code '${code}'`}
         tooltipTriggerText="Class Code: N/A"
       />)
     }
 
     if (clever_id) {
       return (<Tooltip
-        tooltipText="Add students here by adding students to Clever. No class code needed!"
+        tooltipText={`Add students through Clever. Experiencing sync issues? You can add students with the class code '${code}'`}
         tooltipTriggerText="Class Code: N/A"
       />)
     }

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -129,7 +129,6 @@
     "react-textarea-autosize": "^4.3.2",
     "react-timezone": "^2.3.0",
     "react-tooltip": "^4.1.2",
-    "react-transition-group": "^2.9.0",
     "react-wakelock": "0.0.4",
     "react-wakelock-react16": "0.0.7",
     "redux": "^3.3.1",


### PR DESCRIPTION
## WHAT
Update the copy for the Google/Clever class code tooltips to include the code in case teachers need to have their students use it as a last resort. I also removed a package from the `package.json` that wasn't in use and was causing weird errors on this page for some reason.

## WHY
Sometimes there are issues with Clever syncing or Google syncing and teachers should be able to have their students join via class code in that instance.

## HOW
Just update the text.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
