### PR TITLE
LMS Rails 5.0 Prework - Remove to_json calls from some factory initializations

### DIFF
--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -204,9 +204,17 @@ describe Api::V1::ActivitiesController, type: :controller do
     let!(:activity_session_1) { create(:activity_session, activity: activity) }
     let!(:activity_session_2) { create(:activity_session, activity: activity) }
     let!(:activity_session_3) { create(:activity_session, activity: activity) }
-    let!(:concept_result_1) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1}.to_json)}
-    let!(:concept_result_2) { create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75}.to_json)}
-    let!(:concept_result_3) { create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0}.to_json)}
+    let!(:concept_result_1) do
+      create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1})
+    end
+
+    let!(:concept_result_2) do
+       create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75})
+    end
+
+    let!(:concept_result_3) do
+       create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0})
+    end
 
     before do
       ENV['DEFAULT_URL'] = 'https://quill.org'

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -1,15 +1,50 @@
 require 'rails_helper'
 
 describe QuestionHealthDashboard, type: :model do
-
   let!(:activity) { create(:activity) }
   let!(:activity_session_1) { create(:activity_session, activity: activity) }
   let!(:activity_session_2) { create(:activity_session, activity: activity) }
   let!(:activity_session_3) { create(:activity_session, activity: activity) }
-  let!(:concept_result_1) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1}.to_json)}
-  let!(:concept_result_2) { create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75}.to_json)}
-  let!(:concept_result_3) { create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0}.to_json)}
-  let!(:concept_result_4) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 2, questionScore: 1}.to_json)}
+
+  let!(:concept_result_1) do
+    create(:concept_result,
+      activity_session: activity_session_1,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 1
+      }
+    )
+  end
+
+  let!(:concept_result_2) do
+     create(:concept_result,
+      activity_session: activity_session_2,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 0.75
+      }
+    )
+  end
+
+  let!(:concept_result_3) do
+    create(:concept_result,
+      activity_session: activity_session_3,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 0
+      }
+    )
+  end
+
+  let!(:concept_result_4) do
+    create(:concept_result,
+      activity_session: activity_session_1,
+      metadata: {
+        questionNumber: 2,
+        questionScore: 1
+      }
+    )
+  end
 
   describe '#percent_reached_optimal_for_question' do
     it 'calculates the percent of question plays that resulted in an optimal response' do

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -9,9 +9,36 @@ RSpec.describe QuestionHealthObj, type: :model do
     let!(:activity_session_1) { create(:activity_session, activity: activity) }
     let!(:activity_session_2) { create(:activity_session, activity: activity) }
     let!(:activity_session_3) { create(:activity_session, activity: activity) }
-    let!(:concept_result_1) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1}.to_json)}
-    let!(:concept_result_2) { create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75}.to_json)}
-    let!(:concept_result_3) { create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0}.to_json)}
+
+    let!(:concept_result_1) do
+       create(:concept_result,
+        activity_session: activity_session_1,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 1
+        }
+      )
+    end
+
+    let!(:concept_result_2) do
+       create(:concept_result,
+        activity_session: activity_session_2,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 0.75
+        }
+      )
+    end
+
+    let!(:concept_result_3) do
+      create(:concept_result,
+        activity_session: activity_session_3,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 0
+        }
+      )
+    end
 
     before do
       ENV['DEFAULT_URL'] = 'https://quill.org'

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -4,22 +4,95 @@ describe 'SerializeActivityHealth' do
   let!(:question) { create(:question)}
   let!(:another_question) { create(:question)}
   let!(:connect) { create(:activity_classification, key: ActivityClassification::CONNECT_KEY) }
-  let!(:activity) { create(:activity, activity_classification_id: connect.id, data: {questions: [{key: question.uid},{key: another_question.uid}]}.to_json) }
+
+  let!(:activity) do
+    create(:activity,
+      activity_classification_id: connect.id,
+      data: {
+        questions: [
+          {key: question.uid},
+          {key: another_question.uid}
+        ]
+      }
+    )
+  end
+
   let!(:content_partner) { create(:content_partner, activities: [activity])}
   let!(:start_time) { Time.now - 1.day }
