### PR TITLE
LMS - Better Redirects for Blog post url errors

### DIFF
--- a/services/.rubocop_todo.yml
+++ b/services/.rubocop_todo.yml
@@ -444,6 +444,7 @@ Naming/PredicateName:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: always, conditionals
 Style/AndOr:
+  EnforcedStyle: conditionals
   Exclude:
     - 'QuillLMS/app/controllers/schools_controller.rb'
     - 'QuillLMS/app/controllers/sessions_controller.rb'

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -6,6 +6,7 @@ class BlogPostsController < ApplicationController
   def index
     topic_names = BlogPost::TEACHER_TOPICS
     @topics = []
+    @topic = BlogPost::ALL_RESOURCES
     topic_names.each do |name|
       @topics.push({ name: name, slug: CGI::escape(name.downcase.gsub(' ','-'))})
     end
@@ -29,7 +30,7 @@ class BlogPostsController < ApplicationController
     draft_status = (@role == 'staff') ? [true, false] : false
 
     @blog_post = BlogPost.find_by!(slug: params[:slug], draft: draft_status)
-    # TODO remove SQL write from get endpoint
+    # TODO remove SQL write from GET endpoint
     @blog_post.increment_read_count
     @most_recent_posts = BlogPost.most_recent.where.not(id: @blog_post.id)
 
@@ -84,13 +85,14 @@ class BlogPostsController < ApplicationController
         redirect_to "/teacher-center/topic/#{new_topic}"
       end
     else
-      topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
-      if !BlogPost::TOPICS.include?(topic) && !BlogPost::STUDENT_TOPICS.include?(topic)
+      @topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
+      if !BlogPost::TOPICS.include?(@topic) && !BlogPost::STUDENT_TOPICS.include?(@topic)
         raise ActionController::RoutingError, 'Topic Not Found'
       end
-      @blog_posts = BlogPost.for_topics(topic)
+      @blog_posts = BlogPost.for_topics(@topic)
       # hide student part of topic name for display
-      @title = @role == 'student' ? topic.gsub('Student ', '').capitalize : topic
+      @title = @role == 'student' ? topic.gsub('Student ', '').capitalize : @topic
+
       render 'index'
     end
   end

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -1,12 +1,16 @@
 class BlogPostsController < ApplicationController
-  before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_role
+  before_action :redirect_legacy_topic_urls, only: [:show_topic]
+  before_action :redirect_invalid_topics, only: [:show_topic]
+
+  before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_root_url
+
+
 
   def index
     topic_names = BlogPost::TEACHER_TOPICS
     @topics = []
-    @topic = BlogPost::ALL_RESOURCES
     topic_names.each do |name|
       @topics.push({ name: name, slug: CGI::escape(name.downcase.gsub(' ','-'))})
     end
@@ -25,31 +29,27 @@ class BlogPostsController < ApplicationController
   end
 
   def show
-    # find_by_hash = { slug: params[:slug] }
-    # find_by_hash[:draft] = false unless @role == 'staff'
-    draft_status = (@role == 'staff') ? [true, false] : false
+    draft_statuses = @role == 'staff' ? [true, false] : false
 
-    @blog_post = BlogPost.find_by!(slug: params[:slug], draft: draft_status)
-    # TODO remove SQL write from GET endpoint
-    @blog_post.increment_read_count
-    @most_recent_posts = BlogPost.most_recent.where.not(id: @blog_post.id)
+    if @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
+      # TODO remove SQL write from GET endpoint
+      @blog_post.increment_read_count
+      @most_recent_posts = BlogPost.most_recent.where.not(id: @blog_post.id)
 
-    @title = @blog_post.title
-    @description = @blog_post.subtitle || @title
-    @image_link = @blog_post.image_link
-  rescue ActiveRecord::RecordNotFound => e
-    # try fixing params and redirect to correct url.
-
-    corrected_slug = params[:slug]&.gsub(/[^a-zA-Z\d\s-]/, '')&.downcase
-
-    if blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_status)
-      redirect_to blog_post
+      @title = @blog_post.title
+      @description = @blog_post.subtitle || @title
+      @image_link = @blog_post.image_link
     else
