### PR TITLE
update blog post search and spec

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -47,7 +47,9 @@ class BlogPostsController < ApplicationController
     @blog_posts = ActiveRecord::Base.connection.execute("
       SELECT slug, preview_card_content
       FROM blog_posts
-      WHERE draft IS FALSE AND tsv @@ plainto_tsquery(#{ActiveRecord::Base.sanitize(@query)})
+      WHERE draft IS FALSE
+      AND topic != '#{BlogPost::IN_THE_NEWS}'
+      AND tsv @@ plainto_tsquery(#{ActiveRecord::Base.sanitize(@query)})
       ORDER BY ts_rank(tsv, plainto_tsquery(#{ActiveRecord::Base.sanitize(@query)}))
     ").to_a
     @title = "Search: #{@query}"

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -101,6 +101,7 @@ describe BlogPostsController, type: :controller do
 
   describe '#search' do
     let(:blog_posts) { create_list(:blog_post, 3) }
+    let(:in_the_news_post) { create(:blog_post, title: 'Press', topic: BlogPost::IN_THE_NEWS)}
 
     it 'should redirect back if no query is present' do
       request.env["HTTP_REFERER"] = 'https://example.org'
@@ -112,6 +113,12 @@ describe BlogPostsController, type: :controller do
       query = 'example query'
       get :search, query: query
       expect(assigns(:title)).to eq("Search: #{query}")
+    end
+
+    it 'should not return a blog post with the topic "In the news"' do
+      query = 'Press'
+      get :search, query: query
+      expect(assigns(:blog_posts)).to eq([])
     end
 
     xit 'should return posts that match the query' do


### PR DESCRIPTION
## WHAT
Update the search function for blog posts so that "In the news" articles don't show up.

## WHY
These articles were showing up with content, because they're actually external links. We don't want to allow users to search for them any longer.

## HOW
Just add to the `where` clause.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
