### PR TITLE
Change default instructions for fill in the blank prompts

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankQuestion.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankQuestion.jsx
@@ -50,7 +50,7 @@ export class FillInBlankQuestion extends Component {
           />
           <div className="feedback-row student-feedback-inner-container admin-feedback-row">
             <img alt="Directions Icon" className="info" src={icon} />
-            <p>{question.instructions || 'Combine the sentences into one sentence.'}</p>
+            <p>{question.instructions || 'Fill in the blank with the correct option.'}</p>
           </div>
           <p className="control button-group" style={{ marginTop: 10, }}>
             <Link className="button is-outlined is-primary" to='edit'>Edit Question</Link>


### PR DESCRIPTION
## WHAT
Change the default instructions for fill in the blank prompts.

## WHY
These instructions were wrong, which leads to erroneously formatted Fill in the Blank prompts.

## HOW
Make the copy edit to that one line of instruction.

### Screenshots
![Screen Shot 2021-02-19 at 12 29 50 PM](https://user-images.githubusercontent.com/57366100/108546425-b61a8780-72ae-11eb-8028-8e1458ada22a.png)


### Notion Card Links
https://www.notion.so/quill/Default-FITB-Instructions-a8ab3abe181641c59b88adb04f24b7fd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - tiny copy change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
