### PR TITLE
Validate focus points before saving

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::FocusPointsController < Api::ApiController
   end
 
   def update_all
-    @question.update_focus_points(params_as_hash)
+    @question.update_focus_points(valid_params)
     render_all_focus_points
   end
 
@@ -37,13 +37,13 @@ class Api::V1::FocusPointsController < Api::ApiController
     @question = Question.find_by!(uid: params[:question_id])
   end
 
-  private def params_as_hash
-    valid_params.is_a?(Array) ? valid_params.map {|x| x.to_h } : valid_params.to_h
-  end
-
   private def valid_params
     filtered_params = params.require(:focus_point)
-    filtered_params.is_a?(Array) ? filtered_params.map {|x| x.except(:uid).permit! } : filtered_params.except(:uid).permit!
+    if filtered_params.is_a?(Array)
+      filtered_params.map {|x| x.except(:uid).permit!.to_h }
+    else
+      filtered_params.except(:uid).permit!.to_h
+    end
   end
 
   private def render_focus_point

--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -16,8 +16,11 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
 
   def update
     return not_found unless @question.get_incorrect_sequence(params[:id])
-    @question.set_incorrect_sequence(params[:id], valid_params)
-    render_incorrect_sequence(params[:id])
+    if @question.set_incorrect_sequence(params[:id], valid_params)
+      render_incorrect_sequence(params[:id])
+    else
+      render json: @question.errors, status: 422
+    end
   end
 
   def destroy
@@ -26,7 +29,7 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
   end
 
   def update_all
-    @question.update_incorrect_sequences(valid_params)
+    @question.update_incorrect_sequences(params_as_hash)
     render_all_incorrect_sequences
   end
 
@@ -34,16 +37,17 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
     @question = Question.find_by!(uid: params[:question_id])
   end
 
+  private def params_as_hash
+    valid_params.is_a?(Array) ? valid_params.map {|x| x.to_h } : valid_params.to_h
+  end
+
   private def valid_params
-    params.require(:incorrect_sequence).except(:uid)
+    filtered_params = params.require(:incorrect_sequence)
+    filtered_params.is_a?(Array) ? filtered_params.map {|x| x.except(:uid).permit! } : filtered_params.except(:uid).permit!
   end
 
   private def get_question_by_uid
     @question = Question.find_by!(uid: params[:question_id])
-  end
-
-  private def valid_params
-    params.require(:incorrect_sequence)
   end
 
   private def render_incorrect_sequence(incorrect_sequence_id)

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -2,17 +2,17 @@
 #
 # Table name: questions
 #
-#  id            :integer          not null, primary key
-#  data          :jsonb            not null
-#  question_type :string           not null
-#  uid           :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id            :integer
+#  data          :jsonb
+#  question_type :string
+#  uid           :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#  temp_id       :integer          not null, primary key
 #
 # Indexes
 #
 #  index_questions_on_question_type  (question_type)
