### PR TITLE
make sure removing activities actually works

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
@@ -105,6 +105,7 @@ const ActivityTable = ({ data, onSuccess, isOwner, }) => {
 
   const activityRows = activityOrder.map(activityId => {
     const activity = classroomActivityArray.find(act => act.activityId === activityId)
+    if (!activity) { return }
     const toolIcon = imageTagForClassification(activity.activityClassificationId)
     const previewLink = <a href={`/activity_sessions/anonymous?activity_id=${activity.activityId}`} tabIndex={-1}>{activity.name}</a>
     activity.toolAndNameSection = (<a className="interactive-wrapper focus-on-light" href={`/activity_sessions/anonymous?activity_id=${activity.activityId}`} id={`tool-and-name-section-${activity.uaId}`}>
@@ -134,7 +135,7 @@ const ActivityTable = ({ data, onSuccess, isOwner, }) => {
     activity.removable = true
     activity.id = activity.uaId
     return activity
-  })
+  }).filter(Boolean)
   return (<DataTable
     headers={tableHeaders(isOwner)}
     isReorderable={isOwner}


### PR DESCRIPTION
## WHAT
Update code slightly so things don't get weird after you remove an activity from a pack.

## WHY
We want removing activities to work correctly.

## HOW
Just return from that iteration if there is no classroom activity matching that activity id, and then filter all the rows to make sure a `null` one doesn't slip in.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
