### PR TITLE
Remove static banner references

### DIFF
--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -70,7 +70,6 @@ class SessionsController < ApplicationController
     admin_id = session.delete(:admin_id)
     admin = User.find_by_id(admin_id)
     staff_id = session.delete(:staff_id)
-    cookies[:static_banner_closed] = { expires: Time.now }
     cookies[:webinar_banner_closed] = { expires: Time.now }
     if admin.present? and (admin != current_user)
       sign_out

--- a/services/QuillLMS/app/views/layouts/application.html.erb
+++ b/services/QuillLMS/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
       <%= content_tag(:div, "<p>#{value}</p><i class='fas fa-times-circle' aria-hidden='true'></i>".html_safe, {class: "flash #{key}", onClick: "$(this).slideUp(300)"}) %>
     <% end %>
     <%= render partial: 'application/preview_student_banner' %>
-    <%= render partial: 'application/static_banner' %>
     <%= render partial: 'application/webinar_banner' %>
     <% if ENV['UPGRADE'] && ENV['UPGRADE_END_TIME'] && Time.now < Time.parse(ENV['UPGRADE_END_TIME'])%>
       <%= render partial: 'application/upgraded_bar' %>

--- a/services/QuillLMS/app/views/layouts/progress_reports.html.erb
+++ b/services/QuillLMS/app/views/layouts/progress_reports.html.erb
@@ -1,7 +1,6 @@
 <html lang='en'>
   <%= render partial: 'head' %>
   <body>
-    <%= render partial: 'application/static_banner' %>
     <%= render partial: 'application/webinar_banner' %>
     <%= render partial: 'header', media: 'all', 'data-turbolinks-track' => true %>
     <%= render partial: 'admin_dashboard_header' %>

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -29,7 +29,6 @@
     <%= render partial: 'application/head_embed_codes' %>
   </head>
   <body>
-    <%= render partial: 'application/static_banner' %>
     <%= render partial: 'application/webinar_banner' %>
     <%= yield %>
   </body>


### PR DESCRIPTION
## WHAT
Take down the static banner for now, as we are not running the Spotlight Series anymore.

## WHY
We're not running this series anymore since it's a Fall series. We'll keep the code for next Fall but take out the references so the banner stops showing up.

## HOW
Take out code that displays this banner.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
No Notion card -- one off request

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No -- small cosmetic change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
