### PR TITLE
change const and only call analytics for new Clever teacher

### DIFF
--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -31,8 +31,8 @@ class Auth::CleverController < ApplicationController
   # data is a user record
   # have to put a second argument in there due to the send method
   def user_success(data, redirect=nil)
+    CompleteAccountCreation.new(data, request.remote_ip).call if data.previous_changes["id"]
     data.update_attributes(ip_address: request.remote_ip)
-    CompleteAccountCreation.new(data, request.remote_ip).call
     if session[ApplicationController::CLEVER_REDIRECT]
       redirect_route = session[ApplicationController::CLEVER_REDIRECT]
       session[ApplicationController::CLEVER_REDIRECT] = nil

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -27,7 +27,7 @@ module SegmentIo
     ASSIGN_DIAGNOSTIC ||= 'Teacher assigned the diagnostic'
     ASSIGN_RECOMMENDATIONS ||= 'Teacher assigned a recommended activity pack'
     ERROR_500 ||= '500 Error'
-    BEGAN_PREMIUM_TRIAL ||= 'Teacher began premium trial'
+    BEGAN_PREMIUM_TRIAL ||= 'Teacher began teacher premium trial'
     BEGAN_SCHOOL_PREMIUM ||= 'Teacher began paid school premium'
     BEGAN_TEACHER_PREMIUM ||= 'Teacher began paid teacher premium'
     TEACHER_DELETED_STUDENT_ACCOUNT ||= 'Teacher deleted student account'


### PR DESCRIPTION
## WHAT
Change the label for the new premium teacher trial event; make sure to only call analytics for new Clever teachers.

## WHY
Just some small revisions for new analytics stuff.

## HOW
Tiny code changes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-signups-via-Clever-aren-t-triggering-the-Teacher-created-an-account-Segment-event-b254d46fd3c24191b38725abd406960c
https://www.notion.so/quill/Rename-the-Teacher-began-trial-Segment-event-to-Teacher-began-teacher-premium-trial-5b99431d6c214a5ab8750f28c7da1dda

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A