### PR TITLE
fix issue where lessons report would not load

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
@@ -1,7 +1,15 @@
 export const formatString = (str: string) => {
-  return str.replace(/&#x27;/g, "'").replace(/&nbsp;/g, '').replace(/(<([^>]+)>)/ig, '').replace(/&quot;/g, '"')
+  return stringifiedString(str).replace(/&#x27;/g, "'").replace(/&nbsp;/g, '').replace(/(<([^>]+)>)/ig, '').replace(/&quot;/g, '"')
 }
 
 export const formatStringAndAddSpacesAfterPeriods = (str: string) => {
-  return formatString(str).replace(/\.(?=[^ ])/g, '. ')
+  return stringifiedString(str).replace(/\.(?=[^ ])/g, '. ')
+}
+
+export const stringifiedString = (str: string) => {
+  // handles question types in Quill Lessons where we save responses as a key-value store
+  if (typeof str === 'object') {
+    return Object.values(str).join("\n")
+  }
+  return str
 }


### PR DESCRIPTION
## WHAT
Fix issue where Quill Lessons report would not load by handling case where response is saved as hash rather than string.

## WHY
We want teachers to be able to see answers their students submitted in the lesson.

## HOW
In the `formatString` function, handle the case where we are passed an object (which, in the Quill Lessons instance, is a hash where the keys are the prompt and the values are the response) by stringifying the values. Long term, we maybe want to look at both how we're sending this data back from Lessons and also how we display it in these reports, but we needed a fix for this teacher and others in the same position which would handle the data that already exists.
 
### Screenshots
<img width="726" alt="Screen Shot 2021-03-09 at 4 28 06 PM" src="https://user-images.githubusercontent.com/18669014/110540831-f6726600-80f4-11eb-9d26-4520d4f3e195.png">


### Notion Card Links
https://www.notion.so/quill/Teacher-can-t-look-Lesson-results-from-Activity-Summary-41241a6b29b24bec884d592d4b5c72ff

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
