### PR TITLE
Include Curriculum-archived Activities in Activity Scores report

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -39,7 +39,6 @@ class Scorebook::Query
      AND unit_activities.visible
      AND cu.visible
      AND sc.visible
-     AND 'archived' != ANY(activity.flags)
      #{last_unit}
      #{date_conditional_string(begin_date, end_date, offset)}
      GROUP BY

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -33,6 +33,12 @@ describe 'ScorebookQuery' do
     expect(results.map{|res| res["id"]}).to include(activity_session2.id.to_s)
   end
 
+  it 'returns a completed activity even after that activity is archived' do
+    activity2.update(flags: ["archived"])
+    results = Scorebook::Query.run(classroom.id)
+    expect(results.map{|res| res["id"]}).to include(activity_session2.id.to_s)
+  end
+
   describe 'support date constraints' do
     it 'returns activities completed between the specified dates' do
       begin_date = activity_session1.completed_at - 1.days


### PR DESCRIPTION
## WHAT
Show activity sessions with archived activities in the Activity Scores report. If a student has completed an Activity that has since been archived by our Curriculum team, the teacher should still be able to see their report for it in Activity Scores.

This [PR was merged](https://github.com/empirical-org/Empirical-Core/pull/6969) and reverted last month because it revealed data problems for teachers unrelated to the actual changes. Many teachers discovered they had not properly archived activities. We are now re-deploying it after a conversation with Support about the potential trade-offs.

## WHY
Currently, we are showing archived Activities' Activity Sessions in the Activity Summary report, but not in the Activity Scores report. This inconsistency leads to confusion.

## HOW
Remove the query restriction that requires an activity not to be archived.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Discrepancy-between-Activity-Scores-and-Summary-b5313f15023d4a17b582962e371a2aed

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A