### PR TITLE
lms/more-session-race-condition

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -109,7 +109,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
 
       const sessionID = getParameterByName('student', window.location.href)
       // eslint-disable-next-line react/destructuring-assignment
-      if (sessionID && !_.isEqual(session, this.props.session) && !session.pending) {
+      if (sessionID && !_.isEqual(session, this.props.session) && !session.pending && session.hasreceiveddata) {
         updateSession(sessionID, session)
       }
       if(previewMode && questions && session.currentQuestion && !questionToPreview) {


### PR DESCRIPTION
## WHAT
Only save session data for Grammar activities if `hasreceiveddata` is true
## WHY
It looks like there was another rare race condition on the `componentWillReceiveProps` loop.  Early in the lifecycle of the component, the props include a newly-initialized session (with no questions, and no `hasreceiveddata` key), that was getting submitted to the API to save.  Later during set-up, a different set of code populated the question data and set the `hasreceiveddata` key which is also saved.  However, while the second request was always sent after the first, there's no actual guarantee around processing order if the network traffic is routed unusually.
## HOW
Add a condition to avoid saving the `ActiveActivitySession` in cases where `hasreceiveddata` is false.  This should only ever be true during the initial setup of the component, and a later update should always occur.  So we're basically cutting out an unnecessary save that also happened to sometimes break things.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around this functionality
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
