### PR TITLE
update feedback_types enum

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -40,7 +40,8 @@ class FeedbackHistory < ActiveRecord::Base
     PLAGIARISM = "plagiarism",
     RULES_BASED = "rules-based",
     SEMANTIC = "semantic",
-    SPELLING = "spelling"
+    SPELLING = "spelling",
+    OPINION = "opinion"
   ]
 
   before_validation :confirm_prompt_type, on: :create


### PR DESCRIPTION
## WHAT
Add's 'opinion' to enum

## WHY
So that go <> oapi integration works.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/persist-opinion-responses-to-feedback_history-00ca3ee18ac9407eb2f596184ab726c0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
