### PR TITLE
Clear additional fields on user.clear_data

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -396,7 +396,7 @@ class User < ActiveRecord::Base
         ip_address: nil,
         send_newsletter: false
       )
-      StudentsClassrooms.where(student_id: id).update_all(visible: false)
+      StudentsClassrooms.where(student_id: id).destroy_all
       auth_credential.destroy! if auth_credential.present?
       ip_location.destroy! if ip_location.present?
       SchoolsUsers.where(user_id: id).destroy_all

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -729,6 +729,10 @@ describe User, type: :model do
       expect(user.reload.schools_users).to be nil
     end
 
+    it "destroys associated students_classrooms if present" do
+      expect(StudentsClassrooms.where(student_id: user.id).count).to eq(0)
+    end
+
     it "removes the ip address" do
       expect(user.ip_address).to be nil
     end


### PR DESCRIPTION
## WHAT
When `User.clear_data` is called, we want to add some additional fields into the clearing/nulling update. We also want to set some fields of related records (`ActivitySession` and `ClassroomUnit`) to nil.

## WHY
This scrubs our records more thoroughly, so it will be more secure. It also scrubs related records to avoid future errors.

## HOW
Adding fields to the `update` call to be set to nil. Adding some additional logic to null out fields in related records.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Clear-User-Data-to-include-more-Student-items-ad2e67ae46a2410188fdb45ae2058994

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
