### PR TITLE
Lms/rules report view 2 rebased

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
@@ -10,4 +10,10 @@ class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
         render(json: report)
     end
 
+    def rule_detail
+        raise ArgumentError unless params.include?('rule_uid')
+        report = RuleFeedbackHistory.generate_rulewise_report(params['rule_uid'])
+        render(json: report)
+    end
+
 end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -364,6 +364,8 @@ EmpiricalGrammar::Application.routes.draw do
     namespace :v1 do
       get 'activities/uids_and_flags' => 'activities#uids_and_flags'
       get 'rule_feedback_histories' => 'rule_feedback_histories#by_conjunction'
+      get 'rule_feedback_history/:rule_uid' => 'rule_feedback_histories#rule_detail'
+
       resources :activities,              except: [:index, :new, :edit]
       resources :activity_flags,          only: [:index]
       resources :activity_sessions,       except: [:index, :new, :edit]

--- a/services/QuillLMS/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/lib/rule_feedback_history.rb
@@ -26,12 +26,12 @@ class RuleFeedbackHistory
         rules = Comprehension::Rule.find_by_sql(sql)
     end
 
-    def self.feedback_history_to_json(fh)
+    def self.feedback_history_to_json(f_h)
         {
-            response_id: fh.id,
-            datetime: fh.updated_at,
-            entry: fh.entry,
-            highlight: fh.metadata.class == Hash ? fh.metadata['highlight'] : '',
+            response_id: f_h.id,
+            datetime: f_h.updated_at,
+            entry: f_h.entry,
+            highlight: f_h.metadata.class == Hash ? f_h.metadata['highlight'] : '',
             view_session_url: 'Not yet available'
         }
     end
@@ -39,8 +39,8 @@ class RuleFeedbackHistory
     def self.generate_rulewise_report(rule_uid)
         feedback_histories = FeedbackHistory.where(rule_uid: rule_uid)
         response_jsons = []
-        feedback_histories.each do |fh|
-            response_jsons.append(feedback_history_to_json(fh))
+        feedback_histories.each do |f_h|
+            response_jsons.append(feedback_history_to_json(f_h))
         end
 
         {

--- a/services/QuillLMS/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/lib/rule_feedback_history.rb
@@ -26,6 +26,30 @@ class RuleFeedbackHistory
         rules = Comprehension::Rule.find_by_sql(sql)
     end
 
+    def self.feedback_history_to_json(fh)
+        {
+            response_id: fh.id,
+            datetime: fh.updated_at,
+            entry: fh.entry,
+            highlight: fh.metadata.class == Hash ? fh.metadata['highlight'] : '',
+            view_session_url: 'Not yet available'
+        }
+    end
+
+    def self.generate_rulewise_report(rule_uid)
+        feedback_histories = FeedbackHistory.where(rule_uid: rule_uid)
+        response_jsons = []
+        feedback_histories.each do |fh|
+            response_jsons.append(feedback_history_to_json(fh))
+        end
+
+        {
+            "#{rule_uid}": {
+                responses: response_jsons
+            }
+        }
+    end
+
     def self.postprocessing(rules_sql_result)
         rules_sql_result.each do |r| 
             

--- a/services/QuillLMS/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/lib/rule_feedback_history.rb
@@ -32,7 +32,8 @@ class RuleFeedbackHistory
             datetime: f_h.updated_at,
             entry: f_h.entry,
             highlight: f_h.metadata.class == Hash ? f_h.metadata['highlight'] : '',
-            view_session_url: 'Not yet available'
+            view_session_url: 'Not yet available',
+            strength: f_h.feedback_history_ratings.order(updated_at: :desc).first&.rating
         }
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -11,7 +11,14 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
             {"rule_feedback_histories"=>[]}
         )
     end
+  end
 
+  describe '#rule_detail' do 
+    it 'should return successfully' do 
+      get :rule_feedback_history, rule_uid: 1
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)).to eq({})
+    end
   end
   
 end

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -15,9 +15,9 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
   describe '#rule_detail' do 
     it 'should return successfully' do 
-      get :rule_feedback_history, rule_uid: 1
+      get :rule_detail, rule_uid: 1
       expect(response.status).to eq 200
-      expect(JSON.parse(response.body)).to eq({})
+      expect(JSON.parse(response.body)).to eq({"1"=>{"responses"=>[]}})
     end
   end
   

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -164,5 +164,28 @@ RSpec.describe RuleFeedbackHistory, type: :model do
 
   end
 
+  describe '#generate_rulewise_report' do 
+    it 'should render feedback histories' do 
+      so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
+      unused_rule = rule_factory { { name: 'unused', rule_type: 'autoML'} } 
+
+      f_h1 = create(:feedback_history, rule_uid: so_rule1.uid)
+      f_h2 = create(:feedback_history, rule_uid: so_rule1.uid)
+      f_h3 = create(:feedback_history, rule_uid: unused_rule.uid)
+
+      result = RuleFeedbackHistory.generate_rulewise_report(so_rule1.uid)
+
+      expect(result.keys.length).to eq 1
+      expect(result.keys.first.to_s).to eq so_rule1.uid 
+      
+      responses = result[so_rule1.uid.to_sym][:responses]
+
+      response_ids = responses.map {|r| r[:response_id]}
+      expect(
+        Set[*response_ids] == Set[f_h1.id, f_h2.id]
+      ).to be true
+      
+    end
+  end
 
 end

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -186,6 +186,45 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       ).to be true
       
     end
+
+    it 'should display the most recent feedback history rating, if it exists' do 
+      so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
+      unused_rule = rule_factory { { name: 'unused', rule_type: 'autoML'} } 
+
+      # users
+      user1 = create(:user)
+      user2 = create(:user)
+
+      # feedback histories
+      f_h1 = create(:feedback_history, rule_uid: so_rule1.uid)
+      f_h2 = create(:feedback_history, rule_uid: so_rule1.uid)
+      f_h3 = create(:feedback_history, rule_uid: unused_rule.uid)
+
+      # feedback history ratings
+      f_h_r1_old = FeedbackHistoryRating.create!(
+        feedback_history_id: f_h1.id, 
+        user_id: user1.id, 
+        rating: false,
+        updated_at: Time.now - 1.days
+      )
+      f_h_r1_new = FeedbackHistoryRating.create!(
+        feedback_history_id: f_h1.id, 
+        user_id: user2.id, 
+        rating: true,
+        updated_at: Time.now
+      )
+      result = RuleFeedbackHistory.generate_rulewise_report(so_rule1.uid)
+
+      expect(result.keys.length).to eq 1
+      expect(result.keys.first.to_s).to eq so_rule1.uid 
+      
+      responses = result[so_rule1.uid.to_sym][:responses]
+
+      rated_response = responses.find {|r| r[:response_id] == f_h1.id }
+
+      expect(rated_response[:strength]).to eq true
+
+    end
   end
 
 end


### PR DESCRIPTION
## WHAT
View 2 of Rules Report

## WHY
To organize feedbacks grouped by response in the admin reporting tool 

## HOW


### Notion Card Links
https://www.notion.so/quill/view-2-responses-per-rule-3dd3906be7aa45a1bbe63e610878a227

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | n/a
