### PR TITLE
add default concept uids for semantic rules based on prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelWrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelWrapper.tsx
@@ -5,13 +5,13 @@ import { withRouter } from 'react-router-dom';
 import SemanticLabelForm from './semanticLabelForm';
 
 import { RuleInterface } from '../../../interfaces/comprehensionInterfaces';
-import { blankRule } from '../../../../../constants/comprehension';
+import { blankRule, DEFAULT_CONCEPT_UIDS } from '../../../../../constants/comprehension';
 import { fetchRule } from '../../../utils/comprehension/ruleAPIs';
 import { Spinner } from '../../../../Shared/index';
 
 const SemanticLabelWrapper = ({ activityData, isSemantic, isUniversal, requestErrors, submitRule, match }) => {
   const { params } = match;
-  const { activityId, ruleId } = params;
+  const { activityId, ruleId, promptId, } = params;
 
   // cache rule data
   const { data: ruleData } = useQuery({
@@ -19,12 +19,15 @@ const SemanticLabelWrapper = ({ activityData, isSemantic, isUniversal, requestEr
     queryFn: fetchRule
   });
 
+  const prompt = activityData.prompts.find(p => String(p.id) === promptId)
+
   let rule: RuleInterface;
 
   if(!ruleId) {
     const blankSemanticRule = {...blankRule};
     blankSemanticRule.rule_type = 'autoML';
     blankSemanticRule.state = 'inactive';
+    blankSemanticRule.concept_uid = DEFAULT_CONCEPT_UIDS[prompt.conjunction]
     rule = blankSemanticRule
   } else {
     rule = ruleData && ruleData.rule;

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -208,6 +208,12 @@ export const blankUniversalRule = {
   ]
 }
 
+export const DEFAULT_CONCEPT_UIDS = {
+  because: 'qkjnIjFfXdTuKO7FgPzsIg', // Academic Writing | Using Evidence Appropriately | Using Precise Evidence to Illustrate a Cause
+  but: 'KwspxuelfGZQCq7yX6ThPQ', // Academic Writing | Using Evidence Appropriately | Using Precise Evidence to Illustrate a Contrast
+  so: 'IBdOFpAWi42LgfXvcz0scQ' // Academic Writing | Using Evidence Appropriately | Using Precise Evidence to Illustrate a Consequence
+}
+
 export const TITLE = 'Title';
 export const NAME = 'Name';
 export const SCORED_READING_LEVEL = 'Scored reading level';


### PR DESCRIPTION
## WHAT
Add default concept uids for semantic rules based on their prompt conjunction.

## WHY
To reduce the curriculum developer's work.

## HOW
Just add a const with the default concept uids and use them when creating a new semantic rule.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Automatically-see-the-conjunction-specific-concept-in-the-Concepts-field-a0ec1407f76e4a9cb12f8ce51b7bc376

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
