### PR TITLE
update Fill In The Blank prompt to handle text styling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -212,28 +212,19 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 }
               }
             >
-              <span
-                key="0-0"
+              <p
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "I have ",
+                  }
+                }
                 style={
                   Object {
                     "marginRight": 5,
                   }
                 }
-              >
-                I
-              </span>
+              />
               <span
-                key="0-1"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                have
-              </span>
-              <span
-                key="0-2"
                 style={
                   Object {
                     "marginRight": 5,
@@ -260,8 +251,12 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   value=""
                 />
               </span>
-              <span
-                key="1-0"
+              <p
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": " friend named Marco who loves ",
+                  }
+                }
                 style={
                   Object {
                     "marginRight": 5,
@@ -269,57 +264,6 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 }
               />
               <span
-                key="1-1"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                friend
-              </span>
-              <span
-                key="1-2"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                named
-              </span>
-              <span
-                key="1-3"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                Marco
-              </span>
-              <span
-                key="1-4"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                who
-              </span>
-              <span
-                key="1-5"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                loves
-              </span>
-              <span
-                key="1-6"
                 style={
                   Object {
                     "marginRight": 5,
@@ -346,24 +290,18 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   value=""
                 />
               </span>
-              <span
-                key="2-0"
+              <p
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": " football.",
+                  }
+                }
                 style={
                   Object {
                     "marginRight": 5,
                   }
                 }
               />
-              <span
-                key="2-1"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              >
-                football.
-              </span>
             </div>
           </Prompt>
           <Cues

--- a/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/__tests__/__snapshots__/prompt.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/__tests__/__snapshots__/prompt.test.tsx.snap
@@ -4,23 +4,24 @@ exports[`Prompt component should match snapshot 1`] = `
 <div
   style={Object {}}
 >
-  <em
-    style={Object {}}
-  />
-  <strong
+  <p
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<em>Ele</em> <strong>gosta</strong>",
+      }
+    }
     style={Object {}}
   />
   <input
     aria-label="test-label"
     key="3"
   />
-  <span
-    key="4"
-    style={Object {}}
-  >
-    bater
-  </span>
-  <u
+  <p
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "bater <u>papo.</u>",
+      }
+    }
     style={Object {}}
   />
 </div>

--- a/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/__tests__/prompt.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/__tests__/prompt.test.tsx
@@ -24,13 +24,10 @@ describe('Prompt component', () => {
   it('should match snapshot', () => {
     expect(component).toMatchSnapshot();
   });
-  it('should render one <em> element', () => {
-    expect(component.find('em').length).toEqual(1);
+  it('should render one <em> element and one <strong> element in the same <p> tag', () => {
+    expect(component.find('p').first().props().dangerouslySetInnerHTML.__html).toEqual('<em>Ele</em> <strong>gosta</strong>')
   })
-  it('should render one <strong> element', () => {
-    expect(component.find('strong').length).toEqual(1);
-  })
-  it('should render one <u> element', () => {
-    expect(component.find('u').length).toEqual(1);
+  it('should render one <u> element in a <p> tag', () => {
+    expect(component.find('p').last().props().dangerouslySetInnerHTML.__html).toEqual('bater <u>papo.</u>')
   })
 })

--- a/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/prompt.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/fillInBlank/prompt.tsx
@@ -1,40 +1,75 @@
 import * as React from 'react';
-import stripHtml from "string-strip-html";
+
+interface Element {
+  props: {
+    children: string;
+    style: object;
+  }
+};
 
 interface PromptProps {
   style: object;
-  elements: {
-    props: {
-      children: string;
-      style: object;
-    }
-   }[];
+  elements: Element[];
 }
 
-const formattedElement = ({ string, style, element }) => {
-  if(string.startsWith('<em>')) {
-    return <em style={style}>{stripHtml(string)}</em>;
-  } else if(string.startsWith('<strong>')) {
-    return <strong style={style}>{stripHtml(string)}</strong>;
-  } else if(string.startsWith('<u>')) {
-    return <u style={style}>{stripHtml(string)}</u>;
+const getElementObject = (htmlText: string, style: object) => {
+  return {
+    text: htmlText,
+    style: style
   }
-  return element;
+}
+
+const getFormattedElementsArray = (elements: Element[]) => {
+
+  let formattedElements = [];
+  let htmlText = '';
+
+  if(!elements) {
+    return;
+  }
+  elements.map((element: Element, i: number) => {
+    const { props } = element;
+    // children is the html string
+    const { children, style } = props;
+    const nextElementIsInput = elements[i+1] && typeof elements[i+1].props.children !== 'string';
+
+    if(children && typeof children === 'string' && nextElementIsInput) {
+      htmlText += children;
+      const elementObject = getElementObject(htmlText, style);
+      formattedElements.push(elementObject);
+      htmlText = '';
+      // empty span element, add for spacing
+    } else if(!children && nextElementIsInput) {
+      const elementObject = getElementObject(htmlText, style);
+      formattedElements.push(elementObject);
+      htmlText = '';
+      formattedElements.push(<span style={style} />)
+    } else if(typeof children !== 'string') {
+      formattedElements.push(element);
+    } else if(children && i === elements.length - 1) {
+      htmlText += children;
+      const elementObject = getElementObject(htmlText, style);
+      formattedElements.push(elementObject);
+    } else {
+      htmlText += `${children} `;
+    }
+  });
+
+  return formattedElements.map(element => {
+    if(element.text) {
+      return <p dangerouslySetInnerHTML={{__html: element.text}} style={element.style} />
+    }
+    return element;
+  });
 }
 
 const Prompt = (props: PromptProps) => {
   const { elements, style } = props;
-  const filteredElements = elements && elements.map(element => {
-    const { props } = element;
-    const { children, style } = props;
-    if(typeof children !== 'string') {
-      return element;
-    }
-    return formattedElement({ string: children, style, element });
-  });
-  return(
+  const formattedElements = getFormattedElementsArray(elements);
+
+  return (
     <div style={style} >
-      {filteredElements}
+      {formattedElements}
     </div>
   );
 }


### PR DESCRIPTION
## WHAT
update Fill In The Blank prompt to handle italic, bold and underline styles

## WHY
curriculum needs to create prompts with italicized font for College Board

## HOW
added a filtering function to check for embedded elements

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="899" alt="Screen Shot 2020-10-30 at 1 40 36 PM" src="https://user-images.githubusercontent.com/25959584/97744591-82281600-1ab5-11eb-9d95-5589cfbe426c.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Can-t-italicize-in-Fill-in-the-Blank-prompts-729702f183f243698108adf72e718ea9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
