### PR TITLE
Explicitly add 'www.quill.org' to CORS allowed origins

### DIFF
--- a/services/QuillCMS/config/environments/development.rb
+++ b/services/QuillCMS/config/environments/development.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
 
   config.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins 'quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
+      origins 'quill.org', 'www.quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
 
       resource '*',
         headers: :any,

--- a/services/QuillCMS/config/environments/production.rb
+++ b/services/QuillCMS/config/environments/production.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   # Allow cross site origin in the following contexts
   config.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins 'quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
+      origins 'quill.org', 'www.quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
 
       resource '*',
         headers: :any,

--- a/services/QuillCMS/config/initializers/cors.rb
+++ b/services/QuillCMS/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
+    origins 'quill.org', 'www.quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
## WHAT
Explicitly add 'www.quill.org' to CORS allowed origins instead of just relying on the wild-carded "https://*.quill.org"
## WHY
The CORS headers are somehow not working properly for Diagnostic, and hopefully this will fix that
## HOW
Just add an explicit entry for CORS allowed Origins

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around CORS
Have you deployed to Staging? | No - this is a hotfix
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
