### PR TITLE
turning off real http requests in VCR to fix CI failure

### DIFF
--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -23,7 +23,7 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.configure_rspec_metadata!
   c.ignore_hosts 'codeclimate.com'
-  c.allow_http_connections_when_no_cassette = true
+  c.allow_http_connections_when_no_cassette = false
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## WHAT
turning off real http requests in VCR 
## WHY
to fix CI failure. If we want to add additional cassettes, just re-toggle this config, run rspec, then toggle off before PR'ing
## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
