### PR TITLE
Tweak CMS deploy script to open more status windows

### DIFF
--- a/services/QuillCMS/deploy.sh
+++ b/services/QuillCMS/deploy.sh
@@ -19,7 +19,4 @@ sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
 
 eb deploy ${EB_ENVIRONMENT_NAME}
 open "https://rpm.newrelic.com/accounts/2639113/applications/548895592"
-
-# Slack deploy finish
-sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch true
-
+open "https://console.aws.amazon.com/elasticbeanstalk/home?region=us-east-1#/environment/dashboard?applicationName=QuillCMS&environmentId=e-7n7bmkzhp3"


### PR DESCRIPTION
## WHAT
Small tweak to CMS deploy script:
- Don't send "success" message to Slack since the script may complete before the deploy and that message would be wrong
- Open the AWS status page for production when deploying as it's the only good place to monitor deploy status at the moment
## WHY
These are remediations from our last round of post-mortems.
## HOW
Just a couple of lines changed in the deploy script

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  We don't have coverage on deploy scripts
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