-      flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page!"
-      redirect_to blog_posts_path
+      # try fixing params and redirect to correct url.
+      corrected_slug = params[:slug]&.gsub(/[^a-zA-Z\d\s-]/, '')&.downcase
+
+      if blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
+        redirect_to blog_post
+      else
+        flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page."
+        redirect_to blog_posts_path
+      end
     end
-
-
   end
 
   def search
@@ -76,25 +76,14 @@ class BlogPostsController < ApplicationController
   end
 
   def show_topic
-    # handling links that were possibly broken by changing slug function for topic names
-    if params[:topic].include?('_')
-      new_topic = params[:topic].gsub('_', '-')
-      if current_user&.role == 'student'
-        redirect_to "/student-center/topic/#{new_topic}"
-      else
-        redirect_to "/teacher-center/topic/#{new_topic}"
-      end
-    else
-      @topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
-      if !BlogPost::TOPICS.include?(@topic) && !BlogPost::STUDENT_TOPICS.include?(@topic)
-        raise ActionController::RoutingError, 'Topic Not Found'
-      end
-      @blog_posts = BlogPost.for_topics(@topic)
-      # hide student part of topic name for display
-      @title = @role == 'student' ? topic.gsub('Student ', '').capitalize : @topic
+    topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
 
-      render 'index'
-    end
+    @blog_posts = BlogPost.for_topics(topic)
+    # hide student part of topic name for display
+    @topic = @role == 'student' ? topic.gsub('Student ', '').capitalize : topic
+    @title = @topic
+
+    render 'index'
   end
 
   private def set_announcement
@@ -107,5 +96,27 @@ class BlogPostsController < ApplicationController
 
   private def set_root_url
     @root_url = root_url
+  end
+
+  private def redirect_invalid_topics
+    topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
+    return if BlogPost::TOPICS.include?(topic)
+    return if BlogPost::STUDENT_TOPICS.include?(topic)
+
+    flash[:error] = "Oops! We can't seem to find that topic!"
+    center_home_url = @role == 'student' ? '/student-center' : '/teacher-center'
+
+    redirect_to center_home_url and return
+  end
+
+  # handling links that were possibly broken by changing slug function for topic names
+  private def redirect_legacy_topic_urls
+    return unless params[:topic].include?('_')
+
+    new_topic = params[:topic].gsub('_', '-')
+
+    base_url = @role == 'student' ? 'student-center' : 'teacher-center'
+
+    redirect_to "/#{base_url}/topic/#{new_topic}" and return
   end
 end

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -102,7 +102,7 @@ class BlogPostsController < ApplicationController
     return if BlogPost::STUDENT_TOPICS.include?(topic)
 
     flash[:error] = "Oops! We can't seem to find that topic!"
-    center_home_url = @role == 'student' ? '/student-center' : '/teacher-center'
+    center_home_url = current_user&.student? ? '/student-center' : '/teacher-center'
 
     redirect_to center_home_url and return
   end

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -114,7 +114,6 @@ class BlogPostsController < ApplicationController
     return unless params[:topic].include?('_')
 
     new_topic = params[:topic].gsub('_', '-')
-
     base_url = @role == 'student' ? 'student-center' : 'teacher-center'
 
     redirect_to "/#{base_url}/topic/#{new_topic}" and return

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -31,8 +31,10 @@ class BlogPostsController < ApplicationController
   def show
     draft_statuses = @role == 'staff' ? [true, false] : false
 
-    if @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
-      # TODO remove SQL write from GET endpoint
+    @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
+
+    if @blog_post
+      # TODO: remove SQL write from GET endpoint
       @blog_post.increment_read_count
       @most_recent_posts = BlogPost.most_recent.where.not(id: @blog_post.id)
 
@@ -42,8 +44,9 @@ class BlogPostsController < ApplicationController
     else
       # try fixing params and redirect to correct url.
       corrected_slug = params[:slug]&.gsub(/[^a-zA-Z\d\s-]/, '')&.downcase
+      blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
 
-      if blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
+      if blog_post
         redirect_to blog_post
       else
         flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page."

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -28,7 +28,7 @@ class BlogPostsController < ApplicationController
   end
 
   def show
