### PR TITLE
Comprehension/optimize rule feedback query performance

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -1,26 +1,33 @@
 class RuleFeedbackHistory
     def self.generate_report(conjunction:, activity_id:)
         sql_result = exec_query(conjunction: conjunction, activity_id: activity_id)
-        postprocessed = postprocessing(sql_result)
-        format_sql_results(postprocessed)
+        #postprocessed = postprocessing(sql_result)
+        format_sql_results(sql_result)
     end
 
     def self.exec_query(conjunction:, activity_id:)
-        sql = <<~SQL
-          select rules.uid as rules_uid,
-          feedback_histories.feedback_history_ids as feedback_histories_id_array,
-            prompts.activity_id as activity_id,
-            rules.rule_type as rule_type,
-            rules.suborder as rule_suborder,
-            rules.name as rule_name,
-            rules.note as rule_note
-            FROM comprehension_rules as rules
-            INNER JOIN comprehension_prompts_rules as prompts_rules ON rules.id = prompts_rules.rule_id
-            INNER JOIN comprehension_prompts as prompts ON prompts_rules.prompt_id = prompts.id
-            LEFT JOIN feedback_histories_grouped_by_rule_uid as feedback_histories ON feedback_histories.rule_uid = rules.uid
-            WHERE prompts.conjunction = '#{conjunction}' AND activity_id = '#{activity_id}'
-        SQL
-        rules = Comprehension::Rule.find_by_sql(sql)
+        Comprehension::Rule.select(<<~SELECT
+          comprehension_rules.uid AS rules_uid,
+          prompts.activity_id AS activity_id,
+          comprehension_rules.rule_type AS rule_type,
+          comprehension_rules.suborder AS rule_suborder,
+          comprehension_rules.name AS rule_name,
+          comprehension_rules.note AS rule_note,
+          count(feedback_history_ratings.rating) AS total_responses,
+          count(CASE WHEN feedback_history_ratings.rating = true THEN 1 END) AS total_strong,
+          count(CASE WHEN feedback_history_ratings.rating = false THEN 1 END) AS total_weak,
+          count(CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN 1 END) AS repeated_consecutive,
+          count(CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE}' THEN 1 END) AS repeated_non_consecutive
+          SELECT
+        )
+        .joins('INNER JOIN comprehension_prompts_rules as prompts_rules ON comprehension_rules.id = prompts_rules.rule_id')
+        .joins('INNER JOIN comprehension_prompts as prompts ON prompts_rules.prompt_id = prompts.id')
+        .joins('LEFT JOIN feedback_histories ON feedback_histories.rule_uid = comprehension_rules.uid')
+        .joins('LEFT JOIN feedback_history_ratings ON feedback_histories.id = feedback_history_ratings.feedback_history_id')
+        .joins('LEFT JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
+        .where("prompts.conjunction = ? AND activity_id = ?", conjunction, activity_id)
+        .group('rules_uid, activity_id, rule_type, rule_suborder, rule_name, rule_note')
+        .includes(:feedbacks)
     end
 
     def self.feedback_history_to_json(f_h)
@@ -48,56 +55,13 @@ class RuleFeedbackHistory
         }
     end
 
