### PR TITLE
LMS Rails 5.0 Prework - address before_filter deprecation

### DIFF
--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -1,7 +1,7 @@
 class AccountsController < ApplicationController
-  before_filter :signed_in!, only: [:edit, :update]
-  before_filter :set_cache_buster, only: [:new]
-  before_filter :set_user, only: [:create]
+  before_action :signed_in!, only: [:edit, :update]
+  before_action :set_cache_buster, only: [:new]
+  before_action :set_user, only: [:create]
 
   def new
     if params[:redirect]

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -1,7 +1,7 @@
 class ActivitiesController < ApplicationController
   before_action :activity, only: [:update]
-  before_filter :set_activity_by_lesson_id, only: [:preview_lesson]
-  before_filter :set_activity, only: [:supporting_info, :customize_lesson, :name_and_id, :last_unit_template]
+  before_action :set_activity_by_lesson_id, only: [:preview_lesson]
+  before_action :set_activity, only: [:supporting_info, :customize_lesson, :name_and_id, :last_unit_template]
 
   DIAGNOSTIC = 'diagnostic'
 

--- a/services/QuillLMS/app/controllers/api/api_controller.rb
+++ b/services/QuillLMS/app/controllers/api/api_controller.rb
@@ -2,7 +2,7 @@ class Api::ApiController < ActionController::Base
 
   class AccessForbidden < StandardError; end
 
-  before_filter :add_platform_doc_header
+  before_action :add_platform_doc_header
 
   rescue_from ActiveRecord::RecordNotFound do |e|
     not_found

--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ClassroomUnitsController < Api::ApiController
   include QuillAuthentication
-  before_filter :authorize!
+  before_action :authorize!
 
   def student_names
     activity          = Activity.find_by(uid: params[:activity_id])

--- a/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::FocusPointsController < Api::ApiController
-  before_filter :get_question_by_uid
+  before_action :get_question_by_uid
 
   def index
     render_all_focus_points

--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::IncorrectSequencesController < Api::ApiController
-  before_filter :get_question_by_uid
+  before_action :get_question_by_uid
 
   def index
     render_all_incorrect_sequences

--- a/services/QuillLMS/app/controllers/api/v1/title_cards_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/title_cards_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::TitleCardsController < Api::ApiController
   wrap_parameters format: [:json]
   before_action :retrieve_title_card_type, only: [:index, :create]
-  before_filter :title_card_by_uid, only: [:show, :update, :destroy]
+  before_action :title_card_by_uid, only: [:show, :update, :destroy]
 
   def index
     render(json: TitleCard.where(title_card_type: @title_card_type.to_s).as_json || {title_cards:[]})

--- a/services/QuillLMS/app/controllers/cms/README.md
+++ b/services/QuillLMS/app/controllers/cms/README.md
@@ -4,6 +4,6 @@ Controllers in this directory power the Staff dashboard.
 They allow editing of data that is normally locked to a Teacher account.
 Anything that allows us to overwrite user data should be namespaced under the /cms/ route.
 
-Make sure to call ```before_filter :staff!``` before the actions to lock down access
+Make sure to call ```before_action :staff!``` before the actions to lock down access
 
 Controllers should be named ```CMS::[RESOURCE_NAME]Controller``` so that the match the regular resource controller without clashing with the existing Controller actions.

--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -1,8 +1,8 @@
 class Cms::ActivitiesController < Cms::CmsController
-  before_filter :find_classification
-  before_filter :set_activity, only: [:update, :destroy, :edit]
-  before_filter :set_style_and_javascript_file, only: [:new, :edit]
-  before_filter :set_raw_score_options_and_grade_band_hash, only: [:new, :edit]
+  before_action :find_classification
+  before_action :set_activity, only: [:update, :destroy, :edit]
+  before_action :set_style_and_javascript_file, only: [:new, :edit]
+  before_action :set_raw_score_options_and_grade_band_hash, only: [:new, :edit]
 
   def index
     @flag = params[:flag].to_s.to_sym.presence || :production

