### PR TITLE
rename column on app settings

### DIFF
--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  enabled             :boolean          default(FALSE), not null
-#  enabled_for_admins  :boolean          default(FALSE), not null
+#  enabled_for_staff  :boolean          default(FALSE), not null
 #  name                :string           not null
 #  percent_active      :integer          default(0), not null
 #  user_ids_allow_list :integer          default([]), not null, is an Array
@@ -18,9 +18,9 @@
 require 'zlib'
 
 class AppSetting < ActiveRecord::Base
-  validates :percent_active, numericality: { 
-    only_integer: true, 
-    greater_than_or_equal_to: 0, 
+  validates :percent_active, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0,
     less_than_or_equal_to: 100
   }
 
@@ -36,8 +36,8 @@ class AppSetting < ActiveRecord::Base
 
   def self.all_enabled_for_user(user)
     app_settings = AppSetting.enabled
-    app_settings.each_with_object({}) do |app_setting, memo| 
-      memo[app_setting.name] = app_setting.enabled_for_user?(user) 
+    app_settings.each_with_object({}) do |app_setting, memo|
+      memo[app_setting.name] = app_setting.enabled_for_user?(user)
       memo
     end
   end
@@ -45,16 +45,16 @@ class AppSetting < ActiveRecord::Base
   def enabled_for_user?(user)
     return false unless enabled
 
-    return true if enabled_for_admins && user.admin?
+    return true if enabled_for_staff && user.staff?
 
     return true if user_in_rollout_bucket?(user.id)
-    
+
     return true if user_ids_allow_list.include?(user.id)
 
     false
   end
 
-  def user_in_rollout_bucket?(user_id) 
+  def user_in_rollout_bucket?(user_id)
     Zlib.crc32(name + user_id.to_s).digits.take(2).join.to_i < percent_active
   end
 

--- a/services/QuillLMS/db/migrate/20210709155935_rename_enabled_for_admins_to_enabled_for_staff_on_app_settings.rb
+++ b/services/QuillLMS/db/migrate/20210709155935_rename_enabled_for_admins_to_enabled_for_staff_on_app_settings.rb
@@ -1,0 +1,5 @@
+class RenameEnabledForAdminsToEnabledForStaffOnAppSettings < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :app_settings, :enabled_for_admins, :enabled_for_staff
+  end
+end

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -1,11 +1,11 @@
 namespace :app_settings do
   desc 'Creates a new AppSetting.'
   # Example usage: rake 'app_settings:create[theName,true,true,50,[]]'
-  task :create, [:name, :enabled, :enabled_for_admins, :percent_active, :user_ids_allow_list] => :environment do |t, args|
+  task :create, [:name, :enabled, :enabled_for_staff, :percent_active, :user_ids_allow_list] => :environment do |t, args|
     app_setting = AppSetting.create!(
       name: args[:name],
       enabled: args[:enabled],
-      enabled_for_admins: args[:enabled_for_admins],
+      enabled_for_staff: args[:enabled_for_staff],
       percent_active: args[:percent_active],
       user_ids_allow_list: args[:user_ids_allow_list]
     )

--- a/services/QuillLMS/spec/factories/app_setting.rb
+++ b/services/QuillLMS/spec/factories/app_setting.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  enabled             :boolean          default(FALSE), not null
-#  enabled_for_admins  :boolean          default(FALSE), not null
+#  enabled_for_staff   :boolean          default(FALSE), not null
 #  name                :string           not null
 #  percent_active      :integer          default(0), not null
 #  user_ids_allow_list :string           default([]), not null, is an Array

--- a/services/QuillLMS/spec/models/app_setting_spec.rb
+++ b/services/QuillLMS/spec/models/app_setting_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  enabled             :boolean          default(FALSE), not null
-#  enabled_for_admins  :boolean          default(FALSE), not null
+#  enabled_for_staff  :boolean          default(FALSE), not null
 #  name                :string           not null
 #  percent_active      :integer          default(0), not null
 #  user_ids_allow_list :integer          default([]), not null, is an Array
@@ -20,26 +20,26 @@ require 'rails_helper'
 RSpec.describe AppSetting, type: :model do
   let(:user) { create(:user) }
 
