### PR TITLE
comprehension/add-session-detailed-metabase-link

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
@@ -15,6 +15,19 @@ exports[`SessionsIndex component should render SessionsIndex 1`] = `
     <p
       className="link-info-blurb"
     >
+      Use 
+      <a
+        href="https://data.quill.org/question/615?activity_id=undefined"
+      >
+        <strong>
+          this Metabase
+        </strong>
+      </a>
+       query to display feedback sessions on a single page.
+    </p>
+    <p
+      className="link-info-blurb"
+    >
       If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/comprehension#/activities/
       <strong>
         activityID

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionsIndex.tsx
@@ -169,6 +169,7 @@ const SessionsIndex = ({ match }) => {
   const { title } = activity;
   const { activitySessions } = sessionsData;
   const { total_activity_sessions, activity_sessions } = activitySessions;
+  const metabaseLink = `https://data.quill.org/question/615?activity_id=${activity.id}`
 
   return(
     <div className="sessions-index-container">
@@ -176,6 +177,7 @@ const SessionsIndex = ({ match }) => {
         <h1>{title}</h1>
       </section>
       <section>
+        <p className="link-info-blurb">Use <a href={metabaseLink}><strong>this Metabase</strong></a> query to display feedback sessions on a single page.</p>
         <p className="link-info-blurb">If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/comprehension#/activities/<strong>activityID</strong>/<strong>sessionID</strong></p>
         <section className="top-section">
           <section className="total-container">


### PR DESCRIPTION
## WHAT
Add a link to the Metabase session query on the session report page
## WHY
Curriculum wants an easy way to get session-level data in a downloadable form, so linking off to a Metabase query here makes that very straightforward.
## HOW
Add a link (with a query variable) to a custom Metabase query on the report page

### Screenshots
![Screen Shot 2021-06-08 at 10 27 06 AM](https://user-images.githubusercontent.com/331565/121203734-55569100-c844-11eb-86e4-5b6e7914923a.png)

### Notion Card Links
https://www.notion.so/quill/Add-a-link-to-the-View-Sessions-page-with-a-Metabase-query-b60bf85483824e4481fb5a08ceaccf80

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
