### PR TITLE
lms/use-clever-id-for-integration-fallback

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/creators/school.rb
+++ b/services/QuillLMS/app/services/clever_integration/creators/school.rb
@@ -3,7 +3,14 @@ module CleverIntegration::Creators::School
   def self.run(parsed_response)
     unless parsed_response[:nces_id].blank?
       school = ::School.find_by(nces_id: parsed_response[:nces_id])
-      school
+      return school if school.present?
+    end
+    unless parsed_response[:id].blank?
+      # Some schools (often charters) don't use NCES ID values for individual
+      # schools, for those we manually establish the CleverID in our database
+      # for their schools and use this lookup as a fallback
+      school = ::School.find_by(clever_id: parsed_response[:id])
+      return school if school.present?
     end
   end
 

--- a/services/QuillLMS/spec/services/clever_integration/creators/school_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/creators/school_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'CleverIntegration::Creators::School' do
+
+  let!(:nces_school) { create(:school, nces_id: 'NCES_ID') }
+  let!(:clever_school) { create(:school, nces_id: nil, clever_id: 'CLEVER_ID') }
+
+  let(:nces_match) {
+    {
+      id: clever_school.clever_id,
+      nces_id: nces_school.nces_id
+    }
+  }
+
+  let(:nces_mismatch) {
+    {
+      id: clever_school.clever_id,
+      nces_id: 'NO_MATCH'
+    }
+  }
+
+  let(:nces_missing) {
+    {
+      id: clever_school.clever_id
+    }
+  }
+
+  let(:both_mismatch) {
+    {
+      id: 'NO_MATCH',
+      nces_id: 'NO_MATCH'
+    }
+  }
+
+  it 'will find the school by NCES if one is present in the payload' do
+    school = CleverIntegration::Creators::School.run(nces_match)
+    expect(school).to eq(nces_school)
+  end
+
+  it 'will fall back to Clever ID if NCES is missing' do
+    school = CleverIntegration::Creators::School.run(nces_missing)
+    expect(school).to eq(clever_school)
+  end
+
+  it 'will fall back to Clever ID if NCES is present, but there is no matching school' do
+    school = CleverIntegration::Creators::School.run(nces_mismatch)
+    expect(school).to eq(clever_school)
+  end
+
+  it 'will return nil if no Clever ID or NCES ID is present in payload' do
+    school = CleverIntegration::Creators::School.run({})
+    expect(school).to be_nil
+  end
+
+  it 'will return nil if neither Clever ID nor NCES ID match a school' do
+    school = CleverIntegration::Creators::School.run(both_mismatch)
+    expect(school).to be_nil
+  end
+end
+


### PR DESCRIPTION

## WHAT
Allow for fallback identification of schools in Clever in cases where NCES ID doesn't work
## WHY
We've been using NCES ID (sent from Clever) to identify which school record in our database is a match to do things like assign a Clever-synced teacher to the correct school, but some schools don't use NCES ID values on a one-to-one basis with their schools (this is very common with Charters).  We need a back-up method for identifying Clever schools in these situations, and Clever-assigned ID seems to make the most sense.
## HOW
Add a bit of additional code to the existing look-up for cases where the NCES branch does not return a school.  We still fall-back to `nil` as a return value if we can't find any results.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.  I added test coverage for this file, as it was missing before.
Have you deployed to Staging? | Doing so now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
