### PR TITLE
Speed up a long-running SQL query in UserManager search

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -23,7 +23,7 @@ class Cms::UsersController < Cms::CmsController
     user_search_query = user_query_params
     user_search_query_results = user_query(user_query_params)
     user_search_query_results ||= []
-    number_of_pages = (number_of_users_matched / USERS_PER_PAGE).ceil
+    number_of_pages = (user_search_query_results.size / USERS_PER_PAGE).ceil
     render json: {numberOfPages: number_of_pages, userSearchQueryResults: user_search_query_results, userSearchQuery: user_search_query}
   end
 
@@ -270,22 +270,6 @@ class Cms::UsersController < Cms::CmsController
     else
       "ORDER BY last_sign_in DESC"
     end
-  end
-
-  def number_of_users_matched
-    ActiveRecord::Base.connection.execute("
-      SELECT
-      	COUNT(users.id) AS count
-      FROM users
-      LEFT JOIN schools_users ON users.id = schools_users.user_id
-      LEFT JOIN schools ON schools_users.school_id = schools.id
-      LEFT JOIN user_subscriptions ON users.id = user_subscriptions.user_id
-      LEFT JOIN subscriptions ON user_subscriptions.subscription_id = subscriptions.id
-      LEFT JOIN classrooms_teachers ON users.id = classrooms_teachers.user_id
-      LEFT JOIN students_classrooms ON users.id = students_classrooms.student_id
-      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id OR classrooms.id = students_classrooms.classroom_id
-      #{where_query_string_builder}
-    ").to_a[0]['count'].to_i
   end
 
   def set_search_inputs


### PR DESCRIPTION
## WHAT
We had a query running unacceptably long (~90 seconds) in the UserManager search. This PR speeds up that query to an acceptable level (~3 ms).

## WHY
Searches that run over 30 seconds are onerous for our admin, and they also error out because of our load balancer.

## HOW
Instead of using LEFT JOIN on 2 extremely large tables `students_classrooms` and `classrooms_teachers`, use two inner selects that run considerably faster. Also stop running an additional query for the result count and simply count the result using an array size call on the results array.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, but ran existing tests to ensure no breaking changes.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
