### PR TITLE
Tiny webpack dev change

### DIFF
--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -224,7 +224,7 @@
     "build:production:server": "NODE_ENV=production webpack --config webpack.server.rails.build.config.js",
     "build:client": "webpack --config webpack.client.rails.build.config.js",
     "build:dev:client:prod-cms": "RAILS_ENV=development QUILL_CMS=https://cms.quill.org webpack -w --config webpack.client.dev.rails.build.config.js",
-    "build:dev:client": "RAILS_ENV=development webpack -w --config webpack.client.dev.rails.build.config.js",
+    "build:dev:client": "RAILS_ENV=development  node --max-old-space-size=8192 node_modules/webpack/bin/webpack.js -w --config webpack.client.dev.rails.build.config.js ",
     "build:dev:server": "webpack -w --config webpack.server.rails.build.config.js",
     "build:server": "webpack --config webpack.server.rails.build.config.js",
     "hot-assets": "NODE_ENV=development babel-node server-rails-hot.js",


### PR DESCRIPTION
## WHAT
Tiny change to webpack to get my local env to be able to build assets.
## WHY
Compiling the LMS frontend build locally was giving me `JS HEAP out of memory` errors and wouldn't build LMS assets.
## HOW
This change adds more memory (8GB) for the process.
### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (No, tiny change.)
Have you deployed to Staging? | (No, dev only)
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A)
