### PR TITLE
show actions menu in teacher section on classes page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_teacher_section.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_teacher_section.test.jsx.snap
@@ -41,6 +41,11 @@ exports[`ClassroomTeacherSection component should render 1`] = `
           "name": "Status",
           "width": "52px",
         },
+        Object {
+          "attribute": "actions",
+          "isActions": true,
+          "name": "Actions",
+        },
       ]
     }
     rows={

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_teacher_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_teacher_section.tsx
@@ -27,6 +27,10 @@ const activeHeaders = [
     width: '52px',
     name: 'Status',
     attribute: 'status'
+  }, {
+    name: 'Actions',
+    attribute: 'actions',
+    isActions: true
   }
 ]
 


### PR DESCRIPTION
## WHAT
Make sure we're showing the Actions menu in the teacher section on the classes page.

## WHY
Teachers should be able to add and remove coteachers from this page.

## HOW
Just make sure we have the header so the column actually shows.

### Screenshots
<img width="1013" alt="Screen Shot 2021-05-11 at 9 50 40 AM" src="https://user-images.githubusercontent.com/18669014/117826708-5f35a600-b23e-11eb-8388-5347569114d5.png">

### Notion Card Links
https://www.notion.so/quill/Teacher-section-on-classes-page-not-showing-Actions-dropdown-be00a8465a7f4b07a6cf1da8337c83d1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
