### PR TITLE
Remove all open positions from career page

### DIFF
--- a/services/QuillLMS/app/views/pages/careers.html.erb
+++ b/services/QuillLMS/app/views/pages/careers.html.erb
@@ -77,8 +77,12 @@
     <div class="job-listings">
       <h2>Open positions</h2>
       <div class="job-board">
-        <% @open_positions.each do |job| %>
-          <%= render partial: 'pages/job', locals: {job: job} %>
+        <% if @open_positions%>
+          <% @open_positions.each do |job| %>
+            <%= render partial: 'pages/job', locals: {job: job} %>
+          <% end %>
+        <% else %>
+          <p>We have no open positions at this time. Please check back later for postings!</p>
         <% end %>
       </div>
     </div>

--- a/services/QuillLMS/config/careers.yml
+++ b/services/QuillLMS/config/careers.yml
@@ -1,13 +1,2 @@
 default:
   open_positions:
-    - category: 'Product'
-      title: 'Software Engineer'
-      url: 'https://angel.co/company/quill-org/jobs/581557-software-engineer-rails-react-python'
-
-    - category: 'Product'
-      title: 'Senior Software Engineer'
-      url: 'https://angel.co/company/quill-org/jobs/587292-senior-software-engineer-rails-react-python'
-
-    - category: 'Operations'
-      title: 'Chief of Staff'
-      url: 'https://www.linkedin.com/jobs/view/2188732565/'


### PR DESCRIPTION
## WHAT
Remove all the open positions from Careers page (because the positions have all been filled). Put in some default text for when there are no open positions.

## WHY
So our website reflects our up-to-date job postings status.

## HOW
Take out the open position listings from `careers.yml`. Add some default text for when there are no open positions.

### Screenshots
![Screen Shot 2021-01-13 at 4 11 50 PM](https://user-images.githubusercontent.com/57366100/104511523-d2921880-55ba-11eb-9f0c-bd115359eb1e.png)

### Notion Card Links
https://www.notion.so/quill/Remove-Chief-of-staff-and-Engineer-positions-from-the-careers-page-2b046e85cb334e06af641a4e4fb22874

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - tiny copy change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
