### PR TITLE
LMS Rails 5.0 Prework - Fix skip_before_action :verify_authenticity_token

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/firebase_tokens_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/firebase_tokens_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::FirebaseTokensController < Api::ApiController
-  skip_before_action :verify_authenticity_token
-
   def create
     app = FirebaseApp.find_by_name!(params[:app])
     render json: {

--- a/services/QuillLMS/app/controllers/api/v1/lessons_tokens_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/lessons_tokens_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::LessonsTokensController < Api::ApiController
-  skip_before_action :verify_authenticity_token
-
   def create
     token = CreateLessonsToken
       .new(current_user, params[:classroom_unit_id])

--- a/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
-    skip_before_action :verify_authenticity_token
-
     def by_conjunction
         raise ArgumentError unless params.include?('activity_id') && params.include?('conjunction')
         report = RuleFeedbackHistory.generate_report(


### PR DESCRIPTION
## WHAT
`before_action :verify_authenticity_token` is a pulled in via [request_forgery_protection](https://github.com/rails/rails/blob/75ac626c4e21129d8296d4206a1960563cc3d4aa/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L136) which the LMS `ApplicationController` [uses](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/application_controller.rb#L2).  However, the controllers in this PR inherit from [Api::ApiController](https://github.com/empirical-org/Empirical-Core/blob/de3313be4f5c2f27f7d3ffc724d0817aae891cf6/services/QuillLMS/app/controllers/api/api_controller.rb) which doesn't enable `request_forgery_protection`.

## WHY
In Rails 5.0, these particular `skip_before_action` calls will result in an error since `verify_authenticity_token` is not available to the `Api::ApiController`

## HOW
Simply remove the lines.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? |. Not yet - deploying now! 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
