### PR TITLE
Fix premium page bug by removing VisibilitySensor wrapper

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/QuestionsAndAnswers.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/QuestionsAndAnswers.tsx
@@ -61,15 +61,13 @@ export default class QuestionsAndAnswers extends React.Component<QuestionsAndAns
   }
 
   render() {
-    const { supportLink, handleChange } = this.props;
+    const { supportLink } = this.props;
     const style = `support-link ${!supportLink ? 'hidden' : ''}`;
     return(
       <div id="q-and-a">
         <div className="q-and-a-inner-wrapper">
           {/* eslint-disable-next-line react/jsx-no-bind */}
-          <VisibilitySensor onChange={(isVisible) => handleChange(isVisible, QUESTIONS_AND_ANSWERS)}>
-            <h1>Questions and Answers</h1>
-          </VisibilitySensor>
+          <h1>Questions and Answers</h1>
           {this.renderQuestionsAndAnswers()}
           <a className={style} href={supportLink}>View all questions and answers</a>
         </div>


### PR DESCRIPTION
## WHAT
Take out VisibilitySensor wrapper on Questions and Answers header that was causing premium page not to show.

## WHY
Premium page should always show on the website.

## HOW
Taking out this wrapper because the `handleChange` prop is not actually passed.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Premium-page-is-blank-0b3a9c9b9bf54886bf025d361eaa8f2c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, no tests for this.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
