### PR TITLE
Add new Comprehension FeedbackHistory migration separately

### DIFF
--- a/services/QuillLMS/db/migrate/20201022150533_create_comprehension_feedback_history.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20201022150533_create_comprehension_feedback_history.comprehension.rb
@@ -1,0 +1,24 @@
+# This migration comes from comprehension (originally 20201019200539)
+class CreateComprehensionFeedbackHistory < ActiveRecord::Migration
+  def change
+    create_table :comprehension_feedback_histories do |t|
+      t.text :activity_session_uid
+      t.references :prompt, polymorphic: true
+      t.text :concept_uid
+      t.integer :attempt, null: false
+      t.text :entry, null: false
+      t.boolean :optimal, null: false
+      t.boolean :used, null: false
+      t.text :feedback_text
+      t.text :feedback_type, null: false
+      t.datetime :time, null: false
+      t.jsonb :metadata
+
+      t.timestamps null: false
+    end
+    add_index :comprehension_feedback_histories, :activity_session_uid
+    add_index :comprehension_feedback_histories, [:prompt_type, :prompt_id],
+              name: "index_comprehension_feedback_histories_on_prompt_type_and_id"
+    add_index :comprehension_feedback_histories, :concept_uid
+  end
+end


### PR DESCRIPTION
## WHAT
Just the migrations required to prepare the database for the `Comprehension::FeedbackHistory` model

## WHY
We want to deploy our migrations ahead of our models to avoid issues on deploy

## HOW
Finished all the model-related code for `Comprehension::FeedbackHistory` and then installed the migration to the LMS proper.  Then committed just the installed migration file.

### Notion Card Links
https://www.notion.so/quill/Comprehension-FeedbackHistory-API-9548275a77ff4b06af3de4f4eca7f9af

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on migrations
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
