### PR TITLE
Comprehension/close go channel

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -134,6 +134,7 @@ func Endpoint(context *gin.Context) {
 			break
 		}
 	}
+	close(channel)
 
 	// TODO make this a purely async task instead of coroutine that waits to finish
 	wg.Add(1)


### PR DESCRIPTION
## WHAT
Try explicitly closing the Go `channel` object when we finish with it so that goroutines get freed up
## WHY
We think that failing to explicitly close the channel may be contributing to the non-terminating goroutines that are causing the production system to crash out
## HOW
We're explicitly closing the channel object, and modifying the code that sends messages to the channel to make sure it's not closed before we send (since sending things to closed channels crashes the code).

### Notion Card Links
https://www.notion.so/quill/Stop-the-Comprehension-Go-Endpoint-in-Heroku-from-running-so-many-Goroutines-and-runs-out-of-memory-b5bb5d3a07614e27ad488929f88edbb3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes here
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
