### PR TITLE
add uniqueness restriction to teacher saved activities

### DIFF
--- a/services/QuillLMS/app/models/teacher_saved_activity.rb
+++ b/services/QuillLMS/app/models/teacher_saved_activity.rb
@@ -4,4 +4,5 @@ class TeacherSavedActivity < ActiveRecord::Base
 
   validates :activity_id, presence: true
   validates :teacher_id, presence: true
+  validates :activity_id, uniqueness: { scope: :teacher_id }
 end

--- a/services/QuillLMS/db/migrate/20210113130854_add_uniqueness_restriction_to_teacher_id_and_activity_id_on_teacher_saved_activities.rb
+++ b/services/QuillLMS/db/migrate/20210113130854_add_uniqueness_restriction_to_teacher_id_and_activity_id_on_teacher_saved_activities.rb
@@ -1,0 +1,5 @@
+class AddUniquenessRestrictionToTeacherIdAndActivityIdOnTeacherSavedActivities < ActiveRecord::Migration
+  def change
+    add_index :teacher_saved_activities, [:teacher_id, :activity_id], unique: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.12
--- Dumped by pg_dump version 10.12
+-- Dumped from database version 10.13
+-- Dumped by pg_dump version 10.13
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1186,7 +1186,10 @@ CREATE TABLE public.comprehension_prompts (
     text character varying,
     max_attempts_feedback text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    plagiarism_text text,
+    plagiarism_first_feedback text,
+    plagiarism_second_feedback text
 );
 
 
@@ -1309,6 +1312,39 @@ CREATE SEQUENCE public.comprehension_rules_id_seq
 --
 
 ALTER SEQUENCE public.comprehension_rules_id_seq OWNED BY public.comprehension_rules.id;
