### PR TITLE
rename rule description to rule note

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleForm.test.tsx.snap
@@ -24,9 +24,9 @@ exports[`RuleForm component should render RuleForm 1`] = `
       errors={Object {}}
       isUniversal={false}
       ruleConceptUID="a34qreadbgt6"
-      ruleDescription=""
       ruleID={1}
       ruleName="remove all instances of \\"it contains methane\\""
+      ruleNote=""
       ruleOptimal={
         Object {
           "label": "Sub-Optimal",
@@ -40,8 +40,8 @@ exports[`RuleForm component should render RuleForm 1`] = `
         }
       }
       setRuleConceptUID={[Function]}
-      setRuleDescription={[Function]}
       setRuleName={[Function]}
+      setRuleNote={[Function]}
       setRuleOptimal={[Function]}
       setRuleType={[Function]}
     />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
@@ -96,13 +96,13 @@ exports[`RuleGenericAttributes component should render RuleGenericAttributes 1`]
   <p
     className="form-subsection-label"
   >
-    Rule Description
+    Rule Note
   </p>
   <TextEditor
     ContentState={[Function]}
     EditorState={[Function]}
     handleTextChange={[Function]}
-    key="rule-description"
+    key="rule-note"
     text="test description"
   />
 </Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleGenericAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleGenericAttributes.test.tsx
