### PR TITLE
Fix user#clear_data for nil entries on StudentClassrooms

### DIFF
--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -49,7 +49,7 @@ class StudentsClassrooms < ActiveRecord::Base
   end
 
   private def invalidate_classroom_minis
-    if classroom.owner.present?
+    if classroom&.owner.present?
       $redis.del("user_id:#{classroom.owner.id}_classroom_minis")
     end
   end

--- a/services/QuillLMS/lib/tasks/progress_bar.rb
+++ b/services/QuillLMS/lib/tasks/progress_bar.rb
@@ -1,0 +1,12 @@
+class ProgessBar
+  def initialize(total)
+    @total = total
+    @counter = 1
+  end
+
+  def increment
+    complete = format("%<percent_completed>.2f%%", percent_completed: ((@counter / @total.to_f) * 100))
+    print "\r\e[0K#{@counter}/#{@total} (#{complete})"
+    @counter += 1
+  end
+end

--- a/services/QuillLMS/lib/tasks/progress_bar.rb
+++ b/services/QuillLMS/lib/tasks/progress_bar.rb
@@ -5,6 +5,8 @@ class ProgessBar
   end
 
   def increment
+    return if @total.zero?
+
     complete = format("%<percent_completed>.2f%%", percent_completed: ((@counter / @total.to_f) * 100))
     print "\r\e[0K#{@counter}/#{@total} (#{complete})"
     @counter += 1

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -1,5 +1,14 @@
+require_relative './progress_bar'
+
 namespace :users do
-  task clear_data_on_deleted_user: :environment do
-    User.deleted_users.find_each(&:clear_data)
+  task clear_data_on_deleted_users: :environment do
+    deleted_users = User.deleted_users
+
+    progress_bar = ProgessBar.new(deleted_users.size)
+
+    deleted_users.find_each do |user|
+      user.clear_data
+      progress_bar.increment
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug when running users#clear_data.  Also added a progress bar to monitor this task as it takes a couple hours to run.

## WHY
We'd like this rake task to complete on production
![Screen Shot 2021-07-06 at 7 48 17 AM](https://user-images.githubusercontent.com/2057805/124595134-a4d1b200-de2e-11eb-95a4-3b45f47b6d34.png)

## HOW
Add nil check on the failing method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Run-Clear-data-on-all-deleted-users-221b227c3b284fc0b3eda6f95f70c160

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A

