### PR TITLE
only bold response highlight until change is made

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -86,10 +86,18 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   }
 
   formatStudentResponse = (str: string) => {
+    const { prompt, } = this.props
     const lastSubmittedResponse = this.lastSubmittedResponse()
-    if (!(lastSubmittedResponse && lastSubmittedResponse.highlight && lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).length)) {
+
+    if (!lastSubmittedResponse || !lastSubmittedResponse.highlight || !lastSubmittedResponse.entry) { return str }
+
+    const thereAreResponseHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).length
+    const lastSubmittedResponseWithoutStem = lastSubmittedResponse.entry.replace(prompt.text, '').trim()
+
+    if (lastSubmittedResponseWithoutStem !== str || !thereAreResponseHighlights) {
       return str
     }
+
     let wordsToFormat = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).map(hl => hl.text)
     wordsToFormat = wordsToFormat.length === 1 ? wordsToFormat[0] : wordsToFormat
     if (lastSubmittedResponse.feedback_type == 'plagiarism') {


### PR DESCRIPTION
## WHAT
For response highlights, stop bolding the text once a one-character change is made.

## WHY
We had issues where a short highlight (like "we") would result in part of a different word ("were") getting bolded. This avoids that.

## HOW
Just update the logic to not apply the bolding if the text in the editor is different from the last submission.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Bolding-remains-within-the-revised-sentence-3f6c30d8511f4e41a7a6db45fbe9ca3c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES