### PR TITLE
removing strong param restriction in development, updating FeedbackHi…

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
@@ -73,19 +73,25 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
   end
 
   private def batch_feedback_history_params
-    params.permit(feedback_histories: [
-      :activity_session_uid,
-      :prompt_id,
-      :concept_uid,
-      :attempt,
-      :entry,
-      :feedback_text,
-      :feedback_type,
-      :optimal,
-      :used,
-      :time,
-      :metadata,
-      :rule_uid
-    ])[:feedback_histories]
+    # Note: nested params MUST be permitted last in any list
+    params.permit(
+      feedback_histories: [
+        :activity_session_uid,
+        :prompt_id,
+        :concept_uid,
+        :attempt,
+        :entry,
+        :feedback_text,
+        :feedback_type,
+        :optimal,
+        :used,
+        :time,
+        :rule_uid,
+        metadata: [
+          :response_id,
+          highlight: []
+        ]
+      ]
+    )[:feedback_histories]
   end
 end

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -60,6 +60,8 @@ module EmpiricalGrammar
     # Aug 21, 2018 Max Buck]
     config.active_record.schema_format = :sql
 
+    config.action_controller.always_permitted_parameters = %w(controller action format)
+
     # http://stackoverflow.com/questions/14647731/rails-converts-empty-arrays-into-nils-in-params-of-the-request
     config.action_dispatch.perform_deep_munge = false
 

--- a/services/QuillLMS/config/environments/development.rb
+++ b/services/QuillLMS/config/environments/development.rb
@@ -18,7 +18,7 @@ EmpiricalGrammar::Application.configure do
   config.action_controller.asset_host
 
   # Raise an error in development when an invalid parameter is passed.
-  config.action_controller.action_on_unpermitted_parameters = :raise
+  # config.action_controller.action_on_unpermitted_parameters = :raise
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -78,7 +78,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       post :batch, feedback_histories: [{ activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'semantic', metadata: {foo: 'bar'} },
+                                          feedback_type: 'semantic', metadata: {highlight: [], response_id: "0", rule_uid: ""} },
                                         { activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',


### PR DESCRIPTION

## WHAT & WHY
- Permits metadata as a nested json structure so that FeedbackHistories will be recorded properly.
- adds 'always_permitted_parameters' to application.rb so that strong param checking won't choke on rails default params like 'format', which are not necessarily part of an external request
- removes exception raising on unpermitted params in develop, to reflect the production environment.


## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Persist-grammar-feedback-to-feedback_history-37f98751fb344c0d926f41d7edd3cc6d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
