### PR TITLE
Comprehension internal tools/ add migration to revert rule suborder to integer

### DIFF
--- a/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
@@ -3,11 +3,4 @@ class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
   def change
     change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
   end
-
-  Comprehension::Rule.all.each do |rule|
-    if !rule.suborder.nil?
-      rule.suborder = rule.suborder.to_i
-      rule.save!
-    end
-  end
 end

--- a/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
@@ -5,7 +5,7 @@ class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
   end
 
   Comprehension::Rule.all.each do |rule|
-    if rule.suborder != nil
+    if !rule.suborder.nil?
       rule.suborder = rule.suborder.to_i
       rule.save!
     end

--- a/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
@@ -1,0 +1,13 @@
+# This migration comes from comprehension (originally 20210511160025)
+class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
+  def change
+    change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
+  end
+
+  Comprehension::Rule.all.each do |rule|
+    if rule.suborder != nil
+      rule.suborder = rule.suborder.to_i
+      rule.save!
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.15
--- Dumped by pg_dump version 10.15
+-- Dumped from database version 10.16
+-- Dumped by pg_dump version 10.16
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1507,10 +1507,11 @@ CREATE TABLE public.comprehension_rules (
     universal boolean NOT NULL,
     rule_type character varying NOT NULL,
     optimal boolean NOT NULL,
-    suborder text,
-    concept_uid character varying,
+    suborder integer,
+    concept_uid character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
+    sequence_type character varying,
     state character varying NOT NULL
 );
 
@@ -2018,7 +2019,7 @@ ALTER SEQUENCE public.feedback_histories_id_seq OWNED BY public.feedback_histori
 
 CREATE TABLE public.feedback_history_ratings (
     id integer NOT NULL,
-    rating boolean NOT NULL,
+    rating boolean,
     feedback_history_id integer NOT NULL,
     user_id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -7598,4 +7599,8 @@ INSERT INTO schema_migrations (version) VALUES ('20210423165423');
 INSERT INTO schema_migrations (version) VALUES ('20210429151331');
 
 INSERT INTO schema_migrations (version) VALUES ('20210430212613');
+
+INSERT INTO schema_migrations (version) VALUES ('20210505150457');
+
+INSERT INTO schema_migrations (version) VALUES ('20210511161300');
 

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
@@ -2,11 +2,4 @@ class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
   def change
     change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
   end
-
-  Comprehension::Rule.all.each do |rule|
-    if !rule.suborder.nil?
-      rule.suborder = rule.suborder.to_i
-      rule.save!
-    end
-  end
 end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
@@ -1,0 +1,12 @@
+class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
+  def change
+    change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
+  end
+
+  Comprehension::Rule.all.each do |rule|
+    if rule.suborder != nil
+      rule.suborder = rule.suborder.to_i
+      rule.save!
+    end
+  end
+end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
@@ -4,7 +4,7 @@ class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
   end
 
   Comprehension::Rule.all.each do |rule|
-    if rule.suborder != nil
+    if !rule.suborder.nil?
       rule.suborder = rule.suborder.to_i
       rule.save!
     end

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuleFeedbackHistory, type: :model do
 
       expected = {
         api_name: 'autoML',
-        rule_order: "1",
+        rule_order: 1,
         first_feedback: "",
         rule_name: 'so_rule1',
         pct_strong: "0%",


### PR DESCRIPTION
## WHAT
add migration to revert `suborder` type from `text` to `integer`

## WHY
`suborder` should be of type `integer` for sorting purposes

## HOW
just add migration to change column type

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Allow-curriculum-team-to-change-the-order-of-the-regex-rules-7d39bbd4c4a943878e6e0f1fd160a416

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  will manually test
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
