### PR TITLE
Change fallback spelling feedback to "word(s)."

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -2,7 +2,7 @@ module Comprehension
   class SpellingCheck
 
     ALL_CORRECT_FEEDBACK = 'Correct spelling!'
-    FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word.'
+    FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word(s).'
     FEEDBACK_TYPE = Rule::TYPE_SPELLING
     RESPONSE_TYPE = 'response'
     BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'


### PR DESCRIPTION
## WHAT
We sometimes highlight multiple words in spelling bolding feedback, so we want to update the feedback to reflect that.

## WHY
So the feedback is accurate and prompts the student to correct multiple words.

## HOW
Change the text in the feedback constant.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/validate-focus-points-e93590d213774a7db997839fa5cbcd83

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Tests are updated.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