@@ -8,13 +8,13 @@ const mockProps = {
   isUniversal: false,
   errors: {},
   ruleConceptUID: 'test-id',
-  ruleDescription: 'test description',
+  ruleNote: 'test description',
   ruleID: 17,
   ruleName: 'generic rule 17',
   ruleOptimal: false,
   ruleType: { value: 'plagiarism', label: 'Plagiarism'},
   setRuleConceptUID: jest.fn(),
-  setRuleDescription: jest.fn(),
+  setRuleNote: jest.fn(),
   setRuleName: jest.fn(),
   setRuleOptimal: jest.fn(),
   setRuleType: jest.fn(),
@@ -32,9 +32,9 @@ describe('RuleGenericAttributes component', () => {
   });
 
   it('should render the appropriate form components', () => {
-    // TextEditor: Rule Description (1)
+    // TextEditor: Rule Note (1)
     // Input: Name, Concept UID (2)
-    // DropdownInput: Type, Description (2)
+    // DropdownInput: Type, Note (2)
     expect(container.find(TextEditor).length).toEqual(1);
     expect(container.find(Input).length).toEqual(1);
     expect(container.find(DropdownInput).length).toEqual(3);

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
@@ -62,7 +62,7 @@ const Rule = ({ history, match }) => {
       return [];
     } else {
       // format for DataTable to display labels on left side and values on right
-      const { description, feedbacks, name, prompt_ids, rule_type, plagiarism_text } = rule;
+      const { note, feedbacks, name, prompt_ids, rule_type, plagiarism_text } = rule;
       const promptsIcons = getPromptsIcons(activityData, prompt_ids);
       const attributesFields = handleAttributesFields(feedbacks, plagiarism_text);
       const firstFields = [
@@ -75,8 +75,8 @@ const Rule = ({ history, match }) => {
           value: name
         },
         {
-          label: 'Description',
-          value: description ? stripHtml(description) : ''
+          label: 'Note',
+          value: note ? stripHtml(note) : ''
         }
       ];
       const lastFields = [

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
@@ -75,7 +75,7 @@ const Rule = ({ history, match }) => {
           value: name
         },
         {
-          label: 'Note',
+          label: 'Rule Note',
           value: note ? stripHtml(note) : ''
         }
       ];

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleForm.tsx
@@ -27,18 +27,18 @@ interface RuleFormProps {
 
 const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestErrors,  rule, submitRule, universalRuleType }: RuleFormProps) => {
 
-  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, description, feedbacks } = rule;
+  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, note, feedbacks } = rule;
   const initialRuleType = getInitialRuleType({ isUniversal, rule_type, universalRuleType});
   const initialRuleOptimal = optimal ? ruleOptimalOptions[0] : ruleOptimalOptions[1];
   const initialPlagiarismText = plagiarism_text || { text: '' }
-  const initialDescription = description || '';
+  const initialNote = note || '';
   const initialFeedbacks = feedbacks ? formatInitialFeedbacks(feedbacks) : returnInitialFeedback(initialRuleType.value);
 
   const [errors, setErrors] = React.useState<object>({});
   const [plagiarismText, setPlagiarismText] = React.useState<RuleInterface["plagiarism_text"]>(initialPlagiarismText);
   const [regexRules, setRegexRules] = React.useState<object>({});
   const [ruleConceptUID, setRuleConceptUID] = React.useState<string>(concept_uid);
-  const [ruleDescription, setRuleDescription] = React.useState<string>(initialDescription);
+  const [ruleNote, setRuleNote] = React.useState<string>(initialNote);
   const [ruleFeedbacks, setRuleFeedbacks] = React.useState<object>(initialFeedbacks);
   const [ruleOptimal, setRuleOptimal] = React.useState<any>(initialRuleOptimal);
   const [ruleName, setRuleName] = React.useState<string>(name || '');
@@ -100,7 +100,7 @@ const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestEr
       ruleId: null,
       ruleLabelName: null,
       ruleConceptUID,
-      ruleDescription,
+      ruleNote,
       ruleFeedbacks,
       ruleOptimal,
       rulePrompts,
@@ -128,15 +128,15 @@ const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestEr
           errors={errors}
           isUniversal={isUniversal}
           ruleConceptUID={ruleConceptUID}
-          ruleDescription={ruleDescription}
           ruleID={id}
           ruleName={ruleName}
+          ruleNote={ruleNote}
           ruleOptimal={ruleOptimal}
           ruleType={ruleType}
           ruleUID={uid}
           setRuleConceptUID={setRuleConceptUID}
-          setRuleDescription={setRuleDescription}
           setRuleName={setRuleName}
+          setRuleNote={setRuleNote}
           setRuleOptimal={setRuleOptimal}
           setRuleType={setRuleType}
         />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
@@ -3,7 +3,7 @@ import { EditorState, ContentState } from 'draft-js';
 
 import {
   handleSetRuleConceptUID,
-  handleSetRuleDescription,
+  handleSetRuleNote,
   handleSetRuleName,
   handleSetRuleOptimal,
   handleSetRuleType,
@@ -18,7 +18,7 @@ interface RuleGenericAttributesProps {
   isUniversal: boolean,
   errors: any,
   ruleConceptUID: string,
-  ruleDescription: string,
+  ruleNote: string,
   ruleID?: number,
   ruleUID?: string,
   ruleName: string,
@@ -26,7 +26,7 @@ interface RuleGenericAttributesProps {
   ruleType: any,
   concepts: any[],
   setRuleConceptUID: (ruleConceptUID: string) => void,
-  setRuleDescription: (ruleDescription: string) => void,
+  setRuleNote: (ruleNote: string) => void,
   setRuleName: (ruleName: string) => void,
   setRuleOptimal: (ruleOptimal: DropdownObjectInterface) => void,
   setRuleType: (ruleType: DropdownObjectInterface) => void
@@ -39,14 +39,14 @@ const RuleGenericAttributes = ({
   errors,
   concepts,
   ruleConceptUID,
-  ruleDescription,
+  ruleNote,
   ruleID,
   ruleUID,
   ruleName,
   ruleOptimal,
   ruleType,
   setRuleConceptUID,
-  setRuleDescription,
+  setRuleNote,
   setRuleName,
   setRuleOptimal,
   setRuleType
@@ -60,7 +60,7 @@ const RuleGenericAttributes = ({
 
   function onHandleSetRuleOptimal(ruleOptimal: DropdownObjectInterface) { handleSetRuleOptimal(ruleOptimal, setRuleOptimal) }
 
-  function onHandleSetRuleDescription(text: string) { handleSetRuleDescription(text, setRuleDescription)}
+  function onHandleSetRuleNote(text: string) { handleSetRuleNote(text, setRuleNote)}
 
   function renderIDorUID(idOrRuleId, type) {
     return(
@@ -79,7 +79,7 @@ const RuleGenericAttributes = ({
   const conceptOptions = concepts.map(c => ({ value: c.uid, label: c.name, }));
   const selectedConceptOption = conceptOptions.find(co => co.value === ruleConceptUID);
   const nameInputLabel = autoMLParams && autoMLParams['label'] ? autoMLParams['label'] : 'Name';
-  const descriptionLabel = autoMLParams && autoMLParams['notes'] ? autoMLParams['notes'] : 'Rule Description';
+  const noteLabel = autoMLParams && autoMLParams['notes'] ? autoMLParams['notes'] : 'Rule Note';
 
   return(
     <React.Fragment>
@@ -118,13 +118,13 @@ const RuleGenericAttributes = ({
       />
       {ruleID && renderIDorUID(ruleID, 'Rule ID')}
       {ruleUID && renderIDorUID(ruleUID, 'Rule UID')}
-      <p className="form-subsection-label">{descriptionLabel}</p>
+      <p className="form-subsection-label">{noteLabel}</p>
       <TextEditor
         ContentState={ContentState}
         EditorState={EditorState}
-        handleTextChange={onHandleSetRuleDescription}
-        key="rule-description"
-        text={ruleDescription}
+        handleTextChange={onHandleSetRuleNote}
+        key="rule-note"
+        text={ruleNote}
       />
     </React.Fragment>
   )

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -67,7 +67,7 @@ const RuleAnalysis = ({ history, match }) => {
       return [];
     } else {
       // format for DataTable to display labels on left side and values on right
-      const { description, feedbacks, name, rule_type, concept_uid, } = rule;
+      const { note, feedbacks, name, rule_type, concept_uid, } = rule;
 
       const selectedConcept = conceptsData.concepts.find(c => c.uid === concept_uid);
       const selectedConceptNameArray = selectedConcept ? selectedConcept.name.split(' | ') : []
@@ -82,8 +82,8 @@ const RuleAnalysis = ({ history, match }) => {
           value: name
         },
         {
-          label: 'Rule Description',
-          value: description ? stripHtml(description) : ''
+          label: 'Rule Note',
+          value: note ? stripHtml(note) : ''
         },
         {
           label: 'Concept - Level 0',

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
@@ -19,7 +19,7 @@ interface PromptOption extends PromptInterface {
 
 const MoreInfo = (row) => {
   return (<div className="more-info">
-    <p><strong>Rule Description:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.description || "N/A" }} /></p>
+    <p><strong>Rule Note:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.note || "N/A" }} /></p>
     <p><strong>First Layer Feedback:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.firstLayerFeedback || "N/A" }} /></p>
   </div>)
 }
@@ -49,7 +49,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const formattedRows = selectedPrompt && ruleFeedbackHistory && ruleFeedbackHistory.ruleFeedbackHistories && ruleFeedbackHistory.ruleFeedbackHistories.filter(rule => {
     return selectedRuleType.value === DEFAULT_RULE_TYPE || rule.api_name.toLowerCase() === selectedRuleType.value.toLowerCase()
   }).map(rule => {
-    const { rule_name, rule_uid, api_name, rule_order, rule_description, pct_strong, pct_scored, total_responses, scored_responses, first_feedback, } = rule;
+    const { rule_name, rule_uid, api_name, rule_order, note, pct_strong, pct_scored, total_responses, scored_responses, first_feedback, } = rule;
     const apiOrder = ruleOrder[api_name]
     return {
       rule_uid,
@@ -63,7 +63,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       scoredResponses: scored_responses,
       percentageScored: pct_scored,
       activityId,
-      description: rule_description,
+      note,
       firstLayerFeedback: first_feedback,
       handleClick: () => window.location.href = `/cms/comprehension#/activities/${activityId}/rules-analysis/${rule_uid}`
     }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
@@ -33,12 +33,12 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
   const { params } = match;
   const { promptId } = params;
 
-  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, description, feedbacks, state, label } = rule;
+  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, note, feedbacks, state, label } = rule;
 
   const initialRuleType = getInitialRuleType({ isUniversal, rule_type, universalRuleType: null});
   const initialRuleOptimal = optimal ? ruleOptimalOptions[0] : ruleOptimalOptions[1];
   const initialPlagiarismText = plagiarism_text || { text: '' }
-  const initialDescription = description || '';
+  const initialNote = note || '';
   const initialFeedbacks = feedbacks ? formatInitialFeedbacks(feedbacks) : returnInitialFeedback(initialRuleType.value);
   const initialLabel = label && label.name;
   const ruleLabelStatus = state;
@@ -48,7 +48,7 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
   const [plagiarismText, setPlagiarismText] = React.useState<RuleInterface["plagiarism_text"]>(initialPlagiarismText);
   const [regexRules, setRegexRules] = React.useState<object>({});
   const [ruleConceptUID, setRuleConceptUID] = React.useState<string>(concept_uid || '');
-  const [ruleDescription, setRuleDescription] = React.useState<string>(initialDescription);
+  const [ruleNote, setRuleNote] = React.useState<string>(initialNote);
   const [ruleFeedbacks, setRuleFeedbacks] = React.useState<object>(initialFeedbacks);
   const [ruleOptimal, setRuleOptimal] = React.useState<any>(initialRuleOptimal);
   const [ruleName, setRuleName] = React.useState<string>(name || '');
@@ -119,7 +119,7 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
       ruleName,
       ruleLabelName,
       ruleConceptUID,
-      ruleDescription,
+      ruleNote,
       ruleFeedbacks,
       ruleOptimal,
       rulePrompts,
@@ -184,15 +184,15 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
           isAutoML={true}
           isUniversal={isUniversal}
           ruleConceptUID={ruleConceptUID}
-          ruleDescription={ruleDescription}
           ruleID={id}
           ruleName={ruleName}
+          ruleNote={ruleNote}
           ruleOptimal={ruleOptimal}
           ruleType={ruleType}
           ruleUID={uid}
           setRuleConceptUID={setRuleConceptUID}
-          setRuleDescription={setRuleDescription}
           setRuleName={setRuleName}
+          setRuleNote={setRuleNote}
           setRuleOptimal={setRuleOptimal}
           setRuleType={setRuleType}
         />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
@@ -59,7 +59,7 @@ const UniversalRule = ({ history, location, match }) => {
         value: name
       },
       {
-        label: 'Note',
+        label: 'Rule Note',
         value: note && stripHtml(note)
       },
       {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
@@ -47,7 +47,7 @@ const UniversalRule = ({ history, location, match }) => {
       return [];
     }
     // format for DataTable to display labels on left side and values on right
-    const { feedbacks, name, rule_type, description, suborder, } = rule;
+    const { feedbacks, name, rule_type, note, suborder, } = rule;
     const attributesFields = handleAttributesFields(feedbacks);
     const firstFields = [
       {
@@ -59,8 +59,8 @@ const UniversalRule = ({ history, location, match }) => {
         value: name
       },
       {
-        label: 'Description',
-        value: description && stripHtml(description)
+        label: 'Note',
+        value: note && stripHtml(note)
       },
       {
         label: 'Order',

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -18,7 +18,7 @@ export function handleSetRuleOptimal(ruleOptimal: DropdownObjectInterface, setRu
 
 export function handleSetRuleConceptUID(value, setRuleConceptUID) { setRuleConceptUID(value) };
 
-export function handleSetRuleDescription(text: string, setRuleDescription) { setRuleDescription(text) }
+export function handleSetRuleNote(text: string, setRuleNote) { setRuleNote(text) }
 
 export function handleSetPlagiarismText(text: string, plagiarismText, setPlagiarismText) {
   const plagiarismTextObject = {...plagiarismText};
@@ -260,7 +260,7 @@ export const buildRule = ({
   rule,
   rulesCount,
   ruleConceptUID,
-  ruleDescription,
+  ruleNote,
   ruleName,
   ruleLabelName,
   ruleOptimal,
@@ -279,7 +279,7 @@ export const buildRule = ({
 
   let newOrUpdatedRule: any = {
     concept_uid: ruleConceptUID,
-    description: ruleDescription,
+    note: ruleNote,
     feedbacks_attributes: buildFeedbacks(ruleFeedbacks),
     name: ruleName,
     optimal: !!ruleOptimal.value,
@@ -326,7 +326,7 @@ export async function handleSubmitRule({
   ruleId,
   ruleLabelName,
   ruleConceptUID,
-  ruleDescription,
+  ruleNote,
   ruleOptimal,
   rulePrompts,
   rulePromptIds,
@@ -344,7 +344,7 @@ export async function handleSubmitRule({
     ruleName,
     ruleLabelName,
     ruleConceptUID,
-    ruleDescription,
+    ruleNote,
     ruleOptimal,
     rulePrompts,
     rulePromptIds,

--- a/services/QuillLMS/db/migrate/20210429151331_rename_rule_description_to_rule_note.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210429151331_rename_rule_description_to_rule_note.comprehension.rb
@@ -1,0 +1,6 @@
+# This migration comes from comprehension (originally 20210429144611)
+class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration
+  def change
+    rename_column :comprehension_rules, :description, :note
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
@@ -50,7 +50,7 @@ module Comprehension
     end
 
     private def rule_params
-      params.require(:rule).permit(:name, :description, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid,
+      params.require(:rule).permit(:name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid,
          prompt_ids: [],
          plagiarism_text_attributes: [:id, :text],
          regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type],

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -51,7 +51,7 @@ module Comprehension
       options ||= {}
 
       super(options.reverse_merge(
-        only: [:id, :uid, :name, :description, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid, :prompt_ids],
+        only: [:id, :uid, :name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid, :prompt_ids],
         include: [:plagiarism_text, :feedbacks, :label, :regex_rules],
         methods: [:prompt_ids, :display_name]
       ))

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210429144611_rename_rule_description_to_rule_note.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210429144611_rename_rule_description_to_rule_note.rb
@@ -1,0 +1,5 @@
+class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration
+  def change
+    rename_column :comprehension_rules, :description, :note
+  end
+end

--- a/services/QuillLMS/engines/comprehension/lib/tasks/add_grammar_api_rules_and_feedback.rake
+++ b/services/QuillLMS/engines/comprehension/lib/tasks/add_grammar_api_rules_and_feedback.rake
@@ -2,18 +2,18 @@ namespace :grammar_api_rules_and_feedback do
     desc 'data migration for grammar-api specific rules and feedback'
     task :insert => :environment do
         rules_csv = CSV.parse(File.read('engines/comprehension/lib/tasks/rules.csv'), headers: true)
-        valid_rules = rules_csv.select do |r| 
-            ['Grammar API', 'Opinion API'].include?(r['Module']) && r['Rule UID'].present? 
+        valid_rules = rules_csv.select do |r|
+            ['Grammar API', 'Opinion API'].include?(r['Module']) && r['Rule UID'].present?
         end
 
         all_prompts = Comprehension::Prompt.all
 
-        ActiveRecord::Base.transaction do 
+        ActiveRecord::Base.transaction do
             valid_rules.each do |r|
                 created_rule = Comprehension::Rule.find_or_initialize_by(uid: r['Rule UID'])
                 created_rule.attributes = {
                     name: r['Rule'],
-                    description: r['Rule Description'],
+                    note: r['Rule Description'],
                     universal: true,
                     rule_type: r['Module'] == 'Grammar API' ? 'grammar' : 'opinion',
                     optimal: false,
@@ -42,4 +42,3 @@ namespace :grammar_api_rules_and_feedback do
 
     end
 end
-  

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
@@ -36,7 +36,7 @@ module Comprehension
 
           assert_equal @rule.name, parsed_response.first['name']
 
-          assert_equal @rule.description, parsed_response.first['description']
+          assert_equal @rule.note, parsed_response.first['note']
 
           assert_equal @rule.universal, parsed_response.first['universal']
 
@@ -106,14 +106,14 @@ module Comprehension
       should "create a valid record and return it as json" do
         assert_equal 0, Rule.count
 
-        post :create, rule: { concept_uid: @rule.concept_uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: @rule.prompt_ids }
+        post :create, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: @rule.prompt_ids }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
 
         assert_equal @rule.name, parsed_response['name']
 
-        assert_equal @rule.description, parsed_response['description']
+        assert_equal @rule.note, parsed_response['note']
 
         assert_equal @rule.universal, parsed_response['universal']
 
@@ -133,7 +133,7 @@ module Comprehension
       end
 
       should "not create an invalid record and return errors as json" do
-        post :create, rule: { concept_uid: @rule.uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, state: nil, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
+        post :create, rule: { concept_uid: @rule.uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: nil, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
 
         parsed_response = JSON.parse(response.body)
 
@@ -143,7 +143,7 @@ module Comprehension
       end
 
       should "return an error if regex is invalid" do
-        post :create, rule: { concept_uid: @rule.uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, suborder: 1, rule_type: @rule.rule_type, universal: @rule.universal, state: Rule::STATE_INACTIVE,
+        post :create, rule: { concept_uid: @rule.uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, suborder: 1, rule_type: @rule.rule_type, universal: @rule.universal, state: Rule::STATE_INACTIVE,
           regex_rules_attributes:
             [
               {
@@ -162,7 +162,7 @@ module Comprehension
         plagiarism_text = "Here is some text to be checked for plagiarism."
         post :create, rule: {
               concept_uid: @rule.concept_uid,
-              description: @rule.description,
+              note: @rule.note,
               name: @rule.name,
               optimal: @rule.optimal,
               state: @rule.state,
@@ -185,7 +185,7 @@ module Comprehension
         feedback = build(:comprehension_feedback)
         post :create, rule: {
           concept_uid: @rule.concept_uid,
-          description: @rule.description,
+          note: @rule.note,
           name: @rule.name,
           optimal: @rule.optimal,
           state: @rule.state,
@@ -217,7 +217,7 @@ module Comprehension
 
         feedback = create(:comprehension_feedback, rule: @rule)
         highlight = build(:comprehension_highlight, starting_index: 2)
-        post :create, rule: { concept_uid: @rule.concept_uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, feedbacks_attributes: [{text: feedback.text, description: feedback.description, order: feedback.order, highlights_attributes: [{text: highlight.text, highlight_type: highlight.highlight_type, starting_index: highlight.starting_index }]}]}
+        post :create, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, feedbacks_attributes: [{text: feedback.text, description: feedback.description, order: feedback.order, highlights_attributes: [{text: highlight.text, highlight_type: highlight.highlight_type, starting_index: highlight.starting_index }]}]}
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -235,7 +235,7 @@ module Comprehension
         label = build(:comprehension_label)
         post :create, rule: {
           concept_uid: @rule.concept_uid,
-          description: @rule.description,
+          note: @rule.note,
           name: @rule.name,
           optimal: @rule.optimal,
           state: @rule.state,
@@ -261,7 +261,7 @@ module Comprehension
         regex_rule = build(:comprehension_regex_rule)
         post :create, rule: {
           concept_uid: @rule.concept_uid,
-          description: @rule.description,
+          note: @rule.note,
           name: @rule.name,
           optimal: @rule.optimal,
           state: @rule.state,
@@ -302,7 +302,7 @@ module Comprehension
 
         assert_equal @rule.name, parsed_response['name']
 
-        assert_equal @rule.description, parsed_response['description']
+        assert_equal @rule.note, parsed_response['note']
 
         assert_equal @rule.universal, parsed_response['universal']
 
@@ -326,7 +326,7 @@ module Comprehension
 
         assert_equal @rule.name, parsed_response['name']
 
-        assert_equal @rule.description, parsed_response['description']
+        assert_equal @rule.note, parsed_response['note']
 
         assert_equal @rule.universal, parsed_response['universal']
 
@@ -355,7 +355,7 @@ module Comprehension
 
       should "update record if valid, return nothing" do
         new_prompt = create(:comprehension_prompt)
-        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: [new_prompt.id] }
+        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: [new_prompt.id] }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -364,7 +364,7 @@ module Comprehension
       end
 
       should "not update record and return errors as json" do
-        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, description: @rule.description, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
+        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
 
         parsed_response = JSON.parse(response.body)
 

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210317200006) do
+ActiveRecord::Schema.define(version: 20210429144611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 20210317200006) do
   create_table "comprehension_rules", force: :cascade do |t|
     t.string   "uid",         null: false
     t.string   "name",        null: false
-    t.string   "description"
+    t.string   "note"
     t.boolean  "universal",   null: false
     t.string   "rule_type",   null: false
     t.boolean  "optimal",     null: false

--- a/services/QuillLMS/engines/comprehension/test/factories/comprehension/rules.rb
+++ b/services/QuillLMS/engines/comprehension/test/factories/comprehension/rules.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :comprehension_rule, class: 'Comprehension::Rule' do
     uid { SecureRandom.uuid }
     name { "Test Rule" }
-    description { "This rule is a test" }
+    note { "This rule is a test" }
     universal { false }
     rule_type { "plagiarism" }
     optimal { false }

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
@@ -56,7 +56,7 @@ module Comprehension
         assert_equal json_hash['id'], @rule.id
         assert_equal json_hash['uid'], @rule.uid
         assert_equal json_hash['name'], @rule.name
-        assert_equal json_hash['description'], @rule.description
+        assert_equal json_hash['note'], @rule.note
         assert_equal json_hash['universal'], @rule.universal
         assert_equal json_hash['rule_type'], @rule.rule_type
         assert_equal json_hash['optimal'], @rule.optimal


### PR DESCRIPTION
## WHAT
Rename the `description` attribute on the `comprehension_rules` table to `note` and update everywhere we use it in the code and in the Comprehension CMS.

## WHY
"Rule descriptions" have a meaning in Grammar that is different than what we use it to mean here, so it is better to disambiguate.

## HOW
Add a migration that renames the column and then comb through all the front- and back-end Comprehension code to update places where we use it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Rename-Rule-Description-to-Rule-Note-c015e04753524a9197255af63d6c7711

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
