### PR TITLE
Remove PM role from careers page

### DIFF
--- a/services/QuillLMS/config/careers.yml
+++ b/services/QuillLMS/config/careers.yml
@@ -1,10 +1,6 @@
 default:
   open_positions:
     - category: 'Product'
-      title: 'Product Manager'
-      angelco_url: '738265-quill-org-product-manager-nonprofit-edtech-startup'
-
-    - category: 'Product'
       title: 'Software Engineer'
       angelco_url: '581557-software-engineer-rails-react-python'
 


### PR DESCRIPTION
## WHAT
Remove PM role from careers page

## WHY
Because we already hired a PM, so we need the page to be accurate and updated.

## HOW
Take out the lines in config/careers

### Screenshots
<img width="1138" alt="Screen Shot 2020-08-19 at 3 10 45 PM" src="https://user-images.githubusercontent.com/57366100/90679702-8f5f9380-e22e-11ea-976e-59c74d93d9b3.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO tiny change
Have you deployed to Staging? | NO tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
