### PR TITLE
don't allow multiple submissions of the same response to student feedback questions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Student/startup/StudentFeedbackModalAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Student/startup/StudentFeedbackModalAppClient.jsx
@@ -5,6 +5,7 @@ import { requestPost } from '../../../modules/request/index.js';
 
 const StudentFeedbackModal = ({ question, gradeLevels, }) => {
   const [response, setResponse] = React.useState('')
+  const [submitting, setSubmitting] = React.useState(false)
 
   function updateResponse(e) {
     setResponse(e.target.value)
@@ -18,6 +19,9 @@ const StudentFeedbackModal = ({ question, gradeLevels, }) => {
 
   function handleClickSave(e) {
     e.preventDefault()
+    if (submitting) { return }
+
+    setSubmitting(true)
     requestPost('/student_feedback_responses', { student_feedback_response: { question, response, grade_levels: gradeLevels } }, () => {
       document.getElementById('student-feedback-modal-component').style.display = 'none'
       document.cookie = `student_feedback_banner_1_closed=1; path=/`;
@@ -27,7 +31,7 @@ const StudentFeedbackModal = ({ question, gradeLevels, }) => {
   }
 
   let saveButtonClass = 'quill-button contained primary medium focus-on-light';
-  if (!response.length) {
+  if (!response.length || submitting) {
     saveButtonClass += ' disabled';
   }
 


### PR DESCRIPTION
## WHAT
Prevent clicking the Submit button multiple times from creating duplicate submissions in the student feedback modal.

## WHY
We want clean records.

## HOW
Just keep track of a `submitting` state variable, and don't send additional requests once the first one has been made.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
