### PR TITLE
Add pry-byebug for debugging

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -172,6 +172,7 @@ group :test, :development do
   gem 'pry-stack_explorer'
   gem 'pry-coolline'
   gem 'pry-rescue'
+  gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.7.2'
   gem 'factory_bot_rails', '~> 4.8.2', require: false
   gem 'fuubar', '~> 2.0.0.rc1'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -456,6 +456,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     pry-coolline (0.2.5)
       coolline (~> 0.5)
     pry-rails (0.3.9)
@@ -841,6 +844,7 @@ DEPENDENCIES
   prawn-table
   premailer-rails
   pry (~> 0.12.2)
+  pry-byebug
   pry-coolline
   pry-rails
   pry-remote


### PR DESCRIPTION
## WHAT
Add pry-byebug gem to test, development group for debugging purposes.

## WHY
This gem combines utility of byebug with the features of pry. 

## HOW
Add to Gemfile.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO.  This is just a Gem addition only for test and development environments.
Have you deployed to Staging? | NO.  Tiny change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
