### PR TITLE
make it possible to delete images from teacher center

### DIFF
--- a/services/QuillLMS/app/views/cms/images/index.html.erb
+++ b/services/QuillLMS/app/views/cms/images/index.html.erb
@@ -7,7 +7,7 @@
         <div class="gallery-item">
           <p><span>Link:</span> <a target="_blank" href="<%= i.file.url %>"><%= i.file.url %></a></p>
           <a target="_blank" href="<%= i.file.url %>"><img src="<%= i.file.url %>"></img></a>
-          <%= link_to "/cms/images/#{i.id}", method: 'delete', class: 'trash-link' do %>
+          <%= button_to "/cms/images/#{i.id}", method: 'delete', class: 'trash-link' do %>
             <i class="fas fa-icon fa-trash"></i>
           <% end %>
           </span>


### PR DESCRIPTION
## WHAT
Fix issue where admin users couldn't delete images from the teacher center.

## WHY
They want to be able to clean things up.

## HOW
Just change from a `link_to` to a `button_to` since `link_to` stopped accepting method args.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-delete-old-TC-image-uploads-b554a150087b432cbcde884cdb400905

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A