### PR TITLE
comprehension/tweak-go-used-calculation

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -170,9 +170,10 @@ func getAPIResponse(url string, priority int, json_params [] byte, c chan Intern
 }
 
 func identifyUsedFeedbackIndex(feedbacks map[int]InternalAPIResponse) int {
-	for key, feedback := range feedbacks {
+	for i := 0; i < len(feedbacks); i++ {
+		feedback := feedbacks[i]
 		if !feedback.Error && !feedback.APIResponse.Optimal {
-			return key
+			return i
 		}
 	}
 	// If none of the feedbacks are non-optimal, check to see if automl is feedback

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
@@ -161,7 +161,8 @@ func TestAutoMLIndex(t *testing.T) {
 }
 
 func TestIdentifyUsedFeedbackIndex(t *testing.T) {
-	usable_response := InternalAPIResponse { Error: false, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: false, Labels: "test_label" } }
+	usable_used_response := InternalAPIResponse { Error: false, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: false, Labels: "test_label" } }
+	usable_unused_response := InternalAPIResponse { Error: false, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: false, Labels: "test_label" } }
 	error_response := InternalAPIResponse { Error: true, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: false, Labels: "test_label" } }
 	optimal_response := InternalAPIResponse { Error: false, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: true, Labels: "test_label" } }
 
@@ -174,14 +175,15 @@ func TestIdentifyUsedFeedbackIndex(t *testing.T) {
 
 	feedbacks[0] = error_response
 	feedbacks[1] = optimal_response
-	feedbacks[2] = usable_response
+	feedbacks[2] = usable_used_response
+	feedbacks[3] = usable_unused_response
 
 	result = identifyUsedFeedbackIndex(feedbacks)
 	if result != 2 {
 		t.Errorf("Should have identified 2 for unfound used feedback, but got %d", result)
 	}
 
-	for i := 0; i <= automl_index; i++ {
+	for i := 0; i < len(feedbacks); i++ {
 		feedbacks[i] = optimal_response
 	}
 


### PR DESCRIPTION
## WHAT
Use a deterministically determined loop order
## WHY
The return logic assumes that the loop will look over items in priority order (and thus early exit on the highest priority item that matches the return criteria), but the loop in place at the moment does NOT actually do this because `range feedbacks` provides a non-deterministic iteration order.
## HOW
Because items are placed into the map keyed on their priority, it turns out to be the case that the range of `int`s equal to the `len` of the map will give us every item in order of priority.

### Notion Card Links
https://www.notion.so/quill/Bug-Report-User-Feedback-does-not-Match-Report-Feedback-fc313a2a44ff4cb0a1adf20015077cca

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes that can be tested reproducibly
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
