### PR TITLE
LMS Rails 5.0 Prework - Add rails-controller-testing gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -205,6 +205,7 @@ group :test do
   gem 'simplecov-json', require: false
   gem 'codecov'
   gem 'fakeredis', '~> 0.7.0'
+  gem 'rails-controller-testing'
 
   # Remove this gem after upgrading to Rails 5
   gem 'test_after_commit'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -517,6 +517,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.11.3)
       sprockets-rails
+    rails-controller-testing (0.0.3)
+      rails (>= 4.2)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.9)
@@ -861,6 +863,7 @@ DEPENDENCIES
   rack-heartbeat
   rack-host-redirect
   rails (= 4.2.11.3)
+  rails-controller-testing
   rails_12factor
   rails_admin (~> 1.4.2)
   rails_autoscale_agent

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -2,6 +2,8 @@ class PagesController < ApplicationController
   include HTTParty
   include PagesHelper
   before_action :determine_js_file, :determine_flag
+  before_action :set_root_url
+
   layout :determine_layout
 
   NUMBER_OF_SENTENCES = "NUMBER_OF_SENTENCES"
@@ -543,5 +545,9 @@ class PagesController < ApplicationController
 
   private def allow_iframe
     response.headers.delete "X-Frame-Options"
+  end
+  
+  private def set_root_url
+    @root_url = root_url
   end
 end

--- a/services/QuillLMS/app/views/pages/shared/_generic_tabs.erb
+++ b/services/QuillLMS/app/views/pages/shared/_generic_tabs.erb
@@ -5,7 +5,7 @@
         id="<%= tab[:id] || '' %>"
         class="<%= tab[:name] == @active_tab ? 'active' : '' %>"
       >
-        <%= link_to tab[:name], root_url + tab[:url] %>
+        <%= link_to tab[:name], @root_url + tab[:url] %>
       </li>
     <%end-%>
 
@@ -22,7 +22,7 @@
         <ul>
           <%  @tabs.each do |tab| -%>
             <li >
-              <%= link_to tab[:name], root_url + tab[:url] %>
+              <%= link_to tab[:name], @root_url + tab[:url] %>
             </li>
           <%end-%>
         </ul>

--- a/services/QuillLMS/spec/views/pages/careers.html.erb_spec.rb
+++ b/services/QuillLMS/spec/views/pages/careers.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe "pages/careers.html.erb", type: :view do
   include_context 'routing url helpers'
 
   it "displays all the widgets" do
+    assign(:root_url, root_url)
     assign(:open_positions, PagesController::OPEN_POSITIONS)
 
     render


### PR DESCRIPTION
## WHAT
Starting in Rails 5,  `assigns` and `assert_template` are no longer provided in Rails 5+ for functional testes.  The gem [rails-controller-testing](https://github.com/rails/rails-controller-testing) provides these methods.  This PR also addresses a new spec failure that popped up in pages_controller as a result of adding this gem.

## WHY
While we should eventually transition our controller specs to [request specs](https://medium.com/just-tech/rspec-controller-or-request-specs-d93ef563ef11), this gem will serve as a stopgap until that upgrade is made.

## HOW
Add to Gemfile.

### Notion Card Links
https://www.notion.so/quill/Upgrade-LMS-to-Rails-5-0-b742cd5e1764427d8670944d50e2a3e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is just updating the library that calls functions within spec files.
Have you deployed to Staging? | No.  Pushing now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A