### PR TITLE
Sidekiq fix: Run critical jobs first.

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C ./config/puma.rb
-worker: bundle exec sidekiq -q default -q critical
+worker: bundle exec sidekiq -q critical -q default
 reportworker: bundle exec sidekiq -q low


### PR DESCRIPTION
## WHAT
Run the `critical` jobs before the `default` jobs. See the [docs](https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues), we have this backwards in the config
## WHY
Because `critical` jobs should run first. That is not currently the case.
## HOW
We have conflicting queue order logic in `sidekiq.yml` and the the `Procfile` and it appears `default` jobs are running before `critical` jobs (see screens)
### Screenshots
![Screen Shot 2020-08-28 at 10 47 14 AM](https://user-images.githubusercontent.com/1304933/91581222-2d80e700-e91c-11ea-98a5-7a2f1e7e9490.png)
![Screen Shot 2020-08-28 at 10 47 20 AM](https://user-images.githubusercontent.com/1304933/91581224-2e197d80-e91c-11ea-9ca8-a8a9f6308fae.png)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  ('NO' tiny change)
Have you deployed to Staging? | ( NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A )
