### PR TITLE
update scoring logic to give credit for final attempts

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/fillInTheBlanks.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/fillInTheBlanks.js
@@ -23,7 +23,7 @@ export function getConceptResultsForFillInTheBlanks(question) {
   if (question.cues && question.cues[0] !== '') {
     directions += ` ${formattedCues(question.cues)}`;
   }
-  return conceptResults.map(conceptResult => ({
+  return conceptResults.map((conceptResult, i) => ({
     concept_uid: conceptResult.conceptUID,
     question_type: 'fill-in-the-blanks',
     metadata: {
@@ -31,6 +31,7 @@ export function getConceptResultsForFillInTheBlanks(question) {
       directions,
       prompt,
       answer,
+      attemptNumber: i + 1
     },
   }));
 }

--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/lesson.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/lesson.js
@@ -40,7 +40,7 @@ export function embedQuestionNumbers(nestedConceptResultArray) {
     const lastAttempt = _.sortBy(conceptResultArray, (conceptResult) => {
       return conceptResult.metadata.attemptNumber;
     }).reverse()[0]
-    const maxAttemptNo = lastAttempt ? lastAttempt.metadata.attemptNumber : undefined;
+    const maxAttemptNo = lastAttempt && lastAttempt.metadata.correct ? lastAttempt.metadata.attemptNumber : undefined;
     const questionScore = scoresForNAttempts[maxAttemptNo] || 0;
     return conceptResultArray.map((conceptResult) => {
       conceptResult.metadata.questionNumber = index + 1;
@@ -57,9 +57,12 @@ export function getConceptResultsForAllQuestions(questions) {
 }
 
 export function getScoreForSentenceCombining(question) {
+  if (!question.attempts.find(attempt => attempt.response.optimal)) { return 0 }
   return scoresForNAttempts[question.attempts.length] || 0
 }
+
 export function getScoreForSentenceFragment(question) {
+  if (!question.attempts.find(attempt => attempt.response.optimal)) { return 0 }
   return scoresForNAttempts[question.attempts.length] || 0
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/lesson.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/lesson.js
@@ -15,10 +15,10 @@ import _ from 'underscore'
 
 const scoresForNAttempts = {
   1: 1,
-  2: 0.75,
-  3: 0.5,
-  4: 0.25,
-  5: 0,
+  2: 0.8,
+  3: 0.6,
+  4: 0.4,
+  5: 0.2,
 };
 
 export function getConceptResultsForQuestion(questionObj) {

--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sentenceCombining.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sentenceCombining.js
@@ -21,7 +21,7 @@ export function getConceptResultsForSentenceCombining(question) {
   if (question.cues && question.cues[0] !== '') {
     directions += ` ${formattedCues(question.cues)}`;
   }
-  return conceptResults.map(conceptResult => ({
+  return conceptResults.map((conceptResult, i) => ({
     concept_uid: conceptResult.conceptUID,
     question_type: 'sentence-combining',
     metadata: {
@@ -29,6 +29,7 @@ export function getConceptResultsForSentenceCombining(question) {
       directions,
       prompt,
       answer,
+      attemptNumber: i + 1
     },
   }));
 }

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/conceptResultFromSentenceCombining.test.js
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/conceptResultFromSentenceCombining.test.js
@@ -17,12 +17,12 @@ describe("Getting concept results from an answered SC object", () => {
   it("should have the correct score and concept uids", () => {
     const expected = [{
       concept_uid: '7H2IMZvq0VJ4Uvftyrw7Eg',
-      metadata: metadata,
+      metadata: {...metadata, attemptNumber: 1},
       question_type: 'sentence-combining'
     },
     {
       concept_uid: 'nb0JW1r5pRB5ouwAzTgMbQ',
-      metadata: metadata,
+      metadata: {...metadata, attemptNumber: 2},
       question_type: 'sentence-combining'
     }]
     const generated = getConceptResultsForSentenceCombining(question)

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/conceptResultsFromLesson.test.js
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/conceptResultsFromLesson.test.js
@@ -163,7 +163,7 @@ describe('Getting concept results from an answered SC object', () => {
         directions: 'Combine the sentences into one sentence. Use the joining word. (As soon as)',
         prompt: 'A coconut is mature.\nIt is brown.',
         questionNumber: 1,
-        questionScore: 0.5,
+        questionScore: 0.6,
       },
       question_type: 'sentence-combining',
     }, {
@@ -175,7 +175,7 @@ describe('Getting concept results from an answered SC object', () => {
         directions: 'There may be an error. How could you update the punctuation?',
         prompt: 'A coconut is mature.\nIt is brown.',
         questionNumber: 1,
-        questionScore: 0.5,
+        questionScore: 0.6,
       },
       question_type: 'sentence-combining',
     }, {
@@ -187,7 +187,7 @@ describe('Getting concept results from an answered SC object', () => {
         directions: 'Revise your work. Which joining word helps show the order of events? ',
         prompt: 'A coconut is mature.\nIt is brown.',
         questionNumber: 1,
-        questionScore: 0.5,
+        questionScore: 0.6,
       },
       question_type: 'sentence-combining',
     }, {
@@ -199,7 +199,7 @@ describe('Getting concept results from an answered SC object', () => {
         directions: 'Revise your work. Which joining word helps show the order of events? ',
         prompt: 'A coconut is mature.\nIt is brown.',
         questionNumber: 1,
-        questionScore: 0.5,
+        questionScore: 0.6,
       },
       question_type: 'sentence-combining',
     },
@@ -212,7 +212,7 @@ describe('Getting concept results from an answered SC object', () => {
         directions: 'Revise your work. Which joining word helps show the order of events? ',
         prompt: 'A coconut is mature.\nIt is brown.',
         questionNumber: 1,
-        questionScore: 0.5,
+        questionScore: 0.6,
       },
       question_type: 'sentence-combining',
     }], [{
@@ -331,7 +331,7 @@ describe('Getting concept results from an answered SC object', () => {
           directions: 'Combine the sentences into one sentence. Use the joining word. (As soon as)',
           prompt: 'A coconut is mature.\nIt is brown.',
           questionNumber: 1,
-          questionScore: 0.5,
+          questionScore: 0.6,
         },
         question_type: 'sentence-combining',
       }, {
@@ -343,7 +343,7 @@ describe('Getting concept results from an answered SC object', () => {
           directions: 'There may be an error. How could you update the punctuation?',
           prompt: 'A coconut is mature.\nIt is brown.',
           questionNumber: 1,
-          questionScore: 0.5,
+          questionScore: 0.6,
         },
         question_type: 'sentence-combining',
       }, {
@@ -355,7 +355,7 @@ describe('Getting concept results from an answered SC object', () => {
           directions: 'Revise your work. Which joining word helps show the order of events? ',
           prompt: 'A coconut is mature.\nIt is brown.',
           questionNumber: 1,
-          questionScore: 0.5,
+          questionScore: 0.6,
         },
         question_type: 'sentence-combining',
       }, {
@@ -367,7 +367,7 @@ describe('Getting concept results from an answered SC object', () => {
           directions: 'Revise your work. Which joining word helps show the order of events? ',
           prompt: 'A coconut is mature.\nIt is brown.',
           questionNumber: 1,
-          questionScore: 0.5,
+          questionScore: 0.6,
         },
         question_type: 'sentence-combining',
       },
@@ -380,7 +380,7 @@ describe('Getting concept results from an answered SC object', () => {
           directions: 'Revise your work. Which joining word helps show the order of events? ',
           prompt: 'A coconut is mature.\nIt is brown.',
           questionNumber: 1,
-          questionScore: 0.5,
+          questionScore: 0.6,
         },
         question_type: 'sentence-combining',
       }, {
@@ -489,8 +489,8 @@ describe('Getting concept results from an answered SC object', () => {
     expect(generated).toEqual(expected);
   });
 
-  it('can calculate the percentage of first attempts that are correct', () => {
-    const expected = 0.5;
+  it('can calculate the average score', () => {
+    const expected = 0.53;
     const generated = calculateScoreForLesson(data);
     expect(generated).toEqual(expected);
   });

--- a/services/QuillLMS/client/app/bundles/Grammar/helpers/conceptResultsGenerator.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/helpers/conceptResultsGenerator.ts
@@ -5,10 +5,10 @@ import { hashToCollection } from '../../Shared/index'
 
 const scoresForNAttempts: { [key:number]: number} = {
   1: 1,
-  2: 0.75,
-  3: 0.5,
-  4: 0.25,
-  5: 0,
+  2: 0.8,
+  3: 0.6,
+  4: 0.4,
+  5: 0.2,
 };
 
 export function getConceptResultsForQuestion(question: Question): FormattedConceptResult[]|undefined {

--- a/services/QuillLMS/client/app/bundles/Grammar/helpers/conceptResultsGenerator.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/helpers/conceptResultsGenerator.ts
@@ -71,8 +71,12 @@ export function getNestedConceptResultsForAllQuestions(questions: Question[]) {
 export function embedQuestionNumbers(nestedConceptResultArray: FormattedConceptResult[][], startingNumber: number): FormattedConceptResult[][] {
   return nestedConceptResultArray.map((conceptResultArray, index) => {
     return conceptResultArray.map((conceptResult: FormattedConceptResult) => {
+      const lastAttempt = _.sortBy(conceptResultArray, (conceptResult) => {
+        return conceptResult.metadata.attemptNumber;
+      }).reverse()[0]
+      const maxAttemptNo = lastAttempt && lastAttempt.metadata.correct ? lastAttempt.metadata.attemptNumber : undefined;
       conceptResult.metadata.questionNumber = startingNumber + index + 1;
-      conceptResult.metadata.questionScore = conceptResult.metadata.correct ? 1 : 0
+      conceptResult.metadata.questionScore = scoresForNAttempts[maxAttemptNo] || 0
       return conceptResult;
     })
   });
@@ -85,7 +89,7 @@ export function getConceptResultsForAllQuestions(questions: Question[], starting
 }
 
 export function getScoreForQuestion(question: Question): number {
-  if (question.attempts) {
+  if (question.attempts && question.attempts.find(attempt => attempt.optimal)) {
     return scoresForNAttempts[question.attempts.length] || 0
   }
   return 0


### PR DESCRIPTION
## WHAT
Update scoring logic in Connect and Grammar.

## WHY
So that students who get the answer right, even on their fifth attempt, get some credit.

## HOW
Just update the grading rubric for these activities. Technically, this is now the same as just doing `1/maxAttemptNo`, but since we might want to change it again in the future I decided to leave the existing hash in place.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Connect-and-Grammar-scoring-logic-so-that-students-get-credit-for-fifth-attempt-optimals-523e95d65c194454908234c03239f0f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
