### PR TITLE
make sure only premium teachers can see premium banner

### DIFF
--- a/services/QuillLMS/app/models/webinar_banner.rb
+++ b/services/QuillLMS/app/models/webinar_banner.rb
@@ -8,10 +8,12 @@ class WebinarBanner
 
   ONE_OFFS = {}
 
+  OFFICE_HOURS_TITLE = "Quill Office Hours are live now!"
+
   RECURRING = {
     '1-16' => ["<strong>Quill Webinar 101: Getting Started</strong> is live now!", "Click here to register and join.", "#{ZOOM_URL}/WN_a4Z1_Zs6RSGUWwr_t0V18Q"],
-    '3-10' => ["Quill Office Hours are live now!", "Click here to join", "https://quill-org.zoom.us/j/93744355918#success"],
-    '3-16' => ["Quill Office Hours are live now!", "Click here to join", "https://quill-org.zoom.us/j/95335806177#success"]
+    '3-10' => [OFFICE_HOURS_TITLE, "Click here to join", "https://quill-org.zoom.us/j/93744355918#success"],
+    '3-16' => [OFFICE_HOURS_TITLE, "Click here to join", "https://quill-org.zoom.us/j/95335806177#success"]
   }
 
   MLK_DAY_2021 = Date.parse("20210118")

--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -3,7 +3,7 @@
 
 <% if (still_doing_webinars && (!current_user || current_user.teacher?)) %>
   <% banner = WebinarBanner.new(current_time_on_east_coast) %>
-  <% if banner.show? %>
+  <% if banner.show? && (current_user&.subscription || banner.title != WebinarBanner::OFFICE_HOURS_TITLE) %>
     <div class="banner" id="webinar-banner">
       <div class="content-container">
         <img alt="Video player with play symbol" class="banner-icon" src=<%= "#{ENV['CDN_URL']}/images/icons/live-stream.svg" %>>


### PR DESCRIPTION
## WHAT
Make sure only premium teachers can see banner for premium webinars.

## WHY
We don't want non-premium teachers, or people who aren't signed in, having access to this banner.

## HOW
Hotfix that rests on the fact that the premium banners currently have the same title.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
