### PR TITLE
Add rake task for updating user email domain

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -1,13 +1,16 @@
 namespace :users do
   task :update_email_domain, [:old_domain, :new_domain] => [:environment] do |task, args|
-    users = User.where("email ILIKE ?", "%@#{args[:old_domain]}")
+    old_domain = "@#{args[:old_domain]}"
+    new_domain = "@#{args[:new_domain]}"
+
+    users = User.where("email ILIKE ?", "%#{old_domain}")
 
     puts "Going to update #{users.count} email addresses"
     num_updates = 0
 
     ActiveRecord::Base.transaction do
       users.find_each do |user|
-        user.update(email: user.email.sub(args[:old_domain], args[:new_domain]))
+        user.update(email: user.email.sub(old_domain, new_domain))
         num_updates += 1
         print '.'
       end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -1,9 +1,9 @@
 namespace :users do
   task :update_email_domain, [:old_domain, :new_domain] => [:environment] do |task, args|
-    old_domain = "@#{args[:old_domain]}"
-    new_domain = "@#{args[:new_domain]}"
+    old_domain = "@#{args[:old_domain].downcase}"
+    new_domain = "@#{args[:new_domain].downcase}"
 
-    users = User.where("email ILIKE ?", "%#{old_domain}")
+    users = User.where("email LIKE ?", "%#{old_domain}")
 
     puts "Going to update #{users.count} email addresses"
     num_updates = 0

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -1,0 +1,18 @@
+namespace :users do
+  task :update_email_domain, [:old_domain, :new_domain] => [:environment] do |task, args|
+    users = User.where("email ILIKE ?", "%@#{args[:old_domain]}")
+
+    puts "Going to update #{users.count} email addresses"
+    num_updates = 0
+
+    ActiveRecord::Base.transaction do
+      users.find_each do |user|
+        user.update(email: user.email.sub(args[:old_domain], args[:new_domain]))
+        num_updates += 1
+        print '.'
+      end
+    end
+
+    puts "\nUpdated #{num_updates} user emails"
+  end
+end


### PR DESCRIPTION
## WHAT
Add a rake task that allows updating the domain for particular email addresses.

## WHY
A school district is changing its domain so we need to update the corresponding email addresses in our database to main consistency with clever integration.

## HOW
Add a rake task that locates the desired domain and update it with the new one. 

### Screenshots
![Screen Shot 2021-07-01 at 10 06 37 AM](https://user-images.githubusercontent.com/2057805/124137978-35397c80-da54-11eb-933f-f55c1770a532.png)


### Notion Card Links
https://www.notion.so/quill/Update-districts-email-domain-for-all-users-70ac57ce7631451890be383f2ad4a031

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual check on staging; see screenshots
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
