### PR TITLE
Add Try-Catch block to prevent Comprehension search bar from error on Regex

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -68,7 +68,13 @@ const RuleAnalysis = ({ history, match }) => {
   }
 
   function filterResponsesBySearch(r) {
-    if (search.length) { return new RegExp(search, 'i').test(r.entry) }
+    if (search.length) {
+      try {
+        return new RegExp(search, 'i').test(r.entry)
+      } catch (e) {
+        return false
+      }
+    }
 
     return true
   }


### PR DESCRIPTION
## WHAT
BugFix -- In the rule analysis "search by regex" bar, we were sometimes running into an edge case when staff tried to enter an invalid regex string (e.g. "(") into the search bar, which would cause the page to error out because the `RegExp()` function would error.

## WHY
That is very inconvenient for Staff to see the page error out whenever they are trying to type a regex string and haven't finished typing it yet.

## HOW
Just add a `try-catch` block around this line of code to catch when it errors and fail gracefully.

### Screenshots
![Screen Shot 2021-05-20 at 4 48 00 PM](https://user-images.githubusercontent.com/57366100/119046837-29559780-b98b-11eb-955e-c4cf53d9adfe.png)


### Notion Card Links
https://www.notion.so/quill/Using-an-open-parenthesis-in-the-regex-search-causes-the-page-to-time-out-ccb15378a2f44ac0a20192f34b21efe7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, no tests for this search bar.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
