### PR TITLE
Fix string coerce bug with concept results metadata

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -345,7 +345,7 @@ class ActivitySession < ActiveRecord::Base
         end
       end&.id
       concept = Concept.find_by_id_or_uid(concept_result[:concept_id])
-      concept_result[:metadata] = concept_result[:metadata].to_json
+      concept_result[:metadata] = concept_result[:metadata]
       concept_result[:concept_id] = concept.id
       concept_result[:activity_session_id] = activity_session_id
       concept_result.delete(:activity_session_uid)

--- a/services/QuillLMS/app/services/demo/concept_results.rb
+++ b/services/QuillLMS/app/services/demo/concept_results.rb
@@ -44,7 +44,7 @@ module Demo::ConceptResults
   def self.update_metadata(concept_result, key, value)
     new_metadata = concept_result.metadata
     new_metadata[key] = value
-    concept_result.update(metadata: new_metadata.to_json)
+    concept_result.update(metadata: new_metadata)
     concept_result
   end
 
@@ -53,7 +53,7 @@ module Demo::ConceptResults
     crs = []
     number_of_concept_results.to_i.times do |i|
       cr = ConceptResult.find_or_create_by(concept: concept, activity_session: activity_session)
-      cr.update(metadata: {}.to_json)
+      cr.update(metadata: {})
       crs.push(cr)
     end
     crs

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -784,24 +784,24 @@ end
     let!(:unit_activity) { create(:unit_activity, activity: activity, unit: unit) }
     let!(:classroom_unit) { create(:classroom_unit, unit: unit, assigned_student_ids: [student.id]) }
     let(:activity_session) { create(:activity_session, classroom_unit_id: classroom_unit.id, user_id: student.id, activity: activity) }
+    let(:metadata) { { correct: 1 } }
+
     let(:concept_results) do
       [{
         activity_session_uid: activity_session.uid,
         concept_id: concept.id,
-        metadata: {},
+        metadata: metadata,
         question_type: 'lessons-slide'
       }]
     end
 
-    before do
-      activity_session.update_attributes(visible: true)
-    end
+    before { activity_session.update_attributes(visible: true) }
 
     it 'should create a concept result with the hash given' do
       expect(ConceptResult).to receive(:create).with({
         activity_session_id: activity_session.id,
         concept_id: concept.id,
-        metadata: '{}',
+        metadata: metadata,
         question_type: 'lessons-slide'
       })
       ActivitySession.save_concept_results(classroom_unit.id, unit_activity.activity_id, concept_results)


### PR DESCRIPTION
## WHAT
Fix a bug involving concept results metadata field being stored as a string instead of json

## WHY
In Rails 5, JSON strings are being stored as a string rather than a Hash or Array.  [more info here](https://github.com/rails/rails/issues/28292)
The presence of a string instead of an array or hash creates a host of problems downstream.

## HOW
Remove `to_json` calls on model objects before they are saved to the database.

### Notion Card Links
https://www.notion.so/quill/Sentry-Teachers-ProgressReports-DiagnosticReportsController-question_view-04f499a8fb1a4070aad378fa418be449
https://www.notion.so/quill/Sentry-Teachers-ProgressReports-DiagnosticReportsController-students_by_classroom-0bcebfe4a0b54ef59e43ead39578cbb0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
