### PR TITLE
fix issue with removing student whose id is in the selected student array

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 import moment from 'moment'
 
-import { DropdownInput, DataTable } from '../../../Shared/index'
-
 import EditStudentAccountModal from './edit_student_account_modal'
 import ResetStudentPasswordModal from './reset_student_password_modal'
 import MergeStudentAccountsModal from './merge_student_accounts_modal'
 import MoveStudentsModal from './move_students_modal'
 import RemoveStudentsModal from './remove_students_modal'
+
 import ViewAsStudentModal from '../shared/view_as_student_modal'
+import { DropdownInput, DataTable } from '../../../Shared/index'
 
 const emptyDeskSrc = `${process.env.CDN_URL}/images/illustrations/empty-desks.svg`
 const bulbSrc = `${process.env.CDN_URL}/images/illustrations/bulb.svg`
@@ -172,6 +172,12 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
     }
   }
 
+  handleSuccess = (successMessage) => {
+    const { onSuccess, } = this.props
+    this.setState({ selectedStudentIds: [], })
+    onSuccess(successMessage)
+  }
+
   checkRow = (id) => {
     const { selectedStudentIds } = this.state
     const newSelectedStudentIds = selectedStudentIds.concat(id)
@@ -250,68 +256,68 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
   }
 
   renderEditStudentAccountModal = () => {
-    const { classroom, onSuccess } = this.props
+    const { classroom, } = this.props
     const { showModal, studentIdsForModal } = this.state
     if (showModal === modalNames.editStudentAccountModal && studentIdsForModal.length === 1) {
       const student = classroom.students.find(s => s.id === studentIdsForModal[0])
       return (<EditStudentAccountModal
         classroom={classroom}
         close={this.closeModal}
-        onSuccess={onSuccess}
+        onSuccess={this.handleSuccess}
         student={student}
       />)
     }
   }
 
   renderResetStudentPasswordModal = () => {
-    const { classroom, onSuccess } = this.props
+    const { classroom, } = this.props
     const { showModal, studentIdsForModal } = this.state
     if (showModal === modalNames.resetStudentPasswordModal && studentIdsForModal.length === 1) {
       const student = classroom.students.find(s => s.id === studentIdsForModal[0])
       return (<ResetStudentPasswordModal
         classroom={classroom}
         close={this.closeModal}
-        onSuccess={onSuccess}
+        onSuccess={this.handleSuccess}
         student={student}
       />)
     }
   }
 
   renderMergeStudentAccountsModal = () => {
-    const { classroom, onSuccess } = this.props
+    const { classroom, } = this.props
     const { showModal, studentIdsForModal } = this.state
     if (showModal === modalNames.mergeStudentAccountsModal) {
       return (<MergeStudentAccountsModal
         classroom={classroom}
         close={this.closeModal}
-        onSuccess={onSuccess}
+        onSuccess={this.handleSuccess}
         selectedStudentIds={studentIdsForModal}
       />)
     }
   }
 
   renderMoveStudentsModal = () => {
-    const { classroom, onSuccess, classrooms, } = this.props
+    const { classroom, classrooms, } = this.props
     const { showModal, studentIdsForModal } = this.state
     if (showModal === modalNames.moveStudentsModal) {
       return (<MoveStudentsModal
         classroom={classroom}
         classrooms={classrooms}
         close={this.closeModal}
-        onSuccess={onSuccess}
+        onSuccess={this.handleSuccess}
         selectedStudentIds={studentIdsForModal}
       />)
     }
   }
 
   renderRemoveStudentsModal = () => {
-    const { classroom, onSuccess, } = this.props
+    const { classroom, } = this.props
     const { showModal, studentIdsForModal } = this.state
     if (showModal === modalNames.removeStudentsModal) {
       return (<RemoveStudentsModal
         classroom={classroom}
         close={this.closeModal}
-        onSuccess={onSuccess}
+        onSuccess={this.handleSuccess}
         selectedStudentIds={studentIdsForModal}
       />)
     }
@@ -336,6 +342,7 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
 
     const anySelectedStudentsAreGoogleOrClever = selectedStudentIds.some(id => {
       const student = classroom.students.find(s => s.id === id)
+      if (!student) { return false }
       return student.google_id || student.clever_id
     })
 


### PR DESCRIPTION
## WHAT
Fix case where a user selects a student by checking the checkbox in their row, then removes them, resulting in a nonexistent user's in the `selectedStudentIds` array.

## WHY
This was causing the page to break.

## HOW
Fix the immediate error by nullchecking the existence of `student`, but also clear the `selectedStudentIds` array on the `onSuccess` callback from the modal actions, since it doesn't really make sense for that to persist anyway. 

### Screenshots
N/A

### Notion Card Links
https://www.notion.so/quill/Student-removal-from-classroom-does-not-render-result-correctly-6c6096bb3c014eea85a851728b8ce526

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
