### PR TITLE
Add back validating behavior on Fill in Blank questions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
@@ -181,7 +181,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     }
 
     // following condition will return false if no new errors
-    if (newErrors.size) {
+    if (_.size(newErrors)) {
       const newInputVals = inputVals
       this.setState({ inputErrors: newErrors, inputVals: newInputVals })
     } else {
@@ -290,7 +290,8 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
       const question = this.getQuestion();
       const { caseInsensitive, conceptID, key } = question;
       const { inputErrors, responses, } = this.state;
-      if (inputErrors.size === 0) {
+      const noErrors = _.size(inputErrors) === 0;
+      if (noErrors && responses) {
         const zippedAnswer = this.zipInputsAndText();
         const questionUID = key;
         const defaultConceptUID = conceptID;
@@ -394,7 +395,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     const { previewMode } = this.props;
     const { responses, inputErrors, previewAttempt, previewAttemptSubmitted} = this.state
 
-    if (inputErrors && inputErrors.size != 0) {
+    if (inputErrors && _.size(inputErrors) !== 0) {
       const blankFeedback = question.blankAllowed ? ' or leave it blank' : ''
       const feedbackText = `Choose one of the options provided${blankFeedback}. Make sure it is spelled correctly.`
       const feedback = <p>{feedbackText}</p>


### PR DESCRIPTION
## WHAT
Somewhere along the line, we accidentally removed an `OnBlur` callback that validated user input on student-facing fill in the blank questions. This PR adds that back in.
 
## WHY
Without validation, students could type anything they wanted into the blank box, and they would only get the generic feedback. With validation, they'll get feedback directing them to type one of the cues.

## HOW
Adding back the `onBlur` callback, just like we have in the turk-facing activities.

### Screenshots
<img width="769" alt="Screen Shot 2020-11-03 at 2 32 27 PM" src="https://user-images.githubusercontent.com/57366100/98032062-7011e480-1de1-11eb-9a8d-bc3ff8aa58b7.png">


### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=5f21ee1cfba449b6a46300417cfaaf7c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
