### PR TITLE
add migration for image link and image alt text to comprehension_passages table

### DIFF
--- a/services/QuillLMS/db/migrate/20210219164011_add_image_link_and_image_alt_text_to_passages.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210219164011_add_image_link_and_image_alt_text_to_passages.comprehension.rb
@@ -1,0 +1,7 @@
+# This migration comes from comprehension (originally 20210219163806)
+class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration
+  def change
+    add_column :comprehension_passages, :image_link, :string
+    add_column :comprehension_passages, :image_alt_text, :string, default: ''
+  end
+end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210219163806_add_image_link_and_image_alt_text_to_passages.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210219163806_add_image_link_and_image_alt_text_to_passages.rb
@@ -1,0 +1,6 @@
+class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration
+  def change
+    add_column :comprehension_passages, :image_link, :string
+    add_column :comprehension_passages, :image_alt_text, :string, default: ''
+  end
+end


### PR DESCRIPTION
## WHAT
Add migration for image link and image alt text to comprehension_passages table

## WHY
We need these attributes to display images inside of Comprehension passages.

## HOW
Add new migration to the `engines/comprehension/db` file and then run it using the command from the ReadMe, which then duplicated the migration to the exterior folder. I added a default to the alt text but not the image link itself, because we're going to check for the presence of that to determine whether to actually show an image or not, so we do want that to be nil if there's nothing there.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Markdown-to-Support-Images-in-Passages-b8c3a8afb70d4630ad6551009034eef0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, just a migration
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
