### PR TITLE
fix issue where plus sign in prompt was breaking passage

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -128,7 +128,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
 
       // handles case where change is only in the formatted prompt part
       if (splitSubmission.length > 1) {
-        const newValue = `${this.formattedPrompt}${splitSubmission[1]}`
+        const newValue = `${this.htmlStrippedPrompt()}${splitSubmission[1]}`
         this.setState({ html: newValue}, () => {
           this.editor.innerHTML = newValue
         })


### PR DESCRIPTION
## WHAT
Fix issue where having a plus sign in the prompt was breaking the editor in Comprehension.

## WHY
We want to be able to include RegEx special characters as part of the prompt string without everything breaking.

## HOW
Add a function to replace the special character with an escaped version.

### Screenshots
N/A

### Notion Card Links
https://www.notion.so/quill/Comprehension-turk-link-not-working-correctly-74d123c437d242709e0478617e7f851b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
