### PR TITLE
Change plagiarism phrase minimum from six words to ten words

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/plagiarism_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/plagiarism_check.rb
@@ -4,7 +4,7 @@ module Comprehension
     ALL_CORRECT_FEEDBACK = 'All plagiarism checks passed.'
     PASSAGE_TYPE = 'passage'
     ENTRY_TYPE = 'response'
-    MATCH_MINIMUM = 6
+    MATCH_MINIMUM = 10
     OPTIMAL_RULE_KEY = 'optimal_plagiarism_rule_serialized'
     attr_reader :entry, :passage, :nonoptimal_feedback
 

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/feedback_controller_test.rb
@@ -11,7 +11,7 @@ module Comprehension
       create(:comprehension_regex_rule, regex_text: '^test', rule: @rule_regex)
       create(:comprehension_prompts_rule, rule: @rule, prompt: @prompt)
       create(:comprehension_prompts_rule, rule: @rule_regex, prompt: @prompt)
-      create(:comprehension_plagiarism_text, text: "do not plagiarize this text please", rule: @rule)
+      create(:comprehension_plagiarism_text, text: "do not plagiarize this text please there will be consequences", rule: @rule)
       @first_feedback = create(:comprehension_feedback, text: 'here is our first feedback', rule: @rule, order: 0)
       @second_feedback = create(:comprehension_feedback, text: 'here is our second feedback', rule: @rule, order: 1)
     end
@@ -29,14 +29,14 @@ module Comprehension
       end
 
       should "return successfully when there is plagiarism" do
-        post 'plagiarism', entry: "bla bla bla do not plagiarize this text please", prompt_id: @prompt.id, session_id: 1, previous_feedback: []
+        post 'plagiarism', entry: "bla bla bla do not plagiarize this text please there will be consequences", prompt_id: @prompt.id, session_id: 1, previous_feedback: []
         parsed_response = JSON.parse(response.body)
         assert_equal parsed_response["optimal"], false
-        assert_equal parsed_response["highlight"][0]["text"], "do not plagiarize this text please"
-        assert_equal parsed_response["highlight"][1]["text"], "do not plagiarize this text please"
+        assert_equal parsed_response["highlight"][0]["text"], "do not plagiarize this text please there will be consequences"
+        assert_equal parsed_response["highlight"][1]["text"], "do not plagiarize this text please there will be consequences"
         assert_equal parsed_response["feedback"], @first_feedback.text
 
-        post 'plagiarism', entry: "bla bla bla do not plagiarize this text please", prompt_id: @prompt.id, session_id: 1, previous_feedback: [parsed_response]
+        post 'plagiarism', entry: "bla bla bla do not plagiarize this text please there will be consequences", prompt_id: @prompt.id, session_id: 1, previous_feedback: [parsed_response]
         parsed_response = JSON.parse(response.body)
         assert_equal parsed_response["optimal"], false
         assert_equal parsed_response["feedback"], @second_feedback.text

--- a/services/QuillLMS/engines/comprehension/test/lib/plagiarism_check_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/lib/plagiarism_check_test.rb
@@ -9,8 +9,8 @@ module Comprehension
     context '#feedback_object' do
       should 'return appropriate feedback attributes if there is plagiarism' do
         $redis.redis.flushdb
-        entry = "these are s'',ome! r''esponse words to plagiarize"
-        passage = "these are some res,,,,ponse,,,, words to plagiarize"
+        entry = "these are s'',ome! r''esponse words to plagiarize and this is plagiarism"
+        passage = "these are some res,,,,ponse,,,, words to plagiarize and this is plagiarism"
         feedback = "this is some standard plagiarism feedback"
         plagiarism_check = Comprehension::PlagiarismCheck.new(entry, passage, feedback, @rule)
         feedback = plagiarism_check.feedback_object
@@ -29,6 +29,21 @@ module Comprehension
         entry = "these are some response words to plagiarize"
         passage = "it is always bad to plagiarize"
         feedback = "this is some standard plagiarism feedback"
+        optimal_rule = create(:comprehension_rule, rule_type: 'plagiarism', optimal: true)
+        plagiarism_check = Comprehension::PlagiarismCheck.new(entry, passage, feedback, @rule)
+        feedback = plagiarism_check.feedback_object
+        assert feedback[:feedback], Comprehension::PlagiarismCheck::ALL_CORRECT_FEEDBACK
+        assert feedback[:feedback_type], Comprehension::Rule::TYPE_PLAGIARISM
+        assert feedback[:optimal]
+        assert feedback[:entry], entry
+        assert feedback[:rule_uid], optimal_rule.uid
+        assert feedback[:concept_uid], optimal_rule.concept_uid
+      end
+
+      should 'not be plagiarized if the plagiarism word phrase is under the match minimum' do
+        entry = "these are some response words to plagiarize"
+        passage = "it is always bad to plagiarize"
+        feedback = "it is always bad to plagiarize"
         optimal_rule = create(:comprehension_rule, rule_type: 'plagiarism', optimal: true)
         plagiarism_check = Comprehension::PlagiarismCheck.new(entry, passage, feedback, @rule)
         feedback = plagiarism_check.feedback_object


### PR DESCRIPTION
## WHAT
Up the minimum word-count of a plagiarized phrase to 10 words, because Curriculum was finding that 6 words was a little too sensitive.

## WHY
This will help students receive the most helpful feedback.

## HOW
Just change the `MATCH_MINIMUM` variable in the plagiarism check model. And update a bunch of tests because we were testing with 6-word phrases.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Change-plagiarism-algorithm-from-six-consecutive-words-to-ten-075469ce359a4f3abbb02f5afdcf3a8f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
