### PR TITLE
migration to add student feedback tables

### DIFF
--- a/services/QuillLMS/db/migrate/20210216195544_create_student_feedback_responses.rb
+++ b/services/QuillLMS/db/migrate/20210216195544_create_student_feedback_responses.rb
@@ -1,9 +1,9 @@
 class CreateStudentFeedbackResponses < ActiveRecord::Migration
   def change
     create_table :student_feedback_responses do |t|
-      t.text :question
-      t.text :response
-      t.string :grade_levels, array: true
+      t.text :question, default: ''
+      t.text :response, default: ''
+      t.string :grade_levels, array: true, default: []
     end
   end
 end


### PR DESCRIPTION
## WHAT
Just the migration to add a `student_feedback_responses` table to the database.

## WHY
We need it for the following PR, which adds a form for students to submit their feedback for Quill activities.

## HOW
Just create a migration with the necessary tables.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Allow-students-to-submit-content-suggestions-b4d6f122f31649c4a70814f365127da8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  See next PR
Have you deployed to Staging? | See next PR
Self-Review: Have you done an initial self-review of the code below on Github? | See next PR
Design Review: If applicable, have you compared the coded design to the mockups? | See next PR
