### PR TITLE
update engine to use whole activity classification class

### DIFF
--- a/services/QuillLMS/config/initializers/comprehension.rb
+++ b/services/QuillLMS/config/initializers/comprehension.rb
@@ -1,3 +1,3 @@
 # Set the Engines connection to the parent activity here.
 Comprehension.parent_activity_class = "::Activity"
-Comprehension.parent_activity_classification_id = ActivityClassification.comprehension&.id
+Comprehension.parent_activity_classification_class = "::ActivityClassification"

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -34,7 +34,7 @@ module Comprehension
       else
         self.parent_activity = Comprehension.parent_activity_class.find_or_create_by(
           name: title,
-          activity_classification_id: Comprehension.parent_activity_classification_id
+          activity_classification_id: Comprehension.parent_activity_classification_class.comprehension&.id
         )
       end
     end

--- a/services/QuillLMS/engines/comprehension/lib/comprehension.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension.rb
@@ -2,9 +2,14 @@ require "comprehension/engine"
 
 module Comprehension
   mattr_accessor :parent_activity_class
-  mattr_accessor :parent_activity_classification_id
+  mattr_accessor :parent_activity_classification_class
 
   def self.parent_activity_class
     @@parent_activity_class.constantize
   end
+
+  def self.parent_activity_classification_class
+    @@parent_activity_classification_class.constantize
+  end
+
 end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
@@ -43,6 +43,7 @@ module Comprehension
     context "create" do
       setup do
         @activity = build(:comprehension_activity, parent_activity_id: 1, title: "First Activity", target_level: 8, scored_level: "4th grade", name: "First Activity - Name")
+        ::ActivityClassification.create(key: 'comprehension')
       end
 
       should "create a valid record and return it as json" do
@@ -94,7 +95,6 @@ module Comprehension
 
       should "create a new parent activity and activity if no parent_activity_id is passed" do
         post :create, activity: { parent_activity_id: nil, scored_level: @activity.scored_level, target_level: @activity.target_level, title: @activity.title, name: @activity.title, prompts_attributes: [{text: "meat is bad for you.", conjunction: "because"}] }
-
         parent_activity = ::Activity.find_by_name(@activity.title)
         new_activity = Activity.find_by_title(@activity.title)
         assert parent_activity.present?

--- a/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity_classification.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity_classification.rb
@@ -1,0 +1,7 @@
+class ActivityClassification < ActiveRecord::Base
+  COMPREHENSION_KEY = 'comprehension'
+
+  def self.comprehension
+    find_by_key COMPREHENSION_KEY
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/dummy/config/initializers/comprehension.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/config/initializers/comprehension.rb
@@ -1,2 +1,2 @@
 Comprehension.parent_activity_class = "::Activity"
-Comprehension.parent_activity_classification_id = 147 # just a mock number, unused
+Comprehension.parent_activity_classification_class = "::ActivityClassification"

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200005_add_parent_activity_classification.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200005_add_parent_activity_classification.rb
@@ -1,0 +1,7 @@
+class AddParentActivityClassification < ActiveRecord::Migration
+  def change
+    create_table :activity_classifications do |t|
+      t.string :key
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210317200004) do
+ActiveRecord::Schema.define(version: 20210317200005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,10 @@ ActiveRecord::Schema.define(version: 20210317200004) do
   create_table "activities", force: :cascade do |t|
     t.string  "name"
     t.integer "activity_classification_id"
+  end
+
+  create_table "activity_classifications", force: :cascade do |t|
+    t.string "key"
   end
 
   create_table "comprehension_activities", force: :cascade do |t|

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/activity_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/activity_test.rb
@@ -26,6 +26,7 @@ module Comprehension
 
       context 'parent_activity_id' do
         setup do
+          ::ActivityClassification.create(key: 'comprehension')
           parent_activity = ::Activity.create
           create(:comprehension_activity, parent_activity_id: parent_activity.id)
           @activity_with_same_parent = build(:comprehension_activity, parent_activity_id: parent_activity.id)


### PR DESCRIPTION
## WHAT
Update the Comprehension engine so it knows about the whole `ActivityClassification` class instead of just the id for one record.

## WHY
It seems like the initializer loaded before the classes did in production, leading to an error when `ActivityClassification` was called. This should avoid that.

## HOW
Refactor code to use `parent_activity_classification_class` instead of `parent_activity_classification_id`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
