### PR TITLE
Synthetic Data Script - Port to Ruby, add customizations

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -141,6 +141,9 @@ gem 'rack-heartbeat'
 
 # INTEGRATIONS
 gem 'clever-ruby', '~> 2.0.1'
+# Note, there is a version 3 of this gem, but we'd need to update our google-api-client
+# google-cloud-translate-v3
+gem 'google-cloud-translate'
 
 group :production, :staging do
   gem 'rails_12factor'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -223,6 +223,29 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
+    google-cloud-core (1.5.0)
+      google-cloud-env (~> 1.0)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (1.3.0)
+      faraday (~> 0.11)
+    google-cloud-errors (1.0.1)
+    google-cloud-translate (2.0.0)
+      faraday (~> 0.13)
+      google-cloud-core (~> 1.2)
+      google-gax (~> 1.7)
+    google-gax (1.7.1)
+      google-protobuf (~> 3.2)
+      googleapis-common-protos (>= 1.3.5, < 2.0)
+      googleauth (>= 0.6.2, < 0.10.0)
+      grpc (>= 1.7.2, < 2.0)
+      rly (~> 0.2.3)
+    google-protobuf (3.15.1-universal-darwin)
+    googleapis-common-protos (1.3.11)
+      google-protobuf (~> 3.14)
+      googleapis-common-protos-types (>= 1.0.6, < 2.0)
+      grpc (~> 1.27)
+    googleapis-common-protos-types (1.0.6)
+      google-protobuf (~> 3.14)
     googleauth (0.8.0)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
@@ -234,6 +257,9 @@ GEM
       railties
       sprockets-rails
     graphql (1.11.7)
