### PR TITLE
lms/modify-sidekiq-queue-status

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -31,9 +31,7 @@ class StatusesController < ApplicationController
   end
 
   def sidekiq_queue_length
-    render json: {
-      enqueued: Sidekiq::Stats.new.enqueued
-    }
+    render json: Sidekiq::Stats.new.queues
   end
 
   # TODO: Get an actual condition that only raises when Firebase is inaccessible.


### PR DESCRIPTION
## WHAT
Update the payload for Sidekiq queue status
## WHY
To show counts of queue lengths split up by queue so that we can configure our New Relic alarms to only trigger when specific queues get too big
## HOW
Instead of providing the `enqueued` attribute, which is an aggregate of all Sidekiq jobs, we are now sending queue sizes for each individual queue by name

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage for status controllers
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
