### PR TITLE
fix issue where the focus points link sometimes wasn't working

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/question.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/question.jsx
@@ -278,10 +278,10 @@ export class Question extends React.Component {
           <div className="tabs">
             <ul>
               <NavLink activeClassName="is-active" to={`${match.url}/responses`}>Responses</NavLink>
-              <NavLink activeClassName="is-active" to='test'>Play Question</NavLink>
-              <NavLink activeClassName="is-active" to='choose-model'>{data[questionID].modelConceptUID ? 'Edit' : 'Add'} Model Concept</NavLink>
-              <NavLink activeClassName="is-active" to='focus-points'>{data[questionID].focusPoints ? 'Edit' : 'Add'} Focus Points</NavLink>
-              <NavLink activeClassName="is-active" to='incorrect-sequences'>{data[questionID].incorrectSequences ? 'Edit' : 'Add'} Incorrect Sequences</NavLink>
+              <NavLink activeClassName="is-active" to={`${match.url}/test`}>Play Question</NavLink>
+              <NavLink activeClassName="is-active" to={`${match.url}/choose-model`}>{data[questionID].modelConceptUID ? 'Edit' : 'Add'} Model Concept</NavLink>
+              <NavLink activeClassName="is-active" to={`${match.url}/focus-points`}>{data[questionID].focusPoints ? 'Edit' : 'Add'} Focus Points</NavLink>
+              <NavLink activeClassName="is-active" to={`${match.url}/incorrect-sequences`}>{data[questionID].incorrectSequences ? 'Edit' : 'Add'} Incorrect Sequences</NavLink>
               {activeLink}
             </ul>
           </div>


### PR DESCRIPTION
## WHAT
Fix issue where focus points link was sometimes just being appended to the incorrect sequences link, and therefore not working.

## WHY
We want these links to work.

## HOW
Update the nav links to point to the full correct address.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-open-focus-points-page-from-incorrect-sequences-page-3af0f8f73d1b480fba15a33c13f41d12

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
