### PR TITLE
Add a last resort nil check in StudentJoinedClassroomWorker

### DIFF
--- a/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
@@ -14,6 +14,6 @@ class StudentJoinedClassroomWorker
         context: {:ip => student&.ip_address },
         integrations: { intercom: 'false' }
       })
-    analytics.track(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
+    analytics.track(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION) if teacher
   end
 end

--- a/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
@@ -22,4 +22,17 @@ describe StudentJoinedClassroomWorker, type: :worker do
     expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
     worker.perform(teacher.id, student.id)
   end
+
+  it 'in cases where no teacher is sent, it does not track teacher' do
+    expect(analyzer).to receive(:track_with_attributes).with(
+      student,
+      SegmentIo::BackgroundEvents::STUDENT_ACCOUNT_CREATION,
+      {
+        context: {:ip => student.ip_address },
+        integrations: { intercom: 'false' }
+      }
+    )
+    expect(analyzer).not_to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
+    worker.perform(nil, student.id)
+  end
 end


### PR DESCRIPTION
## WHAT
Our nil checks on parameters passed to this worker are failing, and Thomas and I both cannot figure out why. As a last resort, I'm adding a nil check on the call to analytics to stop it if the `teacher` object is nil. 

I've also confirmed with partnerships that it's okay for now to not send these nil teacher records. 

## WHY
Part of our ongoing effort to banish all nil Sentry errors.

## HOW
A nil check before the call to analytics so that it doesn't send any `nil` teacher objects.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A