### PR TITLE
get classroom data every time we load the create_unit component

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -54,9 +54,7 @@ export default class CreateUnit extends React.Component {
     const { classrooms, stage, } = this.state
     this.getProhibitedUnitNames();
 
-    if (!classrooms || !classrooms.length) {
-      this.fetchClassrooms()
-    }
+    this.fetchClassrooms()
 
     if (stage === 1 && this.unitTemplateId()) {
       window.localStorage.removeItem(UNIT_TEMPLATE_ID)


### PR DESCRIPTION
## WHAT
Fetch classrooms on every load of `create_unit`, even if there are already some in `localStorage`.

## WHY
In the assignment flow, we store classrooms in `localStorage` to avoid making the user wait to load them if they're going back and forth from the assignment page. We clear this localStorage entry when the user either finishes assigning or navigates away from the assignment flow in-website (by clicking the Quill logo). However, we don't have a great way to clear it when users leave the website by closing the tab or entering a different domain in the browser, so then if a user's classrooms change they are sometimes stuck with old data in the assignment flow. We don't want them to have to clear their cookies every time this happens. If we refetch the classrooms regardless of whether there are entries in localStorage, we can make sure the user will see up to date classrooms, but also avoid the wait time for users who have the correct data in localStorage.

## HOW
Just remove the conditional wrapping the `fetchClassrooms` call.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
