### PR TITLE
Revert "Lms/update rules report api"

### DIFF
--- a/services/QuillLMS/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/lib/rule_feedback_history.rb
@@ -52,30 +52,28 @@ class RuleFeedbackHistory
         rules_sql_result.each do |r|
 
             feedback_histories = FeedbackHistory
-                .where(id: r.feedback_histories_id_array).includes(:feedback_history_ratings).includes(:feedback_history_flags)
+                .where(id: r.feedback_histories_id_array).includes(:feedback_history_ratings)
 
             total_scored = feedback_histories.reduce(0) do |memo, feedback_history|
                 memo + feedback_history.feedback_history_ratings.count
             end
 
-            total_strong = 0
-            total_weak = 0
-            repeated_consecutive = 0
-            repeated_non_consecutive = 0
-            if total_scored > 0
-                feedback_histories.each do |history|
-                  total_strong += 1 if history.feedback_history_ratings.any?(&:rating)
-                  total_weak += 1 if history.feedback_history_ratings.any? { |hr| hr.rating == false }
-                  repeated_consecutive += 1 if history.feedback_history_flags.any? { |f| f.flag == FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE }
-                  repeated_non_consecutive += 1 if history.feedback_history_flags.any? { |f| f.flag == FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE }
+            if total_scored == 0
+                total_strong = 0
+                r.define_singleton_method(:pct_strong) { 0 }
+                r.define_singleton_method(:pct_scored) { 0 }
+            else
+                total_strong = feedback_histories.reduce(0) do |memo, n|
+                    memo + n.feedback_history_ratings.filter(&:rating).count
                 end
 
+                r.define_singleton_method(:pct_strong) { total_strong/total_scored.to_f }
+                # note: pct_scored may be over counting since the original spec may not
+                # account for one feedback history having more than one score.
+                r.define_singleton_method(:pct_scored) { total_scored/total_scored.to_f }
             end
-            r.define_singleton_method(:total_strong) { total_strong }
-            r.define_singleton_method(:total_weak) { total_weak }
-            r.define_singleton_method(:repeated_consecutive) { repeated_consecutive }
-            r.define_singleton_method(:repeated_non_consecutive) { repeated_non_consecutive }
 
+            r.define_singleton_method(:scored_responses_count) { total_scored }
             r.define_singleton_method(:total_responses) { feedback_histories.count }
         end
 
@@ -91,6 +89,10 @@ class RuleFeedbackHistory
         rules_sql_result
     end
 
+    def self.format_pct(a_float)
+        "#{(a_float * 100).round(2)}%"
+    end
+
     def self.format_sql_results(relations)
         relations.map do |r|
             {
@@ -101,10 +103,9 @@ class RuleFeedbackHistory
                 rule_note: r.rule_note,
                 rule_name: r.rule_name,
                 total_responses: r.total_responses,
-                strong_responses: r.total_strong,
-                weak_responses: r.total_weak,
-                repeated_consecutive_responses: r.repeated_consecutive,
-                repeated_non_consecutive_responses: r.repeated_non_consecutive,
+                pct_strong: format_pct(r.pct_strong),
+                scored_responses: r.scored_responses_count, # may want to rename for clarity
+                pct_scored: format_pct(r.pct_scored)
             }
 
         end

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -40,20 +40,16 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       report = RuleFeedbackHistory.generate_report(conjunction: 'so', activity_id: activity1.id)
 
       expected = {
-        api_name: so_rule1.rule_type,
-        rule_order: so_rule1.suborder,
-        first_feedback: '',
-        rule_name: so_rule1.name,
-        rule_note: so_rule1.note,
-        rule_uid: so_rule1.uid,
-        strong_responses: 0,
-        total_responses: 0,
-        weak_responses: 0,
-        repeated_consecutive_responses: 0,
-        repeated_non_consecutive_responses: 0,
+        api_name: 'autoML',
+        rule_order: 1,
+        first_feedback: "",
+        rule_name: 'so_rule1',
+        pct_strong: "0%",
+        scored_responses: 0,
+        pct_scored: "0%"
       }
 
-      expect(expected).to eq(report.first)
+      expect(expected <= report.first).to be true
 
     end
   end
@@ -112,11 +108,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         f_rating_1a = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user1.id, rating: true)
         f_rating_1b = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user2.id, rating: false)
         f_rating_2a = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user1.id, rating: true)
-        f_rating_2b = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user2.id, rating: nil)
-
-        #feedback flags
-        flag_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE)
-        flag_non_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE)
 
         ActiveRecord::Base.refresh_materialized_view('feedback_histories_grouped_by_rule_uid')
 
@@ -124,11 +115,10 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         post_result = RuleFeedbackHistory.postprocessing(sql_result)
 
         first_row = post_result.first
+        expect(first_row.scored_responses_count).to eq 3
         expect(first_row.total_responses).to eq 2
-        expect(first_row.total_strong).to eq 2
-        expect(first_row.total_weak).to eq 1
-        expect(first_row.repeated_non_consecutive).to eq 1
-        expect(first_row.repeated_consecutive).to eq 1
+        expect(first_row.pct_strong).to eq 0.6666666666666666
+        expect(first_row.pct_scored).to eq 1.0
 
     end
   end


### PR DESCRIPTION
Reverts empirical-org/Empirical-Core#7626

Reverting because we merged the back-end before the front-end was ready, and don't want to deploy breaking changes.