### PR TITLE
Fix teacher center root_url bug

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -1,6 +1,7 @@
 class BlogPostsController < ApplicationController
   before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_role
+  before_action :set_root_url
 
   def index
     topic_names = BlogPost::TEACHER_TOPICS
@@ -81,5 +82,9 @@ class BlogPostsController < ApplicationController
 
   private def set_role
     @role = current_user ? current_user.role : nil
+  end
+
+  private def set_root_url
+    @root_url = root_url
   end
 end

--- a/services/QuillLMS/app/controllers/integrations_controller.rb
+++ b/services/QuillLMS/app/controllers/integrations_controller.rb
@@ -1,6 +1,7 @@
 class IntegrationsController < ApplicationController
   include HTTParty
   layout "integrations"
+  before_action :set_root_url
 
   def amplify
     store_partner_session()
@@ -29,4 +30,7 @@ class IntegrationsController < ApplicationController
     }
   end
 
+  private def set_root_url
+    @root_url = root_url
+  end
 end


### PR DESCRIPTION
## WHAT
There's a bug involving an instance variable @root_url that is not set in the blog_posts controller.

## WHY
We'd like pages to be accessible.

## HOW
Set the instance variable in the appropriate controllers that reference the shared partial.

### Notion Card Links
https://www.notion.so/quill/Teacher-Center-is-giving-a-500-Error-7684f16ceb0245ca9a9b3cf1f2fa3c68

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Spot check.  Will add specs later today.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