-    draft_statuses =current_user&.staff? ? [true, false] : false
+    draft_statuses = current_user&.staff? ? [true, false] : false
 
     @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
 

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -1,5 +1,4 @@
 class BlogPostsController < ApplicationController
-  before_action :set_role
   before_action :redirect_legacy_topic_urls, only: [:show_topic]
   before_action :redirect_invalid_topics, only: [:show_topic]
 
@@ -29,7 +28,7 @@ class BlogPostsController < ApplicationController
   end
 
   def show
-    draft_statuses = @role == 'staff' ? [true, false] : false
+    draft_statuses =current_user&.staff? ? [true, false] : false
 
     @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
 
@@ -83,7 +82,7 @@ class BlogPostsController < ApplicationController
 
     @blog_posts = BlogPost.for_topics(topic)
     # hide student part of topic name for display
-    @topic = @role == 'student' ? topic.gsub('Student ', '').capitalize : topic
+    @topic = current_user&.student? ? topic.gsub('Student ', '').capitalize : topic
     @title = @topic
 
     render 'index'
@@ -91,10 +90,6 @@ class BlogPostsController < ApplicationController
 
   private def set_announcement
     @announcement = Announcement.current_webinar_announcement
-  end
-
-  private def set_role
-    @role = current_user ? current_user.role : nil
   end
 
   private def set_root_url
@@ -117,7 +112,7 @@ class BlogPostsController < ApplicationController
     return unless params[:topic].include?('_')
 
     new_topic = params[:topic].gsub('_', '-')
-    base_url = @role == 'student' ? 'student-center' : 'teacher-center'
+    base_url = current_user&.student? ? 'student-center' : 'teacher-center'
 
     redirect_to "/#{base_url}/topic/#{new_topic}" and return
   end

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -46,7 +46,7 @@ class BlogPostsController < ApplicationController
       blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
 
       if blog_post
-        redirect_to blog_post
+        redirect_to blog_post_path(blog_post.slug)
       else
         flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page."
         redirect_to blog_posts_path

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -1,4 +1,3 @@
-
 module TeacherCenterHelper
   FAQ = 'FAQ'
   PREMIUM = 'Premium'

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -1,0 +1,62 @@
+
+module TeacherCenterHelper
+  FAQ = 'FAQ'
+  PREMIUM = 'Premium'
+  RESEARCH_SHORT = 'Research'
+  ALL_SHORT = 'All'
+
+  def teacher_center_tabs(large: true)
+     [
+      {
+        id: BlogPost::ALL_RESOURCES,
+        name: large ? BlogPost::ALL_RESOURCES : ALL_SHORT,
+        url: 'teacher-center'
+      },
+      {
+        id: BlogPost::GETTING_STARTED,
+        name: BlogPost::GETTING_STARTED,
+        url: 'teacher-center/topic/getting-started'
+      },
+      {
+        id: BlogPost::TEACHER_STORIES,
+        name: BlogPost::TEACHER_STORIES,
+        url: 'teacher-center/topic/teacher-stories'
+      },
+      {
+        id: BlogPost::WRITING_INSTRUCTION_RESEARCH,
+        name: large ? BlogPost::WRITING_INSTRUCTION_RESEARCH : RESEARCH_SHORT,
+        url: 'teacher-center/topic/writing-instruction-research'
+      },
+      {
+        id: FAQ,
+        name: FAQ,
+        url: 'faq'
+      },
+      {
+        id: PREMIUM,
+        name: PREMIUM,
+        url: 'premium'
+      }
+    ]
+  end
+
+  def student_center_tabs(large: true)
+     [
+      {
+        id: BlogPost::ALL_RESOURCES,
+        name: large ? BlogPost::ALL_RESOURCES : ALL_SHORT,
+        url: 'student-center'
+      },
+      {
+        id: BlogPost::GETTING_STARTED,
+        name: BlogPost::GETTING_STARTED,
+        url: 'student-center/topic/student-getting-started'
+      },
+      {
+        id: BlogPost::HOW_TO,
+        name: BlogPost::HOW_TO,
+        url: 'student-center/topic/student-how-to'
+      }
+    ]
+  end
+end

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -84,7 +84,7 @@ class BlogPost < ActiveRecord::Base
   scope :live, -> { where(draft: false) }
   scope :most_recent, -> { live.order('updated_at DESC').limit(MOST_RECENT_LIMIT)}
 
