### PR TITLE
Fix anonymous url bug by including fragment

### DIFF
--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -61,22 +61,10 @@ class ActivityClassification < ActiveRecord::Base
   end
 
   def form_url
-    url_domain_replacer(form_uri)
+    HardcodedDomainRewriter.new(read_attribute(:form_url)).run
   end
 
   def module_url
-    url_domain_replacer(module_uri)
-  end
-
-  private def url_domain_replacer(uri)
-    "#{ENV['DEFAULT_URL']}#{uri.path}#{'?' + uri.query if uri.query}#{'#' + uri.fragment if uri.fragment}"
-  end
-
-  private def form_uri
-    Addressable::URI.parse(read_attribute(:form_url))
-  end
-
-  private def module_uri
-    Addressable::URI.parse(read_attribute(:module_url))
+    HardcodedDomainRewriter.new(read_attribute(:module_url)).run
   end
 end

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -69,7 +69,7 @@ class ActivityClassification < ActiveRecord::Base
   end
 
   private def url_domain_replacer(uri)
-    "#{ENV['DEFAULT_URL']}#{uri_path(uri)}"
+    "#{ENV['DEFAULT_URL']}#{uri.path}#{'?' + uri.query if uri.query}#{'#' + uri.fragment if uri.fragment}"
   end
 
   private def form_uri
@@ -78,9 +78,5 @@ class ActivityClassification < ActiveRecord::Base
 
   private def module_uri
     Addressable::URI.parse(read_attribute(:module_url))
-  end
-
-  private def uri_path(uri)
-    "#{uri.path}#{'?' + uri.query if uri.query}#{'#' + uri.fragment if uri.fragment}"
   end
 end

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -60,4 +60,27 @@ class ActivityClassification < ActiveRecord::Base
     find_by_key CONNECT_KEY
   end
 
+  def form_url
+    url_domain_replacer(form_uri)
+  end
+
+  def module_url
+    url_domain_replacer(module_uri)
+  end
+
+  private def url_domain_replacer(uri)
+    "#{ENV['DEFAULT_URL']}#{uri_path(uri)}"
+  end
+
+  private def form_uri
+    Addressable::URI.parse(read_attribute(:form_url))
+  end
+
+  private def module_uri
+    Addressable::URI.parse(read_attribute(:module_url))
+  end
+
+  private def uri_path(uri)
+    "#{uri.path}#{'?' + uri.query if uri.query}#{'#' + uri.fragment if uri.fragment}"
+  end
 end

--- a/services/QuillLMS/app/services/hardcoded_domain_rewriter.rb
+++ b/services/QuillLMS/app/services/hardcoded_domain_rewriter.rb
@@ -1,0 +1,35 @@
+class HardcodedDomainRewriter
+  attr_accessor :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def run
+    "#{domain}#{path}#{query}#{fragment}"
+  end
+
+  private def domain
+    @domain ||= ENV['DEFAULT_URL']
+  end
+
+  private def fragment
+    return '' if uri.fragment.blank?
+
+    '#' + uri.fragment
+  end
+
+  private def path
+    @path ||= uri.path
+  end
+
+  private def query
+    return '' if uri.query.blank?
+
+    '?' + uri.query
+  end
+
+  private def uri
+    @uri ||= Addressable::URI.parse(url)
+  end
+end

--- a/services/QuillLMS/app/services/hardcoded_domain_rewriter.rb
+++ b/services/QuillLMS/app/services/hardcoded_domain_rewriter.rb
@@ -6,11 +6,11 @@ class HardcodedDomainRewriter
   end
 
   def run
-    "#{domain}#{path}#{query}#{fragment}"
+    "#{domain}#{url_path}"
   end
 
   private def domain
-    @domain ||= ENV['DEFAULT_URL']
+    ENV['DEFAULT_URL']
   end
 
   private def fragment
