### PR TITLE
Set response cache to 8 hours for now.

### DIFF
--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -7,7 +7,7 @@ class ResponsesController < ApplicationController
 
   RESPONSE_LIMIT = 100
   MULTIPLE_CHOICE_LIMIT = 2
-  CACHE_EXPIRY = 60.minutes.to_i
+  CACHE_EXPIRY = 8.hours.to_i
   # MAX_MATCHES: A heuristic to reduce controller compute time
   # see https://github.com/empirical-org/Empirical-Core/pull/7086/files
   # for more context


### PR DESCRIPTION
## WHAT
We are seeing really slow response times on these endpoints for non-cache hits. This will make non-cache hits less frequent. Doesn't solve the issue, but makes it less frequent.
## WHY
Performance. This is slow changing data, we can cache it longer for perfor
## HOW
Change constant.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tiny change
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A =
