### PR TITLE
Take out bold phrase in grammar feedback.

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -163,7 +163,7 @@ export const checkAnswer = (response: string, question: Question, responses: Res
     const incorrectSequences = question.incorrectSequences ? hashToCollection(question.incorrectSequences) : [];
     const defaultConceptUID = question.modelConceptUID || question.concept_uid
     const responseObj = checkGrammarQuestion(questionUID, response, responses, focusPoints, incorrectSequences, defaultConceptUID)
-    responseObj.feedback = responseObj.feedback && responseObj.feedback !== '<br/>' ? responseObj.feedback : "<b>Try again!</b> Unfortunately, that answer is not correct."
+    responseObj.feedback = responseObj.feedback && responseObj.feedback !== '<br/>' ? responseObj.feedback : "Try again! Unfortunately, that answer is not correct."
     dispatch(responseActions.submitResponse(responseObj, null, isFirstAttempt))
     delete responseObj.parent_id
     dispatch(submitResponse(responseObj))


### PR DESCRIPTION

## WHAT
Un-bold the phrase "Try again!" from grammar feedback.

## WHY
Part of Curriculum team request for more uniform feedback.

## HOW
Take out the bold text.

### Screenshots
![Screen Shot 2020-08-17 at 5 46 38 PM](https://user-images.githubusercontent.com/57366100/90447597-9f059d80-e0b1-11ea-9926-be75dd63f0b8.png)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A

