### PR TITLE
comprehension/auto-assign-universal-rules-to-prompts

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
@@ -39,7 +39,7 @@ module Comprehension
     private def assign_universal_rules
       Rule.where(universal: true).all.each do |rule|
         unless rules.include?(rule)
-          self.rules.append(rule)
+          rules.append(rule)
         end
       end
       save!

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
@@ -12,6 +12,7 @@ module Comprehension
     has_many :prompts_rules
     has_many :rules, through: :prompts_rules, inverse_of: :prompts
 
+    after_create :assign_universal_rules
     before_validation :downcase_conjunction
     before_validation :set_max_attempts, on: :create
 
@@ -33,6 +34,15 @@ module Comprehension
 
     private def set_max_attempts
       self.max_attempts = max_attempts || DEFAULT_MAX_ATTEMPTS
+    end
+
+    private def assign_universal_rules
+      Rule.where(universal: true).all.each do |rule|
+        unless rules.include?(rule)
+          self.rules.append(rule)
+        end
+      end
+      save!
     end
   end
 end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -23,6 +23,8 @@ module Comprehension
       'rules-based-3': 'Typo Regex',
       'plagiarism': 'Plagiarism'
     }
+
+    after_create :assign_to_all_prompts, if: :universal
     before_validation :assign_uid_if_missing
 
     has_many :feedbacks, inverse_of: :rule, dependent: :destroy
@@ -75,6 +77,15 @@ module Comprehension
 
     private def assign_uid_if_missing
       self.uid ||= SecureRandom.uuid
+    end
+
+    private def assign_to_all_prompts
+      Prompt.all.each do |prompt|
+        unless prompts.include?(prompt)
+          prompts.append(prompt)
+        end
+      end
+      save!
     end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
@@ -23,5 +23,45 @@ module Comprehension
       should validate_inclusion_of(:conjunction)
         .in_array(%w(because but so))
     end
+
+    context '#after_create' do
+      context '#assign_universal_rules' do
+        should 'assign all universal rules to new prompts' do
+          rule1 = create(:comprehension_rule, universal: true)
+          rule2 = create(:comprehension_rule, universal: true)
+          prompt = create(:comprehension_prompt)
+          assert_equal prompt.rules.length, 2
+          assert prompt.rules.include?(rule1)
+          assert prompt.rules.include?(rule2)
+        end
+
+        should 'not duplicate rule assignments if some exist already' do
+          rule1 = create(:comprehension_rule, universal: true)
+          rule2 = create(:comprehension_rule, universal: true)
+          prompt = create(:comprehension_prompt, rules: [rule1])
+          assert_equal prompt.rules.length, 2
+          assert prompt.rules.include?(rule1)
+          assert prompt.rules.include?(rule2)
+        end
+
+        should 'not add non-universal rules' do
+          universal_rule = create(:comprehension_rule, universal: true)
+          non_universal_rule = create(:comprehension_rule, universal: false)
+          prompt = create(:comprehension_prompt)
+          assert_equal prompt.rules.length, 1
+          assert prompt.rules.include?(universal_rule)
+          refute prompt.rules.include?(non_universal_rule)
+        end
+
+        should 'not remove existing non-universal assignments' do
+          universal_rule = create(:comprehension_rule, universal: true)
+          non_universal_rule = create(:comprehension_rule, universal: false)
+          prompt = create(:comprehension_prompt, rules: [non_universal_rule])
+          assert_equal prompt.rules.length, 2
+          assert prompt.rules.include?(universal_rule)
+          assert prompt.rules.include?(non_universal_rule)
+        end
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
@@ -140,7 +140,31 @@ module Comprehension
         @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required')
         assert @rule.regex_is_passing?('you need this sequence and I do have it')
       end
+    end
 
