### PR TITLE
fix bug causing concept manager to error out

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ArchivedConceptBox.tsx
@@ -287,7 +287,7 @@ class ArchivedConceptBox extends React.Component<ArchivedConceptBoxProps, Archiv
           />
           {this.renderArchivedOrLive(concept)}
         </div>
-        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} />
+        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} formatDateTime={formatDateTime} />
       </div>)
     } else if (this.props.levelNumber === 0) {
       return (<div>
@@ -310,7 +310,7 @@ class ArchivedConceptBox extends React.Component<ArchivedConceptBoxProps, Archiv
           />
           {this.renderArchivedOrLive(concept)}
         </div>
-        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} />
+        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} formatDateTime={formatDateTime} />
       </div>)
     }
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
@@ -285,7 +285,7 @@ class ConceptBox extends React.Component<ConceptBoxProps, ConceptBoxState> {
           />
           {this.renderRenameAndArchiveSection()}
         </div>
-        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} />
+        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} formatDateTime={formatDateTime} />
       </div>)
     } else if (levelNumber === 0) {
       return (<div>
@@ -309,7 +309,7 @@ class ConceptBox extends React.Component<ConceptBoxProps, ConceptBoxState> {
         </div>
         <RuleDescriptionField handleChange={this.changeDescription} ruleDescription={concept.description} />
         <ExplanationField explanation={concept.explanation} handleChange={this.changeExplanation} />
-        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} />
+        <IndividualRecordChangeLogs changeLogs={concept.changeLogs} formatDateTime={formatDateTime} />
       </div>)
     }
   }

--- a/services/QuillLMS/client/app/bundles/Staff/containers/ConceptsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/containers/ConceptsIndex.tsx
@@ -82,10 +82,11 @@ class ConceptsIndex extends React.Component<any, ConceptsIndexState> {
     this.setState({ visible, selectedConcept: {}, searchValue: '' })
   }
 
-  filterConcepts(concepts:Array<Concept>, searchValue:string):Array<Concept>{
+  filterConcepts(concepts:Array<Concept>, searchValue: string):Array<Concept>{
+    const { fuse, } = this.state
     if (searchValue == '') {return concepts};
-    if (this.state.fuse) {
-      return this.state.fuse.search(searchValue)
+    if (fuse) {
+      return fuse.search(searchValue)
     } else {
       const options = {
         shouldSort: true,
@@ -109,8 +110,8 @@ class ConceptsIndex extends React.Component<any, ConceptsIndexState> {
     }
   }
 
-  updateSearchValue(searchValue:string):void {
-    this.setState({searchValue})
+  updateSearchValue(e):void {
+    this.setState({searchValue: e.target.value})
   }
 
   selectConcept(conceptID, levelNumber) {


### PR DESCRIPTION
## WHAT
Fix bug causing the concept manager to error out.

## WHY
We want admin users to be able to use the concept manager fully.

## HOW
Fix issues caused by nil error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Concepts-manager-search-bar-and-change-log-broken-1d84bed2ed5f42c88dfeaa21cc2652da

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
