### PR TITLE
CMS - Update New Relic, ignore certain errors

### DIFF
--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -40,7 +40,8 @@ gem 'elasticsearch-rails', '~> 5.1'
 gem 'kaminari'
 
 # OTHER
-gem 'newrelic_rpm', '~> 6.15.0'
+# TODO: replace with rubygems version when 7.2 is officially released.
+gem 'newrelic_rpm', '~>7.2', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '7.2.0-pre'
 gem 'rubyzip'
 
 # WEBSOCKETS

--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -41,7 +41,8 @@ gem 'kaminari'
 
 # OTHER
 # TODO: replace with rubygems version when 7.2 is officially released.
-gem 'newrelic_rpm', '~>7.2', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '7.2.0-pre'
+# gem 'newrelic_rpm', '~>7.2', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '7.2.0-pre'
+gem 'newrelic_rpm', path: 'vendor/gems/newrelic_rpm-7.2.0'
 gem 'rubyzip'
 
 # WEBSOCKETS

--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -42,7 +42,6 @@ gem 'kaminari'
 
 # OTHER
 # TODO: replace with rubygems version when 7.2 is officially released.
-# gem 'newrelic_rpm', '~>7.2', git: 'https://github.com/newrelic/newrelic-ruby-agent.git', tag: '7.2.0-pre'
 gem 'newrelic_rpm', path: 'vendor/gems/newrelic_rpm-7.2.0'
 gem 'rubyzip'
 

--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -41,8 +41,8 @@ gem 'elasticsearch-rails', '~> 5.1'
 gem 'kaminari'
 
 # OTHER
-# TODO: replace with rubygems version when 7.2 is officially released.
-gem 'newrelic_rpm', path: 'vendor/gems/newrelic_rpm-7.2.0'
+
+gem 'newrelic_rpm'
 gem 'rubyzip'
 
 # WEBSOCKETS

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -1,8 +1,3 @@
-PATH
-  remote: vendor/gems/newrelic_rpm-7.2.0
-  specs:
-    newrelic_rpm (7.2.0)
-
 GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
@@ -171,6 +166,7 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    newrelic_rpm (7.2.0)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -308,7 +304,7 @@ DEPENDENCIES
   httparty
   kaminari
   listen (>= 3.0.5, < 3.2)
