### PR TITLE
fix issue where timetracking data sometimes wasn't getting set

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,8 +85,8 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
   private def activity_session_params
     params.delete(:activity_session)
-    @data = params.delete(:data)
-    @time_tracking = @data && @data['time_tracking']
+    @data ||= params.delete(:data)
+    @time_tracking ||= @data && @data['time_tracking']
     params.permit(:id,
                   :access_token, # Required by OAuth
                   :percentage,


### PR DESCRIPTION
## WHAT
Fix bug where timetracking data was sometimes getting deleted before it could be set.

## WHY
We want this to save consistently.

## HOW
Use `||=` operator for setting data so that it doesn't get reset if the `activity_session_params` function gets called twice.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
