### PR TITLE
fix issue with rendering student feedback banner on some pages

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
@@ -40,6 +40,7 @@ import Ap from './ApAppClient';
 import SpringBoard from './SpringBoardAppClient.tsx';
 
 import StudentNavbarItems from '../../Student/startup/StudentNavbarItemsAppClient'
+import StudentFeedbackModal from '../../Student/startup/StudentFeedbackModalAppClient'
 
 require('../../../assets/styles/home.scss');
 
@@ -81,5 +82,6 @@ ReactOnRails.register({ TeacherGuideApp,
   QuestionsAndAnswersSection,
   PreAp,
   Ap,
-  SpringBoard
+  SpringBoard,
+  StudentFeedbackModal
 });


### PR DESCRIPTION
## WHAT
Fix problem where the activity session review page would load with nothing on it.

## WHY
We want students to be able to see their results.

## HOW

Import the student feedback modal component into the teacher bundle as well since that's where this page is rendered from.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/students-getting-white-screen-after-completing-activities-d735ee232ada46de873818e4613d060b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