-    def self.postprocessing(rules_sql_result)
-        rules_sql_result.each do |r|
-
-            feedback_histories = FeedbackHistory
-                .where(id: r.feedback_histories_id_array).includes(:feedback_history_ratings).includes(:feedback_history_flags)
-
-            total_scored = feedback_histories.reduce(0) do |memo, feedback_history|
-                memo + feedback_history.feedback_history_ratings.count
-            end
-
-            total_strong = 0
-            total_weak = 0
-            repeated_consecutive = 0
-            repeated_non_consecutive = 0
-            if total_scored > 0
-                feedback_histories.each do |history|
-                  total_strong += 1 if history.feedback_history_ratings.any?(&:rating)
-                  total_weak += 1 if history.feedback_history_ratings.any? { |hr| hr.rating == false }
-                  repeated_consecutive += 1 if history.feedback_history_flags.any? { |f| f.flag == FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE }
-                  repeated_non_consecutive += 1 if history.feedback_history_flags.any? { |f| f.flag == FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE }
-                end
-
-            end
-            r.define_singleton_method(:total_strong) { total_strong }
-            r.define_singleton_method(:total_weak) { total_weak }
-            r.define_singleton_method(:repeated_consecutive) { repeated_consecutive }
-            r.define_singleton_method(:repeated_non_consecutive) { repeated_non_consecutive }
-
-            r.define_singleton_method(:total_responses) { feedback_histories.count }
-        end
-
-        rule_feedbacks = Comprehension::Rule
-            .includes(:feedbacks)
-            .where(uid: rules_sql_result.map(&:rules_uid))
-
-        rules_sql_result.each do |r|
-            feedbacks = rule_feedbacks.find_by(uid: r.rules_uid).feedbacks
-            r.first_feedback = feedbacks.empty? ? '' : feedbacks.min_by {|f| f.order}.text
-        end
-
-        rules_sql_result
-    end
-
     def self.format_sql_results(relations)
         relations.map do |r|
             {
                 rule_uid: r.rules_uid,
                 api_name: r.rule_type,
                 rule_order: r.rule_suborder,
-                first_feedback: r.first_feedback,
+                first_feedback: r.feedbacks.first&.text || '',
                 rule_note: r.rule_note,
                 rule_name: r.rule_name,
                 total_responses: r.total_responses,

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -1,7 +1,6 @@
 class RuleFeedbackHistory
     def self.generate_report(conjunction:, activity_id:)
         sql_result = exec_query(conjunction: conjunction, activity_id: activity_id)
-        #postprocessed = postprocessing(sql_result)
         format_sql_results(sql_result)
     end
 

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -17,7 +17,7 @@ class RuleFeedbackHistory
           count(DISTINCT CASE WHEN feedback_history_ratings.rating = false THEN feedback_history_ratings.id END) AS total_weak,
           count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_consecutive,
           count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_non_consecutive
-          SELECT
+        SELECT
         )
         .joins('INNER JOIN comprehension_prompts_rules as prompts_rules ON comprehension_rules.id = prompts_rules.rule_id')
         .joins('INNER JOIN comprehension_prompts as prompts ON prompts_rules.prompt_id = prompts.id')

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -13,11 +13,11 @@ class RuleFeedbackHistory
           comprehension_rules.suborder AS rule_suborder,
           comprehension_rules.name AS rule_name,
           comprehension_rules.note AS rule_note,
-          count(feedback_history_ratings.rating) AS total_responses,
-          count(CASE WHEN feedback_history_ratings.rating = true THEN 1 END) AS total_strong,
-          count(CASE WHEN feedback_history_ratings.rating = false THEN 1 END) AS total_weak,
-          count(CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN 1 END) AS repeated_consecutive,
-          count(CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE}' THEN 1 END) AS repeated_non_consecutive
+          count(DISTINCT CASE WHEN feedback_history_ratings.rating IS NOT NULL THEN feedback_history_ratings.id END) AS total_responses,
+          count(DISTINCT CASE WHEN feedback_history_ratings.rating = true THEN feedback_history_ratings.id END) AS total_strong,
+          count(DISTINCT CASE WHEN feedback_history_ratings.rating = false THEN feedback_history_ratings.id END) AS total_weak,
+          count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_consecutive,
+          count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_non_consecutive
           SELECT
         )
         .joins('INNER JOIN comprehension_prompts_rules as prompts_rules ON comprehension_rules.id = prompts_rules.rule_id')

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       create(:feedback_history, rule_uid: so_rule1.uid)
       create(:feedback_history, rule_uid: so_rule1.uid)
 
+      # feedback_histories
+      f_h1 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h1 lorem")
+      f_h2 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h2 ipsum")
+
+      # users
+      user1 = create(:user)
+      user2 = create(:user)
+      
+      #feedback ratings
+      f_rating_1a = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user1.id, rating: true)
+      f_rating_1b = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user2.id, rating: false)
+      f_rating_2a = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user1.id, rating: true)
+      f_rating_2b = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user2.id, rating: nil)
+
+      #feedback flags
+      flag_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE)
+      flag_non_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE)
+
       report = RuleFeedbackHistory.generate_report(conjunction: 'so', activity_id: activity1.id)
 
       expected = {
@@ -46,89 +64,14 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         rule_name: so_rule1.name,
         rule_note: so_rule1.note,
         rule_uid: so_rule1.uid,
-        strong_responses: 0,
-        total_responses: 0,
-        weak_responses: 0,
-        repeated_consecutive_responses: 0,
-        repeated_non_consecutive_responses: 0,
+        strong_responses: 2,
+        total_responses: 3,
+        weak_responses: 1,
+        repeated_consecutive_responses: 1,
+        repeated_non_consecutive_responses: 1,
       }
 
