### PR TITLE
Bump mime magic to existing version 0.3.6

### DIFF
--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -295,6 +295,7 @@ DEPENDENCIES
   httparty
   kaminari
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.6)
   newrelic_rpm
   pg (~> 1.2)
   pry


### PR DESCRIPTION
## WHAT
Bump `mimemagic` version a patch version `0.3.5` to `0.3.6`.
## WHY
Elastic beanstalk can't find the `0.3.5` version, which has been removed.
https://github.com/minad/mimemagic/branches

https://rubygems.org/gems/mimemagic

## HOW

### Screenshots
<img width="940" alt="Screen Shot 2021-03-24 at 9 57 01 AM" src="https://user-images.githubusercontent.com/1304933/112322482-546f8380-8c87-11eb-9b75-9a179e322823.png">


### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A)
