### PR TITLE
LMS Rails 5.0 Prework - address view and helper spec failures

### DIFF
--- a/services/QuillLMS/spec/helpers/application_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
+  include_context 'routing url helpers'
+
   describe "#combine" do
     it 'should add the arrays' do
       expect(combine([1, 2], [3, 4])).to eq [1, 2, 3, 4]

--- a/services/QuillLMS/spec/helpers/application_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  include_context 'routing url helpers'
+  include_context RSpec::ROUTING_URL_HELPERS
 
   describe "#combine" do
     it 'should add the arrays' do

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 describe NavigationHelper do
   describe '#home_page_should_be_active?' do
     context 'when action name is dashboard, my account, teacher guide or google sync' do
-      before do
-        allow(helper).to receive(:action_name) { "dashboard" }
-      end
+      before { allow(helper).to receive(:action_name) { "dashboard" } }
 
       it 'should return true' do
         expect(helper.home_page_should_be_active?).to eq true
@@ -26,9 +24,7 @@ describe NavigationHelper do
 
   describe '#classes_page_should_be_active?' do
     context 'when teachers classroom controller' do
-      before do
-        allow(helper).to receive(:controller) { double(:controller, class: Teachers::ClassroomsController) }
-      end
+      before { allow(helper).to receive(:controller) { double(:controller, class: Teachers::ClassroomsController) } }
 
       it 'should return true' do
         expect(helper.classes_page_should_be_active?).to eq true
@@ -36,12 +32,15 @@ describe NavigationHelper do
     end
 
     context 'when invite_students action and not in concepts controller' do
-      let(:class_double) { double(:class, parent: "something") }
+      let(:class_double) { double(:klass, parent: "something") }
 
       before do
         allow(helper).to receive(:controller) { double(:controller, class: class_double) }
-        allow(helper).to receive(:action_name) { "invite_students" }
-        allow(helper).to receive(:controller_name) { "anything" }
+
+        without_partial_double_verification do
+          allow(helper).to receive(:action_name) { "invite_students" }
+          allow(helper).to receive(:controller_name) { "anything" }
+        end
       end
 
       it 'should return true' do
@@ -53,7 +52,7 @@ describe NavigationHelper do
   describe "#assign_activity_page_should_be_active?" do
     before do
       allow(helper).to receive(:controller) { double(:controller, class: Teachers::ClassroomManagerController) }
-      allow(helper).to receive(:action_name) { "assign" }
+      without_partial_double_verification { allow(helper).to receive(:action_name) { "assign" } }
     end
 
     it 'should return true when classroom manager controller and assign activities action' do
@@ -64,7 +63,7 @@ describe NavigationHelper do
   describe '#my_activities_page_should_be_active?' do
     before do
       allow(helper).to receive(:controller) { double(:controller, class: Teachers::ClassroomManagerController) }
-      allow(helper).to receive(:action_name) { "lesson_planner" }
+      without_partial_double_verification { allow(helper).to receive(:action_name) { "lesson_planner" } }
     end
 
     it 'should return true if classroom manager controller and lesson planner action' do
@@ -72,14 +71,8 @@ describe NavigationHelper do
     end
   end
 
-  describe '#student_reports_page_should_be_active' do
-
-  end
-
   describe '#admin_page_should_be_active?' do
-    before do
-      allow(helper).to receive(:action_name) { "admin_dashboard" }
-    end
+    before { allow(helper).to receive(:action_name) { "admin_dashboard" } }
 
     it 'should return true on admin dashboard action' do
       expect(helper.admin_page_should_be_active?).to eq true

--- a/services/QuillLMS/spec/helpers/scorebook_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/scorebook_helper_spec.rb
@@ -72,7 +72,9 @@ describe ScorebookHelper, type: :helper do
 
   describe '#scorebook_path' do
     before do
-      allow(helper).to receive(:scorebook_teachers_classrooms_path) { "path" }
+      without_partial_double_verification do
+        allow(helper).to receive(:scorebook_teachers_classrooms_path) { "path" }
+      end
     end
 
     it 'should give path if teacher has classrooms' do

--- a/services/QuillLMS/spec/support/shared/routing_url_helpers.rb
+++ b/services/QuillLMS/spec/support/shared/routing_url_helpers.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context "routing url helpers" do
+  include Rails.application.routes.url_helpers
+
+  def default_url_options
+    { only_path: true }
+  end
+end

--- a/services/QuillLMS/spec/support/shared/routing_url_helpers.rb
+++ b/services/QuillLMS/spec/support/shared/routing_url_helpers.rb
@@ -1,4 +1,6 @@
-RSpec.shared_context "routing url helpers" do
+RSpec::ROUTING_URL_HELPERS = "routing url helpers".freeze
+
+RSpec.shared_context RSpec::ROUTING_URL_HELPERS do
   include Rails.application.routes.url_helpers
 
   def default_url_options

--- a/services/QuillLMS/spec/views/pages/careers.html.erb_spec.rb
+++ b/services/QuillLMS/spec/views/pages/careers.html.erb_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 describe "pages/careers.html.erb", type: :view do
+  include_context 'routing url helpers'
+
   it "displays all the widgets" do
     assign(:open_positions, PagesController::OPEN_POSITIONS)
 
     render
 
-    rendered.should match("Our mission")
+    expect(rendered).to match("Our mission")
   end
 end


### PR DESCRIPTION
## WHAT
There a couple of fixes here:
1.  There's an [issue](https://github.com/rspec/rspec-rails/issues/1076) with stubs in view and helper specs where partial double verification fails.  A [workaround](https://www.rubydoc.info/github/rspec/rspec-mocks/RSpec%2FMocks%2FExampleMethods:without_partial_double_verification) involves using an around hook that temporarily disables it for the offending specs.

2. The second [issue](https://github.com/rspec/rspec-rails/issues/1644) involves route_helpers no longer being available in view and helpers specs. 

## WHY
These particular issues are not present yet in Rails 4, but will manifest after upgrading to Rails 5. 

## HOW

### Notion Card Links
https://www.notion.so/quill/Upgrade-LMS-to-Rails-5-0-b742cd5e1764427d8670944d50e2a3e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.
Have you deployed to Staging? | No.  These are tiny changes only related to specs.
Self-Review: Have you done an initial self-review of the code below on Github? |. YES