### PR TITLE
add new segment event for previewing activities

### DIFF
--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -39,6 +39,7 @@ class ActivitySessionsController < ApplicationController
 
   def anonymous
     @activity = Activity.find_by_id_or_uid(params[:activity_id])
+    PreviewedActivityWorker.perform_async(current_user&.id, params[:activity_id])
     redirect_to anonymous_return_url
   end
 

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -129,6 +129,20 @@ class SegmentAnalytics
     })
   end
 
+  def track_previewed_activity(user_id, activity_id)
+    user = User.find(user_id)
+    activity = Activity.find(activity_id)
+    track(user, {
+      user_id: user_id,
+      event: SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
+      properties: {
+        activity_name: activity.name,
+        tool_name: activity&.classification&.name
+      }
+    })
+
+  end
+
   def track(user, options)
     if backend.present?
       options[:integrations] = integration_rules(user)

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -41,6 +41,7 @@ module SegmentIo
     COTEACHER_ACCEPTANCE ||= 'Teacher accepted coteacher invitation'
     TRANSFER_OWNERSHIP ||= 'Teacher transferred ownership of a classroom'
     VIEWED_AS_STUDENT ||= 'Teacher viewed Quill as a student'
+    PREVIEWED_ACTIVITY ||= 'Teacher previewed an activity'
   end
 
   module Events

--- a/services/QuillLMS/app/workers/previewed_activity_worker.rb
+++ b/services/QuillLMS/app/workers/previewed_activity_worker.rb
@@ -1,0 +1,10 @@
+class PreviewedActivityWorker
+  include Sidekiq::Worker
+
+  def perform(user_id, activity_id)
+    if user_id
+      analytics = SegmentAnalytics.new
+      analytics.track_previewed_activity(user_id, activity_id)
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/previewed_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/previewed_activity_worker_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe PreviewedActivityWorker do
+  let(:subject) { described_class.new }
+
+  describe '#perform' do
+    let!(:user) { create(:user) }
+    let!(:activity) { create(:activity) }
+    let(:analyzer) { double(:analyzer, track_previewed_activity: true) }
+
+    before do
+      allow(SegmentAnalytics).to receive(:new) { analyzer }
+    end
+
+    it 'should track the previewed activity if there is a user id' do
+      expect(analyzer).to receive(:track_previewed_activity).with(user.id, activity.id)
+      subject.perform(user.id, activity.id)
+    end
+
+    it 'should not track the previewed activity if there is no user id' do
+      expect(analyzer).not_to receive(:track_previewed_activity).with(nil, activity.id)
+      subject.perform(nil, activity.id)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add new Segment event for teachers previewing activities.

## WHY
We want to be tracking what activities teachers are previewing and how often.

## HOW
Just add a new Segment event.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-new-Segment-event-to-track-when-teachers-preview-an-activity-91adcaf2bd874f578a9925e2480cc98c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