+    grpc (1.35.0-universal-darwin)
+      google-protobuf (~> 3.14)
+      googleapis-common-protos-types (~> 1.0)
     guard (2.15.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -563,6 +589,7 @@ GEM
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
     retriable (1.4.1)
+    rly (0.2.3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -772,6 +799,7 @@ DEPENDENCIES
   fuubar (~> 2.0.0.rc1)
   global
   google-api-client (= 0.8.6)
+  google-cloud-translate
   graphiql-rails
   graphql
   guard

--- a/services/QuillLMS/lib/google_translate.rb
+++ b/services/QuillLMS/lib/google_translate.rb
@@ -1,0 +1,70 @@
+require "google/cloud/translate"
+# This API authenticates automagically, by setting the ENV vars for:
+# TRANSLATE_PROJECT (project id)
+# TRANSLATE_CREDENTIALS (service account json object created in cloud console)
+class GoogleTranslate
+
+  # NB, there is a V3, but that throws errors with our current Google Integration
+  TRANSLATOR = Google::Cloud::Translate.new(version: :v2)
+  # Use this https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+  DEFAULT_LANGUAGES = [
+    :es, # spanish
+    :ja, # japanese
+    :pt, # portugese
+    :fi, # finnish
+    :da, # danish
+    :pl, # polish
+    :ar, # arabic
+    :zh, # chinese
+    :he, # hebrew
+    :ko # korean
+  ]
+  ENGLISH = :en
+  BATCH_SIZE = 100
+  TEST_INPUT = '/Users/danieldrabik/Downloads/surge_barriers_test.csv'
+  TEST_OUTPUT = '/Users/danieldrabik/Downloads/surge_barriers_test_output.csv'
+
+  # input file is a csv with two columsn and no: text, label
+  # pass in a file path, e.g. /Users/yourname/Desktop/
+  def self.synthetics_from_file(input_file_path, output_file_path)
+    texts_and_labels = CSV.open(input_file_path).to_a
+
+    csv_output = synthetics_for_languages(texts_and_labels)
+
+    CSV.open(output_file_path, "w") do |csv|
+      csv_output.each do |row|
+        csv << row
+      end
+    end
+  end
+
+  def self.synthetics_for_languages(texts_and_labels, languages: DEFAULT_LANGUAGES)
+    texts = texts_and_labels.map(&:first)
+
+    output = []
+    languages.each do |language|
+      synthetics = synthetics_for_language(texts, language: language)
+      transposed_texts_and_labels = synthetics.map.with_index do |text, index|
+        [text, texts_and_labels[index].last]
+      end
+
+      output += transposed_texts_and_labels
+    end
+
+    output
+  end
+
+
+  def self.synthetics_for_language(texts, language: )
+    output = []
+    texts.each_slice(BATCH_SIZE).each do |text_slice|
+
+      translations = TRANSLATOR.translate(text_slice, from: ENGLISH, to: language)
+      english_texts = TRANSLATOR.translate(translations.map(&:text), from: language, to: ENGLISH)
+
+      output += english_texts.map(&:text)
+    end
+
+    output
+  end
+end

--- a/services/QuillLMS/lib/google_translate.rb
+++ b/services/QuillLMS/lib/google_translate.rb
@@ -74,47 +74,4 @@ class GoogleTranslate
       end
     end
   end
-
-
-  def self.synthetics_from_file(input_file_path, output_file_path)
-    texts_and_labels = CSV.open(input_file_path).to_a
-
-    csv_output = synthetics_for_languages(texts_and_labels)
-
-    CSV.open(output_file_path, "w") do |csv|
-      csv_output.each do |row|
-        csv << row
-      end
-    end
-  end
-
-  def self.synthetics_for_languages(texts_and_labels, languages: DEFAULT_LANGUAGES.keys)
-    texts = texts_and_labels.map(&:first)
-
-    output = []
-    languages.each do |language|
-      synthetics = synthetics_for_language(texts, language: language)
-      transposed_texts_and_labels = synthetics.map.with_index do |text, index|
-        [text, texts_and_labels[index].last]
-      end
-
-      output += transposed_texts_and_labels
-    end
-
-    output
-  end
-
-
-  def self.synthetics_for_language(texts, language: )
-    output = []
-    texts.each_slice(BATCH_SIZE).each do |text_slice|
-
-      translations = TRANSLATOR.translate(text_slice, from: ENGLISH, to: language)
-      english_texts = TRANSLATOR.translate(translations.map(&:text), from: language, to: ENGLISH)
-
-      output += english_texts.map(&:text)
-    end
-
-    output
-  end
 end

--- a/services/QuillLMS/lib/google_translate.rb
+++ b/services/QuillLMS/lib/google_translate.rb
@@ -2,30 +2,80 @@ require "google/cloud/translate"
 # This API authenticates automagically, by setting the ENV vars for:
 # TRANSLATE_PROJECT (project id)
 # TRANSLATE_CREDENTIALS (service account json object created in cloud console)
+
 class GoogleTranslate
+
+  Synthetic = Struct.new(:text, :label, :results, keyword_init: true)
 
   # NB, there is a V3, but that throws errors with our current Google Integration
   TRANSLATOR = Google::Cloud::Translate.new(version: :v2)
   # Use this https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-  DEFAULT_LANGUAGES = [
-    :es, # spanish
-    :ja, # japanese
-    :pt, # portugese
-    :fi, # finnish
-    :da, # danish
-    :pl, # polish
-    :ar, # arabic
-    :zh, # chinese
-    :he, # hebrew
-    :ko # korean
-  ]
+  DEFAULT_LANGUAGES = {
+    es: 'spanish',
+    ja:  'japanese',
+    pt:  'portugese',
+    fi:  'finnish',
+    da:  'danish',
+    pl:  'polish',
+    ar:  'arabic',
+    zh:  'chinese',
+    he:  'hebrew',
+    ko:  'korean',
+  }
   ENGLISH = :en
   BATCH_SIZE = 100
   TEST_INPUT = '/Users/danieldrabik/Downloads/surge_barriers_test.csv'
   TEST_OUTPUT = '/Users/danieldrabik/Downloads/surge_barriers_test_output.csv'
 
+  attr_reader :synthetics, :languages
+
+  def initialize(texts_and_labels, languages: DEFAULT_LANGUAGES.keys)
+    @languages = languages
+    @synthetics = texts_and_labels.map do |text_and_label|
+      Synthetic.new(text: text_and_label.first, label: text_and_label.last, results: {})
+    end
+  end
+
+  def fetch_results
+    languages.each do |language|
+      synthetics_for_language(language: language)
+    end
+
+    synthetics
+  end
+
+  def synthetics_for_language(language: )
+    synthetics.each_slice(BATCH_SIZE).each do |synthetics_slice|
+      translations = TRANSLATOR.translate(synthetics_slice.map(&:text), from: ENGLISH, to: language)
+      english_texts = TRANSLATOR.translate(translations.map(&:text), from: language, to: ENGLISH)
+
+      synthetics_slice.each.with_index do |synthetic, index|
+        synthetic.results[language] = english_texts[index].text
+      end
+    end
+  end
+
   # input file is a csv with two columsn and no: text, label
   # pass in a file path, e.g. /Users/yourname/Desktop/
