### PR TITLE
Expire all password-refresh-tokens nightly, make refresh tokens one-use

### DIFF
--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -38,6 +38,7 @@ class PasswordResetController < ApplicationController
     @user = User.find_by_token!(params[:id])
     @user.update_attributes params[:user].permit(:password)
     @user.save validate: false
+    @user.update!(token: nil)
     sign_in @user
     flash[:notice] = 'Your password has been updated.'
     flash.keep(:notice)

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -21,6 +21,7 @@ class Cron
     RenewExpiringRecurringSubscriptionsWorker.perform_async
     ResetDemoAccountWorker.perform_async
     SyncVitallyWorker.perform_async
+    ExpireUserTokensWorker.perform_async
   end
 
   def self.run_saturday

--- a/services/QuillLMS/app/workers/expire_user_tokens_worker.rb
+++ b/services/QuillLMS/app/workers/expire_user_tokens_worker.rb
@@ -1,0 +1,8 @@
+class ExpireUserTokensWorker
+  include Sidekiq::Worker
+
+  def perform
+    User.where.not(token: nil).each {|u| u.update!(token: nil)}
+  end
+
+end

--- a/services/QuillLMS/spec/controllers/password_reset_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/password_reset_controller_spec.rb
@@ -72,6 +72,7 @@ describe PasswordResetController do
       post :update, id: @user.token, user: { password: "test123" }
       expect(session[:user_id]).to eq @user.id
       expect(response.body).to eq({ redirect: '/profile'}.to_json)
+      expect(@user.reload.token).to eq nil
     end
 
   end

--- a/services/QuillLMS/spec/workers/expire_user_tokens_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/expire_user_tokens_worker_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe ExpireUserTokensWorker do 
+  let(:subject) { described_class.new }
+  
+  describe '#perform' do 
+    let!(:user) { create(:user) }
+    let!(:user_2) { create(:user) }
+
+    it 'should set user token to nil' do 
+      user.refresh_token!
+      user_2.refresh_token!
+      subject.perform
+      expect(user.reload.token).to eq nil
+      expect(user_2.reload.token).to eq nil
+    end
+  end
+end
+


### PR DESCRIPTION
## WHAT
Our Forgot Password Token system is out of compliance with CollegeBoard security requirements. The link we give users to reset their password remains permanently valid and can be used multiple times. I wrote a nightly job to expire all the reset-password-links, and expire links after one use.

## WHY
To meet compliance with CollegeBoard site security standards.

## HOW
-A Sidekiq job that runs nightly to expire all current reset-password links. 
-Expire the password token after one use.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Insecure-Password-Reset-94a64fc2acda4fb1af605e26653b1718

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A