### PR TITLE
Rematch All Questions Job

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -24,12 +24,14 @@ class Question < ActiveRecord::Base
     TYPE_DIAGNOSTIC_FILL_IN_BLANKS = 'diagnostic_fill_in_blanks',
     TYPE_GRAMMAR_QUESTION = 'grammar'
   ]
-  validates :data, presence: true
-  validates :question_type, presence: true, inclusion: {in: TYPES}
-  validates :uid, presence: true, uniqueness: true
-  validate :data_must_be_hash
 
-  after_save :expire_all_questions_cache
+  FLAGS = [
+    FLAG_PRODUCTION = 'production',
+    FLAG_ALPHA = 'alpha',
+    FLAG_BETA = 'beta',
+    FLAG_ARCHIVED = 'archived'
+  ]
+  LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
   REMATCH_TYPE_MAPPING = {
@@ -41,6 +43,15 @@ class Question < ActiveRecord::Base
     TYPE_DIAGNOSTIC_FILL_IN_BLANKS => 'diagnostic_fillInBlankQuestions',
     TYPE_GRAMMAR_QUESTION => 'grammar_questions',
   }
+
+  validates :data, presence: true
+  validates :question_type, presence: true, inclusion: {in: TYPES}
+  validates :uid, presence: true, uniqueness: true
+  validate :data_must_be_hash
+
+  after_save :expire_all_questions_cache
+
+  scope :live, -> {where("data->>'flag' IN (?)", LIVE_FLAGS)}
 
   def as_json(options=nil)
     data

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -31,6 +31,17 @@ class Question < ActiveRecord::Base
 
   after_save :expire_all_questions_cache
 
+  # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
+  REMATCH_TYPE_MAPPING = {
+    TYPE_CONNECT_SENTENCE_COMBINING => 'questions',
+    TYPE_CONNECT_SENTENCE_FRAGMENTS => 'sentenceFragments',
+    TYPE_CONNECT_FILL_IN_BLANKS => 'fillInBlankQuestions',
+    TYPE_DIAGNOSTIC_SENTENCE_COMBINING => 'diagnostic_questions',
+    TYPE_DIAGNOSTIC_SENTENCE_FRAGMENTS => 'diagnostic_sentenceFragments',
+    TYPE_DIAGNOSTIC_FILL_IN_BLANKS => 'diagnostic_fillInBlankQuestions',
+    TYPE_GRAMMAR_QUESTION => 'grammar_questions',
+  }
+
   def as_json(options=nil)
     data
   end
@@ -101,6 +112,11 @@ class Question < ActiveRecord::Base
       data['incorrectSequences'].delete(incorrect_sequence_id)
     end
     save
+  end
+
+  # this attribute is used by the CMS's Rematch All process
+  def rematch_type
+    REMATCH_TYPE_MAPPING.fetch(question_type)
   end
 
   private def expire_all_questions_cache

--- a/services/QuillLMS/app/workers/rematch_all_questions_job.rb
+++ b/services/QuillLMS/app/workers/rematch_all_questions_job.rb
@@ -1,0 +1,18 @@
+class RematchAllQuestionsJob
+  include Sidekiq::Worker
+  # Marking as critical, since this unblocks 1MM+ jobs in the CMS.
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  REMATCH_URL = "#{ENV['CMS_URL']}/responses/rematch_all"
+  JSON_HEADERS = {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
+
+  def perform
+    Question.live.select(:id, :uid, :question_type).find_each do |question|
+      HTTParty.post(
+        REMATCH_URL,
+        body: {type: question.rematch_type, id: question.uid}.to_json,
+        headers: JSON_HEADERS
+      )
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/rematch_all_questions_job.rb
+++ b/services/QuillLMS/app/workers/rematch_all_questions_job.rb
@@ -10,7 +10,7 @@ class RematchAllQuestionsJob
     Question.live.select(:id, :uid, :question_type).find_each do |question|
       HTTParty.post(
         REMATCH_URL,
-        body: {type: question.rematch_type, id: question.uid}.to_json,
+        body: {type: question.rematch_type, uid: question.uid}.to_json,
         headers: JSON_HEADERS
       )
     end

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -260,4 +260,19 @@ RSpec.describe Question, type: :model do
       expect($redis.get(key)).to be_nil
     end
   end
+
+  describe 'rematch_type' do
+    it 'should be valid for each question_type' do
+      Question::TYPES.each do |type|
+        question = build(:question, question_type: type)
+        question.rematch_type
+      end
+    end
+
+    it 'should raise for an invalid type' do
+      question = build(:question, question_type: 'non-existent key')
+
+      expect {question.rematch_type }.to raise_error(KeyError)
+    end
+  end
 end

--- a/services/QuillLMS/spec/workers/rematch_all_questions_job_spec.rb
+++ b/services/QuillLMS/spec/workers/rematch_all_questions_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe RematchAllQuestionsJob, type: :worker do
+  let(:worker) { described_class.new }
+
+  it 'post to CMS url for only live questions' do
+    stub_const("RematchAllQuestionsJob::REMATCH_URL", "test_url")
+
+    prod_question = create(:question,
+      data: {flag: Question::FLAG_PRODUCTION},
+      question_type: Question::TYPE_CONNECT_SENTENCE_COMBINING,
+      uid: 'prod_question'
+    )
+    beta_question = create(:question,
+      data: {flag: Question::FLAG_BETA},
+      question_type: Question::TYPE_CONNECT_SENTENCE_COMBINING,
+      uid: 'beta_question'
+    )
+    # will not be sent
+    archived_question = create(:question,
+      data: {flag: Question::FLAG_ARCHIVED},
+      question_type: Question::TYPE_CONNECT_SENTENCE_COMBINING,
+      uid: 'archived_question'
+    )
+
+    expect(HTTParty).to receive(:post).with(
+      "test_url",
+      body: {type: 'questions', id: 'prod_question'}.to_json,
+      headers:  {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
+    ).once
+
+    expect(HTTParty).to receive(:post).with(
+      "test_url",
+      body: {type: 'questions', id: 'beta_question'}.to_json,
+      headers:  {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
+    ).once
+
+    worker.perform
+  end
+end

--- a/services/QuillLMS/spec/workers/rematch_all_questions_job_spec.rb
+++ b/services/QuillLMS/spec/workers/rematch_all_questions_job_spec.rb
@@ -25,13 +25,13 @@ describe RematchAllQuestionsJob, type: :worker do
 
     expect(HTTParty).to receive(:post).with(
       "test_url",
-      body: {type: 'questions', id: 'prod_question'}.to_json,
+      body: {type: 'questions', uid: 'prod_question'}.to_json,
       headers:  {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
     ).once
 
     expect(HTTParty).to receive(:post).with(
       "test_url",
-      body: {type: 'questions', id: 'beta_question'}.to_json,
+      body: {type: 'questions', uid: 'beta_question'}.to_json,
       headers:  {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
     ).once
 


### PR DESCRIPTION
## WHAT
A Job to queue a Rematch All for all live questions in the system.
## WHY
We can regularly run this to ensure that feedback data in the system is up to date.
## HOW
The data needed straddles the CMS (rematch logic) and the LMS (questions). I put this in the LMS because it requires the least amount of back and forth between the applications and because the process is driven by the LMS questions.

It reuses an existing CMS endpoint to run Rematch All for a single question.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
