### PR TITLE
Fix icon sizes in teacher name dropdown

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -130,11 +130,13 @@
       padding: 6px 12px;
       width: 100%;
       display: flex;
+      align-items: center;
       font-weight: 600px;
       color: #027360;
       .image-container {
         display: flex;
-        width: 22px;
+        max-height: 12px;
+        margin-right: 8px;
       }
       .hover {
         display: none;


### PR DESCRIPTION
## WHAT
fix the icon sizes in the teacher name dropdown (they appear larger in the new version of Chrome)

## WHY
so that they match the original design

## HOW
just updated some CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="193" alt="Screen Shot 2021-02-01 at 3 44 02 PM" src="https://user-images.githubusercontent.com/25959584/106521759-58133500-64a4-11eb-9914-d04e559af4a1.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Icons-too-large-in-the-teacher-name-dropdown-a433ee3b189148b5ae5dc0b569cb6768

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- just CSS
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