-  describe '#enabled?' do 
-    let!(:app_setting) do 
-      create(:app_setting, name: 'egosum', enabled: true, percent_active: 100) 
+  describe '#enabled?' do
+    let!(:app_setting) do
+      create(:app_setting, name: 'egosum', enabled: true, percent_active: 100)
     end
 
     context 'AppSetting does not exist' do
-      it 'should return false' do 
+      it 'should return false' do
         expect(AppSetting.enabled?(name: 'nemo', user: user)).to be false
       end
     end
 
-    context 'User and AppSetting exist' do 
-      it 'should invoke enabled_for_user?' do 
+    context 'User and AppSetting exist' do
+      it 'should invoke enabled_for_user?' do
         expect(AppSetting.enabled?(name: 'egosum', user: user)).to be true
       end
     end
   end
 
-  describe '#all_enabled_for_user' do 
-    it 'should return values for globally all enabled app settings' do 
+  describe '#all_enabled_for_user' do
+    it 'should return values for globally all enabled app settings' do
       create(:app_setting, name: 'enabled1', enabled: true, percent_active: 100)
       create(:app_setting, name: 'enabled2', enabled: true, percent_active: 100)
       create(:app_setting)
@@ -54,43 +54,43 @@ RSpec.describe AppSetting, type: :model do
     end
   end
 
-  describe '#enabled_for_user?' do 
-    context 'override is false' do 
+  describe '#enabled_for_user?' do
+    context 'override is false' do
       let(:app_setting_1) { create(:app_setting, percent_active: 100, enabled: false) }
 
-      it 'should return false' do 
+      it 'should return false' do
         expect(app_setting_1.enabled_for_user?(user)).to be false
-      end      
+      end
 
     end
 
-    context 'override is true, admin is true' do 
-      let(:app_setting_1) { create(:app_setting, percent_active: 0, enabled: true, enabled_for_admins: true) }
+    context 'override is true, staff is true' do
+      let(:app_setting_1) { create(:app_setting, percent_active: 0, enabled: true, enabled_for_staff: true) }
 
-      it 'should return true when user is admin' do 
-        allow_any_instance_of(User).to receive(:admin?) { true }
+      it 'should return true when user is staff' do
+        allow_any_instance_of(User).to receive(:staff?) { true }
         expect(app_setting_1.enabled_for_user?(user)).to be true
       end
-    
-      it 'should return true for non-admin user when user is in whitelist' do 
-        allow_any_instance_of(User).to receive(:admin?) { false } 
-        app_setting_1.user_ids_allow_list = [user.id]
-        
-        expect(app_setting_1.enabled_for_user?(user)).to be true
-      end    
 
-      it 'should return false when user does not meet enabled criteria' do 
+      it 'should return true for non-staff user when user is in whitelist' do
+        allow_any_instance_of(User).to receive(:staff?) { false }
+        app_setting_1.user_ids_allow_list = [user.id]
+
+        expect(app_setting_1.enabled_for_user?(user)).to be true
+      end
+
+      it 'should return false when user does not meet enabled criteria' do
         expect(app_setting_1.enabled_for_user?(user)).to be false
       end
     end
 
   end
 
-  describe '#user_in_rollout_bucket?' do 
+  describe '#user_in_rollout_bucket?' do
     let(:one_to_a_hundred) { (1..100).to_a }
 
-    context 'statistical sanity test for hashing algorithm' do 
-      it 'when percent_active is 50, users should be evenishly distributed' do 
+    context 'statistical sanity test for hashing algorithm' do
+      it 'when percent_active is 50, users should be evenishly distributed' do
         app_setting = create(:app_setting, name: 'lorem1', enabled: true, percent_active: 50)
         result = one_to_a_hundred.count {|r| app_setting.user_in_rollout_bucket?(r) }
         expect(result).to eq 49


### PR DESCRIPTION
## WHAT
Change `enabled_for_admins` to `enabled_for_staff` in both name and function.

## WHY
When I started working on implementing the frontend feature that utilizes this code, I realized that `enabled_for_admins` was probably meant to turn on features for Quill admins (ie, staff members), not district admins. I checked with @dandrabik and he confirmed that this was correct, so I updated both the functionality and the naming to hopefully be clearer.

## HOW
Add a migration to change the name, change everywhere we reference that column, and change the logic to check for staff members and not admins.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Change-enabled_for_admins-to-enabled_for_staff-on-App-Settings-c66650b28e6d456e88d1ec4b9f46f7b1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
