### PR TITLE
CMS: Move RematchResponseWorker to Default queue

### DIFF
--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -5,7 +5,7 @@ MAX_RETRIES = 3
 
 class RematchResponseWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: SidekiqQueue::LOW
+  sidekiq_options retry: 3, queue: SidekiqQueue::DEFAULT
 
   DEFAULT_PARAMS_HASH = {
     'parent_id' => nil,


### PR DESCRIPTION
## WHAT
Tiny PR. Give `RematchResponseWorker` higher precedence than `RematchResponsesForQuestionWorker`
## WHY
To keep the enqueued jobs list smaller so we don't run into Redis memory issues. 

I should have thought of this before, but `RematchResponsesForQuestionWorker` enqueues a lot of `RematchResponseWorker` jobs. Adjusting precedence so the jobs that **decrease** the queue have higher precedence than the jobs that **increase** the queue. This should help naturally regulate the queue size.
## HOW
Change `queue`, rely on built-in sidekiq behavior.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', tiny change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes, looks amazing
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
