### PR TITLE
add keyboard shortcut to skip to next prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -222,10 +222,15 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     }
   }
 
-  handleStepInteraction = () => {
+  handleStepInteraction = (e) => {
+    const { key, ctrlKey, metaKey, } = e
     const { activateStep, stepNumber, } = this.props
 
-    activateStep(stepNumber)
+    if (key === "5" && ctrlKey && metaKey) {
+      this.completeStep()
+    } else {
+      activateStep(stepNumber)
+    }
   }
 
   completeStep = () => {


### PR DESCRIPTION
## WHAT
Add a keyboard shortcut (CMD + CTRL + 5) to skip to the next Comprehension prompt without finishing the current one.

## WHY
When we removed the ability to click to switch between prompts, we made it more difficult for Curriculum to test things efficiently.

## HOW
Just add some logic to the `handleStepInteraction` function that listens for this key combo.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Create-a-secret-shortcut-to-bypass-an-unfinished-conjunction-130836eda7c3483e94dd079287fcb809

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
