### PR TITLE
Comprehension internal tools/ semantic label return after create/update

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__mocks__/data.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__mocks__/data.ts
@@ -3,36 +3,39 @@ import { BUT, BECAUSE, SO } from "../../../../../constants/comprehension"
 const FEEDBACK =
   "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul."
 
+const mockPrompts = [
+  {
+    id: 7,
+    conjunction: BECAUSE,
+    text: "1",
+    max_attempts: 5,
+    max_attempts_feedback: FEEDBACK,
+  },
+  {
+    id: 8,
+    conjunction: BUT,
+    text: "2",
+    max_attempts: 5,
+    max_attempts_feedback: FEEDBACK,
+  },
+  {
+    id: 9,
+    conjunction: SO,
+    text: "3",
+    max_attempts: 5,
+    max_attempts_feedback: FEEDBACK,
+  },
+];
+
 export const mockActivity = {
   title: "Could Capybaras Create Chaos?",
-  name: "Could Capybaras Create Chaos? [student testing]",
+  notes: "Could Capybaras Create Chaos? [student testing]",
   scored_level: "7",
   target_level: 7,
   parent_activity_id: "17",
   passages: [{ text: "..." }],
-  prompt_attributes: [
-    {
-      id: 7,
-      conjunction: BECAUSE,
-      text: "1",
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-    },
-    {
-      id: 8,
-      conjunction: BUT,
-      text: "2",
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-    },
-    {
-      id: 9,
-      conjunction: SO,
-      text: "3",
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-    },
-  ],
+  prompt_attributes: mockPrompts,
+  prompts: mockPrompts,
 }
 
 export const mockRule = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Activity Form component should render Activities 1`] = `
       className="name-input"
       handleChange={[Function]}
       label="Activity Notes"
-      value=""
+      value="Could Capybaras Create Chaos? [student testing]"
     />
     <Input
       autoComplete="on"
@@ -95,31 +95,34 @@ exports[`Activity Form component should render Activities 1`] = `
       EditorState={[Function]}
       handleTextChange={[Function]}
       key="max-attempt-feedback"
-      text="Nice effort! You worked hard to make your sentence stronger."
+      text="At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul."
     />
     <PromptsForm
       activityBecausePrompt={
         Object {
           "conjunction": "because",
+          "id": 7,
           "max_attempts": 5,
-          "max_attempts_feedback": "",
-          "text": "",
+          "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+          "text": "1",
         }
       }
       activityButPrompt={
         Object {
           "conjunction": "but",
+          "id": 8,
           "max_attempts": 5,
-          "max_attempts_feedback": "",
-          "text": "",
+          "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+          "text": "2",
         }
       }
       activitySoPrompt={
         Object {
           "conjunction": "so",
+          "id": 9,
           "max_attempts": 5,
-          "max_attempts_feedback": "",
-          "text": "",
+          "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+          "text": "3",
         }
       }
       errors={Object {}}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityStats.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityStats.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`ActivityStats component should render ActivityStats 1`] = `
     <h3>
       Could Capybaras Create Chaos?
     </h3>
