### PR TITLE
Classrooms bug hotfix

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -210,7 +210,7 @@ class Teachers::ClassroomsController < ApplicationController
 
   def format_teachers_for_classroom(classroom)
     classroom.classrooms_teachers.compact.map do |ct|
-      teacher = ct.user.attributes
+      teacher = ct.user&.attributes
       teacher[:classroom_relation] = ct.role
       teacher[:status] = 'Joined'
       teacher


### PR DESCRIPTION
## WHAT
Nil error in this Sentry bug: https://sentry.io/organizations/quillorg-5s/issues/1910531634/?project=11238&query=is%3Aunresolved
This is causing a `500` on the teachers/classrooms page for some users. https://www.notion.so/quill/500-Error-Appearing-on-My-Classes-tab-e2ec436b313b4e53b94dcbb46f2b4d40
## WHY
Errors are bad.
## HOW
Fixing the nil error will add tests shortly
### Screenshots


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Not yet, but will
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
