### PR TITLE
Fix anonymous url activity bug

### DIFF
--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -60,9 +60,19 @@ class ActivityClassification < ActiveRecord::Base
     find_by_key CONNECT_KEY
   end
 
-  def module_url
-    return read_attribute(:module_url) if Rails.env.production?
+  def form_url
+    "#{ENV['DEFAULT_URL']}#{form_path}"
+  end
 
-    "#{ENV['DEFAULT_URL']}#{Addressable::URI.parse(read_attribute(:module_url)).path}"
+  def module_url
+    "#{ENV['DEFAULT_URL']}#{module_path}"
+  end
+
+  private def module_path
+    Addressable::URI.parse(read_attribute(:module_url)).path
+  end
+
+  private def form_path
+    Addressable::URI.parse(read_attribute(:form_url)).path
   end
 end

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -60,4 +60,9 @@ class ActivityClassification < ActiveRecord::Base
     find_by_key CONNECT_KEY
   end
 
+  def module_url
+    return read_attribute(:module_url) if Rails.env.production?
+
+    "#{ENV['DEFAULT_URL']}#{Addressable::URI.parse(read_attribute(:module_url)).path}"
+  end
 end


### PR DESCRIPTION
## WHAT
The table `ActivityClassification` has an attribute `module_url` where values have domains hardcoded.  
![Screen Shot 2021-05-21 at 9 01 59 AM](https://user-images.githubusercontent.com/2057805/119141402-361dce00-ba13-11eb-80d5-dffb312e8201.png)

When this attribute is called on a staging site, it causes links to redirect from a staging site to production.

## WHY
This bug will prevent integration tests from getting accurate results on staging configurations.  For example, a ghost inspector test might click on one of these links and then effectively be testing the production site.

## HOW
As a first step, keep production functionality the same (hence the guard clause), but remove domain information in other configurations.  Ideally, we would get rid of the domain information altogether but at this point, first address the change on staging to confirm that it works.  The inclusion of the `Rails.env.production?` is not ideal, but I don't see any way around that initially since this is an issue between environments rather than application code.

This fix does not address module_urls: `https://quill-writer.firebaseapp.com/` or `https://grammar.quill.org/play/sw` as those domains don't seem to have corresponding staging equivalents.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-anonymous-activity-redirect-bug-68d328a5a63c4193a5861c9f8d01aa0a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
