### PR TITLE
LMS Sidekiq Adjustments- Add setups for both critical internal and external jobs

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -3,8 +3,14 @@ web: bundle exec puma -C ./config/puma.rb
 # Note, using MALLOC_ARENA_MAX=2 based on this article:
 # https://github.com/mperham/sidekiq/wiki/Deployment#heroku
 
-worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
+worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q critical_external -q default
 
-reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low
+reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
 
+# TODO remove (need to leave on initial deploy to drain queue)
 googleworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q google
+
+# Backup workers that we can use in case we need to isolate external jobs from the queue
+externalworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical_external
+
+internalworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default

--- a/services/QuillLMS/app/workers/clever_library_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/clever_library_student_importer_worker.rb
@@ -1,6 +1,6 @@
 class CleverLibraryStudentImporterWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   def perform(classroom_ids, token)
     client = CleverLibrary::Api::Client.new(token)

--- a/services/QuillLMS/app/workers/clever_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/clever_student_importer_worker.rb
@@ -1,6 +1,6 @@
 class CleverStudentImporterWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
 
   def perform(classroom_ids, district_token)

--- a/services/QuillLMS/app/workers/google_student_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_classroom_worker.rb
@@ -1,6 +1,6 @@
 class GoogleStudentClassroomWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::GOOGLE
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   def perform(student_id)
     begin

--- a/services/QuillLMS/app/workers/google_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_importer_worker.rb
@@ -1,6 +1,6 @@
 class GoogleStudentImporterWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::GOOGLE
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   def perform(teacher_id, context = "none", selected_classroom_ids=nil)
     begin

--- a/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
@@ -1,6 +1,6 @@
 class RetrieveGoogleClassroomsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::GOOGLE
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   SERIALIZED_GOOGLE_CLASSROOMS_CACHE_LIFE = 60
 

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -23,6 +23,7 @@ module SidekiqQueue
   # LOW: Jobs that might be long-running that we don't want to clog up the main workers
   # and that can be delayed.
   LOW = 'low'
-  # Google specific jobs to get around Google API issues
-  GOOGLE = 'google'
+  # Critical Jobs that rely on outside APIs, e.g. Google Classroom APIs
+  # Giving them their own queue in case we need to isolate them during an API provider issue
+  CRITICAL_EXTERNAL = 'critical_external'
 end


### PR DESCRIPTION
## WHAT
Sidekiq queue adjustments to account for a few scenarios:
1) An external API like Google Classroom goes down causing backups on the workers.
2) Huge queues can form for `default` jobs if all of the `critical` jobs are failing at once
3) Be able to make worker adjustments without a deploy

## WHY
We want to keep our queue and worker setups to be relatively simple (easier to maintain, scale, monitor, etc.) while also allowing flexibility around known issues.
## HOW

Set up queues for critical internal jobs (`critical`) and for critical jobs that involve an external request like an API call (`critical_external`), but mix them together on the standard background workers. 

On the `reportworker`, make `default` jobs a higher priority, so there's always a trickle of them getting processed.

Add backup setups to allow internal and external critical jobs to be isolated from each other if need be (these would be off by default, but we can turn them on when needed, without a deploy)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, config changes.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