@@ -20,7 +20,7 @@ class HardcodedDomainRewriter
   end
 
   private def path
-    @path ||= uri.path
+    uri.path
   end
 
   private def query
@@ -31,5 +31,9 @@ class HardcodedDomainRewriter
 
   private def uri
     @uri ||= Addressable::URI.parse(url)
+  end
+
+  private def url_path
+    path + query + fragment
   end
 end

--- a/services/QuillLMS/spec/models/activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/activity_classification_spec.rb
@@ -47,4 +47,57 @@ describe ActivityClassification, type: :model, redis: true do
     end
   end
 
+  describe '#form_url' do
+    let(:form_url) { "https://hard-coded-domain.com/#{form_path}" }
+    let(:activity_classification) { build(:activity_classification, form_url: form_url) }
+
+    context 'simple path' do
+      let(:form_path) { 'some_path/with_subdir' }
+
+      it { should_replace_form_url_hardcoded_domain_with_default_url }
+    end
+
+    context 'with fragment' do
+      let(:form_path) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
+
+      it { should_replace_form_url_hardcoded_domain_with_default_url }
+    end
+
+    context 'without fragment' do
+      let(:form_path) { 'path_with_no_fragment?anonymous=true' }
+
+      it { should_replace_form_url_hardcoded_domain_with_default_url }
+    end
+
+    def should_replace_form_url_hardcoded_domain_with_default_url
+      expect(activity_classification.form_url).to eq "#{ENV['DEFAULT_URL']}/#{form_path}"
+    end
+  end
+
+  describe '#module_url' do
+    let(:module_url) { "https://hard-coded-domain.com/#{module_path}" }
+    let(:activity_classification) { build(:activity_classification, module_url: module_url) }
+
+    context 'simple path' do
+      let(:module_path) { 'some_path/with_segment' }
+
+      it { should_replace_module_url_hardcoded_domain_with_default_url }
+    end
+
+    context 'with fragment' do
+      let(:module_path) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
+
+      it { should_replace_module_url_hardcoded_domain_with_default_url }
+    end
+
+    context 'without fragment' do
+      let(:module_path) { 'path_with_no_fragment?anonymous=true' }
+
+      it { should_replace_module_url_hardcoded_domain_with_default_url }
+    end
+
+    def should_replace_module_url_hardcoded_domain_with_default_url
+      expect(activity_classification.module_url).to eq "#{ENV['DEFAULT_URL']}/#{module_path}"
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/activity_classification_spec.rb
@@ -48,56 +48,22 @@ describe ActivityClassification, type: :model, redis: true do
   end
 
   describe '#form_url' do
-    let(:form_url) { "https://hard-coded-domain.com/#{form_path}" }
+    let(:str) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
+    let(:form_url) { "https://hard-coded-domain.com/#{str}" }
     let(:activity_classification) { build(:activity_classification, form_url: form_url) }
 
-    context 'simple path' do
-      let(:form_path) { 'some_path/with_subdir' }
-
-      it { should_replace_form_url_hardcoded_domain_with_default_url }
-    end
-
-    context 'with fragment' do
-      let(:form_path) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
-
-      it { should_replace_form_url_hardcoded_domain_with_default_url }
-    end
-
-    context 'without fragment' do
-      let(:form_path) { 'path_with_no_fragment?anonymous=true' }
-
-      it { should_replace_form_url_hardcoded_domain_with_default_url }
-    end
-
-    def should_replace_form_url_hardcoded_domain_with_default_url
-      expect(activity_classification.form_url).to eq "#{ENV['DEFAULT_URL']}/#{form_path}"
+    it 'uses default url in place of any hardcoded domain value' do
+      expect(activity_classification.form_url).to eq "#{ENV['DEFAULT_URL']}/#{str}"
     end
   end
 
   describe '#module_url' do
