### PR TITLE
handle course requester differently depending whether teacher or student

### DIFF
--- a/services/QuillLMS/app/services/google_integration/classroom/requesters/courses.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/requesters/courses.rb
@@ -2,7 +2,8 @@ module GoogleIntegration::Classroom::Requesters::Courses
 
   def self.run(client, user)
     service = client.discovered_api('classroom', 'v1')
-    google_api_call = client.execute(api_method: service.courses.list, parameters: { teacherId: user.google_id })
+    parameters = user.teacher? ? { teacherId: user.google_id } : { studentId: user.google_id }
+    google_api_call = client.execute(api_method: service.courses.list, parameters: parameters)
     google_api_call
   end
 end


### PR DESCRIPTION
## WHAT
Update the course requester logic to work differently depending on whether the user being passed in is a teacher or a student.

## WHY
Now that we have scoped the requester to only find classes that a given user teaches, we will not be returning the right classes for students who use this method (this is a backup way that we have to make sure students are associated with the right classes).

## HOW
Just pass different params depending on whether it's a teacher or student.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