-  scope :for_topics, -> {|topic| live.order('order_number ASC').where(topic: topic)}
+  scope :for_topics, lambda { |topic| live.order('order_number ASC').where(topic: topic) }
 
   def set_order_number
     if order_number.nil?

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -84,7 +84,7 @@ class BlogPost < ActiveRecord::Base
   scope :live, -> { where(draft: false) }
   scope :most_recent, -> { live.order('updated_at DESC').limit(MOST_RECENT_LIMIT)}
 
-  scope :for_topics, lambda { |topic| live.order('order_number ASC').where(topic: topic) }
+  scope :for_topics, ->(topic) { live.order('order_number ASC').where(topic: topic) }
 
   def set_order_number
     if order_number.nil?

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -73,12 +73,18 @@ class BlogPost < ActiveRecord::Base
   TEACHER_TOPICS = TOPICS.reject { |t| [PRESS_RELEASES, IN_THE_NEWS].include?(t) }
 
   STUDENT_TOPICS = [STUDENT_GETTING_STARTED, STUDENT_HOW_TO]
+  MOST_RECENT_LIMIT = 3
 
   before_create :generate_slug, :set_order_number
 
   belongs_to :author
   has_many :blog_post_user_ratings
   after_save :add_published_at
+
+  scope :live, -> { where(draft: false) }
+  scope :most_recent, -> { live.order('updated_at DESC').limit(MOST_RECENT_LIMIT)}
+
+  scope :for_topics, -> {|topic| live.order('order_number ASC').where(topic: topic)}
 
   def set_order_number
     if order_number.nil?

--- a/services/QuillLMS/app/views/blog_posts/index.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/index.html.erb
@@ -1,16 +1,4 @@
-<% current_path = request.env['PATH_INFO'] %>
-<% if current_path.include?('getting-started') %>
-  <% @active_tab = BlogPost::GETTING_STARTED %>
-<% elsif current_path.include?('teacher-stories') %>
-  <% @active_tab = BlogPost::TEACHER_STORIES %>
-<% elsif current_path.include?('writing-instruction-research') %>
-  <% @active_tab = BlogPost::WRITING_INSTRUCTION_RESEARCH %>
-<% elsif current_path.include?('how-to') %>
-    <% @active_tab = BlogPost::HOW_TO %>
-<% else %>
-  <% @active_tab = BlogPost::ALL_RESOURCES%>
-<% end %>
-<%= render partial: 'pages/shared/teacher_center_navbar', active_tab: @active_tab %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic } %>
 <div class="container">
   <%= react_component('BlogPostsApp', props: {route: 'index', blogPosts: @blog_posts, announcement: @announcement, query: @query, topics: @topics, studentTopics: @student_topics, role: @role, title: @title}) %>
 </div>

--- a/services/QuillLMS/app/views/blog_posts/index.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/index.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } %>
 <div class="container">
-  <%= react_component('BlogPostsApp', props: {route: 'index', blogPosts: @blog_posts, announcement: @announcement, query: @query, topics: @topics, studentTopics: @student_topics, role: @role, title: @title}) %>
+  <%= react_component('BlogPostsApp', props: {route: 'index', blogPosts: @blog_posts, announcement: @announcement, query: @query, topics: @topics, studentTopics: @student_topics, role: current_user&.role, title: @title}) %>
 </div>

--- a/services/QuillLMS/app/views/blog_posts/index.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic } %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } %>
 <div class="container">
   <%= react_component('BlogPostsApp', props: {route: 'index', blogPosts: @blog_posts, announcement: @announcement, query: @query, topics: @topics, studentTopics: @student_topics, role: @role, title: @title}) %>
 </div>

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -13,5 +13,5 @@
   mostRecentPosts: @most_recent_posts,
   author: @author,
   displayPaywall: !@blog_post.can_be_accessed_by(current_user),
-  role: @role
+  role: current_user&.role
 }) %>

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -5,13 +5,13 @@
 <% end %>
 
 <%= render partial: 'teachers/shared/scorebook_tabs' if current_user %>
