### PR TITLE
Add rake task to unbold all instances of "Try again." in hand-graded response feedback

### DIFF
--- a/services/QuillCMS/lib/tasks/unbold_try_again_in_feedback.rake
+++ b/services/QuillCMS/lib/tasks/unbold_try_again_in_feedback.rake
@@ -1,0 +1,12 @@
+desc "Unbold all instances of 'Try again' in hand graded response feedback"
+
+namespace :responses do
+  task :unbold_all => :environment do
+    ActiveRecord::Base.connection.execute("
+      UPDATE responses
+      SET feedback = REGEXP_REPLACE(feedback, '<strong>(Try.*)</strong>','\\1')
+      WHERE author = ''
+      AND (feedback LIKE '<strong>Try%' OR feedback LIKE '<p><strong>Try%')
+    ")
+  end
+end


### PR DESCRIPTION
## WHAT
Add a rake task that will query the CMS and un-bold all bolded instances of "Try again." in the feedback.

## WHY
Curriculum requested this because their style guide has been updated. We no longer want to bold this phrase in any kind of feedback.

## HOW
A rake task. It queries the database for all hand-graded response records that start with a bolded "Try again". Then, it un-bolds whatever is inside those <strong></strong> tags using regex.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-request-un-bold-try-again-in-all-hand-graded-grammar-responses-c8f54cd63e254f938969c8deb677f850

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, just a rake task. I have manually tested it locally.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