+  def self.synthetics_from_file(input_file_path, output_file_path)
+    texts_and_labels = CSV.open(input_file_path).to_a
+
+    synthetics = GoogleTranslate.new(texts_and_labels)
+
+    synthetics.fetch_results
+
+    CSV.open(output_file_path, "w") do |csv|
+      csv << ['Text', 'Label', 'Language', 'Original', 'Changed?']
+      synthetics.synthetics.each do |synthetic|
+          csv << [synthetic.text, synthetic.label, 'original']
+        synthetic.results.each do |language, new_text|
+          csv << [new_text, synthetic.label, DEFAULT_LANGUAGES[language] || language, synthetic.text, new_text == synthetic.text ? 'no_change' : '']
+        end
+      end
+    end
+  end
+
+
   def self.synthetics_from_file(input_file_path, output_file_path)
     texts_and_labels = CSV.open(input_file_path).to_a
 
@@ -38,7 +88,7 @@ class GoogleTranslate
     end
   end
 
-  def self.synthetics_for_languages(texts_and_labels, languages: DEFAULT_LANGUAGES)
+  def self.synthetics_for_languages(texts_and_labels, languages: DEFAULT_LANGUAGES.keys)
     texts = texts_and_labels.map(&:first)
 
     output = []

--- a/services/QuillLMS/lib/google_translate_synthetic.rb
+++ b/services/QuillLMS/lib/google_translate_synthetic.rb
@@ -6,6 +6,16 @@ require "google/cloud/translate"
 class GoogleTranslateSynthetic
 
   SyntheticResult = Struct.new(:original, :label, :translations, keyword_init: true)
+  TrainRow = Struct.new(:text, :label, :synthetic, :type, keyword_init: true) do
+    def to_a
+      [type, text, label]
+    end
+  end
+  TYPE_TRAIN = 'TRAIN'
+  TYPE_VALIDATION = 'VALIDATION'
+  TYPE_TEST = 'TEST'
+  TEST_PERCENTAGE = 0.10
+
 
   # NB, there is a V3, but that throws errors with our current Google Integration
   TRANSLATOR = Google::Cloud::Translate.new(version: :v2)
@@ -22,6 +32,8 @@ class GoogleTranslateSynthetic
     he:  'hebrew',
     ko:  'korean',
   }
+  TRAIN_LANGUAGES = DEFAULT_LANGUAGES.slice(:ko, :he, :ar, :zh)
+
   ENGLISH = :en
   # the API with throw an error if you send too many text strings at a time.
   # Throttling to 100 sentences at a time.
@@ -76,5 +88,50 @@ class GoogleTranslateSynthetic
         end
       end
     end
+  end
+
+  def self.generate_training_export(input_file_path, output_file_path, languages: TRAIN_LANGUAGES.keys)
+    raise if languages.size > 4
+
+    texts_and_labels = CSV.open(input_file_path).to_a
+
+    synthetics = GoogleTranslateSynthetic.new(texts_and_labels, languages: languages)
+
+    synthetics.fetch_results
+
+    data = []
+    synthetics.results.each do |result|
+      data << TrainRow.new(text: result.original, label: result.label, synthetic: false, type: nil)
+      result.translations.each do |_, new_text|
+        data << TrainRow.new(text: new_text, label: result.label, synthetic: true, type: TYPE_TRAIN)
+      end
+    end
+
+    # remove duplicates
+    uniq_data = data.uniq
+    # determine how many test items
+    test_count = (uniq_data.size * TEST_PERCENTAGE).ceil
+    # determine original counts
+    original_count = uniq_data.count {|data| data.type.nil? }
+    #assign test and validations
+    original_types = type_list(count: original_count, test_count: test_count).shuffle
+
+    uniq_data.each do |train_row|
+      next unless train_row.type.nil?
+
+      train_row.type = original_types.shift
+    end
+
+    CSV.open(output_file_path, "w") do |csv|
+      uniq_data.each {|row| csv << row.to_a }
+    end
+  end
+
+  private_class_method def self.type_list(count: , test_count:)
+    [
+      Array.new(test_count, TYPE_TEST),
+      Array.new(test_count, TYPE_VALIDATION),
+      Array.new(count - (test_count * 2), TYPE_TRAIN)
+    ].flatten
   end
 end

--- a/services/QuillLMS/lib/google_translate_synthetic.rb
+++ b/services/QuillLMS/lib/google_translate_synthetic.rb
@@ -29,6 +29,9 @@ class GoogleTranslateSynthetic
 
   attr_reader :results, :languages
 
+  # params:
+  # texts_and_labels: [['text', 'label_5'],['text', 'label_1'],...]
+  # languages: [:es, :ja, ...]
   def initialize(texts_and_labels, languages: DEFAULT_LANGUAGES.keys)
     @languages = languages
     @results = texts_and_labels.map do |text_and_label|

