### PR TITLE
Fix activity icon distortion in activity scores report

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/student-overview.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/student-overview.scss
@@ -68,7 +68,7 @@
       div {
         background-position: center;
         background-size: 70%;
-        height: 30px;
+        height: 40px;
         // width: 30px;
         margin-right: 15px;
         border-radius: 3px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
@@ -17,9 +17,9 @@ export default class extends React.Component {
 
   activityImage(activity_classification_id, color) {
     if (color === 'unstarted') {
-      return <div className={`icon-${color} icon-${activity_classification_id}-lightgray`} />
+      return <div className={`icon-wrapper icon-${color} icon-${activity_classification_id}-lightgray`} />
     }
-    return <div className={`icon-${color} icon-${activity_classification_id}`} />
+    return <div className={`icon-wrapper icon-${color} icon-${activity_classification_id}`} />
   }
 
   activityTableRowsAndAverageScore(unit) {


### PR DESCRIPTION
## WHAT
Fix the sizing of tool icons in the Activity Scores report.

## WHY
We suspect it might be a browser update issue

## HOW
Add an icon-wrapper class to the icon.

### Notion Card Links
https://www.notion.so/quill/Icons-in-the-Activity-Scores-report-are-being-distorted-30da9b8da88f45cf91d48995ee7db3e8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual check, style change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
