### PR TITLE
Comprehension internal tools/ add response percentages

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import DateTimePicker from 'react-datetime-picker';
 
 import { handlePageFilterClick, renderHeader } from "../../../helpers/comprehension";
+import { calculatePercentageForResponses } from "../../../helpers/comprehension/ruleHelpers";
 import { ActivityRouteProps, PromptInterface } from '../../../interfaces/comprehensionInterfaces';
 import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { fetchRuleFeedbackHistories } from '../../../utils/comprehension/ruleFeedbackHistoryAPIs';
@@ -73,11 +74,17 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const [startDateForQuery, setStartDate] = React.useState<string>(initialStartDateString);
   const [endDate, onEndDateChange] = React.useState<Date>(initialEndDate);
   const [endDateForQuery, setEndDate] = React.useState<string>(initialEndDateString);
+  const [totalResponsesByConjunction, setTotalResponsesByConjunction] = React.useState<number>(null);
 
   const selectedConjunction = selectedPrompt ? selectedPrompt.conjunction : promptConjunction
   // cache rules data for updates
   const { data: ruleFeedbackHistory } = useQuery({
     queryKey: [`rule-feedback-history-by-conjunction-${selectedConjunction}-and-activity-${activityId}`, activityId, selectedConjunction, startDateForQuery, endDateForQuery],
+    queryFn: fetchRuleFeedbackHistories
+  });
+
+  const { data: dataForTotalResponseCount } = useQuery({
+    queryKey: [`rule-feedback-history-for-total-response-count`, activityId, selectedConjunction],
     queryFn: fetchRuleFeedbackHistories
   });
 
@@ -110,6 +117,20 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
 
     history.push(url)
   }, [selectedPrompt, selectedRuleType])
