### PR TITLE
Lms/lesson prompt spacing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/styles/components/classroom_lessons/_prompt.scss
+++ b/services/QuillLMS/client/app/bundles/Lessons/styles/components/classroom_lessons/_prompt.scss
@@ -9,7 +9,6 @@
     font-size: 30px;
     color: #000;
     margin: 40px 0px 24px;
-    //display: flex;
     align-items: center;
     flex-wrap: wrap;
     padding-top: 0px;


### PR DESCRIPTION
## WHAT
Tweak style for prompts in Lessons so that line breaks can be inserted
## WHY
We want to create Lessons with multiple lines of prompt data
## HOW
Just remove a rule from the specific area of the card.

### Screenshots
![Screenshot 2020-12-09 135633](https://user-images.githubusercontent.com/331565/101674546-a406a800-3a26-11eb-9ec7-aaeaadf60765.png)
-------------------------------------------
![Screenshot 2020-12-09 135828](https://user-images.githubusercontent.com/331565/101674559-a832c580-3a26-11eb-823e-b170377cd3b9.png)


### Notion Card Links
https://www.notion.so/quill/Spacing-issue-in-Lessons-CMS-4762e98efa964fe39cdf4a5118ff67f5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, just a style change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
