### PR TITLE
Comprehension/ fix prompt order

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/__snapshots__/container.test.tsx.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TurkerView Component should match snapshot 1`] = `
+<div
+  className="activity-container hide-focus-outline"
+>
+  <div
+    className="hide-on-desktop step-links"
+  >
+    <StepLink
+      clickStepLink={[Function]}
+      index={2}
+      renderStepNumber={[Function]}
+    />
+    <StepLink
+      clickStepLink={[Function]}
+      index={3}
+      renderStepNumber={[Function]}
+    />
+    <StepLink
+      clickStepLink={[Function]}
+      index={4}
+      renderStepNumber={[Function]}
+    />
+  </div>
+  <div
+    className="read-passage-container"
+  >
+    <div>
+      <p
+        className="directions"
+      >
+        Read the passage.
+      </p>
+      <h1
+        className="title"
+      >
+        Should Our Use of Plastic Bags be Regulated?
+      </h1>
+      <div
+        className="passage"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": Array [
+              "<p><p>How often do you use plastic bags?</p>",
+            ],
+          }
+        }
+      />
+    </div>
+  </div>
+  <div
+    className="steps-outer-container"
+  >
+    <div
+      className="steps-inner-container"
+    >
+      <div
+        className="read-passage-step-container"
+      >
+        <h2>
+          Read the passage
+        </h2>
+        <button
+          className="quill-button large primary contained done-reading-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Done reading
+        </button>
+      </div>
+      <div>
+        <h2>
+          Then, complete these sentences
+        </h2>
+        <PromptStep
+          activateStep={[Function]}
+          active={false}
+          className="step "
+          completeStep={[Function]}
+          everyOtherStepCompleted={false}
+          key="2"
+          passedRef={[Function]}
+          prompt={
+            Object {
+              "conjunction": "because",
+              "id": 19,
+              "max_attempts": 5,
+              "max_attempts_feedback": "<p>Nice effort! You made some good revisions.",
+              "text": "Plastic bag reduction laws are beneficial because",
+            }
+          }
+          stepNumber={2}
+          stepNumberComponent={
+            <div
+              className="step-number "
+            >
+              1
+            </div>
+          }
+          submitResponse={[Function]}
+          submittedResponses={Array []}
+        />
+        <PromptStep
+          activateStep={[Function]}
+          active={false}
+          className="step "
+          completeStep={[Function]}
+          everyOtherStepCompleted={false}
+          key="3"
+          passedRef={[Function]}
+          prompt={
+            Object {
+              "conjunction": "but",
+              "id": 20,
+              "max_attempts": 5,
+              "max_attempts_feedback": "<p>Nice effort! You made some good revisions.",
+              "text": "Plastic bag reduction laws are beneficial, but",
+            }
+          }
+          stepNumber={3}
+          stepNumberComponent={
+            <div
+              className="step-number "
+            >
+              2
+            </div>
+          }
+          submitResponse={[Function]}
+          submittedResponses={Array []}
+        />
+        <PromptStep
+          activateStep={[Function]}
+          active={false}
+          className="step "
+          completeStep={[Function]}
+          everyOtherStepCompleted={false}
+          key="4"
+          passedRef={[Function]}
+          prompt={
+            Object {
+              "conjunction": "so",
+              "id": 21,
+              "max_attempts": 5,
+              "max_attempts_feedback": "<p>Nice effort! You made some good revisions.",
+              "text": "Plastic bag reduction laws are beneficial so",
+            }
+          }
+          stepNumber={4}
+          stepNumberComponent={
+            <div
+              className="step-number "
+            >
+              3
+            </div>
+          }
+          submitResponse={[Function]}
+          submittedResponses={Array []}
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/__snapshots__/container.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TurkerView Component should match snapshot 1`] = `
+exports[`StudentViewContainer Component should match snapshot 1`] = `
 <div
   className="activity-container hide-focus-outline"
 >

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/container.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/container.test.tsx
@@ -4,7 +4,29 @@ import { shallow } from 'enzyme';
 import { StudentViewContainer } from '../container';
 import { PromptStep } from '../promptStep';
 
-describe('TurkerView Component', () => {
+describe('StudentViewContainer Component', () => {
+  const prompts = [
+  {
+    conjunction: "so",
+    id: 21,
+    max_attempts: 5,
+    max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+    text: "Plastic bag reduction laws are beneficial so"
+  },
+  {
+    conjunction: "but",
+    id: 20,
+    max_attempts: 5,
+    max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+    text: "Plastic bag reduction laws are beneficial, but"
+  },
+  {
+    conjunction: "because",
+    id: 19,
+    max_attempts: 5,
+    max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+    text: "Plastic bag reduction laws are beneficial because"
+  }];
   const mockProps = {
     dispatch: jest.fn(),
     activities: {
@@ -20,25 +42,7 @@ describe('TurkerView Component', () => {
           image_link: null,
           text: "<p>How often do you use plastic bags?"
         }],
-        prompts: [{
-          conjunction: "so",
-          id: 21,
-          max_attempts: 5,
-          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
-          text: "Plastic bag reduction laws are beneficial so"
-        }, {
-          conjunction: "but",
-          id: 20,
-          max_attempts: 5,
-          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
-          text: "Plastic bag reduction laws are beneficial, but"
-        }, {
-          conjunction: "because",
-          id: 19,
-          max_attempts: 5,
-          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
-          text: "Plastic bag reduction laws are beneficial because"
-        }],
+        prompts: [...prompts],
         scored_level: "",
         target_level: 4,
         title: "Should Our Use of Plastic Bags be Regulated?"
@@ -64,9 +68,6 @@ describe('TurkerView Component', () => {
     expect(component).toMatchSnapshot();
   });
   it('should render prompts in correct order', () => {
-    const { activities } = mockProps;
-    const { currentActivity } = activities;
-    const { prompts } = currentActivity;
     expect(component.find(PromptStep).at(0).props().prompt).toEqual(prompts[2])
     expect(component.find(PromptStep).at(1).props().prompt).toEqual(prompts[1])
     expect(component.find(PromptStep).at(2).props().prompt).toEqual(prompts[0])

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/container.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/__tests__/container.test.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { StudentViewContainer } from '../container';
+import { PromptStep } from '../promptStep';
+
+describe('TurkerView Component', () => {
+  const mockProps = {
+    dispatch: jest.fn(),
+    activities: {
+      hasReceivedData: true,
+      currentActivity: {
+        id: 18,
+        activity_id: 18,
+        name: "Should Our Use of Plastic Bags be Regulated?",
+        parent_activity_id: null,
+        passages: [{
+          id: 7,
+          image_alt_text: "",
+          image_link: null,
+          text: "<p>How often do you use plastic bags?"
+        }],
+        prompts: [{
+          conjunction: "so",
+          id: 21,
+          max_attempts: 5,
+          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+          text: "Plastic bag reduction laws are beneficial so"
+        }, {
+          conjunction: "but",
+          id: 20,
+          max_attempts: 5,
+          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+          text: "Plastic bag reduction laws are beneficial, but"
+        }, {
+          conjunction: "because",
+          id: 19,
+          max_attempts: 5,
+          max_attempts_feedback: "<p>Nice effort! You made some good revisions.",
+          text: "Plastic bag reduction laws are beneficial because"
+        }],
+        scored_level: "",
+        target_level: 4,
+        title: "Should Our Use of Plastic Bags be Regulated?"
+      }
+    },
+    session: {
+      sessionID: 'test',
+      submittedResponses: {
+        19: null,
+        20: null,
+        21: null
+      }
+    },
+    location: {
+      search: null
+    },
+    handleFinishActivity: jest.fn(),
+    isTurk: false
+  }
+  const component = shallow(<StudentViewContainer {...mockProps} />);
+
+  it('should match snapshot', () => {
+    expect(component).toMatchSnapshot();
+  });
+  it('should render prompts in correct order', () => {
+    const { activities } = mockProps;
+    const { currentActivity } = activities;
+    const { prompts } = currentActivity;
+    expect(component.find(PromptStep).at(0).props().prompt).toEqual(prompts[2])
+    expect(component.find(PromptStep).at(1).props().prompt).toEqual(prompts[1])
+    expect(component.find(PromptStep).at(2).props().prompt).toEqual(prompts[0])
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -375,7 +375,8 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { currentActivity, } = activities
     const { submittedResponses, } = session
     if (!currentActivity) return
-    const filteredSteps = _.sortBy( currentActivity.prompts, 'id' );
+    // sort by conjunctions in alphabetical order: because, but, so
+    const filteredSteps = _.sortBy( currentActivity.prompts, 'conjunction' );
     const steps =  filteredSteps.map((prompt, i) => {
       // using i + 2 because the READ_PASSAGE_STEP is 1, so the first item in the set of prompts will always be 2
       const stepNumber = i + 2

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import queryString from 'query-string';
 import { connect } from "react-redux";
-import * as _ from 'underscore'
 
 import PromptStep from './promptStep'
 import StepLink from './stepLink'
@@ -376,7 +375,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { submittedResponses, } = session
     if (!currentActivity) return
     // sort by conjunctions in alphabetical order: because, but, so
-    const filteredSteps = _.sortBy( currentActivity.prompts, 'conjunction' );
+    const filteredSteps = currentActivity.prompts.sort((a, b) => a.conjunction.localeCompare(b.conjunction));
     const steps =  filteredSteps.map((prompt, i) => {
       // using i + 2 because the READ_PASSAGE_STEP is 1, so the first item in the set of prompts will always be 2
       const stepNumber = i + 2

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import queryString from 'query-string';
 import { connect } from "react-redux";
+import * as _ from 'underscore'
 
 import PromptStep from './promptStep'
 import StepLink from './stepLink'
@@ -374,8 +375,8 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { currentActivity, } = activities
     const { submittedResponses, } = session
     if (!currentActivity) return
-
-    const steps =  currentActivity.prompts.map((prompt, i) => {
+    const filteredSteps = _.sortBy( currentActivity.prompts, 'id' );
+    const steps =  filteredSteps.map((prompt, i) => {
       // using i + 2 because the READ_PASSAGE_STEP is 1, so the first item in the set of prompts will always be 2
       const stepNumber = i + 2
       const everyOtherStepCompleted = completedSteps.filter(s => s !== stepNumber).length === 3

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -30,7 +30,7 @@ interface PromptStepState {
 
 const RESPONSE = 'response'
 
-export default class PromptStep extends React.Component<PromptStepProps, PromptStepState> {
+export class PromptStep extends React.Component<PromptStepProps, PromptStepState> {
   private editor: any // eslint-disable-line react/sort-comp
 
   constructor(props: PromptStepProps) {
@@ -327,3 +327,5 @@ export default class PromptStep extends React.Component<PromptStepProps, PromptS
     </div>)
   }
 }
+
+export default PromptStep

--- a/services/QuillLMS/client/app/bundles/Comprehension/interfaces/activities.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/interfaces/activities.ts
@@ -1,3 +1,5 @@
+import { Settings } from "http2";
+
 export interface Activity {
   activity_id: number;
   title: string;
@@ -8,6 +10,7 @@ export interface Activity {
 export interface Prompt {
   id: number;
   text: string;
+  conjunction: string;
   max_attempts: number;
   max_attempts_feedback: string;
 }


### PR DESCRIPTION
## WHAT
fix issue with prompts being displayed out of order in the student view

## WHY
they should be displayed in the correct order: because, but, so

## HOW
just add a sort to incoming prompt props

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/The-prompts-are-out-of-order-in-the-student-activity-2482931fdb9840bf85f1bf84ef565e9a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
