### PR TITLE
update how class codes display for Clever and Google Classrooms

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -146,7 +146,6 @@
         margin-right: 8px;
         .text-and-icon-wrapper {
           display: inline-flex;
-          margin-right: 8px;
           align-items: center;
         }
         &.bullet {

--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -144,9 +144,17 @@
         line-height: 1.57;
         color: #646464;
         margin-right: 8px;
+        .text-and-icon-wrapper {
+          display: inline-flex;
+          margin-right: 8px;
+          align-items: center;
+        }
         &.bullet {
           color: #bdbdbd;
         }
+      }
+      .quill-tooltip b {
+        text-decoration: underline;
       }
     }
     .class-settings, .students-section {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as moment from 'moment'
 
-import { Tooltip } from '../../../Shared/index'
+import { Tooltip, helpIcon, } from '../../../Shared/index'
 
 import ClassroomStudentSection from './classroom_student_section'
 import ClassroomTeacherSection from './classroom_teacher_section'
@@ -72,15 +72,15 @@ export default class Classroom extends React.Component<ClassroomProps, Classroom
     const { code, google_classroom_id, clever_id, } = classroom
     if (google_classroom_id) {
       return (<Tooltip
-        tooltipText={`Add students by syncing with Google Classroom. Experiencing sync issues? You can add students with the class code '${code}'`}
-        tooltipTriggerText="Class code: N/A"
+        tooltipText={`Class code: <b>${code}</b><br/><br/>The easiest way for your students to join your class is through Google Classroom. However, if your students are not syncing, try the class code.`}
+        tooltipTriggerText={<div className="text-and-icon-wrapper"><span>Class code:&nbsp;</span><img alt={helpIcon.alt} src={helpIcon.src} /></div>}
       />)
     }
 
     if (clever_id) {
       return (<Tooltip
-        tooltipText={`Add students through Clever. Experiencing sync issues? You can add students with the class code '${code}'`}
-        tooltipTriggerText="Class code: N/A"
+        tooltipText={`Class code: <b>${code}</b><br/><br/>The easiest way for your students to join your class is through Clever. However, if your students are not syncing, try the class code.`}
+        tooltipTriggerText={<div className="text-and-icon-wrapper"><span>Class code:&nbsp;</span><img alt={helpIcon.alt} src={helpIcon.src} /></div>}
       />)
     }
 


### PR DESCRIPTION
## WHAT
Update how class codes display for Clever and Google Classrooms.

## WHY
Teachers were confused by the "N/A" when they needed to use a class code with their students.

## HOW
Just React and CSS.

### Screenshots
<img width="977" alt="Screen Shot 2021-05-10 at 3 33 18 PM" src="https://user-images.githubusercontent.com/18669014/117828230-a4a6a300-b23f-11eb-8260-93d2f09a8a8d.png">
<img width="1440" alt="Screen Shot 2021-05-10 at 3 33 13 PM" src="https://user-images.githubusercontent.com/18669014/117828232-a4a6a300-b23f-11eb-87c1-8f0c9a063c8d.png">


### Notion Card Links
https://www.notion.so/quill/Update-how-we-display-class-codes-for-Google-and-Clever-classes-d24e3274d954487ab2d8d16459aa5453

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
