### PR TITLE
CMS - Set a statement timeout to not cause downstream issues.

### DIFF
--- a/services/QuillCMS/config/database.yml
+++ b/services/QuillCMS/config/database.yml
@@ -1,6 +1,10 @@
+# Setting the variables, statement_timeone based on this
+# https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts#postgresql
 default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  variables:
+    statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "180s" %>
 
 development_env: &development_env
   database: quill_cms_development


### PR DESCRIPTION
## WHAT
Currently, an SQL query in the application can take as long as it wants to finish. This adds a 3-minute timeout on any query
## WHY
We're having queries that are taking 10+ minutes and then the DB is having issue during that period, which results in thousands of errors. By adding a timeout, we're taking the approach of erroring that one request so it doesn't effect the rest of the requests.

I'm setting this reasonable high at 3 minutes (the guide I link to recommends 5 seconds). We do have some long-running queries, but I should note that the queries that are taking 35 minutes on the DB, I can run on the follower in under a second. So it has something to do with the leader DB (it might also be an issue with an index).  
## HOW

### Screenshots
![Screen Shot 2020-11-05 at 5 13 59 PM](https://user-images.githubusercontent.com/1304933/98302450-6677b080-1f8a-11eb-8e9e-eb68545d3a14.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, config change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