-#  index_questions_on_uid            (uid) UNIQUE
 #
 class Question < ActiveRecord::Base
   TYPES = [
@@ -153,16 +153,18 @@ class Question < ActiveRecord::Base
 
   private def validate_sequences
     return if !data.present? || !data.is_a?(Hash)
+    binding.pry
     parse_and_validate(data['incorrectSequences']) && parse_and_validate(data['focusPoints'])
   end
 
   private def parse_and_validate(sequences)
+    binding.pry
     return true if !sequences.present?
     if sequences.is_a?(Hash)
       sequences.each do |key, value|
         validate_text_and_feedback(value)
       end
-    elsif stored_as_array(data)
+    elsif stored_as_array(sequences)
       sequences.each do |value|
         validate_text_and_feedback(value)
       end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -2,17 +2,17 @@
 #
 # Table name: questions
 #
-#  id            :integer
-#  data          :jsonb
-#  question_type :string
-#  uid           :string
-#  created_at    :datetime
-#  updated_at    :datetime
-#  temp_id       :integer          not null, primary key
+#  id            :integer          not null, primary key
+#  data          :jsonb            not null
+#  question_type :string           not null
+#  uid           :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 # Indexes
 #
 #  index_questions_on_question_type  (question_type)
+#  index_questions_on_uid            (uid) UNIQUE
 #
 class Question < ActiveRecord::Base
   TYPES = [

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -67,7 +67,6 @@ class Question < ActiveRecord::Base
     data['focusPoints'] ||= {}
     data['focusPoints'][focus_point_id] = new_data
     save
-    focus_point_id
   end
 
   def update_focus_points(new_data)
@@ -110,7 +109,6 @@ class Question < ActiveRecord::Base
     incorrect_sequence_id = incorrect_sequence_id.to_i if stored_as_array('incorrectSequences')
     data['incorrectSequences'][incorrect_sequence_id] = new_data
     save
-    incorrect_sequence_id
   end
 
   def update_incorrect_sequences(new_data)
@@ -153,13 +151,12 @@ class Question < ActiveRecord::Base
 
   private def validate_sequences
     return if !data.present? || !data.is_a?(Hash)
-    binding.pry
-    parse_and_validate(data['incorrectSequences']) && parse_and_validate(data['focusPoints'])
+    parse_and_validate(data['incorrectSequences'])
+    parse_and_validate(data['focusPoints'])
   end
 
   private def parse_and_validate(sequences)
-    binding.pry
-    return true if !sequences.present?
+    return if !sequences.present?
     if sequences.is_a?(Hash)
       sequences.each do |key, value|
         validate_text_and_feedback(value)

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -161,7 +161,7 @@ class Question < ActiveRecord::Base
       sequences.each do |key, value|
         validate_text_and_feedback(value)
       end
-    elsif stored_as_array(sequences)
+    elsif sequences.is_a?(Array)
       sequences.each do |value|
         validate_text_and_feedback(value)
       end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -185,6 +185,6 @@ class Question < ActiveRecord::Base
   private def validate_regex(regex)
     Regexp.new(regex)
   rescue RegexpError => e
-    errors.add(:data, "There is incorrectly formatted regex.")
+    errors.add(:data, "There is incorrectly formatted regex: #{regex}")
   end
 end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -60,7 +60,12 @@ class Question < ActiveRecord::Base
   end
 
   def add_focus_point(new_data)
-    set_focus_point(new_uuid, new_data)
+    new_uid = new_uuid
+    if set_focus_point(new_uid, new_data)
+      new_uid
+    else
+      nil
+    end
   end
 
   def set_focus_point(focus_point_id, new_data)
@@ -101,7 +106,8 @@ class Question < ActiveRecord::Base
     else
       new_id = new_uuid
     end
-    set_incorrect_sequence(new_id, new_data)
+    return new_id if set_incorrect_sequence(new_id, new_data)
+    nil
   end
 
   def set_incorrect_sequence(incorrect_sequence_id, new_data)

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 
 describe Api::V1::FocusPointsController, type: :controller do
   let!(:question) { create(:question) }
+  let!(:new_q) {create(:question, data: {"focusPoints"=>{"0"=>{"text"=>"text","feedback"=>"fff"}},"incorrectSequences"=>[{"text"=>"foo","feedback"=>"bar"}]}) }
+
 
   describe "#index" do
     it "should return a list of Question Focus Points" do
@@ -40,7 +42,7 @@ describe Api::V1::FocusPointsController, type: :controller do
 
   describe "#create" do
     it "should add a new focus point to the question data" do
-      data = {"foo" => "bar"}
+      data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_count = question.data["focusPoints"].keys.length
       post :create, question_id: question.uid, focus_point: data
       question.reload
@@ -56,7 +58,7 @@ describe Api::V1::FocusPointsController, type: :controller do
 
   describe "#update" do
     it "should update an existing focus point in the question data" do
-      data = {"foo" => "bar"}
+      data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_uid = question.data["focusPoints"].keys.first
       put :update, question_id: question.uid, id: focus_point_uid, focus_point: data
       question.reload
@@ -73,6 +75,19 @@ describe Api::V1::FocusPointsController, type: :controller do
       put :update, question_id: question.uid, id: 'doesnotexist'
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
+    end
+
+    it "should return a 404 if the focus point is not valid" do
+      data = {"key"=>"-Lp-tB4rOx6sGVpm2AG3","text"=>"a(n)?na(')?(s)?(')?(s)? and (my|me|i|mine)|||(my|me|i|mine)(')?(s)?(')?(s)? and lan|||(and|","order"=>1,"feedback"=>"<p>Revise your work. Make sure your sentence tells that the snack belonged to <em>Lana and me</em>.</p>","conceptResults"=>{"N5VXCdTAs91gP46gATuvPQ"=>{"name"=>"Structure | Sentence Quality | Including Details From Prompt","correct"=>false,"conceptUID"=>"N5VXCdTAs91gP46gATuvPQ"}}}
+
+      focus_point_uid = new_q.data["focusPoints"].keys.first
+      binding.pry
+      put :update, question_id: new_q.uid, id: focus_point_uid, focus_point: data
+      expect(response.status).to eq(200)
+      binding.pry
+      # expect(response.body).to include("The resource you were looking for does not exist")
+      new_q.reload
+      expect(new_q.data["focusPoints"][focus_point_uid]).to eq(data)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -78,16 +78,14 @@ describe Api::V1::FocusPointsController, type: :controller do
     end
 
     it "should return a 404 if the focus point is not valid" do
-      data = {"key"=>"-Lp-tB4rOx6sGVpm2AG3","text"=>"a(n)?na(')?(s)?(')?(s)? and (my|me|i|mine)|||(my|me|i|mine)(')?(s)?(')?(s)? and lan|||(and|","order"=>1,"feedback"=>"<p>Revise your work. Make sure your sentence tells that the snack belonged to <em>Lana and me</em>.</p>","conceptResults"=>{"N5VXCdTAs91gP46gATuvPQ"=>{"name"=>"Structure | Sentence Quality | Including Details From Prompt","correct"=>false,"conceptUID"=>"N5VXCdTAs91gP46gATuvPQ"}}}
+      data = {"key"=>"-Lp-tB4rOx6sGVpm2AG3","text"=>"(and|","feedback"=>"feedback"}
 
       focus_point_uid = new_q.data["focusPoints"].keys.first
-      binding.pry
+
       put :update, question_id: new_q.uid, id: focus_point_uid, focus_point: data
-      expect(response.status).to eq(200)
-      binding.pry
-      # expect(response.body).to include("The resource you were looking for does not exist")
-      new_q.reload
-      expect(new_q.data["focusPoints"][focus_point_uid]).to eq(data)
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)["data"]).to include("There is incorrectly formatted regex.")
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -107,7 +107,7 @@ describe Api::V1::FocusPointsController, type: :controller do
 
   describe "#update_all" do
     it "should replace all focusPoints" do
