### PR TITLE
comprehension/redirect-to-dashboard-after-save

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -184,7 +184,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
         so: timeTracking[4],
       })
     }
-    const callback = handleFinishActivity ? handleFinishActivity : window.location.href = '/'
+    const callback = handleFinishActivity ? handleFinishActivity : () => { window.location.href = '/' }
     dispatch(completeActivitySession(sessionID, currentActivity.parent_activity_id, percentage, conceptResults, data, callback))
   }
 


### PR DESCRIPTION
## WHAT
Wrap the window redirect in an anonymous function for callback
## WHY
Currently, when the ternary falls into the redirect path, the `window.location.href` redirect evaluates rather than gets passed as a callback.  This results in it redirecting before the `completeActivitySession` action can complete which terminates in-flight API calls to mark the `ActivitySession` as finished and preventing the activity from being closed out in the LMS for reporting purposes.
## HOW
Just wrap the `window.location.href` change in an anonymous function so that it isn't executed until the action callback.


### Notion Card Links
https://www.notion.so/quill/Student-sessions-appear-as-incomplete-in-teachers-accounts-7034b9c2499845719d247a5a42898d0b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on this functionality
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
