### PR TITLE
Skip archiving classroom associations when merging classrooms with Teacher Fix

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -96,6 +96,7 @@ module TeacherFixes
   def self.move_students_from_one_class_to_another(class_id1, class_id2)
     StudentsClassrooms.where(classroom_id: class_id1).each do |sc|
       if StudentsClassrooms.unscoped.find_by(classroom_id: class_id2, student_id: sc.student_id)
+        sc.skip_archive_student_associations = true
         sc.update(visible: false)
       else
         sc.update(classroom_id: class_id2)

--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -21,10 +21,12 @@ class StudentsClassrooms < ActiveRecord::Base
   belongs_to :classroom, class_name: "Classroom"
   # validates uniqueness of student/classroom on db
   after_save :checkbox, :run_associator
-  after_save :archive_student_associations_for_classroom, if: proc { |sc| !sc.visible && sc.student && sc.classroom }
+  after_save :archive_student_associations_for_classroom, if: proc { |sc| !sc.visible && sc.student && sc.classroom }, unless: :skip_archive_student_associations
   after_commit :invalidate_classroom_minis
 
   default_scope { where(visible: true)}
+
+  attr_accessor :skip_archive_student_associations
 
   def archived_classrooms_manager
     {joinDate: created_at.strftime("%m/%d/%Y"), className: classroom.name, teacherName: classroom.owner.name, id: id}

--- a/services/QuillLMS/spec/controllers/concerns/teacher_fixes_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/teacher_fixes_spec.rb
@@ -180,5 +180,26 @@ describe TeacherFixes do
         TeacherFixes::merge_two_classroom_units(cu1.reload, cu2.reload)
       end
     end
+
+    describe '#move_students_from_one_class_to_another' do
+      it 'should update the classroom values if existing StudentClassroom record is not found' do
+        student_classrooms = StudentsClassrooms.where(classroom_id: classroom.id)
+        TeacherFixes::move_students_from_one_class_to_another(classroom.id, classroom2.id)
+        student_classrooms.each do |sc|
+          expect(sc.classroom).to eq(classroom2)
+        end
+      end
+
+      it 'should archive the old StudentClassroom record if existing StudentClassroom record is found' do
+        student_classrooms = StudentsClassrooms.where(classroom_id: classroom.id)
+        create(:students_classrooms, student: student1, classroom: classroom2)
+        create(:students_classrooms, student: student2, classroom: classroom2)
+        TeacherFixes::move_students_from_one_class_to_another(classroom.id, classroom2.id)
+        student_classrooms.each do |sc|
+          expect(sc.skip_archive_student_associations).to eq(true)
+          expect(sc.visible).to eq(false)
+        end
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/models/students_classrooms_spec.rb
+++ b/services/QuillLMS/spec/models/students_classrooms_spec.rb
@@ -66,6 +66,12 @@ describe StudentsClassrooms, type: :model, redis: true do
         expect(ArchiveStudentAssociationsForClassroomWorker).to receive(:perform_async).with(student.id, student_classroom.classroom_id)
         student_classroom.update(visible: false)
       end
+
+      it "should not call the ArchiveStudentAssociationsForClassroomWorker if skip attribute is set to true" do
+        student_classroom.skip_archive_student_associations = true
+        expect(ArchiveStudentAssociationsForClassroomWorker).not_to receive(:perform_async).with(student.id, student_classroom.classroom_id)
+        student_classroom.update(visible: false)
+      end
     end
 
     context 'invalidate_classroom_minis' do


### PR DESCRIPTION
## WHAT
We currently have a race condition in our code. If an admin uses Teacher Fix to Merge Two Classrooms, we trigger a bunch of asynchronous `ArchiveStudentAssociationsForClassroomsWorker` workers to remove the students in classroom1 from all their classroom units. This is NOT necessary and erases student data that we actually want to move over to the new classroom.

## WHY
We want to fix a frustrating bug where our Support staff have to spend a lot of time manually un-archiving ClassroomUnits every time they try to merge two classrooms.

## HOW
Add an attribute to the `StudentClassroom` model that allows us to easily skip this callback when we want to. Skip the callback in all cases where we are actually merging classrooms and we don't want to archive ClassroomUnit data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Merge-Classes-Teacher-Fix-button-not-successfully-merging-data-2d6c809351ed41d7a7a38c9b418b8f93

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
