### PR TITLE
Hotfix for UserLoginWorker wrong number of arguments

### DIFF
--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -15,7 +15,7 @@ class UserLoginWorker
         # keep these in the following order so the student is the last one identified
         teacher = @user.teacher_of_student
         if teacher.present?
-          analytics.track(
+          analytics.track_with_attributes(
             teacher,
             SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN,
             properties: {

--- a/services/QuillLMS/spec/workers/user_login_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/user_login_worker_spec.rb
@@ -21,7 +21,7 @@ describe UserLoginWorker, type: :worker do
   context 'when student with teacher logs in' do
 
     it 'track teacher student sign in' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN, properties: {student_id: student.id})
+      expect(analyzer).to receive(:track_with_attributes).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN, properties: {student_id: student.id})
       worker.perform(student.id, "127.0.0.1")
     end
   end


### PR DESCRIPTION
## WHAT
I accidentally used the wrong `track` method when I deployed my changes earlier. This is causing `UserLoginWorker` to fail. My fix changes it to the right method call.

## WHY
Get UserLoginWorker working again so we have accurate analytics.

## HOW
Use `track_with_attributes` instead of `track`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
