### PR TITLE
Comprehension internal tools/ update error handling for activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
@@ -11,11 +11,12 @@ jest.mock('string-strip-html', () => ({
 const mockProps = {
   activity: mockActivity,
   closeModal: jest.fn(),
+  requestErrors: [],
   submitActivity: jest.fn()
 };
 
 describe('Activity Form component', () => {
-  const container = shallow(<ActivityForm {...mockProps} />);
+  let container = shallow(<ActivityForm {...mockProps} />);
 
   it('should render Activities', () => {
     expect(container).toMatchSnapshot();
@@ -28,5 +29,10 @@ describe('Activity Form component', () => {
   it('clicking submit button should submit activity', () => {
     container.find('#activity-submit-button').simulate('click');
     expect(mockProps.closeModal).toHaveBeenCalled();
+  });
+  it('should render request errors if present', () => {
+    mockProps.requestErrors = ['passage.text: passage text is too short'];
+    container = shallow(<ActivityForm {...mockProps} />);
+    expect(container.find('p.all-errors-message').text()).toEqual('passage.text: passage text is too short');
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/ruleForm.test.tsx
@@ -11,9 +11,6 @@ jest.mock('../../../helpers/comprehension/ruleHelpers', () => ({
   getInitialRuleType: jest.fn().mockImplementation(() => {
     return { value: 'rules-based-1', label: 'Sentence Structure Regex' }
    }),
-  renderErrorsContainer: jest.fn().mockImplementation(() => {
-    return <strong>error!</strong>
-  }),
   formatInitialFeedbacks: jest.fn().mockImplementation(() => {
     return [{
       id: 7,
@@ -22,6 +19,11 @@ jest.mock('../../../helpers/comprehension/ruleHelpers', () => ({
       text: 'Revise your work. Delete the phrase "it contains methane" because it repeats the first part of the sentence',
       highlights_attributes: []
     }];
+  })
+}));
+jest.mock('../../../helpers/comprehension', () => ({
+  renderErrorsContainer: jest.fn().mockImplementation(() => {
+    return <strong>error!</strong>
   })
 }));
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleForm.tsx
@@ -9,8 +9,8 @@ import RuleUniversalAttributes from './ruleUniversalAttributes';
 
 import { fetchRules, fetchUniversalRules } from '../../../utils/comprehension/ruleAPIs';
 import { fetchConcepts, } from '../../../utils/comprehension/conceptAPIs';
-import { formatPrompts } from '../../../helpers/comprehension';
-import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback, formatRegexRules, renderErrorsContainer } from '../../../helpers/comprehension/ruleHelpers';
+import { formatPrompts, renderErrorsContainer } from '../../../helpers/comprehension';
+import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback, formatRegexRules } from '../../../helpers/comprehension/ruleHelpers';
 import { ruleOptimalOptions, regexRuleTypes, PLAGIARISM } from '../../../../../constants/comprehension';
 import { ActivityInterface, RuleInterface, DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleViewForm.tsx
@@ -11,8 +11,8 @@ import RuleUniversalAttributes from '../configureRules/ruleUniversalAttributes';
 import { Spinner } from '../../../../Shared/index';
 import { deleteRule, fetchRules, fetchUniversalRules } from '../../../utils/comprehension/ruleAPIs';
 import { fetchConcepts, } from '../../../utils/comprehension/conceptAPIs';
-import { formatPrompts } from '../../../helpers/comprehension';
-import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback, renderErrorsContainer, formatRegexRules, getReturnLinkRuleType, getReturnLinkLabel, renderDeleteRuleModal } from '../../../helpers/comprehension/ruleHelpers';
+import { formatPrompts, renderErrorsContainer } from '../../../helpers/comprehension';
+import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback, formatRegexRules, getReturnLinkRuleType, getReturnLinkLabel, renderDeleteRuleModal } from '../../../helpers/comprehension/ruleHelpers';
 import { ruleOptimalOptions, regexRuleTypes, PLAGIARISM } from '../../../../../constants/comprehension';
 import { RuleInterface, DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -4,7 +4,7 @@ import { EditorState, ContentState } from 'draft-js';
 import PromptsForm from './promptsForm';
 
 // import { flagOptions } from '../../../../../constants/comprehension'
-import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction, getActivityPrompt, getActivityPromptSetter } from '../../../helpers/comprehension';
+import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction, getActivityPrompt, getActivityPromptSetter, renderErrorsContainer } from '../../../helpers/comprehension';
 import {
   BECAUSE,
   BUT,
@@ -26,10 +26,11 @@ import { Input, TextEditor, } from '../../../../Shared/index'
 interface ActivityFormProps {
   activity: ActivityInterface,
   closeModal: (event: React.MouseEvent) => void,
+  requestErrors: string[],
   submitActivity: (activity: object) => void
 }
 
-const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProps) => {
+const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: ActivityFormProps) => {
 
   const { parent_activity_id, passages, prompts, prompt_attributes, scored_level, target_level, title, name, } = activity;
   // const formattedFlag = flag ? { label: flag, value: flag } : flagOptions[0];
@@ -127,13 +128,17 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
     if(validationErrors && Object.keys(validationErrors).length !== 0) {
       setErrors(validationErrors);
     } else {
+      setErrors({});
       submitActivity(activityObject);
     }
   }
 
-  const errorsPresent = !!Object.keys(errors).length;
+  const formErrorsPresent = !!Object.keys(errors).length;
+  const requestErrorsPresent = !!(requestErrors && requestErrors.length);
+  const showErrorsContainer = formErrorsPresent || requestErrorsPresent;
   const passageLabelStyle = activityPassages[0].text.length  && activityPassages[0].text !== '<br/>' ? 'has-text' : '';
   const maxAttemptStyle = activityMaxFeedback.length && activityMaxFeedback !== '<br/>' ? 'has-text' : '';
+
   return(
     <div className="activity-form-container">
       <div className="close-button-container">
@@ -223,9 +228,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
           handleSetPrompt={handleSetPrompt}
         />
         <div className="submit-button-container">
-          {errorsPresent && <div className="error-message-container">
-            <p className="all-errors-message">Please check that all fields have been completed correctly.</p>
-          </div>}
+          {showErrorsContainer && renderErrorsContainer(formErrorsPresent, requestErrors)}
           <button className="quill-button fun primary contained" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">
             Submit
           </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettings.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettings.tsx
@@ -19,6 +19,7 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
   const [showEditActivityModal, setShowEditActivityModal] = React.useState<boolean>(false);
   // const [showEditFlagModal, setShowEditFlagModal] = React.useState<boolean>(false);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<string[]>([]);
   const { params } = match;
   const { activityId } = params;
 
@@ -47,15 +48,17 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
 
   const handleUpdateActivity = (activity: ActivityInterface) => {
     updateActivity(activity, activityId).then((response) => {
-      const { error } = response;
-      error && setErrorOrSuccessMessage(error);
-      queryCache.refetchQueries(`activity-${activityId}`)
-      if(!error) {
+      const { errors } = response;
+      if(errors && errors.length) {
+        setErrors(errors);
+      } else {
+        queryCache.refetchQueries(`activity-${activityId}`)
+        setErrors([]);
         setShowEditActivityModal(false);
         // reset errorOrSuccessMessage in case of subsequent submission
         setErrorOrSuccessMessage('Activity successfully updated!');
+        toggleSubmissionModal();
       }
-      toggleSubmissionModal();
     });
   }
 
@@ -96,7 +99,7 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
   const renderActivityForm = () => {
     return(
       <Modal>
-        <ActivityForm activity={data && data.activity} closeModal={toggleEditActivityModal} submitActivity={handleUpdateActivity} />
+        <ActivityForm activity={data && data.activity} closeModal={toggleEditActivityModal} requestErrors={errors} submitActivity={handleUpdateActivity} />
       </Modal>
     );
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
@@ -17,47 +17,49 @@ const Navigation = ({ location, match }) => {
   const { activityId, } = params
   const [showCreateActivityModal, setShowCreateActivityModal] = React.useState<boolean>(false);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<string>('');
+  const [errors, setErrors] = React.useState<string[]>([]);
 
   const csrfToken = getCsrfToken();
   localStorage.setItem('csrfToken', csrfToken);
 
-  const checkOverviewActive = () => {
+  function checkOverviewActive() {
     if(!location) return false;
     return pathname === '/activities' && !showCreateActivityModal;
   }
 
-  const toggleCreateActivityModal = () => {
+  function toggleCreateActivityModal() {
     setShowCreateActivityModal(!showCreateActivityModal);
   }
 
-  const toggleSubmissionModal = () => {
+  function toggleSubmissionModal() {
     setShowSubmissionModal(!showSubmissionModal);
   }
 
-  const submitActivity = (activity: ActivityInterface) => {
+  function submitActivity(activity: ActivityInterface) {
     createActivity(activity).then((response) => {
-      const { error } = response;
-      if(error) setError(error);
-      setShowCreateActivityModal(false);
-      setShowSubmissionModal(true);
-
-      // update activities cache to display newly created activity
-      queryCache.refetchQueries('activities')
+      const { errors } = response;
+      if(errors && errors.length) {
+        setErrors(errors);
+      } else {
+        // update activities cache to display newly created activity
+        queryCache.refetchQueries('activities');
+        setErrors([]);
+        setShowCreateActivityModal(false);
+        setShowSubmissionModal(true);
+      }
     });
   }
 
-  const renderActivityForm = () => {
+  function renderActivityForm() {
     return(
       <Modal>
-        <ActivityForm activity={blankActivity} closeModal={toggleCreateActivityModal} submitActivity={submitActivity} />
+        <ActivityForm activity={blankActivity} closeModal={toggleCreateActivityModal} requestErrors={errors} submitActivity={submitActivity} />
       </Modal>
     );
   }
 
-  const renderSubmissionModal = () => {
-    const message = error ? error : 'Submission successful!';
-    return <SubmissionModal close={toggleSubmissionModal} message={message} />;
+  function renderSubmissionModal () {
+    return <SubmissionModal close={toggleSubmissionModal} message='Submission successful!' />;
   }
 
   let rulesAnalysisSubLinks

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelForm.tsx
@@ -11,7 +11,8 @@ import RuleUniversalAttributes from '../configureRules/ruleUniversalAttributes';
 import { Spinner, Modal } from '../../../../Shared/index';
 import { deleteRule, fetchRules, fetchUniversalRules } from '../../../utils/comprehension/ruleAPIs';
 import { fetchConcepts, } from '../../../utils/comprehension/conceptAPIs';
-import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback, renderErrorsContainer } from '../../../helpers/comprehension/ruleHelpers';
+import { renderErrorsContainer } from '../../../helpers/comprehension';
+import { handleSubmitRule, getInitialRuleType, formatInitialFeedbacks, returnInitialFeedback } from '../../../helpers/comprehension/ruleHelpers';
 import { ruleOptimalOptions, regexRuleTypes, PLAGIARISM } from '../../../../../constants/comprehension';
 import { RuleInterface, DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/universalRules/universalRule.tsx
@@ -8,7 +8,7 @@ import RuleForm from '../configureRules/ruleForm';
 import { updateRule, deleteRule, fetchRule } from '../../../utils/comprehension/ruleAPIs';
 import { RuleInterface } from '../../../interfaces/comprehensionInterfaces';
 import { DataTable, Error, Modal, Spinner } from '../../../../Shared/index';
-import { renderErrorsContainer } from "../../../helpers/comprehension/ruleHelpers";
+import { renderErrorsContainer } from '../../../helpers/comprehension';
 
 const UniversalRule = ({ history, location, match }) => {
   const { params } = match;

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -316,3 +316,20 @@ export const getCsrfToken = () => {
   const token = document.querySelector('meta[name="csrf-token"]')
   if (token) { return token.getAttribute('content') }
 };
+
+export function renderErrorsContainer(formErrorsPresent: boolean, requestErrors: string[]) {
+  if(formErrorsPresent) {
+    return(
+      <div className="error-message-container">
+        <p className="all-errors-message">Please check that all fields have been completed correctly.</p>
+      </div>
+    );
+  }
+  return(
+    <div className="error-message-container">
+      {requestErrors.map((error, i) => {
+        return <p className="all-errors-message" key={i}>{error}</p>
+      })}
+    </div>
+  )
+}

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -436,23 +436,6 @@ export function getPromptIdString(prompts) {
   return promptIdString;
 }
 
-export function renderErrorsContainer(formErrorsPresent: boolean, requestErrors: string[]) {
-  if(formErrorsPresent) {
-    return(
-      <div className="error-message-container">
-        <p className="all-errors-message">Please check that all fields have been completed correctly.</p>
-      </div>
-    );
-  }
-  return(
-    <div className="error-message-container">
-      {requestErrors.map((error, i) => {
-        return <p className="all-errors-message" key={i}>{error}</p>
-      })}
-    </div>
-  )
-}
-
 export function renderDeleteRuleModal(handleDeleteRule, toggleShowDeleteRuleModal) {
   return(
     <Modal>

--- a/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/activityAPIs.ts
@@ -1,5 +1,5 @@
 import { ActivityInterface } from '../../interfaces/comprehensionInterfaces';
-import { handleApiError, apiFetch, mainApiFetch, } from '../../helpers/comprehension';
+import { handleApiError, apiFetch, mainApiFetch, handleRequestErrors, requestFailed } from '../../helpers/comprehension';
 
 export const fetchActivities = async () => {
   let activities: ActivityInterface[];
@@ -32,7 +32,14 @@ export const createActivity = async (activity: object) => {
     method: 'POST',
     body: JSON.stringify(activity)
   });
-  return { error: handleApiError('Failed to create activity, please try again.', response) };
+  const { status } = response;
+
+  if(requestFailed(status)) {
+    const errors = await response.json();
+    const returnedErrors = await handleRequestErrors(errors);
+    return { errors: returnedErrors };
+  }
+  return { errors: [] };
 }
 
 export const updateActivity = async (activity: object, activityId: string) => {
@@ -40,7 +47,14 @@ export const updateActivity = async (activity: object, activityId: string) => {
     method: 'PUT',
     body: JSON.stringify(activity)
   });
-  return { error: handleApiError('Failed to update activity, please try again.', response) }
+  const { status } = response;
+
+  if(requestFailed(status)) {
+    const errors = await response.json();
+    const returnedErrors = await handleRequestErrors(errors);
+    return { errors: returnedErrors };
+  }
+  return { errors: [] };
 }
 
 export const archiveParentActivity = async (parentActivityId: string) => {

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
@@ -17,9 +17,11 @@ module Comprehension
     before_validation :set_max_attempts, on: :create
 
     validates_presence_of :activity
-    validates :text, presence: true, length: { in: MIN_TEXT_LENGTH..MAX_TEXT_LENGTH, allow_nil: true }
+    validates :text, presence: true
     validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }
     validates :max_attempts, inclusion: { in: MIN_MAX_ATTEMPTS..MAX_MAX_ATTEMPTS }
+
+    validate :validate_prompt_text_length, on: [:create, :update]
 
     def serializable_hash(options = nil)
       options ||= {}
@@ -43,6 +45,18 @@ module Comprehension
         end
       end
       save!
+    end
+
+    private def validate_prompt_text_length
+      length = text&.length
+      prompt = "#{conjunction} prompt"
+      if length
+        if length < MIN_TEXT_LENGTH
+          errors.add(:text, "#{prompt} too short (minimum is #{MIN_TEXT_LENGTH} characters)")
+        elsif length > MAX_TEXT_LENGTH
+          errors.add(:text, "#{prompt} too long (maximum is #{MAX_TEXT_LENGTH} characters)")
+        end
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/prompt_test.rb
@@ -16,12 +16,25 @@ module Comprehension
         .in_array([3,4,5,6])
 
       should validate_presence_of(:text)
-      should validate_length_of(:text)
-        .is_at_least(10)
-        .is_at_most(255)
       should validate_presence_of(:conjunction)
       should validate_inclusion_of(:conjunction)
         .in_array(%w(because but so))
+
+      context '#validate_prompt_length' do
+        should 'not allow a prompt to be created that is too short' do
+          activity = create(:comprehension_activity)
+          prompt = build(:comprehension_prompt, conjunction: "but", text: "too short", max_attempts: 5, activity_id: activity.id)
+          assert !prompt.valid?
+          assert prompt.errors[:text].include?("#{prompt.conjunction} prompt too short (minimum is #{Prompt::MIN_TEXT_LENGTH} characters)")
+        end
+        should 'not allow a prompt to be created that is too long' do
+          activity = create(:comprehension_activity)
+          prompt_text = "And both that morning equally lay In leaves no step had trodden black. Oh, I kept the first for another day! Yet knowing how way leads on to way, I doubted if I should ever come back. I shall be telling this with a sigh Somewhere ages and ages hence: Two roads diverged in a wood, and I— I took the one less traveled by, And that has made all the difference."
+          prompt = build(:comprehension_prompt, conjunction: "because", text: prompt_text, max_attempts: 5, activity_id: activity.id)
+          assert !prompt.valid?
+          assert prompt.errors[:text].include?("#{prompt.conjunction} prompt too long (maximum is #{Prompt::MAX_TEXT_LENGTH} characters)")
+        end
+      end
     end
 
     context '#after_create' do


### PR DESCRIPTION
## WHAT
update error handling for creating/updating activities in Comprehension

## WHY
we don't want Curriculum to have to re-enter form data when there are returned errors; we want to display these errors and allow them to fix issues to submit successfully

## HOW
use same helper functions for handling request errors that are used for rules; also update backend error handling to specify which prompts are erroring

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1147" alt="Screen Shot 2021-05-28 at 2 10 00 PM" src="https://user-images.githubusercontent.com/25959584/120038037-3e07e000-bfc8-11eb-8150-fff0d8486a51.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Automatically-input-the-Parent-Activity-ID-in-the-Activity-Settings-Configure-Modal-3a0826691bbf44dcbb6d8db4a649f262

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
