### PR TITLE
Fix dev-blocking bug on Comprehension

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/engine.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/engine.rb
@@ -1,7 +1,7 @@
 # require_relative '../quill_scaffold_controller'
 module Comprehension
   class Engine < ::Rails::Engine
-    config.eager_load_paths << "#{config.root}/lib/comprehension"
+    config.eager_load_paths += %W{#{config.root}/lib/comprehension}
     isolate_namespace Comprehension
 
     config.generators do |g|


### PR DESCRIPTION
## WHAT
Fix a line of code that was causing LMS to crash locally for developers.

## WHY
We want to unblock the developer team and have clean, working code for everyone.

## HOW
Change the syntax on that line so it doesn't cause a `frozenArray` error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested locally and on Eric's dev environment
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
