### PR TITLE
comprehension/fix-missing-model-error

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/feedback_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/feedback_controller.rb
@@ -24,7 +24,9 @@ module Comprehension
 
     def automl
       automl_check = Comprehension::AutomlCheck.new(@entry, @prompt, @previous_feedback)
-      render json: automl_check.feedback_object
+      feedback_object = automl_check.feedback_object
+      return render :body => nil, :status => 404 unless feedback_object
+      render json: feedback_object
     end
 
     def spelling

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
@@ -6,12 +6,12 @@ module Comprehension
     def initialize(entry, prompt, previous_feedback=[])
       @entry = entry
       @prompt = prompt
-      @automl_model = prompt.automl_models.where(state: AutomlModel::STATE_ACTIVE).first
+      @automl_model = prompt&.automl_models.where(state: AutomlModel::STATE_ACTIVE).first
       @previous_feedback = previous_feedback
     end
 
     def feedback_object
-      return nil unless matched_rule
+      return unless matched_rule
       feedback = matched_rule.determine_feedback_from_history(@previous_feedback)
       highlight = feedback.highlights.map do |h|
         {
@@ -37,6 +37,7 @@ module Comprehension
     end
 
     private def fetch_matched_rule
+      return unless @automl_model
       google_automl_label = @automl_model.fetch_automl_label(@entry)
       @prompt.rules.joins(:label).find_by(comprehension_labels: {name: google_automl_label})
     end

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/automl_check.rb
@@ -6,7 +6,7 @@ module Comprehension
     def initialize(entry, prompt, previous_feedback=[])
       @entry = entry
       @prompt = prompt
-      @automl_model = prompt&.automl_models.where(state: AutomlModel::STATE_ACTIVE).first
+      @automl_model = prompt&.automl_models&.where(state: AutomlModel::STATE_ACTIVE)&.first
       @previous_feedback = previous_feedback
     end
 

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
@@ -68,6 +68,16 @@ module Comprehension
     end
 
     context "#automl" do
+      should "return 404 if prompt id does not exist" do
+        post 'automl', entry: 'some text', prompt_id: @prompt.id + 1000, session_id: 1, previous_feedback: []
+        assert_equal response.status, 404
+      end
+
+      should "return 404 if prompt has no associated automl_model" do
+        post 'automl', entry: 'some text', prompt_id: @prompt.id, session_id: 1, previous_feedback: []
+        assert_equal response.status, 404
+      end
+
       should 'return feedback payloads based on the lib matched_rule value' do
         entry = 'entry'
 

--- a/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/lib/automl_check_test.rb
@@ -26,6 +26,12 @@ module Comprehension
         end
       end
 
+      should 'return nil if there is no automl_model associated with the provided prompt' do
+        @automl_model.destroy
+        automl_check = Comprehension::AutomlCheck.new("entry", @prompt)
+        assert_equal automl_check.feedback_object, nil
+      end
+
       should 'return the feedback payload when there is a label match' do
         AutomlModel.stub_any_instance(:fetch_automl_label, @label.name) do
           entry = 'entry'


### PR DESCRIPTION
## WHAT
Have the AutoML Feedback controller action fail gracefully when a prompt is missing or doesn't have an AutoML model configured for it.
## WHY
Sometimes (such as during initial Turking) the Go endpoint will send through a request for feedback for a prompt with no AutoML model.  We want to 404 here rather than 500.
## HOW
Just check to make sure that the provided `Prompt` is valid and that it has a configured `AutomlModel`.

### Notion Card Links
https://www.notion.so/quill/NoMethod-Error-fetch_automl_label-4813559002b44f8d94ea1f819053073f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
