### PR TITLE
update cms standard_levels file to use standard levels instead of sections

### DIFF
--- a/services/QuillLMS/app/views/cms/standard_levels/index.html.slim
+++ b/services/QuillLMS/app/views/cms/standard_levels/index.html.slim
@@ -1,18 +1,18 @@
 .container
   article.simple-rounded-box.chapter-levels-page
-    = form_for [:cms, Section.new] do |f|
+    = form_for [:cms, StandardLevel.new] do |f|
       table.table
         thead
           th.name-column Name
           th.position-column Position
           th.actions-column
 
-        - @sections.order(position: :asc).each do |chapter_level|
+        - @standard_levels.order(position: :asc).each do |chapter_level|
           tr
             td= chapter_level.name
             td= chapter_level.position
             td.actions-column= link_to 'Delete', [:cms, chapter_level], confirm: 'Are you sure?', method: :delete, remote: true, class: 'js-delete-link'
 
         td= f.text_field :name
-        td.position-select= f.select :position, 1.upto(Section.count + 1).to_a
+        td.position-select= f.select :position, 1.upto(StandardLevel.count + 1).to_a
         td.actions-column= f.submit 'Create', class: 'btn btn-primary btn-small'


### PR DESCRIPTION
## WHAT
Replace `Section` with `StandardLevel` in one instance I missed.

## WHY
Because we're getting rid of the `Section` table and replacing it with the `StandardLevel` table.

## HOW
Just update the references.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
