### PR TITLE
catch 404 errors for grammar sessions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -21,6 +21,12 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
   return dispatch => {
     SessionApi.get(sessionID).then((session) => {
       dispatch(handleGrammarSession(session))
+    }).catch((error) => {
+      if (error.status === 404) {
+        dispatch(handleGrammarSession(null))
+      } else {
+        throw error
+      }
     })
   }
 }


### PR DESCRIPTION
## WHAT
Add a `catch` block to handle 404 errors coming back from the `active_activity_sessions` endpoint in Grammar.

## WHY
This solves a bug where students were unable to start new Grammar sessions.

## HOW
Just add a catch block to handle the behavior if there's a 404. If there's an error that isn't a 404, we throw it.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for this part of the code
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
