### PR TITLE
fix bug with having multiple text editors on the same page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -4,14 +4,6 @@ import { convertFromHTML, convertToHTML } from 'draft-convert'
 import createRichButtonsPlugin from 'draft-js-richbuttons-plugin'
 import * as Immutable from 'immutable'
 
-const richButtonsPlugin = createRichButtonsPlugin();
-const {
-  // inline buttons
-  ItalicButton, BoldButton, UnderlineButton,
-  // block buttons
-  BlockquoteButton, ULButton, H3Button
-} = richButtonsPlugin;
-
 // interface TextEditorProps {
 //   text: string;
 //   boilerplate: string;
@@ -35,7 +27,8 @@ class TextEditor extends React.Component <any, any> {
     super(props)
 
     this.state = {
-      text: this.props.EditorState.createWithContent(convertFromHTML(this.props.text || ''))
+      text: this.props.EditorState.createWithContent(convertFromHTML(this.props.text || '')),
+      richButtonsPlugin: createRichButtonsPlugin()
     }
 
     this.handleTextChange = this.handleTextChange.bind(this)
@@ -58,6 +51,13 @@ class TextEditor extends React.Component <any, any> {
   }
 
   render() {
+    const { richButtonsPlugin, } = this.state
+    const {
+      // inline buttons
+      ItalicButton, BoldButton, UnderlineButton,
+      // block buttons
+      BlockquoteButton, ULButton, H3Button
+    } = richButtonsPlugin;
 
     return (
       <div className="card is-fullwidth">


### PR DESCRIPTION
## WHAT
Make sure the `RichButtonPlugins` object is specific to each individual instance of the `TextEditor`.

## WHY
Previously, we had a bug where multiple instances of a text editor on a given page resulted in the rich button plugin not working correctly for all but the last instance.

## HOW
Just assign the rich button plugin object to the state of a given component.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
