### PR TITLE
Increase max highlight length to something absurd: 5000

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/highlight.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/highlight.rb
@@ -1,7 +1,7 @@
 module Comprehension
   class Highlight < ActiveRecord::Base
     MIN_TEXT_LENGTH = 1
-    MAX_TEXT_LENGTH = 500
+    MAX_TEXT_LENGTH = 5000
     TYPES= [
       'passage',
       'response',

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/highlight_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/highlight_test.rb
@@ -8,7 +8,7 @@ module Comprehension
       should validate_presence_of(:text)
       should validate_length_of(:text)
         .is_at_least(1)
-        .is_at_most(500)
+        .is_at_most(5000)
       should validate_presence_of(:highlight_type)
       should validate_inclusion_of(:highlight_type)
         .in_array(Comprehension::Highlight::TYPES)


### PR DESCRIPTION
## WHAT
Increase the maximum length of a feedback highlight
## WHY
Because we're running into issues where Curriculum wants to highlight longer sections of text, and don't currently have time to figure out what the actual limit should be
## HOW
Change the Rails model validation for highlight max length

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
