### PR TITLE
Comprehension/hide scores from students

### DIFF
--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -106,7 +106,7 @@ class UnitActivity < ActiveRecord::Base
       activity.name,
       activity.description,
       activity.repeatable,
-      activity.activity_classification_id,
+      activity_classifications.name AS activity_classification_name,
       unit.id AS unit_id,
       ua.id AS ua_id,
       unit.created_at AS unit_created_at,
@@ -128,6 +128,7 @@ class UnitActivity < ActiveRecord::Base
       LEFT JOIN activity_sessions AS acts ON cu.id = acts.classroom_unit_id AND acts.activity_id = ua.activity_id AND acts.visible = true
       AND acts.user_id = #{user_id.to_i}
       JOIN activities AS activity ON activity.id = ua.activity_id
+      JOIN activity_classifications ON activity.activity_classification_id = activity_classifications.id
       LEFT JOIN classroom_unit_activity_states AS cuas ON ua.id = cuas.unit_activity_id
       AND cu.id = cuas.classroom_unit_id
       WHERE #{user_id.to_i} = ANY (cu.assigned_student_ids::int[])
@@ -136,7 +137,7 @@ class UnitActivity < ActiveRecord::Base
       AND unit.visible = true
       AND ua.visible = true
       AND 'archived' != ANY(activity.flags)
-      GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id
+      GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id, activity_classifications.name
 
       ORDER BY pinned DESC, locked ASC, unit.created_at ASC, max_percentage DESC, ua.order_number ASC, ua.due_date ASC, ua.id ASC").to_a
   end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -106,6 +106,7 @@ class UnitActivity < ActiveRecord::Base
       activity.name,
       activity.description,
       activity.repeatable,
+      activity.activity_classification_id,
       activity_classifications.name AS activity_classification_name,
       unit.id AS unit_id,
       ua.id AS ua_id,

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -107,7 +107,7 @@ class UnitActivity < ActiveRecord::Base
       activity.description,
       activity.repeatable,
       activity.activity_classification_id,
-      activity_classifications.name AS activity_classification_name,
+      activity_classifications.key AS activity_classification_key,
       unit.id AS unit_id,
       ua.id AS ua_id,
       unit.created_at AS unit_created_at,
@@ -138,7 +138,7 @@ class UnitActivity < ActiveRecord::Base
       AND unit.visible = true
       AND ua.visible = true
       AND 'archived' != ANY(activity.flags)
-      GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id, activity_classifications.name
+      GROUP BY unit.id, unit.name, unit.created_at, cu.id, activity.name, activity.activity_classification_id, activity.id, activity.uid, ua.due_date, ua.created_at, unit_activity_id, cuas.completed, cuas.locked, cuas.pinned, ua.id, activity_classifications.key
 
       ORDER BY pinned DESC, locked ASC, unit.created_at ASC, max_percentage DESC, ua.order_number ASC, ua.due_date ASC, ua.id ASC").to_a
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -10,8 +10,10 @@ const grammarSrc = `${process.env.CDN_URL}/images/icons/tool-grammar-gray.svg`
 const proofreaderSrc = `${process.env.CDN_URL}/images/icons/tool-proofreader-gray.svg`
 const lessonsSrc = `${process.env.CDN_URL}/images/icons/tool-lessons-gray.svg`
 
-const LESSONS_ACTIVITY_CLASSIFICATION_ID = "6"
-const DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID = "4"
+const LESSONS_ACTIVITY_CLASSIFICATION_NAME = "Quill Lessons"
+const DIAGNOSTIC_ACTIVITY_CLASSIFICATION_NAME = "Quill Diagnostic"
+const COMPREHENSION_ACTIVITY_CLASSIFICATION_NAME = "Quill Comprehension"
+const UNGRADED_ACTIVITY_CLASSIFICATIONS = [LESSONS_ACTIVITY_CLASSIFICATION_NAME, DIAGNOSTIC_ACTIVITY_CLASSIFICATION_NAME, COMPREHENSION_ACTIVITY_CLASSIFICATION_NAME]
 const PROFICIENT_CUTOFF = 0.8
 const NEARLY_PROFICIENT_CUTOFF = 0.6
 
