### PR TITLE
lms/show-archived-activities-if-assigned

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -211,8 +211,6 @@ class Teachers::UnitsController < ApplicationController
       scores, completed, archived_activities = ''
       if report
         completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0"
-      else
-        archived_activities = "AND 'archived' != ANY(activities.flags)"
       end
       if lessons
         lessons = "AND activities.activity_classification_id = 6"
@@ -259,7 +257,6 @@ class Teachers::UnitsController < ApplicationController
         AND units.visible = true
         AND cu.visible = true
         AND ua.visible = true
-        #{archived_activities}
         #{lessons}
         GROUP BY units.name, units.created_at, cu.id, classrooms.name, classrooms.id, activities.name, activities.activity_classification_id, activities.id, activities.uid, unit_owner.name, unit_owner.id, ua.due_date, ua.created_at, unit_activity_id, state.completed, ua.id
         #{completed}


### PR DESCRIPTION
## WHAT
Allow archived activities to show up in teacher assignment lists
## WHY
So that they can be removed by teachers or support in order to allow clean up activity summary icons
## HOW
Stop filtering out archived activities from assignment lists.

### Notion Card Links
https://www.notion.so/quill/Unable-to-delete-Phantom-Activities-4392088ff1904e27ae44279d2346fb60

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on this query
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
