### PR TITLE
comprehension/add-higlights-to-automl-feedback

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
@@ -13,6 +13,13 @@ module Comprehension
     def feedback_object
       return nil unless matched_rule
       feedback = matched_rule.determine_feedback_from_history(@previous_feedback)
+      highlight = feedback.highlights.map do |h|
+        {
+          type: h.highlight_type,
+          text: h.text,
+          category: ''
+        }
+      end
       {
         feedback: feedback.text,
         feedback_type: Rule::TYPE_AUTOML,
@@ -21,7 +28,7 @@ module Comprehension
         entry: @entry,
         concept_uid: matched_rule&.concept_uid || '',
         rule_uid: matched_rule&.uid || '',
-        highlight: []
+        highlight: highlight
       }
     end
 

--- a/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
@@ -42,6 +42,19 @@ module Comprehension
           }
         end
       end
+
+      should 'include highlight data when the feedback object has highlights' do
+        AutomlModel.stub_any_instance(:fetch_automl_label, @label.name) do
+          highlight = create(:comprehension_highlight, feedback: @feedback)
+          automl_check = Comprehension::AutomlCheck.new('whatever', @prompt)
+
+          assert_equal automl_check.feedback_object[:highlight], [{
+            type: highlight.highlight_type,
+            text: highlight.text,
+            category: ''
+          }]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Make sure to pass configured highlights back with Automl Feedback
## WHY
So that highlights that are configured with feedback are shown when getting AutoML feedback
## HOW
Actually pass the data back when appropriate

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
