### PR TITLE
enable rules analysis highlight output

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -46,7 +46,7 @@ const RuleAnalysis = ({ history, match }) => {
   })
 
   const prompt = activityData ? activityData.activity.prompts.find(prompt => prompt.conjunction === promptConjunction) : {}
-
+  
   React.useEffect(() => {
     if (!ruleFeedbackHistoryData) { return }
     setResponses(ruleFeedbackHistoryData.responses)
@@ -170,6 +170,7 @@ const RuleAnalysis = ({ history, match }) => {
       formattedResponse.response = tooltip
       formattedResponse.datetime = moment(r.datetime).format('MM/DD/YYYY')
       formattedResponse.strengthButtons = (<div className="strength-buttons">{strongButton}{weakButton}</div>)
+      formattedResponse.highlight = r.highlight
 
       return formattedResponse
     })


### PR DESCRIPTION
## WHAT
Displays Highlighted Output in the rules analysis tool. See screenshot:

<img width="1245" alt="Screen Shot 2021-05-17 at 9 16 34 PM" src="https://user-images.githubusercontent.com/90669/118585051-5f113b00-b755-11eb-985d-bbbba34542dc.png">

## WHY
This column was blank previously.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Highlight-Meta-data-not-appearing-in-API-392272bd51c44f5db89b149b03a99437

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - tested manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A 
