### PR TITLE
Fix User Manager search duplicates, add class code search for students

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -173,7 +173,7 @@ class Cms::UsersController < Cms::CmsController
     # ADJUST THE PAGINATION QUERY STRING AS WELL.
     #
     ActiveRecord::Base.connection.execute("
-      SELECT
+      SELECT DISTINCT
       	users.name AS name,
       	users.email AS email,
       	users.role AS role,
@@ -189,7 +189,8 @@ class Cms::UsersController < Cms::CmsController
       AND user_subscriptions.created_at = (SELECT MAX(user_subscriptions.created_at) FROM user_subscriptions WHERE user_subscriptions.user_id = users.id)
       LEFT JOIN subscriptions ON user_subscriptions.subscription_id = subscriptions.id
       LEFT JOIN classrooms_teachers ON users.id = classrooms_teachers.user_id
-      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id
+      LEFT JOIN students_classrooms ON users.id = students_classrooms.student_id
+      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id OR classrooms.id = students_classrooms.classroom_id
       #{where_query_string_builder}
       #{order_by_query_string}
       #{pagination_query_string}
@@ -271,7 +272,8 @@ class Cms::UsersController < Cms::CmsController
       LEFT JOIN user_subscriptions ON users.id = user_subscriptions.user_id
       LEFT JOIN subscriptions ON user_subscriptions.subscription_id = subscriptions.id
       LEFT JOIN classrooms_teachers ON users.id = classrooms_teachers.user_id
-      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id
+      LEFT JOIN students_classrooms ON users.id = students_classrooms.student_id
+      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id OR classrooms.id = students_classrooms.classroom_id
       #{where_query_string_builder}
     ").to_a[0]['count'].to_i
   end

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -41,6 +41,7 @@ describe Cms::UsersController do
       teacher = create(:teacher_with_one_classroom, email: 'test@t.org')
       classroom = teacher.classrooms_i_teach.first
       classroom.teachers = [teacher]
+      student = create(:student, classrooms: [classroom])
       class_code = classroom.code
       get :search, class_code: class_code
       expect(JSON.parse(response.body)).to eq({"numberOfPages"=> 1, "userSearchQueryResults"=>
@@ -53,6 +54,16 @@ describe Cms::UsersController do
           "school"=> nil,
           "school_id"=> nil,
           "id"=> teacher.id.to_s
+        },
+        {
+          "name" => student.name,
+          "email" => student.email,
+          "role" => student.role,
+          "subscription" => nil,
+          "last_sign_in" => nil,
+          "school" => nil,
+          "school_id" => nil,
+          "id" => student.id.to_s
         }], "userSearchQuery"=> {"class_code"=> class_code}})
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:search])
       expect(ChangeLog.last.explanation).to include('class_code')


### PR DESCRIPTION
## WHAT
Fix a bug I introduced where admin were seeing duplicate records in User Manager searches. Add students to search results when searching by class code (not just teachers).

## WHY
The bug was not intended, and also Product requested that I add students to the results, so this PR is doing both.

## HOW
Fix the duplicate problem using `SELECT DISTINCT`. Add students to the results by joining to the `students_classrooms` table.

### Screenshots
<img width="1056" alt="Screen Shot 2021-03-08 at 3 10 26 PM" src="https://user-images.githubusercontent.com/57366100/110382389-737fdb80-8020-11eb-9c7e-262c5cb82050.png">

### Notion Card Links
https://www.notion.so/quill/User-Directory-search-glitch-8cb563eaa1be4a55b10116208704ce92

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
