### PR TITLE
comprehension/add-automl-model-count

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
@@ -24,7 +24,8 @@ module Comprehension
       options ||= {}
 
       super(options.reverse_merge(
-        only: [:id, :automl_model_id, :name, :labels, :state, :prompt_id]
+        only: [:id, :automl_model_id, :name, :labels, :state, :prompt_id],
+        methods: [:older_models]
       ))
     end
 
@@ -62,6 +63,10 @@ module Comprehension
       results = automl_prediction_client.predict(name: automl_model_full_id, payload: automl_payload)
       sorted_results = results.payload.sort_by { |i| i.classification.score }.reverse
       sorted_results[0].display_name
+    end
+
+    def older_models
+      @older_models ||= AutomlModel.where(prompt_id: prompt_id).where("created_at < ?", created_at).count
     end
 
     private def prompt_automl_rules

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/automl_model_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/automl_model_test.rb
@@ -130,7 +130,8 @@ module Comprehension
           name: automl_model.name,
           labels: automl_model.labels,
           state: automl_model.state,
-          prompt_id: automl_model.prompt_id
+          prompt_id: automl_model.prompt_id,
+          older_models: automl_model.older_models
         }.stringify_keys
       end
     end
@@ -302,6 +303,22 @@ module Comprehension
         assert @model.valid?
         assert_equal @model.state, AutomlModel::STATE_ACTIVE
         assert_equal result, @model
+      end
+    end
+
+    context '#older_models' do
+      setup do
+        @first_model = create(:comprehension_automl_model)
+      end
+
+      should 'be 0 if there are no previous models for the prompt' do
+        assert_equal @first_model.older_models, 0
+      end
+
+      should 'be 1 if there is a single previous model for the prompt' do
+        second_model = create(:comprehension_automl_model, prompt: @first_model.prompt)
+        assert_equal @first_model.older_models, 0
+        assert_equal second_model.older_models, 1
       end
     end
   end


### PR DESCRIPTION
## WHAT
Add "older_models" count attribute to AutomlModel
## WHY
We want a constant value that we can use as a short-hand to refer to which model on a prompt we might want to activate.  This number is contiguous within a prompt, and smaller so easier to think/talk about.
## HOW
This just calculates how many AutomlModel instances for a specified prompt existed before this one

### Notion Card Links
https://www.notion.so/quill/Semantic-1-View-Semantic-Rules-Add-Edit-Semantic-Rules-7a6a3c901a06404895be1c5e79b38f64

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
