### PR TITLE
cms/log-elasticsearch-create-index-errors

### DIFF
--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -15,8 +15,9 @@ class CreateOrIncrementResponseWorker
       # Elasticsearch will reject them.  But we don't want to retry indexing
       # those, so we rescue the exception and do make sure AdminUpdates run.
       # The data should persist to the DB safely.
-      rescue Elasticsearch::Transport::Transport::Errors::BadRequest
+      rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
         AdminUpdates.run(response.question_uid)
+        NewRelic::Agent.notice_error(e)
       end
     else
       increment_counts(response, symbolized_vals)

--- a/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
@@ -46,7 +46,9 @@ describe CreateOrIncrementResponseWorker do
 
       it 'should persist a response even if elasticsearch indexing fails' do
         text = 'Totally different text'
-        expect_any_instance_of(Response).to receive(:create_index_in_elastic_search).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest)
+        exception = Elasticsearch::Transport::Transport::Errors::BadRequest
+        expect_any_instance_of(Response).to receive(:create_index_in_elastic_search).and_raise(exception)
+        expect(NewRelic::Agent).to receive(:notice_error).with(exception)
         subject.perform({ text: text })
         expect(Response.find_by(text: 'Totally different text').id).to be
       end


### PR DESCRIPTION
## WHAT
Report handled Elasticsearch errors to NewRelic
## WHY
It's hard to debug issues around Elasticsearch when we don't report the errors to our primary debugging tool
## HOW
Use `NewRelic::Agent.notice_error` inside the error handler

### Notion Card Links
https://www.notion.so/quill/No-responses-showing-up-for-new-diagnostic-prompts-6b4faa40a63b40d699d78991c76e4f1d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
