### PR TITLE
comprehension bug/ fix check for highlights

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -358,8 +358,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
 
     const lastSubmittedResponse = submittedResponsesForActivePrompt[submittedResponsesForActivePrompt.length - 1]
 
-    if (!lastSubmittedResponse.highlight) { return passagesWithoutSpanTags }
-
+    if (!lastSubmittedResponse.highlight || (lastSubmittedResponse.highlight && !lastSubmittedResponse.highlight.length)) { return passagesWithoutSpanTags }
 
     const passageHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === "passage")
 


### PR DESCRIPTION
## WHAT
fix issue where previous highlights were being returned in subsequent prompts

## WHY
we don't want to show these highlights in other prompts

## HOW
just added check for array length rather than just the existence `highlights`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Previous-highlighting-comes-back-in-the-next-conjunction-0c01ad4497fb4f8aa80af3680325fa4f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- tiny change, manually checked
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
