### PR TITLE
Fix proofreader activities to save changes 

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -11,6 +11,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   MY_ACCOUNT = 'my_account'
   ASSIGN = 'assign'
+  SERIALIZED_GOOGLE_CLASSROOMS_FOR_ = 'SERIALIZED_GOOGLE_CLASSROOMS_FOR_'
 
   def lesson_planner
     set_classroom_variables
@@ -158,17 +159,24 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def retrieve_google_classrooms
-    RetrieveGoogleClassroomsWorker.perform_async(current_user.id)
-    render json: { id: current_user.id, quill_retrieval_processing: true }
+    serialized_google_classrooms = $redis.get("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
+    if serialized_google_classrooms
+      render json: JSON.parse(serialized_google_classrooms)
+    else
+      RetrieveGoogleClassroomsWorker.perform_async(current_user.id)
+      render json: { id: current_user.id, quill_retrieval_processing: true }
+    end
   end
 
   def update_google_classrooms
     GoogleIntegration::Classroom::Creators::Classrooms.run(current_user, params[:selected_classrooms])
+    $redis.del("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
     render json: { classrooms: current_user.google_classrooms }.to_json
   end
 
   def import_google_students
     selected_classroom_ids = Classroom.where(id: params[:classroom_id] || params[:selected_classroom_ids]).ids
+    $redis.del("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
     GoogleStudentImporterWorker.perform_async(
       current_user.id,
       'Teachers::ClassroomManagerController',

--- a/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
@@ -21,6 +21,8 @@ class RetrieveGoogleClassroomsWorker
     end
     data = google_response === 'UNAUTHENTICATED' ? {errors: google_response} : {classrooms: google_response}
     serialized_data = data.to_json
+    $redis.set("#{Teachers::ClassroomManagerController::SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{user_id}", serialized_data)
+    $redis.expire("#{Teachers::ClassroomManagerController::SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{user_id}", SERIALIZED_GOOGLE_CLASSROOMS_CACHE_LIFE)
     PusherTrigger.run(user_id, 'google-classrooms-retrieved', "Google classrooms found for #{user_id}.")
   end
 end


### PR DESCRIPTION
## WHAT
Students were not able to save their changes in Proofreader.

This was because we were not correctly passing some arguments to our `handleSession` function, so it wasn't actually sending the session data to the reducer.

## WHY
So that students can save their work in Proofreader and come back later to resume it.

## HOW
Pass the correct arguments to the `handleSession` function.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
