### PR TITLE
Lms/persist fh highlight

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
@@ -51,10 +51,7 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
       :used,
       :time,
       :rule_uid,
-      metadata: [
-        :response_id,
-        highlight: []
-      ]
+      metadata: params.dig('feedback_history', 'metadata')&.keys 
     )
   end
 
@@ -73,10 +70,7 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
         :used,
         :time,
         :rule_uid,
-        metadata: [
-          :response_id,
-          highlight: []
-        ]
+        metadata: params.dig('feedback_history', 'metadata')&.keys 
       ]
     )[:feedback_histories]
   end

--- a/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/feedback_histories_controller.rb
@@ -51,7 +51,14 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
       :used,
       :time,
       :rule_uid,
-      metadata: params.dig('feedback_history', 'metadata')&.keys 
+      metadata: [
+        highlight: [
+          :text,
+          :type,
+          :category,
+          :character
+        ]
+      ] 
     )
   end
 
@@ -70,7 +77,14 @@ class Api::V1::FeedbackHistoriesController < Api::ApiController
         :used,
         :time,
         :rule_uid,
-        metadata: params.dig('feedback_history', 'metadata')&.keys 
+        metadata: [
+          highlight: [
+            :text,
+            :type,
+            :category,
+            :character
+          ]
+        ] 
       ]
     )[:feedback_histories]
   end

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -184,11 +184,16 @@ const RuleAnalysis = ({ history, match }) => {
     { name: "", attribute:"value", width: "750px" }
   ];
 
+  const extractHighlight = (highlightObject) => {
+    if (!highlightObject || !highlightObject.length || !highlightObject[0].text) return '';
+    return highlightObject[0].text;
+  }
+
   const responseRows = () => {
     if (!activityData || !responses) { return [] }
     return responses.filter(filterResponsesByScored).filter(filterResponsesBySearch).map(r => {
-      const formattedResponse = {...r}
-      const highlightedEntry = r.entry.replace(r.highlight, `<strong>${r.highlight}</strong>`)
+      const formattedResponse = {...r,  ...{highlight: extractHighlight(r.highlight)}}
+      const highlightedEntry = r.entry.replace(formattedResponse.highlight, `<strong>${formattedResponse.highlight}</strong>`)
       const strongButton = <button className={r.strength === true ? 'strength-button strong' : 'strength-button'} onClick={() => toggleStrength(r)} tabIndex={-1} type="button">Strong</button> // curriculum developers want to be able to skip these when tab navigating
       const weakButton = <button className={r.strength === false ? 'strength-button weak' : 'strength-button'} onClick={() => toggleWeakness(r)} tabIndex={-1} type="button">Weak</button> // curriculum developers want to be able to skip these when tab navigating
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -17,6 +17,11 @@ const UNSCORED = 'Unscored'
 const STRONG = 'Strong'
 const WEAK = 'Weak'
 
+const extractHighlight = (highlightObject) => {
+  if (!highlightObject || !highlightObject.length || !highlightObject[0].text) return '';
+  return highlightObject[0].text;
+}
+
 const RuleAnalysis = ({ history, match }) => {
   const { params } = match;
   const { activityId, ruleId, promptConjunction, promptId } = params;
@@ -183,11 +188,6 @@ const RuleAnalysis = ({ history, match }) => {
     { name: "", attribute:"field", width: "180px" },
     { name: "", attribute:"value", width: "750px" }
   ];
-
-  const extractHighlight = (highlightObject) => {
-    if (!highlightObject || !highlightObject.length || !highlightObject[0].text) return '';
-    return highlightObject[0].text;
-  }
 
   const responseRows = () => {
     if (!activityData || !responses) { return [] }

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -48,13 +48,22 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should populate metadata['highlight']" do 
+      metadata = { 
+        "highlight" => [
+          { 'text' => 'is',
+            'type' => 'response',
+            'category' => 'lorem',
+            'character' => 40 } 
+        ]
+      } 
+
       post :create, feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: {highlight: "entry"} }
+                                        feedback_type: 'autoML', metadata: metadata }
 
       parsed_response = JSON.parse(response.body)
-      expect(parsed_response['metadata']['highlight']).to eq 'entry'
+      expect(parsed_response['metadata']['highlight'].first.keys).to eq metadata['highlight'].first.keys 
     end
 
     it "should set prompt_type to Comprehension::Prompt if prompt_id is provided" do

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -47,6 +47,16 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       expect(1).to eq(FeedbackHistory.count)
     end
 
+    it "should populate metadata['highlight']" do 
+      post :create, feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+                                        time: DateTime.now, entry: 'This is the entry provided by the student',
+                                        feedback_text: 'This is the feedback provided by the algorithm',
+                                        feedback_type: 'autoML', metadata: {highlight: "entry"} }
+
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['metadata']['highlight']).to eq 'entry'
+    end
+
     it "should set prompt_type to Comprehension::Prompt if prompt_id is provided" do
       activity = Comprehension::Activity.create(target_level: 1, title: 'Test Activity Title')
       prompt = Comprehension::Prompt.create(activity: activity, text: 'Test prompt text', conjunction: 'but')


### PR DESCRIPTION
## WHAT
FeedbackHistory highlights were not being persisted due to a bug in the params.permit controller logic. Also, the client side was expecting the shape of 'highlight' to be a string, which does not match the [spec payload](https://www.notion.so/quill/Comprehension-API-v1-spec-2b3c21accf2d401699118af3399f0deb). 

## WHY

## HOW
I added a defensively-coded highlight extractor on the client side that is compatible with both the old, malformed FeedbackHistory.metadata and the new, correctly formed FeedbackHistory.metadata.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=392272bd51c44f5db89b149b03a99437

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A )
