### PR TITLE
serialize activities with no category

### DIFF
--- a/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
+++ b/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
@@ -68,8 +68,8 @@ class UnitTemplatePseudoSerializer
       INNER JOIN standard_categories ON standards.standard_category_id = standard_categories.id
       INNER JOIN activities_unit_templates ON activities.id = activities_unit_templates.activity_id
       INNER JOIN activity_classifications ON activities.activity_classification_id = activity_classifications.id
-      INNER JOIN activity_category_activities ON activities.id = activity_category_activities.activity_id
-      INNER JOIN activity_categories ON activity_categories.id = activity_category_activities.activity_category_id
+      LEFT JOIN activity_category_activities ON activities.id = activity_category_activities.activity_id
+      LEFT JOIN activity_categories ON activity_categories.id = activity_category_activities.activity_category_id
       WHERE activities_unit_templates.unit_template_id = #{@unit_template.id}
       AND NOT 'archived' = ANY(activities.flags)
       ORDER BY activities_unit_templates.order_number, activity_categories.order_number, activity_category_activities.order_number").to_a

--- a/services/QuillLMS/spec/services/unit_template_pseudo_serializer_spec.rb
+++ b/services/QuillLMS/spec/services/unit_template_pseudo_serializer_spec.rb
@@ -43,4 +43,10 @@ describe UnitTemplatePseudoSerializer do
     serialized_ut = UnitTemplatePseudoSerializer.new(unit_template_with_archived_activity)
     expect(serialized_ut.activities.length).to eq 0
   end
+
+  it('will have an activity even if that activity has no activity categories') do
+    unit_template.activities.each { |a| ActivityCategoryActivity.where(activity_id: a.id).destroy_all }
+    serialized_ut = UnitTemplatePseudoSerializer.new(unit_template)
+    expect(serialized_ut.activities.length).to eq 1
+  end
 end


### PR DESCRIPTION
## WHAT
Update `UnitTemplatePseudoSerializer` query to return activities that do not have associated activity categories.

## WHY
Right now, not having an activity category results in not loading activities for a given unit template, so teachers can't assign it. 

## HOW
Update query and add a test.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
