### PR TITLE
comprehension/fix-rules-report-counts

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -12,7 +12,7 @@ class RuleFeedbackHistory
           comprehension_rules.suborder AS rule_suborder,
           comprehension_rules.name AS rule_name,
           comprehension_rules.note AS rule_note,
-          count(DISTINCT CASE WHEN feedback_history_ratings.rating IS NOT NULL THEN feedback_history_ratings.id END) AS total_responses,
+          count(DISTINCT feedback_histories.id) AS total_responses,
           count(DISTINCT CASE WHEN feedback_history_ratings.rating = true THEN feedback_history_ratings.id END) AS total_strong,
           count(DISTINCT CASE WHEN feedback_history_ratings.rating = false THEN feedback_history_ratings.id END) AS total_weak,
           count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_consecutive,

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       # rules
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
 
-      # feedbacks
-      create(:feedback_history, rule_uid: so_rule1.uid)
-      create(:feedback_history, rule_uid: so_rule1.uid)
-
       # feedback_histories
       f_h1 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h1 lorem")
       f_h2 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h2 ipsum")
@@ -65,7 +61,7 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         rule_note: so_rule1.note,
         rule_uid: so_rule1.uid,
         strong_responses: 2,
-        total_responses: 3,
+        total_responses: 2,
         weak_responses: 1,
         repeated_consecutive_responses: 1,
         repeated_non_consecutive_responses: 1,


### PR DESCRIPTION
## WHAT
Fix the count for total_responses
## WHY
We were counting total RATINGS, but we actually want to count responses themselves
## HOW
Take out the `CASE` code in the count and just count `DISTINCT feedback_histories.id` to get the actual total entries

### Notion Card Links
https://www.notion.so/quill/Rules-Analysis-is-displaying-an-incorrect-of-responses-b0c4ca8820514d7db9189e7d1b7e9eb3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
