### PR TITLE
LMS Rails 5.1 Prework - Fix redirect_to :back deprecation

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -58,7 +58,7 @@ class BlogPostsController < ApplicationController
     @query = params[:query]
     if params[:query].blank?
       flash[:error] = 'Oops! Please enter a search query.'
-      return redirect_to :back
+      return redirect_back(fallback_location: search_blog_posts_path)
     end
     @blog_posts = RawSqlRunner.execute(
       <<-SQL

--- a/services/QuillLMS/app/controllers/cms/announcements_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/announcements_controller.rb
@@ -11,7 +11,7 @@ class Cms::AnnouncementsController < Cms::CmsController
       redirect_to cms_announcements_path
     else
       flash[:error] = 'Rut roh. Something has gone awry! 😭'
-      redirect_to :back
+      redirect_back(fallback_location: new_cms_announcement_path)
     end
   end
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -112,7 +112,7 @@ class Cms::SchoolsController < Cms::CmsController
       redirect_to cms_school_path(params[:id])
     rescue
       flash[:error] = "It didn't work! 😭😭😭"
-      redirect_to :back
+      redirect_back(fallback_location: fallback_location)
     end
   end
 
@@ -127,13 +127,13 @@ class Cms::SchoolsController < Cms::CmsController
       redirect_to cms_school_path(params[:id])
     rescue ActiveRecord::RecordNotFound
       flash[:error] = "It didn't work! Make sure the email you typed is correct."
-      redirect_to :back
+      redirect_back(fallback_location: fallback_location)
     rescue ArgumentError
       flash[:error] = "It didn't work! Make sure the account you entered belogs to a teacher, not staff or student."
-      redirect_to :back
+      redirect_back(fallback_location: fallback_location)
     rescue
       flash[:error] = "It didn't work. See a developer about this issue."
-      redirect_to :back
+      redirect_back(fallback_location: fallback_location)
     end
   end
 
@@ -145,7 +145,7 @@ class Cms::SchoolsController < Cms::CmsController
       else
         flash[:error] = "It didn't work. See a developer about this issue."
       end
-      redirect_to :back
+      redirect_back(fallback_location: fallback_location)
     rescue
       flash[:error] = "It didn't work. Make sure the teacher still exists and belongs to this school."
     end
@@ -342,5 +342,9 @@ class Cms::SchoolsController < Cms::CmsController
 
   private def teacher_search_query_for_school(school_id)
     Cms::TeacherSearchQuery.new(school_id).run
+  end
+  
+  def fallback_location
+    cms_school_path(params[:id].to_i)
   end
 end

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -43,7 +43,7 @@ class Cms::UsersController < Cms::CmsController
       redirect_to cms_school_path(school_id_param)
     else
       flash[:error] = 'Did not save.'
-      redirect_to :back
+      redirect_back(fallback_location: cms_school_path(school_id_param))
     end
   end
 
@@ -61,7 +61,7 @@ class Cms::UsersController < Cms::CmsController
       redirect_to cms_users_path
     else
       flash[:error] = 'Did not save.'
-      redirect_to :back
+      redirect_back(fallback_location: cms_users_path)
     end
   end
 
@@ -76,14 +76,14 @@ class Cms::UsersController < Cms::CmsController
     admin.school_id = params[:school_id]
     admin.user_id = params[:user_id]
     flash[:error] = 'Something went wrong.' unless admin.save
-    redirect_to :back
+    redirect_back(fallback_location: cms_users_path)
   end
 
   def remove_admin
     admin = SchoolsAdmins.find_by(user_id: params[:user_id], school_id: params[:school_id])
     flash[:error] = 'Something went wrong.' unless admin.destroy
     flash[:success] = 'Success! 🎉'
-    redirect_to :back
+    redirect_back(fallback_location: cms_users_path)
   end
 
   def edit

--- a/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
@@ -22,7 +22,7 @@ class Teachers::ClassroomUnitsController < ApplicationController
     )
     rescue ActiveRecord::StatementInvalid
       flash.now[:error] = "We cannot launch this lesson. If the problem persists, please contact support."
-      redirect_to :back
+      redirect_back(fallback_location: dashboard_teachers_classrooms_path)
       return
     end
 
@@ -36,7 +36,7 @@ class Teachers::ClassroomUnitsController < ApplicationController
         redirect_to lesson_url(lesson) and return
       else
         flash.now[:error] = "We cannot launch this lesson. If the problem persists, please contact support."
-        redirect_to :back
+        redirect_back(fallback_location: dashboard_teachers_classrooms_path)
       end
     else
       redirect_to "#{ENV['DEFAULT_URL']}/tutorials/lessons?url=#{URI.encode_www_form_component(launch_lesson_url)}" and return

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -125,7 +125,7 @@ class Teachers::ClassroomsController < ApplicationController
     @classroom = Classroom.find(params[:id])
     if @classroom.students.empty?
       flash[:info] = 'You can print a sheet with student logins once you add students.'
-      return redirect_to :back
+      redirect_back(fallback_location: dashboard_teachers_classrooms_path)
     end
     respond_to do |format|
       format.pdf do


### PR DESCRIPTION
## WHAT
In Rails 5,`redirect_to :back` is [deprecated](https://github.com/rails/rails/pull/22506) in favor of the newer safer `redirect_back` method.

## WHY
Addressing deprecations is part of upgrading to Rails 5.1.

## HOW
Adapt all `redirect_to :back` methods to the `redirect_back` along with a fallback location.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/LMS-Rails-5-1-Prework-Fix-redirect_to-back-deprecation-0236781894f64b28bcb56ad923314163
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is an upgrade.  No new functionality.
Have you deployed to Staging? | Deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
