### PR TITLE
Remember that Title Cards are "TL" not "TC"

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/titleCards.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/titleCards.ts
@@ -33,7 +33,7 @@ function loadSpecifiedTitleCards(uids) {
       results.forEach((result) => {
         questionData[result.uid] = result;
       });
-      sessionActions.populateQuestions("TC", questionData, true)
+      sessionActions.populateQuestions("TL", questionData, true)
       dispatch({ type: C.RECEIVE_TITLE_CARDS_DATA, data: questionData, });
     });
   }


### PR DESCRIPTION
## WHAT
Fix a typo in what really should be a constant
## WHY
So that it gets referenced properly when denormalizing sessions.  (Not sure how this didn't get caught in testing.  Maybe some data differences between environments?)
## HOW
Just change the value


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this one
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
