### PR TITLE
fix issue with activity-less activity sessions

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -80,8 +80,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   end
 
   private def find_activity_session
-    @activity_session = ActivitySession.unscoped.find_by_uid(params[:id]) || ActivitySession.new(activity_session_params.except(:id, :concept_results))
-    @activity_session.uid = params[:id]
+    @activity_session = ActivitySession.unscoped.find_by_uid!(params[:id])
   end
 
   private def activity_session_params

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -165,13 +165,6 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Updated")
     end
 
-    it 'returns a 200 and creates a new activity session record if it does not already exist' do
-      activity_session = build(:activity_session, user: user, percentage: 1.0)
-      put :update, id: activity_session.uid
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body["meta"]["message"]).to eq("Activity Session Updated")
-    end
-
     it 'returns a 422 error if activity session update method fails' do
       # create a double
       activity_session = create(:activity_session, state: 'started', user: user)


### PR DESCRIPTION
## WHAT
Fix issue with activity-less activity sessions by undoing the change I made in [this PR](https://github.com/empirical-org/Empirical-Core/pull/7727) where activity sessions that didn't already exist in the database could be completed.

## WHY
This is resulting, in some cases, in activity sessions that do not have activity ids, which lead to issues around the site.

## HOW
Just put the line back to the way it was before and remove the special test case I wrote for this.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Null-activity_id-for-activity-sessions-66811220acec4b539e8de879d57e97f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
