### PR TITLE
Catch all the nil errors in ActivityHealth and QuestionHealth worker logic

### DIFF
--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -28,7 +28,7 @@ class QuestionHealthDashboard
     begin
       JSON.parse(cms_data.body)
     rescue JSON::ParserError
-      {"percent_common_unmatched": 0, "percent_specified_algos": 0}
+      {}
     end
   end
 

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -25,7 +25,11 @@ class QuestionHealthDashboard
   end
 
   def cms_dashboard_stats
-    JSON.parse(cms_data.body)
+    begin
+      JSON.parse(cms_data.body)
+    rescue JSON::ParserError
+      {"percent_common_unmatched": 0, "percent_specified_algos": 0}
+    end
   end
 
   private def score_to_attempts(score)

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -25,10 +25,9 @@ class QuestionHealthDashboard
   end
 
   def cms_dashboard_stats
-      JSON.parse(cms_data.body)
-    rescue JSON::ParserError
-      {}
-    end
+    JSON.parse(cms_data.body)
+  rescue JSON::ParserError
+    {}
   end
 
   private def score_to_attempts(score)

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -25,7 +25,6 @@ class QuestionHealthDashboard
   end
 
   def cms_dashboard_stats
-    begin
       JSON.parse(cms_data.body)
     rescue JSON::ParserError
       {}

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -17,15 +17,15 @@ class QuestionHealthObj
     health_dashboard = QuestionHealthDashboard.new(@activity.id, @question_number, @question.uid)
     data = @question.data
     {
-      url: [ENV['DEFAULT_URL']&.to_s , "/", @tool, "/#/admin/", question_url, "/", @question&.uid, "/responses"].join(""),
+      url: [ENV['DEFAULT_URL']&.to_s, "/", @tool, "/#/admin/", question_url, "/", @question&.uid, "/responses"].join(""),
       text: data["prompt"],
       flag: data["flag"],
       incorrect_sequences: data["incorrectSequences"]&.length,
       focus_points: data["focusPoints"]&.length,
-      percent_common_unmatched: health_dashboard.cms_dashboard_stats["percent_common_unmatched"].round(2),
-      percent_specified_algorithms: health_dashboard.cms_dashboard_stats["percent_specified_algos"].round(2),
-      difficulty: health_dashboard.average_attempts_for_question.round(2),
-      percent_reached_optimal: health_dashboard.percent_reached_optimal_for_question.round(2)
+      percent_common_unmatched: health_dashboard.cms_dashboard_stats["percent_common_unmatched"]&.round(2),
+      percent_specified_algorithms: health_dashboard.cms_dashboard_stats["percent_specified_algos"]&.round(2),
+      difficulty: health_dashboard.average_attempts_for_question&.round(2),
+      percent_reached_optimal: health_dashboard.percent_reached_optimal_for_question&.round(2)
     }
   end
 

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -17,7 +17,7 @@ class QuestionHealthObj
     health_dashboard = QuestionHealthDashboard.new(@activity.id, @question_number, @question.uid)
     data = @question.data
     {
-      url: [ENV['DEFAULT_URL']&.to_s, "/", @tool, "/#/admin/", question_url, "/", @question&.uid, "/responses"].join(""),
+      url: "#{ENV['DEFAULT_URL']&.to_s}/#{@tool}/#/admin/#{question_url}/#{@question&.uid}/responses",
       text: data["prompt"],
       flag: data["flag"],
       incorrect_sequences: data["incorrectSequences"]&.length,

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -17,7 +17,7 @@ class QuestionHealthObj
     health_dashboard = QuestionHealthDashboard.new(@activity.id, @question_number, @question.uid)
     data = @question.data
     {
-      url: ENV['DEFAULT_URL'].to_s + "/" + @tool + "/#/admin/" + question_url + "/" + @question.uid + "/responses",
+      url: [ENV['DEFAULT_URL']&.to_s , "/", @tool, "/#/admin/", question_url, "/", @question&.uid, "/responses"].join(""),
       text: data["prompt"],
       flag: data["flag"],
       incorrect_sequences: data["incorrectSequences"]&.length,

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -65,7 +65,7 @@ class SerializeActivityHealth
 
   private def average(list, attribute)
     return nil if list.empty?
-    (list.map {|p| p[attribute] || 0 }.sum(0.0) / list.size).round(2)
+    (list.map {|p| p[attribute] || 0}.sum(0.0) / list.size).round(2)
   end
 
   private def standard_deviation(list, attribute)

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -65,7 +65,7 @@ class SerializeActivityHealth
 
   private def average(list, attribute)
     return nil if list.empty?
-    (list.map {|p| p[attribute] }.sum(0.0) / list.size).round(2)
+    (list.map {|p| p[attribute] || 0 }.sum(0.0) / list.size).round(2)
   end
 
   private def standard_deviation(list, attribute)

--- a/services/QuillLMS/app/workers/populate_activity_health_worker.rb
+++ b/services/QuillLMS/app/workers/populate_activity_health_worker.rb
@@ -5,10 +5,12 @@ class PopulateActivityHealthWorker
     @activity = Activity.find(id)
 
     serializer = SerializeActivityHealth.new(@activity)
-    activity_health = ActivityHealth.create!(serializer.data)
+    activity_health = ActivityHealth.create(serializer.data)
 
-    serializer.prompt_data&.each do |prompt_data|
-      PromptHealth.create!(prompt_data.merge({activity_health: activity_health}))
+    if activity_health.valid?
+      serializer.prompt_data&.each do |prompt_data|
+        PromptHealth.create!(prompt_data.merge({activity_health: activity_health}))
+      end
     end
   end
 end

--- a/services/QuillLMS/app/workers/populate_activity_health_worker.rb
+++ b/services/QuillLMS/app/workers/populate_activity_health_worker.rb
@@ -1,5 +1,6 @@
 class PopulateActivityHealthWorker
   include Sidekiq::Worker
+  sidekiq_options retry: 1
 
   def perform(id)
     @activity = Activity.find(id)

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -90,5 +90,15 @@ describe QuestionHealthDashboard, type: :model do
       expect(dashboard_stats["percent_common_unmatched"]).to eq(50)
       expect(dashboard_stats["percent_specified_algos"]).to eq(75)
     end
+
+    it 'should return empty data without raising error if json parser fails' do
+      ENV['CMS_URL'] = 'https://cms.quill.org'
+      question_uid = SecureRandom.uuid
+      stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question_uid}/question_dashboard_data")
+        .to_return(status: 200, body: "there was some kind of error here", headers: {})
+      dashboard_stats = QuestionHealthDashboard.new(activity.id, 1, question_uid).cms_dashboard_stats
+      expect(dashboard_stats["percent_common_unmatched"]).to eq(nil)
+      expect(dashboard_stats["percent_specified_algos"]).to eq(nil)
+    end
   end
 end

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe QuestionHealthObj, type: :model do
       expect(health_obj[:difficulty]).to eq(2.67)
       expect(health_obj[:percent_reached_optimal]).to eq(66.67)
     end
+
+    it 'should return without erroring if one of the url values is nil' do
+      health_obj = QuestionHealthObj.new(activity, question, 1, nil).run
+      expect(health_obj[:url]).to eq("https://quill.org//#/admin/questions/#{question.uid}/responses")
+      expect(health_obj[:text]).to eq(question.data['prompt'])
+      expect(health_obj[:flag]).to eq(question.data['flag'])
+      expect(health_obj[:incorrect_sequences]).to eq(question.data["incorrectSequences"].length)
+      expect(health_obj[:focus_points]).to eq(question.data["focusPoints"].length)
+      expect(health_obj[:percent_common_unmatched]).to eq(50)
+      expect(health_obj[:percent_specified_algorithms]).to eq(75)
+      expect(health_obj[:difficulty]).to eq(2.67)
+      expect(health_obj[:percent_reached_optimal]).to eq(66.67)
+    end
   end
 
 end

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -122,7 +122,7 @@ describe PopulateActivityHealthWorker do
     end
 
     it 'should create a new Activity Health object' do
-      bad_activity = create(:activity, activity_classification_id: connect.id, flags:["nonflag"])
+      bad_activity = create(:activity, activity_classification_id: connect.id, flags: ["nonflag"])
       expect { subject.perform(bad_activity.id) }.not_to raise_error
 
     end

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -120,5 +120,11 @@ describe PopulateActivityHealthWorker do
       expect(PromptHealth.second.text).to eq(another_question.data["prompt"])
       expect(PromptHealth.second.percent_common_unmatched).to eq(100)
     end
+
+    it 'should create a new Activity Health object' do
+      bad_activity = create(:activity, activity_classification_id: connect.id, flags:["nonflag"])
+      expect { subject.perform(bad_activity.id) }.not_to raise_error
+
+    end
   end
 end


### PR DESCRIPTION
## WHAT
We have some very old activities and questions in the database that have oddly formatted JSON data that doesn't match our current schema. This PR adds some more rigorous nil and error catching to the weekly ActivityHealth job's logic, to avoid erroring out on too many of these bad activities.

## WHY
While we shouldn't delete these archived records in case Curriculum wants to refer back to old activities, we do want to do nil catching in our current jobs so these old activities don't trigger too many errors and warnings. We'll also set retry to 1 so that if the health worker fails on one of these activities, it won't keep trying.

## HOW
Nil error catching and exception catching.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=0e51f92ea9144f7d850c52649e40eb0c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
