### PR TITLE
Change the dispatched action when there's not yet a session

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -23,7 +23,7 @@ export const setSessionReducerToSavedSession = (sessionID: string) => {
       dispatch(handleGrammarSession(session))
     }).catch((error) => {
       if (error.status === 404) {
-        dispatch(handleGrammarSession(null))
+        dispatch(startNewSession())
       } else {
         throw error
       }


### PR DESCRIPTION
## WHAT
Change the behavior in Grammar when the system attempts to load a session from the API that hasn't been saved yet (and thus doesn't exist) so that instead of trying to populate an empty session, it just leaves it missing in the API until an `update` gets called to save it intentionally.

## WHY
I believe that what was happening was that during component initialization, Grammar would call `getSession` and `updateSession` from the `actions/session.ts` file.  In cases where `getSession` returned a 404 and fell into its fallback logic of sending a `PUT` call to the Session API, but the `updateSession` call to `PUT` to the Session API happened in before the `getSession` `PUT` call completed, the properly-set-up session would get overridden by a null session.

It's possible that there are some other issues at work, but the timing of the change to `getSession` seems to align with the time we started getting reports of the issue, and it does make sense as a race condition when tracing the code.

## HOW
Change the behavior of `getSession` in cases where the API call returns a 404.  We were initializing a null session in the API (saving it to the LMS database), but since subsequent calls to `updateSession` will create the record if necessary, we can actually just have the front-end blank out its current `session` data if there is no session in the API.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests cover this particular fallback behavior.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