--- a/services/QuillLMS/app/controllers/cms/announcements_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/announcements_controller.rb
@@ -1,5 +1,5 @@
 class Cms::AnnouncementsController < Cms::CmsController
-  before_filter :signed_in!
+  before_action :signed_in!
 
   def index
     @announcements = Announcement.all

--- a/services/QuillLMS/app/controllers/cms/cms_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/cms_controller.rb
@@ -1,5 +1,5 @@
 class Cms::CmsController < ApplicationController
-  before_filter :staff!
+  before_action :staff!
 
   private def subscription_data
     if !@school && !@user && @subscription.schools.any?

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -1,5 +1,5 @@
 class Cms::SchoolsController < Cms::CmsController
-  before_filter :signed_in!
+  before_action :signed_in!
 
   before_action :text_search_inputs, only: [:index, :search]
   before_action :set_school, only: [

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -1,5 +1,5 @@
 class Cms::UsersController < Cms::CmsController
-  before_filter :signed_in!
+  before_action :signed_in!
   before_action :set_flags
   before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :edit_subscription, :new_subscription, :complete_sales_stage]
   before_action :set_search_inputs, only: [:index, :search]

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   include HTTParty
   include PagesHelper
-  before_filter :determine_js_file, :determine_flag
+  before_action :determine_js_file, :determine_flag
   layout :determine_layout
 
   NUMBER_OF_SENTENCES = "NUMBER_OF_SENTENCES"

--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -1,6 +1,6 @@
 class PasswordResetController < ApplicationController
 
-  before_filter :set_title
+  before_action :set_title
 
   def index
     @user = User.new

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_filter :signed_in!
+  before_action :signed_in!
 
   def show
     @user = current_user

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -4,8 +4,8 @@ require 'new_relic/agent'
 class SessionsController < ApplicationController
   CLEAR_ANALYTICS_SESSION_KEY = "clear_analytics_session"
 
-  before_filter :signed_in!, only: [:destroy]
-  before_filter :set_cache_buster, only: [:new]
+  before_action :signed_in!, only: [:destroy]
+  before_action :set_cache_buster, only: [:new]
 
   def create
     email_or_username = params[:user][:email].downcase.strip unless params[:user][:email].nil?

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -1,7 +1,7 @@
 class StudentsController < ApplicationController
   include QuillAuthentication
 
-  before_filter :authorize!, except: [:student_demo, :demo_ap, :join_classroom]
+  before_action :authorize!, except: [:student_demo, :demo_ap, :join_classroom]
   before_action :redirect_to_profile, only: [:index]
 
   def index

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -1,7 +1,7 @@
 class TeacherFixController < ApplicationController
   include TeacherFixes
-  before_filter :staff!
-  before_filter :set_user, only: :archived_units
+  before_action :staff!
+  before_action :set_user, only: :archived_units
 
   def index
   end

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -2,11 +2,11 @@ class Teachers::ClassroomManagerController < ApplicationController
   include CheckboxCallback
 
   respond_to :json, :html
-  before_filter :teacher_or_public_activity_packs, except: [:unset_preview_as_student]
+  before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student]
   # WARNING: these filter methods check against classroom_id, not id.
-  before_filter :authorize_owner!, except: [:scores, :scorebook, :lesson_planner, :preview_as_student, :unset_preview_as_student, :activity_feed]
-  before_filter :authorize_teacher!, only: [:scores, :scorebook, :lesson_planner]
-  before_filter :set_alternative_schools, only: [:my_account, :update_my_account, :update_my_password]
+  before_action :authorize_owner!, except: [:scores, :scorebook, :lesson_planner, :preview_as_student, :unset_preview_as_student, :activity_feed]
+  before_action :authorize_teacher!, only: [:scores, :scorebook, :lesson_planner]
+  before_action :set_alternative_schools, only: [:my_account, :update_my_account, :update_my_password]
   include ScorebookHelper
   include ActivityFeedHelper
   include QuillAuthentication

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -1,10 +1,10 @@
 class Teachers::ClassroomsController < ApplicationController
   respond_to :json, :html, :pdf
