### PR TITLE
get lessons server running locally and fix frontend bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/customize/chooseEdition.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/customize/chooseEdition.tsx
@@ -26,7 +26,7 @@ import {
 import EditionNamingModal from './editionNamingModal';
 import EditionRow from './editionRow';
 import SignupModal from '../classroomLessons/teach/signupModal';
-import CustomizeNavbar from '../navbar/customizeNavbar'
+import CreateCustomizedEditionNavbar from '../navbar/createCustomizedEditionNavbar'
 import { getParameterByName } from '../../libs/getParameterByName';
 import * as CustomizeIntF from '../../interfaces/customize';
 
@@ -300,7 +300,7 @@ class ChooseEdition extends React.Component<any, any> {
 
   render() {
     return (<div>
-      <CustomizeNavbar />
+      <CreateCustomizedEditionNavbar />
       <div className="choose-edition customize-page">
         {this.renderSignupModal()}
         {this.renderBackButton()}

--- a/services/QuillLessonsServer/package.json
+++ b/services/QuillLessonsServer/package.json
@@ -7,7 +7,7 @@
     "build": "babel src -d lib",
     "start": "npm run build && node lib/index.js",
     "serve": "node lib/index.js",
-    "start:dev": "./rethink_local.sh start; PORT=3200 RETHINKDB_HOST=localhost RETHINK_DB_PORT=28015 nodemon src/index.js --exec babel-node src/index.js; ./rethink_local.sh stop",
+    "start:dev": "./rethink_local.sh start; PORT=3200 RETHINKDB_HOSTS=localhost:28015 nodemon src/index.js --exec babel-node src/index.js; ./rethink_local.sh stop",
     "test": "jest test"
   },
   "author": "",


### PR DESCRIPTION
## WHAT
Get Lessons Server running locally by updating `package.json` and fix bug where the wrong navbar was being loaded on the Customize Editions index page.

## WHY
So that we can a) run the server and therefore test Lessons locally and b) not show teachers a confusing button that does nothing.

## HOW
Just add the new env variable that we need to the `package.json` run script and update the frontend to pull in the correct component.

### Screenshots
<img width="1440" alt="Screen Shot 2021-05-06 at 10 25 37 AM" src="https://user-images.githubusercontent.com/18669014/117315700-ec9b8380-ae55-11eb-8e72-08aab1587f98.png">
<img width="1440" alt="Screen Shot 2021-05-06 at 10 26 18 AM" src="https://user-images.githubusercontent.com/18669014/117315703-ec9b8380-ae55-11eb-92ea-d30319560f90.png">


### Notion Card Links
https://www.notion.so/quill/We-re-displaying-the-wrong-top-bar-on-the-Launch-Lesson-page-01cb3f08cae64ca580fa10ffd65877de

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
