### PR TITLE
stop trimming whitespace from blanks in lessons

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/fillInTheBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/fillInTheBlank.tsx
@@ -133,7 +133,7 @@ class FillInTheBlank extends React.Component<fillInTheBlankProps, fillInTheBlank
   updateBlankValue = (e: React.ChangeEvent<HTMLInputElement>, i: number) => {
     const { inputVals, } = this.state
     const existing = [...inputVals];
-    existing[i] = e.target.value.trim();
+    existing[i] = e.target.value
     this.setState({
       editing: existing.find(val => val.length),
       inputVals: existing,


### PR DESCRIPTION
## WHAT
Stop trimming whitespace from inputs for fill in the blank lesson slides.

## WHY
Some of these questions require multiple words in the blank.

## HOW
Just remove the `.trim()`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Quill-Lesson-Spacing-Issue-949e9734e23042ab8511003829934a1f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
