### PR TITLE
end comprehension session after last feedback

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -256,7 +256,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     let className = 'quill-button'
     let onClick = () => this.handleGetFeedbackClick(entry, id, text)
     if (submittedResponses.length === max_attempts || this.lastSubmittedResponse().optimal) {
-      onClick = this.completeStep
+      onClick = everyOtherStepCompleted ? () => window.location.href = "/" : this.completeStep
       buttonCopy = everyOtherStepCompleted ? 'Done' : 'Start next sentence'
     } else if (this.unsubmittableResponses().includes(entry) || awaitingFeedback) {
       className += ' disabled'


### PR DESCRIPTION
## WHAT
Have the Comprehension session save to the LMS after the last attempt for the last prompt has feedback, rather than when students click the "Done" button.

## WHY
To reduce friction.

## HOW
Add `componentDidUpdate` function that checks to see whether this is the case and saves it to the LMS if it is.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Maxing-out-all-three-attempts-registers-an-activity-complete-6ac1d68c4bfc472f90c1ee64596309b8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A