### PR TITLE
Comprehension internal tools/copy changes and bug fixes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Select from 'react-select';
+
 import { HTMLDropdownOption } from './htmlDropdownOption'
 import { HTMLDropdownSingleValue } from './htmlDropdownSingleValue'
 import { CheckableDropdownOption } from './checkableDropdownOption'
@@ -24,7 +25,7 @@ interface DropdownInputProps {
   timesSubmitted?: Number;
   type?: string;
   usesCustomOption?: boolean;
-  value?: string;
+  value?: any;
 }
 
 interface DropdownInputState {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`Activity Form component should render Activities 1`] = `
       text="..."
     />
     <p
-      className="text-editor-label "
+      className="text-editor-label has-text"
     >
       Max Attempts Feedback
     </p>
@@ -88,7 +88,7 @@ exports[`Activity Form component should render Activities 1`] = `
       EditorState={[Function]}
       handleTextChange={[Function]}
       key="max-attempt-feedback"
-      text=""
+      text="Nice effort! You worked hard to make your sentence stronger."
     />
     <PromptsForm
       activityBecausePrompt={

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/labelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/labelsTable.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`LabelsTable component should render LabelsTable 1`] = `
 <section
-  className="semantic-rules-container"
+  className="semantic-labels-container"
 >
   <section
     className="header-container"
   >
     <h5>
-      Semantic Rules/Label: 
+      Semantic Labels: 
       <p />
     </h5>
     <h5>
@@ -17,28 +17,21 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
         1
       </p>
     </h5>
-    <section
-      className="lower-header-container"
+    <button
+      className="quill-button fun primary contained"
+      id="add-rule-button"
+      type="submit"
     >
-      <h5>
-        Prompt Labelset
-      </h5>
-      <button
-        className="quill-button fun primary contained"
-        id="add-rule-button"
-        type="submit"
+      <Link
+        to="/activities/17/semantic-labels/1/new"
       >
-        <Link
-          to="/activities/17/semantic-rules/1/new"
-        >
-          Add Rule/Label
-        </Link>
-      </button>
-    </section>
+        Add Label
+      </Link>
+    </button>
   </section>
   <DataTable
     averageFontWidth={7}
-    className="semantic-rules-table"
+    className="semantic-labels-table"
     headers={
       Array [
         Object {
@@ -47,18 +40,18 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
           "width": "70px",
         },
         Object {
-          "attribute": "name",
-          "name": "Rule Name",
+          "attribute": "descriptive_label",
+          "name": "Descriptive Label",
           "width": "400px",
         },
         Object {
-          "attribute": "label_name",
-          "name": "Label Name",
+          "attribute": "automl_label",
+          "name": "AutoML Label",
           "width": "150px",
         },
         Object {
           "attribute": "state",
-          "name": "Rule/Label Active?",
+          "name": "Active?",
           "width": "150px",
         },
         Object {
@@ -76,11 +69,13 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
     rows={
       Array [
         Object {
+          "automl_label": "label_1",
+          "descriptive_label": "rule_1",
           "edit": <ForwardRef
             className="data-link"
             to={
               Object {
-                "pathname": "/activities/17/semantic-rules/1/1",
+                "pathname": "/activities/17/semantic-labels/1/1",
                 "state": Object {
                   "rule": Object {
                     "id": 1,
@@ -99,8 +94,6 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
             View
           </ForwardRef>,
           "id": 1,
-          "label_name": "label_1",
-          "name": "rule_1",
           "optimal": <img
             alt="quill-circle-checkmark"
             src="/images/red_x.svg"
@@ -112,11 +105,13 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
           "state_for_sort": "active",
         },
         Object {
+          "automl_label": "label_2",
+          "descriptive_label": "rule_2",
           "edit": <ForwardRef
             className="data-link"
             to={
               Object {
-                "pathname": "/activities/17/semantic-rules/1/2",
+                "pathname": "/activities/17/semantic-labels/1/2",
                 "state": Object {
                   "rule": Object {
                     "id": 2,
@@ -135,8 +130,6 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
             View
           </ForwardRef>,
           "id": 2,
-          "label_name": "label_2",
-          "name": "rule_2",
           "optimal": <img
             alt="quill-circle-checkmark"
             src="/images/red_x.svg"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/modelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/modelsTable.test.tsx.snap
@@ -7,24 +7,26 @@ exports[`LabelsTable component should render ModelsTable 1`] = `
   <section
     className="header-container"
   >
-    <section
-      className="lower-header-container"
+    <h5>
+      Prompt Models
+    </h5>
+    <h5
+      id="model-count"
     >
-      <h5>
-        Prompt Models
-      </h5>
-      <button
-        className="quill-button fun primary contained"
-        id="add-model-button"
-        type="submit"
+      Count: 
+      <p />
+    </h5>
+    <button
+      className="quill-button fun primary contained"
+      id="add-model-button"
+      type="submit"
+    >
+      <Link
+        to="/activities/17/semantic-labels/1/add-model"
       >
