### PR TITLE
Apply sorting to incorrect sequences before they are rendered

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -79,8 +79,13 @@ class IncorrectSequencesContainer extends Component {
   }
 
   sortCallback = sortInfo => {
+    const { actionFile } = this.state
+    const { dispatch, match } = this.props;
+    const { params } = match;
+    const { questionID } = params;
     const orderedIds = sortInfo.map(item => item.key);
     this.setState({ orderedIds, });
+    dispatch(actionFile.updateIncorrectSequences(questionID, this.sequencesSortedByOrder()));
   };
 
   saveSequencesAndFeedback = (key) => {


### PR DESCRIPTION
## WHAT
Apply sorting to incorrect sequences before they are rendered in the Connect admin panel.

## WHY
The sort callback was not updating the incorrect sequences with the correct sorting order.

## HOW
Implement the same code we are already using in the focus Points container, which is to keep a list of sorted IDs in state and then get the sorted incorrect sequences with a function before rendering them.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=6feb617388d742a1b630407788c13739

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, no tests here.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
