### PR TITLE
fix weird bug with login bundle

### DIFF
--- a/services/QuillLMS/app/assets/javascripts/login.js
+++ b/services/QuillLMS/app/assets/javascripts/login.js
@@ -1,3 +1,0 @@
-//= require vendor-bundle
-//= require login-bundle
-//= require application_non_webpack.js

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -94,7 +94,6 @@ class SessionsController < ApplicationController
   end
 
   def new
-    @js_file = 'login'
     @user = User.new
     @title = 'Log In'
     session[:role] = nil

--- a/services/QuillLMS/client/app/bundles/Login/startup/LoginFormAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Login/startup/LoginFormAppClient.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-import LoginFormApp from '../../Teacher/components/accounts/login/login_form.jsx';
-
-export default (props) => (
-  <LoginFormApp {...props} />
-);
-

--- a/services/QuillLMS/client/app/bundles/Login/startup/clientRegistration.js
+++ b/services/QuillLMS/client/app/bundles/Login/startup/clientRegistration.js
@@ -1,6 +1,0 @@
-import 'lazysizes';
-import 'lazysizes/plugins/parent-fit/ls.parent-fit';
-import ReactOnRails from 'react-on-rails';
-import LoginFormApp from './LoginFormAppClient.jsx';
-
-ReactOnRails.register({ LoginFormApp, });

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
@@ -37,6 +37,7 @@ import ExpandableUnitSection from './ExpandableUnitClient'
 import QuestionsAndAnswersSection from './QuestionsAndAnswersClient';
 import PreAp from './PreApAppClient';
 import Ap from './ApAppClient';
+import LoginFormApp from './LoginFormAppClient'
 
 require('../../../assets/styles/home.scss');
 
@@ -77,5 +78,6 @@ ReactOnRails.register({ TeacherGuideApp,
   ExpandableUnitSection,
   QuestionsAndAnswersSection,
   PreAp,
-  Ap
+  Ap,
+  LoginFormApp
 });

--- a/services/QuillLMS/client/webpack.client.base.config.js
+++ b/services/QuillLMS/client/webpack.client.base.config.js
@@ -64,9 +64,6 @@ module.exports = {
     session: [
       './app/bundles/Session/startup/clientRegistration'
     ],
-    login: [
-      './app/bundles/Login/startup/clientRegistration'
-    ],
     firewall_test: [
       './app/bundles/Firewall_test/firewall_test.js'
     ],

--- a/services/QuillLMS/client/webpack.client.dev.base.config.js
+++ b/services/QuillLMS/client/webpack.client.dev.base.config.js
@@ -62,9 +62,6 @@ module.exports = {
     session: [
       './app/bundles/Session/startup/clientRegistration'
     ],
-    login: [
-      './app/bundles/Login/startup/clientRegistration'
-    ],
     firewall_test: [
       './app/bundles/Firewall_test/firewall_test.js'
     ],

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -196,7 +196,6 @@ describe SessionsController, type: :controller do
       session[:role] = "something"
       session[ApplicationController::POST_AUTH_REDIRECT] = "something else"
       get :new, redirect: root_path
-      expect(assigns(:js_file)).to eq "login"
       expect(session[:role]).to eq nil
       expect(session[ApplicationController::POST_AUTH_REDIRECT]).to eq root_path
     end


### PR DESCRIPTION
## WHAT
Fix bug with login bundle not being able to find jQuery by just moving it into the teacher bundle, where there actually already existed a `LoginFormAppContainer` file.

## WHY
For whatever reason, the login bundle isn't loading because it can't find `jQuery`, even though I don't think it's actually even using jQuery, and pages that actually are using `jQuery` are loading just fine and the jQuery is working as expected. This solves that issue so the page loads.

## HOW
Stop using the `login` javascript file, make sure it works through the teacher bundle, and delete references to the `login` javascript file. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A