### PR TITLE
Model and Migration files for Activity Health and Prompt Health tables

### DIFF
--- a/services/QuillLMS/app/models/activity_health.rb
+++ b/services/QuillLMS/app/models/activity_health.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: activity_healths
+#
+#  id                      :integer          not null, primary key
+#  activity_categories     :string           is an Array
+#  activity_packs          :string           is an Array
+#  avg_common_unmatched    :float
+#  avg_completion_time     :time
+#  avg_difficulty          :float
+#  content_partners        :string           is an Array
+#  diagnostics             :string           is an Array
+#  name                    :string
+#  recent_assignments      :integer
+#  standard_dev_difficulty :float
+#  tool                    :string
+#  url                     :string
+#
+class ActivityHealth < ActiveRecord::Base
+  ALLOWED_TOOLS = %w(connect grammar)
+
+  has_many :prompt_healths
+
+  validates :tool, inclusion: { in: ALLOWED_TOOLS, allow_nil: true}
+  validates :recent_assignments, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :avg_difficulty, inclusion: { in: 0..5, allow_nil: true }
+end

--- a/services/QuillLMS/app/models/prompt_health.rb
+++ b/services/QuillLMS/app/models/prompt_health.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: prompt_healths
+#
+#  id                           :integer          not null, primary key
+#  difficulty                   :float
+#  flag                         :string
+#  focus_points                 :integer
+#  incorrect_sequences          :integer
+#  percent_common_unmatched     :float
+#  percent_reached_optimal      :float
+#  percent_specified_algorithms :float
+#  text                         :string
+#  url                          :string
+#  activity_health_id           :integer
+#
+# Foreign Keys
+#
+#  fk_rails_...  (activity_health_id => activity_healths.id) ON DELETE => cascade
+#
+class PromptHealth < ActiveRecord::Base
+  FLAGS = %w(production archived alpha beta private)
+
+  belongs_to :activity_health
+
+  validates :flag, inclusion: { in: FLAGS, allow_nil: true}
+  validates :incorrect_sequences, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :focus_points, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :percent_common_unmatched, inclusion: { in: 0..100, allow_nil: true }
+  validates :percent_specified_algorithms, inclusion: { in: 0..100, allow_nil: true }
+  validates :difficulty, inclusion: { in: 0..5, allow_nil: true }
+  validates :percent_reached_optimal, inclusion: { in: 0..100, allow_nil: true }
+end

--- a/services/QuillLMS/db/migrate/20210421190032_create_activity_healths.rb
+++ b/services/QuillLMS/db/migrate/20210421190032_create_activity_healths.rb
@@ -1,0 +1,18 @@
+class CreateActivityHealths < ActiveRecord::Migration
+  def change
+    create_table :activity_healths do |t|
+      t.string               :name
+      t.string               :url
+      t.string               :activity_categories, array: true
+      t.string               :content_partners, array: true
+      t.string               :tool
+      t.integer              :recent_assignments
+      t.string               :diagnostics, array: true
+      t.string               :activity_packs, array: true
+      t.time                 :avg_completion_time
+      t.float                :avg_difficulty
+      t.float                :avg_common_unmatched
+      t.float                :standard_dev_difficulty
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20210421191605_create_prompt_healths.rb
+++ b/services/QuillLMS/db/migrate/20210421191605_create_prompt_healths.rb
@@ -1,0 +1,17 @@
+class CreatePromptHealths < ActiveRecord::Migration
+  def change
+    create_table :prompt_healths do |t|
+      t.string      :text
+      t.string      :url
+      t.string      :flag
+      t.integer     :incorrect_sequences
+      t.integer     :focus_points
+      t.float       :percent_common_unmatched
+      t.float       :percent_specified_algorithms
+      t.float       :difficulty
+      t.float       :percent_reached_optimal
+      t.references  :activity_health
+    end
+    add_foreign_key :prompt_healths, :activity_healths, column: :activity_health_id, on_delete: :cascade
+  end
+end

--- a/services/QuillLMS/spec/models/activity_health_spec.rb
+++ b/services/QuillLMS/spec/models/activity_health_spec.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: activity_healths
+#
+#  id                      :integer          not null, primary key
+#  activity_categories     :string           is an Array
+#  activity_packs          :string           is an Array
+#  avg_common_unmatched    :float
+#  avg_completion_time     :time
+#  avg_difficulty          :float
+#  content_partners        :string           is an Array
+#  diagnostics             :string           is an Array
+#  name                    :string
+#  recent_assignments      :integer
+#  standard_dev_difficulty :float
+#  tool                    :string
+#  url                     :string
+#
+require 'rails_helper'
+
+describe ActivityHealth, type: :model, redis: true do
+
+  it { should have_many(:prompt_healths)}
+
+  it { should validate_inclusion_of(:tool).in_array(ActivityHealth::ALLOWED_TOOLS)}
+  it { should validate_numericality_of(:recent_assignments).is_greater_than_or_equal_to(0)}
+  it { should validate_inclusion_of(:avg_difficulty).in_range(0..5)}
+
+end

--- a/services/QuillLMS/spec/models/prompt_health_spec.rb
+++ b/services/QuillLMS/spec/models/prompt_health_spec.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: prompt_healths
+#
+#  id                           :integer          not null, primary key
+#  difficulty                   :float
+#  flag                         :string
+#  focus_points                 :integer
+#  incorrect_sequences          :integer
+#  percent_common_unmatched     :float
+#  percent_reached_optimal      :float
+#  percent_specified_algorithms :float
+#  text                         :string
+#  url                          :string
+#  activity_health_id           :integer
+#
+# Foreign Keys
+#
+#  fk_rails_...  (activity_health_id => activity_healths.id) ON DELETE => cascade
+#
+require 'rails_helper'
+
+describe PromptHealth, type: :model, redis: true do
+
+  it { should belong_to(:activity_health)}
+
+  it { should validate_inclusion_of(:flag).in_array(PromptHealth::FLAGS)}
+  it { should validate_numericality_of(:incorrect_sequences).is_greater_than_or_equal_to(0)}
+  it { should validate_numericality_of(:focus_points).is_greater_than_or_equal_to(0)}
+  it { should validate_inclusion_of(:percent_common_unmatched).in_range(0..100)}
+  it { should validate_inclusion_of(:percent_specified_algorithms).in_range(0..100)}
+  it { should validate_inclusion_of(:percent_reached_optimal).in_range(0..100)}
+  it { should validate_inclusion_of(:difficulty).in_range(0..5)}
+
+end


### PR DESCRIPTION
## WHAT
Files to create two new models: `ActivityHealth` and `PromptHealth`.

## WHY
As part of the new Connect admin panel, we need to perform a bunch of time-intensive, expensive queries on activity and prompt health. I've decided to perform these query as part of a nightly or weekly Cron job and store the data in these tables, `ActivityHealth` and `PromptHealth`, for quick retrieval when Curriculum needs to see the data.

## HOW
Just migration and model files for now. I will then write the jobs to fetch and store the data in the tables and run the Cron job on a regular basis.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Prompt-Healths-and-Activity-Healths-Tables-3b1da19f1da44817a4a56c77f7cfbf9b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
