### PR TITLE
CMS - Run Rematch All daily for questions updated the previous day. (#7746)

### DIFF
--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -1,11 +1,10 @@
 require 'json'
 require 'net/http'
 
-MAX_RETRIES = 3
-
 class RematchResponseWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: SidekiqQueue::DEFAULT
+
+  sidekiq_options retry: 1, queue: SidekiqQueue::DEFAULT
 
   DEFAULT_PARAMS_HASH = {
     'parent_id' => nil,

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -21,6 +21,7 @@ class Cron
     ResetDemoAccountWorker.perform_async
     SyncVitallyWorker.perform_async
     MaterializedViewRefreshWorker.perform_async
+    RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
   end
 
   def self.run_saturday

--- a/services/QuillLMS/app/workers/rematch_updated_questions_worker.rb
+++ b/services/QuillLMS/app/workers/rematch_updated_questions_worker.rb
@@ -5,7 +5,7 @@ class RematchUpdatedQuestionsWorker
 
   REMATCH_URL = "#{ENV['CMS_URL']}/responses/rematch_all"
   JSON_HEADERS = {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
-  DELAY_PER_QUESTION = 5.minutes.to_i
+  DELAY_PER_QUESTION = 1.minutes.to_i
 
   def perform(start_time = Time.zone.now - 1.day, end_time = Time.zone.now, delay =  DELAY_PER_QUESTION)
     questions = Question

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -36,6 +36,11 @@ describe "Cron", type: :model do
       expect(ResetDemoAccountWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
+
+    it "enqueues RematchUpdatedQuestionsWorker" do
+      expect(RematchUpdatedQuestionsWorker).to receive(:perform_async)
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_saturday" do


### PR DESCRIPTION
* Run Rematch for the questions update the previous day.

* Less retries for Rematch Response.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