-      data = {"foo" => "bar"}
+      data = {"0" => {"text"=>"text", "feedback"=>"feedback"}}
       put :update_all, question_id: question.uid, focus_point: data
       question.reload
       expect(question.data["focusPoints"]).to eq(data)

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -85,7 +85,7 @@ describe Api::V1::FocusPointsController, type: :controller do
       put :update, question_id: new_q.uid, id: focus_point_uid, focus_point: data
 
       expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)["data"]).to include("There is incorrectly formatted regex.")
+      expect(JSON.parse(response.body)["data"]).to include("There is incorrectly formatted regex: (and|")
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -3,7 +3,18 @@ require 'rails_helper'
 
 describe Api::V1::FocusPointsController, type: :controller do
   let!(:question) { create(:question) }
-  let!(:new_q) {create(:question, data: {"focusPoints"=>{"0"=>{"text"=>"text","feedback"=>"fff"}},"incorrectSequences"=>[{"text"=>"foo","feedback"=>"bar"}]}) }
+  let!(:new_q) do
+    create(:question,
+      data: {
+        "focusPoints" => {
+          "0" => { "text" => "text", "feedback"=>"fff" }
+        },
+        "incorrectSequences"=> [
+          { "text"=>"foo", "feedback"=>"bar" }
+        ]
+      }
+    )
+  end
 
 
   describe "#index" do

--- a/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
@@ -40,7 +40,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
 
   describe "#create" do
     it "should add a new incorrect sequence to the question data" do
-      data = {"foo" => "bar"}
+      data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_count = question.data["incorrectSequences"].keys.length
       post :create, question_id: question.uid, incorrect_sequence: data
       question.reload
@@ -50,7 +50,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
 
   describe "#update" do
     it "should update an existing incorrect sequence in the question data" do
-      data = {"foo" => "bar"}
+      data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_uid = question.data["incorrectSequences"].keys.first
       put :update, question_id: question.uid, id: incorrect_sequence_uid, incorrect_sequence: data
       question.reload
@@ -88,14 +88,14 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
 
   describe "#update_all" do
     it "should replace all incorrectSequences" do
-      data = {"foo" => "bar"}
+      data = {"0"=>{"text" => "text", "feedback"=>"feedback"}}
       put :update_all, question_id: question.uid, incorrect_sequence: data
       question.reload
       expect(question.data["incorrectSequences"]).to eq(data)
     end
 
     it "should handle array data as an input" do
