### PR TITLE
Fix hyperlink color on Premium page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -429,6 +429,11 @@ li.premium-tab > a:hover {
         color: black;
         font-size: 16px;
         padding-bottom: 20px;
+        p {
+          a {
+            color: black;
+          }
+        }
       }
       a {
         text-decoration: underline;


### PR DESCRIPTION
## WHAT
change hyperlink color on Premium change from white to black

## WHY
so that users can see the link

## HOW
just updated some CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Links-emails-in-Questions-and-Answers-section-of-Premium-page-are-white-on-white-text-background-5fff4b3454084c55a0ab6ebd8f2c1d35

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- small CSS change
Have you deployed to Staging? | (No-- small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
