### PR TITLE
security/ fix TeacherSavedActivitiesController sentry error

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_saved_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_saved_activities_controller.rb
@@ -1,17 +1,17 @@
 class TeacherSavedActivitiesController < ApplicationController
 
   def saved_activity_ids_for_current_user
-    activity_ids = TeacherSavedActivity.where(teacher_id: current_user.id).map(&:activity_id)
+    activity_ids = TeacherSavedActivity.where(teacher_id: current_user&.id).map(&:activity_id)
     render json: { activity_ids: activity_ids }
   end
 
   def create_by_activity_id_for_current_user
-    saved_activity = TeacherSavedActivity.create(activity_id: params[:activity_id], teacher_id: current_user.id)
+    saved_activity = TeacherSavedActivity.create(activity_id: params[:activity_id], teacher_id: current_user&.id)
     render json: saved_activity.to_json, status: 200
   end
 
   def destroy_by_activity_id_for_current_user
-    TeacherSavedActivity.find_by(activity_id: params[:activity_id], teacher_id: current_user.id)&.destroy
+    TeacherSavedActivity.find_by(activity_id: params[:activity_id], teacher_id: current_user&.id)&.destroy
     render json: {}, status: 200
   end
 

--- a/services/QuillLMS/spec/controllers/teacher_saved_activities_controller.rb
+++ b/services/QuillLMS/spec/controllers/teacher_saved_activities_controller.rb
@@ -17,6 +17,11 @@ describe TeacherSavedActivitiesController do
       expect(response.body).to eq({ activity_ids: [activity1.id, activity2.id]}.to_json)
       expect(response.status).to be(200)
     end
+    it 'should not error if the current_user is nil' do
+      get :saved_activity_ids_for_current_user, current_user: nil
+      expect(response.body).to eq({ activity_ids: []}.to_json)
+      expect(response.status).to be(200)
+    end
   end
 
   describe '#create_by_activity_id_for_current_user' do


### PR DESCRIPTION
## WHAT
fix sentry error for `TeacherSavedActivitiesController#saved_activity_ids_for_current_user - NoMethodError`

## WHY
we don't want our users to be seeing this error

## HOW
add nil check for `current_user`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Sentry-Error-TeacherSavedActivitiesController-saved_activity_ids_for_current_user-NoMethodError-31e476f1a37d455e8a860eaed52addb6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
