### PR TITLE
Comprehension/use spelling rule feedback

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -37,7 +37,7 @@ module Comprehension
 
     private def spelling_rule
       return @spelling_rule if @spelling_rule
-      @spelling_rule = Rule.where(rule_type: FEEDBACK_TYPE).first
+      @spelling_rule ||= Rule.where(rule_type: FEEDBACK_TYPE).first
     end
 
     private def highlight

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -2,8 +2,8 @@ module Comprehension
   class SpellingCheck
 
     ALL_CORRECT_FEEDBACK = 'Correct spelling!'
-    INCORRECT_FEEDBACK = 'Try again. There may be a spelling mistake.'
-    FEEDBACK_TYPE = 'spelling'
+    FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word.'
+    FEEDBACK_TYPE = Rule::TYPE_SPELLING
     RESPONSE_TYPE = 'response'
     BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'
     SPELLING_CONCEPT_UID = 'H-2lrblngQAQ8_s-ctye4g'
@@ -16,7 +16,7 @@ module Comprehension
     def feedback_object
       return {} if error.present?
       {
-        feedback: optimal? ? ALL_CORRECT_FEEDBACK : INCORRECT_FEEDBACK,
+        feedback: optimal? ? ALL_CORRECT_FEEDBACK : non_optimal_feedback_string,
         feedback_type: FEEDBACK_TYPE,
         optimal: optimal?,
         response_id: '',
@@ -27,13 +27,17 @@ module Comprehension
       }
     end
 
+    def non_optimal_feedback_string
+      spelling_rule&.feedbacks&.first&.text || FALLBACK_INCORRECT_FEEDBACK
+    end
+
     def error
       bing_response['error'] ? bing_response['error']['message'] : nil
     end
 
     private def spelling_rule
       return @spelling_rule if @spelling_rule
-      @spelling_rule = Rule.where(rule_type: Rule::TYPE_SPELLING).first
+      @spelling_rule = Rule.where(rule_type: FEEDBACK_TYPE).first
     end
 
     private def highlight

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
@@ -44,9 +44,9 @@ module Comprehension
 
       context 'with actitivites' do
         setup do
-          @first_activity = create(:comprehension_activity, title: "First Activity", target_level: 8)
-          create(:comprehension_activity, title: "Second Activity",
-            target_level: 5)
+          # The controller sorts items alphabetically by "name"
+          @first_activity = create(:comprehension_activity, title: "First Activity", name: "Name 1", target_level: 8)
+          create(:comprehension_activity, title: "Second Activity", name: "Name 2", target_level: 5)
         end
 
         should "return successfully" do
@@ -58,6 +58,7 @@ module Comprehension
           assert_equal Array, parsed_response.class
           refute parsed_response.empty?
 
+          # We expect these to be ordered alphatbetically by name
           assert_equal  "First Activity", parsed_response.first['title']
           assert_equal  8, parsed_response.first['target_level']
           assert_equal  @first_activity.parent_activity.id, parsed_response.first['parent_activity_id']

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210429144611) do
+ActiveRecord::Schema.define(version: 20210511160025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 20210429144611) do
     t.boolean  "universal",   null: false
     t.string   "rule_type",   null: false
     t.boolean  "optimal",     null: false
-    t.text     "suborder"
+    t.integer  "suborder"
     t.string   "concept_uid"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false

--- a/services/QuillLMS/engines/comprehension/test/lib/spelling_check_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/lib/spelling_check_test.rb
@@ -46,5 +46,19 @@ module Comprehension
       end
     end
 
+    context '#non_optimal_feedback_string' do
+      should 'use the fallback feedback if there is no spelling Rule with feedback' do
+        spelling_check = Comprehension::SpellingCheck.new('')
+        assert_equal spelling_check.non_optimal_feedback_string, Comprehension::SpellingCheck::FALLBACK_INCORRECT_FEEDBACK
+      end
+
+      should 'use the feedback from the spelling rule if it is available' do
+        rule = create(:comprehension_rule, rule_type: Comprehension::Rule::TYPE_SPELLING)
+        feedback = create(:comprehension_feedback, rule: rule)
+
+        spelling_check = Comprehension::SpellingCheck.new('')
+        assert_equal spelling_check.non_optimal_feedback_string, feedback.text
+      end
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Pull Spelling feedback from the universal "Spelling" rule in the Comprehension database rather than hard-coding a constant bit of feedback.
## WHY
So that the Curriculum team has more control over what students see in order to maximize the value of the Feedback student get.
## HOW
Leave the constant feedback string as a fallback, but update the code to pull feedback text from the Feedback records associated with the universal Spelling Rule when it is available.

### Notion Card Links
https://www.notion.so/quill/Changing-spelling-feedback-in-the-Universal-Rules-page-doesn-t-change-the-feedback-in-the-student-ap-e104a79991784650962840d44a71484d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
