### PR TITLE
bug-fix/ fix styling for Diagnostic tooltip

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
@@ -71,6 +71,13 @@
     .data-table {
       .data-table-row {
         height: 72px;
+        .quill-tooltip-trigger {
+          .quill-tooltip-wrapper {
+            .quill-tooltip {
+              max-width: 254px;
+            }
+          }
+        }
       }
       .recommendations-row-section, .recommendations-header {
         margin-right: 0px;


### PR DESCRIPTION
## WHAT
fix tooltip styling in Diagnostic Reports

## WHY
we don't want to have a lot of extra space on the side

## HOW
just added a `max-width` property for that section

### Screenshots
(If applicable. Also, please censor any sensitive data)
![Screen Shot 2021-07-12 at 4 59 59 PM](https://user-images.githubusercontent.com/25959584/125361195-9c97dc00-e332-11eb-9cd3-4a04ca179f31.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fix-spacing-issue-for-tooltips-in-the-Overview-and-Diagnostic-top-level-page-47ffcebfbc2e4a18aaa137a6deec468d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- small CSS change
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
