### PR TITLE
update activity pack page title formatting

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
@@ -6,13 +6,22 @@
   .unit-template-profile-container {
     margin: auto;
     width: 950px;
+    padding-top: 54px;
+
+    h2 {
+      font-size: 14px;
+      line-height: 1.5;
+      letter-spacing: normal;
+      text-align: center;
+      color: #646464;
+    }
 
     h1 {
       font-size: 24px;
       font-weight: bold;
       line-height: 1.33;
       text-align: center;
-      margin: 48px 0px 20px;
+      margin: 4px 0px 20px;
     }
 
     .ReactTable.unit-template-profile-activities .rt-table a img {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
@@ -96,12 +96,6 @@ export default class Stage2 extends React.Component {
 
   render() {
     const { unitTemplateName, unitTemplateId, selectedActivities, isFromDiagnosticPath, } = this.props
-    let assignName = 'Activity Pack'
-    if (unitTemplateName) {
-      assignName = unitTemplateName
-    } else if (selectedActivities.every(act => act.activity_classification.key === 'diagnostic')) {
-      assignName = 'Diagnostic'
-    }
     return (
       <div>
         <ScrollToTop />
@@ -112,7 +106,7 @@ export default class Stage2 extends React.Component {
           unitTemplateName={unitTemplateName}
         />
         <div className="name-and-assign-activity-pack container">
-          <h1 className="assign-header">Assign {assignName}</h1>
+          <h1 className="assign-header">Review and assign</h1>
           {this.renderNameSection()}
           {this.renderReviewActivitiesSection()}
           {this.renderAssignStudentsSection()}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -132,7 +132,8 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
           <ScrollToTop />
           {navigation}
           <div className="unit-template-profile-container">
-            <h1>Activity Pack: {name}</h1>
+            <h2>Activity Pack</h2>
+            <h1>{name}</h1>
             <UnitTemplateProfileActivityTable data={data} />
             <div className="first-content-section flex-row space-between first-content-section">
               <div className="description">


### PR DESCRIPTION
## WHAT
Small update to how the title of the featured activity pack and review activities pages are titled.

## WHY
To avoid double colons and reduce confusion.

## HOW
Just HTML/CSS updates.

### Screenshots
<img width="1227" alt="Screen Shot 2021-01-27 at 1 02 26 PM" src="https://user-images.githubusercontent.com/18669014/106033926-47c41a00-60a0-11eb-978c-4341926d4830.png">
<img width="1229" alt="Screen Shot 2021-01-27 at 1 02 15 PM" src="https://user-images.githubusercontent.com/18669014/106033931-47c41a00-60a0-11eb-9f8f-1970e9bda2b5.png">


### Notion Card Links
https://www.notion.so/quill/Change-title-formatting-on-the-activity-pack-and-assign-pages-10f699c272064430b423f4ff443fbd4f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
