### PR TITLE
Update copy for turking so that it makes sense for students, too

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/__tests__/__snapshots__/completed.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/__tests__/__snapshots__/completed.test.tsx.snap
@@ -13,11 +13,8 @@ exports[`TurkCompleted Component should match snapshot 1`] = `
   <p>
     Your responses will be used to develop our system so that millions of students around the world can improve their reading and writing skills.
   </p>
-  <h1>
-    Payment Directions
-  </h1>
   <p>
-    Use the following HIT code for payment:
+    Survey code:
   </p>
   <div
     className="code"

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/__tests__/__snapshots__/landing.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/__tests__/__snapshots__/landing.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`TurkLanding Component should match snapshot 1`] = `
     className="turk-landing-header-container"
   >
     <h1>
-      Amazon Mechanical Turk Task
+      Quill Activity - Beta Testing of New Content
     </h1>
     <p>
       You are completing a reading and writing activity. Your responses will be used to develop our system so that millions of students around the world can improve their reading and writing skills.
@@ -23,11 +23,7 @@ exports[`TurkLanding Component should match snapshot 1`] = `
     <div
       className="bolded"
     >
-      In order to accurately complete the HIT for payment, you 
-      <p>
-        must
-      </p>
-       do the following:
+      You should:
     </div>
     <ul>
       <li>
@@ -112,11 +108,6 @@ exports[`TurkLanding Component should match snapshot 1`] = `
         </p>
       </li>
     </ul>
-    <p
-      className="bolded"
-    >
-      By following these directions, you will be provided with a code to input in order to be paid for the HIT.
-    </p>
   </section>
   <section
     className="button-container"

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/completed.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/completed.tsx
@@ -15,8 +15,7 @@ export const TurkCompleted = ({ code }) => {
       <h1>Activity Completed!</h1>
       <p>Thank you for completing this activity.</p>
       <p>Your responses will be used to develop our system so that millions of students around the world can improve their reading and writing skills.</p>
-      <h1>Payment Directions</h1>
-      <p>Use the following HIT code for payment:</p>
+      <p>Survey code:</p>
       <div className="code">{code}</div>
       {/* Logical shortcut for only displaying the button if the copy command exists */}
       {document.queryCommandSupported('copy') &&

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/landing.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/turkerView/landing.tsx
@@ -15,12 +15,12 @@ export const TurkLanding = ({ handleStartActivity}) => {
   return(
     <section className="turk-landing-container">
       <section className="turk-landing-header-container">
-        <h1>Amazon Mechanical Turk Task</h1>
+        <h1>Quill Activity - Beta Testing of New Content</h1>
         <p>You are completing a reading and writing activity. Your responses will be used to develop our system so that millions of students around the world can improve their reading and writing skills.</p>
       </section>
       <section className="turk-landing-directions-container">
         <h1>Directions:</h1>
-        <div className="bolded">In order to accurately complete the HIT for payment, you <p>must</p> do the following:</div>
+        <div className="bolded">You should:</div>
         <ul>
           {ListElement('Read the passage')}
           {ListElement('Complete all three sentences')}
@@ -33,7 +33,6 @@ export const TurkLanding = ({ handleStartActivity}) => {
           {ListElement('Use proper capitalization (i.e. do not write in capital letters)')}
           {ListElement('Be based on the text, but written in your own words')}
         </ul>
-        <p className="bolded">By following these directions, you will be provided with a code to input in order to be paid for the HIT.</p>
       </section>
       <section className="button-container">
         <button


### PR DESCRIPTION
## WHAT
Remove any direct references to turking and AMT from the Turker flow
## WHY
For our testing in schools it will be beneficial to capture sessions in groups the same way we do with Turking, so we want to use this same interface for students without confusing them by showing them Turk-specific language.
## HOW
Just remove and tweak some language in the pages and update the Jest snapshots

### Screenshots
![Screenshot 2021-04-28 101159](https://user-images.githubusercontent.com/331565/116418523-39ee7400-a80a-11eb-84b6-bee90b5fc54f.png)

### Notion Card Links
https://www.notion.so/Comprehension-AMT-page-changes-d033199fabfb4eaf9f8af345f68304d2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