-      data = [{"foo" => "bar"}, {"boo" => "baz"}]
+      data = [{"text" => "text", "feedback"=>"feedback"}, {"text"=>"text2", "feedback"=>"feedback2"}]
       put :update_all,
         params: {
           question_id: question.uid,

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Question, type: :model do
     it 'should be invalid if a focus point text is invalid regex' do
       question.data = {'focusPoints'=>{'0'=>{'text'=>'(foo|', 'feedback'=>'bar'}}}
       expect(question.valid?).to be false
-      expect(question.errors[:data]).to include('There is incorrectly formatted regex.')
+      expect(question.errors[:data]).to include('There is incorrectly formatted regex: (foo|')
     end
 
     it 'should be valid if focus point has valid regex and feedback' do
@@ -115,7 +115,7 @@ RSpec.describe Question, type: :model do
     it 'should be invalid if an incorrect sequence is invalid regex' do
       question.data = {'incorrectSequences'=>{'0'=>{'text'=>'(foo|', 'feedback'=>'bar'}}}
       expect(question.valid?).to be false
-      expect(question.errors[:data]).to include('There is incorrectly formatted regex.')
+      expect(question.errors[:data]).to include('There is incorrectly formatted regex: (foo|')
     end
 
     it 'should be valid if an incorrect sequence has valid regex and feedback' do

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -2,17 +2,17 @@
 #
 # Table name: questions
 #
-#  id            :integer          not null, primary key
-#  data          :jsonb            not null
-#  question_type :string           not null
-#  uid           :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id            :integer
+#  data          :jsonb
+#  question_type :string
+#  uid           :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#  temp_id       :integer          not null, primary key
 #
 # Indexes
 #
 #  index_questions_on_question_type  (question_type)
-#  index_questions_on_uid            (uid) UNIQUE
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -140,10 +140,10 @@ RSpec.describe Question, type: :model do
   end
 
   describe '#set_focus_point' do
-    it 'should return the passed uid' do
+    it 'should return true on success' do
       uid = SecureRandom.uuid
-      response = question.set_focus_point(uid, {})
-      expect(response).to eq(uid)
+      response = question.set_focus_point(uid, {"text"=>"text","feedback"=>"feedback"})
+      expect(response).to eq(true)
     end
 
     it 'should set the value of the specified focusPoint' do
@@ -240,8 +240,8 @@ RSpec.describe Question, type: :model do
       original_incorrect_sequences = [{"1" => {"text"=>"text", "feedback"=>"bar"}}, {"2" => {"text"=>"text", "feedback"=>"bar"}}, {"3" => {"text"=>"text", "feedback"=>"bar"}}]
       original_length = original_incorrect_sequences.length
       question.update_incorrect_sequences(original_incorrect_sequences)
-      uid = question.add_incorrect_sequence(new_incorrect_sequence)
-      expect(uid).to eq(original_length)
+      question.add_incorrect_sequence(new_incorrect_sequence)
+      expect(question.data["incorrectSequences"][original_length]).to eq(new_incorrect_sequence)
     end
 
     it 'should put the new incorrectSequence in the data attribute' do
@@ -252,10 +252,10 @@ RSpec.describe Question, type: :model do
   end
 
   describe '#set_incorrect_sequence' do
-    it 'should return the passed uid' do
+    it 'should return true on success' do
       uid = SecureRandom.uuid
-      response = question.set_incorrect_sequence(uid, {})
-      expect(response).to eq(uid)
+      response = question.set_incorrect_sequence(uid, {"text"=>"Text","feedback"=>"feedback"})
+      expect(response).to eq(true)
     end
 
     it 'should set the value of the specified incorrectSequence if in hash' do
@@ -266,7 +266,7 @@ RSpec.describe Question, type: :model do
     end
 
     it 'should set the value of the specified incorrectSequence if in array' do
-      question.update_incorrect_sequences([1,2,3])
+      question.update_incorrect_sequences([{"text"=>"text1","feedback"=>"feedback1"},{"text"=>"text2","feedback"=>"feedback2"},{"text"=>"text3","feedback"=>"feedback3"}])
       replace_uid = 0
       question.set_incorrect_sequence(replace_uid, new_incorrect_sequence)
       question.reload


### PR DESCRIPTION
## WHAT
We sometimes have malformed focus points and incorrect sequences in our `Question` records because we save these as JSON objects with no field validations. This PR adds in some validations so we don't error out on bad data.

## WHY
We sometimes see bugs where questions can't be played because of bad focus point or incorrect sequence data.

## HOW
Add validation behavior to validate that each focus point and incorrect sequence:
1. has a text field
2. has a feedback field
3. has valid regex saved in the text field

Add in controller behavior that catches when a focus point or incorrect sequence is invalid and sends back an error response.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/validate-focus-points-e93590d213774a7db997839fa5cbcd83

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
