### PR TITLE
turn off Heap among other integrations

### DIFF
--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -16,6 +16,7 @@
           , Intercom: false
           , Salesmachine: false
           , Vitally: false
+          , Heap: false
           <% end %>
         }
       }


### PR DESCRIPTION
## WHAT
Add a line that should turn off the `Heap` integration.

## WHY
Peter S found something in the Heap docs that suggests that they'll track all user action unless explicitly turned off.

## HOW
Just add this attribute to the `integrations` hash.

### Screenshots
N/A

### Notion Card Links
https://www.notion.so/quill/Student-sessions-still-seem-to-be-triggering-Segment-Identify-and-Page-calls-656c7f27777741f09611207154bb8906

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
