### PR TITLE
update copy for student view in comprehension

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -416,7 +416,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     if (!currentActivity || activeStep !== READ_PASSAGE_STEP) { return }
 
     return (<div className='read-passage-step-container'>
-      <h2>Read the passage</h2>
+      <h2>Read the text.</h2>
       <button className='quill-button large primary contained done-reading-button' onClick={this.handleDoneReadingClick} type="button">Done reading</button>
     </div>)
   }
@@ -450,7 +450,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
       />)
     })
 
-    const headerCopy = activeStep === READ_PASSAGE_STEP ? 'Then, complete these sentences' : 'Complete these sentences'
+    const headerCopy = activeStep === READ_PASSAGE_STEP ? 'Then, use information from the text to finish the sentence. Remember to put the response in your own\u00A0words.' : 'Use information from the text to finish the sentence. Remember to put the response in your own words.'
 
     return (<div>
       <h2>{headerCopy}</h2>

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/container.test.tsx.snap
@@ -165,7 +165,7 @@ But how can democracies have representative governments unless all or most of th
           className="read-passage-step-container"
         >
           <h2>
-            Read the passage
+            Read the text.
           </h2>
           <button
             className="quill-button large primary contained done-reading-button"
@@ -177,7 +177,7 @@ But how can democracies have representative governments unless all or most of th
         </div>
         <div>
           <h2>
-            Then, complete these sentences
+            Then, use information from the text to finish the sentence. Remember to put the response in your own words.
           </h2>
           <PromptStep
             activateStep={[Function]}


### PR DESCRIPTION
## WHAT
Update copy for student view on Comprehension.

## WHY
The title page reminds students to write a response in their own words, and it would be helpful to have those same directions on the activity page as well. 

## HOW
Just a copy change, with a unicode non-breaking space character so that the header doesn't end up with a widowed word.

### Screenshots
<img width="654" alt="Screen Shot 2021-05-25 at 11 40 40 AM" src="https://user-images.githubusercontent.com/18669014/119527677-8d42dc00-bd4e-11eb-9af5-d10ab905f4bf.png">
<img width="654" alt="Screen Shot 2021-05-25 at 11 36 51 AM" src="https://user-images.githubusercontent.com/18669014/119527678-8d42dc00-bd4e-11eb-87ed-0c583de31fc4.png">


### Notion Card Links
https://www.notion.so/quill/Update-the-Comprehension-student-app-directions-5def235c0ab642fa8fcf3b4c61ecfd82

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
