### PR TITLE
CMS Deploy - protect production deploys

### DIFF
--- a/services/QuillCMS/deploy.sh
+++ b/services/QuillCMS/deploy.sh
@@ -6,7 +6,13 @@ case $1 in
   prod)
     EB_ENVIRONMENT_NAME=Quillcms-production
     EB_ENVIRONMENT_ID=e-ddeyrmmznn
-
+    if [[ "$current_branch" != "production" ]]
+    then
+      echo "******** CMS NON-PRODUCTION BRANCH DEPLOY ERROR ********"
+      echo "AWS Elastic Beanstalk uses your local 'production' branch"
+      echo "You must be on *local* branch 'production' to deploy CMS production"
+      exit 1
+    fi
     ;;
   staging)
     EB_ENVIRONMENT_NAME=Quillcms-staging
@@ -21,12 +27,24 @@ echo "******* CMS DEPLOY - AWS ELASTIC BEANSTALK *******"
 read -r -p "Deploy *local* branch '$current_branch' to CMS '$1' environment on AWS Elastic Beanstalk? [y/N]" response
 if [[ "$response" =~ ^([y])$ ]]
 then
+  if [ $1 == 'prod' ]
+  then
+    # stash local changes and update local production branch
+    # you would need to already be on production to get here
+    # but checking out production just in case
+    git stash
+    git fetch origin production
+    git checkout production
+    git pull origin production
+    git stash apply
+  if
+
   # Slack deploy start
   sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
 
   eb deploy ${EB_ENVIRONMENT_NAME} --label `git rev-parse HEAD`
   open "https://rpm.newrelic.com/accounts/2639113/applications/548895592"
-  open "https://console.aws.amazon.com/elasticbeanstalk/home?region=us-east-1#/environment/dashboard?applicationName=${app_name}&environmentId=${EB_ENVIRONMENT_ID}"
+  eb console ${EB_ENVIRONMENT_NAME}
 else
     echo "Ok, we won't deploy. Have a good day!"
 fi

--- a/services/QuillCMS/deploy.sh
+++ b/services/QuillCMS/deploy.sh
@@ -37,7 +37,7 @@ then
     git checkout production
     git pull origin production
     git stash apply
-  if
+  fi
 
   # Slack deploy start
   sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
@@ -45,6 +45,7 @@ then
   eb deploy ${EB_ENVIRONMENT_NAME} --label `git rev-parse HEAD`
   open "https://rpm.newrelic.com/accounts/2639113/applications/548895592"
   eb console ${EB_ENVIRONMENT_NAME}
+
 else
     echo "Ok, we won't deploy. Have a good day!"
 fi


### PR DESCRIPTION
## WHAT
Tiny PR follow up to #7480 . For CMS deploys, confirm that the deployer is on the `production` branch and update that branch for them if they are deploying (so they don't deploy stale code).
## WHY
To cut down on potential human error. Let's be very protective of production deploys. This seems like an easier path for now than integrating AWS CodeCommit setup.
## HOW
Check for correct git branch, else exit. Stash local changes, fetch, and pull.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, config change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
