### PR TITLE
lms/add-missing-nil-check

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/reducers/sessionReducer.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/reducers/sessionReducer.ts
@@ -39,7 +39,7 @@ export default (
             }
             changes.currentQuestion = changes.unansweredQuestions.splice(0, 1)[0]
             // we add the currentQuestion to questionSet only on first load
-            if(!currentState.questionSet.some(question => question && changes.currentQuestion && question.uid === changes.currentQuestion.uid)) {
+            if(changes.currentQuestion && !currentState.questionSet.some(question => question && question.uid === changes.currentQuestion.uid)) {
               changes.questionSet = [changes.currentQuestion, ...currentState.questionSet]
             }
             if (changes.currentQuestion) {


### PR DESCRIPTION
## WHAT
Add a nil-check to the "some" call in case array contains undefined
## WHY
It appears that when the last question has been answered, `questionSet` ends up containing `undefined`
## HOW
Just add a nil-check inside the `some` call

### Notion Card Links
https://www.notion.so/Next-button-frozen-in-activities-on-last-page-d57c1815b395462ebbc4a6f92035876d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A