### PR TITLE
fix feedback styling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/step.scss
@@ -78,7 +78,10 @@
       line-height: normal;
       p {
         white-space: pre-wrap;
-        margin-top: -5px;
+        margin-top: -3px;
+        p {
+          margin-top: 0px;
+        }
       }
       img {
         margin-right: 12px;


### PR DESCRIPTION
## WHAT
Fix feedback styling so that single-line feedback is aligned correctly.

## WHY
So that it is aligned correctly.

## HOW
Just a CSS adjustment.

### Screenshots
<img width="639" alt="Screen Shot 2021-06-01 at 12 49 39 PM" src="https://user-images.githubusercontent.com/18669014/120365354-533c8180-c2dc-11eb-8f3f-37e521f5234b.png">
<img width="635" alt="Screen Shot 2021-06-01 at 12 44 56 PM" src="https://user-images.githubusercontent.com/18669014/120365355-533c8180-c2dc-11eb-9351-55a709a7c233.png">
<img width="632" alt="Screen Shot 2021-06-01 at 12 44 31 PM" src="https://user-images.githubusercontent.com/18669014/120365356-53d51800-c2dc-11eb-9c0f-c256a824f31f.png">

### Notion Card Links
https://www.notion.so/quill/Fix-the-styling-of-the-feedback-44794f234f1d4ea9a65f7c80b1f634f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES