### PR TITLE
Take out some copy on the webinar banner.

### DIFF
--- a/services/QuillLMS/app/views/application/_back_to_school_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_back_to_school_banner.html.erb
@@ -2,7 +2,7 @@
   <div class="banner" id="back-to-school-banner">
     <div class="content-container">
       <img alt="Video player with play symbol" class="banner-icon" src=<%= "#{ENV['CDN_URL']}/images/icons/live-stream.svg" %>>
-      <p>We’re offering five different sessions to help you maximize your writing instruction with Quill. <a href="https://www.quill.org/teacher-center/back-to-school-premium-webinar-series">Learn more and register here. </a></p>
+      <p>We’re offering five different webinars to help you maximize your writing instruction with Quill. <a href="https://www.quill.org/teacher-center/back-to-school-premium-webinar-series">Learn more and register here. </a></p>
       <img alt="White X" id="close-banner" src=<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>>
     </div>
   </div>


### PR DESCRIPTION
## WHAT
Remove one line of copy from the webinar banner so the banner can only have one line of text instead of two.

## WHY
Peter wanted the banner to only have one line of text so he asked for this line to be removed.

## HOW
Removing the line

### Screenshots
![Screen Shot 2020-08-14 at 2 19 54 PM](https://user-images.githubusercontent.com/57366100/90280847-960a9700-de39-11ea-89c7-fc8a2d3475d1.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO copy change
Have you deployed to Staging? | No tiny copy change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
