### PR TITLE
lms/archive-alpha-connect-questions

### DIFF
--- a/services/QuillLMS/lib/tasks/connect.rake
+++ b/services/QuillLMS/lib/tasks/connect.rake
@@ -1,0 +1,14 @@
+namespace :connect do
+  desc "Batch change flags  for connect activities"
+  task :alpha_to_archived => :environment do
+    question_type = 'connect_fill_in_blanks'
+    flag_to_replace = 'alpha'
+    flag_to_set = 'archived'
+
+    questions = Question.where(question_type: question_type).where("data->>'flag' = ?", flag_to_replace)
+    questions.each do |q|
+      q.data['flag'] = flag_to_set
+      q.save
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
We want to change all Connect Fill in the Blank questions with the "alpha" flag to "archived" instead
## WHY
Hannah has apparently been doing this by hand in her free time, and would like us to do this to save her some time
## HOW
Just a rake task that finds all `Question` records with the "alpha" flag and `connect_fill_in_blank` type, then changes the flag value in the db.

### Notion Card Links
https://www.notion.so/quill/Archive-all-alpha-fill-in-the-blank-prompts-in-Connect-653f6013fc114c429a719dbd77fccb46

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
