### PR TITLE
New endpoint in CMS for uploading existing optimal responses

### DIFF
--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -43,16 +43,9 @@ class ResponsesController < ApplicationController
   # POST /responses/create_or_update
   def create_or_update
     symbolized_vals = transformed_new_vals(params_for_create).to_h.symbolize_keys
-    response = Response.find_by(text: symbolized_vals[:text], question_uid: symbolized_vals[:question_uid])
-    if !response.present?
-      response = Response.new(symbolized_vals)
-      if !response.text.blank? && response.save
-        AdminUpdates.run(response.question_uid)
-      end
-    else
-      response.update(symbolized_vals)
-    end
-    if response.valid?
+    response = Response.find_or_initialize_by(text: symbolized_vals[:text], question_uid: symbolized_vals[:question_uid])
+    if response.update(symbolized_vals)
+      AdminUpdates.run(response.question_uid) if !response.text.blank?
       render json: response
     else
       render json: response.errors, status: :unprocessable_entity

--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -44,13 +44,13 @@ class ResponsesController < ApplicationController
   def create_or_update
     symbolized_vals = transformed_new_vals(params_for_create).to_h.symbolize_keys
     response = Response.find_by(text: symbolized_vals[:text], question_uid: symbolized_vals[:question_uid])
-    if !response
+    if !response.present?
       response = Response.new(symbolized_vals)
       if !response.text.blank? && response.save
         AdminUpdates.run(response.question_uid)
       end
     else
-      response = response.update(symbolized_vals)
+      response.update(symbolized_vals)
     end
     if response.valid?
       render json: response

--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -40,6 +40,25 @@ class ResponsesController < ApplicationController
     render json: {}
   end
 
+  # POST /responses/create_or_update
+  def create_or_update
+    symbolized_vals = transformed_new_vals(params_for_create).to_h.symbolize_keys
+    response = Response.find_by(text: symbolized_vals[:text], question_uid: symbolized_vals[:question_uid])
+    if !response
+      response = Response.new(symbolized_vals)
+      if !response.text.blank? && response.save
+        AdminUpdates.run(response.question_uid)
+      end
+    else
+      response = response.update(symbolized_vals)
+    end
+    if response.valid?
+      render json: response
+    else
+      render json: response.errors, status: :unprocessable_entity
+    end
+  end
+
   # PATCH/PUT /responses/1
   def update
     new_vals = transformed_new_vals(response_params)

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -2,7 +2,6 @@ require 'elasticsearch/model'
 
 class Response < ApplicationRecord
   include Elasticsearch::Model
-  before_update :update_concept_results_to_optimal, if: :optimal
   after_create_commit :create_index_in_elastic_search
   after_update_commit :update_index_in_elastic_search
   after_commit :clear_responses_route_cache
@@ -76,19 +75,6 @@ class Response < ApplicationRecord
 
   def destroy_index_in_elastic_search
     __elasticsearch__.delete_document
-  end
-
-  private def optimal?
-    optimal
-  end
-
-  private def update_concept_results_to_optimal
-    return if !concept_results.present?
-    concept_results_hash = JSON.parse(self.concept_results)
-    concept_results_hash.each do |k, v|
-      concept_results_hash[k] = true
-    end
-    self.concept_results = concept_results_hash.to_json
   end
 
   def clear_responses_route_cache

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get  'questions/:question_uid/grade_breakdown' => 'responses#grade_breakdown'
   get  'questions/:question_uid/question_dashboard_data' => 'responses#question_dashboard'
   post 'responses/create_or_increment'
+  post 'responses/create_or_update'
   post 'responses/mass_edit/show_many' => 'responses#show_many'
   put  'responses/mass_edit/edit_many' => 'responses#edit_many'
   post 'responses/mass_edit/delete_many' => 'responses#delete_many'

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -95,9 +95,10 @@ RSpec.describe ResponsesController, type: :controller do
       post :create_or_update, params: {response: response_payload}
 
       expect(Response.count).to eq(count+1)
