### PR TITLE
Make Comprehension Regex Rules work for more than one required sequence

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -32,6 +32,10 @@ module Comprehension
       sequence_type == TYPE_INCORRECT ? regex_match(entry) : !regex_match(entry)
     end
 
+    def is_incorrect_sequence?
+      sequence_type == TYPE_INCORRECT
+    end
+
     private def regex_match(entry)
       case_sensitive? ? Regexp.new(regex_text).match(entry) : Regexp.new(regex_text, Regexp::IGNORECASE).match(entry)
     end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -32,7 +32,7 @@ module Comprehension
       sequence_type == TYPE_INCORRECT ? regex_match(entry) : !regex_match(entry)
     end
 
-    def is_incorrect_sequence?
+    def incorrect_sequence?
       sequence_type == TYPE_INCORRECT
     end
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -67,8 +67,15 @@ module Comprehension
     end
 
     def regex_is_passing?(entry)
-      regex_rules.none? do |regex_rule|
-        regex_rule.entry_failing?(entry)
+      return true if regex_rules.empty?
+      if regex_rules.first.is_incorrect_sequence?
+        regex_rules.none? do |regex_rule|
+          regex_rule.entry_failing?(entry)
+        end
+      else
+        regex_rules.any? do |regex_rule|
+          !regex_rule.entry_failing?(entry)
+        end
       end
     end
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -68,7 +68,7 @@ module Comprehension
 
     def regex_is_passing?(entry)
       return true if regex_rules.empty?
-      if regex_rules.first.is_incorrect_sequence?
+      if regex_rules.first.incorrect_sequence?
         regex_rules.none? do |regex_rule|
           regex_rule.entry_failing?(entry)
         end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -69,18 +69,26 @@ module Comprehension
     def regex_is_passing?(entry)
       return true if regex_rules.empty?
       if regex_rules.first.incorrect_sequence?
-        regex_rules.none? do |regex_rule|
-          regex_rule.entry_failing?(entry)
-        end
+        all_regex_rules_passing?(entry)
       else
-        regex_rules.any? do |regex_rule|
-          !regex_rule.entry_failing?(entry)
-        end
+        at_least_one_regex_rule_passing?(entry)
       end
     end
 
     def display_name
       DISPLAY_NAMES[rule_type.to_sym] || rule_type
+    end
+
+    private def all_regex_rules_passing?(entry)
+      regex_rules.none? do |regex_rule|
+        regex_rule.entry_failing?(entry)
+      end
+    end
+
+    private def at_least_one_regex_rule_passing?(entry)
+      regex_rules.any? do |regex_rule|
+        !regex_rule.entry_failing?(entry)
+      end
     end
 
     private def plagiarism?

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -25,21 +26,6 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.string "key"
   end
 
-  create_table "change_logs", force: :cascade do |t|
-    t.text     "explanation"
-    t.string   "action",              null: false
-    t.integer  "changed_record_id",   null: false
-    t.string   "changed_record_type", null: false
-    t.integer  "user_id",             null: false
-    t.string   "changed_attribute"
-    t.string   "previous_value"
-    t.string   "new_value"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["changed_record_id"], name: "index_change_logs_on_changed_record_id", using: :btree
-    t.index ["user_id"], name: "index_change_logs_on_user_id", using: :btree
-  end
-
   create_table "comprehension_activities", force: :cascade do |t|
     t.string   "title",              limit: 100
     t.integer  "parent_activity_id"
@@ -48,8 +34,9 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.string   "notes"
-    t.index ["parent_activity_id"], name: "index_comprehension_activities_on_parent_activity_id", using: :btree
   end
+
+  add_index "comprehension_activities", ["parent_activity_id"], name: "index_comprehension_activities_on_parent_activity_id", using: :btree
 
   create_table "comprehension_automl_models", force: :cascade do |t|
     t.string   "automl_model_id",              null: false
@@ -69,8 +56,9 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.integer  "order",       null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.index ["rule_id", "order"], name: "index_comprehension_feedbacks_on_rule_id_and_order", unique: true, using: :btree
   end
