### PR TITLE
Comprehension internal tools/ show full feedback and remove tooltip hover

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/promptTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/promptTable.test.tsx.snap
@@ -102,7 +102,9 @@ exports[`PromptTable component should render PromptTable 1`] = `
             : null
           </ForwardRef>,
           "id": "undefined:0:feedback",
-          "results": undefined,
+          "results": <p
+            className="word-wrap"
+          />,
           "status": "1st Feedback",
         },
       ]

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/promptTable.tsx
@@ -68,9 +68,11 @@ const PromptTable = ({ activity, rules, prompt, showHeader, sessionId }: PromptT
     const { id, most_recent_rating } = attempt;
     return(
       <div className="strength-buttons">
+        {/* eslint-disable-next-line react/jsx-no-bind */}
         <button className={most_recent_rating ? 'strength-button strong' : 'strength-button'} onClick={() => toggleStrength(attempt)} type="button">
           {loadingType === `${STRONG}-${id}` ? <ButtonLoadingSpinner /> : STRONG}
         </button>
+        {/* eslint-disable-next-line react/jsx-no-bind */}
         <button className={most_recent_rating === false ? 'strength-button weak' : 'strength-button'} onClick={() => toggleWeakness(attempt)} type="button">
           {loadingType === `${WEAK}-${id}` ? <ButtonLoadingSpinner /> : WEAK}
         </button>
@@ -114,7 +116,7 @@ const PromptTable = ({ activity, rules, prompt, showHeader, sessionId }: PromptT
       const feedbackObject: any = {
         id: `${rule_uid}:${i}:feedback`,
         status: feedbackLabel,
-        results: stripHtml(feedback_text),
+        results: <p className="word-wrap">{stripHtml(feedback_text)}</p>,
         feedback: feedbackLink,
         buttons: getStrongWeakButtons(attempt),
         className: optimal ? 'optimal' : 'sub-optimal'

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/rulesAnalysis/ruleAnalysis.tsx
@@ -225,15 +225,8 @@ const RuleAnalysis = ({ match }) => {
     if (!activityData || !responsesData) { return [] }
     return responsesData.filter(filterResponsesByScored).filter(filterResponsesBySearch).map(r => {
       const formattedResponse = {...r,  ...{highlight: extractHighlight(r.highlight)}}
-      const highlightedEntry = r.entry.replace(formattedResponse.highlight, `<strong>${formattedResponse.highlight}</strong>`)
       const strongButton = <button className={r.strength === true ? 'strength-button strong' : 'strength-button'} onClick={() => toggleStrength(r)} tabIndex={-1} type="button">Strong</button> // curriculum developers want to be able to skip these when tab navigating
       const weakButton = <button className={r.strength === false ? 'strength-button weak' : 'strength-button'} onClick={() => toggleWeakness(r)} tabIndex={-1} type="button">Weak</button> // curriculum developers want to be able to skip these when tab navigating
-
-      const tooltip = (<Tooltip
-        key={r.entry}
-        tooltipText={`<div><b>Feedback:</b><p>${ruleData.rule.feedbacks[0].text}</p><br /><b>Notes:</b><p>${ruleData.rule.note}</p></div>`}
-        tooltipTriggerText={<span dangerouslySetInnerHTML={{ __html: highlightedEntry }} key={r.entry} />}
-      />)
 
       if (selectedIds.includes(r.response_id)) {
         formattedResponse.selected = (<button className="quill-checkbox selected" onClick={() => unselectRow(r.response_id)} type="button">
@@ -243,7 +236,7 @@ const RuleAnalysis = ({ match }) => {
         formattedResponse.selected = <button aria-label="Unchecked checkbox" className="quill-checkbox unselected" onClick={() => selectRow(r.response_id)} type="button" />
       }
 
-      formattedResponse.response = tooltip
+      formattedResponse.response = r.entry
       formattedResponse.datetime = moment(r.datetime).format('MM/DD/YYYY')
       formattedResponse.strengthButtons = (<div className="strength-buttons">{strongButton}{weakButton}</div>)
       formattedResponse.viewSessionLink = <Link className="data-link" rel="noopener noreferrer" target="_blank" to={`/activities/${activityId}/activity-sessions/${r.session_uid}/overview`}>View Session</Link>


### PR DESCRIPTION
## WHAT
show full feedback on the individual activity session page and remove the tooltip hover for the rules analysis page

## WHY
both items were requested by Curriculum for better workflow

## HOW
just add a word wrap css property for the first and remove the tooltip for the second/

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1381" alt="Screen Shot 2021-07-08 at 3 49 37 PM" src="https://user-images.githubusercontent.com/25959584/124988852-20d12300-e004-11eb-8af1-51d25229ed82.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Show-the-full-feedback-on-the-Feedback-Sessions-Individual-pages-2387675d1142401f8038db14cb1a2ff2
https://www.notion.so/quill/Remove-the-hover-on-Rules-Analysis-pages-a4febee0b8d740cf9bf7f97b878852b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
