### PR TITLE
Add autoscale window to deploy script

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -8,6 +8,7 @@ case $1 in
     DEPLOY_GIT_BRANCH=deploy-lms-prod
     HEROKU_APP=empirical-grammar
     URL="https://www.quill.org/"
+    AUTOSCALE_URL="https://app.railsautoscale.com/empirical-grammar/settings/edit"
     NR_URL="https://rpm.newrelic.com/accounts/2639113/applications/548856875"
     current_branch="origin/production"
     ;;
@@ -48,6 +49,7 @@ then
         git push --no-verify --force origin origin/production:refs/heads/$DEPLOY_GIT_BRANCH
 
         sh ../../scripts/post_slack_deploy_description.sh $app_name
+        open $AUTOSCALE_URL
     else
         git fetch origin $DEPLOY_GIT_BRANCH
         git push --no-verify --force origin ${current_branch}:$DEPLOY_GIT_BRANCH


### PR DESCRIPTION
## WHAT
During production deploys, open up a window showing the rails autoscale configuration.

## WHY
This will remind us to autoscale the web and worker dynos down during a deploy to avoid the PG Connections errors.

## HOW
Update `deploy.sh` to include command that opens rails autoscale URL when deploying to production.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Code is outside of application.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
