### PR TITLE
make links from Google work

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -3,6 +3,21 @@
   border: solid 1px #e0e0e0;
   background-color: #ffffff;
   margin-bottom: 24px;
+  &.selected-unit {
+    .unit-name {
+      animation: highlight 5s 1;
+
+      @keyframes highlight {
+        0%  {
+          background-color: #fff3e0;
+        }
+        100% {
+          background-color: #ffffff;
+        }
+      }
+
+    }
+  }
   .unit-name {
     padding: 24px;
     h2 {

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -3,6 +3,7 @@ class StudentsController < ApplicationController
 
   before_filter :authorize!, except: [:student_demo, :demo_ap, :join_classroom]
   before_action :redirect_to_profile, only: [:index]
+  before_action :flash_missing_unit_error, only: [:index]
 
   def index
     @current_user = current_user
@@ -103,6 +104,19 @@ class StudentsController < ApplicationController
       flash[:error] = 'Oops! You do not belong to that classroom. Your teacher may have archived the class or removed you.'
       flash.keep(:error)
       redirect_to classes_path
+    end
+  end
+
+  private def flash_missing_unit_error
+    classroom_id = params["classroom"]
+    unit_id = params["unit_id"]
+
+    return unless classroom_id && unit_id
+
+    classroom_unit = ClassroomUnit.find_by(classroom_id: classroom_id, unit_id: unit_id)
+
+    unless classroom_unit && classroom_unit.assigned_student_ids.include?(current_user.id)
+      flash[:error] = 'Sorry, you do not have access to this activity pack because it has not been assigned to you. Please contact your teacher.'
     end
   end
 

--- a/services/QuillLMS/app/services/google_integration/unit_announcement.rb
+++ b/services/QuillLMS/app/services/google_integration/unit_announcement.rb
@@ -85,7 +85,7 @@ class GoogleIntegration::UnitAnnouncement
   end
 
   private def announcement_text
-    unit_url = classroom_url(classroom.id, anchor: unit.id)
+    unit_url = classroom_url(classroom.id, unit_id: unit.id)
 
     "New Unit: #{unit.name} #{unit_url}"
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -355,12 +355,15 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           ],
         }
       }
+      id="16"
+      isSelectedUnit={false}
       key="16"
       onShowPreviewModal={[Function]}
       unitName="Basic Fragments Group Lessons"
     >
       <div
         className="student-profile-unit"
+        id="16"
       >
         <div
           className="unit-name"
@@ -899,12 +902,15 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"
@@ -2054,12 +2060,15 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           ],
         }
       }
+      id="16"
+      isSelectedUnit={false}
       key="16"
       onShowPreviewModal={[Function]}
       unitName="Basic Fragments Group Lessons"
     >
       <div
         className="student-profile-unit"
+        id="16"
       >
         <div
           className="unit-name"
@@ -2598,12 +2607,15 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"
@@ -3825,12 +3837,15 @@ exports[`StudentProfileUnits component should render only completed activities i
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"
@@ -4682,12 +4697,15 @@ exports[`StudentProfileUnits component should render only incomplete activities 
           ],
         }
       }
+      id="16"
+      isSelectedUnit={false}
       key="16"
       onShowPreviewModal={[Function]}
       unitName="Basic Fragments Group Lessons"
     >
       <div
         className="student-profile-unit"
+        id="16"
       >
         <div
           className="unit-name"