-      expect(Response.last.text).to eq(response_payload[:text])
-      expect(Response.last.question_uid).to eq(response_payload[:question_uid])
-      expect(Response.last.optimal).to eq(response_payload[:optimal])
+      new_response = Response.find_by(text: response_payload[:text])
+      expect(new_response.text).to eq(response_payload[:text])
+      expect(new_response.question_uid).to eq(response_payload[:question_uid])
+      expect(new_response.optimal).to eq(response_payload[:optimal])
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)['text']).to eq(response_payload[:text])
@@ -106,9 +107,13 @@ RSpec.describe ResponsesController, type: :controller do
     end
 
     it 'should update an old response with new attributes if the response text exists' do
-    end
+      new_response = create(:response, question_uid: '123456', text: 'Reading is fundamental.', optimal: false, concept_results: {"12345": false}.to_json)
+      response_payload = {question_uid: new_response.question_uid, text: new_response.text, optimal: true}
+      post :create_or_update, params: {response: response_payload}
 
-    it 'should return the appropriate errors if the response could not be saved' do
+      new_response.reload
+      expect(new_response.optimal).to eq(true)
+      expect(new_response.concept_results).to eq({"12345": true}.to_json)
     end
   end
 

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe ResponsesController, type: :controller do
 
     before do
       allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
+      allow_any_instance_of(Response).to receive(:update_index_in_elastic_search)
       ENV['PUSHER_APP_ID'] = 'pusher-app-id'
       ENV['PUSHER_KEY'] = 'pusher-key'
       ENV['PUSHER_SECRET'] = 'pusher-secret'

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -88,6 +88,30 @@ RSpec.describe ResponsesController, type: :controller do
     end
   end
 
+  describe '#create_or_update' do
+    it 'should create a new response if the response text does not exist' do
+      count = Response.count
+      response_payload = {question_uid: '12345', text: 'response text', optimal: true}
+      post :create_or_update, params: {response: response_payload}
+
+      expect(Response.count).to eq(count+1)
+      expect(Response.last.text).to eq(response_payload[:text])
+      expect(Response.last.question_uid).to eq(response_payload[:question_uid])
+      expect(Response.last.optimal).to eq(response_payload[:optimal])
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['text']).to eq(response_payload[:text])
+      expect(JSON.parse(response.body)['question_uid']).to eq(response_payload[:question_uid])
+      expect(JSON.parse(response.body)['optimal']).to eq(response_payload[:optimal])
+    end
+
+    it 'should update an old response with new attributes if the response text exists' do
+    end
+
+    it 'should return the appropriate errors if the response could not be saved' do
+    end
+  end
+
   describe '#responses_for_question' do
     let(:q_response) { create(:response, question_uid: '123456') }
 

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -19,6 +19,45 @@ RSpec.describe Response do
       expect(response).to receive(:destroy_index_in_elastic_search)
       response.destroy
     end
+
+  end
+
+  describe "#update_concept_results_to_optimal" do
+    it "before_update calls #update_concept_results_to_optimal" do
+      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
+      expect(response).to receive(:update_concept_results_to_optimal)
+      response.update(optimal: true)
+    end
+
+    it "#update_concept_results_to_optimal will update all concept results to optimal" do
+      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
+      response.update(optimal: true)
+
+      response.reload
+      concept_results_hash = JSON.parse(response.concept_results)
+      expect(concept_results_hash["one"]).to eq(true)
+      expect(concept_results_hash["two"]).to eq(true)
+      expect(concept_results_hash["three"]).to eq(true)
+    end
+
+    it "#update_concept_results_to_optimal will not update concept results if response is not optimal" do
+      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
+      response.update(first_attempt_count: 1)
+
+      response.reload
+      concept_results_hash = JSON.parse(response.concept_results)
+      expect(concept_results_hash["one"]).to eq(false)
+      expect(concept_results_hash["two"]).to eq(false)
+      expect(concept_results_hash["three"]).to eq(false)
+    end
+
+    it "#update_concept_results_to_optimal will not update concept results if it is nil" do
+      response = create(:response, optimal: false, concept_results: nil)
+      response.update(optimal: true)
+
+      response.reload
+      expect(response.concept_results).not_to be
+    end
   end
 
   describe "validates unique question_uid + text" do

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -22,44 +22,6 @@ RSpec.describe Response do
 
   end
 
