### PR TITLE
Change "start lesson" to "start activity" to avoid confusion

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/turk/landing.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/turk/landing.jsx
@@ -31,7 +31,7 @@ export default class TurkLanding extends React.Component {
       return (
         <div className="container">
           <div className="landing-page-html" dangerouslySetInnerHTML={{__html: lesson.landingPageHtml}} />
-          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start lesson</button>
+          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start activity</button>
         </div>
       )
     } else {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/turk/landing.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/turk/landing.jsx
@@ -31,7 +31,7 @@ export default class TurkLanding extends React.Component {
       return (
         <div className="container">
           <div className="landing-page-html" dangerouslySetInnerHTML={{__html: landingPageHtml}} />
-          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start lesson</button>
+          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start activity</button>
         </div>
       )
     } else {

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -82,7 +82,7 @@ class Register extends React.Component<any, any> {
       return (
         <div className="container">
           <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: lesson.landingPageHtml, }} />
-          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start lesson</button>
+          <button className="quill-button focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">Start activity</button>
         </div>
       );
     } else if (hasSentenceFragment) {


### PR DESCRIPTION
## WHAT
A simple copy change to put "Start activity" on buttons instead of "Start lesson" because this wording has confused students and teachers.

## WHY
We have a separate app called Quill Lessons so we should avoid using the term "lesson" to refer to any activities that are Connect, Diagnostic, or Grammar.

## HOW
Just change the copy.

### Screenshots
<img width="614" alt="Screen Shot 2021-06-10 at 1 43 28 PM" src="https://user-images.githubusercontent.com/57366100/121572230-ef0f7100-c9f1-11eb-8556-b6f1a7b8305e.png">

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=6c1187a9ea65490ab5c53a92d49b3c5b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