-    let(:module_url) { "https://hard-coded-domain.com/#{module_path}" }
+    let(:str) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
+    let(:module_url) { "https://hard-coded-domain.com/#{str}" }
     let(:activity_classification) { build(:activity_classification, module_url: module_url) }
 
-    context 'simple path' do
-      let(:module_path) { 'some_path/with_segment' }
-
-      it { should_replace_module_url_hardcoded_domain_with_default_url }
-    end
-
-    context 'with fragment' do
-      let(:module_path) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
-
-      it { should_replace_module_url_hardcoded_domain_with_default_url }
-    end
-
-    context 'without fragment' do
-      let(:module_path) { 'path_with_no_fragment?anonymous=true' }
-
-      it { should_replace_module_url_hardcoded_domain_with_default_url }
-    end
-
-    def should_replace_module_url_hardcoded_domain_with_default_url
-      expect(activity_classification.module_url).to eq "#{ENV['DEFAULT_URL']}/#{module_path}"
+    it 'uses default url in place of any hardcoded domain value' do
+      expect(activity_classification.module_url).to eq "#{ENV['DEFAULT_URL']}/#{str}"
     end
   end
 end

--- a/services/QuillLMS/spec/models/activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/activity_classification_spec.rb
@@ -48,22 +48,42 @@ describe ActivityClassification, type: :model, redis: true do
   end
 
   describe '#form_url' do
-    let(:str) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
-    let(:form_url) { "https://hard-coded-domain.com/#{str}" }
-    let(:activity_classification) { build(:activity_classification, form_url: form_url) }
+    form_urls = %w[
+      https://www.quill.org/comprehension/#/play
+      https://www.quill.org/proofreader/#/play/pf
+      https://www.quill.org/diagnostic/#/play/diagnostic/
+      https://www.quill.org/grammar/#/play/sw/
+      https://www.quill.org/connect/#/play/lesson/
+      https://www.quill.org/lessons/#/
+    ]
 
-    it 'uses default url in place of any hardcoded domain value' do
-      expect(activity_classification.form_url).to eq "#{ENV['DEFAULT_URL']}/#{str}"
+    form_urls.each do |form_url|
+      let(:activity_classification) { build(:activity_classification, form_url: form_url) }
+      let(:url_path) { form_url.gsub('https://www.quill.org', '') }
+
+      it 'uses default url in place of any hardcoded domain value' do
+        expect(activity_classification.form_url).to eq "#{ENV['DEFAULT_URL']}#{url_path}"
+      end
     end
   end
 
   describe '#module_url' do
-    let(:str) { 'some_path#/tool/-LKX2VhTOrWyUx9?anonymous=true' }
-    let(:module_url) { "https://hard-coded-domain.com/#{str}" }
-    let(:activity_classification) { build(:activity_classification, module_url: module_url) }
+    module_urls = %w[
+      https://www.quill.org/comprehension/#/play
+      https://www.quill.org/proofreader/#/play/pf
+      https://www.quill.org/diagnostic/#/play/diagnostic/
+      https://www.quill.org/grammar/#/play/sw/
+      https://www.quill.org/connect/#/play/lesson/
+      https://www.quill.org/lessons/#/play/class-lessons/
+    ]
 