-<%= render partial: 'pages/shared/teacher_center_navbar', active_tab: active_tab %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: active_tab} %>
 <%= react_component('BlogPostsApp', props: {
   route: 'show',
   blogPost: @blog_post,
   announcement: @announcement,
   mostRecentPosts: @most_recent_posts,
   author: @author,
-  displayPaywall: @blog_post.can_be_accessed_by(current_user),
+  displayPaywall: !@blog_post.can_be_accessed_by(current_user),
   role: @role
 }) %>

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -1,17 +1,17 @@
 <% if @topic.in?([BlogPost::GETTING_STARTED, @topic == BlogPost::TEACHER_STORIES, @topic == BlogPost::WRITING_INSTRUCTION_RESEARCH]) %>
-  <% @active_tab = @topic %>
+  <% active_tab = @topic %>
 <% else %>
-  <% @active_tab = 'All resources'%>
+  <% active_tab = 'All resources'%>
 <% end %>
 
 <%= render partial: 'teachers/shared/scorebook_tabs' if current_user %>
-<%= render partial: 'pages/shared/teacher_center_navbar', active_tab: @active_tab %>
+<%= render partial: 'pages/shared/teacher_center_navbar', active_tab: active_tab %>
 <%= react_component('BlogPostsApp', props: {
   route: 'show',
   blogPost: @blog_post,
   announcement: @announcement,
   mostRecentPosts: @most_recent_posts,
   author: @author,
-  displayPaywall: @display_paywall,
+  displayPaywall: @blog_post.can_be_accessed_by(current_user),
   role: @role
 }) %>

--- a/services/QuillLMS/app/views/pages/faq.html.erb
+++ b/services/QuillLMS/app/views/pages/faq.html.erb
@@ -1,5 +1,4 @@
-<% @active_tab = 'FAQ' %>
-<%= render partial: 'pages/shared/teacher_center_navbar', active_tab: @active_tab %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: 'FAQ'} %>
 
 <div class="container pages-container pages-faq">
 

--- a/services/QuillLMS/app/views/pages/faq.html.erb
+++ b/services/QuillLMS/app/views/pages/faq.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: 'FAQ'} %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: TeacherCenterHelper::FAQ} %>
 
 <div class="container pages-container pages-faq">
 

--- a/services/QuillLMS/app/views/pages/premium.html.erb
+++ b/services/QuillLMS/app/views/pages/premium.html.erb
@@ -1,7 +1,6 @@
 <% if (current_user && current_user.role == 'teacher') %>
   <%= render 'teachers/shared/scorebook_tabs' %>
 <% else %>
-  <% active_tab = 'Premium' %>
-  <%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: active_tab} %>
+  <%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: TeacherCenterHelper::PREMIUM} %>
 <% end %>
 <%= render 'pages/shared/premium_main' %>

--- a/services/QuillLMS/app/views/pages/premium.html.erb
+++ b/services/QuillLMS/app/views/pages/premium.html.erb
@@ -1,7 +1,7 @@
 <% if (current_user && current_user.role == 'teacher') %>
   <%= render 'teachers/shared/scorebook_tabs' %>
 <% else %>
-  <% @active_tab = 'Premium' %>
-  <%= render partial: 'pages/shared/teacher_center_navbar', active_tab: @active_tab %>
+  <% active_tab = 'Premium' %>
+  <%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: active_tab} %>
 <% end %>
 <%= render 'pages/shared/premium_main' %>

--- a/services/QuillLMS/app/views/pages/shared/_generic_tabs.erb
+++ b/services/QuillLMS/app/views/pages/shared/_generic_tabs.erb
@@ -1,9 +1,9 @@
 <div class="q-nav-bar">
   <ul class='desktop-nav-list'>
-    <%  @tabs.each do |tab| -%>
+    <%  tabs.each do |tab| -%>
       <li
         id="<%= tab[:id] || '' %>"
-        class="<%= tab[:name] == @active_tab ? 'active' : '' %>"
+        class="<%= (tab[:name] == active_tab || tab[:id] == active_tab) ? 'active' : '' %>"
       >
         <%= link_to tab[:name], @root_url + tab[:url] %>
       </li>
@@ -20,7 +20,7 @@
         <input type="checkbox" id="button">
 
         <ul>
