### PR TITLE
make sure expanded rules analysis rows stay open when switching tabs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
@@ -345,6 +345,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
         columns={dataTableFields}
         data={formattedRows ? formattedRows : []}
         defaultPageSize={formattedRows.length}
+        freezeWhenExpanded={true}
         onSortedChange={setSorted}
         pivotBy={["apiName"]}
         showPagination={false}


### PR DESCRIPTION
## WHAT
Make sure expanded Rules Analysis rows stay open when switching tabs.

## WHY
This was requested by curriculum.

## HOW
Use a `ReactTable` prop that handles this.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Rules-Analysis-toggle-should-remain-open-even-when-you-switch-tabs-02d1ceb735dc47d0af1291766d07c93f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
