### PR TITLE
suppressing rubocop error in pages_helper.rb

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -325,6 +325,7 @@ Metrics/ModuleLength:
   Max: 448
   Exclude:
     - 'QuillLMS/app/models/concerns/teacher.rb'
+    - 'QuillLMS/app/helpers/pages_helper.rb'
 
 Style/AsciiComments:
   Enabled: true


### PR DESCRIPTION
## WHAT
Suppresses "module too long" errors in pages_helper.rb

## WHY
The module became too long. This is because we use it to store inline data. There are two paths forward - accept that this module is unique and doesn't need the lint rule, or factor out the inline data into a non-ruby file. I took the former approach, but will implement the latter if someone strongly supports.

## HOW
Edit rubocopy.yml

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/fix-intermittent-rubocop-lint-error-4e35804858534dc98a9972e5ae7e29b0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - no code was changed.
Have you deployed to Staging? | No - tiny change.
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
