### PR TITLE
Make sure that placeholder AutoML feedback has the updated type

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -43,7 +43,7 @@ var urls = [...]string{
 // you can't use const for structs, so this is the closest thing we can get for this value
 var default_api_response = APIResponse{
 	Feedback: "Thank you for your response.",
-	Feedback_type: "semantic",
+	Feedback_type: "autoML",
 	Optimal: true,
 }
 

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
@@ -39,7 +39,7 @@ func TestPublishMessage(t *testing.T) {
 		t.Errorf("The response was not optimal.")
 	}
 
-	if r.Feedback_type != "semantic" {
+	if r.Feedback_type != "autoML" {
 		t.Errorf("The wrong feedback type was returned: %v", r.Feedback_type)
 	}
 }
@@ -71,7 +71,7 @@ func TestDefaultFeedbackFallback(t *testing.T) {
 		t.Errorf("The response was not optimal.")
 	}
 
-	if r.Feedback_type != "semantic" {
+	if r.Feedback_type != "autoML" {
 		t.Errorf("The wrong feedback type was returned: %v", r.Feedback_type)
 	}
 }


### PR DESCRIPTION
## WHAT
Update the Go endpoint default AutoML feedback object (used when there is no AutoML feedback available and all other algorithms are "optimal") to use the "autoML" type rather than "semantic" since we renamed the value in the LMS database and updated validation.
## WHY
Turking on brand new passages that don't have AutoML feedback would fail to log the Turker's entry for any Prompt if it got through all the filters and actually needed to be labeled.
## HOW
Just change the value in the default object and update tests.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No staging for Go endpoint
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
