### PR TITLE
LMS Rails 5.0 Prework - Remove sinatra dependency

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -90,7 +90,6 @@ gem 'redis', '3.3.5'
 gem 'redis-namespace'
 gem 'redis-rails'
 gem 'redis-rack-cache'
-gem 'sinatra', '>= 1.3.0', :require => nil
 
 # JS/APP/UI
 gem 'turbolinks'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -691,10 +691,6 @@ GEM
     simplecov-json (0.2)
       json
       simplecov
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -901,7 +897,6 @@ DEPENDENCIES
   sidekiq-retries
   simplecov
   simplecov-json
-  sinatra (>= 1.3.0)
   slim-rails
   spring
   spring-commands-rspec


### PR DESCRIPTION
## WHAT
The `sidekiq` Web UI used to require `sinatra` as a dependency, but it was eventually [removed](https://github.com/mperham/sidekiq/pull/3075).  

## WHY
This particular version of `sinatra` causes issues with the Rails 5.0 upgrade.  Based on the [commit](https://github.com/empirical-org/Empirical-Core/commit/5e33300fb39d5d96187919b251ed4dac041ebee3) it appears its inclusion in our codebase was related to Sidekiq Web UI.  We should get rid of the dependency if its not required.

## HOW
Remove its Gemfile entry

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No. 
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
