### PR TITLE
fix issue with finish activity worker

### DIFF
--- a/services/QuillLMS/app/workers/finish_activity_worker.rb
+++ b/services/QuillLMS/app/workers/finish_activity_worker.rb
@@ -24,7 +24,7 @@ class FinishActivityWorker
     end
 
     if activity_session.eligible_for_tracking?
-      analytics = Analyzer.new
+      analytics = SegmentAnalytics.new
       analytics.track_activity_completion(activity_session.classroom_owner, activity_session.activity)
     end
 

--- a/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
@@ -9,7 +9,7 @@ describe FinishActivityWorker, type: :worker do
   let(:analyzer) { double(:analyzer) }
 
   before do
-    allow(Analyzer).to receive(:new) { analyzer }
+    allow(SegmentAnalytics).to receive(:new) { analyzer }
   end
 
   it 'sends a segment.io event' do


### PR DESCRIPTION
## WHAT
Make sure we're calling `track_activity_completion` on an instance of `SegmentAnalytics`, not `Analyzer`, which does not have that method.

## WHY
This was resulting in a `NoMethodError` on prod. This will fix that.

## HOW
Just change what is being called.

### Screenshots
N/A

### Notion Card Links
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
