### PR TITLE
Change wording and add explanatory tooltips to Diagnostic reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "lint-staged": {
-    "*.{dsx}": "npm run eslint:staged_files"
+    "*.{js,jsx,ts,tsx}": "npm run eslint:staged_files"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "npm run eslint:staged_files"
+    "*.{dsx}": "npm run eslint:staged_files"
   },
   "repository": {
     "type": "git",

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -56,7 +56,7 @@
         height: 24px;
         border-radius: 2px;
         margin-right: 8px;
-        &.unscored {
+        &.completed {
           background-color: #358fdf;
         }
         &.proficient {

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -135,11 +135,12 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
       csv_string = CSV.generate do |csv|
         csv << ['Student', 'Date', 'Activity', 'Score', 'Standard', 'Tool']
         activity_sessions.map do |session|
+          score = (session['percentage'].to_f == -1.0 ? 'Completed' : "#{session['percentage'].to_f*100}%")
           csv << [
             session['student_name'],
             session['visual_date'],
             session['activity_name'],
-            "#{session['percentage'].to_f*100}%",
+            score,
             session['standard'],
             session['activity_classification_name']
           ]

--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -35,6 +35,9 @@
   &.reorder-section {
     overflow: visible;
   }
+  &.tooltip-section {
+    overflow: visible;
+  }
 }
 
 .data-table-header, .data-table-row-section {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/classroom_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/classroom_activity.jsx
@@ -86,7 +86,7 @@ export default class ClassroomActivity extends React.Component {
     const averageScore = data.cumulativeScore / data.completedCount;
     if (isNaN(averageScore)) {
       return '—';
-    } else if (data.activityClassificationId == DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID) {
+    } else if (data.activityClassificationId === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID) {
       return (<Tooltip
         tooltipText={`This type of activity is not graded.`}
         tooltipTriggerText="N/A"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/classroom_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/classroom_activity.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import Pluralize from 'pluralize';
 import activityFromClassificationId from '../../modules/activity_from_classification_id.js';
+import { Tooltip } from '../../../../Shared/index'
 
 import PreviewOrLaunchModal from '../../shared/preview_or_launch_modal';
 
@@ -81,9 +82,15 @@ export default class ClassroomActivity extends React.Component {
 
   calculateAverageScore = () => {
     const { data, } = this.props
+    const DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID = '4'
     const averageScore = data.cumulativeScore / data.completedCount;
     if (isNaN(averageScore)) {
       return '—';
+    } else if (data.activityClassificationId == DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID) {
+      return (<Tooltip
+        tooltipText={`This type of activity is not graded.`}
+        tooltipTriggerText="N/A"
+      />)
     } else if (Math.round(averageScore).toString().length === 2) {
       return `${averageScore.toPrecision(2)}%`;
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
@@ -59,7 +59,7 @@ export default class extends React.Component {
 
   score(row) {
     if (row.completed_at && !notLessonsOrDiagnostic(row.activity_classification_id)) {
-      return {content: 'Completed', color: 'blue', tooltip: true}
+      return {content: 'Completed', color: 'blue'}
     } else if (row.percentage) {
       return {
         content: Math.round(row.percentage * 100) + '%',
@@ -73,7 +73,6 @@ export default class extends React.Component {
 
   tableRow(row) {
     const scoreInfo = this.score(row);
-    const blurIfNotPremium = this.state.userIsPremium ?  '' : 'non-premium-blur'
     const onClickFunction = row.completed_at ? () => window.location.href = `/teachers/progress_reports/report_from_classroom_unit_activity_and_user/cu/${row.classroom_unit_id}/user/${this.props.studentId}/a/${row.activity_id}` : () => {}
 
     return (
@@ -83,16 +82,29 @@ export default class extends React.Component {
           <a className={scoreInfo.linkColor} href={`/activity_sessions/anonymous?activity_id=${row.activity_id}`}>{row.name}</a>
         </td>
         <td>{this.completedStatus(row)}</td>
-        { scoreInfo.tooltip ?
-            <td className={`score ${blurIfNotPremium}`}><Tooltip
-              tooltipText={`This type of activity is not graded.`}
-              tooltipTriggerText={scoreInfo.content}
-            /></td> :
-            <td className={`score ${blurIfNotPremium}`}>{scoreInfo.content}</td>
-        }
+        {this.scoreContent(scoreInfo)}
         <td className='green-arrow'>{this.greenArrow(row)}</td>
       </tr>
     )
+  }
+
+  scoreContent(scoreInfo) {
+    const blurIfNotPremium = this.state.userIsPremium ?  '' : 'non-premium-blur'
+    const activityUngraded = scoreInfo.content == 'Completed'
+    if (activityUngraded) {
+      return (
+        <td className={`score ${blurIfNotPremium}`}>
+          <Tooltip
+            tooltipText={`This type of activity is not graded.`}
+            tooltipTriggerText={scoreInfo.content}
+          />
+        </td>
+      )
+    } else {
+      return (
+        <td className={`score ${blurIfNotPremium}`}>{scoreInfo.content}</td>
+      )
+    }
   }
 
   unitTable(unit) {
@@ -116,9 +128,9 @@ export default class extends React.Component {
                   {averageScore
                     ? Math.round(averageScore * 100) + '%'
                     : <Tooltip
-                        tooltipText={`This type of activity is not graded.`}
-                        tooltipTriggerText="N/A"
-                      />}
+                      tooltipText={`This type of activity is not graded.`}
+                      tooltipTriggerText="N/A"
+                    />}
                 </div>
               </th>
             </tr>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
@@ -90,7 +90,7 @@ export default class extends React.Component {
 
   scoreContent(scoreInfo) {
     const blurIfNotPremium = this.state.userIsPremium ?  '' : 'non-premium-blur'
-    const activityUngraded = scoreInfo.content == 'Completed'
+    const activityUngraded = scoreInfo.content === 'Completed'
     if (activityUngraded) {
       return (
         <td className={`score ${blurIfNotPremium}`}>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
@@ -4,6 +4,7 @@ import moment from 'moment'
 import gradeColor from '../modules/grade_color.js'
 import notLessonsOrDiagnostic from '../../../../modules/activity_classifications.js'
 import userIsPremium from '../modules/user_is_premium'
+import { Tooltip } from '../../../Shared/index'
 
 export default class extends React.Component {
 
@@ -58,7 +59,7 @@ export default class extends React.Component {
 
   score(row) {
     if (row.completed_at && !notLessonsOrDiagnostic(row.activity_classification_id)) {
-      return {content: 'Not Scored', color: 'blue'}
+      return {content: 'Completed', color: 'blue', tooltip: true}
     } else if (row.percentage) {
       return {
         content: Math.round(row.percentage * 100) + '%',
@@ -82,7 +83,13 @@ export default class extends React.Component {
           <a className={scoreInfo.linkColor} href={`/activity_sessions/anonymous?activity_id=${row.activity_id}`}>{row.name}</a>
         </td>
         <td>{this.completedStatus(row)}</td>
-        <td className={`score ${blurIfNotPremium}`}>{scoreInfo.content}</td>
+        { scoreInfo.tooltip ?
+            <td className={`score ${blurIfNotPremium}`}><Tooltip
+              tooltipText={`This type of activity is not graded.`}
+              tooltipTriggerText={scoreInfo.content}
+            /></td> :
+            <td className={`score ${blurIfNotPremium}`}>{scoreInfo.content}</td>
+        }
         <td className='green-arrow'>{this.greenArrow(row)}</td>
       </tr>
     )
@@ -108,7 +115,10 @@ export default class extends React.Component {
                 <div className={`${blurIfNotPremium}`}>
                   {averageScore
                     ? Math.round(averageScore * 100) + '%'
-                    : 'Not Scored'}
+                    : <Tooltip
+                        tooltipText={`This type of activity is not graded.`}
+                        tooltipTriggerText="N/A"
+                      />}
                 </div>
               </th>
             </tr>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -87,7 +87,6 @@ exports[`ScoreLegend component should render 1`] = `
         <p
           className="explanation"
         >
-          Not Scored
         </p>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -70,26 +70,32 @@ exports[`ScoreLegend component should render 1`] = `
         </p>
       </div>
     </div>
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-blue"
-      />
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
+    <Tooltip
+      tooltipText="This type of activity is not graded."
+      tooltipTriggerText={
+        <div
+          className="icon"
         >
-          Completed
-        </p>
-        <p
-          className="explanation"
-        >
-        </p>
-      </div>
-    </div>
+          <div
+            className="icon-wrapper icon-blue"
+          />
+          <div
+            className="icons-description-wrapper"
+          >
+            <p
+              className="title"
+            >
+              Completed
+            </p>
+            <p
+              className="explanation"
+            >
+              <br />
+            </p>
+          </div>
+        </div>
+      }
+    />
     <div
       className="icon"
     >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
@@ -37,7 +37,7 @@ export default class extends React.Component {
                   <div className="icon-wrapper icon-blue" />
                   <div className="icons-description-wrapper">
                     <p className="title">Completed</p>
-                    <p className="explanation"><br/></p>
+                    <p className="explanation"><br /></p>
                   </div>
                 </div>
               }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
@@ -1,6 +1,7 @@
 'use strict';
 import React from 'react'
 import {proficiencyCutoffsAsPercentage} from '../../../../modules/proficiency_cutoffs.js'
+import { Tooltip } from '../../../Shared/index'
 
 export default class extends React.Component {
   render() {
@@ -29,13 +30,18 @@ export default class extends React.Component {
                 <p className="explanation">{`0-${cutOff.nearlyProficient - 1}%`}</p>
               </div>
             </div>
-            <div className="icon">
-              <div className="icon-wrapper icon-blue" />
-              <div className="icons-description-wrapper">
-                <p className="title">Completed</p>
-                <p className="explanation">Not Scored</p>
-              </div>
-            </div>
+            <Tooltip
+              tooltipText={`This type of activity is not graded.`}
+              tooltipTriggerText={
+                <div className="icon">
+                  <div className="icon-wrapper icon-blue" />
+                  <div className="icons-description-wrapper">
+                    <p className="title">Completed</p>
+                    <p className="explanation"><br/></p>
+                  </div>
+                </div>
+              }
+            />
             <div className="icon">
               <div className="icon-wrapper icon-progress">
                 <img className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -1756,10 +1756,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -1864,7 +1864,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -1939,7 +1939,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -2029,7 +2029,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {
@@ -3867,10 +3867,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -3975,7 +3975,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -4050,7 +4050,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -4140,7 +4140,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {
@@ -6173,10 +6173,10 @@ exports[`StudentProfileUnits component should render all activities and units if
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -6281,7 +6281,7 @@ exports[`StudentProfileUnits component should render all activities and units if
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -6356,7 +6356,7 @@ exports[`StudentProfileUnits component should render all activities and units if
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -6446,7 +6446,7 @@ exports[`StudentProfileUnits component should render all activities and units if
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {
@@ -6988,10 +6988,10 @@ exports[`StudentProfileUnits component should render only completed activities i
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -7096,7 +7096,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -7171,7 +7171,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -7261,7 +7261,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {
@@ -11188,10 +11188,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -11296,7 +11296,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -11371,7 +11371,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -11461,7 +11461,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {
@@ -13494,10 +13494,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "attribute": "score",
-                  "headerClassName": "score-section",
+                  "headerClassName": "score-section tooltip-section",
                   "name": "Score",
                   "noTooltip": true,
-                  "rowSectionClassName": "score-section",
+                  "rowSectionClassName": "score-section tooltip-section",
                   "width": "144px",
                 },
                 Object {
@@ -13602,7 +13602,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                   Activity
                 </button>
                 <button
-                  className="data-table-header score-section"
+                  className="data-table-header score-section tooltip-section"
                   style={
                     Object {
                       "minWidth": "144px",
@@ -13677,7 +13677,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     A, An
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-9"
                     style={
                       Object {
@@ -13767,7 +13767,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     Age of Exploration: Spices
                   </span>
                   <span
-                    className="data-table-row-section score-section"
+                    className="data-table-row-section score-section tooltip-section"
                     key="score-5"
                     style={
                       Object {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
-
 import moment from 'moment'
 
-import { DataTable } from '../../../Shared/index'
-
+import { DataTable, Tooltip } from '../../../Shared/index'
 import activityLaunchLink from '../modules/generate_activity_launch_link.js';
 
 const diagnosticSrc = `${process.env.CDN_URL}/images/icons/tool-diagnostic-gray.svg`
@@ -60,8 +58,8 @@ const completeHeaders = [
     name: 'Score',
     attribute: 'score',
     noTooltip: true,
-    headerClassName: 'score-section',
-    rowSectionClassName: 'score-section'
+    headerClassName: 'score-section tooltip-section',
+    rowSectionClassName: 'score-section tooltip-section'
   }, {
     width: '24px',
     name: 'Tool',
@@ -92,7 +90,7 @@ export default class StudentProfileUnit extends React.Component {
     const { repeatable, max_percentage, locked, marked_complete, activity_classification_id, resume_link, ca_id, activity_id, } = act
     let linkText = 'Start'
 
-    if (repeatable === 'f' && max_percentage) { return <span>Completed</span> }
+    if (repeatable === 'f' && max_percentage) { return <span></span> }
 
     if (max_percentage === null && marked_complete === 't') { return <span>Missed</span> }
 
@@ -119,7 +117,11 @@ export default class StudentProfileUnit extends React.Component {
     const { activity_classification_id, max_percentage, } = act
     const maxPercentage = Number(max_percentage)
     if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
-      return (<div className="score"><div className="unscored" /><span>Unscored</span></div>)
+      return (<div className="score"><div className="completed" /><span>
+        <Tooltip
+        tooltipText={`This type of activity is not graded.`}
+        tooltipTriggerText="Completed"
+      /></span></div>)
     }
 
     if (maxPercentage >= PROFICIENT_CUTOFF) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -117,11 +117,16 @@ export default class StudentProfileUnit extends React.Component {
     const { activity_classification_id, max_percentage, } = act
     const maxPercentage = Number(max_percentage)
     if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
-      return (<div className="score"><div className="completed" /><span>
+      return (
         <Tooltip
         tooltipText={`This type of activity is not graded.`}
-        tooltipTriggerText="Completed"
-      /></span></div>)
+        tooltipTriggerText={
+          <div className="score">
+            <div className="completed" />
+            <span>Completed</span>
+          </div>
+        }
+      />)
     }
 
     if (maxPercentage >= PROFICIENT_CUTOFF) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -90,7 +90,7 @@ export default class StudentProfileUnit extends React.Component {
     const { repeatable, max_percentage, locked, marked_complete, activity_classification_id, resume_link, ca_id, activity_id, } = act
     let linkText = 'Start'
 
-    if (repeatable === 'f' && max_percentage) { return <span></span> }
+    if (repeatable === 'f' && max_percentage) { return <span /> }
 
     if (max_percentage === null && marked_complete === 't') { return <span>Missed</span> }
 
@@ -119,14 +119,14 @@ export default class StudentProfileUnit extends React.Component {
     if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
       return (
         <Tooltip
-        tooltipText={`This type of activity is not graded.`}
-        tooltipTriggerText={
-          <div className="score">
-            <div className="completed" />
-            <span>Completed</span>
-          </div>
-        }
-      />)
+          tooltipText={`This type of activity is not graded.`}
+          tooltipTriggerText={
+            <div className="score">
+              <div className="completed" />
+              <span>Completed</span>
+            </div>
+          }
+        />)
     }
 
     if (maxPercentage >= PROFICIENT_CUTOFF) {


### PR DESCRIPTION
## WHAT
Teachers were very confused about our Diagnostic reports displaying Diagnostics as "Unscored". To clear up the confusion, we're now labeling these activities as "Completed" and adding a tooltip when teachers hover over the icon to explain "This type of activity is not graded."

## WHY
This will help resolve a common point of confusion for teachers and students.

## HOW
Change the wording everywhere we display Diagnostic results. Add a tooltip everywhere we show Diagnostic results as "Completed" instead of showing a percentage.

### Screenshots
<img width="1077" alt="Screen Shot 2021-03-29 at 4 41 04 PM" src="https://user-images.githubusercontent.com/57366100/112904308-5d5cbc80-90ae-11eb-9c56-aa0c69153c91.png">
<img width="527" alt="Screen Shot 2021-03-29 at 4 41 19 PM" src="https://user-images.githubusercontent.com/57366100/112904317-6057ad00-90ae-11eb-928c-1ba35dc8664b.png">
<img width="1107" alt="Screen Shot 2021-03-29 at 4 41 35 PM" src="https://user-images.githubusercontent.com/57366100/112904322-62ba0700-90ae-11eb-8193-fa6f218b1ae7.png">
<img width="624" alt="Screen Shot 2021-03-29 at 4 41 46 PM" src="https://user-images.githubusercontent.com/57366100/112904331-651c6100-90ae-11eb-86f5-3cbb94906106.png">


### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=3f16f0d2b6794f31abb4ea597b71ef8e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
