### PR TITLE
fix issue where teachers could sometimes see activities that are not in their user scope in the activity library

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -84,7 +84,9 @@ export default class CreateUnit extends React.Component {
   }
 
   getActivities = () => {
-    requestGet('/activities/search?flag=private', (body) => {
+    const { stage, } = this.state
+    const privateFlag = stage === 2 ? "?flag=private" : ''
+    requestGet(`/activities/search${privateFlag}`, (body) => {
       const { activities, } = body
       const activityIdsArray = this.props.match.params.activityIdsArray || window.localStorage.getItem(ACTIVITY_IDS_ARRAY)
       const activityIdsArrayAsArray = activityIdsArray.split(',')


### PR DESCRIPTION
## WHAT
Fix issue where teachers could sometimes see activities that are not in their user scope in the activity library.

## WHY
We don't want teachers who do not have certain testing flags to see activities with those testing flags.

## HOW
Make sure that the simple presence of stored selected activity ids doesn't automatically let teachers see activities they shouldn't be able to.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Discrepancy-of-total-activities-assigned-a4e9e404699a46668b4c0816fe76bbee

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
