### PR TITLE
fix issue where students who were not assigned diagnostic would show on recommendations page

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -243,10 +243,12 @@ module PublicProgressReports
                       .where(classroom_unit_id: classroom_unit.id, is_final_score: true, activity: activity_id)
       activity_sessions_counted = activity_sessions_with_counted_concepts(activity_sessions)
       students = classroom.students.map do |s|
+        next unless classroom_unit.assigned_student_ids.include?(s&.id)
         completed = activity_sessions.any? { |session| session.user_id == s&.id }
         {id: s&.id, name: s&.name || "Unknown Student", completed: completed }
       end
-      sorted_students = students.sort_by {|stud| stud[:name].split()[1]}
+
+      sorted_students = students.compact.sort_by {|stud| stud[:name].split()[1]}
 
       recommendations = RecommendationsQuery.new(diagnostic.id).activity_recommendations.map do |activity_pack_recommendation|
         students = []

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -72,6 +72,31 @@ describe PublicProgressReports, type: :model do
     end
   end
 
+  describe "#generate_recommendations_for_classroom" do
+    let!(:unit) { create(:unit) }
+    let!(:classroom) { create(:classroom) }
+    let!(:diagnostic) { create(:diagnostic) }
+    let!(:diagnostic_activity) { create(:diagnostic_activity) }
+    let!(:unit_activity) { create(:unit_activity, activity: diagnostic_activity, unit: unit)}
+    let!(:student_not_in_class) { create(:student) }
+    let!(:student_1) { create(:student) }
+    let!(:student_2) { create(:student) }
+    let!(:student_3) { create(:student) }
+    let!(:students_classrooms_1) { create(:students_classrooms, classroom: classroom, student: student_1)}
+    let!(:students_classrooms_2) { create(:students_classrooms, classroom: classroom, student: student_2)}
+    let!(:students_classrooms_3) { create(:students_classrooms, classroom: classroom, student: student_3)}
+    let!(:classroom_unit_1) { create(:classroom_unit, classroom: classroom, unit: unit, assigned_student_ids: [student_1.id, student_2.id] )}
+
+    it 'will only return students who are in the class and have their ids in the assigned array' do
+      instance = FakeReports.new
+      recommendations = instance.generate_recommendations_for_classroom(unit.id, classroom.id, diagnostic_activity.id)
+      expect(recommendations[:students].find { |s| s[:id] == student_1.id}).to be
+      expect(recommendations[:students].find { |s| s[:id] == student_2.id}).to be
+      expect(recommendations[:students].find { |s| s[:id] == student_3.id}).not_to be
+      expect(recommendations[:students].find { |s| s[:id] == student_not_in_class.id}).not_to be
+    end
+  end
+
   describe '#generic_questions_for_report' do
     let!(:question_1) { create(:question) }
     let!(:question_2) { create(:question) }


### PR DESCRIPTION
## WHAT
Scope `generate_recommendations_for_classroom` to only return students who were assigned the diagnostic.

## WHY
When I updated this to include students who had not finished the diagnostic assignment, I forgot to scope it to only students who had been assigned, so all of the students in a classroom were showing. This fixes that.

## HOW
Just return nil if a student is not assigned the activity.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
