### PR TITLE
Deploy Descriptions Posted to Slack

### DIFF
--- a/scripts/post_slack_deploy_description.sh
+++ b/scripts/post_slack_deploy_description.sh
@@ -1,0 +1,25 @@
+# This will post deploy text to the #product_updates channel
+# Usage
+# sh post_slack_deploy_description.sh $app_name
+# e.g.
+# sh post_slack_deploy_description.sh 'QuillLessons'
+# It will prompt for a description
+
+username=$(git config user.name)
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+echo "*****************************"
+echo "*****************************"
+echo "*** $YELLOW Add a description $NC *****"
+echo "** $YELLOW for #product_updates! $NC **"
+echo "*****************************"
+read -p 'Description for non-engineers: ' description
+
+message=":ship: *$1* Release! Author: $username *Description*: $description"
+webhook=$(heroku config:get SLACK_API_PRODUCT_UPDATES --app empirical-grammar)
+
+# remove single quotes since it messes with the JSON format
+escaped_message="${message//\'/}"
+
+curl -X POST -H 'Content-type: application/json' --data "{'text': '$escaped_message'}" $webhook

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -37,6 +37,10 @@ if [[ "$response" =~ ^([y])$ ]]
 then
     sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
     git push origin -f ${current_branch}:$DEPLOY_GIT_BRANCH
+    if [ $1 == 'prod' ]
+    then
+        sh ../../scripts/post_slack_deploy_description.sh $app_name
+    fi
     open "https://dashboard.heroku.com/apps/$HEROKU_APP/activity"
     open $URL
     open $NR_URL


### PR DESCRIPTION
## WHAT
This adds a deploy description prompt on production deploys of the LMS. The description will be posted to the `#product_updates` Slack channel.
## WHY
The goal is to keep other teams informed of the changes going to the website without our teammates having to monitor our other noisy channels and without developers having to remember on their own to post about every deploy.

Let's try this method out, and if it's not helpful, we can pull it out.
## HOW
Added a webhook for a new Slack channel and wrote a small bash script.
### Screenshots

<img width="921" alt="Screen Shot 2020-09-23 at 6 28 23 PM" src="https://user-images.githubusercontent.com/1304933/94076232-9e57d980-fdca-11ea-9ade-1e0fd8044520.png">
<img width="1402" alt="Screen Shot 2020-09-23 at 6 29 19 PM" src="https://user-images.githubusercontent.com/1304933/94076297-bf202f00-fdca-11ea-9045-660719bc1f66.png">


<img width="1169" alt="Screen Shot 2020-09-23 at 6 26 49 PM" src="https://user-images.githubusercontent.com/1304933/94076136-75cfdf80-fdca-11ea-85a3-288e47fef2fb.png">

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, devops
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
