### PR TITLE
Add a Cron endpoint for CMS that kicks off updating responses in Elas…

### DIFF
--- a/services/QuillCMS/app/controllers/cron_controller.rb
+++ b/services/QuillCMS/app/controllers/cron_controller.rb
@@ -1,0 +1,16 @@
+class CronController < ApplicationController
+
+  def new
+    if request.headers['x-amz-sns-message-type'] == 'SubscriptionConfirmation'
+      response = confirm_subscription(JSON.parse(request.body.read))
+    else
+      Cron.run
+    end
+    render plain: 'OK'
+  end
+
+  def confirm_subscription(request_obj)
+    get_url = URI(request_obj['SubscribeURL'])
+    Net::HTTP.get(get_url)
+  end
+end

--- a/services/QuillCMS/app/models/cron.rb
+++ b/services/QuillCMS/app/models/cron.rb
@@ -1,0 +1,12 @@
+class Cron
+
+  def self.run
+    current_time = Time.zone.now
+    if current_time.hour == 3
+      beginning_of_yesterday = current_time.yesterday.beginning_of_day
+      end_of_yesterday = current_time.yesterday.end_of_day
+      UpdateElasticsearchWorker.perform_async(beginning_of_yesterday, end_of_yesterday)
+      UpdateElasticsearchWorker.perform_async(current_time.beginning_of_day, current_time)
+    end
+  end
+end

--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -26,7 +26,6 @@ class CreateOrIncrementResponseWorker
     response.increment!(:count)
     increment_first_attempt_count(response, symbolized_vals)
     increment_child_count_of_parent(response)
-    response.update_index_in_elastic_search
   end
 
   def increment_first_attempt_count(response, symbolized_vals)

--- a/services/QuillCMS/app/workers/update_elasticsearch_worker.rb
+++ b/services/QuillCMS/app/workers/update_elasticsearch_worker.rb
@@ -1,0 +1,12 @@
+class UpdateElasticsearchWorker
+  include Sidekiq::Worker
+
+  def perform(start_time_string, end_time_string)
+    start_time_object = Time.parse(start_time_string)
+    end_time_object = Time.parse(end_time_string)
+    responses = Response.select(:id).where(updated_at: start_time_object..end_time_object)
+    responses.each do |response|
+      UpdateIndividualResponseWorker.perform_async(response.id)
+    end
+  end
+end

--- a/services/QuillCMS/app/workers/update_individual_response_worker.rb
+++ b/services/QuillCMS/app/workers/update_individual_response_worker.rb
@@ -1,0 +1,7 @@
+class UpdateIndividualResponseWorker
+  include Sidekiq::Worker
+
+  def perform(response_id)
+    Response.find(response_id).update_index_in_elastic_search
+  end
+end

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -36,4 +36,8 @@ Rails.application.routes.draw do
   #fragments controller for passing events to nlp.quill.org
   post 'fragments/is_sentence' => 'fragments#is_sentence'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # cron controller runs a job in the last hour of the day
+  post 'cron' => 'cron#new'
+
 end

--- a/services/QuillCMS/spec/controllers/cron_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/cron_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe CronController, type: :controller do
+  it 'should call Cron.run and return 200' do
+    expect(Cron).to receive(:run)
+    expect(response.status).to eq(200)
+    post :new
+  end
+end

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe ResponsesController, type: :controller do
 
     before do
       allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
-      allow_any_instance_of(Response).to receive(:update_index_in_elastic_search)
     end
 
     it 'should enqueue CreateOrIncrementResponseWorker' do

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Cron do
+  describe "kicks off appropriate jobs at the appropriate time" do
+
+    it "should not kick off jobs if the hour is not 3AM" do
+      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day)
+      expect(UpdateIndividualResponseWorker).to_not receive(:perform_async)
+      Cron.run
+    end
+
+    it "should kick off job if the hour is 3AM" do
+      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
+      expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.yesterday.beginning_of_day, Time.zone.now.yesterday.end_of_day)
+      expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.beginning_of_day, Time.zone.now.beginning_of_day + 3.hour)
+      Cron.run
+    end
+  end
+end

--- a/services/QuillCMS/spec/workers/update_elasticsearch_worker.rb
+++ b/services/QuillCMS/spec/workers/update_elasticsearch_worker.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe UpdateElasticsearchWorker do
+  let(:subject) { described_class.new }
+  let(:response1) { create(:response, created_at: Time.zone.now.beginning_of_day, updated_at: Time.zone.now.beginning_of_day) }
+  let(:response2) { create(:response, created_at: Time.zone.now.beginning_of_day, updated_at: Time.zone.now.beginning_of_day) }
+  let(:response3) { create(:response, created_at: Time.zone.now.yesterday, updated_at: Time.zone.now.yesterday)}
+
+  describe '#perform' do
+    it 'should kick off jobs on responses' do
+      expect(UpdateIndividualResponseWorker).to receive(:perform_async).with(response1.id)
+      expect(UpdateIndividualResponseWorker).to receive(:perform_async).with(response2.id)
+      expect(UpdateIndividualResponseWorker).not_to receive(:perform_async).with(response3.id)
+      subject.perform(Time.zone.now.beginning_of_day.to_s, Time.zone.now.to_s)
+    end
+
+    it 'should kick off jobs on responses within time range' do
+      expect(UpdateIndividualResponseWorker).not_to receive(:perform_async).with(response1.id)
+      expect(UpdateIndividualResponseWorker).not_to receive(:perform_async).with(response2.id)
+      expect(UpdateIndividualResponseWorker).to receive(:perform_async).with(response3.id)
+      subject.perform(Time.zone.now.yesterday.beginning_of_day.to_s, Time.zone.now.yesterday.end_of_day.to_s)
+    end
+  end
+end

--- a/services/QuillCMS/spec/workers/update_individual_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/update_individual_response_worker_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe UpdateIndividualResponseWorker do
+  let(:subject) { described_class.new }
+
+  describe '#perform' do
+    it 'should call update_index_in_elastic_search' do
+      response = double("response", :id => 1)
+      allow(Response).to receive(:find) { response }
+
+      expect(Response).to receive(:find).with(response.id)
+      expect(response).to receive(:update_index_in_elastic_search)
+      subject.perform(response.id)
+    end
+  end
+end


### PR DESCRIPTION
…ticsearch (#6632)

* take out unneeded update calls and tests

* added tests

* end of line

* add route

* newline

* switch response fetching to worker

* put update call back in

* revert response spec

* elasticsearch spec

* dan suggestions

* update to 3am

* for testing take out time

* put time back

* change 24 hour thing

* updated time to be idempotent and tests

* add handling for aws sns confirm subscription

* omit time check for testing

* add time check back in

* change spec

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
