### PR TITLE
tooltip width and copy adjustment

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/recently_assigned_diagnostics_card.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/recently_assigned_diagnostics_card.scss
@@ -30,11 +30,12 @@
   .data-table-body {
     height: 189px;
     overflow: scroll;
-    margin-left: -150px;
-  }
-
-  .data-table-row {
-    margin-left: 150px;
+    .quill-tooltip-wrapper {
+      width: 210px;
+    }
+    .quill-tooltip:not(.visible) {
+      top: -8px;
+    }
   }
 
   .completed-row-section {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/recommendations.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/recommendations.test.jsx.snap
@@ -5019,7 +5019,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5034,7 +5034,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5049,7 +5049,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5064,7 +5064,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5079,7 +5079,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5094,7 +5094,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5109,7 +5109,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5124,7 +5124,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5139,7 +5139,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5154,7 +5154,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5169,7 +5169,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5184,7 +5184,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5199,7 +5199,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5214,7 +5214,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5229,7 +5229,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5244,7 +5244,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5259,7 +5259,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5274,7 +5274,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5289,7 +5289,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
           <div
@@ -5304,7 +5304,7 @@ exports[`Recommendations Component if none of the students have completed the ac
             <div
               className="not-completed-cell"
             >
-              Not Completed
+              Diagnostic not completed
             </div>
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/recommendations.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/recommendations.jsx
@@ -401,7 +401,7 @@ export default class Recommendations extends React.Component {
 
     return (<div className="recommendations-table-row not-completed-row" key={student.id}>
       <div className="recommendations-table-row-name">{student.name}</div>
-      <div className="not-completed-cell">Not Completed</div>
+      <div className="not-completed-cell">Diagnostic not completed</div>
     </div>)
   }
 


### PR DESCRIPTION
## WHAT
Peter reported an issue where on some browsers, CSS that I had written to get tooltips to display outside the width of the parent container caused a scroll bar to display that was wider than the card itself. I adjusted the CSS to make that not happen, and also made a copy change Tom requested.

## WHY
We don't want ugly things on our dashboard.

## HOW
Just updated the CSS to give tooltips in this particular data table a width that won't cause the issue.

### Screenshots
<img width="512" alt="Screen Shot 2020-08-28 at 9 29 18 AM" src="https://user-images.githubusercontent.com/18669014/91567144-aa0ec800-e912-11ea-98e0-a859622790cb.png">

<img width="777" alt="Screen Shot 2020-08-28 at 9 39 01 AM" src="https://user-images.githubusercontent.com/18669014/91567110-9a8f7f00-e912-11ea-8f09-1166e926e43d.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES