### PR TITLE
Deploy Script - Ensure updated local history of origin/production

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -41,10 +41,15 @@ then
     if [ $1 == 'prod' ]
     then
         # For production, push directly from the remote production branch without going local
+        # This 'remote merge' requires your local git history/pointers of the remote branches to be up-to-date, so we run a 'git fetch' to do that.
+        # Documented here: https://github.com/empirical-org/test_repo/blob/destination_branch/test_file.txt
         git fetch origin production
+        git fetch origin $DEPLOY_GIT_BRANCH
         git push --no-verify --force origin origin/production:refs/heads/$DEPLOY_GIT_BRANCH
+
         sh ../../scripts/post_slack_deploy_description.sh $app_name
     else
+        git fetch origin $DEPLOY_GIT_BRANCH
         git push --no-verify --force origin ${current_branch}:$DEPLOY_GIT_BRANCH
     fi
     open "https://dashboard.heroku.com/apps/$HEROKU_APP/activity"


### PR DESCRIPTION
## WHAT
Update `deploy.sh` to do a `git fetch` to get the current metadata for `origin/production` locally for a production deploy.
## WHY
I believe the metadata/history of the remote is needed to ensure that `git push origin origin/production:your_branch` works as expected. I think adding this step will fix the issue of accidentally deploying old code (if your local metadata for the remote branch is out of date).
## HOW

`git fetch` pulls the metadata/history from the remote repository. It's non-destructive and doesn't update the local branches.

[Git Fetch Docs](https://git-scm.com/docs/git-fetch): 
> Fetch branches and/or tags (collectively, "refs") from one or more other repositories, along with the objects necessary to complete their histories.

For more context:
https://www.git-tower.com/learn/git/faq/difference-between-git-fetch-git-pull/
> git fetch really only downloads new data from a remote repository - but it doesn't integrate any of this new data into your working files. Fetch is great for getting a fresh view on all the things that happened in a remote repository.
Due to it's "harmless" nature, you can rest assured: fetch will never manipulate, destroy, or screw up anything. This means you can never fetch often enough.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, DevOps change
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