+    context '#after_create' do
+      context '#assign_to_all_prompts' do
+        should 'assign newly created rule to all prompts if the rule is universal' do
+          prompt = create(:comprehension_prompt)
+          rule = create(:comprehension_rule, universal: true)
+          assert_equal prompt.rules.length, 1
+          assert rule.prompts.include?(prompt)
+        end
+
+        should 'not assign newly created rule to all prompts if the rule is not universal' do
+          prompt = create(:comprehension_prompt)
+          rule = create(:comprehension_rule, universal: false)
+          assert_equal prompt.rules.length, 0
+          refute rule.prompts.include?(prompt)
+        end
+
+        should 'not assign newly created rules to prompts that somehow already have them assigned' do
+          prompt = create(:comprehension_prompt)
+          rule = create(:comprehension_rule, universal: true, prompts: [prompt])
+          assert_equal prompt.rules.length, 1
+          assert rule.prompts.include?(prompt)
+        end
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       create(:feedback_history, rule_uid: so_rule1.uid)
       create(:feedback_history, rule_uid: so_rule1.uid)
 
-      # prompts rules
-      Comprehension::PromptsRule.create!(prompt: so_prompt1, rule: so_rule1)
-      Comprehension::PromptsRule.create!(prompt: because_prompt1, rule: because_rule1)
-
       report = RuleFeedbackHistory.generate_report(conjunction: 'so', activity_id: activity1.id)
 
       expected = {
@@ -76,10 +72,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       create(:feedback_history, rule_uid: so_rule1.uid)
       create(:feedback_history, rule_uid: so_rule1.uid)
 
-      # prompts rules
-      Comprehension::PromptsRule.create!(prompt: so_prompt1, rule: so_rule1)
-      Comprehension::PromptsRule.create!(prompt: because_prompt1, rule: because_rule1)
-
       sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
       post_result = RuleFeedbackHistory.postprocessing(sql_result)
 
@@ -115,10 +107,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         f_rating_1b = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user2.id, rating: false)
         f_rating_2a = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user1.id, rating: true)
   
-        # prompts rules
-        Comprehension::PromptsRule.create!(prompt: so_prompt1, rule: so_rule1)
-        Comprehension::PromptsRule.create!(prompt: because_prompt1, rule: because_rule1)
-  
         sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
         post_result = RuleFeedbackHistory.postprocessing(sql_result)
         
@@ -142,15 +130,10 @@ RSpec.describe RuleFeedbackHistory, type: :model do
     
       # rules
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
-      because_rule1 = rule_factory { {name: 'because_rule1'} } 
 
       # feedbacks
       create(:feedback_history, rule_uid: so_rule1.uid)
       create(:feedback_history, rule_uid: so_rule1.uid)
-
-      # prompts rules
-      Comprehension::PromptsRule.create!(prompt: so_prompt1, rule: so_rule1)
-      Comprehension::PromptsRule.create!(prompt: because_prompt1, rule: because_rule1)
 
       sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
 

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
     
       # rules
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
-      because_rule1 = rule_factory { {name: 'because_rule1'} } 
 
       # feedbacks
       create(:feedback_history, rule_uid: so_rule1.uid)
@@ -61,7 +60,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
     
       # rules
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
-      because_rule1 = rule_factory { {name: 'because_rule1'} } 
 
       #feedbacks
       f3 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 3, text: 'lorem ipsum dolor 3')
@@ -91,7 +89,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       
         # rules
         so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} } 
-        because_rule1 = rule_factory { {name: 'because_rule1'} } 
   
         #feedbacks
         f3 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 3, text: 'lorem ipsum dolor 3')


### PR DESCRIPTION
## WHAT
Add code that auto-assigns universal rules to prompts when either is created
## WHY
We want to make sure that our Universal rules are applied to all Prompts without anyone having to do any work to keep it up
## HOW
Add `after_create` lifecycle events to both `Prompt` and `Rule` to associate "universal" rules with prompts whenever either a new prompt or a new universal rule is created

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
