### PR TITLE
stop asking new teachers for their location

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/sign_up.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/sign_up.scss
@@ -158,13 +158,13 @@
       font-size: 14px;
       padding: 16px 16px 18px;
       line-height: 1;
-      span {
+      .interactive-wrapper {
         cursor: pointer;
         color: #009a80;
         font-weight: 600;
       }
     }
-    .no-school-found, .no-location-found {
+    .no-school-found, .default-school-search {
       height: 258px;
       justify-content: center;
       display: flex;
@@ -186,7 +186,7 @@
         margin-bottom: 8px;
       }
     }
-    .no-location-found {
+    .default-school-search {
       .message {
         font-weight: 600;
       }


### PR DESCRIPTION
## WHAT
Stop asking teachers for their location when they select a school.

## WHY
User research demonstrated that they do not like this.

## HOW
Just get rid of code that requests or uses the teacher's location, and update the copy to reflect that they need to search for their school manually.

### Screenshots
<img width="451" alt="Screen Shot 2021-01-22 at 11 46 51 AM" src="https://user-images.githubusercontent.com/18669014/105520641-f33c2b80-5ca8-11eb-85d9-7b45d24cabca.png">
<img width="441" alt="Screen Shot 2021-01-22 at 11 47 03 AM" src="https://user-images.githubusercontent.com/18669014/105520642-f3d4c200-5ca8-11eb-99ac-d3bf767871b9.png">
<img width="798" alt="Screen Shot 2021-01-22 at 11 49 10 AM" src="https://user-images.githubusercontent.com/18669014/105520643-f3d4c200-5ca8-11eb-9dce-6f0f9369e280.png">


### Notion Card Links
https://www.notion.so/quill/Stop-asking-new-teachers-to-provide-their-location-e471232b68b342eca4cf5e63bed2b22c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