+
+
+--
+-- Name: comprehension_turking_round_activity_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.comprehension_turking_round_activity_sessions (
+    id integer NOT NULL,
+    turking_round_id integer,
+    activity_session_uid character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: comprehension_turking_round_activity_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.comprehension_turking_round_activity_sessions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: comprehension_turking_round_activity_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.comprehension_turking_round_activity_sessions_id_seq OWNED BY public.comprehension_turking_round_activity_sessions.id;
 
 
 --
@@ -1493,7 +1529,8 @@ CREATE TABLE public.content_partners (
     name character varying NOT NULL,
     description character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    visible boolean DEFAULT true
 );
 
 
@@ -2879,40 +2916,6 @@ ALTER SEQUENCE public.teacher_saved_activities_id_seq OWNED BY public.teacher_sa
 
 --
 -- Name: third_party_user_ids; Type: TABLE; Schema: public; Owner: -
-
---
-
-CREATE TABLE public.teacher_saved_activities (
-    id integer NOT NULL,
-    teacher_id integer NOT NULL,
-    activity_id integer NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: teacher_saved_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.teacher_saved_activities_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: teacher_saved_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.teacher_saved_activities_id_seq OWNED BY public.teacher_saved_activities.id;
-
-
---
--- Name: third_party_user_ids; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.third_party_user_ids (
@@ -2989,7 +2992,9 @@ CREATE TABLE public.topics (
     name character varying NOT NULL,
     level integer NOT NULL,
     visible boolean DEFAULT true NOT NULL,
-    parent_id integer
+    parent_id integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
@@ -3526,6 +3531,13 @@ ALTER TABLE ONLY public.comprehension_rules ALTER COLUMN id SET DEFAULT nextval(
 
 
 --
+-- Name: comprehension_turking_round_activity_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comprehension_turking_round_activity_sessions ALTER COLUMN id SET DEFAULT nextval('public.comprehension_turking_round_activity_sessions_id_seq'::regclass);
+
+
+--
 -- Name: comprehension_turking_rounds id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3828,14 +3840,6 @@ ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('publi
 
 --
 -- Name: teacher_saved_activities id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.teacher_saved_activities ALTER COLUMN id SET DEFAULT nextval('public.teacher_saved_activities_id_seq'::regclass);
-
-
---
--- Name: third_party_user_ids id; Type: DEFAULT; Schema: public; Owner: -
-
 --
 
 ALTER TABLE ONLY public.teacher_saved_activities ALTER COLUMN id SET DEFAULT nextval('public.teacher_saved_activities_id_seq'::regclass);
@@ -4156,6 +4160,14 @@ ALTER TABLE ONLY public.comprehension_rule_sets
 
 ALTER TABLE ONLY public.comprehension_rules
     ADD CONSTRAINT comprehension_rules_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: comprehension_turking_round_activity_sessions comprehension_turking_round_activity_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comprehension_turking_round_activity_sessions
+    ADD CONSTRAINT comprehension_turking_round_activity_sessions_pkey PRIMARY KEY (id);
 
 
 --
@@ -4610,6 +4622,20 @@ CREATE INDEX aut ON public.activities_unit_templates USING btree (activity_id, u
 --
 
 CREATE UNIQUE INDEX classroom_invitee_index ON public.coteacher_classroom_invitations USING btree (invitation_id, classroom_id);
+
+
+--
+-- Name: comprehension_turking_sessions_activity_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX comprehension_turking_sessions_activity_uid ON public.comprehension_turking_round_activity_sessions USING btree (activity_session_uid);
+
+
+--
+-- Name: comprehension_turking_sessions_turking_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX comprehension_turking_sessions_turking_id ON public.comprehension_turking_round_activity_sessions USING btree (turking_round_id);
 
 
 --
@@ -5548,6 +5574,13 @@ CREATE INDEX index_teacher_saved_activities_on_activity_id ON public.teacher_sav
 --
 
 CREATE INDEX index_teacher_saved_activities_on_teacher_id ON public.teacher_saved_activities USING btree (teacher_id);
+
+
+--
+-- Name: index_teacher_saved_activities_on_teacher_id_and_activity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_teacher_saved_activities_on_teacher_id_and_activity_id ON public.teacher_saved_activities USING btree (teacher_id, activity_id);
 
 
 --
@@ -6879,4 +6912,14 @@ INSERT INTO schema_migrations (version) VALUES ('20201023212528');
 INSERT INTO schema_migrations (version) VALUES ('20201026184657');
 
 INSERT INTO schema_migrations (version) VALUES ('20201026185613');
+
+INSERT INTO schema_migrations (version) VALUES ('20201116132148');
+
+INSERT INTO schema_migrations (version) VALUES ('20201125190536');
+
+INSERT INTO schema_migrations (version) VALUES ('20201202224853');
+
+INSERT INTO schema_migrations (version) VALUES ('20201203173440');
+
+INSERT INTO schema_migrations (version) VALUES ('20210113130854');
 

--- a/services/QuillLMS/spec/factories/teacher_saved_activity.rb
+++ b/services/QuillLMS/spec/factories/teacher_saved_activity.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :teacher_saved_activity do
     activity { Activity.last || create(:activity) }
-    teacher  { Teacher.last || create(:teacher) }
+    teacher  { User.find_by(role: 'teacher') || create(:teacher) }
   end
 end

--- a/services/QuillLMS/spec/models/teacher_saved_activity_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_saved_activity_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe TeacherSavedActivity, type: :model do
+
+  subject { create(:teacher_saved_activity) }
+
   it { should belong_to(:teacher).class_name('User') }
   it { should belong_to(:activity) }
 
   it { should validate_presence_of(:activity_id) }
   it { should validate_presence_of(:teacher_id) }
+  it { should validate_uniqueness_of(:activity_id).scoped_to(:teacher_id) }
 end


### PR DESCRIPTION
## WHAT
Add uniqueness restriction to teacher ids and activity ids on `TeacherSavedActivity` records, both on the model and database level.

## WHY
We don't want duplicate records in this table.

## HOW
Add a new index to the database and a new validation to the model. I checked to see if we had any duplicate records already in the database and we don't, so we don't need to worry about cleaning up old data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-uniqueness-restriction-to-TeacherSavedActivity-687b4ff6124e43b7a315effccb6dcba9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