-          <%  @tabs.each do |tab| -%>
+          <%  tabs.each do |tab| -%>
             <li >
               <%= link_to tab[:name], @root_url + tab[:url] %>
             </li>

--- a/services/QuillLMS/app/views/pages/shared/_teacher_center_navbar.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_teacher_center_navbar.html.erb
@@ -1,75 +1,23 @@
-<% @all = 'All' %>
-<% @research = 'Research' %>
-<% @faq = 'FAQ' %>
-<% @premium = 'Premium' %>
+<%-# locals: active_tab %>
+<%-# TODO - this feels like a bug, but everything is labeled mobile = false %>
+<% @mobile = false %>
 
 <div class="subnav teacher-center-navbar">
   <div class="container">
     <% if current_user&.role == 'student' %>
-      <% tabs = [
-        {name: BlogPost::ALL_RESOURCES, url: 'student-center'},
-        {name: BlogPost::GETTING_STARTED, url: 'student-center/topic/student-getting-started'},
-        {name: BlogPost::HOW_TO, url: 'student-center/topic/student-how-to'},
-      ]
-        @tabs = tabs
-        @mobile = false
-      %>
-
       <div class="full-screen">
-        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab: @active_tab, mobile: @mobile } %>
+        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: student_center_tabs(large: true), active_tab: active_tab} %>
       </div>
-
-      <% tabs = [
-        {name: @all, url: 'student-center'},
-        {name: BlogPost::GETTING_STARTED, url: 'student-center/topic/student-getting-started'},
-        {name: BlogPost::HOW_TO, url: 'student-center/topic/student-how-to'},
-      ]
-      @tabs = tabs
-      if @active_tab == BlogPost::ALL_RESOURCES
-        @active_tab = @all
-      end
-      %>
       <div class="small-screen">
-        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab:  @active_tab, mobile: @mobile} %>
+        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: student_center_tabs(large: false), active_tab:  active_tab} %>
       </div>
-
     <% else %>
-
-      <% tabs = [
-        {name: BlogPost::ALL_RESOURCES, url: 'teacher-center'},
-        {name: BlogPost::GETTING_STARTED, url: 'teacher-center/topic/getting-started'},
-        {name: BlogPost::TEACHER_STORIES, url: 'teacher-center/topic/teacher-stories'},
-        {name: BlogPost::WRITING_INSTRUCTION_RESEARCH, url: 'teacher-center/topic/writing-instruction-research'},
-        {name: @faq, url: 'faq'},
-        {name: 'Premium', url: 'premium'},
-      ]
-        @tabs = tabs
-        @mobile = false
-      %>
-
       <div class="full-screen">
-        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab: @active_tab, mobile: @mobile } %>
+        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: teacher_center_tabs(large: true), active_tab: active_tab} %>
       </div>
-
-      <% tabs = [
-        {name: @all, url: 'teacher-center'},
-        {name: BlogPost::GETTING_STARTED, url: 'teacher-center/topic/getting-started'},
-        {name: BlogPost::TEACHER_STORIES, url: 'teacher-center/topic/teacher-stories'},
-        {name: @research, url: 'teacher-center/topic/writing-instruction-research'},
-        {name: @faq, url: 'faq'},
-        {name: @premium, url: 'premium'},
-      ]
-      @tabs = tabs
-      if @active_tab == BlogPost::ALL_RESOURCES
-        @active_tab = @all
-      elsif @active_tab == BlogPost::WRITING_INSTRUCTION_RESEARCH
-        @active_tab = @research
-      end
-      %>
       <div class="small-screen">
-        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab:  @active_tab, mobile: @mobile} %>
+        <%= render partial: "pages/shared/generic_tabs", locals: { tabs: teacher_center_tabs(large: false), active_tab:  active_tab} %>
       </div>
     <% end%>
-
   </div>
 </div>

--- a/services/QuillLMS/app/views/pages/shared/_teacher_center_navbar.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_teacher_center_navbar.html.erb
@@ -1,6 +1,4 @@
-<%-# locals: active_tab %>
-<%-# TODO - this feels like a bug, but everything is labeled mobile = false %>
-<% @mobile = false %>
+<%-# required local vars: active_tab %>
 
 <div class="subnav teacher-center-navbar">
   <div class="container">

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -86,8 +86,24 @@ describe BlogPostsController, type: :controller do
     let(:blog_posts) { create_list(:blog_post, 3, topic: topic) }
     let(:draft_post) { create(:blog_post, :draft, topic: topic) }
 
