### PR TITLE
quill component library merge - input component

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
@@ -3,11 +3,12 @@ import { Query, Mutation } from "react-apollo";
 import gql from "graphql-tag";
 import moment from 'moment'
 import _ from 'underscore';
-import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
+import { DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import { Concept } from '../interfaces/interfaces'
 import ConceptChangeLogs from './ConceptChangeLogs'
 import ChangeLogModal from './ChangeLogModal'
+import { Input, } from '../../Shared/index'
 
 
 function levelTwoConceptsQuery(){

--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
@@ -2,13 +2,14 @@ import * as React from "react";
 import { Query, Mutation } from "react-apollo";
 import gql from "graphql-tag";
 import _ from 'lodash'
-import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
+import { DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import { Concept } from '../interfaces/interfaces'
 import RuleDescriptionField from './RuleDescriptionField'
 import ExplanationField from './ExplanationField'
 import ConceptChangeLogs from './ConceptChangeLogs'
 import ChangeLogModal from './ChangeLogModal'
+import { Input, } from '../../Shared/index'
 
 function levelTwoConceptsQuery(){
   return `

--- a/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { Mutation } from "react-apollo";
 import gql from "graphql-tag";
-import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
+import { DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import { Concept } from '../interfaces/interfaces'
 import RuleDescriptionField from './RuleDescriptionField'
 import ExplanationField from './ExplanationField'
 import ChangeLogModal from './ChangeLogModal'
+import { Input, } from '../../Shared/index'
 
 const CREATE_CONCEPT = gql`
   mutation createConcept($name: String!, $parentId: ID, $description: String, $explanation: String, $changeLogs: [ChangeLogInput!]!){

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { DropdownInput, Input, TextEditor } from 'quill-component-library/dist/componentLibrary';
+import { DropdownInput, TextEditor } from 'quill-component-library/dist/componentLibrary';
 import ActivityForm from '../configureSettings/activityForm';
+import { Input, } from '../../../../Shared/index'
 jest.mock('string-strip-html', () => ({
   default: jest.fn()
 }));
@@ -15,8 +16,8 @@ const mockActivity = {
   target_level: 7,
   passages: [{text: '...'}],
   prompts: [
-    { conjunction: 'because', text: '1', max_attempts: 5, max_attempts_feedback: 'WRONG!' }, 
-    { conjunction: 'but', text: '2', max_attempts: 5, max_attempts_feedback: 'WRONG!' }, 
+    { conjunction: 'because', text: '1', max_attempts: 5, max_attempts_feedback: 'WRONG!' },
+    { conjunction: 'but', text: '2', max_attempts: 5, max_attempts_feedback: 'WRONG!' },
     { conjunction: 'so', text: '3', max_attempts: 5, max_attempts_feedback: 'WRONG!' }
   ]
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/regexSection.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/regexSection.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Input } from 'quill-component-library/dist/componentLibrary';
+import { Input } from '../../../../Shared/index';
 import RegexSection from '../configureRegex/regexSection';
 jest.mock('string-strip-html', () => ({
   default: jest.fn()
@@ -8,26 +8,26 @@ jest.mock('string-strip-html', () => ({
 
 const mockRegexRules = {
   'regex-rule-0': {
-    id: 1, 
-    regex_text: 'it contain(s)? methane gas', 
+    id: 1,
+    regex_text: 'it contain(s)? methane gas',
     case_sensitive: false
   },
   'regex-rule-1': {
-    id: 2, 
-    regex_text: 'another reg(ex) line', 
+    id: 2,
+    regex_text: 'another reg(ex) line',
     case_sensitive: true
   },
   'regex-rule-2': {
-    id: 3, 
-    regex_text: 'some m?ore reg(ex', 
+    id: 3,
+    regex_text: 'some m?ore reg(ex',
     case_sensitive: false
   }
 }
 const mockProps = {
-  errors: {}, 
-  handleAddRegexInput: jest.fn(), 
-  handleDeleteRegexRule: jest.fn(), 
-  handleSetRegexRule: jest.fn(), 
+  errors: {},
+  handleAddRegexInput: jest.fn(),
+  handleDeleteRegexRule: jest.fn(),
+  handleSetRegexRule: jest.fn(),
   regexRules: mockRegexRules
 };
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleSetForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleSetForm.test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Input, TextEditor } from 'quill-component-library/dist/componentLibrary';
+import { TextEditor } from 'quill-component-library/dist/componentLibrary';
 import RuleSetForm from '../configureRegex/ruleSetForm';
 import RegexSection from '../configureRegex/regexSection';
+import { Input, } from '../../../../Shared/index'
+
 jest.mock('string-strip-html', () => ({
   default: jest.fn()
 }))

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRegex/regexSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRegex/regexSection.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Input } from 'quill-component-library/dist/componentLibrary';
+import { Input } from '../../../../Shared/index';
 
 interface RegexSectionProps {
   errors: {},
@@ -36,10 +36,10 @@ const RegexSection = ({ errors, handleAddRegexInput, handleDeleteRegexRule, hand
               />
             </div>
           </div>
-          <button 
-            className="quill-button fun primary outlined delete-regex-button" 
-            id="remove-regex-button" 
-            onClick={handleDeleteRegexRule} 
+          <button
+            className="quill-button fun primary outlined delete-regex-button"
+            id="remove-regex-button"
+            onClick={handleDeleteRegexRule}
             type="button"
             value={ruleKey}
           >
@@ -52,10 +52,10 @@ const RegexSection = ({ errors, handleAddRegexInput, handleDeleteRegexRule, hand
   return(
     <div className="regex-rules-container">
       {renderRegexRules()}
-      <button 
-        className="quill-button fun primary outlined add-regex-button" 
+      <button
+        className="quill-button fun primary outlined add-regex-button"
         id="add-regex-button"
-        onClick={handleAddRegexInput} 
+        onClick={handleAddRegexInput}
         type="button"
       >
         Add Regex Rule +

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRegex/ruleSetForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRegex/ruleSetForm.tsx
@@ -1,20 +1,21 @@
 import * as React from "react";
-import { Input, TextEditor } from 'quill-component-library/dist/componentLibrary';
+import { TextEditor } from 'quill-component-library/dist/componentLibrary';
 import { EditorState, ContentState } from 'draft-js'
 import { validateForm } from '../../../helpers/comprehension';
 import { BECAUSE, BUT, SO } from '../../../../../constants/comprehension';
 import { ActivityInterface, ActivityRuleSetInterface, PromptInterface, RegexRuleInterface } from '../../../interfaces/comprehensionInterfaces';
 import RegexSection from './regexSection';
+import { Input, } from '../../../../Shared/index'
 
 interface RuleSetFormProps {
   activityData: ActivityInterface,
   activityRuleSet: ActivityRuleSetInterface,
   closeModal: (event: React.MouseEvent) => void,
   ruleSetsCount: number,
-  submitRuleSet: (argumentsHash: { 
-    ruleSet: { rule_set: ActivityRuleSetInterface}, 
-    rules: RegexRuleInterface[], 
-    rulesToDelete: object, 
+  submitRuleSet: (argumentsHash: {
+    ruleSet: { rule_set: ActivityRuleSetInterface},
+    rules: RegexRuleInterface[],
+    rulesToDelete: object,
     rulesToUpdate: object
   }) => void
 }
@@ -32,7 +33,7 @@ const RuleSetForm = ({ activityData, activityRuleSet, closeModal, ruleSetsCount,
   const [rulesToUpdate, setRulesToUpdate] = React.useState<object>({});
   const [errors, setErrors] = React.useState<object>({});
 
-  React.useEffect(() => {  
+  React.useEffect(() => {
     formatPrompts();
     formatRegexRules();
   }, []);
@@ -41,7 +42,7 @@ const RuleSetForm = ({ activityData, activityRuleSet, closeModal, ruleSetsCount,
     let checkedPrompts = {};
     let formatted = {};
 
-    // get ids of all applied prompts 
+    // get ids of all applied prompts
     activityRuleSet && activityRuleSet.prompts && activityRuleSet.prompts.forEach(prompt => {
       const { id } = prompt;
       checkedPrompts[id] = true;
@@ -52,10 +53,10 @@ const RuleSetForm = ({ activityData, activityRuleSet, closeModal, ruleSetsCount,
       const { conjunction, id } = prompt;
       formatted[conjunction] = {
         id,
-        checked: !!checkedPrompts[id] 
+        checked: !!checkedPrompts[id]
       };
     });
-    
+
     setRuleSetPrompts(formatted);
   }
 
@@ -239,10 +240,10 @@ const RuleSetForm = ({ activityData, activityRuleSet, closeModal, ruleSetsCount,
           </div>
         </div>
         <p className="form-subsection-label" id="regex-rules-label">Regex Rules</p>
-        <RegexSection 
+        <RegexSection
           errors={errors}
-          handleAddRegexInput={handleAddRegexInput} 
-          handleDeleteRegexRule={handleDeleteRegexRule} 
+          handleAddRegexInput={handleAddRegexInput}
+          handleDeleteRegexRule={handleDeleteRegexRule}
           handleSetRegexRule={handleSetRegexRule}
           regexRules={regexRules}
         />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
-import { Input, TextEditor } from 'quill-component-library/dist/componentLibrary';
+import { TextEditor } from 'quill-component-library/dist/componentLibrary';
 import { EditorState, ContentState } from 'draft-js'
 // import { flagOptions } from '../../../../../constants/comprehension'
 import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction } from '../../../helpers/comprehension';
-import { 
-  BECAUSE, 
-  BUT, 
-  SO, 
-  activityFormKeys, 
+import {
+  BECAUSE,
+  BUT,
+  SO,
+  activityFormKeys,
   TITLE,
   SCORED_READING_LEVEL,
   TARGET_READING_LEVEL,
@@ -15,9 +15,10 @@ import {
   PASSAGE,
   BECAUSE_STEM,
   BUT_STEM,
-  SO_STEM 
+  SO_STEM
 } from '../../../../../constants/comprehension';
 import { ActivityInterface, PromptInterface, PassagesInterface } from '../../../interfaces/comprehensionInterfaces';
+import { Input, } from '../../../../Shared/index'
 
 // TODO: add form inputs for course, target reading level and reading level score
 
@@ -62,7 +63,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
 
   const handleSetActivityTargetReadingLevel = (e: InputEvent) => { setActivityTargetReadingLevel(e.target.value) };
 
-  const handleSetActivityPassages = (text: string) => { 
+  const handleSetActivityPassages = (text: string) => {
     const updatedPassages = [...activityPassages];
     updatedPassages[0].text = text;
     setActivityPassages(updatedPassages)
@@ -71,19 +72,19 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
   const handleSetActivityBecausePrompt = (e: InputEvent) => {
     const updatedBecausePrompt = {...activityBecausePrompt};
     updatedBecausePrompt.text = e.target.value;
-    setActivityBecausePrompt(updatedBecausePrompt) 
+    setActivityBecausePrompt(updatedBecausePrompt)
   };
 
-  const handleSetActivityButPrompt = (e: InputEvent) => { 
+  const handleSetActivityButPrompt = (e: InputEvent) => {
     const updatedButPrompt = {...activityButPrompt};
     updatedButPrompt.text = e.target.value;
-    setActivityButPrompt(updatedButPrompt)  
+    setActivityButPrompt(updatedButPrompt)
   };
 
-  const handleSetActivitySoPrompt = (e: InputEvent) => { 
+  const handleSetActivitySoPrompt = (e: InputEvent) => {
     const updatedSoPrompt = {...activitySoPrompt};
     updatedSoPrompt.text = e.target.value;
-    setActivitySoPrompt(updatedSoPrompt)  
+    setActivitySoPrompt(updatedSoPrompt)
   };
 
   const handleSubmitActivity = () => {
@@ -103,9 +104,9 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
       activityScoredReadingLevel,
       activityTargetReadingLevel,
       activityMaxFeedback,
-      activityPassages[0].text, 
-      activityBecausePrompt.text, 
-      activityButPrompt.text, 
+      activityPassages[0].text,
+      activityBecausePrompt.text,
+      activityButPrompt.text,
       activitySoPrompt.text
     ];
     const validationErrors = validateForm(activityFormKeys, state);
@@ -115,7 +116,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
       submitActivity(activityObject);
     }
   }
-  
+
   const errorsPresent = !!Object.keys(errors).length;
   const passageLabelStyle = activityPassages[0].text.length  && activityPassages[0].text !== '<br/>' ? 'has-text' : '';
   const maxAttemptStyle = activityMaxFeedback.length && activityMaxFeedback !== '<br/>' ? 'has-text' : '';
@@ -191,7 +192,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
           className="so-input"
           error={errors[SO_STEM]}
           handleChange={handleSetActivitySoPrompt}
-          label="So Stem" 
+          label="So Stem"
           value={activitySoPrompt.text}
         />
         <div className="submit-button-container">

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/textFields.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/textFields.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Input } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../Shared/index'
 
 class TextFields extends React.Component {
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/student_general.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/student_general.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Input } from 'quill-component-library/dist/componentLibrary';
+import { Input, } from '../../../../Shared/index'
 
 export default class StudentGeneralAccountInfo extends Component {
   constructor(props) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
-  Input,
   DropdownInput
 } from 'quill-component-library/dist/componentLibrary'
 
 import SchoolSelector from '../../shared/school_selector'
 import timezones from '../../../../../modules/timezones'
+import { Input, } from '../../../../Shared/index'
 
 const timeZoneOptions = timezones.map((tz) => {
   const newTz = tz

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/unlink_modal.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/unlink_modal.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Input, } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../../Shared/index'
+
 const smallWhiteCheckSrc = `${process.env.CDN_URL}/images/shared/check-small-white.svg`
 
 export default class UnlinkModal extends React.Component {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/update_password.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/update_password.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Input, } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../../Shared/index'
 
 export default class UpdatePassword extends Component {
   state = {
@@ -37,7 +37,7 @@ export default class UpdatePassword extends Component {
     const { showButtonSection, } = this.state
     const { active, activateSection, isBeingPreviewed, } = this.props;
     if (isBeingPreviewed || active || showButtonSection ) { return }
-    
+
     this.setState({ showButtonSection: true, });
     activateSection();
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import request from 'request';
 import { SegmentAnalytics, Events } from '../../../../../modules/analytics';
-import { Input } from 'quill-component-library/dist/componentLibrary'
 
 import PasswordInfo from './password_info.jsx';
 import AssignActivityPackBanner from '../assignActivityPackBanner'
 import getAuthToken from '../../modules/get_auth_token';
+import { Input, } from '../../../../Shared/index'
 
 class LoginFormApp extends React.Component {
   constructor(props) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/sign_up_student.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/sign_up_student.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import request from 'request'
 import { SegmentAnalytics, Events } from '../../../../../modules/analytics';
-import { Input } from 'quill-component-library/dist/componentLibrary'
 
 import AuthSignUp from './auth_sign_up'
 import AnalyticsWrapper from '../../shared/analytics_wrapper'
 import AgreementsAndLinkToLogin from './agreements_and_link_to_login'
 import getAuthToken from '../../modules/get_auth_token';
+import { Input, } from '../../../../Shared/index'
 
 class SignUpStudent extends React.Component {
   constructor(props) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/sign_up_teacher.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/sign_up_teacher.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import request from 'request'
 import { SegmentAnalytics, Events } from '../../../../../modules/analytics';
-import { Input } from 'quill-component-library/dist/componentLibrary'
 
 import AuthSignUp from './auth_sign_up'
 import AnalyticsWrapper from '../../shared/analytics_wrapper'
 import AgreementsAndLinkToLogin from './agreements_and_link_to_login'
 import AssignActivityPackBanner from '../assignActivityPackBanner'
 import getAuthToken from '../../modules/get_auth_token';
+import { Input, } from '../../../../Shared/index'
 
 const smallWhiteCheckSrc = `${process.env.CDN_URL}/images/shared/check-small-white.svg`
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/reset_password/forgot_password.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/reset_password/forgot_password.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import request from 'request'
-import { Input } from 'quill-component-library/dist/componentLibrary'
 
 import getAuthToken from '../../modules/get_auth_token';
+import { Input, } from '../../../../Shared/index'
 
 const bulbSrc = `${process.env.CDN_URL}/images/onboarding/bulb.svg`
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/reset_password/reset_password.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/reset_password/reset_password.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import request from 'request'
 import { SegmentAnalytics, Events } from '../../../../../modules/analytics';
-import { Input } from 'quill-component-library/dist/componentLibrary'
 
 import getAuthToken from '../../modules/get_auth_token';
+import { Input, } from '../../../../Shared/index'
+
 
 export default class ForgotPassword extends React.Component {
   constructor() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_search/search_activities_input.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_search/search_activities_input.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../../../Shared/index'
 
 const searchIconSrc = `${process.env.CDN_URL}/images/icons/search.svg`
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/create_a_class_inline_form.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/create_a_class_inline_form.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
+import { DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import GradeOptions from '../../../classrooms/grade_options'
+import { Input, } from '../../../../../Shared/index'
 import { requestGet, requestPost } from '../../../../../../modules/request/index.js';
 
 const informationSrc = `${process.env.CDN_URL}/images/icons/information.svg`

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/name_the_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/name_the_unit.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../../../Shared/index'
 
 const NameTheUnit = ({ nameError, unitName, updateUnitName, timesSubmitted, }) => {
   return (

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/unit_assignment_followup.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/unit_assignment_followup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Card, Input, Snackbar, defaultSnackbarTimeout } from 'quill-component-library/dist/componentLibrary'
+import { Card, Snackbar, defaultSnackbarTimeout } from 'quill-component-library/dist/componentLibrary'
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 import AssignmentFlowNavigation from '../assignment_flow_navigation'
@@ -16,6 +16,7 @@ import {
 
 import ScrollToTop from '../../shared/scroll_to_top'
 import ViewAsStudentModal from '../../shared/view_as_student_modal'
+import { Input, } from '../../../../Shared/index'
 
 const assignedActivitiesSrc = `${process.env.CDN_URL}/images/illustrations/assigned-activities.svg`
 const assignActivitiesSrc = `${process.env.CDN_URL}/images/illustrations/assign-activities.svg`

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Input, DataTable } from 'quill-component-library/dist/componentLibrary'
+import { DataTable } from 'quill-component-library/dist/componentLibrary'
 
 import InviteCoteacherModal from '../invite_coteachers_modal'
+import { Input, } from '../../../../Shared/index'
 
 import { classroomWithStudents, classroomProps } from './test_data/test_data'
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/class_code_link.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/class_code_link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { Input } from 'quill-component-library/dist/componentLibrary'
 import {CopyToClipboard} from 'react-copy-to-clipboard';
+import { Input, } from '../../../Shared/index'
 
 interface ClassCodeLinkProps {
   next: (event) => void;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_a_class_form.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_a_class_form.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { Input, DropdownInput } from 'quill-component-library/dist/componentLibrary'
+import { DropdownInput } from 'quill-component-library/dist/componentLibrary'
 
 import GradeOptions from './grade_options'
+import { Input, } from '../../../Shared/index'
 import { requestGet, requestPost } from '../../../../modules/request/index.js';
 
 interface CreateAClassFormProps {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_student_accounts.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_student_accounts.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { DataTable, Input } from 'quill-component-library/dist/componentLibrary'
+import { DataTable } from 'quill-component-library/dist/componentLibrary'
 
 import ButtonLoadingIndicator from '../shared/button_loading_indicator'
+import { Input, } from '../../../Shared/index'
 
 import { requestPost } from '../../../../modules/request/index.js';
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/edit_student_account_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/edit_student_account_modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Input } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../Shared/index'
 
 import { requestPut } from '../../../../modules/request/index.js';
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import * as moment from 'moment'
 
-import { Input, DataTable } from 'quill-component-library/dist/componentLibrary'
+import { DataTable } from 'quill-component-library/dist/componentLibrary'
 
+import { Input, } from '../../../Shared/index'
 import { requestPost, } from '../../../../modules/request/index.js';
 
 interface InviteCoteachersModalProps {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/rename_classroom_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/rename_classroom_modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
-import { Input } from 'quill-component-library/dist/componentLibrary'
-
+import { Input, } from '../../../Shared/index'
 import { requestPut } from '../../../../modules/request/index.js';
 
 interface RenameClassModalProps {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/reset_student_password_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/reset_student_password_modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Input } from 'quill-component-library/dist/componentLibrary'
+import { Input, } from '../../../Shared/index'
 
 import { requestPut } from '../../../../modules/request/index.js';
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import request from 'request'
-import { Input } from 'quill-component-library/dist/componentLibrary'
 import LoadingIndicator from './loading_indicator.jsx';
 import SchoolOption from './school_option'
+import { Input, } from '../../../Shared/index'
 
 const mapSearchSrc = `${process.env.CDN_URL}/images/onboarding/map-search.svg`
 

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/JoinClass.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/JoinClass.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Input } from 'quill-component-library/dist/componentLibrary'
 import { SegmentAnalytics, Events } from '../../../modules/analytics';
 
 import getAuthToken from '../components/modules/get_auth_token'
 import LoadingIndicator from '../components/shared/loading_indicator'
+import { Input, } from '../../Shared/index'
 
 const bulbSrc = `${process.env.CDN_URL}/images/onboarding/bulb.svg`
 


### PR DESCRIPTION
## WHAT
Start importing the Backpack `<Input />` component from the local path rather than the npm package.

## WHY
This is the second-most-imported component, and we want to use the local version rather than the published version for it.

## HOW
I found every instance of the `<Input` component being used, changed where we were importing it from, and then tested it on staging.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no functionality change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
