### PR TITLE
small change to make sure topic url works

### DIFF
--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -52,7 +52,7 @@ class ActivitySearchWrapper
     @activities.each do |a|
       activity_id = a['activity_id'].to_i
       content_partners = a['content_partner_name'] ? [{ name: a['content_partner_name'], description: a['content_partner_description'], id: a['content_partner_id']}] : []
-      topics = a['topic_name'] ? [{ name: a['topic_name'], level: a['topic_level'], id: a['topic_id'], parent_id: a['topic_parent_id']}] : []
+      topics = a['topic_name'] ? [{ name: a['topic_name'], level: a['topic_level'], id: a['topic_id'].to_i, parent_id: a['topic_parent_id'].to_i }] : []
       existing_record = unique_activities_array.find { |act| act[:id] == activity_id }
       # if there is an existing record, it is possible that that's because the activity has more than one content partner
       if existing_record


### PR DESCRIPTION
## WHAT
Update the data that the `activity_search_wrapper` sends back to make sure that filtering by topic and then using that link again works.

## WHY
Topic ids and parent ids were being sent as strings to the frontend, so the filter from the URL wasn't finding the correct activities. This makes sure it's being passed up as a number, so that it does work.

## HOW
Just call `.to_i` on the attributes that should be numbers.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
