### PR TITLE
Revert "Temporarily remove the Quill 101 webinar banner (#7567)"

### DIFF
--- a/services/QuillLMS/app/models/recurring_banner.rb
+++ b/services/QuillLMS/app/models/recurring_banner.rb
@@ -6,13 +6,13 @@ class RecurringBanner < WebinarBanner
   # RECURRING have the key format DayOfWeek-Hour
 
   WEBINARS = {
-    #'1-16' => {
-    #  title: "Quill 101 is live now!",
-    #  link_display_text: "Register and join.",
-    #  link: "#{ZOOM_URL}/WN_a4Z1_Zs6RSGUWwr_t0V18Q",
-    #  subscription_only: false,
-    #  second_or_fourth_only: false
-    #},
+    '1-16' => {
+      title: "Quill 101 is live now!",
+      link_display_text: "Register and join.",
+      link: "#{ZOOM_URL}/WN_a4Z1_Zs6RSGUWwr_t0V18Q",
+      subscription_only: false,
+      second_or_fourth_only: false
+    },
     '3-10' => {
       title: OFFICE_HOURS_TITLE,
       link_display_text: "Click here to join",

--- a/services/QuillLMS/spec/models/recurring_banner_spec.rb
+++ b/services/QuillLMS/spec/models/recurring_banner_spec.rb
@@ -33,11 +33,11 @@ describe RecurringBanner, type: :model do
     expect(banner.title).to eq(nil)
   end
 
-  #it "does return true for show? when the key does have an associated webinar" do
-  #  time =  DateTime.new(2021,1,4,16,1,0)
-  #  banner = RecurringBanner.new(time)
-  #  expect(banner.show?(true)).to eq(true)
-  #end
+  it "does return true for show? when the key does have an associated webinar" do
+    time =  DateTime.new(2021,1,4,16,1,0)
+    banner = RecurringBanner.new(time)
+    expect(banner.show?(true)).to eq(true)
+  end
 
   it "does not return true for show? when the key falls on a skipped day" do
     time =  DateTime.new(2021,1,18,16,1,0)
@@ -45,11 +45,11 @@ describe RecurringBanner, type: :model do
     expect(banner.show?(true)).to eq(false)
   end
 
-  #it "does return correct link and title when the key does have an associated recurring webinar" do
-  #  time =  DateTime.new(2021,1,4,16,1,0)
-  #  banner = RecurringBanner.new(time)
-  #  expect(banner.title).to eq("Quill 101 is live now!")
-  #  expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_a4Z1_Zs6RSGUWwr_t0V18Q")
-  #end
+  it "does return correct link and title when the key does have an associated recurring webinar" do
+    time =  DateTime.new(2021,1,4,16,1,0)
+    banner = RecurringBanner.new(time)
+    expect(banner.title).to eq("Quill 101 is live now!")
+    expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_a4Z1_Zs6RSGUWwr_t0V18Q")
+  end
 
 end


### PR DESCRIPTION
## WHAT
This reverts commit 8798f3931ae3ed9253d99a9f091b20b44634199a.  It adds the "Quill 101" webinar banner back to our scheduled rotation.
## WHY
Partnerships only needed the banner to come down briefly.
## HOW
Just revert the code that removed the banner

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
