### PR TITLE
Make sure concept_uid gets saved to the submittedResponses

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/actions/session.ts
@@ -141,8 +141,9 @@ export const getFeedback = (args: GetFeedbackArguments) => {
     }));
 
     request.post(requestObject, (e, r, body) => {
-      const { feedback, feedback_type, optimal, response_id, highlight, labels, } = body
+      const { concept_uid, feedback, feedback_type, optimal, response_id, highlight, labels, } = body
       const feedbackObj: FeedbackObject = {
+        concept_uid,
         entry,
         feedback,
         feedback_type,

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -856,7 +856,7 @@ end
 
     it 'returns a url including the default url' do
       expect(ActivitySession.generate_activity_url(classroom_unit.id, activity.id))
-        .to include('http://cooolsville.edu')
+        .to include(ENV["DEFAULT_URL"])
     end
 
     it 'returns a url including the classroom unit id' do


### PR DESCRIPTION
## WHAT
Make sure that `concept_uid` gets persisted to `submittedResponses` so that it can be compiled into `ConceptResults`
## WHY
A concept_uid is necessary for the `ConceptResult` to save to the database.  (They're invalid without it.)  I have no idea why this worked when I tested in staging without this code in place.
## HOW
Just add the `concept_uid` to the object persisted.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
