### PR TITLE
remove Google Web Store link from dashboard footer

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/dashboard_footer.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/dashboard_footer.test.jsx.snap
@@ -17,16 +17,5 @@ exports[`DashboardFooter component should render 1`] = `
       Please write a review.
     </a>
   </div>
-  <div
-    className="footer-img col-md-3 col-md-offset-8 col-sm-12"
-  >
-    <a
-      href="https://chrome.google.com/webstore/detail/quill/bponbohdnbmecjheeeagoigamblomimg"
-    >
-      <img
-        src="https://developer.chrome.com/webstore/images/ChromeWebStore_Badge_v2_206x58.png"
-      />
-    </a>
-  </div>
 </div>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/dashboard_footer.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/dashboard_footer.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-export default () => (
+const DashboardFooter = () => (
   <div className="footer-row row">
     <div className="review-request col-md-1 col-sm-12">
       <i className="fas fa-heart" />  Love Quill? <a href="https://www.commonsense.org/education/website/quill">Please write a review.</a>
     </div>
-    <div className="footer-img col-md-3 col-md-offset-8 col-sm-12">
-      <a href="https://chrome.google.com/webstore/detail/quill/bponbohdnbmecjheeeagoigamblomimg">
-        <img src="https://developer.chrome.com/webstore/images/ChromeWebStore_Badge_v2_206x58.png" />
-      </a>
-    </div>
   </div>
 );
+
+export default DashboardFooter


### PR DESCRIPTION
## WHAT
Remove the Google Web Store link and icon from the dashboard footer.

## WHY
Tom pointed out that the image was missing, which turned out to be because Google stopped hosting it. Since they stopped doing the Chrome Web Store thing for web apps, it doesn't really make sense to keep it any longer anyway.

## HOW
Just delete the code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Images-missing-from-the-teacher-overview-page-4244bebc01e54aa891a59480688d3a65

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
