### PR TITLE
fix issue where semantic rules cheat sheet pulls non-semantic rules as well

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRulesCheatSheet.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticRulesCheatSheet.tsx
@@ -18,7 +18,7 @@ const SemanticRulesCheatSheet = ({ match, }) => {
 
   const { data: rulesData } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-${promptId}`, activityId, promptId, 'autoML'],
+    queryKey: [`rules-${activityId}-${promptId}-autoML`, null, promptId, 'autoML'], // we have an activity id, but passing it to this function will result in the wrong url
     queryFn: fetchRules
   });
 


### PR DESCRIPTION
## WHAT
Fix issue where semantic rules cheat sheet pulls all rules for the prompt.

## WHY
We only want to see semantic rules here.

## HOW
Remove the activity argument, which was causing the `getRulesUrl` function to return the wrong url.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
