### PR TITLE
make sure to still default to promotional date when there is no extant subscription

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -77,7 +77,7 @@ class Cms::SchoolsController < Cms::CmsController
   end
 
   def new_subscription
-    @subscription = Subscription.new(start_date: Subscription.redemption_start_date(@school), expiration: Subscription.redemption_start_date(@school) + 1.year)
+    @subscription = Subscription.new(start_date: Subscription.redemption_start_date(@school), expiration: Subscription.default_expiration_date(@school))
   end
 
   # This allows staff members to create a new school.

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -94,7 +94,7 @@ class Cms::UsersController < Cms::CmsController
   end
 
   def new_subscription
-    @subscription = Subscription.new(start_date: Subscription.redemption_start_date(@user), expiration: Subscription.redemption_start_date(@user) + 1.year)
+    @subscription = Subscription.new(start_date: Subscription.redemption_start_date(@user), expiration: Subscription.default_expiration_date(@user))
   end
 
   def update

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -222,6 +222,15 @@ class Subscription < ActiveRecord::Base
     end
   end
 
+  def self.default_expiration_date(school_or_user)
+    last_subscription = school_or_user.subscriptions.active.first
+    if last_subscription.present?
+      redemption_start_date(school_or_user) + 1.year
+    else
+      promotional_dates[:expiration]
+    end
+  end
+
   def update_if_charge_succeeds
     charge = charge_user
     if charge[:status] == 'succeeded'

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -182,13 +182,25 @@ describe Cms::SchoolsController do
 
   describe '#new_subscription' do
     let!(:school) { create(:school) }
+    let!(:school_with_no_subscription) { create(:school) }
     let!(:subscription) { create(:subscription)}
     let!(:school_subscription) { create(:school_subscription, school: school, subscription: subscription) }
 
-    it 'should create a new subscription with starting after the current subscription ends' do
-      get :new_subscription, id: school.id
-      expect(assigns(:subscription).start_date).to eq subscription.expiration
-      expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
+
+    describe 'when there is no existing subscription' do
+      it 'should create a new subscription that starts today and ends at the promotional expiration date' do
+        get :new_subscription, id: school_with_no_subscription.id
+        expect(assigns(:subscription).start_date).to eq Date.today
+        expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
+      end
+    end
+
+    describe 'when there is an existing subscription' do
+      it 'should create a new subscription with starting after the current subscription ends' do
+        get :new_subscription, id: school.id
+        expect(assigns(:subscription).start_date).to eq subscription.expiration
+        expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
+      end
     end
   end
 

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -175,13 +175,24 @@ describe Cms::UsersController do
 
   describe '#new_subscription' do
     let!(:another_user) { create(:user) }
+    let!(:user_with_no_subscription) { create(:user) }
     let!(:subscription) { create(:subscription)}
     let!(:user_subscription) { create(:user_subscription, user: another_user, subscription: subscription) }
 
-    it 'should create a new subscription with starting after the current subscription ends' do
-      get :new_subscription, id: another_user.id
-      expect(assigns(:subscription).start_date).to eq subscription.expiration
-      expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
+    describe 'when there is no existing subscription' do
+      it 'should create a new subscription that starts today and ends at the promotional expiration date' do
+        get :new_subscription, id: user_with_no_subscription.id
+        expect(assigns(:subscription).start_date).to eq Date.today
+        expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
+      end
+    end
+
+    describe 'when there is an existing subscription' do
+      it 'should create a new subscription with starting after the current subscription ends' do
+        get :new_subscription, id: another_user.id
+        expect(assigns(:subscription).start_date).to eq subscription.expiration
+        expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
+      end
     end
   end
 


### PR DESCRIPTION
## WHAT
Make sure to default to promotional date when creating a new subscription.

## WHY
We want to use the promotional dates when schools/users have never had a subscription before.

## HOW
Add new method to determine whether the promotional date or the standard renewal date should be used.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/New-school-subscriptions-are-defaulting-to-one-year-rather-than-standard-renewal-dates-July-31-or-1f5d1314553a4ee08a27c5913982e417

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO- small change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
