### PR TITLE
add missing question prop for Cue component

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/__tests__/question.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/__tests__/question.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Question } from '../question';
+import Cues from '../../renderForQuestions/cues.jsx';
+
+// TODO: add more tests
+
+describe('Question component', () => {
+
+  const mockProps = {
+    match: {
+      params: {
+        questionID: 'abc'
+      }
+    },
+    questions: {
+      hasreceiveddata: true,
+      data: {
+        abc: {
+          value: 'test1'
+        },
+        def: {
+          value: 'test2'
+        },
+        ghi: {
+          value: 'test3'
+        }
+      },
+       states: {
+        abc: {
+          value: 'test1'
+        },
+        def: {
+          value: 'test2'
+        },
+        ghi: {
+          value: 'test3'
+        }
+       }
+    },
+    massEdit: {
+      numSelectedResponses: 3
+    }
+  }
+
+  const component = shallow(<Question {...mockProps} />);
+
+  it('passes the correct props to Cues component', () => {
+    expect(component.find(Cues).props().displayArrowAndText).toEqual(true);
+    expect(component.find(Cues).props().question).toEqual(mockProps.questions.data['abc']);
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/question.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/question.jsx
@@ -25,7 +25,7 @@ import { Modal, UploadOptimalResponses, } from '../../../Shared/index'
 
 const icon = `${process.env.CDN_URL}/images/icons/direction.svg`
 
-class Question extends React.Component {
+export class Question extends React.Component {
   constructor(props) {
     super(props)
 


### PR DESCRIPTION
## WHAT
add missing question prop for `Cue` component in admin Connect Question

## WHY
it was causing the question view page to crash

## HOW
just added missing prop to the `Cue` component

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Can-t-open-Connect-questions-in-Connect-admin-bbf8da613bd543e8a251ef7188dd8556

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
