### PR TITLE
Implement Case Sensitive behavior for Comprehension Regex Rules

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -26,7 +26,7 @@ module Comprehension
       ))
     end
 
-    def is_entry_failing?(entry)
+    def entry_failing?(entry)
       # for "incorrect" type regex rules, we want to "fail" if they have the regex. for "required" type regex
       # rules, we want to "fail" when they dont have the regex.
       sequence_type == TYPE_INCORRECT ? regex_match(entry) : !regex_match(entry)

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -26,6 +26,16 @@ module Comprehension
       ))
     end
 
+    def is_entry_failing?(entry)
+      # for "incorrect" type regex rules, we want to "fail" if they have the regex. for "required" type regex
+      # rules, we want to "fail" when they dont have the regex.
+      sequence_type == TYPE_INCORRECT ? regex_match(entry) : !regex_match(entry)
+    end
+
+    private def regex_match(entry)
+      case_sensitive? ? Regexp.new(regex_text).match(entry) : Regexp.new(regex_text, Regexp::IGNORECASE).match(entry)
+    end
+
     private def set_default_case_sensitivity
       return if case_sensitive.in? CASE_SENSITIVE_ALLOWED_VALUES
       self.case_sensitive = DEFAULT_CASE_SENSITIVITY

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -68,8 +68,10 @@ module Comprehension
 
     def regex_is_passing?(entry)
       regex_rules.none? do |regex_rule|
-        is_matching = match_with_case_sensitive(regex_rule.regex_text, regex_rule.case_sensitive, entry)
-        regex_rule.sequence_type == RegexRule::TYPE_INCORRECT ? is_matching : !is_matching
+        regex_match = match_with_case_sensitive(regex_rule.regex_text, regex_rule.case_sensitive, entry)
+        # for "incorrect" type regex rules, we want to "fail" if they have the regex. for "required" type regex
+        # rules, we want to "fail" when they dont have the regex.
+        regex_rule.sequence_type == RegexRule::TYPE_INCORRECT ? regex_match : !regex_match
       end
     end
 
@@ -77,7 +79,7 @@ module Comprehension
       DISPLAY_NAMES[rule_type.to_sym] || rule_type
     end
 
-    private def match_with_case_sensitive(regex, is_case_sensitive, text)
+    private def match_with_case_sensitive(regex, is_case_sensitive=false, text)
       is_case_sensitive ? Regexp.new(regex).match(text) : Regexp.new(regex, Regexp::IGNORECASE).match(text)
     end
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -68,12 +68,17 @@ module Comprehension
 
     def regex_is_passing?(entry)
       regex_rules.none? do |regex_rule|
-        regex_rule.sequence_type == RegexRule::TYPE_INCORRECT ? Regexp.new(regex_rule.regex_text).match(entry) : !Regexp.new(regex_rule.regex_text).match(entry)
+        is_matching = match_with_case_sensitive(regex_rule.regex_text, regex_rule.case_sensitive, entry)
+        regex_rule.sequence_type == RegexRule::TYPE_INCORRECT ? is_matching : !is_matching
       end
     end
 
     def display_name
       DISPLAY_NAMES[rule_type.to_sym] || rule_type
+    end
+
+    private def match_with_case_sensitive(regex, is_case_sensitive, text)
+      is_case_sensitive ? Regexp.new(regex).match(text) : Regexp.new(regex, Regexp::IGNORECASE).match(text)
     end
 
     private def plagiarism?

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -68,7 +68,7 @@ module Comprehension
 
     def regex_is_passing?(entry)
       regex_rules.none? do |regex_rule|
-        regex_rule.is_entry_failing?(entry)
+        regex_rule.entry_failing?(entry)
       end
     end
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -68,19 +68,12 @@ module Comprehension
 
     def regex_is_passing?(entry)
       regex_rules.none? do |regex_rule|
-        regex_match = match_with_case_sensitive(regex_rule.regex_text, regex_rule.case_sensitive, entry)
-        # for "incorrect" type regex rules, we want to "fail" if they have the regex. for "required" type regex
-        # rules, we want to "fail" when they dont have the regex.
-        regex_rule.sequence_type == RegexRule::TYPE_INCORRECT ? regex_match : !regex_match
+        regex_rule.is_entry_failing?(entry)
       end
     end
 
     def display_name
       DISPLAY_NAMES[rule_type.to_sym] || rule_type