-  before_filter :teacher!
+  before_action :teacher!
   # The excepted/only methods below are ones that should be accessible to coteachers.
   # TODO This authing could probably be refactored.
-  before_filter :authorize_owner!, only: [:update,  :transfer_ownership]
-  before_filter :authorize_teacher!, only: [:scores, :units, :scorebook, :generate_login_pdf]
+  before_action :authorize_owner!, only: [:update,  :transfer_ownership]
+  before_action :authorize_teacher!, only: [:scores, :units, :scorebook, :generate_login_pdf]
 
   INDEX = 'index'
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -3,7 +3,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     include LessonsRecommendations
     require 'pusher'
 
-    before_filter :authorize_teacher!, only: [:question_view, :students_by_classroom, :recommendations_for_classroom, :lesson_recommendations_for_classroom, :previously_assigned_recommendations]
+    before_action :authorize_teacher!, only: [:question_view, :students_by_classroom, :recommendations_for_classroom, :lesson_recommendations_for_classroom, :previously_assigned_recommendations]
 
     def show
         @classroom_id = current_user.classrooms_i_teach&.last&.id || nil

--- a/services/QuillLMS/app/controllers/teachers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/students_controller.rb
@@ -1,6 +1,6 @@
 class Teachers::StudentsController < ApplicationController
-  before_filter :teacher!
-  before_filter :authorize!
+  before_action :teacher!
+  before_action :authorize!
 
   def create
     valid_names = Creators::StudentCreator.check_names(params)

--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -2,10 +2,10 @@ class Teachers::UnitActivitiesController < ApplicationController
   include QuillAuthentication
   require 'pusher'
   respond_to :json
-  before_filter :authorize!, :except => ["update_multiple_due_dates"]
-  before_filter :teacher!
-  before_filter :set_unit_activities, only: [:update, :hide]
-  before_filter :set_activity_session, only: :hide
+  before_action :authorize!, :except => ["update_multiple_due_dates"]
+  before_action :teacher!
+  before_action :set_unit_activities, only: [:update, :hide]
+  before_action :set_activity_session, only: :hide
 
   def update
     @unit_activities.each{ |unit_activity| unit_activity.try(:update_attributes, unit_activity_params)}

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -3,8 +3,8 @@ class Teachers::UnitsController < ApplicationController
   include UnitQueries
 
   respond_to :json
-  before_filter :teacher!
-  before_filter :authorize!
+  before_action :teacher!
+  before_action :authorize!
 
   def create
     if params[:unit][:create]

--- a/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe AccountsController, type: :controller do
-  it { should use_before_filter :signed_in! }
-  it { should use_before_filter :set_cache_buster }
+  it { should use_before_action :signed_in! }
+  it { should use_before_action :set_cache_buster }
 
   let(:user) { create(:user) }
 

--- a/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Cms::ActivitiesController, type: :controller do
-  it { should use_before_filter :find_classification }
-  it { should use_before_filter :set_activity }
+  it { should use_before_action :find_classification }
+  it { should use_before_action :set_activity }
 
   let!(:classification) { create(:activity_classification) }
   let(:activities) { double(:activities, production: "production set", flagged: "flagged set") }

--- a/services/QuillLMS/spec/controllers/cms/announcements_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/announcements_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Cms::AnnouncementsController, type: :controller do
-  it { should use_before_filter :signed_in! }
+  it { should use_before_action :signed_in! }
 
   let(:user) { create(:staff) }
 

--- a/services/QuillLMS/spec/controllers/cms/cms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/cms_controller_spec.rb
@@ -1,4 +1,4 @@
 require 'rails_helper'
 describe Cms::CmsController do
