### PR TITLE
add order migration for classrooms_teachers table

### DIFF
--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -3,6 +3,7 @@
 # Table name: classrooms_teachers
 #
 #  id           :integer          not null, primary key
+#  order        :integer
 #  role         :string           not null
 #  created_at   :datetime
 #  updated_at   :datetime

--- a/services/QuillLMS/db/migrate/20210709161400_add_order_to_classrooms_teachers.rb
+++ b/services/QuillLMS/db/migrate/20210709161400_add_order_to_classrooms_teachers.rb
@@ -1,0 +1,5 @@
+class AddOrderToClassroomsTeachers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :classrooms_teachers, :order, :integer, null: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.15
--- Dumped by pg_dump version 10.15
+-- Dumped from database version 10.16
+-- Dumped by pg_dump version 10.16
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -74,18 +74,6 @@ CREATE FUNCTION public.blog_posts_search_trigger() RETURNS trigger
         return new;
       end
       $$;
-
-
---
--- Name: my_jsonb_to_hstore(jsonb); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.my_jsonb_to_hstore(jsonb) RETURNS public.hstore
-    LANGUAGE sql IMMUTABLE STRICT
-    AS $_$
-            SELECT hstore(array_agg(key), array_agg(value))
-            FROM   jsonb_each_text($1)
-          $_$;
 
 
 --
@@ -1184,6 +1172,7 @@ CREATE TABLE public.classrooms_teachers (
     role character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
+    "order" integer,
     CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
 );
 
@@ -1569,9 +1558,10 @@ CREATE TABLE public.comprehension_rules (
     rule_type character varying NOT NULL,
     optimal boolean NOT NULL,
     suborder integer,
-    concept_uid character varying,
+    concept_uid character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
+    sequence_type character varying,
     state character varying NOT NULL
 );
 
@@ -7317,6 +7307,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210525200201'),
 ('20210528142650'),
 ('20210614190031'),
-('20210614205654');
+('20210614205654'),
+('20210709161400');
 
 

--- a/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
+++ b/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
@@ -3,6 +3,7 @@
 # Table name: classrooms_teachers
 #
 #  id           :integer          not null, primary key
+#  order        :integer
 #  role         :string           not null
 #  created_at   :datetime
 #  updated_at   :datetime


### PR DESCRIPTION
## WHAT
add order column to classrooms_teachers table

## WHY
we need it to make teachers' classrooms sortable

## HOW
just add the migration file

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Allow-teachers-to-re-arrange-classes-642d0f6b976d486db6df1aaa34d89ee6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