@@ -5307,12 +5325,15 @@ exports[`StudentProfileUnits component should render only incomplete activities 
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"
@@ -6576,12 +6597,15 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
           ],
         }
       }
+      id="16"
+      isSelectedUnit={false}
       key="16"
       onShowPreviewModal={[Function]}
       unitName="Basic Fragments Group Lessons"
     >
       <div
         className="student-profile-unit"
+        id="16"
       >
         <div
           className="unit-name"
@@ -7201,12 +7225,15 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"
@@ -8470,12 +8497,15 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
           ],
         }
       }
+      id="16"
+      isSelectedUnit={false}
       key="16"
       onShowPreviewModal={[Function]}
       unitName="Basic Fragments Group Lessons"
     >
       <div
         className="student-profile-unit"
+        id="16"
       >
         <div
           className="unit-name"
@@ -9095,12 +9125,15 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
           ],
         }
       }
+      id="7"
+      isSelectedUnit={false}
       key="7"
       onShowPreviewModal={[Function]}
       unitName="History: Age of Exploration"
     >
       <div
         className="student-profile-unit"
+        id="7"
       >
         <div
           className="unit-name"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -119,7 +119,7 @@ export default class StudentProfileUnit extends React.Component {
     if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
       return (
         <Tooltip
-          tooltipText={`This type of activity is not graded.`}
+          tooltipText="This type of activity is not graded."
           tooltipTriggerText={
             <div className="score">
               <div className="completed" />
@@ -207,8 +207,9 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   render() {
-    const { unitName, } = this.props
-    return (<div className="student-profile-unit">
+    const { unitName, id, isSelectedUnit, } = this.props
+    const className = isSelectedUnit ? "student-profile-unit selected-unit" : "student-profile-unit"
+    return (<div className={className} id={id}>
       <div className="unit-name">
         <h2>{unitName}</h2>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
@@ -95,14 +95,16 @@ export default class StudentProfileUnits extends React.Component {
   }
 
   renderContent = () => {
-    const { loading, nextActivitySession, isBeingPreviewed, } = this.props
+    const { loading, nextActivitySession, isBeingPreviewed, selectedUnitId, } = this.props
     if (loading) { return <LoadingIndicator /> }
 
     const content = this.displayedUnits().map(unit => {
       const { unit_id, unit_name, } = unit[Object.keys(unit)[0]][0]
       return (<StudentProfileUnit
         data={unit}
+        id={unit_id}
         isBeingPreviewed={isBeingPreviewed}
+        isSelectedUnit={String(unit_id) === selectedUnitId}
         key={unit_id}
         nextActivitySession={nextActivitySession}
         onShowPreviewModal={this.handleShowPreviewModal}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Pusher from 'pusher-js';
 import { connect } from 'react-redux';
+import qs from 'qs'
 
 import NotificationFeed  from '../components/student_profile/notification_feed';
 import StudentProfileUnits from '../components/student_profile/student_profile_units.jsx';
@@ -16,7 +17,6 @@ import {
   updateActiveClassworkTab
 } from '../../../actions/student_profile';
 import { TO_DO_ACTIVITIES, COMPLETED_ACTIVITIES, } from '../../../constants/student_profile'
-
 
 class StudentProfile extends React.Component {
   componentDidMount() {
@@ -43,17 +43,30 @@ class StudentProfile extends React.Component {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { selectedClassroomId, history, student, } = this.props
-    if (nextProps.selectedClassroomId && nextProps.selectedClassroomId !== selectedClassroomId) {
-      if (!window.location.href.includes(nextProps.selectedClassroomId)) {
-        history.push(`classrooms/${nextProps.selectedClassroomId}`);
+  componentDidUpdate(prevProps, prevState) {
+    const { selectedClassroomId, history, student, scores, loading, } = this.props
+
+    if (selectedClassroomId && selectedClassroomId !== prevProps.selectedClassroomId) {
+      if (!window.location.href.includes(selectedClassroomId)) {
+        history.push(`classrooms/${selectedClassroomId}`);
       }
     }
 
-    if (student !== nextProps.student) {
-      this.initializePusher(nextProps)
+    if (student !== prevProps.student) {
+      this.initializePusher(this.props)
     }
+
+    if (scores && !prevProps.scores && !loading) {
+      const focusedUnitId = this.parsedQueryParams().unit_id
+      const element = document.getElementById(focusedUnitId)
+      const elementTop = element ? element.getBoundingClientRect().top : 0
+      window.scrollTo(0, window.pageYOffset + elementTop - 70)
+    }
+  }
+
+  parsedQueryParams = () => {
+    const { history, } = this.props
+    return qs.parse(history.location.search.replace('?', ''))
   }
 
   handleClassroomTabClick = (classroomId) => {
@@ -108,6 +121,7 @@ class StudentProfile extends React.Component {
       scores,
       activeClassworkTab,
       isBeingPreviewed,
+      history,
     } = this.props;
 
     if (loading) { return <LoadingIndicator /> }
@@ -136,6 +150,7 @@ class StudentProfile extends React.Component {
           isBeingPreviewed={isBeingPreviewed}
           loading={loading}
           nextActivitySession={nextActivitySession}
+          selectedUnitId={this.parsedQueryParams().unit_id}
           teacherName={student.classroom.teacher.name}
         />
       </div>


### PR DESCRIPTION
## WHAT
We were posting a link to Google Classroom unit announcements that didn't actually take students to the correct unit. Now it will, and we added a highlight that will further help students identify which unit they should be working on, as well as a banner if they are not actually assigned to that unit.

## WHY
So that students aren't confused about what they are supposed to be working on based on the Google Classroom announcement.

## HOW
Update the link, since anchors aren't accessible from  Rails controllers and we wanted to add that flash banner, and then update the frontend to handle the query param correctly.

### Screenshots
<img width="1440" alt="Screen Shot 2021-04-27 at 1 43 53 PM" src="https://user-images.githubusercontent.com/18669014/116288500-95aff300-a75f-11eb-9fc7-baf22435bc31.png">
<img width="1440" alt="Screen Shot 2021-04-27 at 1 44 07 PM" src="https://user-images.githubusercontent.com/18669014/116288501-95aff300-a75f-11eb-8f2a-a72deb7bc9c2.png">


### Notion Card Links
https://www.notion.so/quill/Anchor-links-to-activity-packs-don-t-work-37e013cf53174f77b73ae2bbd0694717

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
