### PR TITLE
onboarding: convenience rake task for local data cleaning

### DIFF
--- a/services/QuillLMS/lib/tasks/localize_classification_module_urls.rake
+++ b/services/QuillLMS/lib/tasks/localize_classification_module_urls.rake
@@ -1,0 +1,15 @@
+namespace :local do
+  desc 'Update seed / prod dump\'d ActivityClassifications so that redirects point to localhost'
+  task :localize_classification_module_urls => :environment do
+  	def change_url_domain(original, domain='http://localhost:3000')
+  	  original.gsub('https://www.quill.org', domain)
+  	end
+
+  	ActivityClassification.all.each do |ac|
+  	  ac.update!(**{
+  	  	module_url: change_url_domain(ac.module_url),
+  	  	form_url: change_url_domain(ac.form_url)
+  	  })
+  	end
+  end
+end


### PR DESCRIPTION
## WHAT
Adds a rake task to update ActivityClassification urls in local DB

## WHY
If this doesn't happen, activities performed locally will error - see screenshot
<img width="1087" alt="Screen Shot 2020-12-15 at 12 05 31 PM" src="https://user-images.githubusercontent.com/90669/102262762-b7a38a00-3ed0-11eb-9307-072610ae2d56.png">

## HOW
Rake task

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
No notion card - this is part of Peter's onboarding learnings.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - does not affect app code.
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A


