### PR TITLE
Make after_commit callbacks fire in tests for Rails 4.2

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -204,6 +204,9 @@ group :test do
   gem 'simplecov-json', require: false
   gem 'codecov'
   gem 'fakeredis', '~> 0.7.0'
+
+  # Remove this gem after upgrading to Rails 5
+  gem 'test_after_commit'
 end
 
 # Memory profiling

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -719,6 +719,8 @@ GEM
     terminal-notifier-guard (1.7.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    test_after_commit (1.2.2)
+      activerecord (>= 3.2, < 5.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -891,6 +893,7 @@ DEPENDENCIES
   sqreen
   stripe
   terminal-notifier-guard
+  test_after_commit
   therubyracer
   time_difference
   timecop

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -145,16 +145,15 @@ class Classroom < ActiveRecord::Base
   end
 
   def hide_appropriate_classroom_units
-    # on commit callback that checks if archived
-    if visible == false
-      hide_all_classroom_units
-    end
+    hide_all_classroom_units unless visible
   end
 
   def hide_all_classroom_units
     ActivitySession.where(classroom_unit: classroom_units).update_all(visible: false)
     classroom_units.update_all(visible: false)
-    SetTeacherLessonCache.perform_async(owner.id)
+    return if owner.nil?
+    
+    SetTeacherLessonCache.perform_async(owner.id) 
     ids = Unit.find_by_sql("
       SELECT unit.id FROM units unit
       LEFT JOIN classroom_units as cu ON cu.unit_id = unit.id AND cu.visible = true


### PR DESCRIPTION
## WHAT
For Rails < [5.0](https://makandracards.com/makandra/54733-rails-5-how-to-get-after_commit-callbacks-fired-in-tests),  `after_commit` callbacks are not fired in tests when using transactional_fixtures or the database_cleaner gem with strategy `:transaction`.

## WHY
Lack of after_commits firing during testing gives an incomplete picture of testing coverage.

## HOW
First, add [test_after_commit](https://github.com/grosser/test_after_commit) gem to enable `after_commit` hook in testing.
Then, address the newly failing specs that stem from `nil` owner [here](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/classroom.rb#L157).  Specs reach this point with `nil` owners due to the classroom factories using the [trait](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/spec/factories/classroom.rb#L48) `with_no_teacher`.

Another fix would be to remove the `with_no_teacher` trait, but that seems more drastic.

### Notion Card Links
https://www.notion.so/quill/Make-after_commit-callbacks-fire-in-tests-for-Rails-4-2-ed4290c66c5a4430873b8f5349c21835

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - this change was to get existing specs running as expected.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? |  YES