### PR TITLE
rename custom activity pack page to activity library; update filters in url

### DIFF
--- a/services/QuillLMS/app/views/pages/connect_tool.erb
+++ b/services/QuillLMS/app/views/pages/connect_tool.erb
@@ -246,7 +246,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Connect.
         </h1>
-        <a href='/assign/create-activity-pack' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/app/views/pages/grammar_tool.erb
+++ b/services/QuillLMS/app/views/pages/grammar_tool.erb
@@ -132,7 +132,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Grammar.
         </h1>
-        <a href='/assign/create-activity-pack' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/app/views/pages/lessons_tool.erb
+++ b/services/QuillLMS/app/views/pages/lessons_tool.erb
@@ -221,7 +221,7 @@
           <h1 class='q-h1'>
               Get started now! Assign Quill Lessons.
           </h1>
-          <a href='/assign/create-activity-pack?tool=lessons' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+          <a href='/assign/activity-library?activityClassificationFilters[]=lessons' class="q-button cta-button bg-quillgreen text-white">Assign</a>
       </section>
       <% end %>
 

--- a/services/QuillLMS/app/views/pages/proofreader_tool.erb
+++ b/services/QuillLMS/app/views/pages/proofreader_tool.erb
@@ -110,7 +110,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Proofreader.
         </h1>
