### PR TITLE
fix links to grammar and proofreader assign pages

### DIFF
--- a/services/QuillLMS/app/views/pages/grammar_tool.erb
+++ b/services/QuillLMS/app/views/pages/grammar_tool.erb
@@ -16,7 +16,7 @@
       <section class="tool-ctas grammar-tool">
         <a href='/activity_sessions/anonymous?activity_id=110' target="_blank" class="q-button cta-button bg-white text-purple">Try a sample activity</a>
         <% if current_user&.teacher? %>
-          <a href='/assign/activity-library?activityClassificationFilters[]=grammar' class="q-button text-white learn-more-button">Assign</a>
+          <a href='/assign/activity-library?activityClassificationFilters[]=sentence' class="q-button text-white learn-more-button">Assign</a>
         <% end %>
       </section>
     </section>

--- a/services/QuillLMS/app/views/pages/proofreader_tool.erb
+++ b/services/QuillLMS/app/views/pages/proofreader_tool.erb
@@ -16,7 +16,7 @@
       <section class="tool-ctas proofreader-tool">
         <a href='/activity_sessions/anonymous?activity_id=244' target="_blank" class="q-button cta-button text-quillblue bg-white">Try a sample activity</a>
         <% if current_user&.teacher? %>
-          <a href='/assign/activity-library?activityClassificationFilters[]=proofreader' class="q-button text-white learn-more-button">Assign</a>
+          <a href='/assign/activity-library?activityClassificationFilters[]=passage' class="q-button text-white learn-more-button">Assign</a>
         <% end %>
       </section>
     </section>


### PR DESCRIPTION
## WHAT
Fix links to the Activity Library that are pre-filtered for Proofreader and Grammar.

## WHY
We want these links to correctly filter the page.

## HOW
Use the correct keys for the filters.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/When-I-click-the-Assign-button-on-the-Proofreader-or-Grammar-tool-page-the-Activity-library-shows--c4eda649a7144a90947346ea6fe8bf11

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
