### PR TITLE
fix issue with flags in activity editor

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/containers/ActivityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/containers/ActivityForm.tsx
@@ -73,7 +73,7 @@ const ActivityForm = ({ activity, activityClassification, contentPartnerOptions,
 
   function handleDescriptionChange(e) { handleAttributeChange('description', e.target.value) }
 
-  function handleFlagChange(e) { handleAttributeChange('flag', e.target.value) }
+  function handleFlagChange(e) { handleAttributeChange('flags', [e.target.value]) }
 
   function handleRepeatableChange(e) { handleAttributeChange('repeatable', e.target.checked)}
 
@@ -131,7 +131,7 @@ const ActivityForm = ({ activity, activityClassification, contentPartnerOptions,
         </section>
         <section>
           <label>Flag</label>
-          <select onChange={handleFlagChange} value={editedActivity.flag}>{flagOptionElements}</select>
+          <select onChange={handleFlagChange} value={editedActivity.flags[0]}>{flagOptionElements}</select>
         </section>
         <section className="repeatable-container checkbox-container">
           <input checked={editedActivity.repeatable} onChange={handleRepeatableChange} type="checkbox" />


### PR DESCRIPTION
## WHAT
Make sure flag dropdown shows correct flag and that it can be changed from this page.

## WHY
We want our staff members to be able to change activity flags from this page.

## HOW
Fix issue where we were attempting to assign a `flag` attribute, which doesn't exist in the database, rather than the `flags` array, which does.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-change-flags-in-Activities-Editor-e8af9a639b6f452e9b5a8a0933039fce

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
