### PR TITLE
fix display for fill in blank questions in lessons

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/styles/components/classroom_lessons/_prompt.scss
+++ b/services/QuillLMS/client/app/bundles/Lessons/styles/components/classroom_lessons/_prompt.scss
@@ -1,6 +1,9 @@
 .student-slide-wrapper {
   .prompt {
     line-height: 1.53;
+    div {
+      display: inline-block;
+    }
   }
   .sentence-fragments {
     line-height: 1.27;


### PR DESCRIPTION
## WHAT
Fix display issue for fill in blank questions in Lessons.

## WHY
We must have updated some HTML or CSS somewhere that broke the styling for fill in blank questions in Quill Lessons activities, resulting in each word being on a new line. This fixes that.

## HOW
Just add a CSS rule.

### Screenshots
<img width="1226" alt="Screen Shot 2020-12-15 at 10 27 22 AM" src="https://user-images.githubusercontent.com/18669014/102235427-52479d00-3ec0-11eb-8f66-9118cac5c84f.png">

### Notion Card Links
https://www.notion.so/quill/Quill-Lesson-Adjectives-Formatting-Bug-f7fecec0d7804f16b84790b16a301662

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
