### PR TITLE
Up Sidekiq Concurrency, pin to DB pool amount.

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C ./config/puma.rb
-worker: bundle exec sidekiq -q critical -q default
-reportworker: bundle exec sidekiq -q critical -q default -q low
+worker: RAILS_MAX_THREADS=8 bundle exec sidekiq -q critical -q default
+reportworker: RAILS_MAX_THREADS=6 bundle exec sidekiq -q critical -q default -q low

--- a/services/QuillLMS/config/sidekiq.yml
+++ b/services/QuillLMS/config/sidekiq.yml
@@ -1,9 +1,9 @@
 ---
-:concurrency: 4
+:concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 staging:
-  :concurrency: 4
+  :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 production:
-  :concurrency: 4
+  :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 :queues:
   - critical
   - default


### PR DESCRIPTION
## WHAT
Given we have an increase in background job volume, I want to experiment with upping the number of workers per server. Trying `8` workers up from `4`.
## WHY
More jobs, more problems.
## HOW
1. Pin the sidekiq concurrency to the Rails Thread Max which is used to set the number of DB connections (so every thread gets a Db connection and we don't get errors for no Connection available). 
2. Pass the thread count in an ENV variable in the work `Procfile` used by Heroku so the BG workers can have a different thread count than the Web servers.

Mainly getting this from here: https://github.com/mperham/sidekiq/issues/2985#issuecomment-221397983
### Screenshots


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO, not really testable
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
