### PR TITLE
Drop LMS old_activity_sessions table

### DIFF
--- a/services/QuillLMS/db/migrate/20210311173333_drop_old_activity_sessions_table.rb
+++ b/services/QuillLMS/db/migrate/20210311173333_drop_old_activity_sessions_table.rb
@@ -1,0 +1,12 @@
+class DropOldActivitySessionsTable < ActiveRecord::Migration
+  def up
+    return unless ActiveRecord::Base.connection.tables.include?('old_activity_sessions')
+
+    execute "ALTER SEQUENCE activity_sessions_id_seq OWNED BY activity_sessions.id"
+    execute "DROP TABLE old_activity_sessions"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## WHAT
Remove an old table that is unused

## WHY
The table and its indices are large so its beneficial to remove it.

## HOW
It looks like `old_activity_sessions` was originally called `activity_sessions` and then renamed `old_activity_sessions`.  However, its sequence generator `activity_sessions_id_seq` kept its name.  Then, a new `activity_sessions` table was created that also used that same sequence.  Before dropping the `old_activity_sessions` table, we first have to remove the dependency between that sequence and the old table, otherwise you get:

```
empirical-grammar-staging::DATABASE=> DROP TABLE old_activity_sessions;
ERROR:  cannot drop table old_activity_sessions because other objects depend on it
DETAIL:  default for table activity_sessions column id depends on sequence activity_sessions_id_seq
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
```

   A more thorough explanation of this process is explained [here](https://dba.stackexchange.com/questions/223018/postgres-two-tables-use-the-same-sequence-how-to-delete-one).


### Notion Card Links
https://www.notion.so/quill/Drop-LMS-old_activity_sessions-table-93ec47966b7e4c17b9469fe65c17d99c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No. 
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
