### PR TITLE
comprehension/add-scoped-unique-validation-to-labels

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/label.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/label.rb
@@ -10,12 +10,21 @@ module Comprehension
     validates :rule, presence: true, uniqueness: true
     validates :name, presence: true, length: {in: NAME_MIN_LENGTH..NAME_MAX_LENGTH}
 
+    validate :name_unique_for_prompt, on: :create
+
     def serializable_hash(options = nil)
       options ||= {}
 
       super(options.reverse_merge(
         only: [:id, :name, :rule_id]
       ))
+    end
+
+    private def name_unique_for_prompt
+      prompt_labels = rule&.prompts&.first&.rules&.map { |r| r.label }
+      if prompt_labels&.map { |l| l&.name }&.include?(name)
+        errors.add(:name, "can't be the same as any other labels related to the same prompt")
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/label_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/label_test.rb
@@ -20,6 +20,17 @@ module Comprehension
         @label.reload
         assert_equal @label.name, old_name
       end
+
+      context '#name_unique_for_prompt' do
+        should 'not allow a label to be created if its name collides with another on the prompt' do
+          prompt = create(:comprehension_prompt)
+          @label.rule.update(prompts: [prompt])
+          rule = create(:comprehension_rule, prompts: [prompt])
+          label = build(:comprehension_label, rule: rule, name: @label.name)
+          assert !label.valid?
+          assert label.errors[:name].include?("can't be the same as any other labels related to the same prompt")
+        end
+      end
     end
 
     context 'relationships' do


### PR DESCRIPTION
## WHAT
Add a validation to Label to prevent name collisions within a prompt
## WHY
If a two or more `AutoML` type `Rules` related to a `Prompt` have `Label`s with the same name, the AutoML Feedback API will start crashing.  We should prevent data from getting into that state.
## HOW
Just add a custom validation function that goes down to the `Prompt` through the `Label`'s `Rule`, then finds all related `Labels` back in the other direction to check their names against the one that's been provided for the new label.

### Notion Card Links
https://www.notion.so/quill/Semantic-1-View-Semantic-Rules-Add-Edit-Semantic-Rules-7a6a3c901a06404895be1c5e79b38f64

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
