### PR TITLE
LMS Rails 5.0 Prework - Address deprecation of strings or symbols for middleware class names

### DIFF
--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -69,7 +69,7 @@ module EmpiricalGrammar
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Affiliates, { param: 'referral_code' }
 
-    config.middleware.insert_before 0, "Rack::Cors" do
+    config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins 'quill.org', %r{https://(.)*.quill.org}, /localhost:.*/, /127.0.0.1:.*/
         resource '/api/*', headers: :any, methods: [:get, :post, :patch, :put, :delete, :options], credentials: true


### PR DESCRIPTION
## WHAT
Rails 5.0 [deprecates](https://github.com/rails/rails/commit/83b767ce) using strings or symbols for middleware class names.  

## WHY
In order to upgrade to Rails 5, we have to address deprecations.

## HOW
Change all middleware calls using strings/symbols to classnames.

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  There is no change in functionality, just addressing a deprecation.
Have you deployed to Staging? | YES.
Self-Review: Have you done an initial self-review of the code below on Github? |. YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
