### PR TITLE
lms/allow-teachers-to-cancel-subscriptions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 export default class extends React.Component {
   handleChange = e => {
-    this.props.changeRecurringStatus(Boolean(e.target.value));
+    // So it turns out that `value={false}` below doesn't set the value to a boolean, but to the string "false" which, of course, evaluates as truth-y.  This meant that both checking the truthiness of the value itself is the same in both cases, and the buttons won't toggle.
+    this.props.changeRecurringStatus(e.target.value !== 'false');
   };
 
   render() {


### PR DESCRIPTION
## WHAT
Fix a bug that prevented users from canceling their recurring subs
## WHY
So that teachers can turn off recurring subscriptions if they don't want to renew
## HOW
Fix a logic bug around "truthiness" of strings.  Stupid Javascript.

### Notion Card Links
https://www.notion.so/quill/Teachers-cannot-edit-their-Next-Plan-for-subscriptions-and-therefore-cannot-turn-off-auto-renew-b3346d96f9784c0ea5af7ad56435deb7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  No tests on this particular code.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
