### PR TITLE
Remove skylight gem and references to it

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -146,7 +146,6 @@ gem 'clever-ruby', '~> 2.0.1'
 group :production, :staging do
   gem 'rails_12factor'
   gem 'lograge' # for making logs more dense
-  gem 'skylight'
   # gem 'rack-timeout'
 end
 

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -650,10 +650,6 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    skylight (3.1.4)
-      skylight-core (= 3.1.4)
-    skylight-core (3.1.4)
-      activesupport (>= 4.2.0)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -854,7 +850,6 @@ DEPENDENCIES
   simplecov
   simplecov-json
   sinatra (>= 1.3.0)
-  skylight
   slim-rails
   spring
   spring-commands-rspec

--- a/services/QuillLMS/config/skylight.yml
+++ b/services/QuillLMS/config/skylight.yml
@@ -1,3 +1,0 @@
----
-# The authentication token for the application.
-authentication: <%= ENV['SKYLIGHT_KEY'] %>


### PR DESCRIPTION
## WHAT
Remove the 'skylight' gem and references to it from the LMS. We are no longer using this gem.

## WHY
Better not to have unused gems lying around, it wastes loading time and could become a vulnerability.

## HOW
Take out skylight from Gemfile and remove all references

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