-  let!(:activity_session_1) { create(:activity_session, activity: activity, state: "finished", started_at: DateTime.new(2021,1,1,4,0,0), completed_at: DateTime.new(2021,1,1,4,5,0)) }
-  let!(:activity_session_2) { create(:activity_session, activity: activity, state: "finished", started_at: start_time, completed_at: start_time + 10.minutes) }
-  let!(:activity_session_3) { create(:activity_session, activity: activity, state: "finished", started_at: start_time, completed_at: start_time + 20.minutes) }
-  let!(:diagnostic) { create(:diagnostic_activity)}
-  let!(:unit_template) { create(:unit_template)}
-  let!(:activities_unit_template) { create(:activities_unit_template, unit_template: unit_template, activity: activity)}
+
+  let!(:activity_session_1) do
+    create(:activity_session,
+      activity: activity,
+      state: "finished",
+      started_at: DateTime.new(2021,1,1,4,0,0),
+      completed_at: DateTime.new(2021,1,1,4,5,0)
+    )
+  end
+
+  let!(:activity_session_2) do
+    create(:activity_session,
+      activity: activity,
+      state: "finished",
+      started_at: start_time,
+      completed_at: start_time + 10.minutes
+    )
+  end
+
+  let!(:activity_session_3) do
+     create(:activity_session,
+      activity: activity,
+      state: "finished",
+      started_at: start_time,
+      completed_at: start_time + 20.minutes
+    )
+  end
+
+  let!(:diagnostic) { create(:diagnostic_activity) }
+  let!(:unit_template) { create(:unit_template) }
+  let!(:activities_unit_template) { create(:activities_unit_template, unit_template: unit_template, activity: activity) }
   let!(:sample_unit) { create(:unit, unit_template: unit_template)}
   let!(:unit_activity) { create(:unit_activity, unit: sample_unit, activity: activity)}
   let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
-  let!(:concept_result_1) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1}.to_json)}
-  let!(:concept_result_2) { create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75}.to_json)}
-  let!(:concept_result_3) { create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0}.to_json)}
-  let!(:concept_result_4) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 2, questionScore: 1}.to_json)}
+
+  let!(:concept_result_1) do
+     create(:concept_result,
+      activity_session: activity_session_1,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 1
+      }
+    )
+  end
+
+  let!(:concept_result_2) do
+    create(:concept_result,
+      activity_session: activity_session_2,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 0.75
+      }
+    )
+  end
+
+  let!(:concept_result_3) do
+    create(:concept_result,
+      activity_session: activity_session_3,
+      metadata: {
+        questionNumber: 1,
+        questionScore: 0
+      }
+    )
+  end
+
+  let!(:concept_result_4) do
+    create(:concept_result,
+      activity_session: activity_session_1,
+      metadata: {
+        questionNumber: 2,
+        questionScore: 1
+      }
+    )
+  end
 
   before do
     ENV['DEFAULT_URL'] = 'https://quill.org'
@@ -38,7 +111,9 @@ describe 'SerializeActivityHealth' do
     expect(data[:activity_categories]).to eq(activity.activity_categories.pluck(:name).sort)
     expect(data[:content_partners]).to eq([content_partner.name])
     expect(data[:tool]).to eq("connect")
-    expect(data[:activity_packs]).to eq(activity.unit_templates.map {|ut| {id: ut.id, name: ut.name}}.sort_by{|h| h[:name]})
+    expect(data[:activity_packs])
+      .to eq(activity.unit_templates.map {|ut| {id: ut.id, name: ut.name}}.sort_by{|h| h[:name]})
+
     expect(data[:diagnostics]).to eq([diagnostic.name])
   end
 

--- a/services/QuillLMS/spec/support/shared/concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/concept_progress_report.rb
@@ -34,65 +34,93 @@ shared_context 'Concept Progress Report' do
                                         ) }
 
 
