### PR TITLE
Use the front-end API to translate between front and back end shapes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/ruleSetAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/ruleSetAPIs.ts
@@ -25,7 +25,7 @@ export const fetchRuleSet = async (key: string, activityId: string, ruleSetId: s
 export const createRuleSet = async (activityId: string, ruleSet: { rule_set: ActivityRuleSetInterface }) => {
   const { rule_set } = ruleSet;
   const { rules } = rule_set;
-  ruleSet.regex_rules = rules;
+  ruleSet.rule_set.regex_rules_attributes = ruleSet.rule_set.rules_attributes;
   const response = await apiFetch(`activities/${activityId}/rule_sets`, {
     method: 'POST',
     body: JSON.stringify(ruleSet)


### PR DESCRIPTION
## WHAT
Have the front-end API tweak the payload from the back-end to make it match the front-end spec
## WHY
We've very slightly changed the way the back-end is shaped, specifically what one of the keys is named, so we need to translate between the old shape that the front-end expects and the new shape that the back-end expects.
## HOW
Just have the API util make changes in place so that the rest of the front-end only knows about the defined front-end structure, and ditto back-end.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test changes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A