### PR TITLE
hide archived activities from featured activity pack page

### DIFF
--- a/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
+++ b/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
@@ -71,6 +71,7 @@ class UnitTemplatePseudoSerializer
       INNER JOIN activity_category_activities ON activities.id = activity_category_activities.activity_id
       INNER JOIN activity_categories ON activity_categories.id = activity_category_activities.activity_category_id
       WHERE activities_unit_templates.unit_template_id = #{@unit_template.id}
+      AND NOT 'archived' = ANY(activities.flags)
       ORDER BY activities_unit_templates.order_number, activity_categories.order_number, activity_category_activities.order_number").to_a
     activity_hashes = activities.map do |act|
       {

--- a/services/QuillLMS/spec/services/unit_template_pseudo_serializer_spec.rb
+++ b/services/QuillLMS/spec/services/unit_template_pseudo_serializer_spec.rb
@@ -4,9 +4,11 @@ describe UnitTemplatePseudoSerializer do
   let(:diagnostic) { create(:diagnostic_activity) }
   let(:lesson) { create(:lesson_activity) }
   let(:grammar) { create(:grammar_activity) }
+  let(:archived_activity) { create(:activity, flags: ['archived']) }
   let(:unit_template) { create(:unit_template, unit_template_category_id: 0, activities: [grammar] ) }
   let(:unit_template_with_diagnostic) { create(:unit_template, activities: [diagnostic] ) }
   let(:unit_template_with_lesson) { create(:unit_template, activities: [lesson] ) }
+  let(:unit_template_with_archived_activity) { create(:unit_template, activities: [archived_activity])}
 
   it('will have nil values for the unit template category attributes if there is no unit template category') do
     serialized_ut = UnitTemplatePseudoSerializer.new(unit_template)
@@ -35,5 +37,10 @@ describe UnitTemplatePseudoSerializer do
     # Note that the "activity" factory puts new activities in two categories by default
     serialized_ut = UnitTemplatePseudoSerializer.new(unit_template)
     expect(serialized_ut.activities.length).to eq 1
+  end
+
+  it('will not include archived activities') do
+    serialized_ut = UnitTemplatePseudoSerializer.new(unit_template_with_archived_activity)
+    expect(serialized_ut.activities.length).to eq 0
   end
 end


### PR DESCRIPTION
## WHAT
Hide archived activities from featured activity pack page.

## WHY
One of our users noticed that we were showing twelve activities on the featured activity pack page for the Complex Sentences pack, but only ten when she actually went to assign it. Since the point of archiving activities is to not have users assign them anymore, we shouldn't show these activities in either place.

## HOW
Update the query to filter archived activities.
### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