+
+  add_index "comprehension_feedbacks", ["rule_id", "order"], name: "index_comprehension_feedbacks_on_rule_id_and_order", unique: true, using: :btree
 
   create_table "comprehension_highlights", force: :cascade do |t|
     t.integer  "feedback_id",    null: false
@@ -95,16 +83,18 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "updated_at",                  null: false
     t.string   "image_link"
     t.string   "image_alt_text", default: ""
-    t.index ["activity_id"], name: "index_comprehension_passages_on_activity_id", using: :btree
   end
+
+  add_index "comprehension_passages", ["activity_id"], name: "index_comprehension_passages_on_activity_id", using: :btree
 
   create_table "comprehension_plagiarism_texts", force: :cascade do |t|
     t.integer  "rule_id",    null: false
     t.string   "text",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id", unique: true, using: :btree
   end
+
+  add_index "comprehension_plagiarism_texts", ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id", unique: true, using: :btree
 
   create_table "comprehension_prompts", force: :cascade do |t|
     t.integer  "activity_id"
@@ -114,17 +104,19 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.text     "max_attempts_feedback"
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
-    t.index ["activity_id"], name: "index_comprehension_prompts_on_activity_id", using: :btree
   end
+
+  add_index "comprehension_prompts", ["activity_id"], name: "index_comprehension_prompts_on_activity_id", using: :btree
 
   create_table "comprehension_prompts_rules", force: :cascade do |t|
     t.integer  "prompt_id",  null: false
     t.integer  "rule_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["prompt_id", "rule_id"], name: "index_comprehension_prompts_rules_on_prompt_id_and_rule_id", unique: true, using: :btree
-    t.index ["rule_id"], name: "index_comprehension_prompts_rules_on_rule_id", using: :btree
   end
+
+  add_index "comprehension_prompts_rules", ["prompt_id", "rule_id"], name: "index_comprehension_prompts_rules_on_prompt_id_and_rule_id", unique: true, using: :btree
+  add_index "comprehension_prompts_rules", ["rule_id"], name: "index_comprehension_prompts_rules_on_rule_id", using: :btree
 
   create_table "comprehension_regex_rules", force: :cascade do |t|
     t.string   "regex_text",     limit: 200,                       null: false
@@ -133,8 +125,9 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "updated_at",                                       null: false
     t.integer  "rule_id"
     t.text     "sequence_type",              default: "incorrect", null: false
-    t.index ["rule_id"], name: "index_comprehension_regex_rules_on_rule_id", using: :btree
   end
+
+  add_index "comprehension_regex_rules", ["rule_id"], name: "index_comprehension_regex_rules_on_rule_id", using: :btree
 
   create_table "comprehension_rules", force: :cascade do |t|
     t.string   "uid",         null: false
@@ -148,17 +141,19 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "state",       null: false
-    t.index ["uid"], name: "index_comprehension_rules_on_uid", unique: true, using: :btree
   end
+
+  add_index "comprehension_rules", ["uid"], name: "index_comprehension_rules_on_uid", unique: true, using: :btree
 
   create_table "comprehension_turking_round_activity_sessions", force: :cascade do |t|
     t.integer  "turking_round_id"
     t.string   "activity_session_uid"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
-    t.index ["activity_session_uid"], name: "comprehension_turking_sessions_activity_uid", unique: true, using: :btree
-    t.index ["turking_round_id"], name: "comprehension_turking_sessions_turking_id", using: :btree
   end
+
+  add_index "comprehension_turking_round_activity_sessions", ["activity_session_uid"], name: "comprehension_turking_sessions_activity_uid", unique: true, using: :btree
+  add_index "comprehension_turking_round_activity_sessions", ["turking_round_id"], name: "comprehension_turking_sessions_turking_id", using: :btree
 
   create_table "comprehension_turking_rounds", force: :cascade do |t|
     t.integer  "activity_id"