-  it { should use_before_filter :staff! }
+  it { should use_before_action :staff! }
 end

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Cms::SchoolsController do
-  it { should use_before_filter :signed_in! }
+  it { should use_before_action :signed_in! }
   it { should use_before_action :text_search_inputs }
   it { should use_before_action :set_school }
   it { should use_before_action :subscription_data }

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Cms::UsersController do
-  it { should use_before_filter :signed_in! }
+  it { should use_before_action :signed_in! }
   it { should use_before_action :set_flags }
   it { should use_before_action :set_user }
   it { should use_before_action :set_search_inputs }

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe PagesController do
-  it { should use_before_filter :determine_js_file }
-  it { should use_before_filter :determine_flag }
+  it { should use_before_action :determine_js_file }
+  it { should use_before_action :determine_flag }
 
   # no route for this action
   # describe '#home' do

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe SessionsController, type: :controller do
-  it { should use_before_filter :signed_in! }
-  it { should use_before_filter :set_cache_buster }
+  it { should use_before_action :signed_in! }
+  it { should use_before_action :set_cache_buster }
 
   describe '#create' do
     let!(:user) { create(:user) }

--- a/services/QuillLMS/spec/controllers/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/students_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 
 describe StudentsController do
-  it { should use_before_filter :authorize! }
+  it { should use_before_action :authorize! }
 
   let(:user) { create(:user) }
 

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe TeacherFixController do
-  it { should use_before_filter :staff! }
+  it { should use_before_action :staff! }
 
   let(:staff) { create(:staff) }
 

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -4,9 +4,9 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
   include ActivityFeedHelper
 
-  it { should use_before_filter :teacher_or_public_activity_packs }
-  it { should use_before_filter :authorize_owner! }
-  it { should use_before_filter :authorize_teacher! }
+  it { should use_before_action :teacher_or_public_activity_packs }
+  it { should use_before_action :authorize_owner! }
+  it { should use_before_action :authorize_teacher! }
 
   describe '#lesson_planner' do
     let!(:teacher) { create(:classrooms_teacher, user: user) }

--- a/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Teachers::ClassroomUnitsController, type: :controller do
-  it { should use_before_filter :authorize! }
-  it { should use_before_filter :teacher! }
+  it { should use_before_action :authorize! }
+  it { should use_before_action :teacher! }
 
   let(:classroom) { create(:classroom)}
   let(:teacher) { classroom.owner }

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe Teachers::ClassroomsController, type: :controller do
-  it { should use_before_filter :teacher! }
-  it { should use_before_filter :authorize_owner! }
-  it { should use_before_filter :authorize_teacher! }
+  it { should use_before_action :teacher! }
+  it { should use_before_action :authorize_owner! }
+  it { should use_before_action :authorize_teacher! }
 
   describe 'new' do
     let(:teacher) { create(:teacher) }

--- a/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Teachers::UnitActivitiesController, type: :controller do
-  it { should use_before_filter :authorize! }
-  it { should use_before_filter :teacher! }
+  it { should use_before_action :authorize! }
+  it { should use_before_action :teacher! }
 
   let(:classroom) { create(:classroom)}
   let(:teacher) { classroom.owner }

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Teachers::UnitsController, type: :controller do
-  it { should use_before_filter :teacher! }
-  it { should use_before_filter :authorize! }
+  it { should use_before_action :teacher! }
+  it { should use_before_action :authorize! }
 
   let!(:student) {create(:student)}
   let!(:classroom) { create(:classroom) }


### PR DESCRIPTION
## WHAT
`before_filter` will be deprecated in favor of `before_action` in Rails 5.1.

## WHY
To get the codebase ready for the Rails 5.0 upgrade, it's important to get deprecations fixed.

## HOW
Just replace `before_filter` with `before_action`

### Notion Card Links
https://www.notion.so/quill/Upgrade-LMS-to-Rails-5-0-b742cd5e1764427d8670944d50e2a3e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just refactoring.
Have you deployed to Staging? | No.  before_action is just [renaming](https://github.com/rails/rails/commit/9d62e04838f01f5589fa50b0baa480d60c815e2c) of before_filter
Self-Review: Have you done an initial self-review of the code below on Github? | YES
