### PR TITLE
remove activity feed from dash

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.jsx
@@ -41,11 +41,10 @@ const Dashboard = ({ onboardingChecklist, firstName, mustSeeModal, linkedToCleve
     getMetrics();
     getDiagnostics()
     getLessons()
-    getActivityFeed()
   }, []);
 
   React.useEffect(() => {
-    if (metrics && diagnostics && lessons && activityFeed && loading) {
+    if (metrics && diagnostics && lessons && loading) {
       setLoading(false)
     }
   }, [metrics, diagnostics, lessons, activityFeed])
@@ -96,7 +95,6 @@ const Dashboard = ({ onboardingChecklist, firstName, mustSeeModal, linkedToCleve
         <KeyMetrics firstName={firstName} metrics={metrics} />
         <DiagnosticMini diagnostics={diagnostics} onMobile={onMobile()} />
         <LessonsMini lessons={lessons} onMobile={onMobile()} />
-        <ActivityFeed activityFeed={activityFeed} onMobile={onMobile()} />
       </main>
       <aside>
         <HandyActions linkedToClever={linkedToClever} />


### PR DESCRIPTION
## WHAT
Remove activity feed from the dashboard.

## WHY
This query is running very slowly for a lot of users, and we want to stop calling it while we are working on a fix.

## HOW
Just remove the code that calls the query and that loads the feed.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
