### PR TITLE
Feature/fix image in email template

### DIFF
--- a/services/QuillLMS/app/views/user_mailer/ell_starter_diagnostic_info_email.html.erb
+++ b/services/QuillLMS/app/views/user_mailer/ell_starter_diagnostic_info_email.html.erb
@@ -8,7 +8,7 @@
     <body class="email-body">
       <div class='header'>
         <div class='main-width'>
-          <img src='https://quill-cdn.s3.amazonaws.com/images/logos/quill-logo-reverse.png'/>
+          <img src='https://quill-cdn.s3.amazonaws.com/images/logos/quill-logo-reverse.png' height="40px"/>
         </div>
       </div>
       <div class='body-text'>


### PR DESCRIPTION
## WHAT
Modifies existing <img> tag in email template

## WHY
Previous image href is broken 

## HOW
Uploaded new image to S3 and referenced it from email template. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=5d344189152749c48153b163834a877e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - no logic change.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
