### PR TITLE
LMS Rails 5.0 Prework - Address deprecation: passing string to define callback

### DIFF
--- a/services/QuillLMS/app/models/content_partner.rb
+++ b/services/QuillLMS/app/models/content_partner.rb
@@ -15,5 +15,5 @@ class ContentPartner < ActiveRecord::Base
 
   validates :name, presence: true
 
-  after_commit 'Activity.clear_activity_search_cache'
+  after_commit { Activity.clear_activity_search_cache }
 end

--- a/services/QuillLMS/app/models/standard.rb
+++ b/services/QuillLMS/app/models/standard.rb
@@ -32,7 +32,7 @@ class Standard < ActiveRecord::Base
 
   accepts_nested_attributes_for :change_logs
 
-  after_commit 'Activity.clear_activity_search_cache'
+  after_commit { Activity.clear_activity_search_cache }
 
   def name_prefix
     name.split(' ').first

--- a/services/QuillLMS/app/models/standard_category.rb
+++ b/services/QuillLMS/app/models/standard_category.rb
@@ -21,5 +21,5 @@ class StandardCategory < ActiveRecord::Base
 
   accepts_nested_attributes_for :change_logs
 
-  after_commit 'Activity.clear_activity_search_cache'
+  after_commit { Activity.clear_activity_search_cache }
 end

--- a/services/QuillLMS/app/models/standard_level.rb
+++ b/services/QuillLMS/app/models/standard_level.rb
@@ -23,7 +23,7 @@ class StandardLevel < ActiveRecord::Base
 
   validates :name, presence: true
 
-  after_commit 'Activity.clear_activity_search_cache'
+  after_commit { Activity.clear_activity_search_cache }
 
   accepts_nested_attributes_for :change_logs
 end

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -25,7 +25,7 @@ class Topic < ActiveRecord::Base
 
   accepts_nested_attributes_for :change_logs
 
-  after_commit 'Activity.clear_activity_search_cache'
+  after_commit { Activity.clear_activity_search_cache }
 
   before_save :validate_parent_by_level
 


### PR DESCRIPTION
## WHAT
This PR addresses a Rails 5 [deprecation](https://github.com/rails/rails/pull/22598) for passing strings to define callbacks.

## WHY
In order to upgrade to Rails 5 need to address deprecations

## HOW
Update the `after_commit` blocks to use class method calls instead of strings.

### Notion Card Links
https://www.notion.so/quill/Upgrade-LMS-to-Rails-5-0-b742cd5e1764427d8670944d50e2a3e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  There is no new functionality here, just a refactoring fo the upgrade.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
