### PR TITLE
update eb deploy to include commit hash, readme update

### DIFF
--- a/services/QuillCMS/README.md
+++ b/services/QuillCMS/README.md
@@ -26,7 +26,11 @@ bundle exec rspec spec
 ```
 
 ## Deployment
+Prerequisites:
+- Ensure the elastic beanstalk CLI is [installed and configured](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html)
+- ```QuillCMS$ eb init```
 ```bash
+git checkout production && git pull
 bash deploy.sh staging|prod
 ```
 

--- a/services/QuillCMS/deploy.sh
+++ b/services/QuillCMS/deploy.sh
@@ -17,6 +17,6 @@ esac
 # Slack deploy start
 sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
 
-eb deploy ${EB_ENVIRONMENT_NAME}
+eb deploy ${EB_ENVIRONMENT_NAME} --label `git rev-parse HEAD`
 open "https://rpm.newrelic.com/accounts/2639113/applications/548895592"
 open "https://console.aws.amazon.com/elasticbeanstalk/home?region=us-east-1#/environment/dashboard?applicationName=QuillCMS&environmentId=e-7n7bmkzhp3"


### PR DESCRIPTION
## WHAT
- Updates readme with eb client setup
- tags CMS deploys with the commit hash, 

## WHY
so that we know definitely what version of the code is on staging/prod, and thus can know what changes the next deployment will make

## HOW

### Screenshots
<img width="886" alt="Screen Shot 2020-12-22 at 1 55 14 PM" src="https://user-images.githubusercontent.com/90669/102932427-804b5500-445d-11eb-9a03-0ca72d66e3b1.png">


### Notion Card Links
None

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A - tested manually by deploying to staging and verifying the commit label within AWS
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | n/a