### PR TITLE
Rename ap_demo route to coach_demo

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -1,5 +1,5 @@
 class Teachers::ProgressReportsController < ApplicationController
-  before_action :authorize!, except: [:demo, :admin_demo, :demo_ap]
+  before_action :authorize!, except: [:demo, :admin_demo, :coach_demo]
   before_action :set_vary_header, if: -> { request.xhr? || request.format == :json }
   layout 'progress_reports'
 
@@ -9,7 +9,7 @@ class Teachers::ProgressReportsController < ApplicationController
     redirect_to demo_redirect_path
   end
 
-  def demo_ap
+  def coach_demo
     set_ap_user
     switch_current_user(@ap_user)
     redirect_to demo_redirect_path
@@ -42,9 +42,9 @@ class Teachers::ProgressReportsController < ApplicationController
     auth_failed
   end
 
-  private def switch_current_user user
+  private def switch_current_user(user)
     sign_out if current_user
-    sign_in user
+    sign_in(user)
   end
 
   private def set_admin_user
@@ -78,10 +78,11 @@ class Teachers::ProgressReportsController < ApplicationController
 
   private def set_ap_user
     @ap_user = User.find_by_email "hello+#{demo_name}+ap@quill.org"
-    if @ap_user.nil?
-      Demo::ReportDemoAPCreator.create_demo(demo_name)
-      set_ap_user
-    end
+
+    return unless @ap_user.nil?
+
+    Demo::ReportDemoAPCreator.create_demo(demo_name)
+    set_ap_user
   end
 
   private def demo_name

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -726,7 +726,7 @@ EmpiricalGrammar::Application.routes.draw do
   end
 
   get 'demo' => 'teachers/progress_reports#demo'
-  get 'demo_ap' => 'teachers/progress_reports#demo_ap'
+  get 'coach_demo' => 'teachers/progress_reports#coach_demo'
   get 'student_demo' => 'students#student_demo'
   get 'student_demo_ap' => 'students#demo_ap'
   get 'admin_demo', to: 'teachers/progress_reports#admin_demo'

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
@@ -23,7 +23,7 @@ describe Teachers::ProgressReportsController do
         end
 
         it 'should use the hello+demot\eacher+ap@quill account and redirect to scorebook teachers classrooms path' do
-          get :demo_ap
+          get :coach_demo
           expect(assigns(:ap_user)).to eq ap_user
           expect(response).to redirect_to scorebook_teachers_classrooms_path
         end
@@ -134,12 +134,12 @@ describe Teachers::ProgressReportsController do
     end
   end
 
-  describe '#demo_ap' do
+  describe '#coach_demo' do
 
     context 'when demo account exists' do
       it 'sets the user and redirects to scorebook teachers classrooms path when user exists' do
         ap_user = create(:user, email: "hello+demoteacher+ap@quill.org")
-        get :demo_ap
+        get :coach_demo
         expect(assigns(:ap_user)).to eq ap_user
         expect(response).to redirect_to scorebook_teachers_classrooms_path
       end
@@ -153,7 +153,7 @@ describe Teachers::ProgressReportsController do
       it 'sets the user, redirects to scorebook teachers classrooms path when user doesnt exist' do
         expect(Demo::ReportDemoAPCreator).to receive(:create_demo).with("demoteacher")
 
-        get :demo_ap
+        get :coach_demo
         expect(response).to redirect_to scorebook_teachers_classrooms_path
       end
     end


### PR DESCRIPTION
## WHAT
Changing demo_ap account to coach_demo

## WHY
The demo_ap got shared externally and a new one is requested.

## HOW
Change entry in routes and update controller method for consistency.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Changing-demo_ap-account-to-coach_demo-eeb9c69f81254d79905514f12f7728b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