-  let!(:correct_writing_result1) { create(:concept_result,
-    activity_session: activity_session,
-    concept: writing_concept,
-    metadata: {
-      "correct" => 1
-    }) }
+  let!(:correct_writing_result1) do
+    create(:concept_result,
+      activity_session: activity_session,
+      concept: writing_concept,
+      metadata: {
+        "correct" => 1
+      }
+    )
+  end
 
-  let!(:correct_writing_result2) { create(:concept_result,
-    activity_session: activity_session,
-    concept: writing_concept,
-    metadata: {
-      "correct" => 1
-    }) }
+  let!(:correct_writing_result2) do
+    create(:concept_result,
+      activity_session: activity_session,
+      concept: writing_concept,
+      metadata: {
+        "correct" => 1
+      }
+    )
+  end
 
-  let!(:incorrect_writing_result) { create(:concept_result,
-    activity_session: activity_session,
-    concept: writing_concept,
-    metadata: {
-      "correct" => 0
-    }) }
+  let!(:incorrect_writing_result) do
+    create(:concept_result,
+      activity_session: activity_session,
+      concept: writing_concept,
+      metadata: {
+        "correct" => 0
+      }
+    )
+  end
 
-  let!(:correct_grammar_result) { create(:concept_result,
-    activity_session: activity_session,
-    concept: grammar_tag,
-    metadata: {
-      "correct" => 1
-    }) }
+  let!(:correct_grammar_result) do
+    create(:concept_result,
+      activity_session: activity_session,
+      concept: grammar_tag,
+      metadata: {
+        "correct" => 1
+      }
+    )
+  end
 
-  let!(:incorrect_grammar_result) { create(:concept_result,
-    activity_session: activity_session,
-    concept: grammar_tag,
-    metadata: {
-      "correct" => 0
-    }) }
+  let!(:incorrect_grammar_result) do
+    create(:concept_result,
+      activity_session: activity_session,
+      concept: grammar_tag,
+      metadata: {
+        "correct" => 0
+      }
+    )
+  end
 
   # Should not be visible on the report
   let!(:other_student) { create(:student) }
   let!(:other_classroom) { create(:classroom) }
   let!(:other_teacher) { other_classroom.owner }
   let!(:other_unit) { create(:unit) }
-  let!(:other_classroom_unit) { create(:classroom_unit,
-    classroom: other_classroom,
-    unit: other_unit
-  )}
-  let!(:other_unit_activity) { create(:unit_activity,
-    unit: other_unit,
-    activity: activity
-  )}
-  let!(:other_activity_session) { create(:activity_session,
-    classroom_unit: other_classroom_unit,
-    user: other_student,
-    state: 'finished',
-    percentage: 0.75) }
-  let!(:other_grammar_result) { create(:concept_result,
-    activity_session: other_activity_session,
-    concept: writing_concept,
-    metadata: {
-      "correct" => 1
-    }) }
+  let!(:other_classroom_unit) do
+    create(:classroom_unit,
+      classroom: other_classroom,
+      unit: other_unit
+    )
+  end
+
+  let!(:other_unit_activity) do
+    create(:unit_activity,
+      unit: other_unit,
+      activity: activity
+    )
+  end
+
+  let!(:other_activity_session) do
+     create(:activity_session,
+      classroom_unit: other_classroom_unit,
+      user: other_student,
+      state: 'finished',
+      percentage: 0.75
+    )
+  end
+
+  let!(:other_grammar_result) do
+    create(:concept_result,
+      activity_session: other_activity_session,
+      concept: writing_concept,
+      metadata: {
+        "correct" => 1
+      }
+    )
+  end
 
   let!(:writing_results) { [correct_writing_result1, correct_writing_result2, incorrect_writing_result] }
   let!(:grammar_results) { [correct_grammar_result, incorrect_grammar_result] }

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -7,21 +7,91 @@ describe PopulateActivityHealthWorker do
     let!(:question) { create(:question)}
     let!(:another_question) { create(:question)}
     let!(:connect) { create(:activity_classification, key: ActivityClassification::CONNECT_KEY) }
