### PR TITLE
comprehension/fix-model-activation-page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/activateModelForm.tsx
@@ -34,7 +34,7 @@ const ActivateModelForm = ({ match }) => {
 
   const { data: rulesData } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}`, activityId, promptId, 'autoML'],
+    queryKey: [`rules-${activityId}`, null, promptId, 'autoML'],
     queryFn: fetchRules
   });
 


### PR DESCRIPTION
## WHAT
Do not pass `activity_id` in for rules query
## WHY
The current implementation of rule look-up ignores additional filter params (around rule type or prompt_id) if you pass an activity_id, but we want to use those filters.  In this particular case, failing to filter for only `automl` rules results in the page crashing when looking for the `label` attribute (which is not present for non-autoML rules).
## HOW
Just pass `null` instead of the `activity_id` when fetching rules so that the filters for prompt and rule type kick in.

### Notion Card Links
https://www.notion.so/quill/Page-times-out-when-trying-to-activate-a-model-5a311d733c6744beab88c025bb2dd02b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Very small change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
