### PR TITLE
lms/team-page-copy-update

### DIFF
--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -55,8 +55,13 @@ module PagesHelper
   def team_info
     [
       {
-        team: 'Leadership team',
+        team: 'Management team',
         members: [
+          {
+            name: 'Christina Collins',
+            title: 'Managing Director of Partnerships',
+            img: 'team-christina-collins@2x.png'
+          },
           {
             name: 'Daniel Drabik',
             title: 'Chief Technology Officer',
@@ -66,6 +71,11 @@ module PagesHelper
             name: 'Peter Gault',
             title: 'Executive Director, Cofounder',
             img: 'team-peter-gault@2x.png'
+          },
+          {
+            name: 'Hannah Monk',
+            title: 'Curriculum Director',
+            img: 'team-hannah-monk@2x.png'
           }
         ]
       },
@@ -92,11 +102,6 @@ module PagesHelper
             name: 'Tom Calabrese',
             title: 'Product Designer',
             img: 'team-tom-calabrese@2x.png'
-          },
-          {
-            name: 'Christina Collins',
-            title: 'Managing Director of Partnerships',
-            img: 'team-christina-collins@2x.png'
           },
           {
             name: 'Rachel Dantzler',
@@ -132,11 +137,6 @@ module PagesHelper
             name: 'Maddy Maher',
             title: 'Partnerships Specialist',
             img: 'team-maddy-maher@2x.png'
-          },
-          {
-            name: 'Hannah Monk',
-            title: 'Curriculum Director',
-            img: 'team-hannah-monk@2x.png'
           },
           {
             name: 'Lindsey Murphy',


### PR DESCRIPTION
## WHAT
- Rename section from "Leadership team" to "Management team"
- Move Christina and Hannah into the "Management team" section of the team page
## WHY
- Language matters, and leadership is something we expect from everyone
- We should recognize people for the work they do and the positions they hold
## HOW
- Just some changes in the JSON data that feeds the team page.  (Bless whoever set that structure up initially.)

### Screenshots
<img width="1172" alt="Screen Shot 2020-09-23 at 10 49 47 AM" src="https://user-images.githubusercontent.com/331565/94037022-8b251980-fd8a-11ea-9cd9-c168014f8703.png">

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on content
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
