### PR TITLE
fix how semantic rules cheat sheet handles rule with no feedback

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRulesCheatSheet.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRulesCheatSheet.tsx
@@ -34,7 +34,7 @@ const SemanticRulesCheatSheet = ({ match, }) => {
       return {
         id: id,
         name: <div dangerouslySetInnerHTML={{ __html: name }} />,
-        firstLayerFeedback: <div dangerouslySetInnerHTML={{ __html: feedbacks[0].text }} />,
+        firstLayerFeedback: <div dangerouslySetInnerHTML={{ __html: feedbacks[0] ? feedbacks[0].text : null }} />,
         note: <div dangerouslySetInnerHTML={{ __html: note }} />,
         edit: ruleLink
       }


### PR DESCRIPTION
## WHAT
Don't error on semantic rule with no feedback.

## WHY
So the page loads.

## HOW
Add null check.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Semantic-rules-cheat-sheet-not-working-879a86db716243cca191ebb86a6675fe

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
