### PR TITLE
LMS Rails 5.0 Prework - Bump shoulda-matchers-to-4

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -193,7 +193,7 @@ group :test, :development, :cypress do
 end
 
 group :test do
-  gem 'shoulda-matchers', '~> 3.1.2'
+  gem 'shoulda-matchers', '~> 4'
   gem 'shoulda-callback-matchers', '~> 1.1.1'
   gem 'capybara'
   gem 'poltergeist'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -667,8 +667,8 @@ GEM
     shellany (0.0.1)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -892,7 +892,7 @@ DEPENDENCIES
   select2-rails
   sentry-raven (>= 0.12.2)
   shoulda-callback-matchers (~> 1.1.1)
-  shoulda-matchers (~> 3.1.2)
+  shoulda-matchers (~> 4)
   sidekiq-pro!
   sidekiq-retries
   simplecov

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -31,9 +31,9 @@ class UnitTemplate < ActiveRecord::Base
   has_many :recommendations, dependent: :destroy
   serialize :grades, Array
 
-  validates :flag,                  inclusion: { in: %w(archived alpha beta production private),
-                                    message: "%<value>s is not a valid flag" }, :allow_nil => true
-
+  validates :flag,
+    inclusion: { in: %w(archived alpha beta production private) },
+    allow_nil: true
 
   scope :production, -> {where("unit_templates.flag IN('production') OR unit_templates.flag IS null")}
   scope :beta_user, -> { where("unit_templates.flag IN('production','beta') OR unit_templates.flag IS null")}


### PR DESCRIPTION
## WHAT
Bump test dependency for shoulda-matchers from `3.1.3` to `4.5.1`

## WHY
This upgrade addresses [issues](https://github.com/thoughtbot/shoulda-matchers/issues/913) related to Rails 5.

## HOW
Update the Gemfile

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No. This is related to specs.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? |  N/A