### PR TITLE
Fix time tracking bug involving strong parameters

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -38,7 +38,6 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   def create
     @activity_session = ActivitySession.new(activity_session_params)
     @activity_session.user = current_user if current_user
-    @activity_session.concept_results = []
 
     if @activity_session.save
       handle_concept_results if @concept_results

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -37,18 +37,13 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
   def create
     @activity_session = ActivitySession.new(activity_session_params)
-    crs = @activity_session.concept_results
     @activity_session.user = current_user if current_user
     @activity_session.concept_results = []
-    # activity_session.owner=(current_user) if activity_session.ownable?
-    # activity_session.data = @data # FIXME: may no longer be necessary?
-    if @activity_session.save
-      if @activity_session.update(activity_session_params)
-        handle_concept_results if @concept_results
 
-        @status = :success
-        @message = "Activity Session Created"
-      end
+    if @activity_session.save
+      handle_concept_results if @concept_results
+      @status = :success
+      @message = "Activity Session Created"
     else
       @status = :failed
       @message = "Activity Session Create Failed"

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     if @activity_session.completed_at
       status = :unprocessable_entity
       message = "Activity Session Already Completed"
-    elsif @activity_session.update(activity_session_params.except(:id, :concept_results))
+    elsif @activity_session.update(activity_session_params)
       status = :ok
       message = "Activity Session Updated"
       NotifyOfCompletedActivity.new(@activity_session).call if @activity_session.classroom_unit_id
@@ -26,21 +26,26 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       @errors = @activity_session.errors
     end
 
-    render json: @activity_session, meta: {message: message, errors: @errors || []}, status: status, serializer: ActivitySessionSerializer
+    render json: @activity_session,
+      meta: {
+        message: message,
+        errors: @errors || []
+      },
+      status: status,
+      serializer: ActivitySessionSerializer
   end
 
   def create
-    @activity_session = ActivitySession.new(activity_session_params.except(:id, :concept_results))
+    @activity_session = ActivitySession.new(activity_session_params)
     crs = @activity_session.concept_results
     @activity_session.user = current_user if current_user
     @activity_session.concept_results = []
     # activity_session.owner=(current_user) if activity_session.ownable?
     # activity_session.data = @data # FIXME: may no longer be necessary?
     if @activity_session.save
-      if @activity_session.update(activity_session_params.except(:id))
-        if @concept_results
-          handle_concept_results
-        end
+      if @activity_session.update(activity_session_params)
+        handle_concept_results if @concept_results
+
         @status = :success
         @message = "Activity Session Created"
       end
@@ -48,17 +53,32 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       @status = :failed
       @message = "Activity Session Create Failed"
     end
-    render json: @activity_session, meta: {status: @status, message: @message, errors: @activity_session.errors}, serializer: ActivitySessionSerializer
+
+    render json: @activity_session,
+      meta: {
+        status: @status,
+        message: @message,
+        errors: @activity_session.errors
+      },
+      serializer: ActivitySessionSerializer
   end
 
   def destroy
     if @activity_session.destroy!
-      render json: ActivitySession.new, meta:
-        {status: 'success', message: "Activity Session Destroy Successful", errors: nil},
+      render json: ActivitySession.new,
+        meta: {
+          status: 'success',
+          message: "Activity Session Destroy Successful",
+          errors: nil
+        },
         serializer: ActivitySessionSerializer
     else
-      render json: @activity_session, meta:
-        {status: 'failed', message: "Activity Session Destroy Failed", errors: @activity_session.errors},
+      render json: @activity_session,
+        meta: {
+          status: 'failed',
+          message: "Activity Session Destroy Failed",
+          errors: @activity_session.errors
+        },
         serializer: ActivitySessionSerializer
     end
   end
@@ -85,22 +105,15 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
   private def activity_session_params
     params.delete(:activity_session)
-    @data ||= params.delete(:data)
-    @time_tracking ||= @data && @data['time_tracking']
-    params.permit(:id,
-                  :access_token, # Required by OAuth
-                  :percentage,
-                  :state,
-                  :question_type,
-                  :completed_at,
-                  :classroom_unit_id,
-                  :activity_uid,
-                  :activity_id,
-                  :anonymous,
-                  :temporary
-                )
-      .merge(data: @data).reject {|k,v| v.nil? }
-      .merge(timespent: @activity_session&.timespent || ActivitySession.calculate_timespent(@time_tracking))
+    data = params.delete(:data)&.permit!
+    time_tracking = data && data['time_tracking']
+    timespent = @activity_session&.timespent || ActivitySession.calculate_timespent(time_tracking)
+
+    params
+      .permit(activity_session_permitted_params)
+      .merge(data: data)
+      .reject { |_, v| v.nil? }
+      .merge(timespent: timespent)
   end
 
   private def transform_incoming_request
@@ -116,11 +129,26 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     end
   end
 
+  private def activity_session_permitted_params
+    [
+      :access_token, # Required by OAuth
+      :activity_id,
+      :activity_uid,
+      :anonymous,
+      :classroom_unit_id,
+      :completed_at,
+      :percentage,
+      :question_type,
+      :state,
+      :temporary
+    ]
+  end
+
   private def concept_results_permitted_params
     [
+      :activity_classification_id,
       :activity_session_id,
       :concept_id,
-      :activity_classification_id,
       :concept_uid,
       :question_type
     ]

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -121,6 +121,34 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         expect(activity_session.concept_results).to eq([])
       end
     end
+
+    context 'data time_tracking is included ' do
+      let(:data) do
+        {
+          'time_tracking' => {
+            'so' => 1,
+            'but' => 2,
+            'because' => 3
+          }
+        }
+      end
+
+      before do
+         put :update,
+          params: {
+           id: activity_session.uid,
+           data: data
+          },
+          as: :json
+      end
+
+      it 'updates timespent on activity session' do
+        activity_session.reload
+
+        expect(activity_session.timespent).to eq 6
+        expect(activity_session.data['time_tracking']).to include(data['time_tracking'])
+      end
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
## WHAT
Fix a bug involving time tracking data not being saved on activity types

## WHY
We'd like to store time tracking information for various reasons.

## HOW
When storing the data value, we have to call `permit!` on this hash:
`data = params.delete(:data).permit!`

Otherwise, when calling `@activity_session.update(activity_session_params)` the value for `data` is not permitted:
![Screen Shot 2021-07-07 at 7 33 56 AM](https://user-images.githubusercontent.com/2057805/124755559-84225e80-def9-11eb-853e-5bd9a7cff4e4.png)


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Timetracking-data-not-saving-for-any-activity-types-except-Lessons-af281f1cfdb34deb900ff7f7ba3132c5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A

