### PR TITLE
created associations with prompts

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/tasks/add_grammar_api_rules_and_feedback.rake
+++ b/services/QuillLMS/engines/comprehension/lib/tasks/add_grammar_api_rules_and_feedback.rake
@@ -6,6 +6,8 @@ namespace :grammar_api_rules_and_feedback do
             ['Grammar API', 'Opinion API'].include?(r['Module']) && r['Rule UID'].present? 
         end
 
+        all_prompts = Comprehension::Prompt.all
+
         ActiveRecord::Base.transaction do 
             valid_rules.each do |r|
                 created_rule = Comprehension::Rule.find_or_initialize_by(uid: r['Rule UID'])
@@ -27,6 +29,14 @@ namespace :grammar_api_rules_and_feedback do
                 )
 
                 feedback.save!
+
+                all_prompts.each do |p|
+                    p_r = Comprehension::PromptsRule.find_or_initialize_by(
+                        prompt_id: p.id, rule_id: created_rule.id
+                    )
+                    p_r.save!
+                end
+
             end
         end
 


### PR DESCRIPTION
## WHAT
Associates Prompts with the newly created universal grammar rules, 
## WHY
so that Rules Report can pick them up correctly via JOINs
## HOW
updated existing idempotent script (it has not yet been run on prod)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Enter-Grammar-Rules-into-the-comprehension_rules-DB-653daceea79a4297925d30d54b08cd46

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a
Have you deployed to Staging? | tested on staging
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
