### PR TITLE
add crossorigin: anonymous to the script tags that load our javascript

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -33,8 +33,8 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <% end %>
   <%= render partial: 'application/head_embed_codes' %>
-  <%= javascript_pack_tag('vendor') %>
-  <%= javascript_pack_tag(@js_file || 'app') %>
+  <%= javascript_pack_tag('vendor', 'crossorigin': 'anonymous') %>
+  <%= javascript_pack_tag((@js_file || 'app'), 'crossorigin': 'anonymous') %>
   <%= csrf_meta_tags %>
   <meta id='current-user-testing-flag' property="flag" content=<%= current_user&.testing_flag%> />
   <meta id='current-user-id' property="id" content=<%= current_user&.id%> />

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -22,8 +22,8 @@
 
     <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>
-    <%= javascript_pack_tag('vendor') %>
-    <%= javascript_pack_tag(@js_file || 'home') %>
+    <%= javascript_pack_tag('vendor', 'crossorigin': 'anonymous') %>
+    <%= javascript_pack_tag((@js_file || 'home'), 'crossorigin': 'anonymous') %>
     <%= stylesheet_pack_tag('home') %>
     <%= csrf_meta_tags %>
     <%= render partial: 'application/head_embed_codes' %>


### PR DESCRIPTION
## WHAT
Add `crossorigin: anonymous` to the script tags that load our Javascript.

## WHY
We are having issues with Coview not being able to collect error information due to a CORS issue (see here for more info: https://www.notion.so/Product-Board-30f97e4eb01246dbb8264253fb385073?p=ce4eb4f58b45430c8c0512c10db81c05). It's difficult to test whether this solves the issue without it being on prod yet, but according to the docs I think that it is at least half of the solution. If this doesn't fix it, I'll go back and try to figure out how to set those headers, but I had to wade through documentation for about five different gems and packages to get this far and I'm hoping this will do it.

## HOW
Set the `crossorigin: anonymous` value in the places where we load the webpack bundles into our templates.

### Screenshots
<img width="468" alt="Screen Shot 2020-09-01 at 2 22 39 PM" src="https://user-images.githubusercontent.com/18669014/91891007-47913100-ec5e-11ea-92b1-d46f2d94c4eb.png">

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
