### PR TITLE
lms/fix-fill-in-blank-turking

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/turk/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/turk/fillInBlank.tsx
@@ -9,6 +9,7 @@ import { getGradedResponsesWithCallback } from '../../actions/responses.js';
 import { Feedback, Prompt, } from '../../../Shared/index';
 import Cues from '../renderForQuestions/cues.jsx';
 import { hashToCollection, } from '../../../Shared/index'
+import updateResponseResource from '../renderForQuestions/updateResponseResource.js';
 
 const qml = require('quill-marking-logic')
 const checkFillInTheBlankQuestion = qml.checkFillInTheBlankQuestion
@@ -87,6 +88,12 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
     return inputs;
   }
 
+  updateResponseResource = (response) => {
+    const { dispatch, } = this.props
+
+    updateResponseResource(response, this.getQuestion().key, this.getQuestion().attempts, dispatch);
+  }
+
   handleChange(i, e) {
     const { inputVals, } = this.state
     const existing = [...inputVals];
@@ -148,6 +155,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
     return (
       <span key={`span${i}`}>
         <input
+          aria-label="text input"
           className={className}
           id={`input${i}`}
           key={i + 100}
@@ -203,6 +211,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
       const responsesArray = hashToCollection(responses);
       const response = {response: checkFillInTheBlankQuestion(questionUID, zippedAnswer, responsesArray, caseInsensitive, defaultConceptUID)}
       this.setResponse(response);
+      this.updateResponseResource(response)
       submitResponse(response);
       this.setState({
         response: '',


### PR DESCRIPTION
## WHAT
Fix a bug in Fill in the Blank Turking that failed to record turked responses.
## WHY
While rare, Curriculum still does create new Fill in the Blank activities on occasion, and needs to be able to Turk them.
## HOW
Submit responses to the CMS when turking Fill in Blank questions while handling the rest of the things we do when an answer is submitted.  This code mirrors the code for non-Turked plays of Fill in the Blank

### Notion Card Links
https://www.notion.so/quill/Activity-not-recording-turked-responses-5211c9de808843f99635bd1f393f7251

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this functionality
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
