### PR TITLE
CMS: Configure sidekiq from sidekiq.yml

### DIFF
--- a/services/QuillCMS/.ebextensions/0002_sidekiq.config
+++ b/services/QuillCMS/.ebextensions/0002_sidekiq.config
@@ -74,6 +74,6 @@ files:
         EB_APP_PID_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k app_pid_dir)
         EB_APP_USER=$(/opt/elasticbeanstalk/bin/get-config container -k app_user)
         cd $EB_APP_DEPLOY_DIR
-        exec su -s /bin/bash -c "sidekiq -e ${RACK_ENV} -c ${SIDEKIQ_WORKERS:-2} -L ${EB_APP_DEPLOY_DIR}/log/sidekiq.log -C ${EB_APP_DEPLOY_DIR}/config/sidekiq.yml -P ${EB_APP_PID_DIR}/sidekiq.pid" $EB_APP_USER
+        exec su -s /bin/bash -c "sidekiq -e ${RACK_ENV} -L ${EB_APP_DEPLOY_DIR}/log/sidekiq.log -C ${EB_APP_DEPLOY_DIR}/config/sidekiq.yml -P ${EB_APP_PID_DIR}/sidekiq.pid" $EB_APP_USER
       EOT
       end script

--- a/services/QuillCMS/config/sidekiq.yml
+++ b/services/QuillCMS/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: <%= ENV.fetch("SIDEKIQ_WORKERS") { 2 } %>
+:concurrency: <%= ENV.fetch("SIDEKIQ_WORKERS") { 4 } %>
 :queues:
   - critical
   - default

--- a/services/QuillCMS/config/sidekiq.yml
+++ b/services/QuillCMS/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 1
+:concurrency: <%= ENV.fetch("SIDEKIQ_WORKERS") { 2 } %>
 :queues:
   - critical
   - default


### PR DESCRIPTION
## WHAT
Tiny PR. We currently have two competing "Number of sidekiq workers" configs in the CMS: `0002_sidekiq.config` and  `sidekiq.yml` with `0002_sidekiq.config` being the one that has precedence. Let's use `sidekiq.yml` instead and eliminate the other.
## WHY
We should only have one config for a setting. The one in `sidekiq.yml` is easier to use and is universal (the other just applies to elastic beanstalk).
## HOW
Remove the `-c ${SIDEKIQ_WORKERS:-2}` from the elastic beanstalk config. 

Also note, during testing I discovered that `0002_sidekiq.config` is only updated for new servers (not restarts or deploys), so when rolling this out, we'll have to put all new servers in place.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  ('NO', just a config change.)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
