### PR TITLE
don't allow users to assign packs with no activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import ButtonLoadingIndicator from '../../../shared/button_loading_indicator';
 import NameTheUnit from './name_the_unit';
 import ReviewActivities from './review_activities'
 import AssignStudents from './assign_students'
+
+import ButtonLoadingIndicator from '../../../shared/button_loading_indicator';
 import AssignmentFlowNavigation from '../../assignment_flow_navigation.tsx'
 import ScrollToTop from '../../../shared/scroll_to_top'
 
@@ -12,7 +13,6 @@ export default class Stage2 extends React.Component {
     super(props)
 
     this.state = {
-      buttonDisabled: false,
       prematureAssignAttempted: false,
       loading: false,
       timesSubmitted: 0
@@ -20,31 +20,32 @@ export default class Stage2 extends React.Component {
   }
 
   assignButton() {
-    return this.state.loading
-      ? <button className={`${this.determineAssignButtonClass()} pull-right`} id="assign">Assigning... <ButtonLoadingIndicator /></button>
-      : <button className={`${this.determineAssignButtonClass()} pull-right`} id="assign" onClick={this.finish}>Assign pack to classes</button>;
+    const { loading, } = this.state
+    return loading
+      ? <button className={`${this.determineAssignButtonClass()} pull-right`} id="assign" type="button">Assigning... <ButtonLoadingIndicator /></button>
+      : <button className={`${this.determineAssignButtonClass()} pull-right`} id="assign" onClick={this.handleClickAssign} type="button">Assign pack to classes</button>;
   }
 
   determineAssignButtonClass() {
+    const { areAnyStudentsSelected, selectedActivities, } = this.props
     let buttonClass = 'quill-button contained primary medium';
-    if (this.state.buttonDisabled || !this.props.areAnyStudentsSelected) {
+    if (!this.buttonEnabled()) {
       buttonClass += ' disabled';
     }
     return buttonClass;
   }
 
-  determineErrorMessageClass() {
-    if (this.state.prematureAssignAttempted) {
-      return 'error-message visible-error-message';
-    }
-    return 'error-message hidden-error-message';
+  buttonEnabled() {
+    const { areAnyStudentsSelected, selectedActivities, } = this.props
+    return areAnyStudentsSelected && selectedActivities.length
   }
 
-  finish = () => {
-    const { buttonDisabled, timesSubmitted, } = this.props
-    if (!this.state.buttonDisabled && !this.props.errorMessage) {
+  handleClickAssign = () => {
+    const { timesSubmitted, } = this.state
+    const { errorMessage, finish, } = this.props
+    if (this.buttonEnabled() && !errorMessage) {
       this.setState({ loading: true, });
-      this.props.finish();
+      finish();
     } else {
       this.setState({ prematureAssignAttempted: true, timesSubmitted: timesSubmitted + 1 });
     }
@@ -72,7 +73,6 @@ export default class Stage2 extends React.Component {
     const { errorMessage, unitName, updateUnitName, } = this.props
     return (<NameTheUnit
       nameError={errorMessage ? errorMessage.name : null}
-      nameError={errorMessage ? errorMessage.name : null}
       timesSubmitted={timesSubmitted}
       unitName={unitName}
       updateUnitName={updateUnitName}
@@ -95,8 +95,7 @@ export default class Stage2 extends React.Component {
   }
 
   render() {
-    const { errorMessage, unitTemplateName, unitTemplateId, selectedActivities, isFromDiagnosticPath, } = this.props
-    const buttonError = errorMessage ? errorMessage.students : null
+    const { unitTemplateName, unitTemplateId, selectedActivities, isFromDiagnosticPath, } = this.props
     let assignName = 'Activity Pack'
     if (unitTemplateName) {
       assignName = unitTemplateName


### PR DESCRIPTION
## WHAT
Don't allow users to assign packs with no activities from the assignment flow.

## WHY
It was previously possible for users to get to this page and then remove all the activities from the pack and still assign it, causing weird behavior. This changes that.

## HOW
Make sure the button is disabled if a user tries to assign the pack with no activities. Also, some general file clean up, because we had some unused code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
