### PR TITLE
link to specific activity filters in activity library

### DIFF
--- a/services/QuillLMS/app/views/pages/connect_tool.erb
+++ b/services/QuillLMS/app/views/pages/connect_tool.erb
@@ -246,7 +246,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Connect.
         </h1>
-        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library?activityClassificationFilters[]=connect' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/app/views/pages/grammar_tool.erb
+++ b/services/QuillLMS/app/views/pages/grammar_tool.erb
@@ -132,7 +132,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Grammar.
         </h1>
-        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library?activityClassificationFilters[]=sentence' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/app/views/pages/proofreader_tool.erb
+++ b/services/QuillLMS/app/views/pages/proofreader_tool.erb
@@ -110,7 +110,7 @@
         <h1 class='q-h1'>
             Get started now! Assign Quill Proofreader.
         </h1>
-        <a href='/assign/activity-library' class="q-button cta-button bg-quillgreen text-white">Assign</a>
+        <a href='/assign/activity-library?activityClassificationFilters[]=passage' class="q-button cta-button bg-quillgreen text-white">Assign</a>
     </section>
     <% end %>
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
@@ -184,7 +184,7 @@ export default class ClassroomLessons extends React.Component {
   }
 
   renderEmptyState() {
-    const assignLessonsLink = <a className="bg-quillgreen text-white" href="/teachers/classrooms/assign_activities/create-unit?tool=lessons" target="_blank">Assign Lessons</a>  // eslint-disable-line react/jsx-no-target-blank
+    const assignLessonsLink = <a className="bg-quillgreen text-white" href="/assign/activity-library?activityClassificationFilters[]=lessons" target="_blank">Assign Lessons</a>  // eslint-disable-line react/jsx-no-target-blank
     const learnMoreLink = <a className="bg-white text-quillgreen" href="/tools/lessons" target="_blank">Learn More</a> // eslint-disable-line react/jsx-no-target-blank
     return (<div className="empty-lessons manage-units">
       <div className="content">


### PR DESCRIPTION
## WHAT
Link to specific classification filters in the activity library where that makes more sense with our call to action.

## WHY
To help teachers find the activities they're looking for.

## HOW
Just update the links.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Make-buttons-that-are-linking-to-the-Activity-Library-more-specific-to-the-tool-they-are-mentioning-c4a83e0db68144b4a29cf0480745fdc3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
