### PR TITLE
Fix activity packs 500 error

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -1,6 +1,7 @@
 class Teachers::UnitTemplatesController < ApplicationController
   before_action :is_teacher?, only: [:show, :index, :count]
   before_action :redirect_to_public_index_if_no_unit_template_found, only: [:show]
+  before_action :set_root_url
 
   include Units
 
@@ -116,4 +117,7 @@ class Teachers::UnitTemplatesController < ApplicationController
     ut.get_cached_serialized_unit_template('profile')
   end
 
+  private def set_root_url
+    @root_url = root_url
+  end
 end


### PR DESCRIPTION
## WHAT
Fix 500 error on Activity Packs page

## WHY
@root_url instance variable is undefined for a share helper method

## HOW
Add before_filter that sets @root_url for the relevant controller

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Packs-also-giving-a-500-Error-836b8882ee6c4f09917e048bf9665552

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Will add specs later today.
Have you deployed to Staging? | NO
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
