### PR TITLE
Add rake task to fix corrupted concept results metadata stored as string

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/concept_results.rake
+++ b/services/QuillLMS/lib/tasks/temporary/concept_results.rake
@@ -1,0 +1,22 @@
+namespace :concept_results do
+  task update_metadata_strings_to_json: :environment do
+    concept_results = ConceptResult.where("id >= 1065661250 AND question_type = 'lessons-slide'")
+
+    puts "Going to check #{concept_results.count} concept results"
+    num_updates = 0
+
+    ActiveRecord::Base.transaction do
+      concept_results.each do |concept_result|
+        metadata = concept_result.metadata
+
+        next unless metadata.is_a?(String)
+
+        concept_result.update(metadata: JSON.parse(metadata))
+        num_updates += 1
+        print '.'
+      end
+    end
+
+    puts "\nUpdated #{num_updates} concept results' metadata"
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/concept_results.rake
+++ b/services/QuillLMS/lib/tasks/temporary/concept_results.rake
@@ -1,6 +1,6 @@
 namespace :concept_results do
-  task update_metadata_strings_to_json: :environment do
-    concept_results = ConceptResult.where("id >= 1065661250 AND question_type = 'lessons-slide'")
+  task :update_metadata_strings_to_json, [:id] => [:environment] do |task, args|
+    concept_results = ConceptResult.where("id >= ? AND question_type = 'lessons-slide'", args[:id])
 
     puts "Going to check #{concept_results.count} concept results"
     num_updates = 0


### PR DESCRIPTION
## WHAT
Fix concept results metadata that has been stored as a string

## WHY
The metadata is unusable in string format

## HOW
Only recent records have been affected from this corruption.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Teachers-ProgressReports-DiagnosticReportsController-question_view-04f499a8fb1a4070aad378fa418be449
https://www.notion.so/quill/Sentry-Teachers-ProgressReports-DiagnosticReportsController-students_by_classroom-0bcebfe4a0b54ef59e43ead39578cbb0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  I tested locally and will also test on staging.
Have you deployed to Staging? | Yes.
Self-Review: Have you done an initial self-review of the code below on Github? |  YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A