-  describe "#update_concept_results_to_optimal" do
-    it "before_update calls #update_concept_results_to_optimal" do
-      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
-      expect(response).to receive(:update_concept_results_to_optimal)
-      response.update(optimal: true)
-    end
-
-    it "#update_concept_results_to_optimal will update all concept results to optimal" do
-      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
-      response.update(optimal: true)
-
-      response.reload
-      concept_results_hash = JSON.parse(response.concept_results)
-      expect(concept_results_hash["one"]).to eq(true)
-      expect(concept_results_hash["two"]).to eq(true)
-      expect(concept_results_hash["three"]).to eq(true)
-    end
-
-    it "#update_concept_results_to_optimal will not update concept results if response is not optimal" do
-      response = create(:response, optimal: false, concept_results: {:one=> false, :two=> false, :three=> false}.to_json)
-      response.update(first_attempt_count: 1)
-
-      response.reload
-      concept_results_hash = JSON.parse(response.concept_results)
-      expect(concept_results_hash["one"]).to eq(false)
-      expect(concept_results_hash["two"]).to eq(false)
-      expect(concept_results_hash["three"]).to eq(false)
-    end
-
-    it "#update_concept_results_to_optimal will not update concept results if it is nil" do
-      response = create(:response, optimal: false, concept_results: nil)
-      response.update(optimal: true)
-
-      response.reload
-      expect(response.concept_results).not_to be
-    end
-  end
-
   describe "validates unique question_uid + text" do
     let(:response) { create(:response) }
 

--- a/services/QuillLMS/client/app/bundles/Connect/actions/responses.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/responses.js
@@ -67,8 +67,6 @@ export function submitResponse(content, prid, isFirstAttempt) {
 
 export function uploadOptimalResponse(content, prid, isFirstAttempt) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
-  rubyConvertedResponse.first_attempt_count = isFirstAttempt ? 1 : 0;
-  rubyConvertedResponse.is_first_attempt = isFirstAttempt;
   return (dispatch) => {
     request.post({
       url: `${process.env.QUILL_CMS}/responses/create_or_update`,
@@ -323,7 +321,6 @@ export function submitOptimalResponses(qid, conceptUID, responses, concepts) {
         feedback: "That's a strong sentence!",
         optimal: true,
         questionUID: qid,
-        count: 1,
         conceptResults: _.isEmpty(obj.concepts) ? defaultConcept : obj.concepts,
       }
       dispatch(uploadOptimalResponse(response))

--- a/services/QuillLMS/client/app/bundles/Connect/actions/responses.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/responses.js
@@ -65,6 +65,25 @@ export function submitResponse(content, prid, isFirstAttempt) {
   };
 }
 
+export function uploadOptimalResponse(content, prid, isFirstAttempt) {
+  const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
+  rubyConvertedResponse.first_attempt_count = isFirstAttempt ? 1 : 0;
+  rubyConvertedResponse.is_first_attempt = isFirstAttempt;
+  return (dispatch) => {
+    request.post({
+      url: `${process.env.QUILL_CMS}/responses/create_or_update`,
+      form: { response: rubyConvertedResponse, }, },
+      (error, httpStatus, body) => {
+        if (error) {
+          dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
+        } else if (httpStatus.statusCode === 204 || httpStatus.statusCode === 200) {
+          dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
+        }
+      },
+    );
+  };
+}
+
 export function submitMassEditFeedback(ids, properties, qid) {
   return (dispatch) => {
     const updated_attribute = properties;
@@ -304,11 +323,10 @@ export function submitOptimalResponses(qid, conceptUID, responses, concepts) {
         feedback: "That's a strong sentence!",
         optimal: true,
         questionUID: qid,
-        gradeIndex: `human${qid}`,
         count: 1,
         conceptResults: _.isEmpty(obj.concepts) ? defaultConcept : obj.concepts,
       }
-      dispatch(submitResponse(response))
+      dispatch(uploadOptimalResponse(response))
     })
   }
 }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/responses.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/responses.js
@@ -67,6 +67,25 @@ export function submitResponse(content, prid, isFirstAttempt) {
   };
 }
 
