### PR TITLE
adds setEnvVars.js for client and uses it in jest

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/actions/session.test.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/actions/session.test.ts
@@ -57,7 +57,7 @@ describe('Session actions', () => {
 
     it('makes a POST request to the feedback API', () => {
       const expectedRequest = {
-        url: `https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-endpoint-go`,
+        url: process.env.GOLANG_FANOUT_URL,
         body: {
           prompt_id: mockPromptID,
           prompt_text: mockPromptText,

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -229,6 +229,7 @@
     ],
     "setupFiles": [
       "<rootDir>/setupTests.ts",
+      "<rootDir>/setEnvVars.js",
       "jest-localstorage-mock"
     ]
   }

--- a/services/QuillLMS/client/setEnvVars.js
+++ b/services/QuillLMS/client/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.GOLANG_FANOUT_URL = 'https://us-central1-comprehension-247816.cloudfunctions.net/comprehension-fanout-staging';


### PR DESCRIPTION
## WHAT
Fixing a spec that I broke from in https://github.com/empirical-org/Empirical-Core/pull/7544

## WHY
failing specs are bad 

## HOW
Sets up a new pattern: use setEnvVars.js for env vars that are needed by jest.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | no
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
