### PR TITLE
Stop requiring Parent Activity ID field in Create Activity form

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -11,7 +11,7 @@ import {
   MAXIMUM_READING_LEVEL,
   TARGET_READING_LEVEL,
   SCORED_READING_LEVEL,
-  PARENT_ACTIVITY_ID
+  PARENT_ACTIVITY_ID,
 } from '../../../constants/comprehension';
 import { PromptInterface } from '../interfaces/comprehensionInterfaces'
 


### PR DESCRIPTION
## WHAT
Don't require the "Parent Activity ID" field when admins are creating or updating an Activity.

## WHY
This field doesn't always apply, and requiring it forces admins to fill in fake numbers, causing confusion in the DB and in the creation flow.

## HOW
Just don't require this field.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=1636fd74c28b4368829f24c585b096c6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, but tested manually
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
