### PR TITLE
Address an edge case where activity sessions sometimes have null completion_time

### DIFF
--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -46,7 +46,7 @@ class SerializeActivityHealth
       .where(activity: @activity, state: "finished")
       .last(MAX_SESSIONS_VIEWED)
       .map(&:minutes_to_complete)
-      .reject{ |b| b==0 }
+      .reject{ |b| !b || b==0 }
     all_session_lengths.empty? ? nil : (all_session_lengths.sum.to_f / all_session_lengths.size).round(2)
   end
 

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -60,6 +60,16 @@ describe 'SerializeActivityHealth' do
     expect(data[:recent_plays]).to eq(nil)
   end
 
+  it 'returns without erroring if some activity sessions have nil minutes to complete' do
+    UnitActivity.where(activity: activity).destroy_all
+    unit = create(:unit)
+    create(:classroom_unit, unit: unit, created_at: Date.today - 1.year)
+    create(:unit_activity, unit: unit, activity: activity)
+    create(:activity_session, activity: activity, state: "finished", started_at: nil, completed_at: nil)
+    data = SerializeActivityHealth.new(activity).data
+    expect(data[:recent_plays]).to eq(2)
+  end
+
   it 'calculates averages and standard deviation using prompt data' do
     data = SerializeActivityHealth.new(activity).data
     expect(data[:avg_common_unmatched]).to eq(75)


### PR DESCRIPTION
## WHAT
Sometimes Activity Session records don't have a `start_time`, and so the `minutes_to_complete` returns nil. This was breaking my code because I was trying to sum an array that sometimes has null values in it.

## WHY
I want my code to run and simply ignore the activity sessions with `null` completion times.

## HOW
Add a check for this edge case to reject those nil values.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
