### PR TITLE
LessonsServer: Fix error with teacher_ids

### DIFF
--- a/services/QuillLessonsServer/src/handlers/sessions.js
+++ b/services/QuillLessonsServer/src/handlers/sessions.js
@@ -53,7 +53,11 @@ export function createOrUpdateClassroomLessonSession({
 // private function, exported for tests
 export function _setSessionDefaults(oldSession, sessionId, teacherObject) {
     let session = oldSession || {};
-    session.teacher_ids = teacherObject ? teacherObject.teacher_ids : undefined;
+
+    if (teacherObject &&  teacherObject.teacher_ids) {
+      session.teacher_ids = teacherObject.teacher_ids;
+    }
+
     session.current_slide = session.current_slide || 0;
     session.startTime = session.startTime || new Date();
     session.id = session.id || sessionId;

--- a/services/QuillLessonsServer/test/handlers/session.test.js
+++ b/services/QuillLessonsServer/test/handlers/session.test.js
@@ -21,7 +21,7 @@ describe('createOrUpdateClassroomLessonSession', () => {
 
     expect(session).toHaveProperty('id', '123');
     expect(session).toHaveProperty('current_slide', 0);
-    expect(session).toHaveProperty('teacher_ids', undefined);
+    expect(session).not.toHaveProperty('teacher_ids');
     expect(session).toHaveProperty('startTime');
   });
 


### PR DESCRIPTION
## WHAT
Small error translating the code in my last bug fix. Fixing that now. Objects in RethinkDB can't be assigned a value of `undefined`. So also adding a check to make sure `teacherObject.teacher_ids` also isn't undefined.
https://sentry.io/organizations/quillorg-5s/issues/1885926395/?project=1876481&query=is%3Aunresolved

```javascript
// Original Code
teacherIdObject ? session.teacher_ids = teacherIdObject.teacher_ids : undefined;
// should be 
if (teacherObject &&  teacherObject.teacher_ids) {
  session.teacher_ids = teacherObject.teacher_ids;
}
// Not (which is how I re-wrote it)
session.teacher_ids = teacherObject ? teacherObject.teacher_ids : undefined;
```
## WHY
Because I mis-read the original code, now my fix is causing an error.
## HOW
Re-write it.
### Screenshots
![Screen Shot 2020-09-09 at 10 15 43 AM](https://user-images.githubusercontent.com/1304933/92612382-d1a54f00-f287-11ea-8084-e4b9d7f9853c.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  ('YES')
Have you deployed to Staging? | ( Not yet - deploying now!)
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A)
