### PR TITLE
Fix improperly displaying html tags on banner

### DIFF
--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -7,7 +7,7 @@
     <div class="banner" id="webinar-banner">
       <div class="content-container">
         <img alt="Video player with play symbol" class="banner-icon" src=<%= "#{ENV['CDN_URL']}/images/icons/live-stream.svg" %>>
-        <p><%=banner.title.html_safe %> <a href=<%= banner.link %> rel="noopener noreferrer" target="_blank"><%= banner.link_display_text %></a></p>
+        <p><%=banner.title.html_safe %> <a href=<%= banner.link %> rel="noopener noreferrer" target="_blank"><%= banner.link_display_text.html_safe %></a></p>
         <img alt="White X" id="close-webinar-banner" src=<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>>
       </div>
     </div>


### PR DESCRIPTION
## WHAT
Our webinar banner was showing the html tags in the text ("<strong>Quill 101</strong>") instead of showing the properly rendered text. This PR fixes it to make sure html tags are properly rendered in the banner text.

## WHY
This looks pretty bad.

## HOW
Add `.html_safe` to all the string variables that are being rendered as html text in the banner.

### Screenshots
<img width="812" alt="Screen Shot 2021-03-08 at 3 19 06 PM" src="https://user-images.githubusercontent.com/57366100/110383265-a70f3580-8021-11eb-86a0-5733fe26b584.png">


### Notion Card Links
No notion card -- reported by Peter Sharkey in the Slack channel

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually and on staging.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
