### PR TITLE
comprehension/prompt-feedback-history-tweak

### DIFF
--- a/services/QuillLMS/app/queries/prompt_feedback_history.rb
+++ b/services/QuillLMS/app/queries/prompt_feedback_history.rb
@@ -5,16 +5,15 @@ class PromptFeedbackHistory
     end
 
     def self.promptwise_sessions(activity_id)
-        activity_sessions = ActivitySession.where(activity_id: activity_id).includes(:feedback_sessions)
-        feedback_session_uids = activity_sessions.reduce([]) {|memo, a_s| memo.concat(a_s.feedback_sessions.pluck(:uid))}
-        return [] unless feedback_session_uids.present?
         sql = <<~SQL 
           SELECT prompt_id, feedback_session_uid, count(*) as session_count, bool_or(optimal) as at_least_one_optimal, MAX(attempt) as attempt_cardinal
           FROM feedback_histories
-          WHERE feedback_session_uid IN (#{feedback_session_uids.map{|e| "'#{e}'"}.join(',')})
+          JOIN comprehension_prompts
+            ON feedback_histories.prompt_id = comprehension_prompts.id
+          WHERE comprehension_prompts.activity_id = ?
           GROUP BY prompt_id, feedback_session_uid
         SQL
-        FeedbackHistory.find_by_sql(sql)
+        FeedbackHistory.find_by_sql([sql, activity_id])
     end
 
     def self.promptwise_postprocessing(grouped_feedback_histories)

--- a/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
@@ -8,18 +8,22 @@ RSpec.describe PromptFeedbackHistory, type: :model do
   
   describe '#promptwise_sessions' do 
     it 'should aggregate rows correctly' do 
-      main_activity = create(:activity)
-      unused_activity = create(:activity)
+      main_activity = Comprehension::Activity.create!(name: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+      unused_activity = Comprehension::Activity.create!(name: 'Title_2', title: 'Title 2', parent_activity_id: 2, target_level: 1)
 
-      as1 = create(:activity_session, activity_id: main_activity.id)
-      as2 = create(:activity_session, activity_id: main_activity.id)
-      as3 = create(:activity_session, activity_id: unused_activity.id)
+      prompt1 = Comprehension::Prompt.create!(activity: main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      prompt2 = Comprehension::Prompt.create!(activity: main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      prompt3 = Comprehension::Prompt.create!(activity: unused_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
 
-      f_h1 = create(:feedback_history, feedback_session_uid: as1.uid, attempt: 1, optimal: false, prompt_id: 1)
-      f_h2 = create(:feedback_history, feedback_session_uid: as1.uid, attempt: 2, optimal: true, prompt_id: 1)
-      f_h3 = create(:feedback_history, feedback_session_uid: as2.uid, attempt: 1, optimal: false, prompt_id: 2)
-      f_h4 = create(:feedback_history, feedback_session_uid: as2.uid, attempt: 2, optimal: false, prompt_id: 2)
-      f_h4 = create(:feedback_history, feedback_session_uid: as3.uid, prompt_id: 3)
+      session_uid1 = SecureRandom.uuid
+      session_uid2 = SecureRandom.uuid
+      session_uid3 = SecureRandom.uuid
+
+      f_h1 = create(:feedback_history, attempt: 1, optimal: false, prompt_id: prompt1.id, feedback_session_uid: session_uid1)
+      f_h2 = create(:feedback_history, attempt: 2, optimal: true, prompt_id: prompt1.id, feedback_session_uid: session_uid1)
+      f_h3 = create(:feedback_history, attempt: 1, optimal: false, prompt_id: prompt2.id, feedback_session_uid: session_uid2)
+      f_h4 = create(:feedback_history, attempt: 2, optimal: false, prompt_id: prompt2.id, feedback_session_uid: session_uid2)
+      f_h4 = create(:feedback_history, prompt_id: prompt3.id, feedback_session_uid: session_uid3)
 
       result = PromptFeedbackHistory.promptwise_sessions(main_activity.id)
 


### PR DESCRIPTION
## WHAT
Tweak the way that we pull prompt feedback history
## WHY
To avoid touching ActivitySession and to be consistent about using the Comprehension `activity_id` instead of the LMS `activity_id`
## HOW
Just tweak the SQL query that's used to pull the data so that it joins through a different path to query by id

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
