### PR TITLE
Comprehension/missing ml feedback

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -199,7 +199,7 @@ func buildBatchFeedbackHistories(request_object APIRequest, feedbacks map[int]In
 	feedback_histories := []FeedbackHistory{}
 	used_key := identifyUsedFeedbackIndex(feedbacks)
 	for key, feedback := range feedbacks {
-		if !feedback.Error {
+		if !feedback.Error || key == automl_index {
 			feedback_histories = append(feedback_histories, buildFeedbackHistory(request_object, feedback, used_key == key, time_received))
 		}
 	}

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -241,7 +242,8 @@ func TestBuildBatchFeedbackHistories(t *testing.T) {
 
 	results := map[int]InternalAPIResponse{}
 	results[0] = InternalAPIResponse { APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: true, Labels: "test_label" } }
-	results[2] = InternalAPIResponse { APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: non-optimal", Feedback_type: "type2", Optimal: false, Labels: "test_label" } }
+	results[automl_index] = InternalAPIResponse { Error: true, APIResponse: default_api_response }
+	results[2] = InternalAPIResponse { Error: true, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: non-optimal", Feedback_type: "type2", Optimal: false, Labels: "test_label" } }
 	results[3] = InternalAPIResponse { APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type3", Optimal: false, Labels: "test_label" } }
 
 	now := time.Now()
@@ -266,15 +268,15 @@ func TestBuildBatchFeedbackHistories(t *testing.T) {
 			FeedbackHistory {
 				Activity_session_uid: api_request.Session_id,
 				Prompt_id: api_request.Prompt_id,
-				Concept_uid: results[2].APIResponse.Concept_uid,
+				Concept_uid: default_api_response.Concept_uid,
 				Attempt: api_request.Attempt,
 				Entry: api_request.Entry,
-				Feedback_text: results[2].APIResponse.Feedback,
-				Feedback_type: results[2].APIResponse.Feedback_type,
-				Optimal: results[2].APIResponse.Optimal,
-				Used: true,
+				Feedback_text: default_api_response.Feedback,
+				Feedback_type: default_api_response.Feedback_type,
+				Optimal: default_api_response.Optimal,
+				Used: false,
 				Time: now,
-				Metadata: FeedbackHistoryMetadata { Labels: results[2].APIResponse.Labels },
+				Metadata: FeedbackHistoryMetadata { Labels: default_api_response.Labels },
 			},
 			FeedbackHistory {
 				Activity_session_uid: api_request.Session_id,
@@ -285,7 +287,7 @@ func TestBuildBatchFeedbackHistories(t *testing.T) {
 				Feedback_text: results[3].APIResponse.Feedback,
 				Feedback_type: results[3].APIResponse.Feedback_type,
 				Optimal: results[3].APIResponse.Optimal,
-				Used: false,
+				Used: true,
 				Time: now,
 				Metadata: FeedbackHistoryMetadata { Labels: results[3].APIResponse.Labels },
 			},
@@ -298,10 +300,14 @@ func TestBuildBatchFeedbackHistories(t *testing.T) {
 
 	payload_json, _ := json.Marshal(payload)
 	payload_str := string(payload_json)
-	expected_json, _ := json.Marshal(expected)
-	expected_str := string(expected_json)
-	if payload_str != expected_str {
-		t.Errorf("Payload not properly formatted.\n\nReceived:\n%s\n\nExpected:\n%s", payload_str, expected_str)
+	for _, feedback_history := range expected.Feedback_histories {
+		expected_json, _ := json.Marshal(feedback_history)
+		expected_str := string(expected_json)
+		if !strings.Contains(payload_str, expected_str) {
+			expected_json, _ := json.Marshal(expected)
+			expected_str := string(expected_json)
+			t.Errorf("Payload not properly formatted.\n\nReceived:\n%s\n\nExpected:\n%s", payload_str, expected_str)
+		}
 	}
 }
 


### PR DESCRIPTION
## WHAT
Tweak the Go endpoint to record more instances of feedback to the `FeedbackHistory` record in the LMS.  We were intentionally not including any "Error" feedback, but we want to include "Errors" if they replace ML feedback.

We also had a bug that was sometimes erroneously suppressing feedback as "Error" feedback when it wasn't.
## WHY
We want to record all relevant feedback history that we can to the Feedback History table
## HOW
Don't exclude Error feedback from history if it's from a call to the ML feedback endpoint.  Also, check the Feedback record itself for the Error flag rather than the Feedback from the channel result that triggered a results scan.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