-        <Link
-          to="/activities/17/semantic-labels/1/add-model"
-        >
-          Add Model
-        </Link>
-      </button>
-    </section>
+        Add Model
+      </Link>
+    </button>
   </section>
   <DataTable
     averageFontWidth={7}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/modelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/modelsTable.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`LabelsTable component should render ModelsTable 1`] = `
         type="submit"
       >
         <Link
-          to="/activities/17/semantic-rules/1/add-model"
+          to="/activities/17/semantic-labels/1/add-model"
         >
           Add Model
         </Link>
@@ -48,8 +48,8 @@ exports[`LabelsTable component should render ModelsTable 1`] = `
           "width": "300px",
         },
         Object {
-          "attribute": "labels",
-          "name": "Labels",
+          "attribute": "label_count",
+          "name": "Label Count",
           "width": "70px",
         },
         Object {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleForm.test.tsx.snap
@@ -35,8 +35,8 @@ exports[`RuleForm component should render RuleForm 1`] = `
       }
       ruleType={
         Object {
-          "label": "Regex",
-          "value": "rules-based",
+          "label": "Sentence Structure Regex",
+          "value": "rules-based-1",
         }
       }
       setRuleConceptUID={[Function]}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
@@ -11,10 +11,6 @@ exports[`RuleGenericAttributes component should render RuleGenericAttributes 1`]
     options={
       Array [
         Object {
-          "label": "Regex",
-          "value": "rules-based",
-        },
-        Object {
           "label": "Sentence Structure Regex",
           "value": "rules-based-1",
         },
@@ -29,10 +25,6 @@ exports[`RuleGenericAttributes component should render RuleGenericAttributes 1`]
         Object {
           "label": "Plagiarism",
           "value": "plagiarism",
-        },
-        Object {
-          "label": "AutoML Evidence",
-          "value": "autoML",
         },
       ]
     }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleSemanticAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleSemanticAttributes.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RuleSemanticAttributes component should render RuleSemanticAttributes 1
     className="label-name-input"
     disabled={false}
     handleChange={[Function]}
-    label="Label Name"
+    label="AutoML Label"
     value="semantic rule"
   />
   <p
@@ -15,13 +15,18 @@ exports[`RuleSemanticAttributes component should render RuleSemanticAttributes 1
   >
     Label requirements: name must be unique (prompt cannot have duplicate label names), labels cannot contain spaces; maximum of 32 characters.
   </p>
+  <p
+    className="label-explanation"
+  >
+    Once the Label Name is submitted, it cannot be edited.
+  </p>
   <section
     className="label-status-container"
   >
     <p
       id="label-status-label"
     >
-      Label/Rule Status
+      Label Status
     </p>
     <p
       id="label-status"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
   <p
     className="form-subsection-label"
   >
-    First Revision - Feedback
+    First Layer Feedback
   </p>
   <TextEditor
     ContentState={[Function]}
@@ -15,7 +15,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     text="test universal feedback"
   />
   <button
-    className="add-highlight quill-button small primary outlined"
+    className="add-highlight quill-button small primary outlined "
+    disabled={false}
     id="0"
     onClick={[Function]}
     type="button"
@@ -115,7 +116,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
   <p
     className="form-subsection-label"
   >
-    Second Revision - Feedback
+    Second Layer Feedback
   </p>
   <TextEditor
     ContentState={[Function]}
@@ -125,7 +126,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     text="test universal feedback"
   />
   <button
-    className="add-highlight quill-button small primary outlined"
+    className="add-highlight quill-button small primary outlined "
+    disabled={false}
     id="1"
     onClick={[Function]}
     type="button"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/semanticRulesOverview.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/semanticRulesOverview.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SemanticRulesOverview component should render SemanticRulesOverview 1`] = `
+exports[`SemanticLabelsOverview component should render SemanticLabelsOverview 1`] = `
 <div
-  className="semantic-rules-overview-container"
+  className="semantic-labels-overview-container"
 >
   <section
     className="prompt-section"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleForm.test.tsx
@@ -8,7 +8,7 @@ import RulePrompts from '../configureRules/rulePrompts';
 
 jest.mock('../../../helpers/comprehension/ruleHelpers', () => ({
   getInitialRuleType: jest.fn().mockImplementation(() => {
-    return { value: 'rules-based', label: 'Regex' }
+    return { value: 'rules-based-1', label: 'Sentence Structure Regex' }
    }),
   formatInitialFeedbacks: jest.fn().mockImplementation(() => {
     return [{
@@ -23,7 +23,7 @@ jest.mock('../../../helpers/comprehension/ruleHelpers', () => ({
 
 const mockRule = {
   id: 1,
-  rule_type: 'regex' ,
+  rule_type: 'rules-based-1' ,
   name: 'remove all instances of "it contains methane"',
   universal: false,
   optimal: false,

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleSemanticAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleSemanticAttributes.test.tsx
@@ -23,6 +23,6 @@ describe('RuleSemanticAttributes component', () => {
     // Input: Rule label name
     // p tag: Rule label status
     expect(container.find(Input).length).toEqual(1);
-    expect(container.find('p').at(2).props().children).toEqual(mockProps.ruleLabelStatus);
+    expect(container.find('p').at(3).props().children).toEqual(mockProps.ruleLabelStatus);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/semanticLabelsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/semanticLabelsIndex.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 
-import SemanticRulesIndex from '../semanticRules/semanticRulesIndex';
+import SemanticLabelsIndex from '../semanticRules/semanticLabelsIndex';
 
 const mockActivity = [{ id: 1, title: 'First' }]
 jest.mock("react-query", () => ({
@@ -27,13 +27,13 @@ const mockProps = {
   }
 }
 
-describe('SemanticRulesIndex component', () => {
+describe('SemanticLabelsIndex component', () => {
   const container = mount(
     <MemoryRouter>
-      <SemanticRulesIndex {...mockProps} />
+      <SemanticLabelsIndex {...mockProps} />
     </MemoryRouter>
   );
-  it('should render SemanticRulesIndex', () => {
-    expect(container.find(SemanticRulesIndex).length).toEqual(1);
+  it('should render SemanticLabelsIndex', () => {
+    expect(container.find(SemanticLabelsIndex).length).toEqual(1);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/semanticRulesOverview.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/semanticRulesOverview.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import SemanticRulesOverview from '../semanticRules/semanticRulesOverview';
+import SemanticLabelsOverview from '../semanticRules/semanticLabelsOverview';
 import LabelsTable from '../semanticRules/labelsTable';
 import ModelsTable from '../semanticRules/modelsTable';
 
@@ -10,10 +10,10 @@ const mockProps = {
   prompts: [{ id: 1 }, { id: 2 }, { id: 3 }]
 };
 
-describe('SemanticRulesOverview component', () => {
-  const container = shallow(<SemanticRulesOverview {...mockProps} />);
+describe('SemanticLabelsOverview component', () => {
+  const container = shallow(<SemanticLabelsOverview {...mockProps} />);
 
-  it('should render SemanticRulesOverview', () => {
+  it('should render SemanticLabelsOverview', () => {
     expect(container).toMatchSnapshot();
   });
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activity.tsx
@@ -6,7 +6,7 @@ import ActivitySettings from './configureSettings/activitySettings';
 import Rules from './configureRules/rules';
 import Rule from './configureRules/rule';
 import TurkSessions from './gatherResponses/turkSessions';
-import SemanticRulesIndex from './semanticRules/semanticRulesIndex';
+import SemanticLabelsIndex from './semanticRules/semanticLabelsIndex';
 
 import { ActivityRouteProps } from '../../interfaces/comprehensionInterfaces';
 
@@ -21,7 +21,7 @@ const Activity: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match, lo
           <Route component={Rule} path='/activities/:activityId/rules/:ruleId' />
           <Route component={Rules} path='/activities/:activityId/rules' />
           <Route component={TurkSessions} path='/activities/:activityId/turk-sessions' />
-          <Route component={SemanticRulesIndex} path='/activities/:activityId/semantic-rules' />
+          <Route component={SemanticLabelsIndex} path='/activities/:activityId/semantic-labels' />
         </Switch>
       </div>
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
@@ -13,6 +13,8 @@ import { InputEvent, DropdownObjectInterface } from '../../../interfaces/compreh
 import { Input, DropdownInput, TextEditor } from '../../../../Shared/index'
 
 interface RuleGenericAttributesProps {
+  autoMLParams?: any,
+  isAutoML?: boolean,
   isUniversal: boolean,
   errors: any,
   ruleConceptUID: string,
@@ -31,6 +33,8 @@ interface RuleGenericAttributesProps {
 }
 
 const RuleGenericAttributes = ({
+  autoMLParams,
+  isAutoML,
   isUniversal,
   errors,
   concepts,
@@ -68,9 +72,14 @@ const RuleGenericAttributes = ({
   }
 
   const ruleTypeDisabled = (ruleID || ruleType.value === 'autoML') ? 'disabled' : '';
-  const options = isUniversal ? universalRuleTypeOptions : ruleTypeOptions;
+  let options = isUniversal ? universalRuleTypeOptions : ruleTypeOptions;
+  if(!isAutoML) {
+    options = options.filter(option => option.value !== 'autoML');
+  }
   const conceptOptions = concepts.map(c => ({ value: c.uid, label: c.name, }));
   const selectedConceptOption = conceptOptions.find(co => co.value === ruleConceptUID);
+  const nameInputLabel = autoMLParams && autoMLParams['label'] ? autoMLParams['label'] : 'Name';
+  const descriptionLabel = autoMLParams && autoMLParams['notes'] ? autoMLParams['notes'] : 'Rule Description';
 
   return(
     <React.Fragment>
@@ -87,7 +96,7 @@ const RuleGenericAttributes = ({
         className="name-input"
         error={errors['Name']}
         handleChange={onHandleSetRuleName}
-        label="Name"
+        label={nameInputLabel}
         value={ruleName}
       />
       <DropdownInput
@@ -109,7 +118,7 @@ const RuleGenericAttributes = ({
       />
       {ruleID && renderIDorUID(ruleID, 'Rule ID')}
       {ruleUID && renderIDorUID(ruleUID, 'Rule UID')}
-      <p className="form-subsection-label">Rule Description</p>
+      <p className="form-subsection-label">{descriptionLabel}</p>
       <TextEditor
         ContentState={ContentState}
         EditorState={EditorState}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleSemanticAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleSemanticAttributes.tsx
@@ -29,12 +29,13 @@ const RuleSemanticAttributes = ({
         disabled={ruleLabelNameDisabled}
         error={errors['Label Name']}
         handleChange={onHandleSetRuleLabelName}
-        label="Label Name"
+        label="AutoML Label"
         value={ruleLabelName}
       />
       <p className="label-explanation">Label requirements: name must be unique (prompt cannot have duplicate label names), labels cannot contain spaces; maximum of 32 characters.</p>
+      <p className="label-explanation">Once the Label Name is submitted, it cannot be edited.</p>
       <section className="label-status-container">
-        <p id="label-status-label">Label/Rule Status</p>
+        <p id="label-status-label">Label Status</p>
         <p id="label-status">{ruleLabelStatus}</p>
       </section>
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleUniversalAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleUniversalAttributes.tsx
@@ -54,9 +54,10 @@ const RuleAttributesSection = ({
 
   function renderFeedbacks(feedbacks) {
     return feedbacks.map((feedback: RuleFeedbackInterface, i: number) => {
+      const disabledStatus = feedbacks.length > 5 ?  'disabled' : '';
       return(
         <React.Fragment key={i}>
-          <p className="form-subsection-label">{`${numericalWordOptions[i]} Revision - Feedback`}</p>
+          <p className="form-subsection-label">{`${numericalWordOptions[i]} Layer Feedback`}</p>
           <TextEditor
             ContentState={ContentState}
             EditorState={EditorState}
@@ -66,7 +67,7 @@ const RuleAttributesSection = ({
             text={universalFeedback[i].text}
           />
           {errors['Universal Feedback'] && errors['Universal Feedback'].length && <p className="error-message">{errors['Universal Feedback'][i]}</p>}
-          <button className="add-highlight quill-button small primary outlined" id={`${i}`} onClick={onHandleAddHighlight} type="button">Add Highlight</button>
+          <button className={`add-highlight quill-button small primary outlined ${disabledStatus}`} disabled={!!disabledStatus} id={`${i}`} onClick={onHandleAddHighlight} type="button">Add Highlight</button>
           {feedback.highlights_attributes && renderHighlights(feedback.highlights_attributes, i, onHandleSetUniversalFeedback)}
         </React.Fragment>
       );

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rules.tsx
@@ -128,17 +128,15 @@ const Rules: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ history, mat
       <div className="header-container">
         <h2>Rules</h2>
       </div>
+      <button className="quill-button fun primary contained" id="add-rule-button" onClick={toggleAddRuleModal} type="submit">
+          Add Rule
+      </button>
       <DataTable
         className="rules-table"
         defaultSortAttribute="name"
         headers={dataTableFields}
         rows={formattedRows ? formattedRows : []}
       />
-      <div className="button-container">
-        <button className="quill-button fun primary contained" id="add-rule-button" onClick={toggleAddRuleModal} type="submit">
-          Add Rule
-        </button>
-      </div>
     </div>
   );
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -31,13 +31,18 @@ interface ActivityFormProps {
 
 const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProps) => {
 
-  const { parent_activity_id, passages, prompts, scored_level, target_level, title, name, } = activity;
+  const { parent_activity_id, passages, prompts, prompt_attributes, scored_level, target_level, title, name, } = activity;
   // const formattedFlag = flag ? { label: flag, value: flag } : flagOptions[0];
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
   const formattedParentActivityId = parent_activity_id ? parent_activity_id.toString() : '';
   const formattedPassage = passages && passages.length ? passages : [{ text: ''}];
-  const formattedMaxFeedback = prompts && prompts[0] && prompts[0].max_attempts_feedback ? prompts[0].max_attempts_feedback : '';
+  let formattedMaxFeedback;
+  if(prompts && prompts[0] && prompts[0].max_attempts_feedback) {
+    formattedMaxFeedback = prompts[0].max_attempts_feedback
+  } else {
+    formattedMaxFeedback = 'Nice effort! You worked hard to make your sentence stronger.';
+  }
   const formattedPrompts = promptsByConjunction(prompts);
   const becausePrompt = formattedPrompts && formattedPrompts[BECAUSE] ? formattedPrompts[BECAUSE] : buildBlankPrompt(BECAUSE);
   const butPrompt = formattedPrompts && formattedPrompts[BUT] ? formattedPrompts[BUT] : buildBlankPrompt(BUT);

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
@@ -74,8 +74,8 @@ const Navigation = ({ location, match }) => {
         <NavLink activeClassName="is-active" to={`/activities/${activityId}/turk-sessions`}>
           Collect Turk Responses
         </NavLink>
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-rules`}>
-          Semantic Rules
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-labels`}>
+          Semantic Labels
         </NavLink>
         <NavLink activeClassName="is-active" to={`/activities/${activityId}/regex-rules`}>
           RegEx Rules

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
@@ -187,9 +187,9 @@ const ActivateModelForm = ({ match }) => {
 
 
   const labelStatusDataTableFields = [
-    { name: "Prompt Label", attribute:"label_name", width: "200px" },
-    { name: "Model Status", attribute:"model_status", width: "200px" },
-    { name: "Active Status", attribute:"status", width: "200px" }
+    { name: "AutoML Label", attribute:"label_name", width: "200px" },
+    { name: "Present in internal tool?", attribute:"model_status", width: "200px" },
+    { name: "Active in AutoML model?", attribute:"status", width: "200px" }
   ];
 
   if((!modelData && !modelsData) || isLoading) {
@@ -212,7 +212,7 @@ const ActivateModelForm = ({ match }) => {
       <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-labels`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
       <section className="activate-model-form">
         <section className="activate-model-section">
