### PR TITLE
Undo an accidental change to RetrieveGoogleClassroomWorker

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -11,6 +11,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   MY_ACCOUNT = 'my_account'
   ASSIGN = 'assign'
+  SERIALIZED_GOOGLE_CLASSROOMS_FOR_ = 'SERIALIZED_GOOGLE_CLASSROOMS_FOR_'
 
   def lesson_planner
     set_classroom_variables
@@ -158,17 +159,24 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def retrieve_google_classrooms
-    RetrieveGoogleClassroomsWorker.perform_async(current_user.id)
-    render json: { id: current_user.id, quill_retrieval_processing: true }
+    serialized_google_classrooms = $redis.get("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
+    if serialized_google_classrooms
+      render json: JSON.parse(serialized_google_classrooms)
+    else
+      RetrieveGoogleClassroomsWorker.perform_async(current_user.id)
+      render json: { id: current_user.id, quill_retrieval_processing: true }
+    end
   end
 
   def update_google_classrooms
     GoogleIntegration::Classroom::Creators::Classrooms.run(current_user, params[:selected_classrooms])
+    $redis.del("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
     render json: { classrooms: current_user.google_classrooms }.to_json
   end
 
   def import_google_students
     selected_classroom_ids = Classroom.where(id: params[:classroom_id] || params[:selected_classroom_ids]).ids
+    $redis.del("#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{current_user.id}")
     GoogleStudentImporterWorker.perform_async(
       current_user.id,
       'Teachers::ClassroomManagerController',


### PR DESCRIPTION
## WHAT
When doing a PR yesterday, I accidentally merged it with an extra file change that was not a part of the PR. I need to reverse that change because it affects Google Imports.

## WHY
To get ImportGoogleClassroom to work.

## HOW
Reverse the mistake that I made.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, not a real change just undoing a mistake.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
