### PR TITLE
remove <br> from Comprehension responses

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -57,7 +57,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     return submittedResponses.map(r => r.entry).concat(text)
   }
 
-  stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>/g, '').replace(/&nbsp;/g, ' ')
+  stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>|<br>/g, '').replace(/&nbsp;/g, ' ')
 
   formattedPrompt = () => {
     const { prompt, } = this.props

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -57,7 +57,7 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     return submittedResponses.map(r => r.entry).concat(text)
   }
 
-  stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>|<br>/g, '').replace(/&nbsp;/g, ' ')
+  stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>|<br>|<br\/>/g, '').replace(/&nbsp;/g, ' ')
 
   formattedPrompt = () => {
     const { prompt, } = this.props


### PR DESCRIPTION
## WHAT
Remove the linebreak tag from Comprehension responses.

## WHY
We end up with confusing grading.

## HOW
Just add `<br>` to the list of tags that get filtered out every time we strip HTML.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Comprehension-Inconsistent-grammar-bug-cf6eac771fd84b08843c7d0348e29e5f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
