### PR TITLE
fix double scrollbar on college board static pages

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/college_board.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/college_board.scss
@@ -1,6 +1,4 @@
 .college-board-container {
-  overflow-y:auto;
-  height: 100%;
   .scrollbox-container {
     opacity: 0;
     position: fixed;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/ap.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/ap.tsx
@@ -55,7 +55,9 @@ const Ap = ({ isPartOfAssignmentFlow, }: ApContainerProps) => {
     if(isVisible && !isScrollingFromClick) {
       setActiveSection(section);
     }
-    if(isVisible && section === TOP_SECTION && showScrollBox === 'show') {
+    if(isVisible && section === WRITING_SKILLS_SURVEYS) {
+      setShowScrollBox('show');
+    } else if(isVisible && section === TOP_SECTION && showScrollBox === 'show') {
       setShowScrollBox('obscure');
     }
   }


### PR DESCRIPTION
## WHAT
Fix double scrollbar on College Board pages 

## WHY
It looks icky.

## HOW
CSS tweaks.  Tested at tablet and desktop breakpoints.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=eaa0ac245c544725ad496d30525f2eb5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A
