### PR TITLE
fix issue with resuming started session

### DIFF
--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -798,8 +798,23 @@ end
       expect(returned_activity_session).to eq(started_activity_session)
     end
 
+    it "returns a started activity session if it exists, even if there are also finished sessions" do
+      started_activity_session = create(:activity_session, :started, user: student, activity: activity, classroom_unit: classroom_unit)
+      finished_activity_sessions = create_list(:activity_session, 10, state: 'finished', user: student, activity: activity, classroom_unit: classroom_unit)
+      returned_activity_session = ActivitySession.find_or_create_started_activity_session(student.id, classroom_unit.id, activity.id)
+      expect(returned_activity_session).to eq(started_activity_session)
+    end
+
     it "finds an unstarted activity session if it exists, updates it to started, and returns it" do
       unstarted_activity_session = create(:activity_session, :unstarted, user: student, activity: activity, classroom_unit: classroom_unit)
+      returned_activity_session = ActivitySession.find_or_create_started_activity_session(student.id, classroom_unit.id, activity.id)
+      expect(returned_activity_session).to eq(unstarted_activity_session)
+      expect(returned_activity_session.state).to eq('started')
+    end
+
+    it "finds an unstarted activity session if it exists, updates it to started, and returns it, even if there are also finished sessions" do
+      unstarted_activity_session = create(:activity_session, :unstarted, user: student, activity: activity, classroom_unit: classroom_unit)
+      finished_activity_sessions = create_list(:activity_session, 10, state: 'finished', user: student, activity: activity, classroom_unit: classroom_unit)
       returned_activity_session = ActivitySession.find_or_create_started_activity_session(student.id, classroom_unit.id, activity.id)
       expect(returned_activity_session).to eq(unstarted_activity_session)
       expect(returned_activity_session.state).to eq('started')


### PR DESCRIPTION
## WHAT
Fix bug where students who had started a replay session of an activity, but not completed it, were not able to resume that session and instead had a new one created.

## WHY
We want students to be able to resume replay sessions consistently.

## HOW
Use a `where` instead of a `find_by` to get an array of all the student's sessions for an activity, not just whatever the find happens to return, and then look through that array for a started or unstarted session.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
