### PR TITLE
make sure tables scroll instead of expanding on smaller screen widths in Comprehension internal tool

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -3,7 +3,7 @@
   border-bottom: 1px solid lightgray;
   overflow: auto;
   .left-side-menu {
-    width: 15vw;
+    width: 200px;
     height: 80vh;
     padding: 20px;
   }
@@ -107,7 +107,8 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    width: 100%;
+    width: calc(100vw - 200px);
+    padding: 0px 20px;    
     .tabs-container {
       display: flex;
       width: 100%;
@@ -320,6 +321,8 @@
       }
     }
     .rules-table, .rule-table, .turk-sessions-table {
+      max-width: 100%;
+      overflow: scroll;
       .data-table-body{
         max-height: 500px;
         overflow: auto;


### PR DESCRIPTION
## WHAT
Add some additional CSS to handle smaller screen widths for Comprehension internal tool layout.

## WHY
We were still having the issue where the data table ran over on a smaller screen.

## HOW
Some more CSS.

### Screenshots
<img width="932" alt="Screen Shot 2021-02-22 at 10 56 52 AM" src="https://user-images.githubusercontent.com/18669014/108733929-eb1c1980-74fc-11eb-86dd-fea54fcf17fb.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - just CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES