### PR TITLE
comprehension/add-filters-to-rules-controller

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
@@ -5,9 +5,11 @@ module Comprehension
 
     # GET /rules.json
     def index
-      @rules = Comprehension::Rule.all
+      @rules = Comprehension::Rule
+      @rules = @rules.joins(:prompts_rules).where(comprehension_prompts_rules: {prompt_id: params[:prompt_id]}) if params[:prompt_id]
+      @rules = @rules.where(rule_type: params[:rule_type]) if params[:rule_type]
 
-      render json: @rules
+      render json: @rules.all
     end
 
     # GET /rules/1.json

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
@@ -52,6 +52,50 @@ module Comprehension
 
         end
       end
+
+      context 'with filter params' do
+        setup do
+          @prompt1 = create(:comprehension_prompt)
+          @prompt2 = create(:comprehension_prompt)
+
+          @rule1 = create(:comprehension_rule, prompts: [@prompt1], rule_type: Rule::TYPE_AUTOML)
+          @rule2 = create(:comprehension_rule, prompts: [@prompt1], rule_type: Rule::TYPE_GRAMMAR)
+          @rule3 = create(:comprehension_rule, prompts: [@prompt2], rule_type: Rule::TYPE_AUTOML)
+          @rule4 = create(:comprehension_rule, prompts: [@prompt2], rule_type: Rule::TYPE_GRAMMAR)
+        end
+
+        should 'only get Rules for specified prompt when provided' do
+          get :index, prompt_id: @prompt1.id
+
+          parsed_response = JSON.parse(response.body)
+
+          assert_equal parsed_response.length, 2
+          parsed_response.each do |r|
+            assert r['prompt_ids'].include?(@prompt1.id)
+          end
+        end
+
+        should 'only get Rules for specified rule type when provided' do
+          get :index, rule_type: Rule::TYPE_AUTOML
+
+          parsed_response = JSON.parse(response.body)
+
+          assert_equal parsed_response.length, 2
+          parsed_response.each do |r|
+            assert_equal r['rule_type'], Rule::TYPE_AUTOML
+          end
+        end
+
+        should 'only get Rules for the intersection of prompt and rule type when both are provided' do
+          get :index, prompt_id: @prompt1.id, rule_type: Rule::TYPE_AUTOML
+
+          parsed_response = JSON.parse(response.body)
+
+          assert_equal parsed_response.length, 1
+          assert parsed_response[0]['prompt_ids'].include?(@prompt1.id)
+          assert_equal parsed_response[0]['rule_type'], Rule::TYPE_AUTOML
+        end
+      end
     end
 
     context "create" do


### PR DESCRIPTION
## WHAT
Add some convenience filters to Rules controller
## WHY
So that we can just get Rules by prompt_id or by rule_type, or both
## HOW
Just add param checks to the `index` action and modify the query that gets `Rule` records when those params are provided

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
