### PR TITLE
Catch invalid regex text before it is saved and return error message

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -30,7 +30,7 @@ module Comprehension
       begin
         Regexp.new(regex_text)
       rescue RegexpError => e
-        self.rule.errors.add(:errors, "Invalid regex: #{e}")
+        rule.errors.add(:errors, "Invalid regex: #{e}")
         false
       end
     end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
@@ -102,8 +102,7 @@ module Comprehension
                 regex_text: '(invalid|',
                 case_sensitive: false
               }
-            ]
-          }
+            ]}
 
         parsed_response = JSON.parse(response.body)
 


### PR DESCRIPTION
## WHAT
Add a callback to check regex text for incorrectly written regex before it is saved into the record. If there is invalid regex, return the full error message in the response payload.

## WHY
Prevent incorrect regex from getting into the db and causing issues on turkers' or students' end.

## HOW
Add a `before_save` callback to check the regex and raise any errors first, so incorrect regex will never be saved into the record.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/V2-Comprehension-RegEx-Error-handling-a6803fba056d452992995a834d117482

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
