### PR TITLE
make sure clear_data path works

### DIFF
--- a/services/QuillLMS/app/views/cms/users/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/users/_form.html.erb
@@ -64,5 +64,5 @@
 </div>
 <br />
 <% if @user.id %>
-  <%= link_to 'Clear User Data', clear_data_cms_user_path(@user), method: :put, data: {confirm: 'Are you sure?'}, class: 'btn btn-danger destroy' %>
+  <%= button_to 'Clear User Data', clear_data_cms_user_path(@user), { :method => :put, :data => {confirm: 'Are you sure?'}, :class => 'btn btn-danger destroy'} %>
 <% end %>

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -500,7 +500,7 @@ EmpiricalGrammar::Application.routes.draw do
       member do
         get :show_json
         put :sign_in
-        get :clear_data
+        put :clear_data
         get :sign_in
         get :edit_subscription
         get :new_subscription


### PR DESCRIPTION
## WHAT
Change the route definition of `clear_data` from a `put` request to a `get` request.

## WHY
That route is designed to work so that a user navigates to that link, and then gets redirected back to the user manager, but it wasn't defined as a `get` so they kept just getting a "page not found" error.

## HOW
Just change the request type in the `routes` file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