@@ -166,9 +161,10 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "expires_at"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.index ["activity_id"], name: "index_comprehension_turking_rounds_on_activity_id", using: :btree
-    t.index ["uuid"], name: "index_comprehension_turking_rounds_on_uuid", unique: true, using: :btree
   end
+
+  add_index "comprehension_turking_rounds", ["activity_id"], name: "index_comprehension_turking_rounds_on_activity_id", using: :btree
+  add_index "comprehension_turking_rounds", ["uuid"], name: "index_comprehension_turking_rounds_on_uuid", unique: true, using: :btree
 
   add_foreign_key "comprehension_automl_models", "comprehension_prompts", column: "prompt_id"
   add_foreign_key "comprehension_highlights", "comprehension_feedbacks", column: "feedback_id", on_delete: :cascade

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -26,6 +25,21 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.string "key"
   end
 
+  create_table "change_logs", force: :cascade do |t|
+    t.text     "explanation"
+    t.string   "action",              null: false
+    t.integer  "changed_record_id",   null: false
+    t.string   "changed_record_type", null: false
+    t.integer  "user_id",             null: false
+    t.string   "changed_attribute"
+    t.string   "previous_value"
+    t.string   "new_value"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["changed_record_id"], name: "index_change_logs_on_changed_record_id", using: :btree
+    t.index ["user_id"], name: "index_change_logs_on_user_id", using: :btree
+  end
+
   create_table "comprehension_activities", force: :cascade do |t|
     t.string   "title",              limit: 100
     t.integer  "parent_activity_id"
@@ -34,9 +48,8 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.string   "notes"
+    t.index ["parent_activity_id"], name: "index_comprehension_activities_on_parent_activity_id", using: :btree
   end
-
-  add_index "comprehension_activities", ["parent_activity_id"], name: "index_comprehension_activities_on_parent_activity_id", using: :btree
 
   create_table "comprehension_automl_models", force: :cascade do |t|
     t.string   "automl_model_id",              null: false
@@ -56,9 +69,8 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.integer  "order",       null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["rule_id", "order"], name: "index_comprehension_feedbacks_on_rule_id_and_order", unique: true, using: :btree
   end
-
-  add_index "comprehension_feedbacks", ["rule_id", "order"], name: "index_comprehension_feedbacks_on_rule_id_and_order", unique: true, using: :btree
 
   create_table "comprehension_highlights", force: :cascade do |t|
     t.integer  "feedback_id",    null: false
@@ -83,18 +95,16 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "updated_at",                  null: false
     t.string   "image_link"
     t.string   "image_alt_text", default: ""
+    t.index ["activity_id"], name: "index_comprehension_passages_on_activity_id", using: :btree
   end
-
-  add_index "comprehension_passages", ["activity_id"], name: "index_comprehension_passages_on_activity_id", using: :btree
 
   create_table "comprehension_plagiarism_texts", force: :cascade do |t|
     t.integer  "rule_id",    null: false
     t.string   "text",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id", unique: true, using: :btree
   end
-
-  add_index "comprehension_plagiarism_texts", ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id", unique: true, using: :btree
 
   create_table "comprehension_prompts", force: :cascade do |t|
     t.integer  "activity_id"
@@ -104,19 +114,17 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.text     "max_attempts_feedback"
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
+    t.index ["activity_id"], name: "index_comprehension_prompts_on_activity_id", using: :btree
   end
-
-  add_index "comprehension_prompts", ["activity_id"], name: "index_comprehension_prompts_on_activity_id", using: :btree
 
   create_table "comprehension_prompts_rules", force: :cascade do |t|
     t.integer  "prompt_id",  null: false
     t.integer  "rule_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["prompt_id", "rule_id"], name: "index_comprehension_prompts_rules_on_prompt_id_and_rule_id", unique: true, using: :btree
+    t.index ["rule_id"], name: "index_comprehension_prompts_rules_on_rule_id", using: :btree
   end
