### PR TITLE
LMS Rails 5.0 Prework - Fix spec failure with case sensitive UUIDs in Comprehension

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round.rb
@@ -8,7 +8,7 @@ module Comprehension
 
     validates_presence_of :activity_id
     validates_presence_of :uuid, on: :update
-    validates :uuid, uniqueness: true
+    validates :uuid, uniqueness: { case_sensitive: false }
     validates :expires_at, presence: true
     validate :expires_at_in_future, on: :create
 

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/turking_round_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/turking_round_test.rb
@@ -11,7 +11,7 @@ module Comprehension
       should validate_presence_of(:expires_at)
 
       should have_readonly_attribute(:uuid)
-      should validate_uniqueness_of(:uuid)
+      should validate_uniqueness_of(:uuid).case_insensitive
 
       should 'validate presence of uuid on any update call' do
         turking_round = create(:comprehension_turking_round)


### PR DESCRIPTION
## WHAT
Turking Round Test yields uniqueness validation failure due to case-sensitive UUIDs: ![Screen Shot 2021-05-17 at 2 01 33 PM](https://user-images.githubusercontent.com/2057805/118535594-a88f6500-b718-11eb-9349-64049e4b629a.png)

## WHY
Fixing this spec now will keep actual upgrade diff small.

## HOW
Update the validation to include `case_sensitive: false` 

### Screenshots

### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |. Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES 
Design Review: If applicable, have you compared the coded design to the mockups? |  N/A
