### PR TITLE
LMS Rails 5.0 Prework - remove unnecessary before_action related code

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -21,7 +21,6 @@ class ApplicationController < ActionController::Base
   # before_action :setup_visitor
   before_action :set_raven_context
   before_action :confirm_valid_session
-  # before_action :stick_to_leader_db
 
   def admin!
     return if current_user.try(:admin?)
@@ -132,10 +131,6 @@ class ApplicationController < ActionController::Base
   protected def set_raven_context
     Raven.user_context(id: session[:current_user_id])
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
-  end
-
-  protected def stick_to_leader_db
-    ActiveRecord::Base.connection.stick_to_master!
   end
 
   protected def confirm_valid_session

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -2,8 +2,6 @@ class BlogPostsController < ApplicationController
   before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_role
 
-  skip_before_action :stick_to_leader_db, only: [:index, :show]
-
   def index
     topic_names = BlogPost::TEACHER_TOPICS
     @topics = []

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -1,5 +1,4 @@
 class StatusesController < ApplicationController
-  skip_before_action :stick_to_leader_db, only: [:database_follower]
   protect_from_forgery with: :null_session
 
   def index

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -1,16 +1,3 @@
-class StickToLeaderDbSidekiqMiddleware
-  def call(worker, msg, queue)
-    ActiveRecord::Base.connection.stick_to_master!
-    yield
-  end
-end
-
-#Sidekiq.configure_server do |config|
-#  config.server_middleware do |chain|
-#    chain.add(StickToLeaderDbSidekiqMiddleware)
-#  end
-#end
-
 module SidekiqQueue
   # QUEUE DEFINITIONS
 

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -29,12 +29,6 @@ describe PagesController do
   # end
 
   describe '#home_new' do
-    #it 'should stick to the leader db' do
-    #  expect(controller).to receive(:stick_to_leader_db).and_call_original
-    #  expect(ActiveRecord::Base.connection).to receive(:stick_to_master!).at_least(:once)
-    #  get :home_new
-    #end
-
     context 'when user is signed in' do
       before do
         allow(controller).to receive(:signed_in?) { true }


### PR DESCRIPTION
## WHAT
The filter `before_action :stick_to_leader_db` has been commented out.  Therefore all of its related code is unreachable and should be removed.

## WHY
This code is no longer used.

## HOW
Remove the references to `:stick_to_leader_db`

### Notion Card Links
https://www.notion.so/quill/Upgrade-LMS-to-Rails-5-0-b742cd5e1764427d8670944d50e2a3e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Code is not used.
Have you deployed to Staging? | NO - tiny change.
Self-Review: Have you done an initial self-review of the code below on Github? |. YES
