### PR TITLE
Allow sorting when some Activity names might be nil

### DIFF
--- a/services/QuillLMS/app/views/cms/activities/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/activities/_form.html.erb
@@ -7,6 +7,6 @@
   rawScoreOptions: @raw_score_options,
   passedTopicOptions: Topic.all.sort_by(&:name),
   flagOptions: Activity::FLAGS,
-  followUpActivityOptions: Activity.all.sort_by(&:name),
+  followUpActivityOptions: Activity.all.sort_by { |a| a.name || '' },
   gradeBands: @grade_band_hash
 }) %>


### PR DESCRIPTION
## WHAT
Use a slightly more complex sorting argument to account for cases where `Activity.name` might be `nil` somehow
## WHY
In production the old way is causing errors stating that `comparison of String with nil failed`.  So some production data definitely has `nil` name values.  This tweak accounts for those values but still sorts.
## HOW
Use a block to use name if it's "truthy", and empty string if it's not, which catches cases of `nil`

### Notion Card Links
https://www.notion.so/quill/500-Error-when-I-try-to-access-the-activities-editor-4715c61115ce4b78b62405b9d022b4c6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Not a behavior change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
