### PR TITLE
add chief of staff to careers page

### DIFF
--- a/services/QuillLMS/app/views/pages/_job.html.erb
+++ b/services/QuillLMS/app/views/pages/_job.html.erb
@@ -7,7 +7,7 @@
     <h3><%= job[:category] %></h3>
   </div>
   <div class="positions">
-    <a target="_blank" href="https://angel.co/company/quill-org/jobs/<%= job[:angelco_url] %>">
+    <a target="_blank" href="<%= job[:url] %>">
       <div class="position">
         <div><%= job[:title] %></div>
         <img class="icon-img" src=<%= "#{expand_icon_url}" %> width=24 height=24 />

--- a/services/QuillLMS/config/careers.yml
+++ b/services/QuillLMS/config/careers.yml
@@ -2,12 +2,12 @@ default:
   open_positions:
     - category: 'Product'
       title: 'Software Engineer'
-      angelco_url: '581557-software-engineer-rails-react-python'
+      url: 'https://angel.co/company/quill-org/jobs/581557-software-engineer-rails-react-python'
 
     - category: 'Product'
       title: 'Senior Software Engineer'
-      angelco_url: '587292-senior-software-engineer-rails-react-python'
+      url: 'https://angel.co/company/quill-org/jobs/587292-senior-software-engineer-rails-react-python'
 
     - category: 'Operations'
       title: 'Chief of Staff'
-      angelco_url: '1020317-quill-org-chief-of-staff-nonprofit-educational-technology'
+      url: 'https://www.linkedin.com/jobs/view/2188732565/'


### PR DESCRIPTION
## WHAT
Add Chief of Staff position to the Careers page.

## WHY
We want people to be able to find the job listing through our website.

## HOW
Add the job to the `yml` file we use to keep track of open positions.

### Screenshots
<img width="823" alt="Screen Shot 2020-10-19 at 9 12 23 AM" src="https://user-images.githubusercontent.com/18669014/96455363-1f986580-11eb-11eb-84f2-aa9ad4a01cba.png">

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for yml files
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
