### PR TITLE
put pages routes on newlines and add preap_units to array

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -532,7 +532,42 @@ EmpiricalGrammar::Application.routes.draw do
     end
   end
 
-  other_pages = %w(beta ideas board press partners develop mission about faq tos privacy activities impact stats team premium teacher_resources media_kit play news home_new map firewall_info referrals_toc announcements backpack careers comprehension proofreader grammar lessons diagnostic connect)
+  other_pages = %w(
+    beta
+    ideas
+    board
+    press
+    partners
+    develop
+    mission
+    about
+    faq
+    tos
+    privacy
+    activities
+    impact
+    stats
+    team
+    premium
+    teacher_resources
+    media_kit
+    play
+    news
+    home_new
+    map
+    firewall_info
+    referrals_toc
+    announcements
+    backpack
+    careers
+    comprehension
+    proofreader
+    grammar
+    lessons
+    diagnostic
+    connect
+    preap_units
+  )
 
   all_pages = other_pages
   all_pages.each do |page|


### PR DESCRIPTION
## WHAT
Break `other_pages` array in the `routes` file up so there's only one route per line, and add `preap_units` to that array.

## WHY
I noticed that the `preap_units` weren't populating on the page, and traced the bug to a missing route definition for `preap_units`. My guess is that this was previously there, but got overwritten due to a merge conflict, which is easy to do with this large, previously one-line array, so I split it up and added preap_units back in.

## HOW
See above.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | NO - small change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
