### PR TITLE
LMS Rails 5.0 Prework - Removing postgres_ext gem, part 1

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/concepts/concept.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/concept.rb
@@ -1,22 +1,22 @@
 class ProgressReports::Concepts::Concept
   def self.results(teacher, filters)
-    # Include:
-    # name of the concept
-    # correct results count
-    # incorrect results count
-    # total results count
-    ::Concept.with(filtered_correct_results: ::ProgressReports::Concepts::ConceptResult.results(teacher, filters))
-      .select(<<-SELECT
-        concepts.id as concept_id,
-        concepts.name as concept_name,
-        COUNT(filtered_correct_results.*) as total_result_count,
-        SUM(CASE WHEN filtered_correct_results.is_correct = 1 THEN 1 ELSE 0 END) as correct_result_count,
-        SUM(CASE WHEN filtered_correct_results.is_correct = 0 THEN 1 ELSE 0 END) as incorrect_result_count,
-        gp_concepts.name as level_2_concept_name
-      SELECT
-      ).joins('JOIN filtered_correct_results ON concepts.id = filtered_correct_results.concept_id')
-      .joins('LEFT JOIN concepts as parent_concepts ON parent_concepts.id = concepts.parent_id')
-      .joins('LEFT JOIN concepts as gp_concepts ON gp_concepts.id = parent_concepts.parent_id')
+    filtered_correct_results_query = ::ProgressReports::Concepts::ConceptResult.results(teacher, filters).to_sql
+    filtered_correct_results = "( #{filtered_correct_results_query} ) AS filtered_correct_results"
+
+    ::Concept
+      .select(
+        <<-SQL
+          concepts.id AS concept_id,
+          concepts.name AS concept_name,
+          COUNT(filtered_correct_results.*) AS total_result_count,
+          SUM(CASE WHEN filtered_correct_results.is_correct = 1 THEN 1 ELSE 0 END) AS correct_result_count,
+          SUM(CASE WHEN filtered_correct_results.is_correct = 0 THEN 1 ELSE 0 END) AS incorrect_result_count,
+          gp_concepts.name AS level_2_concept_name
+        SQL
+      )
+      .joins("JOIN #{filtered_correct_results} ON concepts.id = filtered_correct_results.concept_id")
+      .joins('LEFT JOIN concepts AS parent_concepts ON parent_concepts.id = concepts.parent_id')
+      .joins('LEFT JOIN concepts AS gp_concepts ON gp_concepts.id = parent_concepts.parent_id')
       .group("concepts.id, gp_concepts.name")
       .order("concepts.name asc")
   end

--- a/services/QuillLMS/app/queries/progress_reports/concepts/user.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/user.rb
@@ -1,24 +1,21 @@
 class ProgressReports::Concepts::User
   def self.results(teacher, filters)
-    # Include:
-    # name of the student
-    # correct results count
-    # incorrect results count
-    # total results count
-    # percentage score (correct / total)
-
     last_name = "substring(users.name, '(?=\s).*')"
+    filtered_correct_results_query = ProgressReports::Concepts::ConceptResult.results(teacher, filters).to_sql
+    filtered_correct_results = "( #{filtered_correct_results_query} ) AS filtered_correct_results"
 
-    ::User.with(filtered_correct_results: ::ProgressReports::Concepts::ConceptResult.results(teacher, filters))
-      .select(<<-SELECT
-        users.id,
-        users.name,
-        COUNT(filtered_correct_results.*) as total_result_count,
-        SUM(CASE WHEN filtered_correct_results.is_correct = 1 THEN 1 ELSE 0 END) as correct_result_count,
-        SUM(CASE WHEN filtered_correct_results.is_correct = 0 THEN 1 ELSE 0 END) as incorrect_result_count
-      SELECT
-      ).joins('JOIN filtered_correct_results ON users.id = filtered_correct_results.user_id')
+    ::User
+      .select(
+        <<-SQL
+          users.id,
+          users.name,
+          COUNT(filtered_correct_results.*) AS total_result_count,
+          SUM(CASE WHEN filtered_correct_results.is_correct = 1 THEN 1 ELSE 0 END) AS correct_result_count,
+          SUM(CASE WHEN filtered_correct_results.is_correct = 0 THEN 1 ELSE 0 END) AS incorrect_result_count
+        SQL
+      )
+      .joins("JOIN #{filtered_correct_results} ON users.id = filtered_correct_results.user_id")
       .group('users.id')
