### PR TITLE
lms/fix-proofreader-parenthesis-spacing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/sharedRegexes.ts
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/sharedRegexes.ts
@@ -1,4 +1,4 @@
-export const startsWithPunctuationRegex = /^[.,\/#!$%\^&\*;:=\-_`~()]/
+export const startsWithPunctuationRegex = /^[.,\/#!$%\^&\*;:=\-_`~)]/
 
 export const isAnEditRegex = /{\+([^-]+)-([^|]*)\|([^}]*)}/g
 


### PR DESCRIPTION
## WHAT
Remove '(' from the punctuation regex
## WHY
So that it doesn't forget to put a "space" before parenthetical notes.
## HOW
Remove `(` from the regex string for "startsWithPunctuationRegex".  Note that this seems to be generally used for understanding if the next "word" in Proofreader is a lone punctuation mark.  `(` should always be followed by text, so removing from this check should be safe in all instances of the regex's use.

### Notion Card Links
https://www.notion.so/quill/Spacing-displaying-incorrectly-in-Proofreader-7cdbf128ae954e2ebf804a0b00301235

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around this particular character in the regex
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
