### PR TITLE
comprehension/use-env-for-opinion-api

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -48,8 +48,20 @@ func GetLMSDomain() (string) {
 	return lms_domain
 }
 
+func GetOpinionDomain() (string) {
+	var maybe_domain = os.Getenv("opinion_domain")
+
+	var opinion_domain = "https://opinion-api.quill.org"
+
+	if len(maybe_domain) > 0 {
+		opinion_domain = maybe_domain
+	}
+	return opinion_domain
+}
+
 func AssembleUrls() ([8]string) {
 	lms_domain := GetLMSDomain()
+	opinion_domain := GetOpinionDomain()
 
 	var (
 		automl_api = fmt.Sprintf("%s/api/v1/comprehension/feedback/automl.json", lms_domain)
@@ -60,7 +72,7 @@ func AssembleUrls() ([8]string) {
 		spell_check_bing             = fmt.Sprintf("%s/api/v1/comprehension/feedback/spelling.json", lms_domain)
 
 		grammar_check_api = "https://grammar-api.ue.r.appspot.com"
-		opinion_check_api = "https://opinion-api.ue.r.appspot.com/"
+		opinion_check_api = fmt.Sprintf("%s/", opinion_domain)
 	)
 
 	var urls = [...]string{


### PR DESCRIPTION
## WHAT
Make sure that we get opinion-api from ENV variable
## WHY
This allows us to configure where the Go endpoint looks for the Opinion API with ENV variables.  This is our method for implementing the Opinion API deploy to Heroku.
## HOW
Copy the pattern established for configuring the LMS domain for the Go endpoint

### Notion Card Links
https://www.notion.so/quill/Hosting-Opinion-API-on-Heroku-fff348d92cd142c7b923b5f5f165e685

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
