### PR TITLE
lms/fix-google-login-routing

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -386,6 +386,8 @@ EmpiricalGrammar::Application.routes.draw do
           get 'level_zero_concepts_with_lineage'
         end
       end
+
+      resources :users, only: [:index]
       resources :app_settings, only: [:index, :show], param: :name 
 
       resources :classroom_units,         only: [] do


### PR DESCRIPTION
## WHAT
Re-add a route for "api/v1/users.json"
## WHY
This route must be available for our current Google login flow, and without it no one can log in with Google
## HOW
Just re-add a route that was accidentally removed from the routing config in a previous deploy

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-Link-not-Working-4b0ce3cbb82d40608a6e02119a6074fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A