### PR TITLE
fix issue with making admins from school show page

### DIFF
--- a/services/QuillLMS/app/views/cms/schools/show.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/show.html.erb
@@ -15,27 +15,27 @@
       </thead>
       <tbody>
         <% @teacher_data.each do |teacher| %>
-          
+
           <tr>
             <td><%= teacher['teacher_name'] || 'N/A' %></td>
             <td><%= teacher['flags']&.include?('auditor') ? 'Auditor' : 'Teacher' %></td>
             <td><%= teacher['title'] || 'N/A' %></td>
             <td><%= teacher['flags']&.include?('purchaser') ? 'Purchaser' : '' %></td>
             <td><%= teacher['flags']&.include?('school_point_of_contact') ? 'School\'s Point of Contact' : '' %></td>
-            <% %w(title number_classrooms number_students number_activities_completed last_active subscription).each do |attribute| %>
+            <% %w(number_classrooms number_students number_activities_completed last_active subscription).each do |attribute| %>
               <td><%= teacher[attribute] || 'N/A' %></td>
             <% end %>
             <td>
               <% unless teacher['admin_id'].blank? %>
-                <%= link_to 'Remove Admin', cms_user_remove_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
+                <%= button_to 'Remove Admin', cms_user_remove_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
               <% else %>
-                <%= link_to 'Make Admin', cms_user_make_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
+                <%= button_to 'Make Admin', cms_user_make_admin_path(user_id: teacher['user_id'], school_id: params[:id]), method: :put %>
               <% end %>
             </td>
             <td>
               <%= link_to 'edit', edit_cms_user_path(teacher['user_id']) %>
             </td>
-            <td><%= link_to 'Sign In', sign_in_cms_user_path(teacher['user_id']), method: :put %></td>
+            <td><%= link_to 'Sign In', sign_in_cms_user_path(teacher['user_id']) %></td>
           </tr>
         <% end %>
       </tbody>
@@ -81,7 +81,7 @@
             <tr>
               <td><%= admin[:name] %></td>
               <td><%= admin[:email] %></td>
-              <td><%= link_to 'Remove Admin', cms_user_remove_admin_path(user_id: admin[:user_id], school_id: admin[:school_id]), data: { confirm: 'Are you sure?' }, method: :put %></td>
+              <td><%= button_to 'Remove Admin', cms_user_remove_admin_path(user_id: admin[:user_id], school_id: admin[:school_id]), data: { confirm: 'Are you sure?' }, method: :put %></td>
             </tr>
           <% end %>
         </tbody>


### PR DESCRIPTION
## WHAT
Fix issue with the Make Admin button (as well as the Remove Admin buttons) on the school show page

## WHY
We want our team to be able to make people school admins from this page.

## HOW
Switch the `link_to` to a `button_to` to make the `method: :put` part work.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for erb templates
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? |N/A
