### PR TITLE
allow users to modify html for concept explanations

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/edit.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/edit.tsx
@@ -62,7 +62,7 @@ export default class Edit extends React.Component<EditProps, {mounting: boolean,
     if (!(concept && concept.explanation)) { return <span /> }
     return (<div className="explanation">
       <p className="label">Explanation</p>
-      <p>{concept.explanation}</p>
+      <p dangerouslySetInnerHTML={{ __html: concept.explanation }} />
     </div>)
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
@@ -176,9 +176,8 @@ class ConceptBox extends React.Component<ConceptBoxProps, ConceptBoxState> {
     }
   }
 
-  changeExplanation = (e) => {
+  changeExplanation = (explanation) => {
     const { concept, } = this.state
-    const explanation = e.target.value
     if (explanation !== concept.explanation) {
       const newConcept = Object.assign({}, concept, { explanation })
       this.setState({ concept: newConcept })

--- a/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
@@ -76,9 +76,8 @@ class CreateConceptBox extends React.Component<CreateConceptBoxProps, CreateConc
     }
   }
 
-  changeExplanation = (e) => {
+  changeExplanation = (explanation) => {
     const { concept, } = this.state
-    const explanation = e.target.value
     if (explanation !== concept.explanation) {
       const newConcept = Object.assign({}, concept, { explanation })
       this.setState({ concept: newConcept })

--- a/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { EditorState, ContentState } from 'draft-js'
+import { TextEditor } from 'quill-component-library/dist/componentLibrary'
 
 export default class ExplanationField extends React.Component<any, any> {
   constructor(props) {
@@ -37,10 +39,12 @@ export default class ExplanationField extends React.Component<any, any> {
           {isNew ? '' : <p className="remove-concept-attribute-field" onClick={this.cancel}><i className="fas fa-archive" /><span>Remove</span></p>}
         </div>
         <p className="concept-attribute-field-editor-subheader">Displays in Proofreader</p>
-        <textarea
+        <TextEditor
+          ContentState={ContentState}
+          EditorState={EditorState}
+          handleTextChange={handleChange}
           key="concept-explanation"
-          onChange={handleChange}
-          value={explanation}
+          text={explanation}
         />
         {isNew ? <p className="cancel-concept-attribute-field" onClick={this.cancel}>Cancel</p> : ''}
       </div>


### PR DESCRIPTION
## WHAT
Allow users to modify HTML for concept explanations and then have it be displayed on the frontend.

## WHY
The curriculum team wanted to be able to underline, italicize, and bold parts of the concept explanation for Proofreader.

## HOW
Just update the concept manager to use the component library's TextEditor, which has these features built in, and update the Proofreader front end to display HTML.

### Screenshots


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - small change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
