### PR TITLE
fix regex for finding concept uids and wrong answers

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/passageReviewer.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/passageReviewer.tsx
@@ -78,9 +78,9 @@ export default class PassageReviewer extends React.Component<PassageReviewerProp
         if (typeof parts[i] === "string" && parts[i][0] === '+') {
           const plusMatch = parts[i].match(/\+([^-]+)-/m)
           const plus = plusMatch ? plusMatch[1] : ''
-          const conceptUIDMatch = parts[i].match(/\|([^-]+)/m)
+          const conceptUIDMatch = parts[i].match(/\|(.+)/m)
           const conceptUID = conceptUIDMatch ? conceptUIDMatch[1] : ''
-          const negativeMatch = parts[i].match(/\-([^-]+)\|/m)
+          const negativeMatch = parts[i].match(/\-(.+)\|/m)
           const negative = negativeMatch ? negativeMatch[1] : null
           const concept = concepts.find(c => c.uid === conceptUID)
           const indexToPass = index


### PR DESCRIPTION
## WHAT
Update the regex for finding concept uids and wrong answers from Proofreader edits so it doesn't split on dashes.

## WHY
Rachel reported an issue where the concept explanations weren't showing up for some concepts in Proofreader. This was because those concept uids contained dashes, and the regex logic was returning only part of the concept uid string. While dashes can't be part of the correct string in Proofreader, because we use them to demarcate the incorrect answer, there's no reason they can't be in a concept uid or an incorrect answer - I think this part of the regex was probably just copied from the correct answer regex and we never noticed the issue.

## HOW
Just updated the regex.

### Screenshots
<img width="343" alt="Screen Shot 2020-09-11 at 10 04 26 AM" src="https://user-images.githubusercontent.com/18669014/92935117-59b95f00-f416-11ea-9033-6ff5465c18b9.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
