### PR TITLE
Replace word-by-word bolding with phrase-by-phrase bolding in Comprehension

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -94,8 +94,6 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     return str.replace(wordsToFormat, boldedString)
   }
 
-  // for now this function is identical to formatPlagiarismHighlight, but we may want to
-  // change the highlighting behavior when feedback is spelling/grammar related
   formatSpellingGrammarHighlight = (str: string, wordsToFormat: string | string[]) => {
     let wordArray = [].concat(wordsToFormat)
     let newString = str


### PR DESCRIPTION
## WHAT
Fix two Comprehension issues -- punctuated words not getting bolded in bolded responses, and students not being able to add spaces to bolded words in their response.

## WHY
To get Comprehension in working order for turking.

## HOW
We are currently implementing response highlighting in Comprehension by bolding words one by one. We are also stripping all punctuation and spaces out of words when we bold them, which causes issues when the user is then trying to edit the bolded words by adding spaces. This PR changes word-by-word bolding to be substring bolding, and stops editing punctuation.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Comprehension-plagiarism-bolding-issue-a9b34acd32b34a8eba62c4f87315d9c1
https://www.notion.so/quill/Comprehension-spacing-issue-5f129d3a470944b985c78ffcc2d52a02

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