-          <h4>Model Set To Be Active</h4>
+          <h4>New Model</h4>
           {modelToActivate && <DataTable
             className="model-activate-table"
             headers={dataTableFields}
@@ -220,7 +220,7 @@ const ActivateModelForm = ({ match }) => {
           />}
         </section>
         <section className="activate-model-section">
-          <h4>Current Model Active</h4>
+          <h4>Current Active Model</h4>
           {activeModel && <DataTable
             className="model-activate-table"
             headers={dataTableFields}
@@ -230,7 +230,7 @@ const ActivateModelForm = ({ match }) => {
         </section>
         <section className="activate-model-section">
           <section className="missing-labels-header">
-            <h4>Missing Labels from Model</h4>
+            <h4>Missing Labels</h4>
             <button className="quill-button fun primary contained" id="add-rule-button" type="submit">{labelLink}</button>
           </section>
           {showMissingLabelsTable && <section>
@@ -245,7 +245,7 @@ const ActivateModelForm = ({ match }) => {
           {activeModelisModelToActivate && <p className="activation-label">Model is already active.</p>}
         </section>
         <section className="activate-model-section">
-          <h4>Label Changes</h4>
+          <h4>Label Status</h4>
           {showLabelStatusTable && <DataTable
             className="label-status-table"
             headers={labelStatusDataTableFields}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
@@ -205,11 +205,11 @@ const ActivateModelForm = ({ match }) => {
   const activeModelisModelToActivate = activeModel && modelToActivate && activeModel.id === modelToActivate.id;
   const buttonDisabled = !modelReady || activeModelisModelToActivate
   const buttonStyle = buttonDisabled ? 'disabled' : '';
-  const labelLink = <Link to={`/activities/${activityId}/semantic-rules/${promptId}/new`}>Add Label</Link>;
+  const labelLink = <Link to={`/activities/${activityId}/semantic-labels/${promptId}/new`}>Add Label</Link>;
 
   return(
     <div className="activate-model-container">
-      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-rules`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
+      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-labels`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
       <section className="activate-model-form">
         <section className="activate-model-section">
           <h4>Model Set To Be Active</h4>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
@@ -22,13 +22,13 @@ const LabelsTable = ({ activityId, prompt }) => {
     const formattedRows = rulesData.rules.map(rule => {
       const { name, id, state, optimal, label } = rule;
       const ruleLink = (
-        <Link className="data-link" to={{ pathname: `/activities/${activityId}/semantic-rules/${prompt.id}/${id}`, state: { rule: rule } }}>View</Link>
+        <Link className="data-link" to={{ pathname: `/activities/${activityId}/semantic-labels/${prompt.id}/${id}`, state: { rule: rule } }}>View</Link>
       );
       const isActive = state === 'active';
       return {
         id: id,
-        name: name,
-        label_name: label && label.name,
+        descriptive_label: name,
+        automl_label: label && label.name,
         state_for_sort: state,
         state: getCheckIcon(isActive),
         optimal: getCheckIcon(optimal),
@@ -48,26 +48,23 @@ const LabelsTable = ({ activityId, prompt }) => {
 
   const dataTableFields = [
     { name: "Rule ID", attribute:"id", width: "70px" },
-    { name: "Rule Name", attribute:"name", width: "400px" },
-    { name: "Label Name", attribute:"label_name", width: "150px" },
-    { name: "Rule/Label Active?", attribute:"state", width: "150px" },
+    { name: "Descriptive Label", attribute:"descriptive_label", width: "400px" },
+    { name: "AutoML Label", attribute:"automl_label", width: "150px" },
+    { name: "Active?", attribute:"state", width: "150px" },
     { name: "Optimal?", attribute:"optimal", width: "70px" },
     { name: "", attribute:"edit", width: "70px" }
   ];
-  const addRuleLink = <Link to={`/activities/${activityId}/semantic-rules/${prompt.id}/new`}>Add Rule/Label</Link>;
+  const addRuleLink = <Link to={`/activities/${activityId}/semantic-labels/${prompt.id}/new`}>Add Label</Link>;
 
   return(
-    <section className="semantic-rules-container">
+    <section className="semantic-labels-container">
       <section className="header-container">
-        <h5>Semantic Rules/Label: <p>{prompt.conjunction}</p></h5>
+        <h5>Semantic Labels: <p>{prompt.conjunction}</p></h5>
         <h5>Prompt ID: <p>{prompt.id}</p></h5>
-        <section className="lower-header-container">
-          <h5>Prompt Labelset</h5>
-          <button className="quill-button fun primary contained" id="add-rule-button" type="submit">{addRuleLink}</button>
-        </section>
+        <button className="quill-button fun primary contained" id="add-rule-button" type="submit">{addRuleLink}</button>
       </section>
       <DataTable
-        className="semantic-rules-table"
+        className="semantic-labels-table"
         headers={dataTableFields}
         rows={getFormattedRows()}
       />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/model.tsx
@@ -77,9 +77,13 @@ const Model = ({ match }) => {
     });
   }
 
-  const dataTableFields = [
+  const upperDataTableFields = [
     { name: "", attribute:"field", width: "200px" },
     { name: "", attribute:"value", width: "400px" }
+  ];
+  const lowerDataTableFields = [
+    { name: "Descriptive Label", attribute:"field", width: "200px" },
+    { name: "AutoML Label", attribute:"value", width: "400px" }
   ];
   // const modelNotesStyle = modelNotes && modelNotes.length && modelNotes !== '<br/>' ? 'has-text' : '';
   // const errorsPresent = !!Object.keys(errors).length;
@@ -98,7 +102,7 @@ const Model = ({ match }) => {
       <section className="model-form">
         <DataTable
           className="model-table"
-          headers={dataTableFields}
+          headers={upperDataTableFields}
           rows={upperSectionRows(modelData)}
         />
         {/* <p className={`text-editor-label ${modelNotesStyle}`}>Model Notes</p>
@@ -112,7 +116,7 @@ const Model = ({ match }) => {
         /> */}
         <DataTable
           className="model-table"
-          headers={dataTableFields}
+          headers={lowerDataTableFields}
           rows={lowerSectionRows(modelData)}
         />
       </section>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/model.tsx
@@ -94,7 +94,7 @@ const Model = ({ match }) => {
 
   return(
     <div className="model-container">
-      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-rules`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
+      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-labels`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
       <section className="model-form">
         <DataTable
           className="model-table"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelForm.tsx
@@ -32,7 +32,7 @@ const ModelForm = ({ history, match }) => {
           setErrors(updatedErrors);
           setIsLoading(false);
         } else {
-          history.push(`/activities/${activityId}/semantic-rules/model/${model.id}`);
+          history.push(`/activities/${activityId}/semantic-labels/model/${model.id}`);
         }
       });
     }
@@ -48,7 +48,7 @@ const ModelForm = ({ history, match }) => {
 
   return(
     <div className="model-form-container">
-      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-rules`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
+      <Link className="return-link" to={{ pathname: `/activities/${activityId}/semantic-labels`, state: 'returned-to-index' }}>← Return to Semantic Rules Index</Link>
       <Input
         className="model-id"
         error={errors['Model ID']}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelsTable.tsx
@@ -61,14 +61,14 @@ const ModelsTable = ({ activityId, prompt }) => {
   ];
 
   const addModelLink = <Link to={`/activities/${activityId}/semantic-labels/${prompt.id}/add-model`}>Add Model</Link>;
+  const count = modelsData && modelsData.models && modelsData.models.length
 
   return(
     <section className="models-container">
       <section className="header-container">
-        <section className="lower-header-container">
-          <h5>Prompt Models</h5>
-          <button className="quill-button fun primary contained" id="add-model-button" type="submit">{addModelLink}</button>
-        </section>
+        <h5>Prompt Models</h5>
+        <h5 id="model-count">Count: <p>{count}</p></h5>
+        <button className="quill-button fun primary contained" id="add-model-button" type="submit">{addModelLink}</button>
       </section>
       <DataTable
         className="models-table"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/modelsTable.tsx
@@ -19,17 +19,17 @@ const ModelsTable = ({ activityId, prompt }) => {
       const formattedRows = modelsData.models.map(model => {
         const { id, created_at, name, older_models, labels, state } = model;
         const viewLink = (
-          <Link className="data-link" to={`/activities/${activityId}/semantic-rules/model/${id}`}>View</Link>
+          <Link className="data-link" to={`/activities/${activityId}/semantic-labels/model/${id}`}>View</Link>
         );
         const activateLink = (
-          <Link className="data-link" to={`/activities/${activityId}/semantic-rules/${prompt.id}/model/${id}/activate`}>Activate</Link>
+          <Link className="data-link" to={`/activities/${activityId}/semantic-labels/${prompt.id}/model/${id}/activate`}>Activate</Link>
         );
         return {
           id: id,
           created_at: moment(created_at).format('MM/DD/YY'),
           version: older_models + 1,
           name: name,
-          labels: `${labels.length} labels`,
+          label_count: `${labels.length} labels`,
           status: state,
           view: viewLink,
           activate: activateLink,
@@ -54,13 +54,13 @@ const ModelsTable = ({ activityId, prompt }) => {
     { name: "Version", attribute:"version", width: "70px" },
     { name: "Model Name", attribute:"name", width: "300px" },
     // { name: "Model Notes", attribute:"", width: "200px" },
-    { name: "Labels", attribute:"labels", width: "70px" },
+    { name: "Label Count", attribute:"label_count", width: "70px" },
     { name: "Status", attribute:"status", width: "70px" },
     { name: "", attribute:"view", width: "100px" },
     { name: "", attribute:"activate", width: "150px" }
   ];
 
-  const addModelLink = <Link to={`/activities/${activityId}/semantic-rules/${prompt.id}/add-model`}>Add Model</Link>;
+  const addModelLink = <Link to={`/activities/${activityId}/semantic-labels/${prompt.id}/add-model`}>Add Model</Link>;
 
   return(
     <section className="models-container">

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
@@ -15,7 +15,7 @@ import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnIni
 import { ruleOptimalOptions, regexRuleTypes, blankRule } from '../../../../../constants/comprehension';
 import { RuleInterface, DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 
-interface SemanticRuleFormProps {
+interface SemanticLabelFormProps {
   activityData?: any,
   activityId?: string,
   isUniversal?: boolean,
@@ -28,7 +28,7 @@ interface SemanticRuleFormProps {
   match: any,
 }
 
-const SemanticRuleForm = ({ activityId, isSemantic, isUniversal, rule, submitRule, location, history, match }: SemanticRuleFormProps) => {
+const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, rule, submitRule, location, history, match }: SemanticLabelFormProps) => {
   const { params } = match;
   const { promptId } = params;
 
@@ -142,12 +142,17 @@ const SemanticRuleForm = ({ activityId, isSemantic, isUniversal, rule, submitRul
       toggleShowDeleteRuleModal();
       // update ruleSets cache to remove delete ruleSet
       queryCache.refetchQueries(`rules-${activityId}`);
-      history.push(`/activities/${activityId}/semantic-rules/all`);
+      history.push(`/activities/${activityId}/semantic-labels/all`);
     });
   }
 
   const errorsPresent = !!Object.keys(errors).length;
-  const cancelLink = (<Link to={`/activities/${activityId}/semantic-rules`}>Cancel</Link>);
+  const cancelLink = (<Link to={`/activities/${activityId}/semantic-labels`}>Cancel</Link>);
+  const autoMLParams = {
+    label: 'Descriptive Label',
+    notes: 'Label Notes',
+    layerFeedback: 'First Layer Feedback'
+  }
 
   if(isLoading) {
     return(
@@ -161,15 +166,17 @@ const SemanticRuleForm = ({ activityId, isSemantic, isUniversal, rule, submitRul
     <div className="rule-form-container">
       {showDeleteRuleModal && renderDeleteRuleModal()}
       <section className="semantic-rule-form-header">
-        <Link className="return-link" to={`/activities/${activityId}/semantic-rules`}>← Return to Semantic Rules Index</Link>
+        <Link className="return-link" to={`/activities/${activityId}/semantic-labels`}>← Return to Semantic Rules Index</Link>
         <button className="quill-button fun primary contained" id="rule-delete-button" onClick={toggleShowDeleteRuleModal} type="button">
           Delete
         </button>
       </section>
       <form className="semantic-rule-form">
         <RuleGenericAttributes
+          autoMLParams={autoMLParams}
           concepts={conceptsData ? conceptsData.concepts : []}
           errors={errors}
+          isAutoML={true}
           isUniversal={isUniversal}
           ruleConceptUID={ruleConceptUID}
           ruleDescription={ruleDescription}
@@ -235,4 +242,4 @@ const SemanticRuleForm = ({ activityId, isSemantic, isUniversal, rule, submitRul
   )
 }
 
-export default withRouter<any, any>(SemanticRuleForm);
+export default withRouter<any, any>(SemanticLabelForm);

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelWrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelWrapper.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import { useQuery } from 'react-query';
 import { withRouter } from 'react-router-dom';
 
-import SemanticRule from './semanticRule';
+import SemanticLabelForm from './semanticLabelForm';
 
 import { blankRule } from '../../../../../constants/comprehension';
 import { fetchRule } from '../../../utils/comprehension/ruleAPIs';
 import { Spinner } from '../../../../Shared/index';
 
-const SemanticRuleWrapper = ({ activityData, isSemantic, isUniversal, submitRule, match }) => {
+const SemanticLabelWrapper = ({ activityData, isSemantic, isUniversal, submitRule, match }) => {
   const { params } = match;
   const { activityId, ruleId } = params;
 
@@ -37,7 +37,7 @@ const SemanticRuleWrapper = ({ activityData, isSemantic, isUniversal, submitRule
   }
 
   return(
-    <SemanticRule
+    <SemanticLabelForm
       activityData={activityData}
       activityId={activityId}
       isSemantic={isSemantic}
@@ -48,4 +48,4 @@ const SemanticRuleWrapper = ({ activityData, isSemantic, isUniversal, submitRule
   );
 }
 
-export default withRouter<any, any>(SemanticRuleWrapper)
+export default withRouter<any, any>(SemanticLabelWrapper)

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsIndex.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { useQuery, queryCache } from 'react-query';
 import { NavLink, Redirect, Route, Switch, withRouter } from 'react-router-dom';
 
-import SemanticRulesOverview from './semanticRulesOverview'
-import SemanticRuleWrapper from './semanticRuleWrapper';
+import SemanticLabelsOverview from './semanticLabelsOverview'
+import SemanticLabelWrapper from './semanticLabelWrapper';
 import ModelForm from './modelForm';
 import ActivateModelForm from './activateModelForm';
 import Model from './model';
@@ -15,7 +15,7 @@ import { createRule, updateRule } from '../../../utils/comprehension/ruleAPIs';
 import { Error, Spinner } from '../../../../Shared/index';
 import { RuleInterface } from '../../../interfaces/comprehensionInterfaces';
 
-const SemanticRulesIndex = ({ history, match, location }) => {
+const SemanticLabelsIndex = ({ history, match, location }) => {
   const { params } = match;
   const { activityId } = params;
 
@@ -41,7 +41,7 @@ const SemanticRulesIndex = ({ history, match, location }) => {
       }
       // update rules cache to display newly created rule
       queryCache.refetchQueries(`rules-${activityId}`).then(() => {
-        history.push(`/activities/${activityId}/semantic-rules/all`);
+        history.push(`/activities/${activityId}/semantic-labels/all`);
       });
       return rule;
     });
@@ -55,7 +55,7 @@ const SemanticRulesIndex = ({ history, match, location }) => {
       }
       // update rules cache to display newly updated rule
       queryCache.refetchQueries(`rules-${activityId}`).then(() => {
-        history.push(`/activities/${activityId}/semantic-rules/all`);
+        history.push(`/activities/${activityId}/semantic-labels/all`);
       });
       return rule;
     });
@@ -80,46 +80,46 @@ const SemanticRulesIndex = ({ history, match, location }) => {
   const showTabs = tabOptions.some(option => location.pathname.includes(option));
 
   return(
-    <div className="semantic-rules-container">
+    <div className="semantic-labels-container">
       <div className="header-container">
         {activityData && renderTitle(activityData)}
       </div>
       {showTabs && <div className="tabs-container">
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-rules/all`}>
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-labels/all`}>
           <div className="tab-option">
             All
           </div>
         </NavLink>
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-rules/because`}>
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-labels/because`}>
           <div className="tab-option">
             Because
           </div>
         </NavLink>
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-rules/but`}>
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-labels/but`}>
           <div className="tab-option">
             But
           </div>
         </NavLink>
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-rules/so`}>
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/semantic-labels/so`}>
           <div className="tab-option">
             So
           </div>
         </NavLink>
       </div>}
       <Switch>
-        <Redirect exact from='/activities/:activityId/semantic-rules' to='/activities/:activityId/semantic-rules/all' />
+        <Redirect exact from='/activities/:activityId/semantic-labels' to='/activities/:activityId/semantic-labels/all' />
         {/* eslint-disable react/jsx-no-bind */}
-        <Route component={() => <SemanticRulesOverview activityId={activityId} prompts={getPromptForComponent(activityData, ALL)} />} path='/activities/:activityId/semantic-rules/all' />
-        <Route component={() => <SemanticRulesOverview activityId={activityId} prompts={getPromptForComponent(activityData, BECAUSE)} />} path='/activities/:activityId/semantic-rules/because' />
-        <Route component={() => <SemanticRulesOverview activityId={activityId} prompts={getPromptForComponent(activityData, BUT)} />} path='/activities/:activityId/semantic-rules/but' />
-        <Route component={() => <SemanticRulesOverview activityId={activityId} prompts={getPromptForComponent(activityData, SO)} />} path='/activities/:activityId/semantic-rules/so' />
-        <Route component={ActivateModelForm} path='/activities/:activityId/semantic-rules/:promptId/model/:modelId/activate' />
-        <Route component={Model} path='/activities/:activityId/semantic-rules/model/:modelId' />
-        <Route component={ModelForm} path='/activities/:activityId/semantic-rules/:promptId/add-model' />
+        <Route component={() => <SemanticLabelsOverview activityId={activityId} prompts={getPromptForComponent(activityData, ALL)} />} path='/activities/:activityId/semantic-labels/all' />
+        <Route component={() => <SemanticLabelsOverview activityId={activityId} prompts={getPromptForComponent(activityData, BECAUSE)} />} path='/activities/:activityId/semantic-labels/because' />
+        <Route component={() => <SemanticLabelsOverview activityId={activityId} prompts={getPromptForComponent(activityData, BUT)} />} path='/activities/:activityId/semantic-labels/but' />
+        <Route component={() => <SemanticLabelsOverview activityId={activityId} prompts={getPromptForComponent(activityData, SO)} />} path='/activities/:activityId/semantic-labels/so' />
+        <Route component={ActivateModelForm} path='/activities/:activityId/semantic-labels/:promptId/model/:modelId/activate' />
+        <Route component={Model} path='/activities/:activityId/semantic-labels/model/:modelId' />
+        <Route component={ModelForm} path='/activities/:activityId/semantic-labels/:promptId/add-model' />
         <Route
-          path='/activities/:activityId/semantic-rules/:promptId/new'
+          path='/activities/:activityId/semantic-labels/:promptId/new'
           render={() =>
-            (<SemanticRuleWrapper
+            (<SemanticLabelWrapper
               activityData={activityData && activityData.activity}
               isSemantic={true}
               isUniversal={false}
@@ -127,9 +127,9 @@ const SemanticRulesIndex = ({ history, match, location }) => {
             />)}
         />
         <Route
-          path='/activities/:activityId/semantic-rules/:promptId/:ruleId'
+          path='/activities/:activityId/semantic-labels/:promptId/:ruleId'
           render={() =>
-            (<SemanticRuleWrapper
+            (<SemanticLabelWrapper
               activityData={activityData && activityData.activity}
               isSemantic={true}
               isUniversal={false}
@@ -141,4 +141,4 @@ const SemanticRulesIndex = ({ history, match, location }) => {
   );
 }
 
-export default withRouter(SemanticRulesIndex)
+export default withRouter(SemanticLabelsIndex)

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsOverview.tsx
@@ -5,7 +5,7 @@ import ModelsTable from './modelsTable';
 
 import { Spinner } from '../../../../Shared/index';
 
-const SemanticRulesOverview = ({ activityId, prompts }) => {
+const SemanticLabelsOverview = ({ activityId, prompts }) => {
 
 function renderPrompts() {
   return prompts.map(prompt => {
@@ -27,10 +27,10 @@ function renderPrompts() {
   }
 
   return(
-    <div className="semantic-rules-overview-container">
+    <div className="semantic-labels-overview-container">
       {renderPrompts()}
     </div>
   );
 }
 
-export default SemanticRulesOverview
+export default SemanticLabelsOverview

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRuleWrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRuleWrapper.tsx
@@ -20,8 +20,9 @@ const SemanticRuleWrapper = ({ activityData, isSemantic, isUniversal, submitRule
 
   let rule;
   if(!ruleId) {
-    const blankSemanticRule = blankRule;
+    const blankSemanticRule = {...blankRule};
     blankSemanticRule.rule_type = 'autoML';
+    blankSemanticRule.state = 'inactive';
     rule = blankSemanticRule
   } else {
     rule = ruleData && ruleData.rule;

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -104,6 +104,8 @@ export const buildActivity = ({
 }) => {
   // const { label } = activityFlag;
   const prompts = [activityBecausePrompt, activityButPrompt, activitySoPrompt];
+  const maxFeedback = activityMaxFeedback || 'Nice effort! You worked hard to make your sentence stronger.';
+  prompts.forEach(prompt => prompt.max_attempts_feedback = maxFeedback);
   return {
     activity: {
       name: activityName,

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { EditorState, ContentState } from 'draft-js';
+import stripHtml from "string-strip-html";
 
 import { validateForm } from '../comprehension';
 import { AUTO_ML, ACTIVE, INACTIVE } from '../../../../constants/comprehension';
@@ -304,7 +305,7 @@ export const buildRule = ({
   } else if(newOrUpdatedRule.rule_type === 'plagiarism') {
     newOrUpdatedRule.plagiarism_text_attributes = {
       id: plagiarismText.id,
-      text: plagiarismText.text
+      text: stripHtml(plagiarismText.text)
     };
   } else if(newOrUpdatedRule.rule_type === AUTO_ML) {
     newOrUpdatedRule.label_attributes = {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -323,9 +323,9 @@
       }
     }
   }
-  .rules-container, .rule-container, .turk-sessions-container, .semantic-rules-container, .model-container {
+  .rules-container, .rule-container, .turk-sessions-container, .semantic-labels-container, .model-container {
     width: 80vw;
-    .semantic-rules-overview-container {
+    .semantic-labels-overview-container {
       .prompt-section {
         border-top: 2px solid #e0e0e0;
         border-bottom: 2px solid #e0e0e0;
@@ -416,16 +416,14 @@
           font-weight: bold;
         }
       }
-      .lower-header-container {
-        display: flex;
-        align-items: center;
-        #add-rule-button, #add-model-button {
-          margin-left: 20px;
-          a {
-            color: white;
-            text-decoration: none;
-          }
+      #add-rule-button, #add-model-button {
+        a {
+          color: white;
+          text-decoration: none;
         }
+      }
+      #add-model-button {
+        margin-top: 15px;
       }
     }
     .tabs-container {
@@ -434,7 +432,7 @@
         text-align: center;
       }
     }
-    .rules-table, .rule-table, .turk-sessions-table, .semantic-rules-table, .models-table {
+    .rules-table, .rule-table, .turk-sessions-table, .semantic-labels-table, .models-table {
       max-width: 100%;
       overflow: scroll;
       .data-table-body{
@@ -499,7 +497,7 @@
     }
   }
 
-  .models-container, .semantic-rules-container {
+  .models-container, .semantic-labels-container {
     padding: 20px 0px 20px 0px;
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -6,6 +6,13 @@
     width: 200px;
     padding: 20px;
   }
+  .card {
+    max-width: 650px;
+    padding: 10px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    margin-top: 20px;
+  }
   .modal {
     display: flex;
     .modal-container {
@@ -386,13 +393,6 @@
         color: #7f7f7f;
         margin-top: 15px;
       }
-      .card {
-        max-width: 650px;
-        padding: 10px;
-        border: 1px solid #e0e0e0;
-        border-radius: 6px;
-        margin-top: 20px;
-      }
     }
     .header-container {
       margin-bottom: 20px;
@@ -507,13 +507,6 @@
     .model-form {
       .text-editor-label, .card {
         margin-left: 16px;
-      }
-      .card {
-        max-width: 650px;
-        padding: 10px;
-        border: 1px solid #e0e0e0;
-        border-radius: 6px;
-        margin-top: 20px;
       }
     }
   }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -423,7 +423,7 @@
         }
       }
       #add-model-button {
-        margin-top: 15px;
+        margin-top: 5px;
       }
     }
     .tabs-container {
@@ -499,6 +499,13 @@
 
   .models-container, .semantic-labels-container {
     padding: 20px 0px 20px 0px;
+  }
+  .models-container {
+    .header-container {
+      #model-count {
+        margin-top: 12px;
+      }
+    }
   }
 
   .model-container {

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -72,7 +72,7 @@ export const ruleTypeOptions = [
   {"value":"rules-based-2","label":"Post-Topic Regex"},
   {"value":"rules-based-3","label":"Typo Regex"},
   {"value":"plagiarism","label":"Plagiarism"},
-  {"value":"autoML","label":"AutoML Evidence"},
+  {"value":"autoML","label":"AutoML Evidence— AutoML or Semantic"},
 ];
 
 export const universalRuleTypeOptions = [

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -72,7 +72,7 @@ export const ruleTypeOptions = [
   {"value":"rules-based-2","label":"Post-Topic Regex"},
   {"value":"rules-based-3","label":"Typo Regex"},
   {"value":"plagiarism","label":"Plagiarism"},
-  {"value":"autoML","label":"AutoML Evidence— AutoML or Semantic"},
+  {"value":"autoML","label":"AutoML"},
 ];
 
 export const universalRuleTypeOptions = [

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -121,6 +121,7 @@ export const INACTIVE = 'inactive';
 
 export const blankActivity = {
   title: '',
+  name: '',
   // flag:'',
   scored_level: '',
   target_level: null,
@@ -130,19 +131,19 @@ export const blankActivity = {
       conjunction: 'because',
       text: '',
       max_attempts: 5,
-      max_attempts_feedback: 'try again.'
+      max_attempts_feedback: 'Nice effort! You worked hard to make your sentence stronger.'
     },
     {
       conjunction: 'but',
       text: '',
       max_attempts: 5,
-      max_attempts_feedback: 'try again.'
+      max_attempts_feedback: 'Nice effort! You worked hard to make your sentence stronger.'
     },
     {
       conjunction: 'so',
       text: '',
       max_attempts: 5,
-      max_attempts_feedback: 'try again.'
+      max_attempts_feedback: 'Nice effort! You worked hard to make your sentence stronger.'
     }
   ]
 }

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -65,10 +65,9 @@ export const readingLevelOptions = [
   },
 ];
 
-export const regexRuleTypes = ["rules-based", "rules-based-1", "rules-based-2", "rules-based-3"];
+export const regexRuleTypes = ["rules-based-1", "rules-based-2", "rules-based-3"];
 
 export const ruleTypeOptions = [
-  {"value":"rules-based","label":"Regex"},
   {"value":"rules-based-1","label":"Sentence Structure Regex"},
   {"value":"rules-based-2","label":"Post-Topic Regex"},
   {"value":"rules-based-3","label":"Typo Regex"},
@@ -154,6 +153,7 @@ export const blankRule = {
   universal: false,
   rule_type: '',
   optimal: false,
+  state: 'active',
   suborder: 0,
   concept_uid: 'Kr8PdUfXnU0L7RrGpY4uqg',
   prompt_ids: []


### PR DESCRIPTION
## WHAT
various copy changes for semantic labels and autoML model forms (updated file and component names to match), remove `Regex` as a rule option, fix issue where `AutoML` rule type was locked and displayed for generic rule form after navigating from semantic rule form (removed option from generic form completely), fix issue with `max_attempts_feedback` in activity updates; strip `plagiarism_text` value of HTML to prevent them from being stored in the DB

## WHY
Curriculum requested the copy changes to better match their terminology and make it easier to use the tool. Bug fixes to ensure internal tool functions as expected

## HOW
updated `options` const, pass in copy of `blankRule` with updated rule type to `SemanticLabelForm`, updated all references of `semantic rule` to `semantic label`, updated logic for handling `maxAttemptFeedback`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Copy-Changes-for-Semantic-Labels-Models-a49fcb7d5c264c9e9fe26d584d5ed135
https://www.notion.so/quill/Remove-Regex-choice-in-Rule-Type-dropdown-da85b96180e7439e801d0aaafe7b7748
https://www.notion.so/quill/Max-Attempts-Issue-Comprehension-Internal-Tool-e55aee0279b4461682303aadad2129f6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
