### PR TITLE
fix bug with changing prompt text in Comprehension

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -119,7 +119,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
       const splitSubmission = text.split('&nbsp;')
 
       // handles case where change is only in the formatted prompt part
-      if (splitSubmission[1]) {
+      if (splitSubmission.length > 1) {
         const newValue = `${formattedPrompt}${splitSubmission[1]}`
         this.setState({ html: newValue}, () => {
           this.editor.innerHTML = newValue


### PR DESCRIPTION
## WHAT
Fix bug that occurred when students changed the text of a prompt in Comprehension.

## WHY
If students change the part of the text box that is the prompt, nothing should happen.

## HOW
Fix edge case that rested on an empty string evaluating to `false` in Javascript by just checking for the length of an array rather than the presence of a second element.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentence-stem-bug-83e12eb680584b0c8d1aeb699e69ec49

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
