### PR TITLE
fixing intermittently failing specs

### DIFF
--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -7,13 +7,15 @@ describe InvitationsController, type: :controller do
   let(:classroom) { create(:classroom) }
   let(:user) { classroom.owner }
 
-  before do
+  before(:each) do
     # It is necessary to load Invitation here explicitly.
     # Otherwise, RSpec will stub Invitation as a Module (rather than an ActiveRecord::Base descendent) 
     # when stub_const is called within a spec.
     # Reference: 
     # https://stackoverflow.com/questions/32563359/stubing-a-model-constant-for-assosiation-undefined-method-relation-delegate-cl
+    # rubocop:disable all
     CoteacherClassroomInvitation
+    # rubocop:enable all
     allow(controller).to receive(:current_user) { user }
   end
 

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -13,7 +13,7 @@ describe InvitationsController, type: :controller do
     # when stub_const is called within a spec.
     # Reference: 
     # https://stackoverflow.com/questions/32563359/stubing-a-model-constant-for-assosiation-undefined-method-relation-delegate-cl
-    Invitation.class 
+    CoteacherClassroomInvitation
     allow(controller).to receive(:current_user) { user }
   end
 


### PR DESCRIPTION
## WHAT
Forces a loading of a Ruby class to avoid RSpec mistakenly loading it as a module

## WHY
Certain invitations_controller specs intermittently fail on develop. Example: https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/6687/workflows/6135f1fd-393e-47f3-a8bc-1c93e689eaec/jobs/141383

## HOW

### Screenshots


### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
