### PR TITLE
comprehension/fix-feedback-history-url

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -34,7 +34,7 @@ var client = &http.Client {
 
 func GetFeedbackHistoryUrl() (string) {
 	lms_domain := GetLMSDomain()
-	return fmt.Sprintf("%s/api/v1/feedback_histories/batch.json", lms_domain)
+	return fmt.Sprintf("%s/api/v1/feedback_histories.json", lms_domain)
 }
 
 func GetLMSDomain() (string) {


### PR DESCRIPTION
## WHAT
Use non-batch FeedbackHistory creation endpoint
## WHY
Now that we're not sending FeedbackHistory in batches anymore.
## HOW
Just update the path to the URL to point at the non-`batch.json` creation endpoint.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on URL config
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
