### PR TITLE
update report boxes to make sure prompts have the correct spacing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import createReactClass from 'create-react-class';
 
-import formatString from './formatString'
+import { formatString, formatStringAndAddSpacesAfterPeriods, } from './formatString'
 
 import ScoreColor from '../../modules/score_color.js'
 import ConceptResultTableRow from './concept_result_table_row.tsx'
@@ -118,7 +118,7 @@ export default createReactClass({
             <tr>
               <td>Prompt</td>
               <td />
-              <td>{formatString(prompt).replace(/\.(?=[^ ])/g, '. ')}</td>
+              <td>{formatStringAndAddSpacesAfterPeriods(data.prompt)}</td>
             </tr>
             {this.questionScore()}
             {this.emptyRow()}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
@@ -1,5 +1,7 @@
-const formatString = (str: string) => {
+export const formatString = (str: string) => {
   return str.replace(/&#x27;/g, "'").replace(/&nbsp;/g, '').replace(/(<([^>]+)>)/ig, '').replace(/&quot;/g, '"')
 }
 
-export default formatString
+export const formatStringAndAddSpacesAfterPeriods = (str: string) => {
+  return formatString(str).replace(/\.(?=[^ ])/g, '. ')
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import formatString from './formatString'
+
+import { formatString, formatStringAndAddSpacesAfterPeriods, } from './formatString'
 
 import ScoreColor from '../../modules/score_color.js'
 import ConceptResultTableRow from './concept_result_table_row.tsx'
@@ -34,7 +35,7 @@ export class StudentReportBox extends React.Component<StudentReportBoxProps> {
       <tr>
         <td>Prompt</td>
         <td />
-        <td><span dangerouslySetInnerHTML={{ __html: formatString(prompt).replace(/\.(?=[^ ])/g, '. ')}} /></td>
+        <td><span dangerouslySetInnerHTML={{ __html: formatStringAndAddSpacesAfterPeriods(prompt)}} /></td>
       </tr>
     );
   }


### PR DESCRIPTION
## WHAT
Prompts that have two or more sentences sometimes lack spaces between those sentences on the reports page. This fixes that.

## WHY
We don't want to have incorrect spacing on a teacher-facing page.

## HOW
Just add a regex lookahead that finds periods that are not followed by a space and replaces them with a period followed by a space.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Ensure-there-are-spaces-between-sentences-in-the-Prompt-field-on-student-reports-2f831618b97348f997c57a065594e989

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
