### PR TITLE
Remove preview_as_student Segment event

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -193,7 +193,6 @@ class Teachers::ClassroomManagerController < ApplicationController
     student = User.find_by_id(params[:student_id])
     if student && (student&.classrooms&.to_a & current_user&.classrooms_i_teach)&.any?
       self.preview_student_id= params[:student_id]
-      Analyzer.new.track(current_user, SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
     end
     redirect_to '/profile'
   end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -427,7 +427,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
     let!(:student1) { create(:student)}
     let!(:student2) { create(:student)}
     let!(:students_classrooms) { create(:students_classrooms, student: student1, classroom: classroom)}
-    let(:analyzer) { double(:analyzer, track: true) }
 
     before do
       allow(controller).to receive(:current_user) { teacher }
@@ -452,11 +451,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
     it 'will redirect to the profile path' do
       get :preview_as_student, student_id: 'random'
       expect(response).to redirect_to profile_path
-    end
-
-    it 'will track event' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
-      get :preview_as_student, student_id: student1.id
     end
   end
 


### PR DESCRIPTION
## WHAT
Remove the new `preview_as_student` Segment event for now.
## WHY
This should be firing as a `"teacher"` session event, but is firing as a `"student"` session event in Heap, which "is creating additional non-teacher sessions in Heap, which could impact our pricing if we leave it in place". Removing it for now since we may need a more nuanced work around.
## HOW
Just removing it.

### Notion Card Links
See comment on this card: https://www.notion.so/quill/Add-new-Segment-event-to-track-usage-of-view-as-student-feature-0931fa76996b423e8c98f135095110b0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
