### PR TITLE
update segment identify calls to explicitly only identify teachers

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -110,7 +110,7 @@ class SegmentAnalytics
 
 
   def identify(user)
-    if backend.present? && !user&.student?
+    if backend.present? && user&.teacher?
       backend.identify(identify_params(user))
     end
   end

--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -35,7 +35,8 @@
     <% elsif @logging_user_out %>
       analytics.reset()
     <% end %>
-    <% unless current_user&.student? %>
+
+    <% if current_user&.teacher? %>
       analytics.page();
     <% end %>
 


### PR DESCRIPTION
## WHAT
Update Segment `.identify` calls to explicitly only identify teachers, rather than just not-students.

## WHY
We are having a weird rise in the number of users with no role set, and the associated pages appear to be student-facing, so it seems like somehow some users are slipping through the cracks.

## HOW
Just change the logic.

### Screenshots
N/A

### Notion Card Links
https://www.notion.so/quill/Student-sessions-still-seem-to-be-triggering-Segment-Identify-and-Page-calls-656c7f27777741f09611207154bb8906

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
