### PR TITLE
Add Inspectlet to track teacher sessions

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -21,6 +21,7 @@
   <meta name="og:description" content="<%= @description || @content %>">
 
   <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
+  <!-- Inspectlet tracking -->
   <% if current_user&.teacher? %>
     <script type="text/javascript">
       (function() {


### PR DESCRIPTION
## WHAT
Turn on Insepectlet for the QuillLMS.

## WHY
We want to capture some sessions of teachers logging in and using then new Custom Activity Pack page.

## HOW
Add the Inspectlet script into the head of QuillLMS pages.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Have-Inspeclet-track-sessions-in-the-teacher-LMS-fc7b2036070442789567b669082883c7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, but tested manually to make sure Inspectlet works.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A