### PR TITLE
lms/add-segment-group-call

### DIFF
--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -27,6 +27,11 @@
     %>
     <% if current_user %>
       analytics.identify(<%= raw(generate_segment_identify_arguments(current_user, load_intercom?)) %>);
+      <% if current_user.school %>
+        analytics.group("<%= raw(current_user.school.id) %>", {
+          name: "<%= raw(current_user.school.name) %>"
+        })
+      <% end %>
     <% elsif @logging_user_out %>
       analytics.reset()
     <% end %>


### PR DESCRIPTION
## WHAT
Add `analytics.group` calls if current_user.school exists
## WHY
Segment offers a `group` call that does some magic to assign users to groups.  This data can flow along our integrations to both Intercom and Vitally, allowing for easy identification of which school a user belongs to when we look at their data.
## HOW
Just check to see if the `current_user` has a school assigned to them, and if so add a call to `analytics.group` right after `analytics.identify`.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on header template code
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
