### PR TITLE
comprehension/spelling-rule-uid-in-feedback

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -22,13 +22,18 @@ module Comprehension
         response_id: '',
         entry: @entry,
         concept_uid: SPELLING_CONCEPT_UID,
-        rule_uid: '',
+        rule_uid: spelling_rule&.uid || '',
         highlight: optimal? ? [] : highlight
       }
     end
 
     def error
       bing_response['error'] ? bing_response['error']['message'] : nil
+    end
+
+    private def spelling_rule
+      return @spelling_rule if @spelling_rule
+      @spelling_rule = Rule.where(rule_type: Rule::TYPE_SPELLING).first
     end
 
     private def highlight

--- a/services/QuillLMS/lib/tasks/add_spelling_api_rule_and_feedback.rake
+++ b/services/QuillLMS/lib/tasks/add_spelling_api_rule_and_feedback.rake
@@ -1,0 +1,22 @@
+namespace :add_spelling_api_rule_and_feedback do
+  task :run => :environment do
+    ActiveRecord::Base.transaction do
+      rule = Comprehension::Rule.create!(
+        uid: '7deb9bfc-4f4d-433f-a366-caf810849a32',
+        name: 'Spelling',
+        description: 'Try again. There may be a spelling mistake.',
+        optimal: false,
+        universal: true,
+        rule_type: Comprehension::Rule::TYPE_SPELLING,
+        suborder: 1,
+        state: 'active'
+      )
+      Comprehension::Feedback.create!(
+        rule: rule,
+        text: 'Try again. There may be a spelling mistake.',
+        order: 1
+      )
+      FeedbackHistory.where(feedback_type: FeedbackHistory::SPELLING).update_all(rule_uid: rule.uid)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a migration to insert Comprehension Spelling universal rule, and tweak the Spelling feedback system to return that new rule's UID
## WHY
We want the Rules Report in Comprehension to work for Spelling, and that requires us to connect `FeedbackHistory` records to `Comprehension::Rule` entries.
## HOW
This script inserts a new `Comprehension::Rule` entry with a pre-defined UID, and then finds all existing `FeedbackHistory` records with a `feedback_type` of "spelling" to use the newly created UID.

### Notion Card Links
Product Board card: https://www.notion.so/quill/Update-Spelling-API-to-use-comprehension_rules-so-the-team-can-edit-the-feedback-82b9ce0cdb1f45388194fb3f4a4c5dd8
Rule UID source: https://www.notion.so/quill/860620e6d04f448784182a878be45b50?v=549b5aefa74e4ac8b354b27d12c95fb2


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, this is pure data entry
Have you deployed to Staging? | No - small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
