### PR TITLE
fix grammar css

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/styles/question.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/question.scss
@@ -1,5 +1,5 @@
 .question {
-  padding-bottom: 100px;
+  padding: 0px 30px 100px;
 
   h1 {
     font-size: 22px;

--- a/services/QuillLMS/client/app/bundles/Grammar/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/style.scss
@@ -28,10 +28,6 @@ body, #app {
   }
 }
 
-#main-content {
-  padding: 0px 30px;
-}
-
 button.card-footer-item {
   color: #3273dc;
   cursor: pointer;


### PR DESCRIPTION
## WHAT
Small fix for CSS issue in Grammar where the question size was not responsive.

## WHY
We want the styling not to change.

## HOW
Just add the necessary CSS rules.

### Screenshots
<img width="1440" alt="Screen Shot 2021-02-22 at 9 58 26 AM" src="https://user-images.githubusercontent.com/18669014/108726599-9aed8900-74f5-11eb-8cf7-a6478e29c2b9.png">
<img width="1440" alt="Screen Shot 2021-02-22 at 10 05 22 AM" src="https://user-images.githubusercontent.com/18669014/108726603-9c1eb600-74f5-11eb-8a44-d5ca6635bed4.png">
<img width="1440" alt="Screen Shot 2021-02-22 at 10 05 30 AM" src="https://user-images.githubusercontent.com/18669014/108726604-9c1eb600-74f5-11eb-94b4-cbfc6c718c71.png">
<img width="197" alt="Screen Shot 2021-02-22 at 10 05 51 AM" src="https://user-images.githubusercontent.com/18669014/108726916-f455b800-74f5-11eb-8a43-5f73725893fd.png">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - non-app change, NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
