### PR TITLE
don't change role when an existing user tries to sign up with Google again

### DIFF
--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -32,10 +32,11 @@ class GoogleIntegration::User
         post_google_classroom_assignments: user.new_record? ? true : user.post_google_classroom_assignments,
         auth_credential_attributes: auth_credential_attributes,
       }
+
       params[:name]      = data.name      if data.name.present?
       params[:email]     = data.email     if data.email.present?
       params[:google_id] = data.google_id if data.google_id.present?
-      params[:role]      = data.role      if data.role.present?
+      params[:role]      = data.role      if data.role.present? && user.new_record?
       params[:clever_id] = nil
 
       params

--- a/services/QuillLMS/spec/services/google_integration/user_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/user_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe GoogleIntegration::User do
+  describe '#update_or_initialize' do
+
+    before(:each) do
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:access_token).and_return('whatever')
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:refresh_token).and_return('whatever')
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:expires_at).and_return('the future')
+    end
+
+    let!(:teacher) { create(:teacher, google_id: 234)}
+
+    it 'returns a user with the passed-in role if initializing a new user' do
+      @profile1 = GoogleIntegration::Profile.new({}, {})
+
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:name).and_return('Jane Smith')
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:email).and_return('janesmith@google.com')
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:google_id).and_return(123)
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:role).and_return('student')
+      user = GoogleIntegration::User.new(@profile1).update_or_initialize
+      expect(user.role).to eq('student')
+    end
+
+    it 'returns a user with their existing role if the user already exists' do
+      @profile2 = GoogleIntegration::Profile.new({}, {})
+
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:name).and_return(teacher.name)
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:email).and_return(teacher.email)
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:google_id).and_return(teacher.google_id)
+      allow_any_instance_of(GoogleIntegration::Profile).to receive(:role).and_return('student')
+
+      user = GoogleIntegration::User.new(@profile2).update_or_initialize
+      expect(user.role).to eq('teacher')
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Update our Google integration so if an existing teacher tries to "Sign up as a student" through Google, it doesn't change their role to a student.

## WHY
Teachers were getting confused about why they could no longer access their teacher account after signing up as a student with the same account. We bounced around a couple of options for solving it, but ended up deciding to handle it in the simplest possible way first and monitor as necessary.

## HOW
Only set the `role` if the user is a new record.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
