### PR TITLE
Take down the "End of School Year" banner 

### DIFF
--- a/services/QuillLMS/app/views/application/_webinar_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_webinar_banner.html.erb
@@ -2,32 +2,6 @@
 <% still_doing_webinars = current_time_on_east_coast > Date.parse("20210103") && current_time_on_east_coast < Date.parse("20210520") %>
 
 <% if (still_doing_webinars && (!current_user || current_user.teacher?)) %>
-  <div class="banner" id="static-banner">
-    <div class="content-container">
-      <img alt="Video player with play symbol" class="banner-icon" src=<%= "#{ENV['CDN_URL']}/images/icons/live-stream.svg" %>>
-      <p>We have <a href="https://www.quill.org/teacher-center/quills-implementation-library#summer" rel="noopener noreferrer" target="_blank">brand new teacher resources to support you</a> as you finish the school year with Quill.</p>
-      <img alt="White X" id="close-static-banner" src=<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>>
-    </div>
-  </div>
-
-  <script>
-    window.addEventListener('load', function(e) {
-      if (document.cookie.indexOf('static_banner_closed=1') === -1) {
-        document.getElementById('static-banner').style.display = 'block';
-      }
-    });
-
-    document.getElementById('close-static-banner').addEventListener('click', function(e) {
-        e.preventDefault();
-        document.getElementById('static-banner').style.display = 'none';
-        let date = new Date();
-        // set the cookie to expire at the start of the next hour so we can show the next webinar
-        date.setHours(date.getHours() + 1,0,0);
-        document.cookie = `static_banner_closed=1; expires=${date.toGMTString()}; path=/`;
-    }, false);
-
-  </script>
-
   <% recurring_banner = RecurringBanner.new(current_time_on_east_coast) %>
   <% if recurring_banner.show?(current_user&.subscription&.account_type) %>
     <div class="banner" id="webinar-banner-recurring">


### PR DESCRIPTION
## WHAT
Remove the "End of School Year" banner.

## WHY
We've reached the end of our date range for having this up.

## HOW
Just remove it.

### Screenshots
![Screen Shot 2021-05-12 at 12 25 18 PM](https://user-images.githubusercontent.com/57366100/120022281-ce86f600-bfb1-11eb-8a10-973e965e1e06.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, copy change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
