### PR TITLE
change css to fix layout issue

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -107,8 +107,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    width: 70vw;
-    border-right: 1px solid lightgray;
+    width: 100%;
     .tabs-container {
       display: flex;
       width: 100%;


### PR DESCRIPTION
## WHAT
Small CSS fix for misaligned table.

## WHY
Table was overlapping with left navigation panel.

## HOW
Just update the CSS.

### Screenshots
<img width="1440" alt="Screen Shot 2021-02-17 at 10 28 07 AM" src="https://user-images.githubusercontent.com/18669014/108226529-fe00a980-710a-11eb-96f2-f14dae3248f8.png">

### Notion Card Links
https://www.notion.so/quill/Page-Layout-Fixes-Internal-Tool-cb0b585d2f1e42ff8fd9345b41ebbee6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