@@ -114,9 +116,9 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   score = (act) => {
-    const { activity_classification_id, max_percentage, } = act
+    const { activity_classification_name, max_percentage, } = act
     const maxPercentage = Number(max_percentage)
-    if (activity_classification_id === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_ID || activity_classification_id === LESSONS_ACTIVITY_CLASSIFICATION_ID) {
+    if (UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_name)) {
       return (
         <Tooltip
           tooltipText="This type of activity is not graded."

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -10,10 +10,10 @@ const grammarSrc = `${process.env.CDN_URL}/images/icons/tool-grammar-gray.svg`
 const proofreaderSrc = `${process.env.CDN_URL}/images/icons/tool-proofreader-gray.svg`
 const lessonsSrc = `${process.env.CDN_URL}/images/icons/tool-lessons-gray.svg`
 
-const LESSONS_ACTIVITY_CLASSIFICATION_NAME = "Quill Lessons"
-const DIAGNOSTIC_ACTIVITY_CLASSIFICATION_NAME = "Quill Diagnostic"
-const COMPREHENSION_ACTIVITY_CLASSIFICATION_NAME = "Quill Comprehension"
-const UNGRADED_ACTIVITY_CLASSIFICATIONS = [LESSONS_ACTIVITY_CLASSIFICATION_NAME, DIAGNOSTIC_ACTIVITY_CLASSIFICATION_NAME, COMPREHENSION_ACTIVITY_CLASSIFICATION_NAME]
+const LESSONS_ACTIVITY_CLASSIFICATION_KEY = "lessons"
+const DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY = "diagnostic"
+const COMPREHENSION_ACTIVITY_CLASSIFICATION_KEY = "comprehension"
+const UNGRADED_ACTIVITY_CLASSIFICATIONS = [LESSONS_ACTIVITY_CLASSIFICATION_KEY, DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY, COMPREHENSION_ACTIVITY_CLASSIFICATION_KEY]
 const PROFICIENT_CUTOFF = 0.8
 const NEARLY_PROFICIENT_CUTOFF = 0.6
 
@@ -116,9 +116,9 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   score = (act) => {
-    const { activity_classification_name, max_percentage, } = act
+    const { activity_classification_key, max_percentage, } = act
     const maxPercentage = Number(max_percentage)
-    if (UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_name)) {
+    if (UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_key)) {
       return (
         <Tooltip
           tooltipText="This type of activity is not graded."

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -214,6 +214,7 @@ describe ProfilesController, type: :controller do
                 'description' => activity.description,
                 'repeatable' => activity.repeatable,
                 'activity_classification_id' => activity.activity_classification_id,
+                'activity_classification_key' => activity.classification.key,
                 'unit_id' => unit.id,
                 'ua_id' => unit_activity.id,
                 'order_number' => unit_activity.order_number,


### PR DESCRIPTION
## WHAT
Treat Comprehension reporting as "ungraded" in the same way that we do Diagnostic and Lessons.  This allows us to show "Complete" instead of "Proficient" or whatever.
## WHY
The design of Comprehension expects students to have to make multiple attempts on every prompt, and in a strict grading system we expect most students to "score" less than 50%.  Since this is the expectation, we don't want to show students that they are "not proficient" if they are meeting our expectations.
## HOW
Originally as part of score reporting we returned the `ActivityClassification.id` value and checked against a hard-coded list of numbers.  However, because of the way that we added "Comprehension" as an `ActivityClassification`, it may not have the same ID in every environment.  Therefore, it made sense to me to pull the `ActivityClassification.name` in the API call, and hard code those values for comparison instead.  Same results, but slightly less brittle across environments.

One note: I left the `ActivityClassification.id` in the query in case it's used somewhere else, but I suspect that it is not.  Still, better safe than sorry.

### Notion Card Links
https://www.notion.so/quill/Do-not-show-Comprehension-activity-scores-to-students-who-completed-Comprehension-activities-369b9c6243204fd9be5f27c3025d39cb

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on this
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