-    <h4 />
+    <h4>
+      Could Capybaras Create Chaos? [student testing]
+    </h4>
   </section>
   <ReactTable
     AggregatedComponent={[Function]}

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/labelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/labelsTable.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
               Object {
                 "pathname": "/activities/17/semantic-labels/1/1",
                 "state": Object {
+                  "conjunction": "because",
                   "rule": Object {
                     "id": 1,
                     "label": Object {
@@ -88,6 +89,7 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
               Object {
                 "pathname": "/activities/17/semantic-labels/1/2",
                 "state": Object {
+                  "conjunction": "because",
                   "rule": Object {
                     "id": 2,
                     "label": Object {
@@ -128,7 +130,7 @@ exports[`LabelsTable component should render LabelsTable 1`] = `
         Object {
           "pathname": "/activities/17/semantic-labels/1/new",
           "state": Object {
-            "conjunction": undefined,
+            "conjunction": "because",
           },
         }
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`PlagiarismRulesIndex component should render PlagiarismRulesIndex 1`] =
     <h3>
       Could Capybaras Create Chaos?
     </h3>
-    <h4 />
+    <h4>
+      Could Capybaras Create Chaos? [student testing]
+    </h4>
   </section>
   <section
     className="plagiarism-section"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/labelsTable.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/labelsTable.test.tsx
@@ -20,7 +20,7 @@ jest.mock("react-query", () => ({
 describe('LabelsTable component', () => {
   const mockProps = {
     activityId: '17',
-    prompt: { id: 1 }
+    prompt: { id: 1, conjunction: 'because' }
   }
   const container = shallow(
     <LabelsTable {...mockProps} />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/labelsTable.tsx
@@ -23,7 +23,7 @@ const LabelsTable = ({ activityId, prompt }) => {
     const formattedRows = rulesData.rules.map(rule => {
       const { name, id, state, optimal, label } = rule;
       const ruleLink = (
-        <Link className="data-link" to={{ pathname: `/activities/${activityId}/semantic-labels/${prompt.id}/${id}`, state: { rule: rule } }}>View</Link>
+        <Link className="data-link" to={{ pathname: `/activities/${activityId}/semantic-labels/${prompt.id}/${id}`, state: { rule: rule, conjunction: prompt.conjunction } }}>View</Link>
       );
       const isActive = state === 'active';
       return {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/semanticRules/semanticLabelsIndex.tsx
@@ -10,7 +10,7 @@ import ActivateModelForm from './activateModelForm';
 import Model from './model';
 
 import { ALL, BECAUSE, BUT, SO } from '../../../../../constants/comprehension';
-import { getPromptForComponent } from '../../../helpers/comprehension';
+import { getPromptForComponent, getPromptConjunction } from '../../../helpers/comprehension';
 import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { createRule, updateRule } from '../../../utils/comprehension/ruleAPIs';
 import { Error, Spinner } from '../../../../Shared/index';
@@ -35,11 +35,11 @@ const SemanticLabelsIndex = ({ location, history, match }) => {
       if(errors && errors.length) {
         setErrors(errors);
       } else {
+        const { prompt_ids } = rule;
+        const conjunction = getPromptConjunction(activityData, prompt_ids[0]);
         setErrors([]);
-        // update rules cache to display newly created rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
-          history.push(`/activities/${activityId}/semantic-labels/all`);
-        });
+        queryCache.clear();
+        history.push(`/activities/${activityId}/semantic-labels/${conjunction}`);
       }
       return rule;
     });
@@ -51,11 +51,11 @@ const SemanticLabelsIndex = ({ location, history, match }) => {
       if(errors && errors.length) {
         setErrors(errors);
       } else {
+        const { prompt_ids } = rule;
+        const conjunction = getPromptConjunction(activityData, prompt_ids[0]);
         setErrors([]);
-        // update rules cache to display newly updated rule
-        queryCache.refetchQueries(`rules-${activityId}`).then(() => {
-          history.push(`/activities/${activityId}/semantic-labels/all`);
-        });
+        queryCache.clear();
+        history.push(`/activities/${activityId}/semantic-labels/${conjunction}`);
       }
       return rule;
     });

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/comprehension.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/comprehension.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { mockActivity } from '../../components/comprehension/__mocks__/data';
+import { getPromptConjunction } from '../comprehension';
+import { BECAUSE, BUT, SO, ALL } from '../../../../constants/comprehension';
+
+describe('Comprehension helper functions', () => {
+
+  describe('#getPromptConjunction', () => {
+    it('should return expected outputs for each prompt matching valid numerical or string prompt ID input', () => {
+      expect(getPromptConjunction({ activity: mockActivity}, 7)).toEqual(BECAUSE);
+      expect(getPromptConjunction({ activity: mockActivity}, '8')).toEqual(BUT);
+      expect(getPromptConjunction({ activity: mockActivity}, 9)).toEqual(SO);
+    });
+    it('should return all if no valid prompt ID received', () => {
+      expect(getPromptConjunction({ activity: mockActivity}, 17)).toEqual(ALL);
+    });
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -13,7 +13,8 @@ import {
   SCORED_READING_LEVEL,
   IMAGE_LINK,
   IMAGE_ALT_TEXT,
-  PLAGIARISM
+  PLAGIARISM,
+  ALL
 } from '../../../constants/comprehension';
 import { PromptInterface, ActivityInterface } from '../interfaces/comprehensionInterfaces'
 
@@ -184,7 +185,7 @@ export function getPromptConjunction(activityData: any, id: number | string) {
   const formattedId = typeof id === 'string' ? parseInt(id) : id;
   const appliedPrompt = prompts.filter(prompt => prompt.id === formattedId)[0];
   if(!appliedPrompt) {
-    return 'all'
+    return ALL;
   }
   return appliedPrompt.conjunction;
 }

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -175,6 +175,20 @@ export function getPromptForComponent(activityData: any, key: string) {
   return promptsHash[key];
 }
 
+export function getPromptConjunction(activityData: any, id: number | string) {
+  if(!activityData || activityData && !activityData.activity) {
+    return null;
+  }
+  const { activity } = activityData;
+  const { prompts } = activity;
+  const formattedId = typeof id === 'string' ? parseInt(id) : id;
+  const appliedPrompt = prompts.filter(prompt => prompt.id === formattedId)[0];
+  if(!appliedPrompt) {
+    return 'all'
+  }
+  return appliedPrompt.conjunction;
+}
+
 export function getActivityPrompt({
   activityBecausePrompt,
   activityButPrompt,


### PR DESCRIPTION
## WHAT
have the user be redirected to the relevant conjunction tab when creating/updating a semantic label

## WHY
Curriculum requested this as better workflow

## HOW
created a helper function to grab the conjunction from `activityData` based off of the associated `promptId` in order to redirect to that path

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Go-back-to-the-previous-tab-when-submitting-a-Semantic-Label-d677a577fd5045d791ca9f408ab8bb67

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
