### PR TITLE
Add a new status endpoint that returns the length of the Sidekiq queue

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -30,6 +30,12 @@ class StatusesController < ApplicationController
     render plain: 'OK'
   end
 
+  def sidekiq_queue_length
+    render json: {
+      enqueued: Sidekiq::Stats.new.enqueued
+    }
+  end
+
   # TODO: Get an actual condition that only raises when Firebase is inaccessible.
   def firebase
     # I'm not sure that this stub is even the right approach, but I do know

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -640,7 +640,7 @@ EmpiricalGrammar::Application.routes.draw do
   # Uptime status
   resource :status, only: [] do
     collection do
-      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :firebase
+      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :firebase, :sidekiq_queue_length
     end
   end
 


### PR DESCRIPTION
## WHAT
Add a new status endpoint that returns the length of the Sidekiq queue

## WHY
This will allow us to set up custom monitoring for alarms

## HOW
Just return a JSON payload with the current number of enqueued items in Sidekiq here, then we'll configure an alarm in New Relic to go off if this value gets too high.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on status endpoints
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
