### PR TITLE
lms/split-critical-sidekiq-queue

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -8,5 +8,3 @@ worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
 reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low
 
 googleworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q google
-
-defaultworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low


### PR DESCRIPTION
## WHAT
Add a new worker type to process the non-critical queue
## WHY
So that we can bypass big backups in the critical queue
## HOW
Modify the `Procfile` to add a new queue

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on configs
Have you deployed to Staging? | No - small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
