### PR TITLE
Change the find call in ActiveActivitySession to not error out when record not found

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/actions/sessions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/sessions.js
@@ -121,14 +121,14 @@ function normalizeQuestion(question) {
 }
 
 function handleSessionSnapshot(session, callback) {
-  if (session.currentQuestion) {
-    if (session.currentQuestion.question) {
-      session.currentQuestion.question.attempts = session.currentQuestion.question.attempts || [];
-    } else {
-      session.currentQuestion.data.attempts = session.currentQuestion.data.attempts || [];
+  if (session != null) {
+    if (session.currentQuestion) {
+      if (session.currentQuestion.question) {
+        session.currentQuestion.question.attempts = session.currentQuestion.question.attempts || [];
+      } else {
+        session.currentQuestion.data.attempts = session.currentQuestion.data.attempts || [];
+      }
     }
-  }
-  if (session.unansweredQuestions) {
     session.unansweredQuestions ? true : session.unansweredQuestions = [];
   }
   callback(session);

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/sessions.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/sessions.js
@@ -33,14 +33,14 @@ export default {
 };
 
 function processSession(session) {
-  if (session.currentQuestion) {
-    if (session.currentQuestion.question) {
-      session.currentQuestion.question.attempts = [];
-    } else {
-      session.currentQuestion.data.attempts = [];
+  if (session != null) {
+    if (session.currentQuestion) {
+      if (session.currentQuestion.question) {
+        session.currentQuestion.question.attempts = [];
+      } else {
+        session.currentQuestion.data.attempts = [];
+      }
     }
-  }
-  if (session.unansweredQuestions) {
     session.unansweredQuestions = session.unansweredQuestions || [];
   }
   return session


### PR DESCRIPTION
## WHAT
The `find_by!` call in `ActiveActivitySession` was erroring out every time it couldn't find a record, which was sending 500 errors to the front end. 
This PR changes the function so that it returns nil instead of erroring out.

## WHY
There is a specific case, when the student has clicked "Start" on the Activity but hasn't answered a question yet, when the front-end will try to fetch an `ActiveActivitySession` but should receive `nil` because the record hasn't been created yet. We should let the front-end receive a null object in this case, instead of returning a 500 error.

## HOW
Changing the method call to `find_by` which returns `nil`

### Screenshots

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