-    it 'uses default url in place of any hardcoded domain value' do
-      expect(activity_classification.module_url).to eq "#{ENV['DEFAULT_URL']}/#{str}"
+    module_urls.each do |module_url|
+      let(:activity_classification) { build(:activity_classification, module_url: module_url) }
+      let(:url_path) { module_url.gsub('https://www.quill.org', '') }
+
+      it 'uses default url in place of any hardcoded domain value' do
+        expect(activity_classification.module_url).to eq "#{ENV['DEFAULT_URL']}#{url_path}"
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/hardcoded_domain_rewriter_spec.rb
+++ b/services/QuillLMS/spec/services/hardcoded_domain_rewriter_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe HardcodedDomainRewriter do
+  let(:rewriter) { described_class.new(url) }
+  let(:url) { "https://hard-coded-domain.com/#{str}" }
+
+  context 'simple_path' do
+    let(:str) { 'some_path/with_segment' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'with query' do
+    let(:str) { 'some_path/with_segment?key=value' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'with query then fragment' do
+    let(:str) { 'some_path/with_segment?key=value#/anchor' }
+  end
+
+  context 'with fragment' do
+    let(:str) { 'some_path#/fragment/-someuid' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'with fragment then query' do
+    let(:str) { 'some_path#/fragment/-someuid?key=value' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  def should_replace_domain_with_env_default_url
+    expect(rewriter.run).to eq "#{ENV['DEFAULT_URL']}/#{str}"
+  end
+end

--- a/services/QuillLMS/spec/services/hardcoded_domain_rewriter_spec.rb
+++ b/services/QuillLMS/spec/services/hardcoded_domain_rewriter_spec.rb
@@ -2,37 +2,57 @@ require 'rails_helper'
 
 RSpec.describe HardcodedDomainRewriter do
   let(:rewriter) { described_class.new(url) }
-  let(:url) { "https://hard-coded-domain.com/#{str}" }
+  let(:url) { "https://hard-coded-domain.com#{url_path}" }
 
-  context 'simple_path' do
-    let(:str) { 'some_path/with_segment' }
-
-    it { should_replace_domain_with_env_default_url }
-  end
-
-  context 'with query' do
-    let(:str) { 'some_path/with_segment?key=value' }
+  context 'empty' do
+    let(:url_path) { '' }
 
     it { should_replace_domain_with_env_default_url }
   end
 
-  context 'with query then fragment' do
-    let(:str) { 'some_path/with_segment?key=value#/anchor' }
-  end
-
-  context 'with fragment' do
-    let(:str) { 'some_path#/fragment/-someuid' }
+  context 'path' do
+    let(:url_path) { '/some_path/with_segment' }
 
     it { should_replace_domain_with_env_default_url }
   end
 
-  context 'with fragment then query' do
-    let(:str) { 'some_path#/fragment/-someuid?key=value' }
+  context 'query' do
+    let(:url_path) { '/?key=value' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'fragment' do
+    let(:url_path) { '/#/fragment/-someuid' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'path and query' do
+    let(:url_path) { '/some_path/with_segment?key=value' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'path and fragment' do
+    let(:url_path) { '/some_path#/fragment/-someuid' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'path, query, and fragment' do
+    let(:url_path) { '/some_path/with_segment?key=value#/anchor' }
+
+    it { should_replace_domain_with_env_default_url }
+  end
+
+  context 'path, fragment, and query' do
+    let(:url_path) { '/some_path#/fragment/-someuid?key=value' }
 
     it { should_replace_domain_with_env_default_url }
   end
 
   def should_replace_domain_with_env_default_url
-    expect(rewriter.run).to eq "#{ENV['DEFAULT_URL']}/#{str}"
+    expect(rewriter.run).to eq "#{ENV['DEFAULT_URL']}#{url_path}"
   end
 end


### PR DESCRIPTION
## WHAT
Original failed PR is here: https://github.com/empirical-org/Empirical-Core/pull/7685

The table ActivityClassification has an attribute module_url where values have domains hardcoded.
When this attribute is called on a staging site, it causes links to redirect from a staging site to production.

## WHY
This bug will prevent integration tests from getting accurate results on staging configurations. For example, a ghost inspector test might click on one of these links and then effectively be testing the production site.

## HOW
Use `Addressable::URI.parse` to partition the url into its components.  Then reconstruct, this time including the crucial 'fragment' component which is strings following `'#'`: 

`"#{domain}#{path}#{query}#{fragment}"`

### Notion Card Links
https://www.notion.so/quill/Fix-anonymous-activity-redirect-bug-68d328a5a63c4193a5861c9f8d01aa0a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
