### PR TITLE
lms/fix-feedback-history-flag-race-condition

### DIFF
--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe FeedbackHistory, type: :model do
     end
   end
 
-  context 'after_create' do
+  context 'after_commit, on: :create' do
     before(:each) do
       @feedback_history = build(:feedback_history)
     end
@@ -473,6 +473,7 @@ RSpec.describe FeedbackHistory, type: :model do
         expect(payload[:prompts][:so][:attempts][3][0][:most_recent_rating]).to eq(@first_session_feedback6.most_recent_rating)
       end
     end
+
     context '#most_recent_rating' do
       setup do
         @prompt = Comprehension::Prompt.create(text: 'Test text')


### PR DESCRIPTION
## WHAT
Swap after_create for after_commit callbacks
## WHY
It looks like the after_create is triggering a race condition where the ID of the FeedbackHistory models haven't been completely committed when the worker is queued and attempts to run and locate the specified ID.  Using an after_commit callback should ensure that the ID is fully committed in the DB before the worker runs.
## HOW
Delay triggering the flag calculation worker until we're sure that the new FeedbackHistory record is fully committed in the database to avoid a race condition.

### New Relic Link
https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=cross-account&platform[timeRange][duration]=604800000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiM2QxYTRmM2QtYmU2NC0xMWViLTkxMWUtMDI0MmFjMTEwMDA5XzBfNDUzNyIsIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUlkIjoiTWpZek9URXhNM3hCVUUxOFFWQlFURWxEUVZSSlQwNThOVFE0T0RVMk9EYzEifQ&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNall6T1RFeE0zeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5UUTRPRFUyT0RjMSIsInNlbGVjdGVkTmVyZGxldCI6eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXcifX0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
