### PR TITLE
Fix ActionController::InvalidCrossOriginRequest routing error

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -65,8 +65,8 @@ class ApplicationController < ActionController::Base
       # in a content-less error response at all, but CORS security logic in Rails
       # falsely flags lack of content-type headers in responses to routes that end
       # in ".js" as a class of responses that need CORS protection and 500s when
-      # attempting to serve a 404.  So we set the header to an empty value here.
-      format.js { render nothing: true, status: status, content_type: '' }
+      # attempting to serve a 404.  So, we set the content_type to 'text/html'.
+      format.js { render nothing: true, status: status, content_type: 'text/html' }
       format.all { render nothing: true, status: status }
     end
   end


### PR DESCRIPTION
## WHAT
Fix a bug due to handling requests for nonexistent javascript assets.

## WHY
After the Rails 5 upgrade we started seeing: 

![Screen Shot 2021-06-21 at 8 52 23 AM](https://user-images.githubusercontent.com/2057805/122764956-02ca9b00-d26e-11eb-8a18-e3eafa597c4a.png)

Errors were triggered by requests for nonexistent javascript assets that confusingly originated from the same domain (e.g. https://www.quill.org/webpack/student-bundle-6f76278f78c2eb85b076.js
).

## HOW
While [this](https://github.com/empirical-org/Empirical-Core/blob/385aacaeedc993ff1edd6d5529c08133b0b19a24/services/QuillLMS/app/controllers/application_controller.rb#L69) mitigation worked for Rails 4, setting content_type: to `''` in Rails 5 does not;  content_type must be set to an explicit value, otherwise Rails infers the content-type based on the request (i.e. `text/javascript`)

A more thorough explanation of what is happening is found in this [post](
https://die-antwort.eu/techblog/2018-08-avoid-invalid-cross-origin-request-with-catch-all-route/)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - manual check.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
