### PR TITLE
fix quill logo size in Connect and Grammar

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/styles/components/_student-nav.scss
+++ b/services/QuillLMS/client/app/bundles/Connect/styles/components/_student-nav.scss
@@ -8,7 +8,4 @@
    font-weight: 600;
    line-height: normal;
   }
-  img {
-   height: 25px;
-  }
 }

--- a/services/QuillLMS/client/app/bundles/Grammar/styles/headerStyling.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/headerStyling.scss
@@ -8,7 +8,4 @@
    font-weight: 600;
    line-height: normal;
   }
-  img {
-   height: 25px;
-  }
 }


### PR DESCRIPTION
## WHAT
Make sure logo renders at proper size in Connect and Grammar.

## WHY
It was smaller than everywhere else in these two places for some reason.

## HOW
Remove CSS rules that were restricting logo size.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Quill-logo-too-small-in-Quill-Connect-and-Quill-Grammar-61a97ed99ed541ac8379ef50b4137691

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested (just CSS)
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
