### PR TITLE
fix issue with clever coteachers being created as dual owners

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
@@ -2,8 +2,8 @@ module CleverIntegration::Associators::ClassroomsToTeacher
 
   def self.run(classrooms, teacher)
     updated_classrooms = classrooms.map do |classroom|
-      ClassroomsTeacher.find_or_create_by(classroom: classroom, user: teacher, role: 'owner')
-      classroom.update(teacher_id: teacher.id)
+      role = classroom&.owner && classroom&.owner != teacher ? 'coteacher' : 'owner'
+      ClassroomsTeacher.find_or_create_by(classroom: classroom, user: teacher, role: role)
       classroom.reload
     end
     updated_classrooms

--- a/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'CleverIntegration::Associators::ClassroomsToTeacher' do
+
+  let!(:classroom1) { create(:classroom, :with_no_teacher) }
+  let!(:classroom2) { create(:classroom, :with_no_teacher) }
+  let!(:teacher1) { create(:teacher) }
+  let!(:teacher2) { create(:teacher) }
+  let!(:classrooms_teacher) { create(:classrooms_teacher, user: teacher1, classroom: classroom2)}
+
+  context 'when the classroom has no owner' do
+    it 'creates a classroom owner record' do
+      CleverIntegration::Associators::ClassroomsToTeacher.run([classroom1], teacher1)
+      expect(ClassroomsTeacher.find_by(classroom_id: classroom1.id, user_id: teacher1.id, role: 'owner')).to be
+    end
+  end
+
+  context 'when the classroom has an owner and that owner is the passed teacher' do
+    it 'creates a classroom owner record' do
+      CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher1)
+      expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher1.id, role: 'owner')).to be
+    end
+  end
+
+  context 'when the classroom has an owner and that owner is not the passed teacher' do
+    it 'creates a classroom owner record' do
+      CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher2)
+      expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher2.id, role: 'coteacher')).to be
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Make sure to create coteacher records, not owner records, when a Clever classroom already exists in Quill and has an owner that is not the same as the current user.

## WHY
Our system isn't set up to handle classrooms with two owners, but we were creating them anyway when Clever classrooms had two teachers.

## HOW
Just add some logic to check to see if there already is an owner and if that owner is the same as the current user. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Clever-Integration-Bug-b06893b72f724db486c2010c018203cf

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
