### PR TITLE
make sure banners stay closed by adding a `path` to the cookies

### DIFF
--- a/services/QuillLMS/app/views/application/_static_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_static_banner.html.erb
@@ -19,7 +19,7 @@
         document.getElementById('static-banner').style.display = 'none';
         let date = new Date();
         date.setTime(date.getTime()+(24*60*60*1000));
-        document.cookie = `static_banner_closed=1; expires=${date.toGMTString()}`;
+        document.cookie = `static_banner_closed=1; expires=${date.toGMTString()}; path=/`;
     }, false);
 
   </script>

--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -25,7 +25,7 @@
           let date = new Date();
           // set the cookie to expire at the start of the next hour so we can show the next webinar
           date.setHours(date.getHours() + 1,0,0);
-          document.cookie = `webinar_banner_closed=1; expires=${date.toGMTString()}`;
+          document.cookie = `webinar_banner_closed=1; expires=${date.toGMTString()}; path=/`;
       }, false);
 
     </script>


### PR DESCRIPTION
## WHAT
Add a `path` value to the cookies so that they persist on different paths in the website.

## WHY
Tom reported this issue here: https://www.notion.so/quill/Closing-webinar-banners-appearing-again-in-the-same-session-5c8a3062045841afb509a7812442a26a. It looks like our cookies were using the default path, which is the current path, and therefore when users switched pages they would often see a banner they'd already closed.

## HOW
Just add `; path=/` to both places we set `document.cookie`.

### Screenshots
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
