### PR TITLE
lms/add-vitally-track-calls

### DIFF
--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -44,7 +44,7 @@
       // our integration with Salesmachine, our integration with Vitally suppresses .page()
       // calls.  This means that we need to track pageviews for Vitally with explicit
       // calls to `analytics.track()`.  But we only need to send this data to Vitally.
-      analytics.track(`Vitally Pageview: ${window.location.href}`, {}, {
+      analytics.track(`Vitally Pageview`, {}, {
         All: false,
         Vitally: true
       });


### PR DESCRIPTION
## WHAT
Add a "track" call to duplicate "pageview" events for Vitally
## WHY
We have historically used "Pageview" events from Segment to update the "last seen" date for users in Salesmachine and Intercom.  We were hoping to do the same for Vitally, but apparently Vitally throws away "Pageview" events.  Instead, Vitally uses "Track" events for updating "last seen" dates.  Thus we need to send a special "Track" event that basically just duplicates the "Pageview" event just for Vitally.
## HOW
We've been using `load_intercom?` as a proxy for "this user is a teacher".  For cases where the user is a teacher, we make a special call to `analytics.track` with an optional config that tells Segment to only forward the events to Vitally since they're effectively redundant with Pageview calls that all of our other integrations get.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around front-end template generation, which this falls under
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