-      expect(expected).to eq(report.first)
-
-    end
-  end
-
-  describe '#postprocessing' do
-    it 'should include feedback_histories' do
-      # activities
-      activity1 = Comprehension::Activity.create!(title: 'Title 1', parent_activity_id: 1, target_level: 1, name: 'an_activity_1')
-
-      # prompts
-      so_prompt1 = Comprehension::Prompt.create!(activity: activity1, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      because_prompt1 = Comprehension::Prompt.create!(activity: activity1, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-
-      # rules
-      so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
-
-      #feedbacks
-      f3 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 3, text: 'lorem ipsum dolor 3')
-      f1 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 1, text: 'lorem ipsum dolor 1')
-      f2 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 2, text: 'lorem ipsum dolor 2')
-
-      # feedback_histories
-      create(:feedback_history, rule_uid: so_rule1.uid)
-      create(:feedback_history, rule_uid: so_rule1.uid)
-
-      sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
-      post_result = RuleFeedbackHistory.postprocessing(sql_result)
-
-      expect(post_result.first.first_feedback).to eq f1.text
-    end
-
-    it 'should calculate rating metrics correctly' do
-        user1 = create(:user)
-        user2 = create(:user)
-
-        # activities
-        activity1 = Comprehension::Activity.create!(title: 'Title 1', parent_activity_id: 1, target_level: 1, name: 'an_activity_1')
-
-        # prompts
-        so_prompt1 = Comprehension::Prompt.create!(activity: activity1, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-        because_prompt1 = Comprehension::Prompt.create!(activity: activity1, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-
-        # rules
-        so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
-
-        #feedbacks
-        f3 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 3, text: 'lorem ipsum dolor 3')
-        f1 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 1, text: 'lorem ipsum dolor 1')
-        f2 = Comprehension::Feedback.create!(rule_id: so_rule1.id, order: 2, text: 'lorem ipsum dolor 2')
-
-        # feedback_histories
-        f_h1 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h1 lorem")
-        f_h2 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h2 ipsum")
-        
-        #feedback ratings
-        f_rating_1a = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user1.id, rating: true)
-        f_rating_1b = FeedbackHistoryRating.create!(feedback_history_id: f_h1.id, user_id: user2.id, rating: false)
-        f_rating_2a = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user1.id, rating: true)
-        f_rating_2b = FeedbackHistoryRating.create!(feedback_history_id: f_h2.id, user_id: user2.id, rating: nil)
-
-        #feedback flags
-        flag_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE)
-        flag_non_consecutive = create(:feedback_history_flag, feedback_history_id: f_h1.id, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE)
-
-        ActiveRecord::Base.refresh_materialized_view('feedback_histories_grouped_by_rule_uid')
-
-        sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
-        post_result = RuleFeedbackHistory.postprocessing(sql_result)
-
-        first_row = post_result.first
-        expect(first_row.total_responses).to eq 2
-        expect(first_row.total_strong).to eq 2
-        expect(first_row.total_weak).to eq 1
-        expect(first_row.repeated_non_consecutive).to eq 1
-        expect(first_row.repeated_consecutive).to eq 1
+      expect(report.first).to eq(expected)
 
     end
   end
@@ -151,8 +94,8 @@ RSpec.describe RuleFeedbackHistory, type: :model do
 
       sql_result = RuleFeedbackHistory.exec_query(conjunction: 'so', activity_id: activity1.id)
 
-      expect(sql_result.count).to eq 1
-      expect(sql_result.first.rule_type).to eq 'autoML'
+      expect(sql_result.all.length).to eq 1
+      expect(sql_result[0].rule_type).to eq 'autoML'
     end
   end
 


### PR DESCRIPTION
## WHAT
This is an attempt to reduce the complexity of this report by doing all the aggregate calculation in SQL rather than ruby
## WHY
The Ruby version of this code iterates over a series of rows, and for each row does additional queries to the database (admittedly by ID, so not expensive individually, only in aggregate).  This approach makes a single query and in doing so is trying to focus the complexity on a single trip to the database.
## HOW
Rather than doing a Ruby "post-processing" step, we just do an aggregate query and feed that data into the serialization code.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
