### PR TITLE
removing old comprehension build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ jobs:
             cd services/QuillLMS
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
             bundle exec rspec -- ${TESTFILES}
-      - run:
-          name: Run engine tests 
-          command: |
-          cd services/QuillLMS/engines/comprehension
-          bundle exec rake test
   lms_node_build:
     working_directory: ~/Empirical-Core
     parallelism: 3
@@ -246,7 +241,6 @@ workflows:
       - lms_node_build
       - marking_logic_node_build
       - cms_rails_build
-      - comprehension_rails_build
       - comprehension_python_build
   lint-code:
     jobs:


### PR DESCRIPTION
## WHAT
- removes unused circleCi comprehension build step


## WHY
Shaves almost a minute off every build!

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
None.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (No)
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
