### PR TITLE
turn &quot; into " in student reports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import createReactClass from 'create-react-class';
+
+import formatString from './formatString'
+
 import ScoreColor from '../../modules/score_color.js'
 import ConceptResultTableRow from './concept_result_table_row.tsx'
 import NumberSuffix from '../../modules/numberSuffixBuilder.js'
@@ -19,7 +22,7 @@ export default createReactClass({
   <tr className={classNameAndText}>
     <td>{classNameAndText}</td>
     <td />
-    <td>{directionsOrFeedback.replace(/&#x27;/g, "'")}</td>
+    <td>{formatString(directionsOrFeedback)}</td>
   </tr>)
 		}
 	},
@@ -57,6 +60,7 @@ export default createReactClass({
 			}
 			attemptNum += 1;
 		}
+
 		return results;
 	},
 
@@ -114,7 +118,7 @@ export default createReactClass({
             <tr>
               <td>Prompt</td>
               <td />
-              <td>{data.prompt.replace(/&#x27;/g, "'")}</td>
+              <td>{formatString(data.prompt)}</td>
             </tr>
             {this.questionScore()}
             {this.emptyRow()}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
@@ -1,0 +1,5 @@
+const formatString = (str: string) => {
+  return str.replace(/&#x27;/g, "'").replace(/&nbsp;/g, '').replace(/(<([^>]+)>)/ig, '').replace(/&quot;/g, '"')
+}
+
+export default formatString

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import formatString from './formatString'
+
 import ScoreColor from '../../modules/score_color.js'
 import ConceptResultTableRow from './concept_result_table_row.tsx'
 import Concept from '../../../../interfaces/concept.ts';
@@ -32,19 +34,15 @@ export class StudentReportBox extends React.Component<StudentReportBoxProps> {
       <tr>
         <td>Prompt</td>
         <td />
-        <td><span dangerouslySetInnerHTML={{ __html: prompt }} /></td>
+        <td><span dangerouslySetInnerHTML={{ __html: formatString(prompt) }} /></td>
       </tr>
     );
-  }
-
-  formatAnswer = (answer: string) => {
-    return answer.replace(/&#x27;/g, "'").replace(/&nbsp;/g, '').replace(/(<([^>]+)>)/ig, '')
   }
 
   render() {
     const { boxNumber, questionData } = this.props;
     const { answer, concepts, directions, prompt, score } = questionData;
-    const formattedAnswer = answer ? this.formatAnswer(answer) : ''
+    const formattedAnswer = answer ? formatString(answer) : ''
     return(
       <div className='individual-activity-report'>
         <div className="student-report-box">


### PR DESCRIPTION
## WHAT
We are sometimes having `&quot;` show up instead of quotation marks in student reports. This fixes that, and standardizes weird character formatting through both report components via shared function.

## WHY
We want text shown to teachers to be human-readable.

## HOW
Add a new shared function that includes replacing `&quot;` with `"` and use it where we had previously been formatting prompt and answer strings.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Quotation-marks-showing-up-incorrectly-on-teacher-facing-side-7c9bea6f30ca4e47a192e205d5196b21

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
