### PR TITLE
Comprehension internal tools/ fix activity sessions timestamp

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionsIndex.tsx
@@ -151,7 +151,7 @@ const SessionsIndex = ({ match }) => {
       const { start_date, session_uid, because_attempts, but_attempts, so_attempts, complete } = session;
       const dateObject = new Date(start_date);
       const date = moment(dateObject).format("MM/DD/YY");
-      const time = moment(dateObject).format("HH:MM A");
+      const time = moment(dateObject).format("hh:mm a");
       const total = because_attempts + but_attempts + so_attempts;
       const formattedSession = {
         ...session,


### PR DESCRIPTION
## WHAT
fix activity sessions timestamp

## WHY
it was displaying a wrong rounded timestamp

## HOW
just update the `moment` format string

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Responses-on-the-View-Sessions-page-always-have-06-as-the-minute-99a75220b32e4da2af2e4c76bb73cfb4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
