### PR TITLE
make updates for FeedbackHistory to use feedback_type autoML rather than semantic

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -41,7 +41,7 @@ class FeedbackHistory < ActiveRecord::Base
     RULES_BASED_ONE = "rules-based-1",
     RULES_BASED_TWO = "rules-based-2",
     RULES_BASED_THREE = "rules-based-3",
-    SEMANTIC = "semantic",
+    AUTO_ML = "autoML",
     SPELLING = "spelling",
     OPINION = "opinion"
   ]

--- a/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
@@ -26,7 +26,8 @@ export const setSessionId = (sessionID: string) => {
 export const getFeedback = (args: GetFeedbackArguments) => {
   const { sessionID, activityUID, entry, promptID, promptText, attempt, previousFeedback, callback, } = args
   return (dispatch: Function) => {
-    const feedbackURL = 'https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-endpoint-go'
+    // const feedbackURL = 'https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-endpoint-go'
+    const feedbackURL = 'https://staging2.quill.org/api/v1/comprehension/feedback/automl.json'
     const promptRegex = new RegExp(`^${promptText}`)
     const entryWithoutStem = entry.replace(promptRegex, "").trim()
     const mostRecentFeedback = previousFeedback.slice(-1)[0] || {}

--- a/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
@@ -26,8 +26,7 @@ export const setSessionId = (sessionID: string) => {
 export const getFeedback = (args: GetFeedbackArguments) => {
   const { sessionID, activityUID, entry, promptID, promptText, attempt, previousFeedback, callback, } = args
   return (dispatch: Function) => {
-    // const feedbackURL = 'https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-endpoint-go'
-    const feedbackURL = 'https://staging2.quill.org/api/v1/comprehension/feedback/automl.json'
+    const feedbackURL = 'https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-endpoint-go'
     const promptRegex = new RegExp(`^${promptText}`)
     const entryWithoutStem = entry.replace(promptRegex, "").trim()
     const mostRecentFeedback = previousFeedback.slice(-1)[0] || {}

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import queryString from 'query-string';
 import { connect } from "react-redux";
+import stripHtml from "string-strip-html";
 
 import PromptStep from './promptStep'
 import StepLink from './stepLink'
@@ -316,9 +317,10 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
       passages = passages.map((passage: Passage) => {
         let formattedPassage = passage;
         const { text } = passage;
+        const strippedText = stripHtml(hl.text);
         const passageBeforeCharacterStart = text.substring(0, characterStart)
         const passageAfterCharacterStart = text.substring(characterStart)
-        const highlightedPassageAfterCharacterStart = passageAfterCharacterStart.replace(hl.text, `<span class="passage-highlight">${hl.text}</span>`)
+        const highlightedPassageAfterCharacterStart = passageAfterCharacterStart.replace(strippedText, `<span class="passage-highlight">${strippedText}</span>`)
         formattedPassage.text = `${passageBeforeCharacterStart}${highlightedPassageAfterCharacterStart}`
         return formattedPassage
       })

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -270,7 +270,7 @@ export const buildRule = ({
   ruleFeedbacks,
   universalRulesCount
 }) => {
-  const { suborder, universal } =  rule;
+  const { suborder, universal, state } =  rule;
   const promptIds = [];
   Object.keys(rulePrompts).forEach(key => {
     rulePrompts[key].checked && promptIds.push(rulePrompts[key].id);
@@ -287,7 +287,7 @@ export const buildRule = ({
     rule_type: ruleType.value,
     suborder: suborder ? suborder : order,
     universal: universal,
-    state: ruleType.value === AUTO_ML ? INACTIVE : ACTIVE
+    state
   };
 
   if(regexRuleTypes.includes(newOrUpdatedRule.rule_type)) {

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
@@ -22,7 +22,7 @@ module Comprehension
       end
       {
         feedback: feedback.text,
-        feedback_type: 'semantic',
+        feedback_type: Rule::TYPE_AUTOML,
         optimal: matched_rule.optimal,
         response_id: '',
         entry: @entry,

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
@@ -77,7 +77,7 @@ module Comprehension
             parsed_response = JSON.parse(response.body)
             assert_equal parsed_response, {
               feedback: @first_feedback.text,
-              feedback_type: 'semantic',
+              feedback_type: 'autoML',
               optimal: @rule.optimal,
               response_id: '',
               entry: entry,

--- a/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
@@ -32,7 +32,7 @@ module Comprehension
           automl_check = Comprehension::AutomlCheck.new(entry, @prompt)
           assert_equal automl_check.feedback_object, {
             feedback: @feedback.text,
-            feedback_type: 'semantic',
+            feedback_type: 'autoML',
             optimal: @rule.optimal,
             response_id: '',
             entry: entry,

--- a/services/QuillLMS/lib/tasks/update_feedback_history_type.rake
+++ b/services/QuillLMS/lib/tasks/update_feedback_history_type.rake
@@ -1,11 +1,8 @@
 namespace :update_feedback_history_type do
   desc 'update feedback histories with type "semantic" to "autoML" to match rule_type'
   task :run => :environment do
-    FeedbackHistory.all.each do |feedback_history|
-      if feedback_history.feedback_type == 'semantic'
-        feedback_history.feedback_type = 'autoML'
-        feedback_history.save!
-      end
+    FeedbackHistory.where(feedback_type: 'semantic').each do |feedback_history|
+      feedback_history.update(feedback_type: 'autoML')
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/update_feedback_history_type.rake
+++ b/services/QuillLMS/lib/tasks/update_feedback_history_type.rake
@@ -1,0 +1,11 @@
+namespace :update_feedback_history_type do
+  desc 'update feedback histories with type "semantic" to "autoML" to match rule_type'
+  task :run => :environment do
+    FeedbackHistory.all.each do |feedback_history|
+      if feedback_history.feedback_type == 'semantic'
+        feedback_history.feedback_type = 'autoML'
+        feedback_history.save!
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -38,7 +38,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       post :create, feedback_history: { activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'semantic', metadata: {foo: 'bar'} }
+                                        feedback_type: 'autoML', metadata: {foo: 'bar'} }
 
       parsed_response = JSON.parse(response.body)
 
@@ -53,7 +53,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       post :create, feedback_history: { activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'semantic', metadata: {foo: 'bar'}, prompt_id: prompt.id }
+                                        feedback_type: 'autoML', metadata: {foo: 'bar'}, prompt_id: prompt.id }
 
       parsed_response = JSON.parse(response.body)
 
@@ -78,11 +78,11 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       post :batch, feedback_histories: [{ activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'semantic', metadata: {highlight: [], response_id: "0", rule_uid: ""} },
+                                          feedback_type: 'autoML', metadata: {highlight: [], response_id: "0", rule_uid: ""} },
                                         { activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'semantic', metadata: {foo: 'bar'} }]
+                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }]
 
       assert_equal 201, response.code.to_i
       assert_equal 2, FeedbackHistory.count
@@ -92,11 +92,11 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       post :batch, feedback_histories: [{ activity_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'semantic', metadata: {foo: 'bar'} },
+                                          feedback_type: 'autoML', metadata: {foo: 'bar'} },
                                         { attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'semantic', metadata: {foo: 'bar'} }]
+                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }]
 
       parsed_response = JSON.parse(response.body)
 
@@ -135,9 +135,9 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       @feedback_history.save
 
       get :show, id: @feedback_history.id
-      
+
       parsed_response = JSON.parse(response.body)
-      
+
       assert_equal 200, response.code.to_i
       assert_equal prompt.as_json, parsed_response['prompt']
     end

--- a/services/QuillLMS/spec/factories/feedback_history.rb
+++ b/services/QuillLMS/spec/factories/feedback_history.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     attempt { 1 }
     entry { "This is what the student submitted." }
     feedback_text { "This is the feedback the student got." }
-    feedback_type { "semantic" }
+    feedback_type { "autoML" }
     optimal { true }
     used { true }
     time { DateTime.now }

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -126,26 +126,26 @@ RSpec.describe FeedbackHistory, type: :model do
       @valid_fh_params = {
         activity_session_uid: SecureRandom.uuid,
         attempt: 1,
-	entry: 'This is the student entry',
-	feedback_text: 'This is the feedback text',
-	feedback_type: 'semantic',
-	optimal: false,
-	time: Time.now,
-	used: true
+        entry: 'This is the student entry',
+        feedback_text: 'This is the feedback text',
+        feedback_type: 'autoML',
+        optimal: false,
+        time: Time.now,
+        used: true
       }
       @invalid_fh_params = {}
     end
 
     it 'should save and return if all creations are valid' do
         assert_equal FeedbackHistory.count, 0
-	FeedbackHistory.batch_create([@valid_fh_params, @valid_fh_params, @valid_fh_params])
-	assert_equal FeedbackHistory.count, 3
+        FeedbackHistory.batch_create([@valid_fh_params, @valid_fh_params, @valid_fh_params])
+        assert_equal FeedbackHistory.count, 3
     end
 
     it 'should save any valid records if, but not any valid ones' do
         assert_equal FeedbackHistory.count, 0
-	results = FeedbackHistory.batch_create([@invalid_fh_params, @valid_fh_params])
-	assert_equal FeedbackHistory.count, 1
+        results = FeedbackHistory.batch_create([@invalid_fh_params, @valid_fh_params])
+        assert_equal FeedbackHistory.count, 1
         assert results[0].errors[:entry].include?("can't be blank")
         assert results[1].valid?
     end

--- a/services/comprehension/main-api/comprehension/views/ml_feedback.py
+++ b/services/comprehension/main-api/comprehension/views/ml_feedback.py
@@ -11,7 +11,7 @@ from ..utils import construct_feedback_payload
 from ..utils import construct_highlight_payload
 
 
-FEEDBACK_TYPE = 'semantic'
+FEEDBACK_TYPE = 'autoML'
 
 
 class MLFeedbackView(ApiView):


### PR DESCRIPTION
## WHAT
fix issue with mismatch between `FeedbackHistory` feedback_type and `Comprehension::Rule` rule_type

## WHY
we want the correct feedback to be given for AutoML labels

## HOW
update references of `feedback_type` to be "autoML" rather than "semantic"

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Second-layer-feedback-and-highlighting-isn-t-working-53a1f5b006b74897bd0de9ecf6fbe9f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