+
+  React.useEffect(() => {
+    if(!totalResponsesByConjunction && dataForTotalResponseCount && dataForTotalResponseCount.ruleFeedbackHistories) {
+      let count = 0;
+      const { ruleFeedbackHistories } = dataForTotalResponseCount;
+      ruleFeedbackHistories.map(feedbackHistory => {
+        if(feedbackHistory.total_responses) {
+          count += feedbackHistory.total_responses;
+        }
+      });
+      count = count * 1.0;
+      setTotalResponsesByConjunction(count);
+    }
+  });
 
   function handleFilterClick() {
     handlePageFilterClick({ startDate, endDate, setStartDate, setEndDate, setShowError, setPageNumber: null, storageKey: RULES_ANALYSIS });
@@ -187,9 +208,18 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       accessor: "totalResponses",
       key: "totalResponses",
       width: 100,
-      aggregate: vals => _.sum(vals),
-      Aggregated: (row) => (<span>{row.value}</span>),
-      Cell: (data) => (<button className={data.original.className} onClick={data.original.handleClick} type="button">{data.original.totalResponses}</button>),
+      aggregate: (values) => {
+        const totalResponses = _.sum(values);
+        const percentageOutOfAllResponses = calculatePercentageForResponses(totalResponses, totalResponsesByConjunction);
+        return { totalResponses, percentageOutOfAllResponses }
+      },
+      Aggregated: (row) => (<span>{row.value.percentageOutOfAllResponses}% <span className="gray">({row.value.totalResponses})</span></span>),
+      Cell: (data) => {
+        const { original } = data;
+        const { className, handleClick, totalResponses } = original;
+        const percentageOutOfAllResponses = calculatePercentageForResponses(totalResponses, totalResponsesByConjunction);
+        return (<button className={className} onClick={handleClick} type="button">{percentageOutOfAllResponses}% <span className="gray">({totalResponses})</span></button>)
+      },
     },
     {
       Header: "Rule Repeated: Consecutive",

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { mockRule } from '../../components/comprehension/__mocks__/data';
-import { getRefetchQueryString } from '../comprehension/ruleHelpers';
+import { getRefetchQueryString, calculatePercentageForResponses } from '../comprehension/ruleHelpers';
 import { RULES_BASED_1, RULES_BASED_2, RULES_BASED_3, PLAGIARISM, AUTO_ML } from '../../../../constants/comprehension';
 
 describe('Comprehension rule helper functions', () => {
@@ -16,13 +16,19 @@ describe('Comprehension rule helper functions', () => {
       'default': { ...mockRule, rule_type: 'other' }
     }
     const activityId = '17';
-    it('should return expect output for query string', () => {
+    it('should return the expected output for query string', () => {
       expect(getRefetchQueryString(mockRulesHash[RULES_BASED_1], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_1}`);
       expect(getRefetchQueryString(mockRulesHash[RULES_BASED_2], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_2}`);
       expect(getRefetchQueryString(mockRulesHash[RULES_BASED_3], activityId)).toEqual(`rules-${activityId}-${RULES_BASED_3}`);
       expect(getRefetchQueryString(mockRulesHash[PLAGIARISM], activityId)).toEqual(`rules-${activityId}-${PLAGIARISM}`);
       expect(getRefetchQueryString(mockRulesHash[AUTO_ML], activityId)).toEqual(`rules-${activityId}-${AUTO_ML}`);
       expect(getRefetchQueryString(mockRulesHash['default'], activityId)).toEqual(`rules-${activityId}`);
+    });
+  });
+  describe('#calculatePercentageForResponses', () => {
+    it('should return the expected percentage amount', () => {
+      expect(calculatePercentageForResponses(3, 9)).toEqual(33.33);
+      expect(calculatePercentageForResponses(3, 4)).toEqual(75);
     });
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/__tests__/ruleHelpers.test.tsx
@@ -27,8 +27,8 @@ describe('Comprehension rule helper functions', () => {
   });
   describe('#calculatePercentageForResponses', () => {
     it('should return the expected percentage amount', () => {
-      expect(calculatePercentageForResponses(3, 9)).toEqual(33.33);
-      expect(calculatePercentageForResponses(3, 4)).toEqual(75);
+      expect(calculatePercentageForResponses(3, 9)).toEqual('33.33');
+      expect(calculatePercentageForResponses(3, 4)).toEqual('75.00');
     });
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -20,8 +20,7 @@ import { PromptInterface, ActivityInterface } from '../interfaces/comprehensionI
 
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
-const mainApiBaseUrl = `https://www.quill.org/api/v1/`;
-// const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
+const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
 const comprehensionBaseUrl = `${mainApiBaseUrl}comprehension/`;
 const fetchDefaults = require("fetch-defaults");
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -19,7 +19,8 @@ import { PromptInterface, ActivityInterface } from '../interfaces/comprehensionI
 
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
-const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
+const mainApiBaseUrl = `https://www.quill.org/api/v1/`;
+// const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
 const comprehensionBaseUrl = `${mainApiBaseUrl}comprehension/`;
 const fetchDefaults = require("fetch-defaults");
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension/ruleHelpers.tsx
@@ -497,3 +497,10 @@ export function renderDeleteRuleModal(handleDeleteRule, toggleShowDeleteRuleModa
     </Modal>
   );
 }
+
+export function calculatePercentageForResponses(totalResponsesByRule, totalResponsesByConjunction) {
+  if(!totalResponsesByRule || !totalResponsesByConjunction) {
+    return null;
+  }
+  return ((totalResponsesByRule / totalResponsesByConjunction) * 100).toFixed(2);
+}

--- a/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/ruleFeedbackHistoryAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/ruleFeedbackHistoryAPIs.ts
@@ -1,6 +1,6 @@
 import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl } from '../../helpers/comprehension';
 
-export const fetchRuleFeedbackHistories = async (key: string, activityId: string, selectedConjunction: string, startDate: string, endDate?: string) => {
+export const fetchRuleFeedbackHistories = async (key: string, activityId: string, selectedConjunction: string, startDate?: string, endDate?: string) => {
   if (!selectedConjunction) { return }
   const url = getRuleFeedbackHistoriesUrl({ activityId, selectedConjunction, startDate, endDate });
   const response = await mainApiFetch(url);
@@ -11,7 +11,7 @@ export const fetchRuleFeedbackHistories = async (key: string, activityId: string
   };
 }
 
-export const fetchRuleFeedbackHistoriesByRule = async (key: string, ruleUID: string, promptId: string, startDate: string, endDate?: string) => {
+export const fetchRuleFeedbackHistoriesByRule = async (key: string, ruleUID: string, promptId: string, startDate?: string, endDate?: string) => {
   const url = getRuleFeedbackHistoryUrl({ ruleUID, promptId, startDate, endDate });
   const response = await mainApiFetch(url);
   const ruleFeedbackHistories = await response.json();


### PR DESCRIPTION
## WHAT
add percentage values to the total responses columns for Rules Analysis

## WHY
so that Curriculum can quickly identify higher priority items

## HOW
just add some logic for calculating percentages based off of total responses

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1665" alt="Screen Shot 2021-06-30 at 12 54 18 PM" src="https://user-images.githubusercontent.com/25959584/124008681-4d50c380-d9a2-11eb-810b-cb6f61fa0dfc.png">
<img width="1668" alt="Screen Shot 2021-06-30 at 12 54 02 PM" src="https://user-images.githubusercontent.com/25959584/124008684-4e81f080-d9a2-11eb-81ab-8d55046c65e6.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Rules-Analysis-display-the-percentage-of-responses-for-each-rule-eaed9bebfaaf45d98f1c0c956a9b0e06

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
