### PR TITLE
add new staged files eslint rule about import order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
   "plugins": [
     "react",
     "@typescript-eslint/eslint-plugin",
-    "jsx-a11y"
+    "jsx-a11y",
+    "import"
   ],
   "parserOptions": {
     "sourceType": "module",

--- a/staged_files_eslint.json
+++ b/staged_files_eslint.json
@@ -26,6 +26,7 @@
     "react/jsx-handler-names": "error",
     "react/jsx-key": "error",
     "react/jsx-no-bind": ["error", { "ignoreRefs": true }],
-    "react/jsx-curly-brace-presence": "error"
+    "react/jsx-curly-brace-presence": "error",
+    "import/order": ["error", {"groups": ["builtin", "external", "index", "sibling", "parent"], "newlines-between": "always"}]"
   }
 }


### PR DESCRIPTION
## WHAT
This adds a rule so that the order will always be:

- built in libraries
- external libraries
- index files
- sibling files
- parent files

## WHY
In the process of pulling components out of the component library, it's been making me a little crazy that our import order isn't standardized throughout the files. This will help us maintain a standard order going forward.

## HOW
Just add the rule.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no functionality change
Have you deployed to Staging? | (NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
