### PR TITLE
fix isLastQuestion logic

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -29,13 +29,15 @@ const request = require('request');
 
 export class Lesson extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
+
+    const isLastQuestion = props.playLesson.unansweredQuestions.length === 0 && props.playLesson.answeredQuestions.length > 0;
 
     this.state = {
       hasOrIsGettingResponses: false,
       sessionInitialized: false,
       introSkipped: false,
-      isLastQuestion: props.playLesson.unansweredQuestions.length === 0
+      isLastQuestion: isLastQuestion 
     }
   }
 
@@ -84,16 +86,16 @@ export class Lesson extends React.Component {
       }
       // user has toggled to last question
       if(previewMode && questionToPreview && playLesson && playLesson.questionSet && !isLastQuestion && !this.getNextPreviewQuestion(questionToPreview)) {
-        this.setIsLastQuestion();
+        this.toggleIsLastQuestion();
       }
       // user has toggled to another question from last question
       if(previewMode && questionToPreview && playLesson && playLesson.questionSet && isLastQuestion && this.getNextPreviewQuestion(questionToPreview)) {
-        this.setIsLastQuestion();
+        this.toggleIsLastQuestion();
       }
     }
   }
 
-  setIsLastQuestion = () => {
+  toggleIsLastQuestion = () => {
     this.setState(prevState => ({ isLastQuestion: !prevState.isLastQuestion }));
   }
 
@@ -191,7 +193,7 @@ export class Lesson extends React.Component {
       if(nextPreviewQuestion) {
         onHandleToggleQuestion(nextPreviewQuestion)
       } else {
-        this.setIsLastQuestion();
+        this.toggleIsLastQuestion();
       }
     } else {
       const next = nextQuestion();


### PR DESCRIPTION
## WHAT
fix isLastQuestion logic for teacher preview in Connect

## WHY
the first question Next button was disabled after max attempts

## HOW
just updated `isLastQuestion` initial state

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- tiny change
Have you deployed to Staging? | No-- tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
