### PR TITLE
Turn on Sentry for Connect

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/app.tsx
@@ -16,15 +16,14 @@ import fillInBlankActions from './actions/fillInBlank';
 import sentenceFragmentActions from './actions/sentenceFragments';
 import lessonActions from './actions/lessons';
 import titleCardActions from './actions/titleCards.ts';
-//import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
 import quillNormalizer from './libs/quillNormalizer';
 import Home from './components/home.tsx';
 
-// TO-DO: re-enable Sentry errors for QuillConnect when errors have been reduced
 
-// if (process.env.NODE_ENV === 'production') {
-//   Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
-// }
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
+}
 
 BackOff();
 const store = createStore();


### PR DESCRIPTION
## WHAT
Turning on Sentry reporting for Connect

## WHY
We want to fix some issues that were recurring on Connect at that time and we now have the Sentry bandwidth to turn on the error reporting to diagnose and fix them.

## HOW
Un-commenting out the Sentry errors that were commented out earlier this year.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
