### PR TITLE
adding security gem and regression tests

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -24,6 +24,7 @@ gem "doorkeeper", ">= 4.2.0"
 gem 'omniauth'
 gem 'omniauth-google-oauth2', '0.6.0'
 gem 'omniauth-clever'
+gem 'omniauth-rails_csrf_protection'
 gem 'cancancan'
 gem 'firebase_token_generator'
 gem 'rack-attack'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -411,6 +411,9 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     optimist (3.0.1)
     os (1.1.1)
     paperclip (6.1.0)
@@ -836,6 +839,7 @@ DEPENDENCIES
   omniauth
   omniauth-clever
   omniauth-google-oauth2 (= 0.6.0)
+  omniauth-rails_csrf_protection
   paperclip
   parallel_tests
   parslet

--- a/services/QuillLMS/spec/requests/cve_2015_9284_spec.rb
+++ b/services/QuillLMS/spec/requests/cve_2015_9284_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'CVE-2015-9284', type: :request do
+  describe 'GET /auth/:provider' do
+    it do
+      expect do 
+        get '/auth/google_oauth2'
+      end.to raise_error
+      expect(response).not_to have_http_status(:redirect)
+    end
+  end
+
+  describe 'POST /auth/:provider without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it do
+      expect {
+        post '/auth/google_oauth2'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Omniauth remediation (patched gem not available).

## WHY
security 

## HOW
Install an additional security gem which limits GET requests in the oauth context, as well as adding CSRF protection. This is the recommended remediation for this security vuln. 

I also added regression tests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/manually-patch-omniauth-f5cad5ed878040978fafb6944c7cf788

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.) yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A 
