### PR TITLE
LMS Rails 5.0 Prework - Change jsonb/json datatypes defaults

### DIFF
--- a/services/QuillLMS/db/migrate/20210518151248_change_classroom_unit_activity_states_data_default.rb
+++ b/services/QuillLMS/db/migrate/20210518151248_change_classroom_unit_activity_states_data_default.rb
@@ -1,0 +1,9 @@
+class ChangeClassroomUnitActivityStatesDataDefault < ActiveRecord::Migration
+  def up
+    change_column_default :classroom_unit_activity_states, :data, {}
+  end
+
+  def down
+    change_column_default :classroom_unit_activity_states, :data, '{}'
+  end
+end

--- a/services/QuillLMS/db/migrate/20210518162719_change_notifications_meta_default.rb
+++ b/services/QuillLMS/db/migrate/20210518162719_change_notifications_meta_default.rb
@@ -1,0 +1,9 @@
+class ChangeNotificationsMetaDefault < ActiveRecord::Migration
+  def up
+    change_column_default :notifications, :meta, {}
+  end
+
+  def down
+    change_column_default :notifications, :meta, '{}'
+  end
+end


### PR DESCRIPTION
## WHAT
Change the column default value for a couple of jsonb/json datatypes from `'{}'` to `{}`

## WHY
In Rails 4.2, the behavior `add_column :table_name, :column :jsonb, default: '{}'` had [rails bug](https://github.com/rails/rails/issues/25594#issuecomment-229931308
) where the default string '{}' was converted to a hash.

This was fixed in Rails 5+, but existing defaults need to be updated.

## HOW
Add migrations that update default column value.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Spot check
Have you deployed to Staging? | Not yet.  Deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? |. YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