-      .order("#{last_name} asc, users.name asc")
+      .order("#{last_name} ASC, users.name ASC")
   end
 end

--- a/services/QuillLMS/app/queries/progress_reports/standards/classroom.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/classroom.rb
@@ -4,17 +4,28 @@ class ProgressReports::Standards::Classroom
   end
 
   def results(filters)
-    ::Classroom.with(user_info: ProgressReports::Standards::Student.new(@teacher).results(filters))
-      .select("
-        classrooms.name as name,
-        classrooms.id as id,
-        COUNT(DISTINCT(user_info.id)) as total_student_count,
-        #{ProficiencyEvaluator.proficient_and_not_sql}"
+    user_info_query = ProgressReports::Standards::Student.new(@teacher).results(filters).to_sql
+    user_info = "( #{user_info_query} ) AS user_info"
+
+    ::Classroom
+      .select(
+        <<-SQL
+          classrooms.name AS name,
+          classrooms.id AS id,
+          COUNT(DISTINCT(user_info.id)) AS total_student_count,
+          #{ProficiencyEvaluator.proficient_and_not_sql}
+        SQL
       )
-      .joins("INNER JOIN classrooms_teachers ON classrooms_teachers.user_id = #{@teacher.id} AND classrooms_teachers.classroom_id = classrooms.id")
+      .joins(
+        <<-SQL
+          JOIN classrooms_teachers
+            ON classrooms_teachers.user_id = #{@teacher.id}
+           AND classrooms_teachers.classroom_id = classrooms.id
+        SQL
+      )
       .joins(:students)
-      .joins('INNER JOIN user_info ON user_info.id = users.id')
-      .order("classrooms.name asc")
+      .joins("JOIN #{user_info} ON user_info.id = users.id")
+      .order("classrooms.name ASC")
       .group("classrooms.id")
   end
 end

--- a/services/QuillLMS/app/queries/progress_reports/standards/new_student.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/new_student.rb
@@ -5,68 +5,98 @@ class ProgressReports::Standards::NewStudent
   end
 
   def results(filters)
-    standard_id = filters ? filters["standard_id"] : nil
-    classroom_id = filters ? filters["classroom_id"] : nil
-    results = ::User.with(best_activity_sessions:
-     ("SELECT activity_sessions.*, activities.standard_id FROM activity_sessions
-          JOIN classroom_units ON activity_sessions.classroom_unit_id = classroom_units.id
-          JOIN activities ON activity_sessions.activity_id = activities.id
-          JOIN classrooms ON classroom_units.classroom_id = classrooms.id
-          JOIN classrooms_teachers ON classrooms.id = classrooms_teachers.classroom_id AND classrooms_teachers.user_id = #{@teacher.id}
-          WHERE activity_sessions.is_final_score
-          #{standard_conditional(standard_id)}
-          #{classroom_conditional(classroom_id)}
-          AND activity_sessions.visible
-          AND classroom_units.visible")).with(best_per_standard_user: ProgressReports::Standards::Student.best_per_standard_user).select(<<-SQL
-        users.id,
-        users.name,
-        #{User.sorting_name_sql},
-        AVG(best_activity_sessions.percentage) as average_score,
-        COUNT(DISTINCT(best_activity_sessions.standard_id)) as total_standard_count,
-        COUNT(DISTINCT(best_activity_sessions.activity_id)) as total_activity_count,
-        COALESCE(AVG(proficient_count.standard_count), 0)::integer as proficient_standard_count,
-        COALESCE(AVG(not_proficient_count.standard_count), 0)::integer as not_proficient_standard_count
-          SQL
-    ).joins('JOIN best_activity_sessions ON users.id = best_activity_sessions.user_id')
-      .joins("
-      LEFT JOIN (
-          select COUNT(DISTINCT(standard_id)) as standard_count, user_id
-           from best_per_standard_user
-           where avg_score_in_standard >= #{@proficiency_cutoff}
-           group by user_id
-        ) as proficient_count ON proficient_count.user_id = users.id"
-      ).joins(<<-JOINS
-      LEFT JOIN (
-          select COUNT(DISTINCT(standard_id)) as standard_count, user_id
-           from best_per_standard_user
-           where avg_score_in_standard < #{@proficiency_cutoff}
-           group by user_id
-        ) as not_proficient_count ON not_proficient_count.user_id = users.id
-      JOINS
+    @standard_id = filters ? filters["standard_id"] : nil
+    @classroom_id = filters ? filters["classroom_id"] : nil
+
+    ::User
+      .select(
+        <<-SQL
+          users.id,
+          users.name,
+          #{User.sorting_name_sql},
+          AVG(best_activity_sessions.percentage) AS average_score,
+          COUNT(DISTINCT(best_activity_sessions.standard_id)) AS total_standard_count,
+          COUNT(DISTINCT(best_activity_sessions.activity_id)) AS total_activity_count,
+          COALESCE(AVG(proficient_count.standard_count), 0)::integer AS proficient_standard_count,
+          COALESCE(AVG(not_proficient_count.standard_count), 0)::integer AS not_proficient_standard_count
+        SQL
       )
+      .joins("JOIN #{best_activity_sessions} ON users.id = best_activity_sessions.user_id")
+      .joins("LEFT JOIN #{proficient_count} ON proficient_count.user_id = users.id")
+      .joins("LEFT JOIN #{not_proficient_count} ON not_proficient_count.user_id = users.id")
       .group('users.id, sorting_name')
       .order('sorting_name asc')
-      results
   end
 
-  # Helper method used as CTE in other queries. Do not attempt to use this by itself
-  def self.best_per_standard_user
-    <<-BEST
-      select standard_id, user_id, AVG(percentage) as avg_score_in_standard
-      from best_activity_sessions
-      group by standard_id, user_id
-    BEST
+  private def best_activity_sessions
+    <<-SQL
+      (
+        SELECT activity_sessions.*, activities.standard_id
+        FROM activity_sessions
+        JOIN classroom_units
+          ON activity_sessions.classroom_unit_id = classroom_units.id
+        JOIN activities
+          ON activity_sessions.activity_id = activities.id
+        JOIN classrooms
+          ON classroom_units.classroom_id = classrooms.id
+        JOIN classrooms_teachers
+          ON classrooms.id = classrooms_teachers.classroom_id
+          AND classrooms_teachers.user_id = #{@teacher.id}
+        WHERE activity_sessions.is_final_score
+          #{standard_conditional}
+          #{classroom_conditional}
+          AND activity_sessions.visible
+          AND classroom_units.visible
+      ) AS best_activity_sessions
+    SQL
   end
 
-  def standard_conditional(standard_id)
-    if standard_id
-      "AND activities.standard_id = #{standard_id}"
-    end
+  private def best_per_standard_user
+    <<-SQL
+      (
+        SELECT
+          standard_id,
+          user_id,
+          AVG(percentage) AS avg_score_in_standard
+        FROM #{best_activity_sessions}
+        GROUP By standard_id, user_id
+      ) AS best_per_standard_user
+    SQL
   end
 
-  def classroom_conditional(classroom_id)
-    if classroom_id && classroom_id != 0 && classroom_id != '0'
-      "AND classrooms.id = #{classroom_id}"
+  private def proficient_count
+    <<-SQL
+      (
+        SELECT
+          COUNT(DISTINCT(standard_id)) AS standard_count,
+          user_id
+        FROM #{best_per_standard_user}
+        WHERE avg_score_in_standard >= #{@proficiency_cutoff}
+        GROUP BY user_id
+      ) AS proficient_count
+    SQL
+  end
+
+  private def not_proficient_count
+    <<-SQL
+      (
+        SELECT
+          COUNT(DISTINCT(standard_id)) AS standard_count,
+          user_id
+        FROM #{best_per_standard_user}
+        WHERE avg_score_in_standard < #{@proficiency_cutoff}
+        GROUP BY user_id
+      ) AS not_proficient_count
+    SQL
+  end
+
+  private def standard_conditional
+    "AND activities.standard_id = #{@standard_id}" if @standard_id
+  end
+
+  private def classroom_conditional
+    if @classroom_id && @classroom_id != 0 && @classroom_id != '0'
+      "AND classrooms.id = #{@classroom_id}"
     end
   end
 end

--- a/services/QuillLMS/app/queries/progress_reports/standards/standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/standard.rb
@@ -5,37 +5,67 @@ class ProgressReports::Standards::Standard
   end
 
   def results(filters)
-    best_activity_sessions = ProgressReports::Standards::ActivitySession.new(@teacher).results(filters)
-    ::Standard.from_cte('best_activity_sessions', best_activity_sessions)
-      .with(best_per_standard_user: ProgressReports::Standards::Student.best_per_standard_user)
-      .select(<<-SQL
-        standards.id,
-        standards.name,
-        standard_levels.name as standard_level_name,
-        AVG(best_activity_sessions.percentage) as average_score,
-        COUNT(DISTINCT(best_activity_sessions.activity_id)) as total_activity_count,
-        COUNT(DISTINCT(best_activity_sessions.user_id)) as total_student_count,
-        COALESCE(AVG(proficient_count.user_count), 0)::integer as proficient_student_count,
-        COALESCE(AVG(not_proficient_count.user_count), 0)::integer as not_proficient_student_count
-      SQL
-    ).joins('JOIN standards ON standards.id = best_activity_sessions.standard_id')
-      .joins('JOIN standard_levels ON standard_levels.id = standards.standard_level_id')
-      .joins("LEFT JOIN (
-          select COUNT(DISTINCT(user_id)) as user_count, standard_id
-           from best_per_standard_user
-           where avg_score_in_standard >= #{@proficiency_cutoff}
-           group by standard_id
-        ) as proficient_count ON proficient_count.standard_id = standards.id"
-      ).joins(<<-JOINS
-      LEFT JOIN (
-          select COUNT(DISTINCT(user_id)) as user_count, standard_id
-           from best_per_standard_user
-           where avg_score_in_standard < #{@proficiency_cutoff}
-           group by standard_id
-        ) as not_proficient_count ON not_proficient_count.standard_id = standards.id
-      JOINS
+    best_activity_sessions_query = ProgressReports::Standards::ActivitySession.new(@teacher).results(filters).to_sql
+    @best_activity_sessions = "( #{best_activity_sessions_query} ) AS best_activity_sessions"
+
+    ::Standard
+      .select(
+        <<-SQL
+          standards.id,
+          standards.name,
+          standard_levels.name AS standard_level_name,
+          AVG(best_activity_sessions.percentage) AS average_score,
+          COUNT(DISTINCT(best_activity_sessions.activity_id)) AS total_activity_count,
+          COUNT(DISTINCT(best_activity_sessions.user_id)) AS total_student_count,
+          COALESCE(AVG(proficient_count.user_count), 0)::integer AS proficient_student_count,
+          COALESCE(AVG(not_proficient_count.user_count), 0)::integer AS not_proficient_student_count
+        SQL
       )
+      .joins('JOIN standard_levels ON standard_levels.id = standards.standard_level_id')
+      .joins("JOIN #{@best_activity_sessions} ON standards.id = best_activity_sessions.standard_id")
+      .joins("LEFT JOIN #{not_proficient_count} ON not_proficient_count.standard_id = standards.id")
+      .joins("LEFT JOIN #{proficient_count} ON proficient_count.standard_id = standards.id")
       .group('standards.id, standard_levels.name')
-      .order('standards.name asc')
+      .order('standards.name ASC')
+  end
+
+  private def best_per_standard_user
+    <<-SQL
+      (
+        SELECT
+          standard_id,
+          user_id,
+          AVG(percentage) AS avg_score_in_standard
+        FROM #{@best_activity_sessions}
+        GROUP By standard_id, user_id
+      ) AS best_per_standard_user
+    SQL
+  end
+
+  private def proficient_count
+    <<-SQL
+      (
+        SELECT
+          COUNT(DISTINCT(user_id)) AS user_count,
+          standard_id
+        FROM #{best_per_standard_user}
+        WHERE avg_score_in_standard >= #{@proficiency_cutoff}
+        GROUP BY standard_id
+      ) AS proficient_count
+    SQL
+  end
+
+  private def not_proficient_count
+    <<-SQL
+      (
+        SELECT
+          COUNT(DISTINCT(user_id)) AS user_count,
+          standard_id
+        FROM #{best_per_standard_user}
+        WHERE avg_score_in_standard < #{@proficiency_cutoff}
+        GROUP BY standard_id
+      ) AS not_proficient_count
+    SQL
   end
 end
+

--- a/services/QuillLMS/app/queries/progress_reports/standards/unit.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/unit.rb
@@ -4,12 +4,14 @@ class ProgressReports::Standards::Unit
   end
 
   def results(filters)
-    best_activity_sessions = ProgressReports::Standards::ActivitySession.new(@teacher).results(filters)
-    ::Unit.with(best_activity_sessions: best_activity_sessions)
-      .select("units.id as id, units.name as name")
+    best_activity_sessions_query = ProgressReports::Standards::ActivitySession.new(@teacher).results(filters).to_sql
+    best_activity_sessions = "( #{best_activity_sessions_query} ) AS best_activity_sessions"
+
+    ::Unit
+      .select("units.id AS id, units.name AS name")
       .joins('JOIN classroom_units ON classroom_units.unit_id = units.id')
-      .joins('JOIN best_activity_sessions ON best_activity_sessions.classroom_unit_id = classroom_units.id')
+      .joins("JOIN #{best_activity_sessions} ON best_activity_sessions.classroom_unit_id = classroom_units.id")
       .group('units.id')
-      .order("units.created_at asc, units.name asc") # Try order by creation date, fall back to name)
+      .order('units.created_at ASC, units.name ASC')
   end
 end

--- a/services/QuillLMS/app/workers/archive_student_associations_for_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/archive_student_associations_for_classroom_worker.rb
@@ -1,11 +1,10 @@
 class ArchiveStudentAssociationsForClassroomWorker
   include Sidekiq::Worker
-
+  
   def perform(student_id, classroom_id)
-    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).where.contains(assigned_student_ids: [student_id])
-    classroom_units.each do |cu|
-      cu.remove_assigned_student(student_id)
-    end
+    ClassroomUnit
+      .where(classroom_id: classroom_id)
+      .where("classroom_units.assigned_student_ids @> '{?}'", ActiveRecord::Base.connection.quote(student_id))
+      .each { |classroom_unit| classroom_unit.remove_assigned_student(student_id) }
   end
-
 end


### PR DESCRIPTION
## WHAT
This is the first of two parts of removing the `postgres_ext` gem in preparation for the Rails 5 upgrade.

For this PR translates the following ActiveRecord::Relation extensions:

1.  [from_cte](https://github.com/empirical-org/Empirical-Core/blob/6bbf785dd6944fcd1455531f66be97191d2921f0/services/QuillLMS/app/queries/progress_reports/standards/student.rb#L9)
1.  [with](https://github.com/empirical-org/Empirical-Core/blob/6bbf785dd6944fcd1455531f66be97191d2921f0/services/QuillLMS/app/queries/progress_reports/concepts/concept.rb#L8)
1.  [contains](https://github.com/empirical-org/Empirical-Core/blob/6bbf785dd6944fcd1455531f66be97191d2921f0/services/QuillLMS/app/workers/archive_student_associations_for_classroom_worker.rb#L5)

Since the gem is no longer [maintained](https://github.com/DavyJonesLocker/postgres_ext#this-gem-is-no-longer-maintained) for Rails > 5, we will need to remove it and translate all of the method calls to pure ActiveRecord ones.  Gem removal will be a separate PR.

## WHY
This part of the roadmap for upgrading the LMS to Rails 5.0

## HOW
The contains query is translated via the [contains](https://github.com/DavyJonesLocker/postgres_ext/blob/master/docs/querying.md#---array-contains-operator) operator.

The bulk of this PR involves converting the common table expression functionality to pure Rails functionality.  Initially, the approach was to use raw sql containing via `WITH table AS ( [query] )` but that involved using AREL which I decided would be less readable and maintainable for our team.  I found the conversion to subqueries more natural based on the existing codebase.

I'll explain the general pattern I'm based on this [example](https://github.com/empirical-org/Empirical-Core/blob/c0b65e5a4a0050f99e210d4a1d8340cd279e922f/services/QuillLMS/app/models/classroom.rb#L96)

1.  The original assignment looked like: 
```best_activity_sessions = ProgressReports::Standards::ActivitySession.new(owner).results(filters)```

2.  Rename this variable and convert sql string: 
```best_activity_sessions_query = ProgressReports::Standards::ActivitySession.new(owner).results(filters).to_sql```

3.  Construct a subquery string:  
```best_activity_sessions = "( #{best_activity_sessions_query} ) AS best_activity_sessions"```

4.  Insert the subquery into the relevant join: 
```.joins("JOIN #{best_activity_sessions} ON activity_sessions.id = best_activity_sessions.id")```


### Notion Card Links
https://www.notion.so/quill/Remove-gem-postgres_ext-from-LMS-96bf31ec355343e4bb001d6e5c78ea01

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is refactoring.
Have you deployed to Staging? |. YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
