### PR TITLE
Add rake task for clearing data from deleted users

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -164,6 +164,16 @@ class User < ActiveRecord::Base
 
   attr_accessor :newsletter
 
+  def self.deleted_users
+    where(
+      <<-SQL
+        name LIKE 'Deleted_User_%'
+          AND email LIKE 'deleted_user_%'
+          AND username LIKE 'deleted_user_%'
+      SQL
+    )
+  end
+
   def testing_flag
     role == STAFF ? ARCHIVED : flags.detect{|f| TESTING_FLAGS.include?(f)}
   end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -1,0 +1,5 @@
+namespace :users do
+  task clear_data_on_deleted_user: :environment do
+    User.deleted_users.find_each(&:clear_data)
+  end
+end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1318,4 +1318,16 @@ describe User, type: :model do
       expect(user.valid?).to be
     end
   end
+
+  describe '.deleted_users' do
+    before { user.save }
+
+    let!(:to_be_deleted_user) { create(:user) }
+
+    it 'returns all deleted users' do
+      expect(User.count).to eq 2
+
+      expect { to_be_deleted_user.clear_data }.to change { User.deleted_users.count }.from(0).to(1)
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Add a rake task that calls `clear_data` on all deleted users.

## WHY
Over time the `clear_data` method on `User` has been updated resulting in inconsistencies in not-cleared-out-data between older and newer deleted users.

## HOW
First run a query to find deleted users, then call `clear_data` on each of them.

### Notion Card Links
https://www.notion.so/quill/Run-Clear-data-on-all-deleted-users-221b227c3b284fc0b3eda6f95f70c160

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
