### PR TITLE
CMS - Add create_or_increment_response to critical queue.

### DIFF
--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -1,6 +1,6 @@
 class CreateOrIncrementResponseWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::DEFAULT
+  sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(new_vals)
     symbolized_vals = new_vals.symbolize_keys

--- a/services/QuillCMS/config/initializers/sidekiq.rb
+++ b/services/QuillCMS/config/initializers/sidekiq.rb
@@ -12,6 +12,7 @@ end
 
 module SidekiqQueue
   # QUEUE DEFINITIONS
+  CRITICAL = 'critical'
   DEFAULT = 'default'
   # LOW: Jobs that might be long-running that we don't want to clog up the main workers
   # and that can be delayed.

--- a/services/QuillCMS/config/sidekiq.yml
+++ b/services/QuillCMS/config/sidekiq.yml
@@ -1,4 +1,5 @@
 :concurrency: <%= ENV.fetch("SIDEKIQ_WORKERS") { 4 } %>
 :queues:
+  - critical
   - default
   - low


### PR DESCRIPTION
## WHAT
Tiny PR. Move to `CreateOrIncrementResponseWorker` to `critical` queue.
## WHY
These jobs average about `5ms` to run. Since they are so fast, let's get them out of the way to keep our queue backlog small.
## HOW
Add a new queue to sidekiq, assign the job to it.
### Screenshots
![Screen Shot 2021-05-17 at 5 16 48 PM](https://user-images.githubusercontent.com/1304933/118557825-bd2d2680-b733-11eb-8188-0da8e544b62e.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tiny change that should be covered by tests
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
