### PR TITLE
TeacherFix bug

### DIFF
--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -69,7 +69,7 @@ module Student
       else
 
         new_unit_name = "#{name}'s Activities from #{old_classroom.name}"
-        unit = Unit.create(user_id: new_classroom.owner.id, name: new_unit_name)
+        unit = Unit.create!(user_id: new_classroom.owner.id, name: new_unit_name)
         new_cu = ClassroomUnit.find_or_create_by(unit_id: unit.id, classroom_id: new_classroom_id, assigned_student_ids: [user_id])
 
         classroom_units.each do |cu|

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -67,9 +67,8 @@ module Student
           hide_extra_activity_sessions(cu.id)
         end
       else
-
         new_unit_name = "#{name}'s Activities from #{old_classroom.name}"
-        unit = Unit.create!(user_id: new_classroom.owner.id, name: new_unit_name)
+        unit = Unit.create_with_incremented_name(user_id: new_classroom.owner.id, name: new_unit_name)
         new_cu = ClassroomUnit.find_or_create_by(unit_id: unit.id, classroom_id: new_classroom_id, assigned_student_ids: [user_id])
 
         classroom_units.each do |cu|

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -73,6 +73,16 @@ class Unit < ActiveRecord::Base
     end
   end
 
+  def self.create_with_incremented_name(user_id:, name: )
+    unit = Unit.create(user_id: user_id, name: name)
+    return unit if unit.persisted?
+    (2..20).each do |counter|
+      unit = Unit.create(user_id: user_id, name: "#{name} #{counter}")
+      return unit if unit.persisted?
+    end
+    false
+  end
+
   private def create_any_new_classroom_unit_activity_states
     lesson_unit_activities = unit_activities.select { |ua| ua.activity.is_lesson? }
     lesson_unit_activities.each do |ua|

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -79,6 +79,17 @@ describe 'Student Concern', type: :model do
       expect(new_ca.classroom).to eq(classroom2)
       expect(new_ca.assigned_student_ids).to include(student1.id)
     end
+
+    it 'should not raise error when moving to unit that has a naming collision' do 
+      new_unit_name = "#{student1.name}'s Activities from #{classroom.name}"
+      same_named_unit = Unit.create!(name: new_unit_name, user_id: classroom2.owner.id)
+      
+      student1.move_activity_sessions(classroom, classroom2)
+      started.reload
+      new_ca = started.classroom_unit
+      expect(new_ca.classroom).to eq(classroom2)
+      expect(new_ca.assigned_student_ids).to include(student1.id)
+    end
   end
 
   describe("#merge_student_account") do

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -46,6 +46,26 @@ describe Unit, type: :model do
     end
   end
 
+  describe '#create_with_incremented_name' do 
+    context 'collision occurs' do 
+      it 'should create a Unit with an incremented name' do 
+        Unit.create!(user_id: teacher.id, name: 'used name')
+        expect do 
+          Unit.create_with_incremented_name(user_id: teacher.id, name: 'used name')
+        end.to change { Unit.count }.by 1
+        expect(Unit.find_by(user_id: teacher.id, name: 'used name 2').present?).to be true
+      end
+    end
+
+    context 'normal path - no collision' do 
+      it 'should create a well-formed Unit' do 
+        expect do 
+          Unit.create_with_incremented_name(user_id: teacher.id, name: 'unique name')
+        end.to change { Unit.count }.by 1
+      end
+    end
+  end
+
   describe 'the name field' do
 
     context "it should be unique" do


### PR DESCRIPTION
## WHAT
removes situation where Unit creation fails silently. 

## WHY
Sentry surfaced this error 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/500-error-TeacherFixController-move_student_from_one_class_to_another-14601ff38edf4e8ab17b99ac68a1c8f4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
