### PR TITLE
Lms/show newest activity analysis

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -152,7 +152,7 @@ module TeacherFixes
     end
 
     remaining_activity_sessions = get_all_completed_activity_sessions_for_a_given_user_and_activity(user_id, activity_id)
-    if remaining_activity_sessions.length > 1 && remaining_activity_sessions.none? { |as| as.is_final_score} && remaining_activity_sessions.any? { |as| as.state === 'finished'}
+    if remaining_activity_sessions.length >= 1 && remaining_activity_sessions.none? { |as| as.is_final_score} && remaining_activity_sessions.any? { |as| as.state === 'finished'}
       remaining_activity_sessions.order(:percentage).first.update(is_final_score: true)
     end
   end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -201,7 +201,7 @@ class ActivitySession < ActiveRecord::Base
                        .where.not(id: id).first
     if a.nil?
       update_columns is_final_score: true
-    elsif percentage > a.percentage || activity.is_comprehension?
+    elsif a.percentage.nil? || percentage >= a.percentage
       update_columns is_final_score: true
       a.update_columns is_final_score: false
     end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -201,7 +201,7 @@ class ActivitySession < ActiveRecord::Base
                        .where.not(id: id).first
     if a.nil?
       update_columns is_final_score: true
-    elsif percentage > a.percentage
+    elsif percentage > a.percentage || activity.is_comprehension?
       update_columns is_final_score: true
       a.update_columns is_final_score: false
     end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -736,6 +736,21 @@ end
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
 
+    it 'updates when new activity session has equal percentage ' do
+      previous_final_score
+      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update_attributes completed_at: Time.now, state: 'finished', percentage: previous_final_score.percentage
+      expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
+    end
+
+    it 'updates when new and old session percentages are nil' do
+      previous_final_score
+      previous_final_score.update(percentage: nil)
+      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update_attributes completed_at: Time.now, state: 'finished', percentage: nil
+      expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
+    end
+
     it 'doesnt update when new activity session has lower percentage' do
       previous_final_score
       new_activity_session =  create(:activity_session, completed_at: Time.now, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)


### PR DESCRIPTION
## WHAT
Tweak the logic that determines which `ActivitySession` is going to be used for LMS reporting so that newer Comprehension play-throughs will be reported when a student replays the same activity.
Also make a tweak so that for other types of activities (such as Connect), if a replay has the same score as the existing reported activity, the newer play-through replaces the older one in reports.
## WHY
So that teachers will see the most recent play-through that their students may have done for a Comprehension activity.
## HOW
Tweak the logic in `determine_if_final_score` which is intended to set the flag on which `ActivitySession` should be used for reporting on a given assignment to account for a given play-through of an assignment.

### Notion Card Links
https://www.notion.so/quill/LMS-Bug-2-Activity-Analysis-captures-the-first-session-instead-of-the-last-played-session-6a49d3529d0a43458ea15e46bf6dc09c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
