### PR TITLE
Fix logic for finding Feedback in Rule Feedback History report

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -6,6 +6,7 @@ class RuleFeedbackHistory
 
     def self.exec_query(conjunction:, activity_id:, start_date:, end_date:)
         query = Comprehension::Rule.select(<<~SELECT
+          comprehension_rules.id,
           comprehension_rules.uid AS rules_uid,
           prompts.activity_id AS activity_id,
           comprehension_rules.rule_type AS rule_type,
@@ -24,8 +25,9 @@ class RuleFeedbackHistory
         .joins('LEFT JOIN feedback_histories ON feedback_histories.rule_uid = comprehension_rules.uid')
         .joins('LEFT JOIN feedback_history_ratings ON feedback_histories.id = feedback_history_ratings.feedback_history_id')
         .joins('LEFT JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
+        .where("feedback_histories.used = ?", true)
         .where("prompts.conjunction = ? AND activity_id = ?", conjunction, activity_id)
-        .group('rules_uid, activity_id, rule_type, rule_suborder, rule_name, rule_note')
+        .group('comprehension_rules.id, rules_uid, activity_id, rule_type, rule_suborder, rule_name, rule_note')
         .includes(:feedbacks)
         query = query.where("feedback_histories.time >= ?", start_date) if start_date
         query = query.where("feedback_histories.time <= ?", end_date) if end_date
@@ -65,7 +67,7 @@ class RuleFeedbackHistory
                 rule_uid: r.rules_uid,
                 api_name: r.rule_type,
                 rule_order: r.rule_suborder,
-                first_feedback: r.feedbacks.first&.text || '',
+                first_feedback: r.feedbacks.order(:order).first&.text || '',
                 rule_note: r.rule_note,
                 rule_name: r.rule_name,
                 total_responses: r.total_responses,

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         repeated_non_consecutive_responses: 1,
       }
 
-      RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 10000
-      expect(so_feedback.rule_id).to eq(so_rule1.id)
       expect(report.first).to eq(expected)
 
     end


### PR DESCRIPTION
## WHAT
Fix the Rules report to actually pull Feedback objects
## WHY
It was supposed to be part of the repot already, but the tests didn't cover confirming that the code pulling it worked
## HOW
We expected `.includes(:feedbacks)` to make this work (doing an auto-magic Rails join to the `Feedback` table for these records), but it turns out that secretly `includes` only works when you have the `id` that's used for the join relationship in the `select`.  Since `Feedback` relies on `rule_id` for its relationships, we need to ensure that the `rules.id` column is part of the `select`, which is what this change does.  While I was at it, I ensured that we ordered `Feedback` records to get the lowest `:order` value.

### Notion Card Links
https://www.notion.so/quill/Rules-Analysis-Fix-rule-note-feedback-bug-and-add-second-layer-feedback-to-toggle-62f1ee623349422989f5ea4981edfa29#423daa25cbc54dc98f60b941024de58a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
