### PR TITLE
fix issue with nearpod iframes

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -444,26 +444,32 @@ class PagesController < ApplicationController
   end
 
   def comprehension
+    allow_iframe
     @style_file = ApplicationController::COMPREHENSION
   end
 
   def proofreader
+    allow_iframe
     @style_file = ApplicationController::PROOFREADER
   end
 
   def grammar
+    allow_iframe
     @style_file = ApplicationController::GRAMMAR
   end
 
   def lessons
+    allow_iframe
     @style_file = ApplicationController::LESSONS
   end
 
   def connect
+    allow_iframe
     @style_file = ApplicationController::CONNECT
   end
-  
+
   def diagnostic
+    allow_iframe
     @style_file = ApplicationController::DIAGNOSTIC
   end
 
@@ -524,5 +530,8 @@ class PagesController < ApplicationController
     return true if session.key?(SessionsController::CLEAR_ANALYTICS_SESSION_KEY)
   end
 
+  def allow_iframe
+    response.headers.delete "X-Frame-Options"
+  end
 
 end


### PR DESCRIPTION
## WHAT
Add some code to our activity controller methods that allows those pages to be iframed.

## WHY
Our Nearpod integration relies on iframing our tools. Evidently, the LMS has different headers than the `connect.quill.org`, etc links did, so it was failing to load for them. This solves that issue.

## HOW
Just remove the header that tells the other webpage not to allow an iframe.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
