### PR TITLE
fix small premium page bugs

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -178,9 +178,8 @@ li.premium-tab > a:hover {
   }
   .pricing-mini {
     font-size: 15px;
-    min-height: 513px;
     width: 300px;
-    height: 597px;
+    height: 621px;
     border-radius: 4px;
     border: solid 1px #e0e0e0;
     background-color: white;
@@ -262,7 +261,7 @@ li.premium-tab > a:hover {
     }
     .pricing-info {
       color: #333333;
-      height: 435px;
+      height: 462px;
       @media (max-width: 990px) {
         min-height: 0;
         ul {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -41,7 +41,7 @@ export default class PremiumPricingMinisRow extends React.Component {
   };
 
   renderPremiumConfirmationModal() {
-    const { showPremiumConfirmationModal, } = this.state
+    const { showPremiumConfirmationModal, subscriptionStatus, } = this.state
     if (!showPremiumConfirmationModal) { return }
     return (<PremiumConfirmationModal
       hideModal={this.hidePremiumConfirmationModal}


### PR DESCRIPTION
## WHAT
Fix CSS issue and an undefined error.

## WHY
When testing some webpack updates, I noticed that a) the last modal on the page was too short for its content and b) the premium success modal never opened because the `subscriptionStatus` value was undefined. This fixes those small bugs.

## HOW
Just update the CSS in line with the Zeplin and correctly define the `subscriptionStatus` attribute.

### Screenshots
<img width="994" alt="Screen Shot 2020-09-04 at 10 33 57 AM" src="https://user-images.githubusercontent.com/18669014/92251067-46e4de80-ee9a-11ea-98d9-f8983e31cae2.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
