### PR TITLE
Add more informative support message to Google Login error

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -56,7 +56,8 @@ class Auth::GoogleController < ApplicationController
     end
     @user = GoogleIntegration::User.new(@profile).update_or_initialize
     if @user.new_record? && session[:role].blank?
-      flash[:error] = "The google account #{@profile.email} is not associated with any Quill accounts yet. <a href='/account/new'>Sign up</a> to create a Quill account with this Google account."
+      flash[:error] = "<p align='left'>The Google account #{@profile.email} is not associated with any Quill accounts yet. <a href='/account/new'>Sign up</a> to create a Quill account with this Google account."\
+      "<br/>If you believe this is an error, please contact <strong>support@quill.org</strong> with the following info to unblock your account: <i>failed login of #{@profile.email} and googleID #{@profile.google_id} at #{Time.zone.now}</i>."
       flash.keep(:error)
       redirect_to(new_session_path, status: :see_other)
     end


### PR DESCRIPTION
## WHAT
After fixing the Google login error for users who get it by mistake (chose the wrong gmail account), we suspect that there still may be some users who are seeing this error due to a deeper bug in our system (based on the frequency of this error). However it's very difficult to debug without more info on when this occurs. So after talking to Jeremy, Dan G, and Thomas, we've decided to add a message to the Login error banner directing users to Support.

## WHY
If users hitting this error go to support with the info we provide, that will help us identify how often this error is happening and debug for the specific users that are hitting it.

## HOW
Add a message directing users to support if they're stuck in the Google Login loop.

### Screenshots
<img width="1186" alt="Screen Shot 2020-08-27 at 3 02 44 PM" src="https://user-images.githubusercontent.com/57366100/91487213-687f0e00-e87b-11ea-839f-5681bf53b87d.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, copy change
Have you deployed to Staging? | Not yet, deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
