### PR TITLE
Remove a bunch of webinar banners

### DIFF
--- a/services/QuillLMS/app/models/webinar_banner.rb
+++ b/services/QuillLMS/app/models/webinar_banner.rb
@@ -7,16 +7,6 @@ class WebinarBanner
   # RECURRING have the key format DayOfWeek-Hour
 
   ONE_OFFS = {
-    '10-7-11' => ["Quill's Spotlight on Exploring the Activity Library", "#{ZOOM_URL}/WN_uzoWu3HuQCa2ZpyQ0j4C5g"],
-    '10-7-16' => ["Quill's Spotlight on Exploring the Activity Library", "#{ZOOM_URL}/WN_ptLJPr_ZQTilmzklfDVrjA"],
-    '10-14-11' => ["Quill's Spotlight on Ways to Use Quill with Google Classroom", "#{ZOOM_URL}/WN_DhZRpHV7Q4K413v4SzcK1A"],
-    '10-14-16' => ["Quill's Spotlight on Ways to Use Quill with Google Classroom", "#{ZOOM_URL}/WN_DHVXyOXzS3mytUCqK_UbIA"],
-    '10-21-11' => ["Quill's Spotlight on Keeping Your Remote Classroom on Track", "#{ZOOM_URL}/WN_UiN_HtS7TwmYQObgOVCOGw"],
-    '10-21-16' => ["Quill's Spotlight on Keeping Your Remote Classroom on Track", "#{ZOOM_URL}/WN_DHVXyOXzS3mytUCqK_UbIA"],
-    '10-28-11' => ["Quill's Spotlight on Using Quill to Support Students with IEPs", "#{ZOOM_URL}/WN_4RGmnNfiSSSqO-EB13ecbw"],
-    '10-28-16' => ["Quill's Spotlight on Using Quill to Support Students with IEPs", "#{ZOOM_URL}/WN_YgimZ7j2TTCGW7HiniJAwg"],
-    '11-4-11' => ["Quill's Spotlight on Data and Instruction", "#{ZOOM_URL}/WN_8Dq0_YxNRa23-qWZT4qDaQ"],
-    '11-4-16' => ["Quill's Spotlight on Data and Instruction", "#{ZOOM_URL}/WN_d_oq8DgBQjGpeHzXXzM1AA"],
     '11-18-16' => ["Quill's Spotlight on Equitable Grading using Quill", "#{ZOOM_URL}/WN_BNF3nVnyRVqrKQ9udZis-w"],
     '12-2-16' => ["Quill's Spotlight on Using Quill to Support English Language Learners", "#{ZOOM_URL}/WN_R3h0pKEHTVqiLlNwdFHF4g"],
     '12-9-16' => ["Quill's Spotlight on Sentence Fluency at the Lesson Level", "#{ZOOM_URL}/WN_M0eiXLFaSEq-GQOAzj0kSA"],


### PR DESCRIPTION
## WHAT
Removing some webinar banners that Partnerships has canceled.

## WHY
Since Partnerships canceled these webinars, we don't want to show the banners anymore.

## HOW
Take out the listings from the array of webinar banners.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-some-live-banners-for-partnerships-webinars-aa445bd244084e84b5b8e756554d79f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, essentially a copy change
Have you deployed to Staging? | Not yet - deploying now! 
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A