### PR TITLE
filter responses by strong or weak

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -14,6 +14,8 @@ import { DataTable, Error, Spinner, Input, Tooltip, } from '../../../../Shared/i
 const ALL = 'All'
 const SCORED = 'Scored'
 const UNSCORED = 'Unscored'
+const STRONG = 'Strong'
+const WEAK = 'Weak'
 
 const RuleAnalysis = ({ history, match }) => {
   const { params } = match;
@@ -58,6 +60,8 @@ const RuleAnalysis = ({ history, match }) => {
     if (filter === ALL) { return true }
     if (filter === SCORED && r.strength !== null) { return true }
     if (filter === UNSCORED && r.strength === null) { return true }
+    if (filter === STRONG && r.strength === true) { return true }
+    if (filter === WEAK && r.strength === false) { return true }
 
     return false
   }
@@ -244,6 +248,18 @@ const RuleAnalysis = ({ history, match }) => {
           <label id={UNSCORED}>
             <input aria-labelledby={UNSCORED} checked={filter === UNSCORED} onChange={handleFilterChange} type="radio" value={UNSCORED} />
             Show only unscored responses
+          </label>
+        </div>
+        <div className="radio">
+          <label id={STRONG}>
+            <input aria-labelledby={STRONG} checked={filter === STRONG} onChange={handleFilterChange} type="radio" value={STRONG} />
+            Show only strong responses
+          </label>
+        </div>
+        <div className="radio">
+          <label id={WEAK}>
+            <input aria-labelledby={WEAK} checked={filter === WEAK} onChange={handleFilterChange} type="radio" value={WEAK} />
+            Show only weak responses
           </label>
         </div>
       </div>


### PR DESCRIPTION
## WHAT
Add radio button to filter responses by strong and weak.

## WHY
So that users can easily see which responses have been marked as strong and which have been marked as weak.

## HOW
Just add an additional filter category.

### Screenshots
<img width="1055" alt="Screen Shot 2021-05-11 at 1 41 14 PM" src="https://user-images.githubusercontent.com/18669014/117868430-9bc9c780-b267-11eb-89ef-4ea13c11406f.png">
<img width="960" alt="Screen Shot 2021-05-11 at 1 41 20 PM" src="https://user-images.githubusercontent.com/18669014/117868431-9bc9c780-b267-11eb-9ff1-e0963bbe1791.png">


### Notion Card Links
https://www.notion.so/quill/Filter-responses-on-the-Rules-Analysis-page-by-strong-or-weak-f52e0452d6e9428fa492ad69cd929dfc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