-
-  add_index "comprehension_prompts_rules", ["prompt_id", "rule_id"], name: "index_comprehension_prompts_rules_on_prompt_id_and_rule_id", unique: true, using: :btree
-  add_index "comprehension_prompts_rules", ["rule_id"], name: "index_comprehension_prompts_rules_on_rule_id", using: :btree
 
   create_table "comprehension_regex_rules", force: :cascade do |t|
     t.string   "regex_text",     limit: 200,                       null: false
@@ -125,9 +133,8 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "updated_at",                                       null: false
     t.integer  "rule_id"
     t.text     "sequence_type",              default: "incorrect", null: false
+    t.index ["rule_id"], name: "index_comprehension_regex_rules_on_rule_id", using: :btree
   end
-
-  add_index "comprehension_regex_rules", ["rule_id"], name: "index_comprehension_regex_rules_on_rule_id", using: :btree
 
   create_table "comprehension_rules", force: :cascade do |t|
     t.string   "uid",         null: false
@@ -141,19 +148,17 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "state",       null: false
+    t.index ["uid"], name: "index_comprehension_rules_on_uid", unique: true, using: :btree
   end
-
-  add_index "comprehension_rules", ["uid"], name: "index_comprehension_rules_on_uid", unique: true, using: :btree
 
   create_table "comprehension_turking_round_activity_sessions", force: :cascade do |t|
     t.integer  "turking_round_id"
     t.string   "activity_session_uid"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
+    t.index ["activity_session_uid"], name: "comprehension_turking_sessions_activity_uid", unique: true, using: :btree
+    t.index ["turking_round_id"], name: "comprehension_turking_sessions_turking_id", using: :btree
   end
-
-  add_index "comprehension_turking_round_activity_sessions", ["activity_session_uid"], name: "comprehension_turking_sessions_activity_uid", unique: true, using: :btree
-  add_index "comprehension_turking_round_activity_sessions", ["turking_round_id"], name: "comprehension_turking_sessions_turking_id", using: :btree
 
   create_table "comprehension_turking_rounds", force: :cascade do |t|
     t.integer  "activity_id"
@@ -161,10 +166,9 @@ ActiveRecord::Schema.define(version: 20210614190110) do
     t.datetime "expires_at"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["activity_id"], name: "index_comprehension_turking_rounds_on_activity_id", using: :btree
+    t.index ["uuid"], name: "index_comprehension_turking_rounds_on_uuid", unique: true, using: :btree
   end
-
-  add_index "comprehension_turking_rounds", ["activity_id"], name: "index_comprehension_turking_rounds_on_activity_id", using: :btree
-  add_index "comprehension_turking_rounds", ["uuid"], name: "index_comprehension_turking_rounds_on_uuid", unique: true, using: :btree
 
   add_foreign_key "comprehension_automl_models", "comprehension_prompts", column: "prompt_id"
   add_foreign_key "comprehension_highlights", "comprehension_feedbacks", column: "feedback_id", on_delete: :cascade

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
@@ -63,16 +63,16 @@ module Comprehension
       end
     end
 
-    context 'is_incorrect_sequence?' do
+    context 'incorrect_sequence?' do
 
       should 'be true if regex rule is incorrect sequence_type' do
         incorrect_rule = create(:comprehension_regex_rule, sequence_type: 'incorrect')
-        assert incorrect_rule.is_incorrect_sequence?
+        assert incorrect_rule.incorrect_sequence?
       end
 
       should 'be false if regex rule is required sequence type' do
         required_rule = create(:comprehension_regex_rule, sequence_type: 'required')
-        refute required_rule.is_incorrect_sequence?
+        refute required_rule.incorrect_sequence?
       end
     end
   end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/regex_rule_test.rb
@@ -62,5 +62,18 @@ module Comprehension
         refute @regex_rule.entry_failing?('TEST REGEX')
       end
     end
