### PR TITLE
Remove vestigial reference to Firebase

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
@@ -49,6 +49,7 @@ export default class ClassroomLessons extends React.Component {
 
   getLessonsWithEditions = () => {
     // TODO: Figure out if we should be pulling this data from RethinkDB instead
+    // Use 'git blame' on this file to see the commit where this TODO was added to see what the code originally looked like
     this.setState({lessonUidsWithEditions: [], loaded: true})
   }
 


### PR DESCRIPTION
## WHAT
Remove vestigial reference to Firebase
## WHY
We want to phase out the use of Firebase, and this code references Firebase without actually doing anything
## HOW
Replace the existing code which connects to a non-existent Firebase data endpoint and (because there's no data there) sets an empty array value, just set the empty array value.  Add a TODO (and a Task card to the Product board) to replace this with code that goes through LessonsServer and RethinkDB to get this data if necessary.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavioral changes.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
