### PR TITLE
make sure ccss slider is usable now that some activities have no standard level

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/shared.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/shared.ts
@@ -24,6 +24,8 @@ export const activityClassificationGroupings = [
 ]
 
 export const getNumberFromString = (string) => {
+  if (!string) { return null }
+  
   const numberMatch = string.match(/\d+/g)
   if (numberMatch) { return Number(numberMatch[0]) }
 


### PR DESCRIPTION
## WHAT
Fix for logic that handles filtering on CCSS Standard Level now that some activities have no standard level.

## WHY
This was causing an error that made the page go blank when you attempted to change the CCSS Grade Level slider.

## HOW
Just a nil check.

### Screenshots
N/A

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
