### PR TITLE
remove save and exit button when user is a turker

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/Header.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/Header.tsx
@@ -47,12 +47,13 @@ export class Header extends React.Component<any, any> {
   }
 
   render() {
+    const isNotTurk = !window.location.href.includes('turk')
     return (
       <div className="header">
         <div>
           <img alt="Quill.org logo" className="hide-on-desktop" src={mobileLogoSrc} />
           <img alt="Quill.org logo" className="hide-on-mobile" src={logoSrc} />
-          <button className="save-and-exit" onClick={this.handleOnClick} type="button"><span>Save and exit</span></button>
+          {isNotTurk && <button className="save-and-exit" onClick={this.handleOnClick} type="button"><span>Save and exit</span></button>}
         </div>
       </div>
     );


### PR DESCRIPTION
## WHAT
Remove the Save and Exit button in Comprehension when the user is a turker.

## WHY
Because there is no way for turkers to resume a session, leading to confusion for them.

## HOW
Just add a conditional.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/For-Comprehension-activities-remove-Save-and-exit-button-from-Mechanical-Turk-HITs-7f87ee7477694cc1aad0d06c2455916e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
