### PR TITLE
don't try to save sessions with weird uids

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -262,7 +262,8 @@ export class Lesson extends React.Component {
 
   saveSessionIdToState = () => {
     let sessionID = getParameterByName('student');
-    if (sessionID === 'null') {
+    const badSessionIds = ['null', 'nullhttps://connect.quill.org/', 'nullhttps:/connect.quill.org/']
+    if (badSessionIds.includes(sessionID)) {
       sessionID = undefined;
     }
     this.setState({ sessionID, sessionInitialized: true}, () => {


### PR DESCRIPTION
## WHAT
Don't try to save sessions with the weird uids we're seeing from these errors: https://www.notion.so/quill/ActivitySessions-call-Routing-Error-possibly-from-legacy-apps-d3dff87f33a94056a520ff90092f8763#291056dd6d434d59b8006195301d0b6c

## WHY
I couldn't figure out what was causing this error (ie, what was forming this link), but since this is a really loud error that makes it difficult for us to accurately assess our error rates and graphs, we want to stop having it (especially since this is presumably an anonymous session anyway).

## HOW
Just make sure we're not persisting sessions with this bad UID.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/ActivitySessions-call-Routing-Error-possibly-from-legacy-apps-d3dff87f33a94056a520ff90092f8763?d=2f1bb6ea-3a2f-4108-9c62-8f488f10d007

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
