### PR TITLE
Fix logic for when teacher changes School Type in Account Settings

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
@@ -88,14 +88,14 @@ export default class TeacherGeneralAccountInfo extends React.Component {
   };
 
   handleSubmit = e => {
-    const { name, email, timeZone, school, changedSchools, } = this.state
+    const { name, email, timeZone, school, changedSchools } = this.state
     e.preventDefault()
     const data = {
       name,
       email,
       time_zone: timeZone,
       school_id: school.id,
-      school_options_do_not_apply: !changedSchools,
+      school_options_do_not_apply: !changedSchools
     };
     this.props.updateUser(data, '/teachers/update_my_account', 'Settings saved')
   };


### PR DESCRIPTION
## WHAT
Send `changedSchool: true` to the back end when the teacher changes their school type. This way teachers can change the type of school they belong to and see that setting persist.

## WHY
So teachers can properly save their `School Type` setting. Right now that setting can be changed, but never saved (it just reverts to the old attribute).

## HOW
Change the front-end to send `changedSchools: true` when the teacher changes their School type. This will trigger the back end to change the teacher's school.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-attempts-to-change-account-setting-reverts-back-dc5f1100e41d48188261921768954c1b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
