### PR TITLE
Change "Unscored" to "Completed" in student view of finished Diagnostics

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-
 import moment from 'moment'
 
 import { DataTable } from '../../../Shared/index'
-
 import activityLaunchLink from '../modules/generate_activity_launch_link.js';
 
 const diagnosticSrc = `${process.env.CDN_URL}/images/icons/tool-diagnostic-gray.svg`
@@ -119,7 +117,7 @@ export default class StudentProfileUnit extends React.Component {
     const { activity_classification_id, max_percentage, } = act
     const maxPercentage = Number(max_percentage)
     if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
-      return (<div className="score"><div className="unscored" /><span>Unscored</span></div>)
+      return (<div className="score"><div className="unscored" /><span>Completed</span></div>)
     }
 
     if (maxPercentage >= PROFICIENT_CUTOFF) {


### PR DESCRIPTION
## WHAT
Change the term "Unscored" to "Completed" for students viewing their completed Diagnostics.

## WHY
The current wording is confusing and causes a lot of teachers asking why students' diagnostics are not "scored". In fact they are instantly graded, so we should simply tell students that their diagnostics are "completed" so they're not waiting around for them to be scored.

## HOW
Change the copy.

### Screenshots
![Screen Shot 2020-11-18 at 5 35 04 PM](https://user-images.githubusercontent.com/57366100/99596553-84023c80-29c4-11eb-8497-1d158d6921ea.png)

### Notion Card Links
https://www.notion.so/Changing-completed-Diagnostic-from-Unscored-to-Completed-83aee76faa834b24a7d13a5c56ae2df6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny copy change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