+export function uploadOptimalResponse(content, prid, isFirstAttempt) {
+  const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
+  rubyConvertedResponse.first_attempt_count = isFirstAttempt ? 1 : 0;
+  rubyConvertedResponse.is_first_attempt = isFirstAttempt;
+  return (dispatch) => {
+    request.post({
+      url: `${process.env.QUILL_CMS}/responses/create_or_update`,
+      form: { response: rubyConvertedResponse, }, },
+      (error, httpStatus, body) => {
+        if (error) {
+          dispatch({ type: C.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
+        } else if (httpStatus.statusCode === 204 || httpStatus.statusCode === 200) {
+          dispatch({ type: C.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
+        }
+      },
+    );
+  };
+}
+
 export function submitMassEditFeedback(ids, properties, qid) {
   return (dispatch) => {
     const updated_attribute = properties;
@@ -269,11 +288,10 @@ export function submitOptimalResponses(qid, conceptUID, responses, concepts) {
         feedback: "That's a strong sentence!",
         optimal: true,
         questionUID: qid,
-        gradeIndex: `human${qid}`,
         count: 1,
         conceptResults: _.isEmpty(obj.concepts) ? defaultConcept : obj.concepts,
       }
-      dispatch(submitResponse(response))
+      dispatch(uploadOptimalResponse(response))
     })
   }
 }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/responses.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/responses.js
@@ -69,8 +69,6 @@ export function submitResponse(content, prid, isFirstAttempt) {
 
 export function uploadOptimalResponse(content, prid, isFirstAttempt) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
-  rubyConvertedResponse.first_attempt_count = isFirstAttempt ? 1 : 0;
-  rubyConvertedResponse.is_first_attempt = isFirstAttempt;
   return (dispatch) => {
     request.post({
       url: `${process.env.QUILL_CMS}/responses/create_or_update`,
@@ -288,7 +286,6 @@ export function submitOptimalResponses(qid, conceptUID, responses, concepts) {
         feedback: "That's a strong sentence!",
         optimal: true,
         questionUID: qid,
-        count: 1,
         conceptResults: _.isEmpty(obj.concepts) ? defaultConcept : obj.concepts,
       }
       dispatch(uploadOptimalResponse(response))


### PR DESCRIPTION
## WHAT
We currently have a `create_or_increment` endpoint in the CMS for creating responses if they don't exist or incrementing their count if they do. Curriculum requests a new behavior where you can `create_or_update` a response -- create if it doesn't exist, update and save all the existing attributes if it does exist.

## WHY
This will allow staff to upload optimal responses from a spreadsheet and see the values of that response change to reflect the new attributes in the upload. 

## HOW
Add a `create_or_update` endpoint in the CMS that updates all the attributes in an existing Response record if the record already exists.

Point the `uploadOptimalResponses` functions from the front end to POST to this new endpoint.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Optimal-Response-Uploads-Override-Existing-Responses-0fb69d042a4b41b1ad8c3156b63ac55e
https://www.notion.so/quill/Refactor-Connect-Upload-Optimal-Responses-workflow-to-update-the-optimal-flag-on-responses-that-al-77ed3ef9fc3a47bf863f0521cca680dd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