-    let!(:activity) { create(:activity, activity_classification_id: connect.id, data: {questions: [{key: question.uid},{key: another_question.uid}]}.to_json) }
+    let!(:activity) do
+       create(:activity,
+        activity_classification_id: connect.id,
+        data: {
+          questions: [
+            {key: question.uid},
+            {key: another_question.uid}
+          ]
+        }
+      )
+    end
+
     let!(:content_partner) { create(:content_partner, activities: [activity])}
-    let!(:activity_session_1) { create(:activity_session, activity: activity, started_at: DateTime.new(2021,1,1,4,0,0), completed_at: DateTime.new(2021,1,1,4,5,0)) }
-    let!(:activity_session_2) { create(:activity_session, activity: activity, started_at: DateTime.new(2021,1,2,4,0,0), completed_at: DateTime.new(2021,1,2,4,10,0)) }
-    let!(:activity_session_3) { create(:activity_session, activity: activity, started_at: DateTime.new(2021,1,3,4,0,0), completed_at: DateTime.new(2021,1,3,4,20,0)) }
+    let!(:activity_session_1) do
+      create(:activity_session,
+        activity: activity,
+        started_at: DateTime.new(2021,1,1,4,0,0),
+        completed_at: DateTime.new(2021,1,1,4,5,0)
+      )
+    end
+
+    let!(:activity_session_2) do
+      create(:activity_session,
+        activity: activity,
+        started_at: DateTime.new(2021,1,2,4,0,0),
+        completed_at: DateTime.new(2021,1,2,4,10,0)
+      )
+    end
+
+    let!(:activity_session_3) do
+      create(:activity_session,
+        activity: activity,
+        started_at: DateTime.new(2021,1,3,4,0,0),
+        completed_at: DateTime.new(2021,1,3,4,20,0)
+      )
+    end
+
     let!(:diagnostic) { create(:diagnostic_activity)}
     let!(:unit_template) { create(:unit_template)}
-    let!(:activities_unit_template) { create(:activities_unit_template, unit_template: unit_template, activity: activity)}
+    let!(:activities_unit_template) do
+       create(:activities_unit_template, unit_template: unit_template, activity: activity)
+    end
     let!(:sample_unit) { create(:unit, unit_template: unit_template)}
     let!(:unit_activity) { create(:unit_activity, unit: sample_unit, activity: activity)}
     let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
-    let!(:concept_result_1) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 1, questionScore: 1}.to_json)}
-    let!(:concept_result_2) { create(:concept_result, activity_session: activity_session_2, metadata: {questionNumber: 1, questionScore: 0.75}.to_json)}
-    let!(:concept_result_3) { create(:concept_result, activity_session: activity_session_3, metadata: {questionNumber: 1, questionScore: 0}.to_json)}
-    let!(:concept_result_4) { create(:concept_result, activity_session: activity_session_1, metadata: {questionNumber: 2, questionScore: 1}.to_json)}
+
+    let!(:concept_result_1) do
+      create(:concept_result,
+        activity_session: activity_session_1,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 1
+        }
+      )
+    end
+
+    let!(:concept_result_2) do
+      create(:concept_result,
+        activity_session: activity_session_2,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 0.75
+        }
+      )
+    end
+
+    let!(:concept_result_3) do
+      create(:concept_result,
+        activity_session: activity_session_3,
+        metadata: {
+          questionNumber: 1,
+          questionScore: 0
+        }
+      )
+    end
+
+    let!(:concept_result_4) do
+      create(:concept_result,
+        activity_session: activity_session_1,
+        metadata: {
+          questionNumber: 2,
+          questionScore: 1
+        }
+      )
+    end
 
     before do
       ENV['DEFAULT_URL'] = 'https://quill.org'


### PR DESCRIPTION
## WHAT
`ConceptResult` `metadata` and `Activity` `data` fields are `json` and `jsonb` data types respectively.  When creating objects using a factories, calls to `to_json` are not needed since the database should be making the update based on data type.  However, in Rails 5, using `to_json` breaks the due to commit callbacks being [fired](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/activity.rb#L37)

## WHY
This change is required to get specs passing for Rails 5.

## HOW
Remove `to_json` calls in the appropriate places.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is refactoring specs.
Have you deployed to Staging? | NO - these are specs
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