-  newrelic_rpm!
+  newrelic_rpm
   pg (~> 1.2)
   pry (~> 0.10.4)
   puma (~> 4.3.8)

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/newrelic/newrelic-ruby-agent.git
+  revision: 24bf088f4fb2536cb0753b72960bbe5b5a420031
+  tag: 7.2.0-pre
+  specs:
+    newrelic_rpm (7.2.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
@@ -166,7 +173,6 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    newrelic_rpm (6.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -302,7 +308,7 @@ DEPENDENCIES
   httparty
   kaminari
   listen (>= 3.0.5, < 3.2)
-  newrelic_rpm (~> 6.15.0)
+  newrelic_rpm (~> 7.2)!
   pg (~> 1.2)
   pry (~> 0.10.4)
   puma (~> 4.3.8)

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -1,7 +1,5 @@
-GIT
-  remote: https://github.com/newrelic/newrelic-ruby-agent.git
-  revision: 24bf088f4fb2536cb0753b72960bbe5b5a420031
-  tag: 7.2.0-pre
+PATH
+  remote: vendor/gems/newrelic_rpm-7.2.0
   specs:
     newrelic_rpm (7.2.0)
 
@@ -308,7 +306,7 @@ DEPENDENCIES
   httparty
   kaminari
   listen (>= 3.0.5, < 3.2)
-  newrelic_rpm (~> 7.2)!
+  newrelic_rpm!
   pg (~> 1.2)
   pry (~> 0.10.4)
   puma (~> 4.3.8)

--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -2,7 +2,7 @@ class CreateOrIncrementResponseWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
-  class RaceConditionError < StandardError;
+  class RaceConditionError < StandardError; end
 
   def perform(new_vals)
     symbolized_vals = new_vals.symbolize_keys

--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -6,7 +6,7 @@ class RematchResponseWorker
 
   sidekiq_options retry: 1, queue: SidekiqQueue::DEFAULT
 
-  # retry 10 seconds later to spread out attempts
+  # spread out retries
   sidekiq_retry_in { 5 }
 
   DEFAULT_PARAMS_HASH = {

--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -19,7 +19,7 @@ class RematchResponseWorker
     'spelling_error' => false
   }.freeze
 
-  class LambdaError < StandardError; end
+  class LambdaHTTPError < StandardError; end
 
   def perform(response_id, question_type, question_hash, reference_response_ids)
     response = Response.find_by(id: response_id)
@@ -64,7 +64,7 @@ class RematchResponseWorker
     end
 
     if resp.code != '200'
-      raise RematchResponseWorker::LambdaError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
+      raise RematchResponseWorker::LambdaHTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
     end
 
     JSON.parse(resp.body)

--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -19,6 +19,8 @@ class RematchResponseWorker
     'spelling_error' => false
   }.freeze
 
+  class LambdaError < StandardError; end
+
   def perform(response_id, question_type, question_hash, reference_response_ids)
     response = Response.find_by(id: response_id)
     return unless response
@@ -62,7 +64,7 @@ class RematchResponseWorker
     end
 
     if resp.code != '200'
-      raise Net::HTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
+      raise RematchResponseWorker::LambdaError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
     end
 
     JSON.parse(resp.body)

--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -6,6 +6,9 @@ class RematchResponseWorker
 
   sidekiq_options retry: 1, queue: SidekiqQueue::DEFAULT
 
+  # retry 10 seconds later to spread out attempts
+  sidekiq_retry_in { 5 }
+
   DEFAULT_PARAMS_HASH = {
     'parent_id' => nil,
     'author' => nil,
@@ -59,7 +62,7 @@ class RematchResponseWorker
     end
 
     if resp.code != '200'
-      raise Net::HTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}", resp.code)
+      raise Net::HTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
     end
 
     JSON.parse(resp.body)

--- a/services/QuillCMS/config/newrelic.yml
+++ b/services/QuillCMS/config/newrelic.yml
@@ -27,11 +27,12 @@ common: &default_settings
   # from affecting your application's error rate and Apdex score.
   # This allows you to retain the error information for troubleshooting purposes
   # while avoiding alerts based on error rate or Apdex score.
-  # error_collector.expected_classes:
-  #   - 'Net::HTTPRetriableError'
-  #   - 'ActionController::RoutingError'
-  #   - 'Net::ReadTimeout'
-  #   - 'CreateOrIncrementResponseWorker::RaceConditionError'
+  error_collector.expected_classes:
+    - 'Net::HTTPRetriableError'
+    - 'ActionController::RoutingError'
+    - 'Net::ReadTimeout'
+    - 'CreateOrIncrementResponseWorker::RaceConditionError'
+    - 'RematchResponseWorker::LambdaError'
 
 
 # Environment-specific settings are in this section.

--- a/services/QuillCMS/config/newrelic.yml
+++ b/services/QuillCMS/config/newrelic.yml
@@ -27,11 +27,11 @@ common: &default_settings
   # from affecting your application's error rate and Apdex score.
   # This allows you to retain the error information for troubleshooting purposes
   # while avoiding alerts based on error rate or Apdex score.
-  error_collector.expected_classes:
-    - 'Net::HTTPRetriableError'
-    - 'ActionController::RoutingError'
-    - 'Net::ReadTimeout'
-    - 'CreateOrIncrementResponseWorker::RaceConditionError'
+  # error_collector.expected_classes:
+  #   - 'Net::HTTPRetriableError'
+  #   - 'ActionController::RoutingError'
+  #   - 'Net::ReadTimeout'
+  #   - 'CreateOrIncrementResponseWorker::RaceConditionError'
 
 
 # Environment-specific settings are in this section.

--- a/services/QuillCMS/config/newrelic.yml
+++ b/services/QuillCMS/config/newrelic.yml
@@ -23,6 +23,15 @@ common: &default_settings
 
   # Logging level for log/newrelic_agent.log
   log_level: info
+  # Expecting errors prevents the specified exception classes or codes
+  # from affecting your application's error rate and Apdex score.
+  # This allows you to retain the error information for troubleshooting purposes
+  # while avoiding alerts based on error rate or Apdex score.
+  error_collector.expected_classes:
+    - 'Net::HTTPRetriableError'
+    - 'ActionController::RoutingError'
+    - 'Net::ReadTimeout'
+    - 'CreateOrIncrementResponseWorker::RaceConditionError'
 
 
 # Environment-specific settings are in this section.
@@ -30,7 +39,7 @@ common: &default_settings
 # If your application has other named environments, configure them here.
 development:
   <<: *default_settings
-  app_name: My Application (Development)
+  app_name: Quill CMS (Development)
 
 test:
   <<: *default_settings
@@ -39,7 +48,7 @@ test:
 
 staging:
   <<: *default_settings
-  app_name: My Application (Staging)
+  app_name: Quill CMS (Staging)
 
 production:
   <<: *default_settings

--- a/services/QuillCMS/config/newrelic.yml
+++ b/services/QuillCMS/config/newrelic.yml
@@ -32,7 +32,7 @@ common: &default_settings
     - 'ActionController::RoutingError'
     - 'Net::ReadTimeout'
     - 'CreateOrIncrementResponseWorker::RaceConditionError'
-    - 'RematchResponseWorker::LambdaError'
+    - 'RematchResponseWorker::LambdaHTTPError'
 
 
 # Environment-specific settings are in this section.

--- a/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
@@ -48,7 +48,7 @@ describe CreateOrIncrementResponseWorker do
         text = 'Totally different text'
         exception = Elasticsearch::Transport::Transport::Errors::BadRequest
         expect_any_instance_of(Response).to receive(:create_index_in_elastic_search).and_raise(exception)
-        expect(NewRelic::Agent).to receive(:notice_error).with(exception)
+
         subject.perform({ text: text })
         expect(Response.find_by(text: 'Totally different text').id).to be
       end


### PR DESCRIPTION
## WHAT
New Relic has a new version of their gem in pre-release, with which, we can ignore errors from our error rate and alerts. Integrating this and ignoring some errors, with some app changes to make that more explicit.
## WHY
Cut down on spurious alerts. We want our alerts and error rate to indicate site issues. Some errors, like retryable ones in background jobs or an incorrect route, are better to remove from these calculations to keep our alerts accurate.
## HOW
Upgrade gem. They released 7.2.0 officially.
~~Upgrade to pre-release `7.2.0`. Note, I had to vendor this to make deploying work(they haven't pushed this to RubyGems yet) and am still testing this (If I run into issues, we can just wait for them to publish).~~

I made some errors more specific so that we can feel confident ignoring them, e.g. `RematchResponseWorker::LambdaError`


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Mostly no, since this is a monitoring change.
Have you deployed to Staging? | YES, still testing.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
