### PR TITLE
remove notification feed from lms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/class_overview.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'underscore';
-import NotificationFeed from './notifications/container';
 import OverviewMini from './overview_mini';
 import PremiumMini from './premium_mini';
 import TeacherGuide from '../teacher_guide/teacher_guide';
@@ -67,7 +66,6 @@ export default class ClassOverview extends React.Component {
         {this.hasPremium()}
         {this.lessonsList()}
         {this.overviewMinis()}
-        <NotificationFeed notifications={this.props.notifications} />
       </div>
     );
   }


### PR DESCRIPTION
## WHAT
Remove NotificationFeed from teacher dashboard.

## WHY
Currently, it's rendering as "Error :(" but even in the best of times we aren't using it, so it shouldn't be here.

## HOW
Just remove it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Error-message-showing-on-the-Teacher-Overview-page-347513a3faa2426db0c4d66a3d12118a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
