### PR TITLE
Isolate Google jobs into separate Sidekiq queue.

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -6,3 +6,5 @@ web: bundle exec puma -C ./config/puma.rb
 worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
 
 reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default -q low
+
+googleworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q google

--- a/services/QuillLMS/app/workers/google_student_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_classroom_worker.rb
@@ -1,6 +1,6 @@
 class GoogleStudentClassroomWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::GOOGLE
 
   def perform(student_id)
     begin

--- a/services/QuillLMS/app/workers/google_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_importer_worker.rb
@@ -1,6 +1,6 @@
 class GoogleStudentImporterWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::GOOGLE
 
   def perform(teacher_id, context = "none", selected_classroom_ids=nil)
     begin

--- a/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
@@ -1,6 +1,6 @@
 class RetrieveGoogleClassroomsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::GOOGLE
 
   SERIALIZED_GOOGLE_CLASSROOMS_CACHE_LIFE = 60
 

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -23,4 +23,6 @@ module SidekiqQueue
   # LOW: Jobs that might be long-running that we don't want to clog up the main workers
   # and that can be delayed.
   LOW = 'low'
+  # Google specific jobs to get around Google API issues
+  GOOGLE = 'google'
 end


### PR DESCRIPTION
## WHAT
Isolate Google BG jobs into their own queue to unclog the sidekiq queues while google has issues. (This is hopefully temporary)
## WHY
Right now, google seems to be having issues with its API. Since Google Jobs are `critical` they are all picked up first and they are all taking several minutes, thus blocking out all other jobs from running
## HOW
Making a separate queue and worker for Google jobs. This is hopefully a temporary measure.
### Screenshots
<img width="898" alt="Screen Shot 2020-11-05 at 9 59 41 AM" src="https://user-images.githubusercontent.com/1304933/98257502-bedc8d00-1f4d-11eb-9543-de2074a47579.png">

<img width="1238" alt="Screen Shot 2020-11-05 at 9 59 26 AM" src="https://user-images.githubusercontent.com/1304933/98257516-c3a14100-1f4d-11eb-98bc-7eb0affed305.png">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, config change
Have you deployed to Staging? | NO - fixing a prod issue
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | na
