### PR TITLE
Prevent automatic chrome translation of activities

### DIFF
--- a/services/QuillLMS/app/views/layouts/activity.html.erb
+++ b/services/QuillLMS/app/views/layouts/activity.html.erb
@@ -1,4 +1,4 @@
-<html lang='en'>
+<html translate='no' lang='en'>
   <%= render partial: 'head' %>
   <script>
     function handleTabNavigation(e) {


### PR DESCRIPTION
## WHAT
We've gotten reports that students with their Chrome language set to a non-English language (in this case, Spanish) have been getting their activities automatically translated to Spanish because of Chrome native behavior. This small tweak prevents that as it marks the HTML block as non-translatable.

## WHY
Teachers do not want their students using Quill in a non-English language because the goal of using Quill is to improve students' English skills.

## HOW
Just add this attribute to the HTMl tag and the Chrome auto-translate will ignore the text in the tag.

### Screenshots
<img width="901" alt="Screen Shot 2021-05-25 at 11 04 17 AM" src="https://user-images.githubusercontent.com/57366100/119531022-2a027b00-bd49-11eb-93ab-0b9826c9d43a.png">

### Notion Card Links
https://www.notion.so/quill/Translations-of-Quill-Activities-b1230578adb7472b81e539a7975cc672

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually because I need to replicate Chrome behavior.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