-    end
-
-    private def match_with_case_sensitive(regex, is_case_sensitive=false, text)
-      is_case_sensitive ? Regexp.new(regex).match(text) : Regexp.new(regex, Regexp::IGNORECASE).match(text)
     end
 
     private def plagiarism?

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
@@ -37,29 +37,29 @@ module Comprehension
       end
     end
 
-    context 'is_entry_failing?' do
+    context 'entry_failing?' do
       setup do
         @rule = create(:comprehension_rule)
         @regex_rule = RegexRule.create(rule: @rule, regex_text: '^test', sequence_type: 'required', case_sensitive: false)
       end
 
       should 'flag entry as failing if regex does not match and sequence type is required' do
-        assert @regex_rule.is_entry_failing?('not test passing')
+        assert @regex_rule.entry_failing?('not test passing')
       end
 
       should 'flag entry as failing if regex matches and sequence type is incorrect' do
         @regex_rule.update(sequence_type: 'incorrect')
-        assert @regex_rule.is_entry_failing?('test regex')
+        assert @regex_rule.entry_failing?('test regex')
       end
 
       should 'flag entry as failing case-insensitive if the regex_rule is case insensitive' do
         @regex_rule.update(sequence_type: 'incorrect')
-        assert @regex_rule.is_entry_failing?('TEST REGEX')
+        assert @regex_rule.entry_failing?('TEST REGEX')
       end
 
       should 'not flag entry as failing if the regex_rule is case sensitive and the casing does not match' do
         @regex_rule.update(sequence_type: 'incorrect', case_sensitive: true)
-        refute @regex_rule.is_entry_failing?('TEST REGEX')
+        refute @regex_rule.entry_failing?('TEST REGEX')
       end
     end
   end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
@@ -36,5 +36,31 @@ module Comprehension
         refute @regex_rule.valid?
       end
     end
+
+    context 'is_entry_failing?' do
+      setup do
+        @rule = create(:comprehension_rule)
+        @regex_rule = RegexRule.create(rule: @rule, regex_text: '^test', sequence_type: 'required', case_sensitive: false)
+      end
+
+      should 'flag entry as failing if regex does not match and sequence type is required' do
+        assert @regex_rule.is_entry_failing?('not test passing')
+      end
+
+      should 'flag entry as failing if regex matches and sequence type is incorrect' do
+        @regex_rule.update(sequence_type: 'incorrect')
+        assert @regex_rule.is_entry_failing?('test regex')
+      end
+
+      should 'flag entry as failing case-insensitive if the regex_rule is case insensitive' do
+        @regex_rule.update(sequence_type: 'incorrect')
+        assert @regex_rule.is_entry_failing?('TEST REGEX')
+      end
+
+      should 'not flag entry as failing if the regex_rule is case sensitive and the casing does not match' do
+        @regex_rule.update(sequence_type: 'incorrect', case_sensitive: true)
+        refute @regex_rule.is_entry_failing?('TEST REGEX')
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
@@ -140,6 +140,16 @@ module Comprehension
         @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required')
         assert @rule.regex_is_passing?('you need this sequence and I do have it')
       end
+
+      should 'be true if rule is NOT case sensitive and entry matches regardless of casing' do
+        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: false)
+        assert @rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I DO HAVE IT')
+      end
+
+      should 'be false if rule IS case sensitive and entry does not match casing' do
+        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: true)
+        assert !@rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I do not HAVE IT in the right casing')
+      end
     end
 
     context 'one_plagiarism_per_prompt' do


### PR DESCRIPTION
## WHAT
Due to my own oversight, I wasn't actually implementing Regex Rules as case sensitive or case insensitive even though I built the flagging ability into the model. This PR just implements that behavior so that case INSENSITIVE regex rules are applied insensitive to case.

## WHY
Curriculum wants these regex rules to work if they flag them as case insensitive

## HOW
Add branching behavior based on whether the regex rule is case sensitive or case insensitive

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Comprehension-regex-case-insensitive-button-is-not-working-488edc5f24dd4788a790265b80b2119b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
