### PR TITLE
LMS Rails 5.0 Prework - Downgrade websocket-driver before Rails 5.0 upgrade

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -74,6 +74,7 @@ gem 'comprehension', path: 'engines/comprehension'
 
 # WEBSOCKETS
 gem 'pusher'
+gem 'websocket-driver', '0.6.5'
 
 # PARSING
 gem 'parslet'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -759,9 +759,9 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.0)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -911,6 +911,7 @@ DEPENDENCIES
   vcr
   webmock
   webpacker (~> 3.0.0)
+  websocket-driver (= 0.6.5)
 
 RUBY VERSION
    ruby 2.6.6p146


### PR DESCRIPTION
## WHAT
Downgrade websocket-driver from 0.7.0 to 0.6.5

## WHY
`rails (5.0.7)` has the dependency `actioncable (5.0.7)`, which in turn has the requirement `websocket-driver (~> 0.6.1)`. In order for the Rails upgrade to work, we first need to get its dependencies in order.

## HOW
Explicitly specify the version in the gemfile.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
