### PR TITLE
remove concept id from csv report

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -4,7 +4,14 @@ import userIsPremium from '../modules/user_is_premium'
 import _ from 'underscore'
 import _l from 'lodash'
 
-export default class extends React.Component {
+function formatData(data) {
+  return data.map(row => {
+    delete row['Concept Id']
+    return row
+  })
+}
+
+export default class CSVDownloadForProgressReports extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -114,15 +121,15 @@ export default class extends React.Component {
             <div className='button-wrapper'>
 
               <button className="print-button" onClick={window.print}>
-                <img 
-                  alt="print" 
-                  className="print-img" 
-                  src="https://assets.quill.org/images/icons/download-report-premium.svg" 
+                <img
+                  alt="print"
+                  className="print-img"
+                  src="https://assets.quill.org/images/icons/download-report-premium.svg"
                 />PDF
               </button>
 
-              <CSVLink 
-                data={this.state.data} 
+              <CSVLink
+                data={formatData(this.state.data)}
                 filename={this.formatFilename(this.props.studentName)}
                 target="_blank"
               >


### PR DESCRIPTION
## WHAT
Remove the Concept ID from the CSV version of the downloaded report.

## WHY
So that the data on the PDF and the CSV version of the downloads are the same and both match what is shown to the user on the screen.

## HOW
Just filter out that key.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Concepts-Report-Not-Displaying-Student-Name-When-Downloaded-7138ece11cc4445aad7e9eb2dca928d6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
