### PR TITLE
lms/tweak-class-code-word-list

### DIFF
--- a/services/QuillLMS/db/noun_3.db
+++ b/services/QuillLMS/db/noun_3.db
@@ -1,5 +1,4 @@
 away
-ball
 best
 black
 block


### PR DESCRIPTION

## WHAT
Removing "ball" from class name generation options
## WHY
Per Partnerships request because some students are as immature as me.  Hehe.  Ball.
## HOW
Just remove the word from the `nouns_3` list.

### Notion Card Links
https://www.notion.so/quill/Remove-ball-as-an-option-for-a-class-code-word-6294dc382a4441deb5c7512884d89ea8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on name generation data
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