-    it 'should return a 404 if topic slug is not found' do
-      expect { get :show_topic, topic: 'does-not-exist' }.to raise_error ActionController::RoutingError
+    it 'should redirect a legacy_url' do
+      get :show_topic, topic: 'param_with_underscores'
+
+      expect(response).to redirect_to '/teacher-center/topic/param-with-underscores'
+    end
+
+    it 'should redirect to teacher_center if topic slug is not found' do
+      get :show_topic, topic: 'does-not-exist'
+
+      expect(response).to redirect_to '/teacher-center'
+    end
+
+    it 'should redirect students to student_center if topic slug is not found' do
+      allow(controller).to receive(:current_user) { create(:student) }
+
+      get :show_topic, topic: 'does-not-exist'
+
+      expect(response).to redirect_to '/student-center'
     end
 
     it 'should never return a draft' do

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -47,7 +47,7 @@ describe BlogPostsController, type: :controller do
     it 'should redirect to blog post even if there are extra chars' do
       get :show, slug: blog_post.slug + ')()('
 
-      expect(response).to redirect_to blog_post
+      expect(response).to redirect_to "/teacher-center/#{blog_post.slug}"
     end
 
     it 'should increment the blog post read count' do

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -32,13 +32,22 @@ describe BlogPostsController, type: :controller do
     let(:blog_post) { create(:blog_post) }
     let(:three_most_recent_posts) { create_list(:blog_post, 3) }
 
-    it 'should return a 404 if no such post found' do
-      expect { get :show, slug: 'does-not-exist' }.to raise_error ActiveRecord::RecordNotFound
+    it 'should redirect to teacher center home if no such post found' do
+      get :show, slug: 'does-not-exist'
+
+      expect(response).to redirect_to blog_posts_path
+      expect(flash[:error]).to include("Oops! We can't seem to find that blog post.")
     end
 
     it 'should return the called blog post' do
       get :show, slug: blog_post.slug
       expect(assigns(:blog_post)).to eq(blog_post)
+    end
+
+    it 'should redirect to blog post even if there are extra chars' do
+      get :show, slug: blog_post.slug + ')()('
+
+      expect(response).to redirect_to blog_post
     end
 
     it 'should increment the blog post read count' do


### PR DESCRIPTION
## WHAT
We get a good amount of errors that originate from bad links to our blog posts or areas within the Teacher/Student Centers.
This PR attempts to eliminate those errors and give the users a better experience by:
1. Auto-correcting  links that have extra characters (e.g. ending parentheses or punctuation from bad markdown, `/blog-slug)`, `/blog-slug.`,`/blog-slug)!`)
2. For uncorrectable urls, redirect to the homepage of `Teacher Center` or `Student Center` rather than a generic error page.
## WHY
1. To eliminate error reports. 
2. To give users with a slightly-off link a better chance of finding what they are looking for. Landing on a generic error page with no direction where to go isn't a great experience. On the Teacher Center, they can browse and search for what they were looking for.
## HOW
I was trying to be as light touch as possible, but I ended up refactoring a bunch of the view and controller (there's honestly more to refactor, but I accomplished my goal, and decided to step away - I debated separating the student and teacher logic into separate controllers, since there is still some weirdness on these pages).


### Notion Card Links
[Sample error in NR](https://one.newrelic.com/launcher/nr1-core.explorer?platform[timeRange][duration]=86400000&pane=eyJwYWdlIjoic2hvdyIsInRyYWNlSWQiOiIyNjExMjdhMi1kZTliLTExZWItODk3NS0wMjQyYWMxMTAwMDlfMF82NjgyIiwibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3IiwiZW50aXR5R3VpZCI6Ik1qWXpPVEV4TTN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRRNE9EVTJPRGMxIn0=&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1qWXpPVEV4TTN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRRNE9EVTJPRGMxIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ==&state=f180344b-1b37-0580-2d72-debbbb619f55)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
