### PR TITLE
Comprehension internal tools/ add second layer feedback

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -68,7 +68,7 @@ class RuleFeedbackHistory
                 api_name: r.rule_type,
                 rule_order: r.rule_suborder,
                 first_feedback: r.feedbacks.order(:order).first&.text || '',
-                second_feedback: r.feedbacks.order(:order).last&.text || '',
+                second_feedback: r.feedbacks.order(:order).second&.text || '',
                 rule_note: r.rule_note,
                 rule_name: r.rule_name,
                 total_responses: r.total_responses,

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -68,6 +68,7 @@ class RuleFeedbackHistory
                 api_name: r.rule_type,
                 rule_order: r.rule_suborder,
                 first_feedback: r.feedbacks.order(:order).first&.text || '',
+                second_feedback: r.feedbacks.order(:order).last&.text || '',
                 rule_note: r.rule_note,
                 rule_name: r.rule_name,
                 total_responses: r.total_responses,

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/rulesAnalysis.tsx
@@ -48,6 +48,7 @@ const MoreInfo = (row) => {
   return (<div className="more-info">
     <p><strong>Rule Note:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.note || "N/A" }} /></p>
     <p><strong>First Layer Feedback:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.firstLayerFeedback || "N/A" }} /></p>
+    <p><strong>Second Layer Feedback:</strong> <span dangerouslySetInnerHTML={{ __html: row.original.secondLayerFeedback || "N/A" }} /></p>
   </div>)
 }
 
@@ -125,7 +126,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const formattedRows = selectedPrompt && ruleFeedbackHistory && ruleFeedbackHistory.ruleFeedbackHistories && ruleFeedbackHistory.ruleFeedbackHistories.filter(rule => {
     return selectedRuleType.value === DEFAULT_RULE_TYPE || rule.api_name === selectedRuleType.value
   }).map(rule => {
-    const { rule_name, rule_uid, api_name, rule_order, note, total_responses, strong_responses, weak_responses, first_feedback, repeated_consecutive_responses, repeated_non_consecutive_responses } = rule;
+    const { rule_name, rule_uid, api_name, rule_order, note, total_responses, strong_responses, weak_responses, first_feedback, second_feedback, repeated_consecutive_responses, repeated_non_consecutive_responses } = rule;
     const apiOrder = apiOrderLookup[api_name] || Object.keys(apiOrderLookup).length
     return {
       rule_uid,
@@ -143,6 +144,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       activityId,
       note,
       firstLayerFeedback: first_feedback,
+      secondLayerFeedback: second_feedback,
       handleClick: () => window.open(`/cms/comprehension#/activities/${activityId}/rules-analysis/${selectedPrompt.conjunction}/rule/${rule_uid}/prompt/${selectedPrompt.id}`, '_blank')
     }
   }).sort(firstBy('apiOrder').thenBy('ruleOrder'));

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -20,8 +20,7 @@ import { PromptInterface, ActivityInterface } from '../interfaces/comprehensionI
 
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
-// const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
-const mainApiBaseUrl = `https://www.quill.org/api/v1/`;
+const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
 const comprehensionBaseUrl = `${mainApiBaseUrl}comprehension/`;
 const fetchDefaults = require("fetch-defaults");
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -20,7 +20,8 @@ import { PromptInterface, ActivityInterface } from '../interfaces/comprehensionI
 
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
-const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
+// const mainApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/`;
+const mainApiBaseUrl = `https://www.quill.org/api/v1/`;
 const comprehensionBaseUrl = `${mainApiBaseUrl}comprehension/`;
 const fetchDefaults = require("fetch-defaults");
 

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
 
       # feedback
-      so_feedback = feedback_factory { { rule: so_rule1 } }
+      so_feedback1 = feedback_factory { { rule: so_rule1 } }
+      so_feedback2 = feedback_factory { { rule: so_rule1, order: 2 } }
 
       # feedback_histories
       f_h1 = create(:feedback_history, rule_uid: so_rule1.uid, entry: "f_h1 lorem")
@@ -70,7 +71,8 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       expected = {
         api_name: so_rule1.rule_type,
         rule_order: so_rule1.suborder,
-        first_feedback: so_feedback.text,
+        first_feedback: so_feedback1.text,
+        second_feedback: so_feedback2.text,
         rule_name: so_rule1.name,
         rule_note: so_rule1.note,
         rule_uid: so_rule1.uid,


### PR DESCRIPTION
## WHAT
add second layer feedback to the Rules Analysis page

## WHY
it was never being supplied to the frontend and Curriculum needs to be able to see the value

## HOW
just add a second property `second_feedback` to the backend payload and add it to the  `RulesAnalysis` table

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Rules-Analysis-Fix-rule-note-feedback-bug-and-add-second-layer-feedback-to-toggle-62f1ee623349422989f5ea4981edfa29

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
