### PR TITLE
Comprehension internal tools/add rule UID to feedback history

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -109,7 +109,7 @@ class FeedbackHistory < ActiveRecord::Base
   end
 
   def serialize_by_activity_session_detail
-   serializable_hash(only: [:entry, :feedback_text, :feedback_type, :optimal, :used], include: []).symbolize_keys
+   serializable_hash(only: [:entry, :feedback_text, :feedback_type, :optimal, :used, :rule_uid], include: []).symbolize_keys
   end
 
   def rule_violation_repititions?
@@ -196,7 +196,7 @@ class FeedbackHistory < ActiveRecord::Base
     prompt_groups.each do |conjunction, _|
       prompt_groups[conjunction][:attempts] = attempt_groups[conjunction]
     end
-    
+
     output[:prompts] = prompt_groups
     output.symbolize_keys
   end

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
@@ -47,6 +47,7 @@ const PromptTable = ({ activity, prompt, showHeader }: PromptTableProps) => {
     keys.map(key => {
       const filteredAttempt = attempts[key].filter(attempt => attempt.used)[0];
       const attempt = filteredAttempt || attempts[key][0];
+      console.log("🚀 ~ file: promptTable.tsx ~ line 50 ~ formatFeedbackData ~ attempt", attempt)
       const { entry, feedback_text, feedback_type, optimal } = attempt;
       const { attemptLabel, feedbackLabel } = PROMPT_ATTEMPTS_FEEDBACK_LABELS[key];
       const attemptObject: any = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
@@ -47,7 +47,6 @@ const PromptTable = ({ activity, prompt, showHeader }: PromptTableProps) => {
     keys.map(key => {
       const filteredAttempt = attempts[key].filter(attempt => attempt.used)[0];
       const attempt = filteredAttempt || attempts[key][0];
-      console.log("🚀 ~ file: promptTable.tsx ~ line 50 ~ formatFeedbackData ~ attempt", attempt)
       const { entry, feedback_text, feedback_type, optimal } = attempt;
       const { attemptLabel, feedbackLabel } = PROMPT_ATTEMPTS_FEEDBACK_LABELS[key];
       const attemptObject: any = {


### PR DESCRIPTION
## WHAT
add `rule_uid` to activity session detail payload

## WHY
it's needed for the FeedbackSessions Report in the frontend

## HOW
just add key to returned  hash

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Product-Updates-Feedback-Sessions-Report-f126d0b01aee4a80bfcd407184070783

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
