### PR TITLE
Add a nil check that's causing pages to crash

### DIFF
--- a/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
+++ b/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
@@ -45,7 +45,7 @@ class UnitTemplatePseudoSerializer
     author = @unit_template.author
     {
       name: author&.name,
-      avatar_url: author.avatar_url
+      avatar_url: author&.avatar_url
     }
   end
 


### PR DESCRIPTION
## WHAT
Add a nil check that's causing pages to crash
## WHY
We don't actually display this info to users, it's just part of the serialization template (probably a left-over).  I consulted with Curriculum, and it sounds like they don't care about the value of Author, so if it's not set they want their content to still work.
## HOW
Just nil check the value before trying to get attributes from it

### Notion Card Links
https://www.notion.so/quill/SB-Rec-Pack-page-not-loading-1cb56b48370346b6b5a153bf2b8cf505

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No real behavior changes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