-        <a href='/assign/create-activity-pack' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/navbar/teacherNavbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/navbar/teacherNavbar.tsx
@@ -348,7 +348,7 @@ class TeacherNavbar extends React.Component<any, any> {
     const { classroomSessions, } = this.props
     const { preview } = classroomSessions.data
     if (preview === true) {
-      const assignLink = `${process.env.DEFAULT_URL}/assign/create-activity-pack?tool=lessons`
+      const assignLink = `${process.env.DEFAULT_URL}/assign/activity-library?activityClassificationFilters[]=lessons`
       const studentLink = window.location.href.replace('teach', 'play').concat('&student=student')
       /* eslint-disable react/jsx-no-target-blank */
       return (<div className="lessons-teacher-preview-bar">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignment_flow_navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignment_flow_navigation.tsx
@@ -18,7 +18,7 @@ const learningProcessSlug = 'learning-process'
 const diagnosticSlug = 'diagnostic'
 const activityTypeSlug = 'activity-type'
 const collegeBoardSlug = COLLEGE_BOARD_SLUG
-const createActivityPackSlug = 'create-activity-pack'
+const activityLibrarySlug = 'activity-library'
 const selectClassesSlug = 'select-classes'
 const featuredActivityPacksSlug = 'featured-activity-packs'
 const preApSlug = PRE_AP_SLUG
@@ -29,7 +29,7 @@ const learningProcess = () => <Link key="learning-process" to={`/assign/${learni
 const diagnostic = () => <Link key="diagnostic" to={`/assign/${diagnosticSlug}`}>Diagnostic</Link>
 const activityType = () => <Link key="activity-type" to={`/assign/${activityTypeSlug}`}>Activity type</Link>
 const collegeBoard = () => <Link key="college-board" to={`/assign/${collegeBoardSlug}`}>College Board</Link>
-const createActivityPack = () => <Link key="custom-activity-pack" to={`/assign/${createActivityPackSlug}`}>Custom activity pack</Link>
+const createActivityPack = () => <Link key="custom-activity-pack" to={`/assign/${activityLibrarySlug}`}>Activity library</Link>
 const selectClasses = () => <Link key="assign-" to={`/assign/${selectClassesSlug}`}>Assign</Link>
 const activityPack = () => <Link key="activity-pack" to={`/assign/${featuredActivityPacksSlug}`}>Activity pack</Link>
 const preAp = () => <Link key="activity-pack" to={`/assign/${preApSlug}`}>Pre-AP</Link>
@@ -55,7 +55,7 @@ const routeLinks = {
   [preApSlug]: () => [slash(1), learningProcess(), slash(2), collegeBoard(), slash(3), preAp()],
   [apSlug]: () => [slash(1), learningProcess(), slash(2), collegeBoard(), slash(3), ap()],
   [collegeBoardSlug]: () => [slash(1), learningProcess(), slash(2), collegeBoard()],
-  [createActivityPackSlug]: () => [slash(1), learningProcess(), slash(2), activityType(), slash(3), createActivityPack()],
+  [activityLibrarySlug]: () => [slash(1), learningProcess(), slash(2), activityType(), slash(3), createActivityPack()],
   [selectClassesSlug]: (unitTemplateId, unitTemplateName, isFromDiagnosticPath) => {
     if (isFromDiagnosticPath) {
       return [
@@ -107,7 +107,7 @@ const routeProgress = {
   [collegeBoardSlug]: () => 'step-two',
   [preApSlug]: () => 'step-three',
   [apSlug]: () => 'step-three',
-  [createActivityPackSlug]: () => 'step-three',
+  [activityLibrarySlug]: () => 'step-three',
   [selectClassesSlug]: () => 'step-five',
   [featuredActivityPacksSlug]: (unitTemplateId, unitTemplateName) => {
     if (unitTemplateId && unitTemplateName) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_type.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/activity_type.tsx
@@ -42,7 +42,7 @@ const minis = (props) => [
     header="Create your own activity pack"
     imgAlt="sheets of paper overlaid"
     imgSrc={packsCustomSrc}
-    selectCard={() => selectCard(props.history, `/assign/create-activity-pack`)}
+    selectCard={() => selectCard(props.history, `/assign/activity-library`)}
   />)
 ]
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/index.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/index.test.tsx
@@ -4,6 +4,14 @@ import { mount } from 'enzyme';
 import { activities } from './data'
 import CustomActivityPack from '../index'
 
+jest.mock('query-string', () => ({
+    default: {
+      parseUrl: jest.fn(() => ({ query: {} })),
+      stringifyUrl: jest.fn(() => '')
+    }
+  })
+)
+
 describe('CustomActivityPack Index component', () => {
 
   it('should render', () => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
@@ -20,7 +20,7 @@ export default class UnitTemplateMini extends React.Component {
     let link
     if (this.props.data.id == 'createYourOwn') {
       if (this.isSignedIn()) {
-        link = '/assign/create-activity-pack'
+        link = '/assign/activity-library'
       } else {
         link = '/account/new'
       }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/lessons_list.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/lessons_list.jsx
@@ -118,7 +118,7 @@ export default class extends React.Component {
           <h3 >
             List of Assigned Quill Lessons
           </h3>
-          <a href="/assign/create-activity-pack?tool=lessons">View and Assign Quill Lessons </a>
+          <a href="/assign/activity-library?activityClassificationFilters[]=lessons">View and Assign Quill Lessons </a>
         </div>
         <div className="no-assigned-lessons">
           <img src={`${process.env.CDN_URL}/images/illustrations/empty_state_lessons_launch_card.svg`} />

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/AssignActivitiesRouter.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/AssignActivitiesRouter.jsx
@@ -23,7 +23,7 @@ const AssignActivitiesRouter = props => (
       <Route component={routerProps => <AssignAp {...props} {...routerProps} />} path="/assign/ap" />
       <Route component={routerProps => <CollegeBoard {...props} {...routerProps} />} path="/assign/college-board" />
       <Route component={routerProps => <AssignADiagnostic {...props} {...routerProps} />} path="/assign/diagnostic" />
-      <Route component={routerProps => <CreateUnit {...props} {...routerProps} />} path="/assign/create-activity-pack" />
+      <Route component={routerProps => <CreateUnit {...props} {...routerProps} />} path="/assign/activity-library" />
       <Route component={routerProps => <CreateUnit {...props} {...routerProps} />} path="/assign/select-classes" />
       <Route component={routerProps => <CreateUnit {...props} {...routerProps} />} path="/assign/referral" />
       <Route component={routerProps => <CreateUnit {...props} {...routerProps} />} path="/assign/add-students" />

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/LessonPlanner.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/LessonPlanner.jsx
@@ -292,7 +292,7 @@ export default class LessonPlanner extends React.Component {
     // if (this.state.unitTemplatesManager.assignSuccess === true && (!tabParam || tabParam === ('featured-activity-packs' || 'explore-activity-packs'))) {
     // 	tabSpecificComponents = <UnitTemplatesAssigned data={this.state.unitTemplatesManager.lastActivityAssigned} actions={this.unitTemplatesAssignedActions()}/>;
     // } else
-    if ((tabParam === 'create-activity-pack' || (this.state.tab === 'createUnit' && !tabParam))) {
+    if ((tabParam === 'activity-library' || (this.state.tab === 'createUnit' && !tabParam))) {
       tabSpecificComponents = (<CreateUnit
         actions={{
           toggleStage: this.toggleStage,

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -8022,6 +8022,14 @@
         "warning": "^2.0.0"
       },
       "dependencies": {
+        "query-string": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
+          "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
+          "requires": {
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
         "warning": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
@@ -11835,11 +11843,20 @@
       "dev": true
     },
     "query-string": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
-      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+      "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
       "requires": {
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
       }
     },
     "querystring": {
@@ -14931,6 +14948,11 @@
           }
         }
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -66,6 +66,7 @@
     "postcss-loader": "^0.8.2",
     "promise-polyfill": "^6.1.0",
     "pusher-js": "^5.0.1",
+    "query-string": "^6.13.6",
     "quill-component-library": "0.10.2",
     "quill-marking-logic": "0.13.7",
     "quill-string-normalizer": "0.0.9",

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -644,7 +644,8 @@ EmpiricalGrammar::Application.routes.draw do
 
   get 'assign' => 'teachers/classroom_manager#assign', as: 'assign_path'
   get 'assign/assign-a-diagnostic' => redirect('/assign/diagnostic')
-  get 'assign/create-unit' => redirect('/assign/create-activity-pack')
+  get 'assign/create-unit' => redirect('/assign/activity-library')
+  get 'assign/create-activity-pack' => redirect('/assign/activity-library')
   get 'assign/:tab' => 'teachers/classroom_manager#assign'
   get 'assign/featured-activity-packs/category/:category' => 'teachers/classroom_manager#assign'
   get 'assign/featured-activity-packs/grade/:grade' => 'teachers/classroom_manager#assign'


### PR DESCRIPTION
## WHAT
Rename the custom activity pack page to "Activity library", and update the filters so that they change the url when they are set, and going to a given url will activate the filters in the query params.

## WHY
We want to be able to link teachers to the page with different filters activated.

## HOW
Use the `query-string` library to stringify an object with the filters in it, and to parse it when the page is loaded.

### Screenshots
N/A

### Notion Card Links
https://www.notion.so/quill/Custom-activity-pack-page-odds-and-ends-39c45cf5caf9471a98c6637a8a913509

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
