### PR TITLE
comprehension/stop-sending-unused-feedback-histories

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
@@ -51,7 +51,7 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
       :used,
       :time,
       :rule_uid,
-      :metadata: [
+      metadata: [
         :response_id,
         highlight: []
       ]

--- a/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
@@ -50,8 +50,11 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
       :optimal,
       :used,
       :time,
-      :metadata,
-      :rule_uid
+      :rule_uid,
+      :metadata: [
+        :response_id,
+        highlight: []
+      ]
     )
   end
 

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -32,7 +32,7 @@ var client = &http.Client {
 	},
 }
 
-func GetBatchFeedbackHistoryUrl() (string) {
+func GetFeedbackHistoryUrl() (string) {
 	lms_domain := GetLMSDomain()
 	return fmt.Sprintf("%s/api/v1/feedback_histories/batch.json", lms_domain)
 }
@@ -143,7 +143,7 @@ func Endpoint(responseWriter http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	go batchRecordFeedback(request_object, results, GetBatchFeedbackHistoryUrl())
+	go recordFeedback(request_object, returnable_result, GetFeedbackHistoryUrl())
 
 	responseWriter.Header().Set("Access-Control-Allow-Origin", "*")
 	responseWriter.Header().Set("Content-Type", "application/json")
@@ -209,62 +209,37 @@ func identifyUsedFeedbackIndex(feedbacks map[int]InternalAPIResponse) int {
 	return -1
 }
 
-func buildFeedbackHistory(request_object APIRequest, feedback InternalAPIResponse, used bool, time_received time.Time) FeedbackHistory {
+func buildFeedbackHistory(request_object APIRequest, feedback APIResponse, used bool, time_received time.Time) FeedbackHistory {
 	return FeedbackHistory{
 		Feedback_session_uid: request_object.Session_id,
 		Prompt_id: request_object.Prompt_id,
-		Concept_uid: feedback.APIResponse.Concept_uid,
+		Concept_uid: feedback.Concept_uid,
 		Attempt: request_object.Attempt,
 		Entry: request_object.Entry,
-		Feedback_text: feedback.APIResponse.Feedback,
-		Feedback_type: feedback.APIResponse.Feedback_type,
-		Optimal: feedback.APIResponse.Optimal,
+		Feedback_text: feedback.Feedback,
+		Feedback_type: feedback.Feedback_type,
+		Optimal: feedback.Optimal,
 		Used: used,
 		Time: time_received,
-		Rule_uid: feedback.APIResponse.Rule_uid,
+		Rule_uid: feedback.Rule_uid,
 		Metadata: FeedbackHistoryMetadata{
-			Highlight: feedback.APIResponse.Highlight,
-			Labels: feedback.APIResponse.Labels,
-			Response_id: feedback.APIResponse.Response_id,
+			Highlight: feedback.Highlight,
+			Labels: feedback.Labels,
+			Response_id: feedback.Response_id,
 		},
 	}
 }
 
-func buildBatchFeedbackHistories(
-	request_object APIRequest, 
-	feedbacks map[int]InternalAPIResponse, 
-	time_received time.Time,
-	) (BatchHistoriesAPIRequest, error) {
-	feedback_histories := []FeedbackHistory{}
-	used_key := identifyUsedFeedbackIndex(feedbacks)
-	for key, feedback := range feedbacks {
-		if !feedback.Error{
-			feedback_histories = append(feedback_histories, buildFeedbackHistory(request_object, feedback, used_key == key, time_received))
-		} else if key == automl_index {
-			fallback_feedback := InternalAPIResponse{APIResponse: default_api_response}
-			feedback_histories = append(feedback_histories, buildFeedbackHistory(request_object, fallback_feedback, used_key == -1, time_received))
-		}
-	}
-
-	return BatchHistoriesAPIRequest {
-		Feedback_histories: feedback_histories,
-	}, nil
-}
-
-func batchRecordFeedback(incoming_params APIRequest, feedbacks map[int]InternalAPIResponse, batch_feedback_history_url string) {
+func recordFeedback(incoming_params APIRequest, feedback APIResponse, feedback_history_url string) {
 	defer wg.Done() // mark task as done in WaitGroup on return
 
-	histories, err := buildBatchFeedbackHistories(incoming_params, feedbacks, time.Now())
+	history := buildFeedbackHistory(incoming_params, feedback, true, time.Now())
 
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	histories_json, _ := json.Marshal(histories)
+	history_json, _ := json.Marshal(history)
 
 	// TODO For now, just swallow any errors from this, but we'd want to report errors.
 	// TODO: Replace "client" with "http" when we remove the segment above
-	client.Post(batch_feedback_history_url, "application/json",  bytes.NewBuffer(histories_json))
+	client.Post(feedback_history_url, "application/json",  bytes.NewBuffer(history_json))
 }
 
 type APIRequest struct {
@@ -319,8 +294,4 @@ type FeedbackHistory struct {
 	Time time.Time `json:"time"`
 	Metadata FeedbackHistoryMetadata `json:"metadata"`
 	Rule_uid string `json:"rule_uid"`
-}
-
-type BatchHistoriesAPIRequest struct {
-	Feedback_histories []FeedbackHistory `json:"feedback_histories"`
 }

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
-	"strings"
 	"time"
 	"os"
 )
@@ -218,22 +217,19 @@ func TestBuildFeedbackHistory(t *testing.T) {
 		Session_id: "test session_id",
 		Attempt: 1,
 	}
-	feedback := InternalAPIResponse {
-		Error: false,
-		APIResponse: APIResponse {
-			Concept_uid: "test concept_uid",
-			Feedback: "test feedback",
-			Feedback_type: "test feedback_type",
-			Optimal: false,
-			Response_id: "test response_id",
-			Labels: "test labels",
-			Highlight: []Highlight {
-				Highlight {
-					Type: "passage",
-					Text: "test highlight",
-					Category: "test highlight category",
-					Character: 0,
-				},
+	feedback := APIResponse {
+		Concept_uid: "test concept_uid",
+		Feedback: "test feedback",
+		Feedback_type: "test feedback_type",
+		Optimal: false,
+		Response_id: "test response_id",
+		Labels: "test labels",
+		Highlight: []Highlight {
+			Highlight {
+				Type: "passage",
+				Text: "test highlight",
+				Category: "test highlight category",
+				Character: 0,
 			},
 		},
 	}
@@ -244,97 +240,23 @@ func TestBuildFeedbackHistory(t *testing.T) {
 	expected := FeedbackHistory {
 		Feedback_session_uid: request_object.Session_id,
 		Prompt_id: request_object.Prompt_id,
-		Concept_uid: feedback.APIResponse.Concept_uid,
+		Concept_uid: feedback.Concept_uid,
 		Attempt: request_object.Attempt,
 		Entry: request_object.Entry,
-		Feedback_text: feedback.APIResponse.Feedback,
-		Feedback_type: feedback.APIResponse.Feedback_type,
-		Optimal: feedback.APIResponse.Optimal,
+		Feedback_text: feedback.Feedback,
+		Feedback_type: feedback.Feedback_type,
+		Optimal: feedback.Optimal,
 		Used: used,
 		Time: time_received,
 		Metadata: FeedbackHistoryMetadata{
-			Highlight: feedback.APIResponse.Highlight,
-			Labels: feedback.APIResponse.Labels,
-			Response_id: feedback.APIResponse.Response_id,
+			Highlight: feedback.Highlight,
+			Labels: feedback.Labels,
+			Response_id: feedback.Response_id,
 		},
 	}
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("buildFeedbackHistory did not generate expected payload")
-	}
-}
-
-func TestBuildBatchFeedbackHistories(t *testing.T) {
-	api_request := APIRequest{Prompt_text: "They cut funding because", Entry: "they needed to save money.", Prompt_id: 4, Session_id: "Asfasdf", Attempt: 2}
-
-	results := map[int]InternalAPIResponse{}
-	results[0] = InternalAPIResponse { APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type1", Optimal: true, Labels: "test_label" } }
-	results[1] = InternalAPIResponse { Error: true, APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: non-optimal", Feedback_type: "type2", Optimal: false, Labels: "test_label" } }
-	results[2] = InternalAPIResponse { APIResponse: APIResponse { Concept_uid: "test_concept", Feedback: "Feedback text: optimal", Feedback_type: "type3", Optimal: false, Labels: "test_label" } }
-	results[automl_index] = InternalAPIResponse { Error: true, APIResponse: default_api_response }
-
-	now := time.Now()
-
-	payload, _ := buildBatchFeedbackHistories(api_request, results, now)
-
-	expected := BatchHistoriesAPIRequest {
-		Feedback_histories: []FeedbackHistory{
-			FeedbackHistory {
-				Feedback_session_uid: api_request.Session_id,
-				Prompt_id: api_request.Prompt_id,
-				Concept_uid: results[0].APIResponse.Concept_uid,
-				Attempt: api_request.Attempt,
-				Entry: api_request.Entry,
-				Feedback_text: results[0].APIResponse.Feedback,
-				Feedback_type: results[0].APIResponse.Feedback_type,
-				Optimal: results[0].APIResponse.Optimal,
-				Used: false,
-				Time: now,
-				Metadata: FeedbackHistoryMetadata { Labels: results[0].APIResponse.Labels },
-			},
-			FeedbackHistory {
-				Feedback_session_uid: api_request.Session_id,
-				Prompt_id: api_request.Prompt_id,
-				Concept_uid: results[2].APIResponse.Concept_uid,
-				Attempt: api_request.Attempt,
-				Entry: api_request.Entry,
-				Feedback_text: results[2].APIResponse.Feedback,
-				Feedback_type: results[2].APIResponse.Feedback_type,
-				Optimal: results[2].APIResponse.Optimal,
-				Used: true,
-				Time: now,
-				Metadata: FeedbackHistoryMetadata { Labels: results[2].APIResponse.Labels },
-			},
-			FeedbackHistory {
-				Feedback_session_uid: api_request.Session_id,
-				Prompt_id: api_request.Prompt_id,
-				Concept_uid: default_api_response.Concept_uid,
-				Attempt: api_request.Attempt,
-				Entry: api_request.Entry,
-				Feedback_text: default_api_response.Feedback,
-				Feedback_type: default_api_response.Feedback_type,
-				Optimal: default_api_response.Optimal,
-				Used: false,
-				Time: now,
-				Metadata: FeedbackHistoryMetadata { Labels: default_api_response.Labels },
-			},
-		},
-	}
-
-	if len(payload.Feedback_histories) != len(expected.Feedback_histories){
-		t.Errorf("Batch Feedback History rolled up the wrong number of items.\nReceived: %d\nExpected: %d", len(payload.Feedback_histories), len(expected.Feedback_histories))
-	}
-
-	payload_json, _ := json.Marshal(payload)
-	payload_str := string(payload_json)
-	for _, feedback_history := range expected.Feedback_histories {
-		expected_json, _ := json.Marshal(feedback_history)
-		expected_str := string(expected_json)
-		if !strings.Contains(payload_str, expected_str) {
-			expected_json, _ := json.Marshal(expected)
-			expected_str := string(expected_json)
-			t.Errorf("Payload not properly formatted.\n\nReceived:\n%s\n\nExpected:\n%s", payload_str, expected_str)
-		}
 	}
 }
 


### PR DESCRIPTION
## WHAT
Replace batch feedback storage with only saving used feedback
## WHY
Since we never actually do reports on unused feedback, we don't need to store information about it
## HOW
- Refactor the code that posts FeedbackHistory records in the Go endpoint to post single entries to the base `create` route in LMS instead
- Remove the code in Go that handled batching FeedbackHistory records since we no longer need to do that
- Make a small tweak to the LMS permit params so that batch and single create both have the same params

### Notion Card Links
https://www.notion.so/quill/Turn-Off-Recording-Unused-Feedback-History-1fd6aa1cc0264310bddd7deff3c5959d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes, mostly in the form of removal
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A