### PR TITLE
add timestamps to student feedback responses

### DIFF
--- a/services/QuillLMS/db/migrate/20210222201347_add_timestamps_to_student_feedback.rb
+++ b/services/QuillLMS/db/migrate/20210222201347_add_timestamps_to_student_feedback.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToStudentFeedback < ActiveRecord::Migration
+  def change
+    add_timestamps :student_feedback_responses
+  end
+end


### PR DESCRIPTION
## WHAT
Add timestamps to student feedback responses.

## WHY
We want to know when responses were submitted, and I forgot that you have to include this explicitly.

## HOW
Just add a migration that will add them.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
