### PR TITLE
Fix Nil Error - Sidekiq/SyncVitallyUsersWorker

### DIFF
--- a/services/QuillLMS/app/services/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/serialize_vitally_sales_user.rb
@@ -148,7 +148,7 @@ class SerializeVitallySalesUser
   end
 
   private def sum_students(records)
-    records.map { |r| r.assigned_student_ids.count }.sum || 0
+    records.map { |r| r&.assigned_student_ids&.count || 0 }.sum || 0
   end
 
   private def this_school_year(records, school_year_start)

--- a/services/QuillLMS/spec/services/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_vitally_sales_user_spec.rb
@@ -260,4 +260,15 @@ describe 'SerializeVitallySalesUser' do
       teacher_link: "https://www.quill.org/cms/users/#{teacher.id}/sign_in"
     )
   end
+  
+  context 'testing private methods' do
+    let(:teacher) { create(:teacher, :with_classrooms_students_and_activities) }
+    let(:classroom_unit) { [teacher.classroom_units[0]] }
+    let(:records) { classroom_unit + [nil] }
+    let(:vitally_user) { SerializeVitallySalesUser.new(teacher) }
+
+    it 'handles nil record #sum_students' do
+      expect(vitally_user.send(:sum_students, records)).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Resolve a sentry error involving `sum_students` method

## WHY
Some records passed to `sum_students` method contain nil objects.  These nil objects are subsequently asked `assigned_student_ids` which fails.

## HOW
Using safe navigation we can effectively skip these entries when tabulating the `sum_students`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Nil-Error-Sidekiq-SyncVitallyUsersWorker-b640cc21904e41c3b1acab1c4b63bc39

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
