### PR TITLE
lms/split-critical-sidekiq-queue (#6942)

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -5,6 +5,6 @@ web: bundle exec puma -C ./config/puma.rb
 
 worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
 
-reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default -q low
+reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low
 
 googleworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q google


### PR DESCRIPTION
* Add a new worker type to process the non-critical queue

So that we can bypass big backups in the critical queue

* Remove critical queue from reportworker designation

Just to have more workers processing non-critical jobs

* Remove new worker type now that we've modified reportworker

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
