### PR TITLE
last batch of nil error catches

### DIFF
--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -42,7 +42,7 @@ class Auth::CleverController < ApplicationController
         url = session[ApplicationController::POST_AUTH_REDIRECT]
         session.delete(ApplicationController::POST_AUTH_REDIRECT)
         return redirect_to url
-      elsif current_user.is_new_teacher_without_school?
+      elsif current_user&.is_new_teacher_without_school?
         # then the user does not have a school and needs one
         return redirect_to '/sign-up/add-k12'
       end

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -248,7 +248,7 @@ module PublicProgressReports
       activity_sessions = ActivitySession.includes(concept_results: :concept)
                       .where(classroom_unit_id: classroom_unit.id, is_final_score: true, activity: activity_id)
       activity_sessions_counted = activity_sessions_with_counted_concepts(activity_sessions)
-      unique_students = activity_sessions.map {|activity_session| user = activity_session.user; {id: user.id, name: user.name}}
+      unique_students = activity_sessions.map {|activity_session| user = activity_session.user; {id: user&.id, name: user&.name || "Unknown Student"}}
                                          .sort_by {|stud| stud[:name].split()[1]}
 
       recommendations = RecommendationsQuery.new(diagnostic.id).activity_recommendations.map do |activity_pack_recommendation|


### PR DESCRIPTION
## WHAT
Last batch of nil error catches

## WHY
Clear up all the nil errors in Sentry so our users don't have to see them!

## HOW
1. The first catch is just to avoid a nil error when `current_user` is nil in `clever_controller`. Not sure why this happens but with the catch it will just redirect the user to sign in again.

2. The second catch is for a rare situation where the admin are using the demo account and it tries to pull a dummy progress report for a demo student, Maya Angelou, who has been deleted. This shouldn't happen either and I'm not sure why it happens (it's rare) but this catch will just prevent the nil error on her name.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny changes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
