### PR TITLE
Stop displaying student feedback banner

### DIFF
--- a/services/QuillLMS/app/views/layouts/application.html.erb
+++ b/services/QuillLMS/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
       <%= content_tag(:div, "<p>#{value}</p><i class='fas fa-times-circle' aria-hidden='true'></i>".html_safe, {class: "flash #{key}", onClick: "$(this).slideUp(300)"}) %>
     <% end %>
     <%= render partial: 'application/preview_student_banner' %>
-    <%= render partial: 'application/student_feedback_banner' %>
     <%= render partial: 'application/webinar_banner' %>
     <% if ENV['UPGRADE'] && ENV['UPGRADE_END_TIME'] && Time.now < Time.parse(ENV['UPGRADE_END_TIME'])%>
       <%= render partial: 'application/upgraded_bar' %>


### PR DESCRIPTION
## WHAT
Stop displaying student feedback banner.

## WHY
Curriculum requested that we stop showing students this banner for now.

## HOW
Remove the line that renders the banner view.

### Screenshots
<img width="1065" alt="Screen Shot 2021-02-24 at 1 42 53 PM" src="https://user-images.githubusercontent.com/57366100/109056590-3b82ab00-76a6-11eb-9668-0ecee4e1374d.png">


### Notion Card Links
https://www.notion.so/quill/Remove-student-feedback-form-45a3e5a3a61a44f0b9bda4ca6bbf4ede

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested manually
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
