### PR TITLE
Comprehension internal tools/ update parent activity ID rendering

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -47,13 +47,20 @@ exports[`Activity Form component should render Activities 1`] = `
       label="Target Reading Level"
       value="7"
     />
-    <Input
-      autoComplete="on"
-      className="parent-activity-id-input"
-      handleChange={[Function]}
-      label="Parent Activity ID"
-      value="17"
-    />
+    <section
+      className="label-status-container"
+    >
+      <p
+        id="label-status-label"
+      >
+        Parent Activity ID
+      </p>
+      <p
+        id="label-status"
+      >
+        17
+      </p>
+    </section>
     <Input
       autoComplete="on"
       className="image-link-input"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/ruleGenericAttributes.tsx
@@ -8,6 +8,7 @@ import {
   handleSetRuleOptimal,
   handleSetRuleType,
 } from '../../../helpers/comprehension/ruleHelpers';
+import { renderIDorUID } from '../../../helpers/comprehension';
 import { ruleTypeOptions, universalRuleTypeOptions, ruleOptimalOptions } from '../../../../../constants/comprehension';
 import { InputEvent, DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 import { Input, DropdownInput, TextEditor } from '../../../../Shared/index'
@@ -63,15 +64,6 @@ const RuleGenericAttributes = ({
   function onHandleSetRuleOptimal(ruleOptimal: DropdownObjectInterface) { handleSetRuleOptimal(ruleOptimal, setRuleOptimal) }
 
   function onHandleSetRuleNote(text: string) { handleSetRuleNote(text, setRuleNote)}
-
-  function renderIDorUID(idOrRuleId, type) {
-    return(
-      <section className="label-status-container">
-        <p id="label-status-label">{type}</p>
-        <p id="label-status">{idOrRuleId}</p>
-      </section>
-    );
-  }
 
   let options = isUniversal ? universalRuleTypeOptions : ruleTypeOptions;
   if(!isAutoML) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -4,7 +4,7 @@ import { EditorState, ContentState } from 'draft-js';
 import PromptsForm from './promptsForm';
 
 // import { flagOptions } from '../../../../../constants/comprehension'
-import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction, getActivityPrompt, getActivityPromptSetter } from '../../../helpers/comprehension';
+import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction, getActivityPrompt, getActivityPromptSetter, renderIDorUID } from '../../../helpers/comprehension';
 import {
   BECAUSE,
   BUT,
@@ -14,11 +14,11 @@ import {
   NAME,
   SCORED_READING_LEVEL,
   TARGET_READING_LEVEL,
-  PARENT_ACTIVITY_ID,
   MAX_ATTEMPTS_FEEDBACK,
   PASSAGE,
   IMAGE_LINK,
-  IMAGE_ALT_TEXT
+  IMAGE_ALT_TEXT,
+  PARENT_ACTIVITY_ID
 } from '../../../../../constants/comprehension';
 import { ActivityInterface, PromptInterface, PassagesInterface, InputEvent } from '../../../interfaces/comprehensionInterfaces';
 import { Input, TextEditor, } from '../../../../Shared/index'
@@ -31,11 +31,10 @@ interface ActivityFormProps {
 
 const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProps) => {
 
-  const { parent_activity_id, passages, prompts, prompt_attributes, scored_level, target_level, title, name, } = activity;
+  const { parent_activity_id, passages, prompts, scored_level, target_level, title, name, } = activity;
   // const formattedFlag = flag ? { label: flag, value: flag } : flagOptions[0];
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
-  const formattedParentActivityId = parent_activity_id ? parent_activity_id.toString() : '';
   const formattedPassage = passages && passages.length ? passages : [{ text: ''}];
   let formattedMaxFeedback;
   if(prompts && prompts[0] && prompts[0].max_attempts_feedback) {
@@ -53,7 +52,6 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
   // const [activityFlag, setActivityFlag] = React.useState<FlagInterface>(formattedFlag);
   const [activityScoredReadingLevel, setActivityScoredReadingLevel] = React.useState<string>(formattedScoredLevel);
   const [activityTargetReadingLevel, setActivityTargetReadingLevel] = React.useState<string>(formattedTargetLevel);
-  const [activityParentActivityId, setActivityParentActivityId] = React.useState<string>(formattedParentActivityId);
   const [activityPassages, setActivityPassages] = React.useState<PassagesInterface[]>(formattedPassage);
   const [activityMaxFeedback, setActivityMaxFeedback] = React.useState<string>(formattedMaxFeedback)
   const [activityBecausePrompt, setActivityBecausePrompt] = React.useState<PromptInterface>(becausePrompt);
@@ -72,8 +70,6 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
   function handleSetActivityScoredReadingLevel(e: InputEvent){ setActivityScoredReadingLevel(e.target.value) };
 
   function handleSetActivityTargetReadingLevel(e: InputEvent){ setActivityTargetReadingLevel(e.target.value) };
-
-  function handleSetActivityParentActivityId(e: InputEvent){ setActivityParentActivityId(e.target.value) };
 
   function handleSetImageLink(e: InputEvent){ handleSetActivityPassages('image_link', e.target.value) };
 
@@ -102,7 +98,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
       activityTitle,
       activityScoredReadingLevel,
       activityTargetReadingLevel,
-      activityParentActivityId,
+      activityParentActivityId: parent_activity_id,
       activityPassages,
       activityMaxFeedback,
       activityBecausePrompt,
@@ -114,7 +110,6 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
       activityName,
       activityScoredReadingLevel,
       activityTargetReadingLevel,
-      activityParentActivityId,
       activityPassages[0].text,
       activityMaxFeedback,
       activityBecausePrompt.text,
@@ -176,13 +171,7 @@ const ActivityForm = ({ activity, closeModal, submitActivity }: ActivityFormProp
           label="Target Reading Level"
           value={activityTargetReadingLevel}
         />
-        <Input
-          className="parent-activity-id-input"
-          error={errors[PARENT_ACTIVITY_ID]}
-          handleChange={handleSetActivityParentActivityId}
-          label="Parent Activity ID"
-          value={activityParentActivityId}
-        />
+        {parent_activity_id && renderIDorUID(parent_activity_id, PARENT_ACTIVITY_ID)}
         <Input
           className="image-link-input"
           error={errors[IMAGE_LINK]}

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -106,7 +106,7 @@ export const buildActivity = ({
     activity: {
       name: activityName,
       title: activityTitle,
-      parent_activity_id: parseInt(activityParentActivityId),
+      parent_activity_id: activityParentActivityId ? parseInt(activityParentActivityId) : null,
       // flag: label,
       scored_level: activityScoredReadingLevel,
       target_level: parseInt(activityTargetReadingLevel),
@@ -271,9 +271,6 @@ export const validateForm = (keys: string[], state: any[], ruleType?: string) =>
           errors[keys[i]] = 'Concept UID cannot be blank. Default for plagiarism rules is "Kr8PdUfXnU0L7RrGpY4uqg"'
         }
         break;
-      case PARENT_ACTIVITY_ID:
-        // this field is not required
-        break;
       default:
         const strippedValue = value && stripHtml(value);
         if(!strippedValue || strippedValue.length === 0) {
@@ -316,3 +313,12 @@ export const getCsrfToken = () => {
   const token = document.querySelector('meta[name="csrf-token"]')
   if (token) { return token.getAttribute('content') }
 };
+
+export const renderIDorUID = (idOrRuleId: string | number, type: string) => {
+  return(
+    <section className="label-status-container">
+      <p id="label-status-label">{type}</p>
+      <p id="label-status">{idOrRuleId}</p>
+    </section>
+  );
+}

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -243,6 +243,22 @@
         color: #29d8bc;
       }
     }
+    .activity-form {
+      .label-status-container {
+        min-height: 58px;
+        margin-top: 8px;
+        #label-status-label {
+          font-size: 12px;
+          font-weight: 600;
+          color: #7f7f7f;
+        }
+        #label-status {
+          font-size: 16px;
+          color: #7f7f7f;
+          margin: 0;
+        }
+      }
+    }
     .activity-form , .rule-form, .semantic-rule-form {
       padding: 0px 30px 0px 30px;
       max-height: 80vh;
@@ -910,9 +926,6 @@
         font-weight: 300;
       }
     }
-    .link-info-blurb {
-      margin-top: 16px;
-    }
     .top-section {
       display: flex;
       .total-container {
@@ -929,18 +942,11 @@
         }
       }
       .dropdown-container {
-        margin-right: 32px;
         .dropdown {
           .dropdown__control {
             display: flex;
           }
         }
-      }
-      .session-filters-dropdown {
-        width: 280px;
-      }
-      .page-number-dropdown {
-        width:  104px;
       }
     }
     .activity-sessions-table {
@@ -948,22 +954,8 @@
       overflow-x: hidden;
       .data-table-body {
         .data-table-row {
-          span:nth-of-type(3) {
-            font-weight: bold;
-          }
-          span:nth-of-type(8) {
-            color: #d20303;
-          }
-          span:nth-of-type(9) {
-            color: #03d268;
-          }
-          span {
-            text-align: center !important;
-          }
-        }
-        .quill-tooltip-trigger {
-          span {
-            text-align: center !important;
+          span:nth-of-type(4), span:nth-of-type(5), span:nth-of-type(6), span:nth-of-type(7) {
+            text-align: left !important;
           }
         }
       }
@@ -1018,10 +1010,6 @@
           .data-table-row {
             height: auto;
             padding: 10px 16px;
-            .data-table-row-section {
-              word-wrap: break-word;
-              white-space: normal;
-            }
             span {
               div {
                 .entry {
@@ -1070,19 +1058,6 @@
     a {
       color: white;
       text-decoration: none;
-    }
-  }
-  .strength-buttons {
-    display: flex;
-    .strength-button {
-      margin-right: 8px;
-      background-color: white;
-      &.strong {
-        background-color: green;
-      }
-      &.weak {
-        background-color: red;
-      }
     }
   }
 }

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -232,7 +232,7 @@ export const TITLE = 'Title';
 export const NAME = 'Name';
 export const SCORED_READING_LEVEL = 'Scored reading level';
 export const TARGET_READING_LEVEL = 'Target reading level';
-export const PARENT_ACTIVITY_ID = 'Parent activity ID'
+export const PARENT_ACTIVITY_ID = 'Parent Activity ID'
 export const PASSAGE = 'Passage';
 export const MAX_ATTEMPTS_FEEDBACK = 'Max attempts feedback';
 export const BECAUSE_STEM = 'Because stem';
@@ -246,7 +246,6 @@ export const activityFormKeys = [
   TITLE,
   SCORED_READING_LEVEL,
   TARGET_READING_LEVEL,
-  PARENT_ACTIVITY_ID,
   PASSAGE,
   MAX_ATTEMPTS_FEEDBACK,
   BECAUSE_STEM,


### PR DESCRIPTION
## WHAT
only render the parent activity ID after an activity is created

## WHY
we don't want Curriculum to manually input this value

## HOW
just conditionally render based off of the presence of `parent_activity_id`

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="907" alt="Screen Shot 2021-06-01 at 2 56 21 PM" src="https://user-images.githubusercontent.com/25959584/120382677-8c2f2300-c2e9-11eb-8a4f-23c60067703d.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Automatically-input-the-Parent-Activity-ID-in-the-Activity-Settings-Configure-Modal-3a0826691bbf44dcbb6d8db4a649f262

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
