### PR TITLE
restrict prompt order in Comprehension

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -434,10 +434,13 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
       // using i + 2 because the READ_PASSAGE_STEP is 1, so the first item in the set of prompts will always be 2
       const stepNumber = i + 2
       const everyOtherStepCompleted = completedSteps.filter(s => s !== stepNumber).length === 3
+      const canBeClicked = completedSteps.includes(stepNumber - 1) || completedSteps.includes(stepNumber) // can click on completed steps or the one after the last completed
+
       return (<PromptStep
         activateStep={this.activateStep}
         active={stepNumber === activeStep}
-        className={`step ${activeStep === stepNumber ? 'active' : ''}`}
+        canBeClicked={canBeClicked}
+        className={`step ${canBeClicked ? 'clickable' : ''} ${activeStep === stepNumber ? 'active' : ''}`}
         completeStep={this.completeStep}
         everyOtherStepCompleted={everyOtherStepCompleted}
         key={stepNumber}

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -18,7 +18,8 @@ interface PromptStepProps {
   activateStep: (event: any) => void;
   prompt: any,
   passedRef: any,
-  submittedResponses: Array<any>
+  submittedResponses: Array<any>,
+  canBeClicked: boolean
 }
 
 interface PromptStepState {
@@ -346,11 +347,20 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   }
 
   render() {
-    const { className, passedRef, } = this.props
-    return (<div className={className} onClick={this.handleStepInteraction} onKeyDown={this.handleStepInteraction} ref={passedRef} role="button" tabIndex={0}>
-      <div className="step-content">
-        {this.renderActiveContent()}
-      </div>
+    const { className, passedRef, canBeClicked, } = this.props
+    const stepContent = (<div className="step-content">
+      {this.renderActiveContent()}
+    </div>)
+
+    if (canBeClicked) {
+      return (<div className={className} onClick={this.handleStepInteraction} onKeyDown={this.handleStepInteraction} ref={passedRef} role="button" tabIndex={0}>
+        {stepContent}
+      </div>)
+
+    }
+
+    return (<div className={className}>
+      {stepContent}
     </div>)
   }
 }

--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/step.scss
@@ -5,8 +5,10 @@
   max-width: 631px;
   margin-bottom: 10px;
   display: flex;
-  cursor: pointer;
   overflow: hidden;
+  &.clickable {
+    cursor: pointer;
+  }
   &:focus {
     outline: none;
   }

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/container.test.tsx.snap
@@ -182,7 +182,8 @@ But how can democracies have representative governments unless all or most of th
           <PromptStep
             activateStep={[Function]}
             active={false}
-            className="step "
+            canBeClicked={false}
+            className="step  "
             completeStep={[Function]}
             everyOtherStepCompleted={false}
             key="2"
@@ -210,11 +211,7 @@ But how can democracies have representative governments unless all or most of th
             submittedResponses={Array []}
           >
             <div
-              className="step "
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={0}
+              className="step  "
             >
               <div
                 className="step-content"
@@ -246,7 +243,8 @@ But how can democracies have representative governments unless all or most of th
           <PromptStep
             activateStep={[Function]}
             active={false}
-            className="step "
+            canBeClicked={false}
+            className="step  "
             completeStep={[Function]}
             everyOtherStepCompleted={false}
             key="3"
@@ -274,11 +272,7 @@ But how can democracies have representative governments unless all or most of th
             submittedResponses={Array []}
           >
             <div
-              className="step "
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={0}
+              className="step  "
             >
               <div
                 className="step-content"
@@ -310,7 +304,8 @@ But how can democracies have representative governments unless all or most of th
           <PromptStep
             activateStep={[Function]}
             active={false}
-            className="step "
+            canBeClicked={false}
+            className="step  "
             completeStep={[Function]}
             everyOtherStepCompleted={false}
             key="4"
@@ -338,11 +333,7 @@ But how can democracies have representative governments unless all or most of th
             submittedResponses={Array []}
           >
             <div
-              className="step "
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={0}
+              className="step  "
             >
               <div
                 className="step-content"

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -25,10 +25,6 @@ exports[`PromptStep component active state before any responses have been submit
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -142,10 +138,6 @@ exports[`PromptStep component active state when a profane response has been subm
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -343,10 +335,6 @@ exports[`PromptStep component active state when a response with multiple sentenc
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -554,10 +542,6 @@ exports[`PromptStep component active state when a suboptimal response has been s
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -788,10 +772,6 @@ exports[`PromptStep component active state when a too-long response has been sub
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -989,10 +969,6 @@ exports[`PromptStep component active state when a too-short response has been su
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -1200,10 +1176,6 @@ exports[`PromptStep component active state when an optimal response has been sub
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -1460,10 +1432,6 @@ exports[`PromptStep component active state when the max attempts have been reach
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -1708,10 +1676,6 @@ exports[`PromptStep component active state when the max attempts have been reach
 >
   <div
     className="step active"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"
@@ -1916,10 +1880,6 @@ exports[`PromptStep component inactive state renders 1`] = `
 >
   <div
     className="step"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
   >
     <div
       className="step-content"


### PR DESCRIPTION
## WHAT
Stop allowing users to complete prompts out of sequence. 

## WHY
Simplifying this functionality.

## HOW
Don't allow users to click on prompts that are not either already completed or the next in the sequence from the last completed one.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Lock-remaining-prompts-until-the-student-completes-the-preceding-prompt-s-Blocks-Time-Tracking-55d4c1a4d8434ee1b1bdce857377fd8a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
