### PR TITLE
Comprehension internal tools/ fix bug where updated regex rule doesn't show changes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/plagiarismRules/plagiarismRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/plagiarismRules/plagiarismRulesIndex.tsx
@@ -6,7 +6,7 @@ import stripHtml from "string-strip-html";
 import { promptsByConjunction, titleCase } from "../../../helpers/comprehension";
 import { getPromptIdString } from '../../../helpers/comprehension/ruleHelpers';
 import { ActivityRouteProps, RuleInterface } from '../../../interfaces/comprehensionInterfaces';
-import { BECAUSE, BUT, SO,  PLAGIARISM } from '../../../../../constants/comprehension';
+import { BECAUSE, BUT, SO, PLAGIARISM } from '../../../../../constants/comprehension';
 import { fetchRules } from '../../../utils/comprehension/ruleAPIs';
 import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { DataTable, Error, Spinner } from '../../../../Shared/index';
@@ -34,7 +34,7 @@ const PlagiarismRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = 
 
   const { data: plagiarismRulesData } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}`, null, promptIds, PLAGIARISM],
+    queryKey: [`rules-${activityId}-${PLAGIARISM}`, null, promptIds, PLAGIARISM],
     queryFn: fetchRules
   });
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/plagiarismRules/plagiarismRulesRouter.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/plagiarismRules/plagiarismRulesRouter.tsx
@@ -9,6 +9,7 @@ import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { createRule, updateRule } from '../../../utils/comprehension/ruleAPIs';
 import { Error, Spinner } from '../../../../Shared/index';
 import { RuleInterface } from '../../../interfaces/comprehensionInterfaces';
+import { getRefetchQueryString } from '../../../helpers/comprehension/ruleHelpers';
 
 const PlagiarismRulesRouter = ({ history, match }) => {
   const { params } = match;
@@ -37,8 +38,9 @@ const PlagiarismRulesRouter = ({ history, match }) => {
         setErrors(errors);
       } else {
         setErrors([]);
+        const queryString = getRefetchQueryString(rule, activityId);
         // update rules cache to display newly created rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
+        queryCache.refetchQueries(queryString).then(() => {
           history.push(`/activities/${activityId}/plagiarism-rules`);
         });
       }
@@ -46,7 +48,7 @@ const PlagiarismRulesRouter = ({ history, match }) => {
     });
   }
 
-  function handleUpdateRule({rule}: {rule: RuleInterface}, ruleId) {
+  function handleUpdateRule({rule}: {rule: RuleInterface}, ruleId: number) {
     updateRule(ruleId, rule).then((response) => {
       const { errors } = response;
       if(errors && errors.length) {
@@ -54,7 +56,7 @@ const PlagiarismRulesRouter = ({ history, match }) => {
       } else {
         setErrors([]);
         // update rules cache to display newly updated rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
+        queryCache.refetchQueries(`rule-${ruleId}`).then(() => {
           history.push(`/activities/${activityId}/plagiarism-rules`);
         });
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesIndex.tsx
@@ -6,7 +6,7 @@ import { firstBy } from 'thenby';
 import { getPromptsIcons } from '../../../helpers/comprehension';
 import { getPromptIdString } from '../../../helpers/comprehension/ruleHelpers';
 import { ActivityRouteProps, RuleInterface, RegexRuleInterface } from '../../../interfaces/comprehensionInterfaces';
-import { BECAUSE, BUT, SO } from '../../../../../constants/comprehension';
+import { BECAUSE, BUT, SO, RULES_BASED_1, RULES_BASED_2, RULES_BASED_3 } from '../../../../../constants/comprehension';
 import { fetchRules } from '../../../utils/comprehension/ruleAPIs';
 import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { DataTable, Error, Spinner } from '../../../../Shared/index';
@@ -33,19 +33,19 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
 
   const { data: rulesBased1Data } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-regex-sentence-structure`, null, promptIds, 'rules-based-1'],
+    queryKey: [`rules-${activityId}-${RULES_BASED_1}`, null, promptIds, RULES_BASED_1],
     queryFn: fetchRules
   });
 
   const { data: rulesBased2Data } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-regex-post-topic`, null, promptIds, 'rules-based-2'],
+    queryKey: [`rules-${activityId}-${RULES_BASED_2}`, null, promptIds, RULES_BASED_2],
     queryFn: fetchRules
   });
 
   const { data: rulesBased3Data } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-regex-typo`, null, promptIds, 'rules-based-3'],
