### PR TITLE
update css so the metrics timeframe dropdown on safari renders correctly

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/key_metrics.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/key_metrics.scss
@@ -17,6 +17,7 @@
         .dropdown__value-container {
           display: flex;
           justify-content: flex-end;
+          overflow: visible;
         }
         .dropdown__single-value {
           width: min-content;
@@ -24,7 +25,6 @@
         .dropdown__menu {
           margin-top: -25px;
           width: 140px;
-          margin-left: -70px;
         }
       }
       label {


### PR DESCRIPTION
## WHAT
Update CSS so the timeframe dropdown in the "Key Metrics" section on the new teacher dashboard renders the same on Safari as it does on Chrome.

## WHY
Because Safari is dumb.

## HOW
Just edit the CSS and test in both Safari and Chrome to make sure it still looks okay.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Weekly-yearly-drop-down-on-teacher-home-page-is-being-cut-off-in-Safari-336245cba1ae4bd28b4bbb58a3656486

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A - just CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
