### PR TITLE
Fix spelling bug where spelling concept wasn't being added to concept results

### DIFF
--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.20",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.14.6",
+    "quill-marking-logic": "0.14.7",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/packages/quill-marking-logic/package-lock.json
+++ b/packages/quill-marking-logic/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.14.2",
+  "version": "0.14.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/interfaces/index.ts
+++ b/packages/quill-marking-logic/src/interfaces/index.ts
@@ -30,6 +30,7 @@ export interface PartialResponse {
   first_attempt_count?: number|null,
   child_count?: number|null,
   concept_results?: Array<ConceptResult>|null,
+  conceptResults?: Array<ConceptResult>|null,
   created_at?: string,
   id?: number,
   key?: string,

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
@@ -54,14 +54,16 @@ export function checkSentenceCombining(
   const spellingPass = checkForMatches(spellCheckedData, firstPassMatchers, true); // check for a match w the spelling corrected
   const misspelledWords = getMisspelledWords(data.response, spellCheckedData.spellCorrectedResponse)
   if (spellingPass) {
-    let foundConcepts = spellingPass.conceptResults
-    //convert concept_results to an array if it's not already
+    let foundConcepts = spellingPass.conceptResults || spellingPass.concept_results
+    //convert concept results to an array if it's not already
     if (typeof foundConcepts === 'object' && foundConcepts.constructor === Object) {
       spellingPass.conceptResults =
         Object.keys(foundConcepts).map((k) => foundConcepts[k])
     }
     if (Array.isArray(spellingPass.conceptResults)) {
       spellingPass.conceptResults.push(conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
+    } else if (Array.isArray(spellingPass.concept_results)) {
+      spellingPass.concept_results.push(conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
     }
     const spellingAwareFeedback = getSpellingFeedback(spellingPass);
     const spellingFeedbackObj = {

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
@@ -1,10 +1,10 @@
 import * as _ from 'underscore';
+
 import {Response, PartialResponse, IncorrectSequence, FocusPoint, GradingObject} from '../../interfaces';
 import {correctSentenceFromSamples} from '../spellchecker/main';
 import {getOptimalResponses} from '../sharedResponseFunctions';
 import {conceptResultTemplate} from '../helpers/concept_result_template'
 import {removePunctuation} from '../helpers/remove_punctuation'
-
 import {exactMatch} from '../matchers/exact_match';
 import {focusPointChecker} from '../matchers/focus_point_match';
 import {incorrectSequenceChecker} from '../matchers/incorrect_sequence_match';
@@ -54,14 +54,14 @@ export function checkSentenceCombining(
   const spellingPass = checkForMatches(spellCheckedData, firstPassMatchers, true); // check for a match w the spelling corrected
   const misspelledWords = getMisspelledWords(data.response, spellCheckedData.spellCorrectedResponse)
   if (spellingPass) {
-    let foundConcepts = spellingPass.concept_results
+    let foundConcepts = spellingPass.conceptResults
     //convert concept_results to an array if it's not already
     if (typeof foundConcepts === 'object' && foundConcepts.constructor === Object) {
-      spellingPass.concept_results =
+      spellingPass.conceptResults =
         Object.keys(foundConcepts).map((k) => foundConcepts[k])
     }
-    if (Array.isArray(spellingPass.concept_results)) {
-      spellingPass.concept_results.push(conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
+    if (Array.isArray(spellingPass.conceptResults)) {
+      spellingPass.conceptResults.push(conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
     }
     const spellingAwareFeedback = getSpellingFeedback(spellingPass);
     const spellingFeedbackObj = {

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
@@ -1,12 +1,14 @@
 const questionPrompt: string = "Bats have wings. They can fly."
-import {responses, focusPoints, incorrectSequences} from '../../../test/data/batswings'
 import { assert } from 'chai';
+import { match } from 'react-router';
+
 import {checkSentenceCombining} from './sentence_combining';
+
+import {responses, focusPoints, incorrectSequences} from '../../../test/data/batswings'
 import {Response} from '../../interfaces';
 import { feedbackStrings, spellingFeedbackStrings } from '../constants/feedback_strings';
 import {spacingBeforePunctuation} from '../algorithms/spacingBeforePunctuation'
 import { conceptResultTemplate } from '../helpers/concept_result_template';
-import { match } from 'react-router';
 
 describe('The checking a sentence combining question', () => {
 
@@ -91,6 +93,13 @@ describe('The checking a sentence combining question', () => {
 
     it('should add spelling concept result to concept results', () => {
       const questionString = "Batss wings, so they can fly."
+      const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
+      assert.equal(matchedResponse.spelling_error, true);
+      assert.include(matchedResponse.concept_results, conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
+    });
+
+    it('should add spelling concept result to concept results if there are two or more spelling errors', () => {
+      const questionString = "Batss wingss, so they can fly."
       const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
       assert.equal(matchedResponse.spelling_error, true);
       assert.include(matchedResponse.concept_results, conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -63,7 +63,7 @@
     "promise-polyfill": "^6.1.0",
     "pusher-js": "^5.0.1",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "0.14.6",
+    "quill-marking-logic": "0.14.7",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^16.13.1",

--- a/services/QuillLMS/package-lock.json
+++ b/services/QuillLMS/package-lock.json
@@ -836,9 +836,9 @@
       "dev": true
     },
     "quill-marking-logic": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.14.6.tgz",
-      "integrity": "sha512-APj2NE18WfXZZhMNcw7GzcR+ONM9kX2oCgHexlNmUqod1pKbkJ2sGAiZ27D8sSdfeanzyH7IewSOX+EnXr8JaQ==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.14.7.tgz",
+      "integrity": "sha512-/vc9JCddyhD5D28GYm5Ghbm2rT/M8pDqzUKIE0PkJjc/jnO+UQFxZd7Nv8ei/c6vmAZbD+mFLUkRRY0CSpMgJA==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -1079,9 +1079,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "vlq": {
       "version": "0.2.3",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.14.6",
+    "quill-marking-logic": "0.14.7",
     "react-csv": "^1.1.2",
     "react-select": "^1.1.0",
     "react-table": "^6.10.3"


### PR DESCRIPTION
## WHAT
We do a bad thing in `quill-marking-logic` where we use both the variable name `concept_results` and `conceptResults` to denote the same thing. This caused a bug where spelling concept results weren't being appropriately added to an array because we were fetching `concept_results` instead of `conceptResults`. This PR temporarily fixes this without resolving the larger issue of inconsistent naming.

## WHY
Curriculum asked for this fix in order to comply with quality standards for an upcoming CollegeBoard study.

## HOW
Change the field name we're looking in to be `conceptResults`.

Long term, we should be looking to consolidate naming so that we are only using one type of name throughout the code base.

### Screenshots
![Screen Shot 2021-04-20 at 5 12 25 PM](https://user-images.githubusercontent.com/57366100/115464802-a1e5fe80-a1fb-11eb-96be-151d3440e77a.png)

### Notion Card Links
https://www.notion.so/quill/Connect-algorithm-issues-957f7bd8d574400d84422f938b48e79a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
