### PR TITLE
Comprehension/fix concept result correct value

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/libs/conceptResults.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/libs/conceptResults.ts
@@ -32,7 +32,7 @@ export const generateConceptResults = (currentActivity, submittedResponses) => {
         metadata: {
           answer: response.entry,
           attemptNumber: attempt,
-          correct: response.optimal,
+          correct: response.optimal ? 1 : 0,
           directions: (attempt == 1) ? COMPREHENSION_DIRECTIONS : responses[index - 1].feedback,
           prompt: prompt.text,
           questionNumber: conjunctionToQuestionNumber[prompt.conjunction],

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.data.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.data.ts
@@ -116,7 +116,7 @@ export const expectedPayload = {
       "metadata":{
         "answer":"Type an answer because some response may be provided.",
         "attemptNumber":1,
-        "correct":true,
+        "correct":1,
         "directions":"Complete this sentence",
         "prompt":"Type an answer because",
         "questionNumber":1,
@@ -129,7 +129,7 @@ export const expectedPayload = {
       "metadata":{
         "answer":"Type an answer, but some response must be provided.",
         "attemptNumber":1,
-        "correct":false,
+        "correct":0,
         "directions":"Complete this sentence",
         "prompt":"Type an answer, but",
         "questionNumber":2,
@@ -142,7 +142,7 @@ export const expectedPayload = {
       "metadata":{
         "answer":"Type an answer, but some response may be provided.",
         "attemptNumber":2,
-        "correct":true,
+        "correct":1,
         "directions":"Remember, for this activity, avoid giving your opinion—your thoughts, feelings, or suggestions. Rewrite your response without the word must, and make sure that your response expresses an idea from the text.",
         "prompt":"Type an answer, but",
         "questionNumber":2,
@@ -155,7 +155,7 @@ export const expectedPayload = {
       "metadata":{
         "answer":"Type an answer, so some response should be provided.",
         "attemptNumber":1,
-        "correct":false,
+        "correct":0,
         "directions":"Complete this sentence",
         "prompt":"Type an answer, so",
         "questionNumber":3,
@@ -168,7 +168,7 @@ export const expectedPayload = {
       "metadata":{
         "answer":"Type an answer, so some response shud be provided.",
         "attemptNumber":2,
-        "correct":true,
+        "correct":1,
         "directions":"Remember, for this activity, avoid giving your opinion—your thoughts, feelings, or suggestions. Rewrite your response without the word should, and make sure that your response expresses an idea from the text.",
         "prompt":"Type an answer, so",
         "questionNumber":3,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report.tsx
@@ -49,7 +49,7 @@ export class StudentReport extends React.Component<RouteComponentProps, StudentR
     const studentData = this.selectedStudent(students);
     const concept_results = _.sortBy(studentData.concept_results, 'question_number')
     return concept_results.map((question: QuestionData, index: number) => {
-      if (studentData.activity_classification === 'connect' || studentData.activity_classification === 'sentence') {
+      if (studentData.activity_classification === 'connect' || studentData.activity_classification === 'sentence' || studentData.activity_classification === 'comprehension') {
         return <ConnectStudentReportBox boxNumber={index + 1} key={index} questionData={question} />
       }
       return <StudentReportBox boxNumber={index + 1} key={index} questionData={question} />


### PR DESCRIPTION
## WHAT
A couple more small fixes for LMS reporting on Comprehension activities
## WHY
We want these reports to work for Comprehension
## HOW
- Use `1` instead of `true` for "correct" values since the back-end does an explicit comparison of `== 1` instead of something truthy
- Make sure to load the "larger" "Connect" report box for Comprehension activities
- 
### Notion Card Links
https://www.notion.so/quill/LMS-Student-Report-Bugs-49bcbe5830d340aca8f88d25e8c8ea5b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