+    queryKey: [`rules-${activityId}-${RULES_BASED_3}`, null, promptIds, RULES_BASED_3],
     queryFn: fetchRules
   });
 
@@ -139,9 +139,9 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     { name: "So", attribute:"so_prompt", width: "50px" },
     { name: "", attribute:"view", width: "50px" },
   ];
-  const addRulesBased1Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: 'rules-based-1' }}}>Add Sentence Structure Regex Rule</Link>;
-  const addRulesBased2Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: 'rules-based-2' }}}>Add Post-Topic Regex Rule</Link>;
-  const addRulesBased3Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: 'rules-based-3' }}}>Add Typo Regex Rule</Link>;
+  const addRulesBased1Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: RULES_BASED_1 }}}>Add Sentence Structure Regex Rule</Link>;
+  const addRulesBased2Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: RULES_BASED_2 }}}>Add Post-Topic Regex Rule</Link>;
+  const addRulesBased3Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: RULES_BASED_3 }}}>Add Typo Regex Rule</Link>;
   const rulesBased1Rows = getFormattedRows(rulesBased1Data);
   const rulesBased2Rows = getFormattedRows(rulesBased2Data);
   const rulesBased3Rows = getFormattedRows(rulesBased3Data);

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesRouter.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesRouter.tsx
@@ -9,6 +9,7 @@ import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { createRule, updateRule } from '../../../utils/comprehension/ruleAPIs';
 import { Error, Spinner } from '../../../../Shared/index';
 import { RuleInterface } from '../../../interfaces/comprehensionInterfaces';
