### PR TITLE
Add stats from 2019-2020 school year to Impact page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/impact_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/impact_page.scss
@@ -46,7 +46,7 @@
       .bar {
         height: 10px;
       }
-      &.eighteen-nineteen {
+      &.nineteen-twenty {
         h2 {
           margin-left: 32px;
           line-height: 1;
@@ -60,19 +60,22 @@
           align-items: center;
         }
       }
+      &.eighteen-nineteen .bar {
+        width: 273.9px;
+      }
       &.seventeen-eighteen .bar {
-        width: 233.4px;
+        width: 154px;
       }
       &.sixteen-seventeen .bar {
-        width: 114.7px;
+        width: 75.7px;
       }
       &.fifteen-sixteen .bar {
-        width: 31.5px;
+        width: 20.8px;
       }
       &.fourteen-fifteen .bar {
-        width: 14.2px;
+        width: 9.4px;
       }
-      &:not(.eighteen-nineteen) {
+      &:not(.nineteen-twenty) {
         p {
           color: #646464;
           margin-bottom: 4px;

--- a/services/QuillLMS/app/views/pages/impact.html.erb
+++ b/services/QuillLMS/app/views/pages/impact.html.erb
@@ -36,12 +36,21 @@
     <div class="student-usage-by-school-year hide-mobile">
       <h2 class="student-usage-title">Student usage by school year</h2>
       <div class="student-usage-rows">
+        <div class="student-usage-row nineteen-twenty">
+          <div class="year-and-bar">
+            <p>2019 - 2020</p>
+            <div class="bar-and-count">
+              <div class="bar"></div>
+              <h2>1.5 million</h2>
+            </div>
+          </div>
+        </div>
+
         <div class="student-usage-row eighteen-nineteen">
           <div class="year-and-bar">
             <p>2018 - 2019</p>
             <div class="bar-and-count">
               <div class="bar"></div>
-              <h2>1 million</h2>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## WHAT
Add a new bar reflecting the numbers for the 2019-2020 school year in our Impact page.

## WHY
So our website reflects the most recent (and most impressive) data we have.

## HOW
Add it in as an HTML element with appropriate styling.

### Screenshots
<img width="1001" alt="Screen Shot 2020-09-15 at 3 29 59 PM" src="https://user-images.githubusercontent.com/57366100/93256464-6668ea80-f769-11ea-8517-d0b590f50848.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny front end change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
