### PR TITLE
LMS - Put TeacherActivityFeed in place.

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.jsx
@@ -41,10 +41,11 @@ const Dashboard = ({ onboardingChecklist, firstName, mustSeeModal, linkedToCleve
     getMetrics();
     getDiagnostics()
     getLessons()
+    getActivityFeed()
   }, []);
 
   React.useEffect(() => {
-    if (metrics && diagnostics && lessons && loading) {
+    if (metrics && diagnostics && lessons && activityFeed && loading) {
       setLoading(false)
     }
   }, [metrics, diagnostics, lessons, activityFeed])
@@ -95,6 +96,7 @@ const Dashboard = ({ onboardingChecklist, firstName, mustSeeModal, linkedToCleve
         <KeyMetrics firstName={firstName} metrics={metrics} />
         <DiagnosticMini diagnostics={diagnostics} onMobile={onMobile()} />
         <LessonsMini lessons={lessons} onMobile={onMobile()} />
+        <ActivityFeed activityFeed={activityFeed} onMobile={onMobile()} />
       </main>
       <aside>
         <HandyActions linkedToClever={linkedToClever} />


### PR DESCRIPTION
## WHAT
Reinstate the Teacher Activity Feed.
## WHY
We only turned it off for performance issues, which we've fixed.
## HOW
Just the reverse of this [PR](https://github.com/empirical-org/Empirical-Core/pull/7528/files): 
### Screenshots
<img width="805" alt="Screen Shot 2021-06-04 at 3 12 04 PM" src="https://user-images.githubusercontent.com/1304933/120851918-8171c980-c547-11eb-8ee8-f7ca5ff3f64e.png">
<img width="746" alt="Screen Shot 2021-06-04 at 3 11 51 PM" src="https://user-images.githubusercontent.com/1304933/120851919-820a6000-c547-11eb-858d-f77831f4c04b.png">


### Notion Card Links
https://www.notion.so/quill/Activity-Feed-Performance-Improvements-b2ad0429bad74b6fbc063db700235a43

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A (hasn't been edited since initial deploy.
