### PR TITLE
Update firebase references in GenerateConceptsInUseArrayWorker

### DIFF
--- a/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
+++ b/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
@@ -1,28 +1,51 @@
 class GenerateConceptsInUseArrayWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
+  
+  REDIS_KEY_QUESTION_TYPES = {
+    "SC_QUESTIONS" => "connect_sentence_combining",
+    "FIB_QUESTIONS" => "connect_fill_in_blanks",
+    "SF_QUESTIONS" => "connect_sentence_fragments",
+    "D_QUESTIONS" => "diagnostic_sentence_combining",
+    "D_FIB_QUESTIONS" => "diagnostic_fill_in_blanks",
+    "D_SF_QUESTIONS" => "diagnostic_sentence_fragments",
+  }.freeze
+
+  CONCEPTS_IN_USE = [%w(
+    name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities
+    grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions
+    part_of_diagnostic_recommendations last_retrieved
+  )].to_json.freeze
 
   def perform
-    concepts_in_use = []
-    headers = %w(name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions part_of_diagnostic_recommendations last_retrieved)
-    concepts_in_use << headers
-    $redis.set("CONCEPTS_IN_USE", concepts_in_use.to_json)
-    $redis.set("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET", Time.now)
-    sc_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/questions.json").parsed_response
-    $redis.set('SC_QUESTIONS', sc_questions.to_json)
-    fib_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/fillInBlankQuestions.json").parsed_response
-    $redis.set('FIB_QUESTIONS', fib_questions.to_json)
-    sf_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/sentenceFragments.json").parsed_response
-    $redis.set('SF_QUESTIONS', sf_questions.to_json)
-    d_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/diagnostic_questions.json").parsed_response
-    $redis.set('D_QUESTIONS', d_questions.to_json)
-    d_fib_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/diagnostic_fillInBlankQuestions.json").parsed_response
-    $redis.set('D_FIB_QUESTIONS', d_fib_questions.to_json)
-    d_sf_questions = HTTParty.get("https://quillconnect.firebaseio.com/v2/diagnostic_sentenceFragments.json").parsed_response
-    $redis.set('D_SF_QUESTIONS', d_sf_questions.to_json)
+    set_concepts_in_use
+    set_question_types
+    run_individual_concept_workers
+  end
+  
+  private
+  
+  def question_response(question_type)
+    HTTParty
+      .get("https://www.quill.org/api/v1/questions?question_type=#{question_type}")
+      .parsed_response
+      .to_json
+  end
 
+  def run_individual_concept_workers
     Concept.visible_level_zero_concept_ids.each do |id|
       GetConceptsInUseIndividualConceptWorker.perform_async(id)
+    end
+  end
+  
+  def set_concepts_in_use
+    $redis.set("CONCEPTS_IN_USE", CONCEPTS_IN_USE)
+    $redis.set("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET", Time.now)
+  end
+  
+  def set_question_types
+    REDIS_KEY_QUESTION_TYPES.each_pair do |redis_key, question_type|
+      $redis.set(redis_key, question_response(question_type))
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix the assignment of redis values for question types.

## WHY
This particular worker relies on a firebase endpoint that we no longer use.

## HOW
Updating the assignment of various question types to point to the new questions controller.

### Screenshots

### Notion Card Links
https://www.notion.so/quill/Update-firebase-references-in-GenerateConceptsInUseArrayWorker-8779ec2f733e4216aed943eecfa6ea6c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual testing.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
