### PR TITLE
comprehension/null-activity-session-percentage

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -15,7 +15,7 @@ import { completeActivitySession,
          getFeedback,
          processUnfetchableSession,
          saveActiveActivitySession } from '../../actions/session'
-import { calculatePercentage, generateConceptResults, } from '../../libs/conceptResults'
+import { generateConceptResults, } from '../../libs/conceptResults'
 import { ActivitiesReducerState } from '../../reducers/activitiesReducer'
 import { SessionReducerState } from '../../reducers/sessionReducer'
 import getParameterByName from '../../helpers/getParameterByName';
@@ -114,7 +114,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { activities, dispatch, session, } = this.props
     const { sessionID, submittedResponses, } = session
     const { currentActivity, } = activities
-    const percentage = calculatePercentage(submittedResponses)
+    const percentage = null // We always set percentages to "null"
     const conceptResults = generateConceptResults(currentActivity, submittedResponses)
     dispatch(completeActivitySession(sessionID, percentage, conceptResults))
   }

--- a/services/QuillLMS/client/app/bundles/Comprehension/libs/conceptResults.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/libs/conceptResults.ts
@@ -8,11 +8,6 @@ export const ATTEMPTS_TO_SCORE = {
 
 export const COMPREHENSION_DIRECTIONS = 'Complete this sentence'
 
-export const calculatePercentage = (submittedResponses) => {
-  const attemptCounts = Object.values(submittedResponses).map((responses) => ATTEMPTS_TO_SCORE[responses.length])
-  return attemptCounts.reduce((total, value) => total + value) / attemptCounts.length
-}
-
 export const generateConceptResults = (currentActivity, submittedResponses) => {
   const conjunctionToQuestionNumber = {
     because: 1,

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.data.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.data.ts
@@ -108,7 +108,7 @@ export const currentActivity = {
 
 export const expectedPayload = {
   "state":"finished",
-  "percentage":0.8333333333333334,
+  "percentage":null,
   "concept_results":[
     {
       "concept_uid": "placeholder",

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.test.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/libs/conceptResults.test.ts
@@ -12,11 +12,6 @@ import {
 } from './conceptResults.data'
 
 describe("Getting concept results from a completed Comprehension activity", () => {
-  it("should determine the correct percentage", () => {
-    const result = calculatePercentage(submittedResponses)
-    expect(result).toEqual(0.8333333333333334)
-  })
-
   it("should generate concept results with concept UIDs and optimal flags", () => {
     const result = generateConceptResults(currentActivity, submittedResponses)
     expect(result).toEqual(expectedPayload.concept_results)    


### PR DESCRIPTION
## WHAT
Tweak LMS reporting to give "null" scores
## WHY
Since we don't expect more traditional performance in Comprehension, we don't want to provide confusing numbers
## HOW
Just change the code that calculates a live percentage for code that sets the constant value `null` when saving the `ActivitySession`.

### Notion Card Links
https://www.notion.so/quill/Remove-Comprehension-Scores-b185c1265505449fbb5c85e9bfd31ac2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
