### PR TITLE
Add rake task to fix corrupted concept results metadata stored as str…

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/concept_results.rake
+++ b/services/QuillLMS/lib/tasks/temporary/concept_results.rake
@@ -1,0 +1,22 @@
+namespace :concept_results do
+  task :update_metadata_strings_to_json, [:id] => [:environment] do |task, args|
+    concept_results = ConceptResult.where("id >= ? AND question_type = 'lessons-slide'", args[:id])
+
+    puts "Going to check #{concept_results.count} concept results"
+    num_updates = 0
+
+    ActiveRecord::Base.transaction do
+      concept_results.each do |concept_result|
+        metadata = concept_result.metadata
+
+        next unless metadata.is_a?(String)
+
+        concept_result.update(metadata: JSON.parse(metadata))
+        num_updates += 1
+        print '.'
+      end
+    end
+
+    puts "\nUpdated #{num_updates} concept results' metadata"
+  end
+end


### PR DESCRIPTION
…ing (#7836)

* Add rake task to fix corrupted concept results metadata stored as string

* Add id parameter

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