--- a/services/QuillLMS/lib/google_translate_synthetic.rb
+++ b/services/QuillLMS/lib/google_translate_synthetic.rb
@@ -56,7 +56,7 @@ class GoogleTranslateSynthetic
   end
 
   # input file is a csv with two columsn and no: text, label
-  # pass in a file path, e.g. /Users/yourname/Desktop/
+  # pass in file paths, e.g. /Users/yourname/Desktop/
   def self.generate_from_file(input_file_path, output_file_path)
     texts_and_labels = CSV.open(input_file_path).to_a
 

--- a/services/QuillLMS/lib/google_translate_synthetic.rb
+++ b/services/QuillLMS/lib/google_translate_synthetic.rb
@@ -55,17 +55,17 @@ class GoogleTranslateSynthetic
     end
   end
 
-  # input file is a csv with two columsn and no: text, label
+  # input file is a csv with two columns and no header: text, label
   # pass in file paths, e.g. /Users/yourname/Desktop/
-  def self.generate_from_file(input_file_path, output_file_path)
+  def self.generate_from_file(input_file_path, output_file_path, languages: DEFAULT_LANGUAGES.keys)
     texts_and_labels = CSV.open(input_file_path).to_a
 
-    synthetics = GoogleTranslateSynthetic.new(texts_and_labels)
+    synthetics = GoogleTranslateSynthetic.new(texts_and_labels, languages: languages)
 
     synthetics.fetch_results
 
     CSV.open(output_file_path, "w") do |csv|
-      csv << ['Text', 'Label', 'Original', 'Changed?', 'Language',]
+      csv << ['Text', 'Label', 'Original', 'Changed?', 'Language']
       synthetics.results.each do |result|
           csv << [result.original, result.label,'','', 'original']
         result.translations.each do |language, new_text|

--- a/services/QuillLMS/spec/lib/google_translate_synthetic_spec.rb
+++ b/services/QuillLMS/spec/lib/google_translate_synthetic_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe GoogleTranslateSynthetic do
+
+  describe 'initialization' do
+    let(:sample_data) { [['text string', 'label_5'], ['other text', 'label_11']] }
+
+    it 'should setup properly with empty translations' do
+      synthetics = GoogleTranslateSynthetic.new(sample_data, languages: [:es])
+      first_result = synthetics.results.first
+
+      expect(synthetics.languages.count).to eq 1
+      expect(synthetics.results.count).to eq 2
+
+      expect(first_result.original).to eq 'text string'
+      expect(first_result.label).to eq 'label_5'
+      expect(first_result.translations).to eq({})
+    end
+
+
+    it 'should fetch_results' do
+      # stub translator
+      stubbed_translator = double()
+      stub_const("GoogleTranslateSynthetic::TRANSLATOR", stubbed_translator)
+
+      # translate to spanish mock
+      expect(stubbed_translator).to receive(:translate).with(sample_data.map(&:first), from: :en, to: :es).and_return([double(text: 'adios'), double(text: 'hola')])
+      # translate to english mock
+      expect(stubbed_translator).to receive(:translate).with(['adios', 'hola'], from: :es, to: :en).and_return([double(text: 'goodbye'), double(text: 'hello')])
+
+      synthetics = GoogleTranslateSynthetic.new(sample_data, languages: [:es])
+
+      synthetics.fetch_results
+
+      expect(synthetics.results.count).to eq 2
+
+      first_result = synthetics.results.first
+
+      expect(first_result.original).to eq 'text string'
+      expect(first_result.label).to eq 'label_5'
+      expect(first_result.translations[:es]).to eq 'goodbye'
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
A small console script to generate synthetic data for Comprehension labeling. This takes text strings, translates them to a different language, say Japanese, then translates them back. The 'noise' in the back-and-forth translation causes slightly different sentences (e.g. noun and verbs may subtly change), which gives us more training data that has already been labeled.

Note, the immediately plan to do these adhoc as experiments. I might not merge this code in, since it's not used in Production right now, but if it is useful, then it can be merged.

Also note, I wrote this as a single file in the LMS proper, but it likely belongs in the Comprehension engine. I started to port it there, hit some gem dependency issues, then decided to stop since this is a small, timeboxed task that is done in the sense that I have generated the files for curriculum..
## WHY

This will help us generate more training data to improve our ML models cheaply. 

## HOW

This script is run in the Rails console `GoogleTranslateSynthetic.generate_from_file(input_file_path, output_file_path)` and you'll need local API keys. 

Note, I tried to write this in a way that could be used by application code in the future.



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - will deploy if I plan to merge
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A 
