### PR TITLE
Revert "CMS - Delay response writes until off hours. (#7187)"

### DIFF
--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -36,8 +36,7 @@ class ResponsesController < ApplicationController
   # POST /responses/create_or_increment
   def create_or_increment
     transformed_response = transformed_new_vals(params_for_create).to_h
-    # delaying this to off-hours to eliminate read/write traffic in peak hours
-    CreateOrIncrementResponseWorker.perform_in(6.hours, transformed_response)
+    CreateOrIncrementResponseWorker.perform_async(transformed_response)
     render json: {}
   end
 

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -19,46 +19,46 @@ RSpec.describe ResponsesController, type: :controller do
     get_ids(array&.select { |r| r['parent_id'].nil?})
   end
 
-  describe "#count_affected_by_incorrect_sequences" do
-    before(:each) do
+  describe "#count_affected_by_incorrect_sequences" do 
+    before(:each) do 
       create(:response, question_uid: '123', text: "some words", optimal: nil)
       create(:response, question_uid: '123', text: "matchyword some words", optimal: nil)
       create(:response, question_uid: '123', text: "some matchyword words", optimal: nil)
     end
 
-    it 'should enumerate matching responses' do
+    it 'should enumerate matching responses' do 
       post :count_affected_by_incorrect_sequences, params: {
         "data" => {
-          "used_sequences"=>[],
+          "used_sequences"=>[], 
           "selected_sequences"=>["matchyword", ""]
-          },
-          "question_uid"=>'123',
+          }, 
+          "question_uid"=>'123', 
           "response"=>{}
       }
       matched_count = JSON.parse(response.body)["matchedCount"]
       expect(matched_count).to eq 2
     end
 
-    it 'should enumerate matching responses with && delimited input' do
+    it 'should enumerate matching responses with && delimited input' do 
       post :count_affected_by_incorrect_sequences, params: {
         "data" => {
-          "used_sequences"=>[],
+          "used_sequences"=>[], 
           "selected_sequences"=>["matchyword&&some", ""]
-          },
-          "question_uid"=>'123',
+          }, 
+          "question_uid"=>'123', 
           "response"=>{}
       }
       matched_count = JSON.parse(response.body)["matchedCount"]
       expect(matched_count).to eq 2
     end
 
-    it 'should not match when sequences are already used' do
+    it 'should not match when sequences are already used' do 
       post :count_affected_by_incorrect_sequences, params: {
         "data" => {
-          "used_sequences"=>['matchyword'],
+          "used_sequences"=>['matchyword'], 
           "selected_sequences"=>["matchy&&word", ""]
-          },
-          "question_uid"=>'123',
+          }, 
+          "question_uid"=>'123', 
           "response"=>{}
       }
       matched_count = JSON.parse(response.body)["matchedCount"]
@@ -76,13 +76,13 @@ RSpec.describe ResponsesController, type: :controller do
     end
 
     it 'should enqueue CreateOrIncrementResponseWorker' do
-      expect(CreateOrIncrementResponseWorker).to receive(:perform_in).with(6.hours, response_payload)
+      expect(CreateOrIncrementResponseWorker).to receive(:perform_async).with(response_payload)
       post :create_or_increment, params: {response: response_payload}
 
     end
 
     it 'should return a 200' do
-      allow(CreateOrIncrementResponseWorker).to receive(:perform_in)
+      allow(CreateOrIncrementResponseWorker).to receive(:perform_async)
       post :create_or_increment, params: {response: response_payload}
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
This reverts commit e63f709a1eda07497604dd0ad0dc63d715488be7.

## WHAT
Removes delay on Response workers 

## WHY
It's interfering with the curriculum team's workflows, and the underlying performance issue may be resolved tomorrow with the Rails 6 upgrade.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | n/a