+import { getRefetchQueryString } from '../../../helpers/comprehension/ruleHelpers';
 
 const RegexRulesRouter = ({ history, match }) => {
   const { params } = match;
@@ -36,9 +37,10 @@ const RegexRulesRouter = ({ history, match }) => {
       if(errors && errors.length) {
         setErrors(errors);
       } else {
+        const queryString = getRefetchQueryString(rule, activityId);
         setErrors([]);
         // update rules cache to display newly created rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
+        queryCache.refetchQueries(queryString).then(() => {
           history.push(`/activities/${activityId}/regex-rules`);
         });
       }
@@ -54,7 +56,7 @@ const RegexRulesRouter = ({ history, match }) => {
       } else {
         setErrors([]);
         // update rules cache to display newly updated rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
+        queryCache.refetchQueries(`rule-${ruleId}`).then(() => {
           history.push(`/activities/${activityId}/regex-rules`);
         });
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
@@ -6,12 +6,13 @@ import { firstBy } from 'thenby';
 import { fetchRules } from '../../../utils/comprehension/ruleAPIs';
 import { DataTable, Spinner } from '../../../../Shared/index';
 import { getCheckIcon } from '../../../helpers/comprehension';
+import { AUTO_ML } from '../../../../../constants/comprehension';
 
 const LabelsTable = ({ activityId, prompt }) => {
 
   const { data: rulesData } = useQuery({
     // cache rules data for updates
-    queryKey: [`rules-${activityId}`, null, prompt.id, 'autoML'],
+    queryKey: [`rules-${activityId}-${AUTO_ML}`, null, prompt.id, AUTO_ML],
     queryFn: fetchRules
   });
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { mockRule } from '../../components/comprehension/__mocks__/data';
+import { getRefetchQueryString } from '../comprehension/ruleHelpers';
+import { RULES_BASED_1, RULES_BASED_2, RULES_BASED_3, PLAGIARISM, AUTO_ML } from '../../../../constants/comprehension';
+
+describe('Comprehension rule helper functions', () => {
+
+  describe('#getRefetchQueryString', () => {
+    const mockRulesHash = {
+      [RULES_BASED_1]: { ...mockRule, rule_type: RULES_BASED_1 },
+      [RULES_BASED_2]: { ...mockRule, rule_type: RULES_BASED_2 },
+      [RULES_BASED_3]: { ...mockRule, rule_type: RULES_BASED_3 },
+      [PLAGIARISM]: { ...mockRule, rule_type: PLAGIARISM },
+      [AUTO_ML]: { ...mockRule, rule_type: AUTO_ML },
+      'default': { ...mockRule, rule_type: 'other' }
+    }
+    const activityId = '17';
+    it('should return expect output for query string', () => {
+      expect(getRefetchQueryString(mockRulesHash[RULES_BASED_1], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_1}`);
+      expect(getRefetchQueryString(mockRulesHash[RULES_BASED_2], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_2}`);
+      expect(getRefetchQueryString(mockRulesHash[RULES_BASED_3], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_3}`);
+      expect(getRefetchQueryString(mockRulesHash[PLAGIARISM], activityId)).toEqual(`rules-${activityId}-${PLAGIARISM}`);
+      expect(getRefetchQueryString(mockRulesHash[AUTO_ML], activityId)).toEqual(`rules-${activityId}-${AUTO_ML}`);
+      expect(getRefetchQueryString(mockRulesHash['default'], activityId)).toEqual(`rules-${activityId}`);
+    });
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -13,8 +13,11 @@ import {
   HIGHLIGHT_TYPE,
   FEEDBACK_LAYER_ADDITION,
   FEEDBACK_LAYER_REMOVAL,
+  RULES_BASED_1,
+  RULES_BASED_2,
+  RULES_BASED_3
 } from '../../../../constants/comprehension';
-import { InputEvent, DropdownObjectInterface } from '../../interfaces/comprehensionInterfaces';
+import { InputEvent, DropdownObjectInterface, RuleInterface } from '../../interfaces/comprehensionInterfaces';
 import { ruleTypeOptions, universalRuleTypeOptions, ruleHighlightOptions, numericalWordOptions, regexRuleSequenceOptions, regexRuleTypes } from '../../../../constants/comprehension';
 import { TextEditor, DropdownInput, Modal } from '../../../Shared/index';
 
@@ -143,7 +146,7 @@ export function handleSetFeedback({
     highlightIndex
 }) {
   let updatedFeedback = [...feedback];
-  
+
   switch(updateType) {
     case FEEDBACK:
       updatedFeedback[feedbackIndex].text = text;
@@ -445,6 +448,24 @@ export function getReturnLinkLabel(ruleType) {
     return label + 'Plagiarism Rules Index';
   }
   return label + 'Rules Index';
+}
+
+export function getRefetchQueryString(rule: RuleInterface, activityId: string) {
+  const { rule_type } = rule;
+  switch (rule_type) {
+    case RULES_BASED_1:
+      return `rules-${activityId}-${RULES_BASED_1}`;
+    case RULES_BASED_2:
+      return `rules-${activityId}-${RULES_BASED_2}`;
+    case RULES_BASED_3:
+      return `rules-${activityId}-${RULES_BASED_3}`;
+    case PLAGIARISM:
+      return `rules-${activityId}-${PLAGIARISM}`;
+    case AUTO_ML:
+      return `rules-${activityId}-${AUTO_ML}`;
+    default:
+      return `rules-${activityId}`;
+  }
 }
 
 export function getPromptIdString(prompts) {

--- a/services/QuillLMS/client/app/bundles/Staff/interfaces/comprehensionInterfaces.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/interfaces/comprehensionInterfaces.ts
@@ -1,6 +1,7 @@
 export interface ActivityRouteProps {
   activityId: string,
-  type?: string
+  type?: string,
+  promptConjunction?: string
 }
 
 export interface ActivityInterface {

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -15,6 +15,9 @@ export const WEAK =  'weak';
 export const COMPLETE =  'complete';
 export const INCOMPLETE =  'incomplete';
 export const STRONG =  'strong';
+export const RULES_BASED_1 = 'rules-based-1';
+export const RULES_BASED_2 = 'rules-based-2';
+export const RULES_BASED_3 = 'rules-based-3';
 
 export const flagOptions = [
   {


### PR DESCRIPTION
## WHAT
fix issue where an updated regex rule wasn't showing the updates in the internal tools without a refresh. this also cleans up some organization and handling of query refetches

## WHY
we want Curriculum to be able to see their changes immediately without refreshing the page

## HOW
added a helper function to determine which query key string to pass back to the query refetch function

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/If-you-update-a-regex-rule-you-have-to-refresh-the-page-to-see-the-updates-in-the-CMS-e2374ee157fa4694b933a124a80fc807

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
