### PR TITLE
LMS Rails 5.0 Prework - Refactor ActiveRecord::Base.connection.execute calls to use TypeMapByOID, Part 2

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -188,35 +188,43 @@ class Cms::SchoolsController < Cms::CmsController
 
     # NOTE: IF YOU CHANGE THIS QUERY'S CONDITIONS, PLEASE BE SURE TO
     # ADJUST THE PAGINATION QUERY STRING AS WELL.
-    ActiveRecord::Base.connection.execute("
-      SELECT
-        schools.name AS school_name,
-        schools.leanm AS district_name,
-        COALESCE(schools.city, schools.mail_city) AS school_city,
-        COALESCE(schools.state, schools.mail_state) AS school_state,
-        COALESCE(schools.zipcode, schools.mail_zipcode) AS school_zip,
-        schools.free_lunches AS frl,
-        COUNT(DISTINCT schools_users.id) AS number_teachers,
-        subscriptions.account_type AS premium_status,
-        COUNT(DISTINCT schools_admins.id) AS number_admins,
-        schools.id AS id
-      FROM schools
-      LEFT JOIN schools_users ON schools_users.school_id = schools.id
-      LEFT JOIN schools_admins ON schools_admins.school_id = schools.id
-      LEFT JOIN school_subscriptions ON school_subscriptions.school_id = schools.id
-      LEFT JOIN subscriptions ON subscriptions.id = school_subscriptions.subscription_id
-      #{where_query_string_builder}
-      GROUP BY schools.name, schools.leanm, schools.city, schools.state, schools.zipcode, schools.free_lunches, subscriptions.account_type, schools.id
-      #{having_string}
-      #{order_by_query_string}
-      #{pagination_query_string}
-    ").to_a.map do |school|
-      school['school_zip'] = school['school_zip'].to_i
-      school['number_teachers'] = school['number_teachers'].to_i
-      school['number_admins'] = school['number_admins'].to_i
-      school['frl'] = school['frl'].to_i
-      school
-    end
+    RawSqlRunner.execute(
+      <<-SQL
+        SELECT
+          schools.name AS school_name,
+          schools.leanm AS district_name,
+          COALESCE(schools.city, schools.mail_city) AS school_city,
+          COALESCE(schools.state, schools.mail_state) AS school_state,
+          COALESCE(schools.zipcode, schools.mail_zipcode) AS school_zip,
+          schools.free_lunches AS frl,
+          COUNT(DISTINCT schools_users.id) AS number_teachers,
+          subscriptions.account_type AS premium_status,
+          COUNT(DISTINCT schools_admins.id) AS number_admins,
+          schools.id AS id
+        FROM schools
+        LEFT JOIN schools_users
+          ON schools_users.school_id = schools.id
+        LEFT JOIN schools_admins
+          ON schools_admins.school_id = schools.id
+        LEFT JOIN school_subscriptions
+          ON school_subscriptions.school_id = schools.id
+        LEFT JOIN subscriptions
+          ON subscriptions.id = school_subscriptions.subscription_id
+        #{where_query_string_builder}
+        GROUP BY
+          schools.name,
+          schools.leanm,
+          schools.city,
+          schools.state,
+          schools.zipcode,
+          schools.free_lunches,
+          subscriptions.account_type,
+          schools.id
+        #{having_string}
+        #{order_by_query_string}
+        #{pagination_query_string}
+      SQL
+    ).to_a
   end
 
   private def having_string
@@ -278,19 +286,27 @@ class Cms::SchoolsController < Cms::CmsController
   end
 
   private def number_of_schools_matched
-    ActiveRecord::Base.connection.execute("
-      SELECT count(*) as count FROM
-        (SELECT
-        	COUNT(schools.id) AS count
-        FROM schools
-        LEFT JOIN schools_users ON schools_users.school_id = schools.id
-        LEFT JOIN schools_admins ON schools_admins.school_id = schools.id
-        LEFT JOIN school_subscriptions ON school_subscriptions.school_id = schools.id
-        LEFT JOIN subscriptions ON subscriptions.id = school_subscriptions.subscription_id
-        #{where_query_string_builder}
-        GROUP BY schools.id
-        #{having_string}) as subquery
-    ").to_a[0]['count'].to_i
+    result = RawSqlRunner.execute(
+      <<-SQL
+        SELECT count(*) as count
+        FROM (
+          SELECT COUNT(schools.id) AS count
+          FROM schools
+          LEFT JOIN schools_users
+            ON schools_users.school_id = schools.id
+          LEFT JOIN schools_admins
+            ON schools_admins.school_id = schools.id
+          LEFT JOIN school_subscriptions
+            ON school_subscriptions.school_id = schools.id
+          LEFT JOIN subscriptions
+            ON subscriptions.id = school_subscriptions.subscription_id
+          #{where_query_string_builder}
+          GROUP BY schools.id
+          #{having_string}
+        ) AS subquery
+      SQL
+    )
+    result.to_a[0]['count']
   end
 
   private def order_by_query_string

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -288,7 +288,7 @@ class Cms::SchoolsController < Cms::CmsController
   private def number_of_schools_matched
     result = RawSqlRunner.execute(
       <<-SQL
-        SELECT count(*) as count
+        SELECT COUNT(*) as count
         FROM (
           SELECT COUNT(schools.id) AS count
           FROM schools
@@ -306,7 +306,8 @@ class Cms::SchoolsController < Cms::CmsController
         ) AS subquery
       SQL
     )
-    result.to_a[0]['count']
+
+    result.to_a[0]['count'].to_i
   end
 
   private def order_by_query_string

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -251,48 +251,27 @@ class Teachers::ClassroomManagerController < ApplicationController
 
 
   private def classroom_with_students_json(classrooms)
-    {
-        classrooms_and_their_students: classrooms.map { |classroom|
-          classroom_json(classroom)
-        }
-    }
+    { classrooms_and_their_students: classrooms.map { |classroom| classroom_json(classroom) } }
   end
 
   private def classroom_json(classroom)
-    {  classroom: classroom, students: classroom.students.sort_by(&:sorting_name)}
+    { classroom: classroom, students: classroom.students.sort_by(&:sorting_name) }
   end
 
-  private def invited_classrooms
-    ActiveRecord::Base.connection.execute("
-        SELECT coteacher_classroom_invitations.id AS classroom_invitation_id, users.name AS inviter_name, classrooms.name AS classroom_name, TRUE AS invitation
-        FROM invitations
-        JOIN coteacher_classroom_invitations ON coteacher_classroom_invitations.invitation_id = invitations.id
-        JOIN users ON users.id = invitations.inviter_id
-        JOIN classrooms ON classrooms.id = coteacher_classroom_invitations.classroom_id
-        WHERE invitations.invitee_email = #{ActiveRecord::Base.sanitize(current_user.email)} AND invitations.archived = false;
-      ").to_a
-  end
-
-  private def active_and_inactive_classrooms_hash
-    classrooms = {}
-    classrooms[:active] = invited_classrooms
-    classrooms[:inactive] = []
-    ClassroomsTeacher.where(user_id: current_user.id).each do |classrooms_teacher|
-      classroom = Classroom.unscoped.find(classrooms_teacher.classroom_id)
-      if classroom.visible
-        classrooms[:active] << classroom.archived_classrooms_manager
-      else
-        classrooms[:inactive] << classroom.archived_classrooms_manager
-      end
-    end
-    classrooms
-  end
 
   private def classrooms_with_data
-    ActiveRecord::Base.connection.execute(
-      "SELECT classrooms.id, classrooms.id AS value, classrooms.name from classrooms_teachers AS ct
-      JOIN classrooms ON ct.classroom_id = classrooms.id AND classrooms.visible = TRUE
-      WHERE ct.user_id = #{current_user.id}"
+    RawSqlRunner.execute(
+      <<-SQL
+        SELECT
+          classrooms.id,
+          classrooms.id AS value,
+          classrooms.name
+        FROM classrooms_teachers AS ct
+        JOIN classrooms
+          ON ct.classroom_id = classrooms.id
+          AND classrooms.visible = true
+        WHERE ct.user_id = #{current_user.id}
+      SQL
     ).to_a
   end
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -137,21 +137,31 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
         }
       end
     else
-      csv_string = CSV.generate do |csv|
-        csv << ['Student', 'Date', 'Activity', 'Score', 'Standard', 'Tool']
-        activity_sessions.map do |session|
-          score = (session['percentage'] == -1.0 ? 'Completed' : "#{session['percentage'] * 100}%")
-          csv << [
-            session['student_name'],
-            session['visual_date'],
-            session['activity_name'],
-            score,
-            session['standard'],
-            session['activity_classification_name']
-          ]
-        end
+      render text: csv_string(activity_sessions)
+    end
+  end
+
+  private def score(percentage)
+    case percentage
+    when nil then ''
+    when -1 then 'Completed'
+    else "#{percentage * 100}%"
+    end
+  end
+
+  private def csv_string(activity_sessions)
+    CSV.generate do |csv|
+      csv << ['Student', 'Date', 'Activity', 'Score', 'Standard', 'Tool']
+      activity_sessions.map do |session|
+        csv << [
+          session['student_name'],
+          session['visual_date'],
+          session['activity_name'],
+          score(session['percentage']),
+          session['standard'],
+          session['activity_classification_name']
+        ]
       end
-      render text: csv_string
     end
   end
 end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -143,7 +143,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
 
   private def score(percentage)
     case percentage
-    when nil then ''
+    when nil then 0
     when -1 then 'Completed'
     else "#{percentage * 100}%"
     end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -45,76 +45,82 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
 
     # Note to maintainers: if you update this query, please be sure to
     # also update the page count query below if applicable.
-    activity_sessions = ActiveRecord::Base.connection.execute("
-      SELECT
-        activity_sessions.id AS activity_session_id,
-        activity_classifications.name AS activity_classification_name,
-        classrooms_teachers.classroom_id AS classroom_id,
-        EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
-        activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
-        (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
-        standards.name AS standard,
-        activity_sessions.user_id AS student_id,
-        activities.name AS activity_name,
-        users.name AS student_name,
-        substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
-      FROM classrooms_teachers
-      JOIN classrooms
-        ON classrooms.id = classrooms_teachers.classroom_id
-        AND classrooms.visible = TRUE
-      JOIN classroom_units
-        ON classroom_units.classroom_id = classrooms.id
-        #{classroom_units_filter}
-        #{unit_filter}
-        AND classroom_units.visible = TRUE
-      JOIN students_classrooms
-        ON students_classrooms.classroom_id = classrooms.id
-        AND students_classrooms.visible = TRUE
-      JOIN users
-        ON users.id = students_classrooms.student_id
-      JOIN activity_sessions
-        ON activity_sessions.classroom_unit_id = classroom_units.id
-        AND activity_sessions.state = 'finished'
-        AND activity_sessions.visible = TRUE
-        AND activity_sessions.user_id = users.id
-       #{student_filter}
-      JOIN activities
-        ON activities.id = activity_sessions.activity_id
-      JOIN activity_classifications
-        ON activity_classifications.id = activities.activity_classification_id
-      LEFT JOIN standards
-        ON standards.id = activities.standard_id
-      WHERE classrooms_teachers.user_id = #{current_user.id}
-      ORDER BY #{sort_field} #{sort_direction}
-      #{query_limit}
-      #{query_offset}
-    ").to_a;
-
-    if should_return_json
-      page_count = (ActiveRecord::Base.connection.execute("
-        SELECT count(activity_sessions.id) FROM classrooms_teachers
+    activity_sessions = RawSqlRunner.execute(
+      <<-SQL
+        SELECT
+          activity_sessions.id AS activity_session_id,
+          activity_classifications.name AS activity_classification_name,
+          classrooms_teachers.classroom_id AS classroom_id,
+          EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
+          activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
+          (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
+          standards.name AS standard,
+          activity_sessions.user_id AS student_id,
+          activities.name AS activity_name,
+          users.name AS student_name,
+          substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
+        FROM classrooms_teachers
         JOIN classrooms
           ON classrooms.id = classrooms_teachers.classroom_id
-          AND classrooms.visible = TRUE
+          AND classrooms.visible = true
         JOIN classroom_units
           ON classroom_units.classroom_id = classrooms.id
           #{classroom_units_filter}
           #{unit_filter}
-          AND classroom_units.visible = TRUE
+          AND classroom_units.visible = true
         JOIN students_classrooms
           ON students_classrooms.classroom_id = classrooms.id
-          AND students_classrooms.visible = TRUE
+          AND students_classrooms.visible = true
         JOIN users
           ON users.id = students_classrooms.student_id
         JOIN activity_sessions
           ON activity_sessions.classroom_unit_id = classroom_units.id
           AND activity_sessions.state = 'finished'
-          AND activity_sessions.visible = TRUE
+          AND activity_sessions.visible = true
           AND activity_sessions.user_id = users.id
-         #{student_filter}
+          #{student_filter}
+        JOIN activities
+          ON activities.id = activity_sessions.activity_id
+        JOIN activity_classifications
+          ON activity_classifications.id = activities.activity_classification_id
+        LEFT JOIN standards
+          ON standards.id = activities.standard_id
         WHERE classrooms_teachers.user_id = #{current_user.id}
-      ").to_a[0]['count'].to_f / PAGE_SIZE).ceil
+        ORDER BY #{sort_field} #{sort_direction}
+        #{query_limit}
+        #{query_offset}
+      SQL
+    ).to_a
 
+    if should_return_json
+      count = RawSqlRunner.execute(
+        <<-SQL
+          SELECT count(activity_sessions.id)
+          FROM classrooms_teachers
+          JOIN classrooms
+            ON classrooms.id = classrooms_teachers.classroom_id
+            AND classrooms.visible = true
+          JOIN classroom_units
+            ON classroom_units.classroom_id = classrooms.id
+            #{classroom_units_filter}
+            #{unit_filter}
+            AND classroom_units.visible = true
+          JOIN students_classrooms
+            ON students_classrooms.classroom_id = classrooms.id
+            AND students_classrooms.visible = true
+          JOIN users
+            ON users.id = students_classrooms.student_id
+          JOIN activity_sessions
+            ON activity_sessions.classroom_unit_id = classroom_units.id
+            AND activity_sessions.state = 'finished'
+            AND activity_sessions.visible = true
+            AND activity_sessions.user_id = users.id
+            #{student_filter}
+          WHERE classrooms_teachers.user_id = #{current_user.id}
+        SQL
+      ).to_a[0]['count']
+
+      page_count = (count.to_f / PAGE_SIZE).ceil
 
       if params[:without_filters]
         render json: {
@@ -134,7 +140,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
       csv_string = CSV.generate do |csv|
         csv << ['Student', 'Date', 'Activity', 'Score', 'Standard', 'Tool']
         activity_sessions.map do |session|
-          score = (session['percentage'].to_f == -1.0 ? 'Completed' : "#{session['percentage'].to_f*100}%")
+          score = (session['percentage'] == -1.0 ? 'Completed' : "#{session['percentage'] * 100}%")
           csv << [
             session['student_name'],
             session['visual_date'],

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
@@ -20,18 +20,28 @@ class Teachers::ProgressReports::Standards::ClassroomsController < Teachers::Pro
   end
 end
 
-private
+private def student_names_and_ids(classroom_id)
+  classroom_conditional = "AND classrooms.id = #{classroom_id}" if classroom_id
 
-def student_names_and_ids(classroom_id)
-  if classroom_id
-    classroom_conditional = "AND classrooms.id = #{classroom_id}"
-  end
-    ActiveRecord::Base.connection.execute("SELECT DISTINCT students.name, students.id, substring(students.name, '([^[:space:]]+)(?:,|$)') AS last_name FROM users AS teacher
-    JOIN classrooms_teachers AS ct ON ct.user_id = teacher.id
-    JOIN classrooms ON classrooms.id = ct.classroom_id AND classrooms.visible = TRUE
-    JOIN students_classrooms AS sc ON sc.classroom_id = ct.classroom_id
-    JOIN users AS students ON students.id = sc.student_id
-    WHERE teacher.id = #{current_user.id}
-    #{classroom_conditional}
-    ORDER BY substring(students.name, '([^[:space:]]+)(?:,|$)')").to_a
+  RawSqlRunner.execute(
+    <<-SQL
+      SELECT DISTINCT
+        students.name,
+        students.id,
+        SUBSTRING(students.name, '([^[:space:]]+)(?:,|$)') AS last_name
+      FROM users AS teacher
+      JOIN classrooms_teachers AS ct
+        ON ct.user_id = teacher.id
+      JOIN classrooms
+        ON classrooms.id = ct.classroom_id
+        AND classrooms.visible = TRUE
+      JOIN students_classrooms AS sc
+        ON sc.classroom_id = ct.classroom_id
+      JOIN users AS students
+        ON students.id = sc.student_id
+      WHERE teacher.id = #{current_user.id}
+        #{classroom_conditional}
+      ORDER BY SUBSTRING(students.name, '([^[:space:]]+)(?:,|$)')
+    SQL
+  ).to_a
 end

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -24,14 +24,21 @@ module Student
     protected :classroom_unit_score_join
 
     def student_average_score
-      avg_str = ActiveRecord::Base.connection.execute(
-       "select avg(percentage) from activity_sessions
-        join users on activity_sessions.user_id = users.id
-        join activities on activity_sessions.activity_id = activities.id
-        where activities.activity_classification_id != 6
-        and activities.activity_classification_id != 4
-        and users.id = #{id}").to_a[0]['avg']
-      (avg_str.to_f * 100).to_i
+      avg = RawSqlRunner.execute(
+        <<-SQL
+          SELECT AVG(percentage)
+          FROM activity_sessions
+          JOIN users
+            ON activity_sessions.user_id = users.id
+          JOIN activities
+            ON activity_sessions.activity_id = activities.id
+          WHERE activities.activity_classification_id != 6
+            AND activities.activity_classification_id != 4
+            AND users.id = #{id}
+        SQL
+      ).to_a.first['avg']
+
+      (avg * 100).to_i
     end
 
     def move_student_from_one_class_to_another(old_classroom, new_classroom)

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -53,7 +53,6 @@ class QuestionHealthDashboard
         cr.metadata::json->>'questionScore',
         cr.activity_session_id
     SQL
-    @attempt_data ||= ActiveRecord::Base.connection.execute(query).to_a
+    @attempt_data ||= RawSqlRunner.execute(query).to_a
   end
-
 end

--- a/services/QuillLMS/app/queries/activity_search.rb
+++ b/services/QuillLMS/app/queries/activity_search.rb
@@ -15,39 +15,56 @@ class ActivitySearch
       flags = "'production'"
     end
 
-    ActiveRecord::Base.connection.execute("SELECT DISTINCT
-        activities.name AS activity_name,
-    		activities.description AS activity_description,
-    		activities.flags AS activity_flag,
-    		activities.id AS activity_id,
-    		activities.uid AS activity_uid,
-        activity_categories.id AS activity_category_id,
-        activity_categories.name AS activity_category_name,
-        standard_levels.id AS standard_level_id,
-        standard_levels.name AS standard_level_name,
-        standards.name AS standard_name,
-        activity_classifications.id AS classification_id,
-        activity_classifications.order_number,
-        activity_categories.order_number,
-        activity_category_activities.order_number,
-        content_partners.name AS content_partner_name,
-        content_partners.description AS content_partner_description,
-        content_partners.id AS content_partner_id,
-        topics.id AS topic_id,
-        topics.name AS topic_name,
-        topics.parent_id AS topic_parent_id,
-        topics.level AS topic_level
-      FROM activities
-      LEFT JOIN activity_classifications ON activities.activity_classification_id = activity_classifications.id
-      LEFT JOIN standards ON activities.standard_id = standards.id
-      LEFT JOIN standard_levels ON standards.standard_level_id = standard_levels.id
-      LEFT JOIN activity_category_activities ON activities.id = activity_category_activities.activity_id
-      LEFT JOIN activity_categories ON activity_category_activities.activity_category_id = activity_categories.id
-      LEFT JOIN content_partner_activities ON content_partner_activities.activity_id = activities.id
-      LEFT JOIN content_partners ON content_partners.id = content_partner_activities.content_partner_id
-      LEFT JOIN activity_topics ON activity_topics.activity_id = activities.id
-      LEFT JOIN topics ON activity_topics.topic_id = topics.id AND topics.visible
-      WHERE activities.flags && ARRAY[#{flags}]::varchar[]
-      ORDER BY activity_classifications.order_number asc, activity_categories.order_number asc, activity_category_activities.order_number asc").to_a
+    RawSqlRunner.execute(
+      <<-SQL
+        SELECT DISTINCT
+          activities.name AS activity_name,
+          activities.description AS activity_description,
+          activities.flags AS activity_flag,
+          activities.id AS activity_id,
+          activities.uid AS activity_uid,
+          activity_categories.id AS activity_category_id,
+          activity_categories.name AS activity_category_name,
+          standard_levels.id AS standard_level_id,
+          standard_levels.name AS standard_level_name,
+          standards.name AS standard_name,
+          activity_classifications.id AS classification_id,
+          activity_classifications.order_number,
+          activity_categories.order_number,
+          activity_category_activities.order_number,
+          content_partners.name AS content_partner_name,
+          content_partners.description AS content_partner_description,
+          content_partners.id AS content_partner_id,
+          topics.id AS topic_id,
+          topics.name AS topic_name,
+          topics.parent_id AS topic_parent_id,
+          topics.level AS topic_level
+        FROM activities
+        LEFT JOIN activity_classifications
+          ON activities.activity_classification_id = activity_classifications.id
+        LEFT JOIN standards
+          ON activities.standard_id = standards.id
+        LEFT JOIN standard_levels
+          ON standards.standard_level_id = standard_levels.id
+        LEFT JOIN activity_category_activities
+          ON activities.id = activity_category_activities.activity_id
+        LEFT JOIN activity_categories
+          ON activity_category_activities.activity_category_id = activity_categories.id
+        LEFT JOIN content_partner_activities
+          ON content_partner_activities.activity_id = activities.id
+        LEFT JOIN content_partners
+          ON content_partners.id = content_partner_activities.content_partner_id
+        LEFT JOIN activity_topics
+          ON activity_topics.activity_id = activities.id
+        LEFT JOIN topics
+          ON activity_topics.topic_id = topics.id
+          AND topics.visible
+        WHERE activities.flags && ARRAY[#{flags}]::varchar[]
+        ORDER BY
+          activity_classifications.order_number ASC,
+          activity_categories.order_number ASC,
+          activity_category_activities.order_number ASC
+      SQL
+    ).to_a
   end
 end

--- a/services/QuillLMS/app/queries/cms/teacher_search_query.rb
+++ b/services/QuillLMS/app/queries/cms/teacher_search_query.rb
@@ -4,28 +4,46 @@ class Cms::TeacherSearchQuery
   end
 
   def run
-    ActiveRecord::Base.connection.execute("
-      SELECT
-        users.name AS teacher_name,
-        COUNT(DISTINCT classrooms.id) AS number_classrooms,
-        COUNT(DISTINCT students_classrooms.student_id) AS number_students,
-        COUNT(DISTINCT activity_sessions) AS number_activities_completed,
-        TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
-        subscriptions.account_type AS subscription,
-        users.id AS user_id,
-        schools_admins.id AS admin_id
-      FROM schools_users
-      LEFT JOIN users ON schools_users.user_id = users.id
-      LEFT JOIN classrooms_teachers ON classrooms_teachers.user_id = users.id AND classrooms_teachers.role = 'owner'
-      LEFT JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id AND classrooms.visible = true
-      LEFT JOIN students_classrooms ON classrooms.id =  students_classrooms.classroom_id
-      LEFT JOIN activity_sessions ON students_classrooms.student_id = activity_sessions.user_id AND completed_at IS NOT NULL
-      LEFT JOIN user_subscriptions ON schools_users.user_id = user_subscriptions.user_id
-      LEFT JOIN subscriptions ON subscriptions.id = user_subscriptions.subscription_id
-      LEFT JOIN schools_admins ON users.id = schools_admins.user_id
-      WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(school_id)}
-      GROUP BY users.name, users.last_sign_in, subscriptions.account_type, users.id, schools_admins.id
-    ").to_a
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        SELECT
+          users.name AS teacher_name,
+          COUNT(DISTINCT classrooms.id) AS number_classrooms,
+          COUNT(DISTINCT students_classrooms.student_id) AS number_students,
+          COUNT(DISTINCT activity_sessions) AS number_activities_completed,
+          TO_CHAR(GREATEST(users.last_sign_in, MAX(activity_sessions.completed_at)), 'Mon DD, YYYY') AS last_active,
+          subscriptions.account_type AS subscription,
+          users.id AS user_id,
+          schools_admins.id AS admin_id
+        FROM schools_users
+        LEFT JOIN users
+          ON schools_users.user_id = users.id
+        LEFT JOIN classrooms_teachers
+          ON classrooms_teachers.user_id = users.id
+          AND classrooms_teachers.role = 'owner'
+        LEFT JOIN classrooms
+          ON classrooms.id = classrooms_teachers.classroom_id
+          AND classrooms.visible = true
+        LEFT JOIN students_classrooms
+          ON classrooms.id = students_classrooms.classroom_id
+        LEFT JOIN activity_sessions
+          ON students_classrooms.student_id = activity_sessions.user_id
+          AND completed_at IS NOT NULL
+        LEFT JOIN user_subscriptions
+          ON schools_users.user_id = user_subscriptions.user_id
+        LEFT JOIN subscriptions
+          ON subscriptions.id = user_subscriptions.subscription_id
+        LEFT JOIN schools_admins
+          ON users.id = schools_admins.user_id
+        WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(school_id)}
+        GROUP BY
+          users.name,
+          users.last_sign_in,
+          subscriptions.account_type,
+          users.id,
+          schools_admins.id
+      SQL
+    ).to_a
   end
 
   attr_reader :school_id

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -5,59 +5,70 @@ class Scorebook::Query
   def self.run(classroom_id, current_page=1, unit_id=nil, begin_date=nil, end_date=nil, offset=0)
     first_unit = units(unit_id) ? units(unit_id).first : nil
     last_unit = units(unit_id) ? units(unit_id).last : nil
-    ActiveRecord::Base.connection.execute(
-    "SELECT
-       students.id AS user_id,
-        cu.id AS cu_id,
-        cuas.completed AS marked_complete,
-        students.name AS name,
-        activity.activity_classification_id,
-        activity.name AS activity_name,
-        activity.id AS activity_id,
-        activity.description AS activity_description,
-        MAX(acts.updated_at) AS updated_at,
-        MIN(acts.started_at) AS started_at,
-        MAX(acts.percentage) AS percentage,
-        SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) AS completed_attempts,
-        SUM(CASE WHEN acts.state = 'started' THEN 1 ELSE 0 END) AS started,
-        SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS id
-     FROM classroom_units AS cu
-     LEFT JOIN students_classrooms AS sc on cu.classroom_id = sc.classroom_id
-     RIGHT JOIN users AS students ON students.id = sc.student_id
-     #{first_unit}
-     LEFT JOIN unit_activities ON unit_activities.unit_id = cu.unit_id
-     INNER JOIN activities AS activity ON activity.id = unit_activities.activity_id
-     LEFT JOIN activity_sessions AS acts ON (
-           acts.classroom_unit_id = cu.id
-           AND acts.user_id = students.id
-           AND acts.activity_id = activity.id
-           AND acts.visible
-           )
-     LEFT JOIN classroom_unit_activity_states AS cuas ON cuas.unit_activity_id = unit_activities.id AND cuas.classroom_unit_id = cu.id
-     WHERE cu.classroom_id = #{classroom_id}
-     AND  students.id = ANY (cu.assigned_student_ids::int[])
-     AND unit_activities.visible
-     AND cu.visible
-     AND sc.visible
-     AND 'archived' != ANY(activity.flags)
-     #{last_unit}
-     #{date_conditional_string(begin_date, end_date, offset)}
-     GROUP BY
-      students.id,
-       students.name, cu.id, activity.activity_classification_id, activity.name, activity.description, cuas.completed, activity.id
-     ORDER BY split_part( students.name, ' ' , 2),
-       CASE WHEN SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
-       MIN(acts.completed_at),
-       CASE WHEN SUM(CASE WHEN acts.state = 'started' THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
-       cu.created_at ASC
-       OFFSET (#{(current_page.to_i - 1) * SCORES_PER_PAGE})
-       FETCH NEXT #{SCORES_PER_PAGE} ROWS ONLY"
+    RawSqlRunner.execute(
+      <<-SQL
+        SELECT
+          students.id AS user_id,
+          cu.id AS cu_id,
+          cuas.completed AS marked_complete,
+          students.name AS name,
+          activity.activity_classification_id,
+          activity.name AS activity_name,
+          activity.id AS activity_id,
+          activity.description AS activity_description,
+          MAX(acts.updated_at) AS updated_at,
+          MIN(acts.started_at) AS started_at,
+          MAX(acts.percentage) AS percentage,
+          SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) AS completed_attempts,
+          SUM(CASE WHEN acts.state = 'started' THEN 1 ELSE 0 END) AS started,
+          SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS id
+        FROM classroom_units AS cu
+        LEFT JOIN students_classrooms AS sc
+          ON cu.classroom_id = sc.classroom_id
+        RIGHT JOIN users AS students
+          ON students.id = sc.student_id
+        #{first_unit}
+        LEFT JOIN unit_activities ON unit_activities.unit_id = cu.unit_id
+        JOIN activities AS activity ON activity.id = unit_activities.activity_id
+        LEFT JOIN activity_sessions AS acts
+          ON acts.classroom_unit_id = cu.id
+          AND acts.user_id = students.id
+          AND acts.activity_id = activity.id
+          AND acts.visible
+        LEFT JOIN classroom_unit_activity_states AS cuas
+          ON cuas.unit_activity_id = unit_activities.id
+          AND cuas.classroom_unit_id = cu.id
+        WHERE cu.classroom_id = #{classroom_id}
+          AND students.id = ANY (cu.assigned_student_ids::int[])
+          AND unit_activities.visible
+          AND cu.visible
+          AND sc.visible
+          AND 'archived' != ANY(activity.flags)
+          #{last_unit}
+          #{date_conditional_string(begin_date, end_date, offset)}
+        GROUP BY
+          students.id,
+          students.name,
+          cu.id,
+          activity.activity_classification_id,
+          activity.name,
+          activity.description,
+          cuas.completed,
+          activity.id
+        ORDER BY split_part( students.name, ' ' , 2),
+          CASE WHEN SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
+          MIN(acts.completed_at),
+          CASE WHEN SUM(CASE WHEN acts.state = 'started' THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
+          cu.created_at ASC
+          OFFSET (#{(current_page.to_i - 1) * SCORES_PER_PAGE})
+          FETCH NEXT #{SCORES_PER_PAGE} ROWS ONLY
+      SQL
     ).to_a
   end
 
   def self.units(unit_id)
     if unit_id && !unit_id.blank?
-      ["INNER JOIN units ON cu.unit_id = units.id", "AND units.id = #{ActiveRecord::Base.sanitize(unit_id)}"]
+      ["JOIN units ON cu.unit_id = units.id", "AND units.id = #{ActiveRecord::Base.sanitize(unit_id)}"]
     end
   end
 

--- a/services/QuillLMS/app/services/units/creator.rb
+++ b/services/QuillLMS/app/services/units/creator.rb
@@ -7,11 +7,16 @@ module Units::Creator
     unit_template = UnitTemplate.find(unit_template_id)
     # unit fix: pass whole teacher object
     teacher = User.find(teacher_id)
-    activities_data = ActiveRecord::Base.connection.execute("
-      SELECT activities.id FROM activities JOIN activities_unit_templates ON
-      activities.id = activity_id WHERE unit_template_id = #{unit_template_id}
-      ORDER BY activities_unit_templates.id;
-    ").map { |a| {id: a["id"].to_i, due_date: nil}}
+    activities_data = RawSqlRunner.execute(
+      <<-SQL
+        SELECT activities.id
+        FROM activities
+        JOIN activities_unit_templates
+          ON activities.id = activity_id
+        WHERE unit_template_id = #{unit_template_id}
+        ORDER BY activities_unit_templates.id;
+      SQL
+    ).map { |a| { id: a["id"], due_date: nil } }
 
     # unit fix: may be able to better optimize this one, but possibly not
     classrooms_data = teacher.classrooms_i_teach.map{ |c| {id: c.id, student_ids: [], assign_on_join: true} }
@@ -24,11 +29,16 @@ module Units::Creator
     # converted to array so we can map in helper function as we would otherwise
     # unit fix: pass whole teacher object
     teacher = User.find(teacher_id)
-    activities_data = ActiveRecord::Base.connection.execute("
-      SELECT activities.id FROM activities JOIN activities_unit_templates ON
-      activities.id = activity_id WHERE unit_template_id = #{unit_template_id}
-      ORDER BY activities_unit_templates.id;
-    ").map { |a| {id: a["id"].to_i, due_date: nil}}
+    activities_data = RawSqlRunner.execute(
+      <<-SQL
+        SELECT activities.id
+        FROM activities
+        JOIN activities_unit_templates
+          ON activities.id = activity_id
+        WHERE unit_template_id = #{unit_template_id}
+        ORDER BY activities_unit_templates.id;
+      SQL
+    ).map { |a| {id: a["id"], due_date: nil}}
     create_helper(teacher, unit_template.name, activities_data, classroom_array, unit_template_id, current_user_id)
   end
 

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsSchoolIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsSchoolIndexAppClient.jsx
@@ -53,7 +53,7 @@ export default class CmsSchoolIndex extends React.Component {
           accessor: 'frl',
           resizable: false,
           minWidth: 60,
-          Cell: row => `${row.original.frl}%`,
+          Cell: row => row.original.frl ? `${row.original.frl}%` : '',
         }, {
           Header: "Teachers",
           accessor: 'number_teachers',

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -8,9 +8,7 @@ describe Cms::SchoolsController do
 
   let(:user) { create(:staff) }
 
-  before do
-    allow(controller).to receive(:current_user) { user }
-  end
+  before { allow(controller).to receive(:current_user) { user } }
 
   describe "SCHOOLS_PER_PAGE" do
     it 'should have the correct value' do
@@ -21,9 +19,7 @@ describe Cms::SchoolsController do
   describe '#index' do
     let(:school_hash) { {school_zip: "1234", number_teachers: 23, number_admins: 5, frl: "frl"} }
 
-    before do
-      allow(ActiveRecord::Base.connection).to receive(:execute) { [school_hash] }
-    end
+    before { allow(RawSqlRunner).to receive(:execute) { [school_hash] } }
 
     it 'should allows staff memeber to view and search through school' do
       get :index
@@ -36,9 +32,7 @@ describe Cms::SchoolsController do
   describe '#search' do
     let(:school_hash) { {school_zip: 1234, number_teachers: 23, number_admins: 5, frl: "frl"} }
 
-    before do
-      allow(ActiveRecord::Base.connection).to receive(:execute).and_return([school_hash])
-    end
+    before { allow(RawSqlRunner).to receive(:execute).and_return([school_hash]) }
 
     it 'should search for the school and give the results' do
       get :search

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -249,7 +249,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     before do
       allow(controller).to receive(:current_user) { teacher }
-      allow(ActiveRecord::Base.connection).to receive(:execute).and_return([classroom, classroom1])
+      allow(RawSqlRunner).to receive(:execute).and_return([classroom, classroom1])
       allow(controller).to receive(:classroom_teacher!) { true }
     end
 
@@ -344,7 +344,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
             }
           ])
         end
-        
+
       end
 
     end

--- a/services/QuillLMS/spec/models/referrals_user_spec.rb
+++ b/services/QuillLMS/spec/models/referrals_user_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ReferralsUser, type: :model do
         create(:classroom_unit_with_activity_sessions, classroom_id: classroom_id)
       end
 
-      expect(ReferralsUser.ids_due_for_activation).to eq([referrals_user.id.to_s])
+      expect(ReferralsUser.ids_due_for_activation).to eq([referrals_user.id])
     end
   end
 end

--- a/services/QuillLMS/spec/queries/activity_search_spec.rb
+++ b/services/QuillLMS/spec/queries/activity_search_spec.rb
@@ -19,22 +19,22 @@ describe ActivitySearch do
           "activity_name" => activity.name,
           "activity_description" => activity.description ,
           "activity_flag" => "{beta,production}",
-          "activity_id" => activity.id.to_s,
+          "activity_id" => activity.id,
           "activity_uid" => activity.uid,
-          "activity_category_id" => activity_category.id.to_s,
+          "activity_category_id" => activity_category.id,
           "activity_category_name" => activity_category.name,
-          "standard_level_id" => standard_level.id.to_s,
+          "standard_level_id" => standard_level.id,
           "standard_level_name" => standard_level.name,
           "standard_name" => standard.name,
-          "topic_id" => topic.id.to_s,
-          "topic_level" => topic.level.to_s,
+          "topic_id" => topic.id,
+          "topic_level" => topic.level,
           "topic_name" => topic.name,
-          "topic_parent_id" => topic.parent_id ? topic.parent_id.to_s : topic.parent_id,
+          "topic_parent_id" => topic.parent_id,
           "content_partner_description" => content_partner.description,
-          "content_partner_id" => content_partner.id.to_s,
+          "content_partner_id" => content_partner.id,
           "content_partner_name" => content_partner.name,
-          "order_number" => activity_category_activity.order_number.to_s,
-          "classification_id" => activity_classification.id.to_s
+          "order_number" => activity_category_activity.order_number,
+          "classification_id" => activity_classification.id
         }
       )
     end

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -38,21 +38,21 @@ describe 'ScorebookQuery' do
       begin_date = activity_session1.completed_at - 1.days
       end_date = activity_session1.completed_at + 1.days
       results = Scorebook::Query.run(classroom.id, 1, nil, begin_date.to_s, end_date.to_s)
-      expect(results.map{|res| res['id']}).to include(activity_session1.id.to_s)
+      expect(results.map{|res| res['id']}).to include(activity_session1.id)
     end
 
     it 'does not return activities completed after the specified end date' do
       begin_date = activity_session1.completed_at + 1.days
       end_date = activity_session1.completed_at + 2.days
       results = Scorebook::Query.run(classroom.id, 1, nil, begin_date.to_s, end_date.to_s)
-      expect(results.map{|res| res['id']}).not_to include(activity_session1.id.to_s)
+      expect(results.map{|res| res['id']}).not_to include(activity_session1.id)
     end
 
     it 'does not return activities completed before the specified start date' do
       begin_date = activity_session1.completed_at - 2.days
       end_date = activity_session1.completed_at - 1.days
       results = Scorebook::Query.run(classroom.id, 1, nil, begin_date.to_s, end_date.to_s)
-      expect(results.map{|res| res['id']}).not_to include(activity_session1.id.to_s)
+      expect(results.map{|res| res['id']}).not_to include(activity_session1.id)
     end
 
     context 'time zones' do

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -30,7 +30,7 @@ describe 'ScorebookQuery' do
 
   it 'returns a completed activity that is a final scores' do
     results = Scorebook::Query.run(classroom.id)
-    expect(results.map{|res| res["id"]}).to include(activity_session2.id.to_s)
+    expect(results.map{|res| res["id"]}).to include(activity_session2.id)
   end
 
   describe 'support date constraints' do
@@ -73,7 +73,7 @@ describe 'ScorebookQuery' do
         begin_date = (activity_session1.reload.completed_at).to_date.to_s
         end_date = begin_date
         results = Scorebook::Query.run(classroom.id, 1, nil, begin_date, end_date, offset)
-        expect(results.find{|res| res['id'] == activity_session2.id.to_s}).to be
+        expect(results.find{|res| res['id'] == activity_session2.id}).to be
         expect(results.length).to eq(1)
       end
     end


### PR DESCRIPTION
## WHAT
This is part 2 of https://github.com/empirical-org/Empirical-Core/pull/7711

There are 100+ occurrences of `ActiveRecord::Base.connection.execute` and this is another batch of replacements.
Refactor `ActiveRecord::Base.connection.execute` calls in Rails 4 into a new call RawSqlRunner.execute that fills in the appropriate TypeMap so that the resulting PG:Result matches the one in Rails 5.

## WHY
ActiveRecord::Base.connection.execute yields a PG::Result. Calling to_a on that PG::Result gives different values in Rails 4 and Rails 5. This seems to be due to the TypeMap associated with the PG::Result which is used in casting values.

## HOW

Large diff in `services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb` is due to some dead code.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Refactor-ActiveRecord-Base-connection-execute-calls-to-use-TypeMapByOID-5b1a320b11824b7088a63458667891e8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
