### PR TITLE
Release 9-23-2020 Set Sidekiq threads to DB Pool minus 1. (#6777)

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -3,6 +3,6 @@ web: bundle exec puma -C ./config/puma.rb
 # Note, using MALLOC_ARENA_MAX=2 based on this article:
 # https://github.com/mperham/sidekiq/wiki/Deployment#heroku
 
-worker: MALLOC_ARENA_MAX=2 RAILS_MAX_THREADS=4 bundle exec sidekiq -q critical -q default
+worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
 
-reportworker: MALLOC_ARENA_MAX=2 RAILS_MAX_THREADS=4 bundle exec sidekiq -q critical -q default -q low
+reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default -q low

--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development_env: &development_env

--- a/services/QuillLMS/config/sidekiq.yml
+++ b/services/QuillLMS/config/sidekiq.yml
@@ -1,9 +1,9 @@
 ---
-:concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 4 } %>
+:concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
 staging:
-  :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 4 } %>
+  :concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
 production:
-  :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 4 } %>
+  :concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
 :queues:
   - critical
   - default


### PR DESCRIPTION
* Revert sidekicks settings.

* Set Sidekiq workers to 1 less than DB threads.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