+
+    context 'is_incorrect_sequence?' do
+
+      should 'be true if regex rule is incorrect sequence_type' do
+        incorrect_rule = create(:comprehension_regex_rule, sequence_type: 'incorrect')
+        assert incorrect_rule.is_incorrect_sequence?
+      end
+
+      should 'be false if regex rule is required sequence type' do
+        required_rule = create(:comprehension_regex_rule, sequence_type: 'required')
+        refute required_rule.is_incorrect_sequence?
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/models/comprehension/rule_test.rb
@@ -117,6 +117,7 @@ module Comprehension
       setup do
         @rule = create(:comprehension_rule)
         @regex_rule = create(:comprehension_regex_rule, rule: @rule, regex_text: "^Hello", sequence_type: 'incorrect')
+        @regex_rule_two = create(:comprehension_regex_rule, rule: @rule, regex_text: "^Something", sequence_type: 'incorrect')
       end
 
       should 'be true if entry does not match the regex text' do
@@ -127,28 +128,43 @@ module Comprehension
         assert @rule.regex_is_passing?('Nope, I dont start with hello.')
       end
 
+      should 'be false if sequence_type is incorrect and entry matches the regex text and there are more than one sequences' do
+        refute @rule.regex_is_passing?('Something is wrong here.')
+      end
+
       should 'be false if sequence_type is incorrect and entry matches regex text' do
         assert !@rule.regex_is_passing?('Hello!!!')
       end
 
       should 'be false if sequence_type is required and entry does not match regex text' do
-        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required')
-        assert !@rule.regex_is_passing?('I do not have the right sequence')
+        required_rule = create(:comprehension_rule)
+        @regex_rule_three= create(:comprehension_regex_rule, rule: required_rule, regex_text: "you need this sequence", sequence_type: 'required')
+        assert !required_rule.regex_is_passing?('I do not have the right sequence')
       end
 
       should 'be true if sequence_type is required and entry matches regex text' do
-        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required')
-        assert @rule.regex_is_passing?('you need this sequence and I do have it')
+        required_rule = create(:comprehension_rule)
+        @regex_rule_three= create(:comprehension_regex_rule, rule: required_rule, regex_text: "you need this sequence", sequence_type: 'required')
+        assert required_rule.regex_is_passing?('you need this sequence and I do have it')
+      end
+
+      should 'be true if sequence_type is required and entry matches regex text and there are multiple required sequences' do
+        required_rule = create(:comprehension_rule)
+        @regex_rule_three= create(:comprehension_regex_rule, rule: required_rule, regex_text: "you need this sequence", sequence_type: 'required')
+        @regex_rule_four= create(:comprehension_regex_rule, rule: required_rule, regex_text: "or you need this one", sequence_type: 'required')
+        assert required_rule.regex_is_passing?('you need this sequence and I do have it')
       end
 
       should 'be true if rule is NOT case sensitive and entry matches regardless of casing' do
-        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: false)
-        assert @rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I DO HAVE IT')
+        required_rule = create(:comprehension_rule)
+        @regex_rule_three= create(:comprehension_regex_rule, rule: required_rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: false)
+        assert required_rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I DO HAVE IT')
       end
 
       should 'be false if rule IS case sensitive and entry does not match casing' do
-        @regex_rule_two= create(:comprehension_regex_rule, rule: @rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: true)
-        assert !@rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I do not HAVE IT in the right casing')
+        required_rule = create(:comprehension_rule)
+        @regex_rule_three= create(:comprehension_regex_rule, rule: required_rule, regex_text: "you need this sequence", sequence_type: 'required', case_sensitive: true)
+        assert !required_rule.regex_is_passing?('YOU NEED THIS SEQUENCE AND I do not HAVE IT in the right casing')
       end
     end
 


### PR DESCRIPTION
## WHAT
Regex Rules with more than one required sequence are currently failing because the back-end tries to ensure that the student entry matches **all** the required sequences. Actually, we should only ensure that the entry matches one or more of the required sequences.

## WHY
Required sequence criteria for passing differs from Incorrect Sequence criteria for passing.

## HOW
Add branching logic to apply the right criteria for required sequences. Use the array method `any?` instead of the array method `none?` to match for true on any required sequence if the Rule contains required sequences.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
None, reported bug in #comprehension-bugs Slack

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
