### PR TITLE
fix issue where recommendations and criteria were not deletable

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/recommendations_table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/recommendations_table.scss
@@ -1,0 +1,8 @@
+.cms-recommendations-table {
+  .button_to {
+    margin-bottom: 0px;
+    .interactive-wrapper {
+      font-size: 16px;
+    }
+  }
+}

--- a/services/QuillLMS/app/views/cms/recommendations/_recommendation.html.erb
+++ b/services/QuillLMS/app/views/cms/recommendations/_recommendation.html.erb
@@ -12,14 +12,15 @@
     %>
   </td>
   <td>
-    <%= link_to 'Delete',
+    <%= button_to 'Delete',
       cms_activity_classification_activity_recommendation_path(
         @activity_classification,
         @activity,
         recommendation
       ),
       method: :delete,
-      data: { confirm: 'Are you sure?' }
+      data: { confirm: 'Are you sure?' },
+      class: 'interactive-wrapper'
     %>
   </td>
 <% end -%>

--- a/services/QuillLMS/app/views/cms/recommendations/index.html.erb
+++ b/services/QuillLMS/app/views/cms/recommendations/index.html.erb
@@ -4,7 +4,7 @@
     <hr>
     <h2>Independent Practice</h2>
     <% if @recommendations.independent_practice.present? %>
-      <table class="table table-responsive">
+      <table class="table table-responsive cms-recommendations-table">
         <thead>
           <tr>
             <th>Order</th>

--- a/services/QuillLMS/app/views/cms/recommendations/show.html.erb
+++ b/services/QuillLMS/app/views/cms/recommendations/show.html.erb
@@ -4,7 +4,7 @@
     <hr>
     <h2>Criteria</h2>
     <% if @recommendation.present? && @recommendation.criteria.present? -%>
-      <table class="table">
+      <table class="table cms-recommendations-table">
         <thead>
           <tr>
             <th>Concept</th>
@@ -31,7 +31,7 @@
               %>
             </td>
             <td>
-              <%= link_to 'Delete',
+              <%= button_to 'Delete',
                 cms_activity_classification_activity_recommendation_criterion_path(
                   @activity_classification,
                   @activity,
@@ -39,7 +39,8 @@
                   criterion
                 ),
                 method: :delete,
-                data: { confirm: 'Are you sure?' }
+                data: { confirm: 'Are you sure?' },
+                class: 'interactive-wrapper'
               %>
             </td>
           </tr>


### PR DESCRIPTION
## WHAT
Fix issue where recommendations and criteria were not deletable.

## WHY
Curriculum team members need to be able to delete recommendations and the criteria for recommending them.

## HOW
Switch `link_to` to `button_to` in both places and add some CSS to make sure the buttons still look like the rest of the links in the table.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-delete-criteria-in-Activities-Manager-c727a6732f294e2ea0786564363798f1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
