### PR TITLE
LMS Rails 5.1 Prework - Fix deprecation involving positional params in controller specs

### DIFF
--- a/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
@@ -16,7 +16,7 @@ describe AccountsController, type: :controller do
     end
 
     it 'should kick off the background job, set the session values and variables' do
-      get :new, redirect: "www.test.com"
+      get :new, params: { redirect: "www.test.com" }
       expect(session[:role]).to eq 'something'
       expect(session[:post_sign_up_redirect]).to eq "www.test.com"
       expect(assigns(:teacher_from_google_signup)).to eq false
@@ -27,17 +27,17 @@ describe AccountsController, type: :controller do
   describe '#role' do
     context 'when role is student or teacher' do
       it 'should set the js_file and role in session' do
-        post :role, role: "student"
+        post :role, params: { role: "student" }
         expect(session[:role]).to eq "student"
 
-        post :role, role: "teacher"
+        post :role, params: { role: "teacher" }
         expect(session[:role]).to eq "teacher"
       end
     end
 
     context 'when role is not student or teacher' do
       it 'should set the js file but not the role in session' do
-        post :role, role: "not student or teacher"
+        post :role, params: { role: "not student or teacher" }
         expect(session[:role]).to eq nil
       end
     end
@@ -60,12 +60,12 @@ describe AccountsController, type: :controller do
 
         it 'should kick off the account creation callback' do
           expect(callbacks).to receive(:call)
-          post :create, user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" }
+          post :create, params: { user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" } }
         end
 
         it 'should subscribe the user to the newsletter' do
           expect_any_instance_of(User).to receive(:subscribe_to_newsletter)
-          post :create, user: { classcode: "code", email: "test@test.com", password: "test123", role: "teacher", send_newsletter: true }
+          post :create, params: { user: { classcode: "code", email: "test@test.com", password: "test123", role: "teacher", send_newsletter: true } }
         end
 
         context 'when user is a teacher and affliate tag present' do
@@ -78,7 +78,7 @@ describe AccountsController, type: :controller do
             end
 
             it 'should create the referralsuser' do
-              post :create, user: { email: "test@test.com", password: "test123", role: "teacher" }
+              post :create, params: { user: { email: "test@test.com", password: "test123", role: "teacher" } }
               new_user = User.find_by_email("test@test.com")
               expect(ReferralsUser.find_by_user_id(user.id).present?).to eq true
               expect(ReferralsUser.find_by_referred_user_id(new_user.id).present?).to eq true
@@ -92,7 +92,7 @@ describe AccountsController, type: :controller do
           end
 
           it 'should render the json' do
-            post :create, user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" }
+            post :create, params: { user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" } }
             expect(response.body).to eq({
               redirect: "www.test.com"
             }.to_json)
@@ -107,7 +107,7 @@ describe AccountsController, type: :controller do
             end
 
             it 'should render the teachers classroom path json' do
-              post :create, user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" }
+              post :create, params: { user: { classcode: "code", email: "test@test.com", password: "test123", role: "student" } }
               expect(response.body).to eq({redirect: teachers_classrooms_path}.to_json)
             end
           end
@@ -117,7 +117,7 @@ describe AccountsController, type: :controller do
 
       context 'when user is not saved' do
         it 'should render the errors json' do
-          post :create, user: { classcode: "code", email: "test", role: "user" }
+          post :create, params: { user: { classcode: "code", email: "test", role: "user" } }
           expect(response.status).to eq 422
           expect(response.body).to eq({errors: {email: ["Enter a valid email"]}}.to_json)
         end
@@ -128,14 +128,14 @@ describe AccountsController, type: :controller do
   describe '#update' do
     context 'user got updated' do
       it 'should redirect to updated_account_path' do
-        post :update, user: { email: "new@email.com" }
+        post :update, params: { user: { email: "new@email.com" } }
         expect(response).to redirect_to root_path
       end
     end
 
     context 'user did not get updated' do
       it 'should render accounts edit' do
-        post :update, user: { email: "new" }
+        post :update, params: { user: { email: "new" } }
         expect(response).to render_template "accounts/edit"
       end
     end

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -29,7 +29,7 @@ describe ActivitiesController, type: :controller, redis: true do
         let!(:milestone) { create(:milestone, name: "View Lessons Tutorial", users: [student]) }
 
         it 'should redirect to the preview url' do
-          get :preview_lesson, lesson_id: activity.id
+          get :preview_lesson, params: { lesson_id: activity.id }
           expect(response).to redirect_to preview_url
         end
       end
@@ -38,7 +38,7 @@ describe ActivitiesController, type: :controller, redis: true do
         let!(:milestone) { create(:milestone, name: "View Lessons Tutorial", users: []) }
 
         it 'should redirect to the tutorials/lessons/preview url' do
-          get :preview_lesson, lesson_id: activity.id
+          get :preview_lesson, params: { lesson_id: activity.id }
           expect(response).to redirect_to tutorial_lesson_preview_url
         end
       end
@@ -51,7 +51,7 @@ describe ActivitiesController, type: :controller, redis: true do
       end
 
       it 'should redirect to preview url' do
-        get :preview_lesson, lesson_id: activity.id
+        get :preview_lesson, params: { lesson_id: activity.id }
         expect(response).to redirect_to preview_url
       end
     end
@@ -61,7 +61,7 @@ describe ActivitiesController, type: :controller, redis: true do
     let!(:activity) { create(:activity) }
 
     it 'should redirect to the correct url' do
-      get :customize_lesson, id: activity.id
+      get :customize_lesson, params: { id: activity.id }
       expect(response).to redirect_to "#{activity.classification_form_url}customize/#{activity.uid}"
     end
   end

--- a/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
@@ -27,26 +27,26 @@ describe ActivitySessionsController, type: :controller do
         allow_any_instance_of(Activity).to receive(:activity_classification_id) { 3 }
       end
       it 'should redirect to module url' do
-        get :play, id: activity_session.id
+        get :play, params: { id: activity_session.id }
         expect(response).to redirect_to activity.module_url(activity_session)
       end
   end
 
   describe '#result' do
     it 'should set the activity results classroom_id' do
-      get :result, uid: activity_session.uid
+      get :result, params: { uid: activity_session.uid }
       expect(assigns(:activity)).to eq activity_session
       expect(assigns(:results)).to eq activity_session.parse_for_results
       expect(assigns(:classroom_id)).to eq activity_session.classroom_unit.classroom_id
     end
 
     it 'should allow iFrames for this endpoint' do
-      get :result, uid: activity_session.uid
+      get :result, params: { uid: activity_session.uid }
       expect(response.headers).not_to include('X-Frame-Options')
     end
 
     it 'shouldnt error unfound sessions' do
-      get :result, uid: 923123213123123123
+      get :result, params: { uid: 923123213123123123 }
 
       expect(response.code).to eq("404")
     end
@@ -59,12 +59,12 @@ describe ActivitySessionsController, type: :controller do
       end
 
       it 'should assign the activity' do
-        get :anonymous, activity_id: activity.id
+        get :anonymous, params: { activity_id: activity.id }
         expect(assigns(:activity)).to eq activity
       end
 
       it 'should redirect to preview lesson url' do
-        get :anonymous, activity_id: activity.id
+        get :anonymous, params: { activity_id: activity.id }
         expect(response).to redirect_to "#{ENV['DEFAULT_URL']}/preview_lesson/#{activity.uid}"
       end
     end
@@ -75,7 +75,7 @@ describe ActivitySessionsController, type: :controller do
       end
 
       it 'should redirect to anonymous module url' do
-        get :anonymous, activity_id: activity.id
+        get :anonymous, params: { activity_id: activity.id }
         expect(response).to redirect_to activity.anonymous_module_url.to_s
       end
     end
@@ -91,7 +91,7 @@ describe ActivitySessionsController, type: :controller do
     end
 
     it 'should redirect to the correct activity session url' do
-      get :activity_session_from_classroom_unit_and_activity, classroom_unit_id: cu.id, activity_id: activity.id
+      get :activity_session_from_classroom_unit_and_activity, params: { classroom_unit_id: cu.id, activity_id: activity.id }
       expect(response).to redirect_to activity_session_url
     end
   end

--- a/services/QuillLMS/spec/controllers/admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admins_controller_spec.rb
@@ -20,28 +20,28 @@ describe AdminsController  do
     end
 
     it 'should render the correct json' do
-      get :show, id: teacher.id
+      get :show, params: { id: teacher.id }
       expect(response.body).to eq(({id: user.id}).to_json)
     end
   end
 
   describe '#sign_in_classroom_manager' do
     it 'should redirect to teachers classrooms path' do
-      get :sign_in_classroom_manager, id: teacher.id
+      get :sign_in_classroom_manager, params: { id: teacher.id }
       expect(response).to redirect_to teachers_classrooms_path
     end
   end
 
   describe '#sign_in_progress_reports' do
     it 'should redirect to progress reports standards classrooms path' do
-      get :sign_in_progress_reports, id: teacher.id
+      get :sign_in_progress_reports, params: { id: teacher.id }
       expect(response).to redirect_to teachers_progress_reports_standards_classrooms_path
     end
   end
 
   describe '#sign_in_accounts_path' do
     it 'should redirect to teaches my account path' do
-      get :sign_in_account_settings, id: teacher.id
+      get :sign_in_account_settings, params: { id: teacher.id }
       expect(response).to redirect_to teachers_my_account_path
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller.rb
@@ -6,12 +6,12 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
 
   describe "#show" do
     it "should return the specified active_activity_session" do
-      get :show, id: active_activity_session.uid
+      get :show, params: { id: active_activity_session.uid }
       expect(JSON.parse(response.body)).to eq(active_activity_session.data)
     end
 
     it "should return a 404 if the requested activity session is not found" do
-      get :show, id: 'doesnotexist'
+      get :show, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -20,14 +20,14 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, id: active_activity_session.uid, active_activity_session: data
+      put :update, params: { id: active_activity_session.uid, active_activity_session: data }
       active_activity_session.reload
       expect(active_activity_session.data).to eq(data)
     end
 
     it "should create a new session if the requested activity session is not found" do
       data = {"foo" => "bar"}
-      put :update, id: 'doesnotexist', active_activity_session: data
+      put :update, params: { id: 'doesnotexist', active_activity_session: data }
       expect(response.status).to eq(200)
       expect(response.body).to eq(data.to_json)
       new_activity_session = ActiveActivitySession.find_by(uid: 'doesnotexist')
@@ -38,7 +38,7 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
     it "should retain the values in keys not updated in the payload" do
       old_data = active_activity_session.data
       new_data = {"newkey" => "newvalue"}
-      put :update, id: active_activity_session.uid, active_activity_session: new_data
+      put :update, params: { id: active_activity_session.uid, active_activity_session: new_data }
       active_activity_session.reload
       expect(active_activity_session.data.keys).to eq(old_data.keys + new_data.keys)
     end
@@ -50,26 +50,26 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
         raise(ActiveRecord::RecordNotUnique, 'Error') if call_count == 1
         true
       end
-      put :update, id: active_activity_session.uid, active_activity_session: active_activity_session.data
+      put :update, params: { id: active_activity_session.uid, active_activity_session: active_activity_session.data }
     end
 
     it "should raise an ActiveRecord::RecordNotUnique error if that is raised both during save and on retry" do
       err = ActiveRecord::RecordNotUnique.new('Error')
       allow_any_instance_of(ActiveActivitySession).to receive(:save!).and_raise(err)
       expect do
-        put :update, id: active_activity_session.uid, active_activity_session: active_activity_session.data
+        put :update, params: { id: active_activity_session.uid, active_activity_session: active_activity_session.data }
       end.to raise_error(err)
     end
   end
 
   describe "#destroy" do
     it "should destroy the existing record" do
-      delete :destroy, id: active_activity_session.uid
+      delete :destroy, params: { id: active_activity_session.uid }
       expect(ActiveActivitySession.where(uid: active_activity_session.uid).count).to eq(0)
     end
 
     it "should return a 404 if the requested activity session is not found" do
-      delete :destroy, id: 'doesnotexist'
+      delete :destroy, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     before do
       @activity1 = create(:activity)
 
-      get :show, format: :json, id: @activity1.uid
+      get :show, params: { format: :json, id: @activity1.uid }
       @parsed_body = JSON.parse(response.body)
     end
 
@@ -19,7 +19,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     end
 
     it 'responds with 404 if activity does not exist' do
-      get :show, format: :json, id: 'doesnotexist'
+      get :show, params: { format: :json, id: 'doesnotexist' }
       expect(response.status).to eq(404)
     end
 
@@ -38,7 +38,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     let!(:activity) { create(:activity) }
 
     before do
-      put :update, format: :json, id: activity.uid, name: 'foobar'
+      put :update, params: { format: :json, id: activity.uid, name: 'foobar' }
       @parsed_body = JSON.parse(response.body)
     end
 
@@ -56,12 +56,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     let(:activity_classification) { create(:activity_classification) }
 
     subject do
-      post :create, {
-        name: 'foobar',
-        uid: 'abcdef123',
-        standard_uid: standard.uid,
-        activity_classification_uid: activity_classification.uid
-      }
+      post :create, params: { name: 'foobar', uid: 'abcdef123', standard_uid: standard.uid, activity_classification_uid: activity_classification.uid }
     end
 
     describe 'general API behavior' do
@@ -110,7 +105,7 @@ describe Api::V1::ActivitiesController, type: :controller do
         # So far the only way to create an invalid activity
         # is to give it a non-unique uid.
         another_activity = create(:activity)
-        post :create, foobar: 'whatever', uid: another_activity.uid
+        post :create, params: { foobar: 'whatever', uid: another_activity.uid }
         expect(response.status).to eq(422)
       end
     end
@@ -122,7 +117,7 @@ describe Api::V1::ActivitiesController, type: :controller do
 
     context 'when the destroy is successful' do
       it 'should return the success json' do
-        get :destroy, format: :json, id: activity.uid
+        get :destroy, params: { format: :json, id: activity.uid }
         expect(JSON.parse(response.body)["meta"]).to eq({"status" => 'success', "message" => "Activity Destroy Successful", "errors" => nil})
       end
     end
@@ -133,7 +128,7 @@ describe Api::V1::ActivitiesController, type: :controller do
       end
 
       it 'should return the failed json' do
-        get :destroy, format: :json, id: activity.uid
+        get :destroy, params: { format: :json, id: activity.uid }
         expect(JSON.parse(response.body)["meta"]).to eq({"status" => 'failed', "message" => "Activity Destroy Failed", "errors" => {}})
       end
     end
@@ -145,7 +140,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     let(:activity) { create(:activity, follow_up_activity: follow_up_activity) }
 
     it 'should render the correct json' do
-      get :follow_up_activity_name_and_supporting_info, id: activity.id, format: :json
+      get :follow_up_activity_name_and_supporting_info, params: { id: activity.id, format: :json }
       expect(response.body).to eq({
         follow_up_activity_name: activity.follow_up_activity.name,
         supporting_info: activity.supporting_info
@@ -157,7 +152,7 @@ describe Api::V1::ActivitiesController, type: :controller do
     let(:activity) { create(:activity) }
 
     it 'should render the correct json' do
-      get :supporting_info, id: activity.id, format: :json
+      get :supporting_info, params: { id: activity.id, format: :json }
       expect(response.body).to eq ({supporting_info: activity.supporting_info}.to_json)
     end
   end
@@ -276,13 +271,13 @@ describe Api::V1::ActivitiesController, type: :controller do
 
     it 'PUT #update returns 401 Unauthorized' do
       activity = create(:activity)
-      put :update, format: :json, id: activity.uid
+      put :update, params: { format: :json, id: activity.uid }
       expect(response.status).to eq(401)
     end
 
     it 'DELETE #destroy returns 401 Unauthorized' do
       activity = create(:activity)
-      delete :destroy, format: :json, id: activity.uid
+      delete :destroy, params: { format: :json, id: activity.uid }
       expect(response.status).to eq(401)
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -111,7 +111,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
             }
           }
         ]
-        put :update, id: activity_session.uid, concept_results: results
+        put :update, params: { id: activity_session.uid, concept_results: results }
       end
 
       # this is no longer the case, as results should not be saved with nonexistent concept tag
@@ -155,7 +155,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     let!(:session) { create(:activity_session) }
 
     it 'renders the correct json' do
-      get :show, id: session.uid
+      get :show, params: { id: session.uid }
       expect(JSON.parse(response.body)["meta"]).to eq({
           "status" => "success",
           "message" => nil,
@@ -181,14 +181,14 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     before { allow(controller).to receive(:doorkeeper_token) {token} }
 
     it 'returns a 422 error if activity session is already saved' do
-      put :update, id: activity_session.uid
+      put :update, params: { id: activity_session.uid }
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Already Completed")
     end
 
     it 'returns a 200 if the activity session is not already finished and can be updated' do
       activity_session.update(completed_at: nil, state: 'started')
-      put :update, id: activity_session.uid
+      put :update, params: { id: activity_session.uid }
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Updated")
     end
@@ -198,7 +198,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       activity_session = create(:activity_session, state: 'started', user: user)
       activity_session.stub(:update) { false }
 
-      put :update, id: activity_session.uid
+      put :update, params: { id: activity_session.uid }
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Already Completed")
     end
@@ -225,7 +225,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     let!(:session) { create(:proofreader_activity_session) }
 
     it 'destroys the activity session' do
-      delete :destroy, id: session.uid, format: :json
+      delete :destroy, params: { id: session.uid, format: :json }
       expect(JSON.parse(response.body)["meta"]).to eq({
         "status" => "success",
         "message" => "Activity Session Destroy Successful",

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
     it "returns a success response" do
       create(:app_setting, name: 'lorem', enabled: false)
       
-      get(:show, name: 'lorem') 
+      get(:show, params: { name: 'lorem' }) 
       
       expect(response).to be_success
       expect(JSON.parse(response.body)).to eq({ "lorem" => false })

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -25,42 +25,26 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   context '#student_names' do
     it 'does not authenticate a teacher who is not associated with the classroom activity' do
       session[:user_id] = other_teacher.id
-      get(:student_names,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(response.status).to be_in([303, 404])
     end
 
     it 'authenticates a teacher who is associated with the classroom activity classroom' do
       session[:user_id] = teacher.id
-      get(:student_names,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(response.status).not_to eq(303)
     end
 
     it 'returns JSON object with activity session name key values' do
       session[:user_id] = teacher.id
-      get(:student_names,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(JSON.parse(response.body)['activity_sessions_and_names'].keys.count)
         .to eq(5)
     end
 
     it 'returns JSON object with student id key values' do
       session[:user_id] = teacher.id
-      get(:student_names,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(JSON.parse(response.body)['student_ids'].keys.count).to eq(5)
     end
   end
@@ -68,28 +52,19 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   context '#teacher_and_classroom_name' do
     it 'does not authenticate a teacher who is not associated with the classroom activity' do
       session[:user_id] = other_teacher.id
-      get(:teacher_and_classroom_name,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(response.status).to be_in([303, 404])
     end
 
     it 'authenticates a teacher who is associated with the classroom activity classroom' do
       session[:user_id] = teacher.id
-      get(:teacher_and_classroom_name,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(response.status).not_to eq(303)
     end
 
     it 'returns JSON object with activity session name key values' do
       session[:user_id] = teacher.id
-      get(:teacher_and_classroom_name,
-        classroom_unit_id: classroom_unit.id,
-        format: 'json'
-      )
+      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
       expect(JSON.parse(response.body))
         .to eq({"teacher"=>teacher.name, "classroom"=>classroom.name})
     end
@@ -101,13 +76,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
 
     it 'does not authenticate a teacher who does not own the classroom activity' do
       session[:user_id] = other_teacher.id
-      put(:finish_lesson,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        concept_results: [],
-        follow_up: true,
-        format: 'json'
-      )
+      put(:finish_lesson, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, concept_results: [], follow_up: true, format: 'json' })
       expect(response.status).to be_in([303, 404])
     end
 
@@ -180,11 +149,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
     end
 
     it 'should unpin and lock the state of classroom unit activity' do
-      put(:unpin_and_lock_activity,
-        activity_id: activity.uid,
-        classroom_unit_id: classroom_unit.id,
-        format: :json
-      )
+      put(:unpin_and_lock_activity, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: :json })
 
       expect(classroom_unit_activity_state.reload).to have_attributes(
         pinned: false,
@@ -201,10 +166,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
     end
 
     it 'should return the teacher ids in the classroom' do
-      get(:classroom_teacher_and_coteacher_ids,
-        format: :json,
-        classroom_unit_id: classroom_unit.id
-      )
+      get(:classroom_teacher_and_coteacher_ids, params: { format: :json, classroom_unit_id: classroom_unit.id })
       expect(response.body).to eq({ teacher_ids: teacher_ids }.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/comprehension_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/comprehension_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Comprehension::ActivitiesController, :type => :controller do
   it "hits the correct engine endpoint and renders json" do
     activity = Comprehension::Activity.create(notes: "some notes", title: "some title", target_level: 5, parent_activity_id: 1)
 
-    get :show, id: activity.id
+    get :show, params: { id: activity.id }
     expect(response.status).to eq(200)
 
     parsed_response = JSON.parse(response.body)

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -6,24 +6,24 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
 
   describe "#index" do
     it "should return a list of ConceptFeedbacks" do
-      get :index, activity_type: concept_feedback.activity_type
+      get :index, params: { activity_type: concept_feedback.activity_type }
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should include the response from the db" do
-      get :index, activity_type: concept_feedback.activity_type
+      get :index, params: { activity_type: concept_feedback.activity_type }
       expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
     end
   end
 
   describe "#show" do
     it "should return the specified concept_feedback" do
-      get :show, activity_type: concept_feedback.activity_type, id: concept_feedback.uid
+      get :show, params: { activity_type: concept_feedback.activity_type, id: concept_feedback.uid }
       expect(JSON.parse(response.body)).to eq(concept_feedback.data)
     end
 
     it "should return a 404 if the requested ConceptFeedback is not found" do
-      get :show, activity_type: concept_feedback.activity_type, id: 'doesnotexist'
+      get :show, params: { activity_type: concept_feedback.activity_type, id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -35,7 +35,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       data = {foo: "bar"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = ConceptFeedback.count
-      post :create, activity_type: concept_feedback.activity_type, concept_feedback: data
+      post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: data }
       expect(ConceptFeedback.count).to eq(pre_create_count + 1)
     end
   end
@@ -43,7 +43,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, activity_type: concept_feedback.activity_type, id: concept_feedback.uid, concept_feedback: data
+      put :update, params: { activity_type: concept_feedback.activity_type, id: concept_feedback.uid, concept_feedback: data }
       concept_feedback.reload
       expect(concept_feedback.data).to eq(data)
     end
@@ -52,7 +52,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       data = {"foo" => "bar"}
       uid = SecureRandom.uuid
       expect(ConceptFeedback.find_by(uid: uid)).to be_nil
-      put :update, activity_type: concept_feedback.activity_type, id: uid, concept_feedback: data
+      put :update, params: { activity_type: concept_feedback.activity_type, id: uid, concept_feedback: data }
       expect(ConceptFeedback.find_by(uid: uid)).to be
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V1::ConceptsController, type: :controller do
     let!(:parent_concept) { create(:concept) }
 
     def subject
-      post :create, {concept: {name: concept_name, parent_uid: parent_concept.uid}}
+      post :create, params: { concept: {name: concept_name, parent_uid: parent_concept.uid} }
     end
 
     it_behaves_like 'protected endpoint'

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -35,10 +35,10 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
 
   context "create" do
     it "should create a valid record and return it as json" do
-      post :create, feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: {foo: 'bar'} }
+                                        feedback_type: 'autoML', metadata: {foo: 'bar'} } }
 
       parsed_response = JSON.parse(response.body)
 
@@ -57,10 +57,10 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
         ]
       } 
 
-      post :create, feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: metadata }
+                                        feedback_type: 'autoML', metadata: metadata } }
 
       parsed_response = JSON.parse(response.body)
       expect(parsed_response['metadata']['highlight'].first.keys).to eq metadata['highlight'].first.keys 
@@ -69,10 +69,10 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     it "should set prompt_type to Comprehension::Prompt if prompt_id is provided" do
       activity = Comprehension::Activity.create(target_level: 1, title: 'Test Activity Title')
       prompt = Comprehension::Prompt.create(activity: activity, text: 'Test prompt text', conjunction: 'but')
-      post :create, feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
                                         feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: {foo: 'bar'}, prompt_id: prompt.id }
+                                        feedback_type: 'autoML', metadata: {foo: 'bar'}, prompt_id: prompt.id } }
 
       parsed_response = JSON.parse(response.body)
 
@@ -82,7 +82,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should not create an invalid record and return errors as json" do
-      post :create, feedback_history: { entry: nil }
+      post :create, params: { feedback_history: { entry: nil } }
 
       parsed_response = JSON.parse(response.body)
 
@@ -94,28 +94,28 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
 
   context "batch" do
     it "should create valid records and return them as json" do
-      post :batch, feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+      post :batch, params: { feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
                                           feedback_type: 'autoML', metadata: {highlight: [], response_id: "0", rule_uid: ""} },
                                         { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }]
+                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }] }
 
       expect(201).to eq(response.code.to_i)
       expect(2).to eq(FeedbackHistory.count)
     end
 
     it "should not create valid records if one is invalid record but return errors as json" do
-      post :batch, feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
+      post :batch, params: { feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
                                           feedback_type: 'autoML', metadata: {foo: 'bar'} },
                                         { attempt: 1, optimal: false, used: true,
                                           time: DateTime.now, entry: 'This is the entry provided by the student',
                                           feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }]
+                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }] }
 
       parsed_response = JSON.parse(response.body)
 
@@ -133,7 +133,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should return json if found" do
-      get :show, id: @feedback_history.id
+      get :show, params: { id: @feedback_history.id }
 
       parsed_response = JSON.parse(response.body)
 
@@ -142,7 +142,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should raise if not found (to be handled by parent app)" do
-      get :show, id: 99999
+      get :show, params: { id: 99999 }
       expect(404).to eq(response.status)
       expect(response.body.include?("The resource you were looking for does not exist")).to be
     end
@@ -154,7 +154,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       feedback_history.prompt = prompt
       feedback_history.save
 
-      get :show, id: feedback_history.id
+      get :show, params: { id: feedback_history.id }
 
       parsed_response = JSON.parse(response.body)
       

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -47,15 +47,15 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       expect(1).to eq(FeedbackHistory.count)
     end
 
-    it "should populate metadata['highlight']" do 
-      metadata = { 
+    it "should populate metadata['highlight']" do
+      metadata = {
         "highlight" => [
           { 'text' => 'is',
             'type' => 'response',
             'category' => 'lorem',
-            'character' => 40 } 
+            'character' => 40 }
         ]
-      } 
+      }
 
       post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
                                         time: DateTime.now, entry: 'This is the entry provided by the student',
@@ -63,7 +63,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
                                         feedback_type: 'autoML', metadata: metadata } }
 
       parsed_response = JSON.parse(response.body)
-      expect(parsed_response['metadata']['highlight'].first.keys).to eq metadata['highlight'].first.keys 
+      expect(parsed_response['metadata']['highlight'].first.keys).to eq metadata['highlight'].first.keys
     end
 
     it "should set prompt_type to Comprehension::Prompt if prompt_id is provided" do
@@ -94,28 +94,75 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
 
   context "batch" do
     it "should create valid records and return them as json" do
-      post :batch, params: { feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                          time: DateTime.now, entry: 'This is the entry provided by the student',
-                                          feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {highlight: [], response_id: "0", rule_uid: ""} },
-                                        { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                          time: DateTime.now, entry: 'This is the entry provided by the student',
-                                          feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }] }
+      post :batch,
+        params: {
+          feedback_histories: [
+            {
+              feedback_session_uid: '1',
+              attempt: 1,
+              optimal: false,
+              used: true,
+              time: DateTime.now,
+              entry: 'This is the entry provided by the student',
+              feedback_text: 'This is the feedback provided by the algorithm',
+              feedback_type: 'autoML',
+              metadata: {
+                highlight: [],
+                response_id: "0",
+                rule_uid: ""
+              }
+            },
+            {
+              feedback_session_uid: '1',
+              attempt: 1,
+              optimal: false,
+              used: true,
+              time: DateTime.now,
+              entry: 'This is the entry provided by the student',
+              feedback_text: 'This is the feedback provided by the algorithm',
+              feedback_type: 'autoML',
+              metadata: {
+                foo: 'bar'
+              }
+            }
+          ]
+        }
 
       expect(201).to eq(response.code.to_i)
       expect(2).to eq(FeedbackHistory.count)
     end
 
     it "should not create valid records if one is invalid record but return errors as json" do
-      post :batch, params: { feedback_histories: [{ feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                          time: DateTime.now, entry: 'This is the entry provided by the student',
-                                          feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {foo: 'bar'} },
-                                        { attempt: 1, optimal: false, used: true,
-                                          time: DateTime.now, entry: 'This is the entry provided by the student',
-                                          feedback_text: 'This is the feedback provided by the algorithm',
-                                          feedback_type: 'autoML', metadata: {foo: 'bar'} }] }
+      post :batch,
+        params: {
+          feedback_histories: [
+            {
+              feedback_session_uid: '1',
+              attempt: 1,
+              optimal: false,
+              used: true,
+              time: DateTime.now,
+              entry: 'This is the entry provided by the student',
+              feedback_text: 'This is the feedback provided by the algorithm',
+              feedback_type: 'autoML',
+              metadata: {
+                foo: 'bar'
+              }
+            },
+            {
+              attempt: 1,
+              optimal: false,
+              used: true,
+              time: DateTime.now,
+              entry: 'This is the entry provided by the student',
+              feedback_text: 'This is the feedback provided by the algorithm',
+              feedback_type: 'autoML',
+              metadata: {
+                foo: 'bar'
+              }
+            }
+          ]
+        }
 
       parsed_response = JSON.parse(response.body)
 
@@ -157,7 +204,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       get :show, params: { id: feedback_history.id }
 
       parsed_response = JSON.parse(response.body)
-      
+
       expect(200).to eq(response.code.to_i)
       expect(prompt.as_json).to eq(parsed_response['prompt'])
     end

--- a/services/QuillLMS/spec/controllers/api/v1/firebase_tokens_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/firebase_tokens_controller_spec.rb
@@ -12,7 +12,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
       end
 
       def subject
-        post :create, app: 'foobar'
+        post :create, params: { app: 'foobar' }
       end
 
       it 'responds with 200' do
@@ -34,7 +34,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
       end
 
       def subject
-        post :create, app: 'foobar'
+        post :create, params: { app: 'foobar' }
       end
 
       it 'responds with 200' do
@@ -50,7 +50,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
 
     context 'when the firebase app does not exist' do
       subject do
-        post :create, app: 'nonexistent'
+        post :create, params: { app: 'nonexistent' }
       end
 
       it 'responds with 404' do
@@ -70,7 +70,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
     end
 
     def subject
-      post :create_for_connect, "json" => { "app" => 'foobar' }.to_json, format: :json
+      post :create_for_connect, params: { "json" => { "app" => 'foobar' }.to_json, format: :json }
     end
 
     it 'should respond with the connect token' do

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -19,12 +19,12 @@ describe Api::V1::FocusPointsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Question Focus Points" do
-      get :index, question_id: question.uid
+      get :index, params: { question_id: question.uid }
       expect(JSON.parse(response.body)).to eq(question.data["focusPoints"])
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, question_id: 'doesnotexist'
+      get :index, params: { question_id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -33,19 +33,19 @@ describe Api::V1::FocusPointsController, type: :controller do
   describe "#show" do
     it "should return the containing focus points object" do
       fp_id = question.data["focusPoints"].keys.first
-      get :show, question_id: question.uid, id: fp_id
+      get :show, params: { question_id: question.uid, id: fp_id }
       expect(JSON.parse(response.body)).to eq(question.data["focusPoints"][fp_id])
     end
 
     it "should return a 404 if the requested Question is not found" do
       fp_id = question.data["focusPoints"].keys.first
-      get :show, question_id: 'doesnotexist', id: fp_id
+      get :show, params: { question_id: 'doesnotexist', id: fp_id }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested FocusPoint is not found" do
-      get :show, question_id: question.id, id: "doesnotexist"
+      get :show, params: { question_id: question.id, id: "doesnotexist" }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -55,13 +55,13 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should add a new focus point to the question data" do
       data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_count = question.data["focusPoints"].keys.length
-      post :create, question_id: question.uid, focus_point: data
+      post :create, params: { question_id: question.uid, focus_point: data }
       question.reload
       expect(question.data["focusPoints"].keys.length).to eq(focus_point_count + 1)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, question_id: 'doesnotexist'
+      get :index, params: { question_id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -71,19 +71,19 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should update an existing focus point in the question data" do
       data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_uid = question.data["focusPoints"].keys.first
-      put :update, question_id: question.uid, id: focus_point_uid, focus_point: data
+      put :update, params: { question_id: question.uid, id: focus_point_uid, focus_point: data }
       question.reload
       expect(question.data["focusPoints"][focus_point_uid]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update, question_id: 'doesnotexist', id: 'doesnotexist'
+      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified focusPoint" do
-      put :update, question_id: question.uid, id: 'doesnotexist'
+      put :update, params: { question_id: question.uid, id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -93,7 +93,7 @@ describe Api::V1::FocusPointsController, type: :controller do
 
       focus_point_uid = new_q.data["focusPoints"].keys.first
 
-      put :update, question_id: new_q.uid, id: focus_point_uid, focus_point: data
+      put :update, params: { question_id: new_q.uid, id: focus_point_uid, focus_point: data }
 
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)["data"]).to include("There is incorrectly formatted regex: (and|")
@@ -104,13 +104,13 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should delete the focus point" do
       focus_point_uid = question.data["focusPoints"].keys.first
       pre_delete_count = question.data["focusPoints"].keys.length
-      delete :destroy, question_id: question.uid, id: focus_point_uid
+      delete :destroy, params: { question_id: question.uid, id: focus_point_uid }
       question.reload
       expect(question.data["focusPoints"].keys.length).to eq(pre_delete_count - 1)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      delete :destroy, question_id: 'doesnotexist', id: 'doesnotexist'
+      delete :destroy, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -119,13 +119,13 @@ describe Api::V1::FocusPointsController, type: :controller do
   describe "#update_all" do
     it "should replace all focusPoints" do
       data = {"0" => {"text"=>"text", "feedback"=>"feedback"}}
-      put :update_all, question_id: question.uid, focus_point: data
+      put :update_all, params: { question_id: question.uid, focus_point: data }
       question.reload
       expect(question.data["focusPoints"]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_all, question_id: 'doesnotexist'
+      put :update_all, params: { question_id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
@@ -6,12 +6,12 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
 
   describe "#index" do
     it "should include the response from the db" do
-      get :index, question_id: question.uid
+      get :index, params: { question_id: question.uid }
       expect(JSON.parse(response.body)).to eq(question.data["incorrectSequences"])
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, question_id: 'doesnotexist'
+      get :index, params: { question_id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -20,19 +20,19 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
   describe "#show" do
     it "should return the specified question" do
       is_id = question.data["incorrectSequences"].keys.first
-      get :show, question_id: question.uid, id: is_id
+      get :show, params: { question_id: question.uid, id: is_id }
       expect(JSON.parse(response.body)).to eq(question.data["incorrectSequences"][is_id])
     end
 
     it "should return a 404 if the requested Question is not found" do
       is_id = question.data["incorrectSequences"].keys.first
-      get :show, question_id: 'doesnotexist', id: is_id
+      get :show, params: { question_id: 'doesnotexist', id: is_id }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified incorrectSequence" do
-      put :show, question_id: question.uid, id: 'doesnotexist'
+      put :show, params: { question_id: question.uid, id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -42,7 +42,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should add a new incorrect sequence to the question data" do
       data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_count = question.data["incorrectSequences"].keys.length
-      post :create, question_id: question.uid, incorrect_sequence: data
+      post :create, params: { question_id: question.uid, incorrect_sequence: data }
       question.reload
       expect(question.data["incorrectSequences"].keys.length).to eq(incorrect_sequence_count + 1)
     end
@@ -52,19 +52,19 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should update an existing incorrect sequence in the question data" do
       data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_uid = question.data["incorrectSequences"].keys.first
-      put :update, question_id: question.uid, id: incorrect_sequence_uid, incorrect_sequence: data
+      put :update, params: { question_id: question.uid, id: incorrect_sequence_uid, incorrect_sequence: data }
       question.reload
       expect(question.data["incorrectSequences"][incorrect_sequence_uid]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update, question_id: 'doesnotexist', id: 'doesnotexist'
+      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified incorrectSequence" do
-      put :update, question_id: question.uid, id: 'doesnotexist'
+      put :update, params: { question_id: question.uid, id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -74,13 +74,13 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should delete the incorrect sequence" do
       incorrect_sequence_uid = question.data["incorrectSequences"].keys.first
       pre_delete_count = question.data["incorrectSequences"].keys.length
-      delete :destroy, question_id: question.uid, id: incorrect_sequence_uid
+      delete :destroy, params: { question_id: question.uid, id: incorrect_sequence_uid }
       question.reload
       expect(question.data["incorrectSequences"].keys.length).to eq(pre_delete_count - 1)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      delete :destroy, question_id: 'doesnotexist', id: 'doesnotexist'
+      delete :destroy, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -89,7 +89,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
   describe "#update_all" do
     it "should replace all incorrectSequences" do
       data = {"0"=>{"text" => "text", "feedback"=>"feedback"}}
-      put :update_all, question_id: question.uid, incorrect_sequence: data
+      put :update_all, params: { question_id: question.uid, incorrect_sequence: data }
       question.reload
       expect(question.data["incorrectSequences"]).to eq(data)
     end
@@ -108,7 +108,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_all, question_id: 'doesnotexist'
+      put :update_all, params: { question_id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
@@ -7,24 +7,24 @@ describe Api::V1::LessonsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Lessons" do
-      get :index, lesson_type: "connect_lesson"
+      get :index, params: { lesson_type: "connect_lesson" }
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should include the response from the db" do
-      get :index, lesson_type: "connect_lesson"
+      get :index, params: { lesson_type: "connect_lesson" }
       expect(JSON.parse(response.body).keys.first).to eq(activity.uid)
     end
   end
 
   describe "#show" do
     it "should return the specified lesson" do
-      get :show, id: activity.uid
+      get :show, params: { id: activity.uid }
       expect(JSON.parse(response.body)).to eq(activity.data)
     end
 
     it "should return a 404 if the requested Lesson is not found" do
-      get :show, id: 'doesnotexist'
+      get :show, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -36,7 +36,7 @@ describe Api::V1::LessonsController, type: :controller do
       data = {foo: "bar", name: "name", flag: "alpha"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = Activity.count
-      post :create, lesson_type: "connect_lesson", lesson: data
+      post :create, params: { lesson_type: "connect_lesson", lesson: data }
       expect(Activity.count).to eq(pre_create_count + 1)
       expect(Activity.find_by(name: data[:name]).flag = data[:flag])
     end
@@ -45,14 +45,14 @@ describe Api::V1::LessonsController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar", "flag" => "alpha", "name" => "new name"}
-      put :update, id: activity.uid, lesson: data
+      put :update, params: { id: activity.uid, lesson: data }
       activity.reload
       expect(activity.data).to eq(data)
       expect(Activity.find_by(name: data["name"]).flag = data["flag"])
     end
 
     it "should return a 404 if the requested Lesson is not found" do
-      get :update, id: 'doesnotexist'
+      get :update, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -64,20 +64,20 @@ describe Api::V1::LessonsController, type: :controller do
 
     it "should destroy the existing record if the current user is staff" do
       allow(controller).to receive(:current_user).and_return(staff)
-      delete :destroy, id: activity.uid
+      delete :destroy, params: { id: activity.uid }
       expect(Activity.where(uid: activity.uid).count).to eq(0)
     end
 
     it "should return a 404 if the requested Lesson is not found if the current user is staff" do
       allow(controller).to receive(:current_user).and_return(staff)
-      delete :destroy, id: 'doesnotexist'
+      delete :destroy, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 403 if the current user is not staff" do
       allow(controller).to receive(:current_user).and_return(teacher)
-      delete :destroy, id: activity.uid
+      delete :destroy, params: { id: activity.uid }
       expect(response.status).to eq(403)
       expect(response.body).to include("You are not authorized to access this resource")
     end
@@ -86,14 +86,14 @@ describe Api::V1::LessonsController, type: :controller do
   describe "#add_question" do
     it "should add a question to the existing record" do
       data = {"key" => question.uid, "questionType" => "questions"}
-      put :add_question, id: activity.uid, question: data
+      put :add_question, params: { id: activity.uid, question: data }
       activity.reload
       expect(activity.data["questions"]).to include(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
       data = {"question" => {"key" => "notarealID", "questionType" => "question"}}
-      put :add_question, id: activity.uid, question: data
+      put :add_question, params: { id: activity.uid, question: data }
       expect(response.status).to eq(404)
       expect(response.body).to include("does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -21,25 +21,25 @@ describe Api::V1::ProgressReportsController, type: :controller do
   context '#student_overview_data' do
     it 'should not allow access if no teacher classroom relationship exists' do
       session[:user_id] = unaffiliated_teacher.id
-      get :student_overview_data, student_id: student.id, classroom_id: classroom.id
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
       expect(response).to redirect_to new_session_path
     end
 
     it 'should not allow access if student is not in classroom' do
       session[:user_id] = teacher.id
-      get :student_overview_data, student_id: unaffiliated_student.id, classroom_id: classroom.id
+      get :student_overview_data, params: { student_id: unaffiliated_student.id, classroom_id: classroom.id }
       expect(response).to redirect_to new_session_path
     end
 
     it 'should not allow access if teacher is admin but not admin of that school' do
       session[:user_id] = admin.id
-      get :student_overview_data, student_id: student.id, classroom_id: classroom.id
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
       expect(response).to redirect_to new_session_path
     end
 
     it 'should return appropriate data' do
       session[:user_id] = teacher.id
-      get :student_overview_data, student_id: student.id, classroom_id: classroom.id
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
       expect(response.body).to eq({
         report_data: ProgressReports::StudentOverview.results(classroom.id, student.id),
         student_data: {

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -7,26 +7,26 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#index" do
     it "should return a list of Questions" do
       expect($redis).to receive(:get).and_return(nil)
-      get :index, question_type: 'connect_sentence_combining'
+      get :index, params: { question_type: 'connect_sentence_combining' }
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should set cache if it is empty" do
       expect($redis).to receive(:get).and_return(nil)
       expect($redis).to receive(:set)
-      get :index, question_type: 'connect_sentence_combining'
+      get :index, params: { question_type: 'connect_sentence_combining' }
     end
 
     it "should not set cache if there is a cache hit" do
       mock_cached_data = {"foo" => "bar"}
       expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
       expect($redis).not_to receive(:set)
-      get :index, question_type: 'connect_sentence_combining'
+      get :index, params: { question_type: 'connect_sentence_combining' }
       expect(JSON.parse(response.body)).to eq(mock_cached_data)
     end
 
     it "should include the response from the db" do
-      get :index, question_type: 'connect_sentence_combining'
+      get :index, params: { question_type: 'connect_sentence_combining' }
       puts response.body
       expect(JSON.parse(response.body).keys.first).to eq(question.uid)
     end
@@ -34,26 +34,26 @@ describe Api::V1::QuestionsController, type: :controller do
 
   describe "#show" do
     it "should return the specified question" do
-      get :show, id: question.uid
+      get :show, params: { id: question.uid }
       expect(JSON.parse(response.body)).to eq(question.data)
     end
 
     it "should set cache if it is empty" do
       expect($redis).to receive(:get).and_return(nil)
       expect($redis).to receive(:set)
-      get :show, id: question.uid
+      get :show, params: { id: question.uid }
     end
 
     it "should not set cache if there is a cache hit" do
       mock_cached_data = {"foo" => "bar"}
       expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
       expect($redis).not_to receive(:set)
-      get :show, id: question.uid
+      get :show, params: { id: question.uid }
       expect(JSON.parse(response.body)).to eq(mock_cached_data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :show, id: 'doesnotexist'
+      get :show, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -65,7 +65,7 @@ describe Api::V1::QuestionsController, type: :controller do
       data = {foo: "bar"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = Question.count
-      post :create, question_type: 'connect_sentence_combining', question: data
+      post :create, params: { question_type: 'connect_sentence_combining', question: data }
       expect(Question.count).to eq(pre_create_count + 1)
     end
   end
@@ -73,13 +73,13 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, id: question.uid, question: data
+      put :update, params: { id: question.uid, question: data }
       question.reload
       expect(question.data).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :update, id: 'doesnotexist'
+      get :update, params: { id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -102,13 +102,13 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#update_flag" do
     it "should update the flag attribute in the data" do
       new_flag = 'newflag'
-      put :update_flag, id: question.uid, question: {flag: new_flag}
+      put :update_flag, params: { id: question.uid, question: {flag: new_flag} }
       question.reload
       expect(question.data["flag"]).to eq(new_flag)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_flag, id: 'doesnotexist', question: {flag: nil}
+      put :update_flag, params: { id: 'doesnotexist', question: {flag: nil} }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -117,13 +117,13 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#update_model_concept" do
     it "should update the model concept uid attribute in the data" do
       new_model_concept = SecureRandom.uuid
-      put :update_model_concept, id: question.uid, question: {modelConcept: new_model_concept}
+      put :update_model_concept, params: { id: question.uid, question: {modelConcept: new_model_concept} }
       question.reload
       expect(question.data["modelConceptUID"]).to eq(new_model_concept)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_model_concept, id: 'doesnotexist', question: {flag: nil}
+      put :update_model_concept, params: { id: 'doesnotexist', question: {flag: nil} }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
   describe '#by_conjunction' do
     it 'should return successfully' do
-        get :by_conjunction, conjunction: 'so', activity_id: 1
+        get :by_conjunction, params: { conjunction: 'so', activity_id: 1 }
 
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq(
@@ -28,13 +28,13 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
         start_date: START_DATE,
         end_date: END_DATE,
       })
-      get :by_conjunction, conjunction: CONJUNCTION, activity_id: ACTIVITY_ID, start_date: START_DATE, end_date: END_DATE
+      get :by_conjunction, params: { conjunction: CONJUNCTION, activity_id: ACTIVITY_ID, start_date: START_DATE, end_date: END_DATE }
     end
   end
 
   describe '#rule_detail' do
     it 'should return successfully' do
-      get :rule_detail, rule_uid: 1, prompt_id: 1
+      get :rule_detail, params: { rule_uid: 1, prompt_id: 1 }
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)).to eq({"1"=>{"responses"=>[]}})
     end
@@ -43,7 +43,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
   describe '#prompt_health' do
     context 'no associated feedback sessions' do
       it 'should return successfully' do
-        get :prompt_health, activity_id: 1
+        get :prompt_health, params: { activity_id: 1 }
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq({})
       end
@@ -64,7 +64,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
         f_h1 = create(:feedback_history, feedback_session_uid: as1.uid, attempt: 1, optimal: false, prompt_id: prompt.id)
 
-        get :prompt_health, activity_id: main_activity.id
+        get :prompt_health, params: { activity_id: main_activity.id }
         expect(response.status).to eq 200
         expect(JSON.parse(response.body).keys.length).to eq 1
       end

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -45,7 +45,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it "should skip pages if specified" do
-          get :index, page: 2
+          get :index, params: { page: 2 }
 
           parsed_response = JSON.parse(response.body)
 
@@ -63,7 +63,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified activity' do
-          get :index, activity_id: @activity.id
+          get :index, params: { activity_id: @activity.id }
 
           parsed_response = JSON.parse(response.body)
 
@@ -92,7 +92,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified time constraints' do
-          get :index, start_date: '2021-04-06T20:43:27.698Z'
+          get :index, params: { start_date: '2021-04-06T20:43:27.698Z' }
 
           parsed_response = JSON.parse(response.body)
 
@@ -101,7 +101,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified time constraints' do
-          get :index, start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z'
+          get :index, params: { start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z' }
 
           parsed_response = JSON.parse(response.body)
 
@@ -119,7 +119,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
     end
 
     it "should return json if found" do
-      get :show, id: @feedback_history.feedback_session_uid
+      get :show, params: { id: @feedback_history.feedback_session_uid }
 
       parsed_response = JSON.parse(response.body)
 
@@ -128,7 +128,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
     end
 
     it "should raise if not found (to be handled by parent app)" do
-      get :show, id: 99999
+      get :show, params: { id: 99999 }
       expect(404).to eq(response.status)
       expect(response.body.include?("The resource you were looking for does not exist")).to be
     end

--- a/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::SharedCacheController, type: :controller do
   describe "#show" do
     it "should return a 404 if the custom cache key isn't set" do
       expect($redis).to receive(:get).with(COMBINED_KEY).and_return(nil)
-      get :show, id: KEY
+      get :show, params: { id: KEY }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -18,7 +18,7 @@ describe Api::V1::SharedCacheController, type: :controller do
         foo: 'bar'
       }
       expect($redis).to receive(:get).with(COMBINED_KEY).and_return(CACHED_DATA.to_json)
-      get :show, id: KEY, data: CACHED_DATA
+      get :show, params: { id: KEY, data: CACHED_DATA }
       expect(response.status).to eq(200)
       expect(response.body).to eq(CACHED_DATA.to_json)
     end
@@ -28,7 +28,7 @@ describe Api::V1::SharedCacheController, type: :controller do
     it "should set the cache for the specified key" do
       SET_DATA = {"foo" => "bar"}
       expect($redis).to receive(:set).with(COMBINED_KEY, SET_DATA.to_json, {ex: Api::V1::SharedCacheController::SHARED_CACHE_EXPIRY})
-      put :update, id: KEY, data: SET_DATA
+      put :update, params: { id: KEY, data: SET_DATA }
       expect(response.status).to eq(200)
       expect(response.body).to eq(SET_DATA.to_json)
     end
@@ -37,7 +37,7 @@ describe Api::V1::SharedCacheController, type: :controller do
   describe "#destroy" do
     it "should delete the existing record" do
       expect($redis).to receive(:del).with(COMBINED_KEY)
-      delete :destroy, id: KEY
+      delete :destroy, params: { id: KEY }
       expect(response.status).to eq(200)
       expect(response.body).to eq("OK")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/title_cards_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/title_cards_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::TitleCardsController, type: :controller do
     it 'should render TitleCard objects if they exist' do
       # Persist the factory-generated TitleCard so that .all works in the controller
       title_card.save
-      get :index, title_card_type: 'connect_title_card'
+      get :index, params: { title_card_type: 'connect_title_card' }
       expect(response.status).to eq(200)
       expect(response.body).to include(title_card.uid)
       expect(response.body).to include(title_card.content)
@@ -17,7 +17,7 @@ describe Api::V1::TitleCardsController, type: :controller do
 
     it 'should render an empty array if no TitleCards exist' do
       title_card.delete
-      get :index, title_card_type: 'connect_title_card'
+      get :index, params: { title_card_type: 'connect_title_card' }
       expect(response.status).to eq(200)
       expect(response.body).to eq('{"title_cards":[]}')
     end
@@ -25,7 +25,7 @@ describe Api::V1::TitleCardsController, type: :controller do
 
   describe "#show" do
     it 'should render the requested TitleCard object if it exists' do
-      get :show, title_card_type: 'connect_title_card', id: title_card.uid
+      get :show, params: { title_card_type: 'connect_title_card', id: title_card.uid }
       expect(response.status).to eq(200)
       expect(response.body).to include(title_card.uid)
       expect(response.body).to include(title_card.content)
@@ -33,7 +33,7 @@ describe Api::V1::TitleCardsController, type: :controller do
     end
 
     it 'should return a 404 if the requested TitleCard is not found' do
-      get :show, title_card_type: 'connect_title_card', id: 'doesnotexist'
+      get :show, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -46,20 +46,20 @@ describe Api::V1::TitleCardsController, type: :controller do
 
     it 'should update the specified TitleCard if all data is valid and return it' do
       new_content = 'updated content'
-      put :update, title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: new_content}
+      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: new_content} }
       expect(response.status).to eq(200)
       expect(title_card.reload.content).to eq(new_content)
     end
 
     it 'should 404 NOT FOUND if the provided UID does not match a known TitleCard' do
-      put :update, title_card_type: 'connect_title_card', id: 'doesnotexist'
+      put :update, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the posted data is invalid' do
       invalid_content = nil
-      put :update, title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: invalid_content}
+      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: invalid_content} }
       expect(response.status).to eq(422)
       expect(response.body).to match(/content.*can't be blank/)
     end
@@ -67,7 +67,7 @@ describe Api::V1::TitleCardsController, type: :controller do
     it 'should 422 UNPROCESSABLE ENTITY if the provided UID already belongs to an existing TitleCard' do
       used_uid = SecureRandom.uuid
       create(:title_card, uid: used_uid)
-      put :update, title_card_type: 'connect_title_card', id: title_card.uid, title_card: {uid: used_uid}
+      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {uid: used_uid} }
       expect(response.status).to eq(422)
       expect(response.body).to match(/uid.*has already been taken/)
     end
@@ -96,26 +96,26 @@ describe Api::V1::TitleCardsController, type: :controller do
     end
 
     it 'should create a new TitleCard if all data is valid and return it' do
-      post :create, title_card_type: 'connect_title_card', title_card: create_params
+      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params }
       expect(response.status).to eq(200)
       expect(TitleCard.find_by(uid: create_params[:uid])).not_to be_nil
     end
 
     it 'should provide a UID automatically if we do not set one explicitly' do
-      post :create, title_card_type: 'connect_title_card', title_card: create_params.except(:uid)
+      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.except(:uid) }
       expect(response.status).to eq(200)
       expect(response.body).to include(create_params[:content])
       expect(response.body).to include(create_params[:title])
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the posted data is invalid' do
-      post :create, title_card_type: 'connect_title_card', title_card: create_params.except(:content)
+      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.except(:content) }
       expect(response.status).to eq(422)
       expect(response.body).to match(/content.*can't be blank/)
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the provided UID already belongs to an existing TitleCard' do
-      post :create, title_card_type: 'connect_title_card', title_card: create_params.update({uid: title_card.uid})
+      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.update({uid: title_card.uid}) }
       expect(response.status).to eq(422)
       expect(response.body).to match(/uid.*has already been taken/)
     end

--- a/services/QuillLMS/spec/controllers/auth/google_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/google_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Auth::GoogleController, type: :controller do
 
   it 'shows error message for nonexistent accounts with no role' do
-    get 'google', {:role => nil}
+    get 'google', params: { :role => nil }
     expect(flash[:error]).to include("We could not find your account. Is this your first time logging in?")
     expect(response).to redirect_to "/session/new"
   end

--- a/services/QuillLMS/spec/controllers/blog_post_user_ratings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_post_user_ratings_controller_spec.rb
@@ -11,26 +11,26 @@ RSpec.describe BlogPostUserRatingsController, type: :controller do
       end
 
       it 'should create a new rating' do
-        post :create, user_id: teacher.id, blog_post_id: blog_post.id, rating: 2
+        post :create, params: { user_id: teacher.id, blog_post_id: blog_post.id, rating: 2 }
         expect(BlogPostUserRating.find_by(user_id: teacher.id, blog_post_id: blog_post.id).rating).to eq(2)
       end
 
       it 'should update an old rating' do
         BlogPostUserRating.create(user_id: teacher.id, blog_post_id: blog_post.id, rating: 0)
         expect(BlogPostUserRating.find_by(user_id: teacher.id, blog_post_id: blog_post.id).rating).to eq(0)
-        post :create, user_id: teacher.id, blog_post_id: blog_post.id, rating: 1
+        post :create, params: { user_id: teacher.id, blog_post_id: blog_post.id, rating: 1 }
         expect(BlogPostUserRating.find_by(user_id: teacher.id, blog_post_id: blog_post.id).rating).to eq(1)
       end
 
       it 'should not create a rating if the specified rating is not in ACCEPTABLE_RATINGS' do
-        post :create, user_id: teacher.id, blog_post_id: blog_post.id, rating: BlogPostUserRating::ACCEPTABLE_RATINGS.max + 1
+        post :create, params: { user_id: teacher.id, blog_post_id: blog_post.id, rating: BlogPostUserRating::ACCEPTABLE_RATINGS.max + 1 }
         expect(response.status).to be(401)
       end
     end
 
     context 'when no user is logged in' do
       it 'should return an unauthorized error' do
-        post :create, user_id: teacher.id, blog_post_id: blog_post.id, rating: 2
+        post :create, params: { user_id: teacher.id, blog_post_id: blog_post.id, rating: 2 }
         expect(response.status).to be(401)
       end
     end

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -33,50 +33,50 @@ describe BlogPostsController, type: :controller do
     let(:three_most_recent_posts) { create_list(:blog_post, 3) }
 
     it 'should redirect to teacher center home if no such post found' do
-      get :show, slug: 'does-not-exist'
+      get :show, params: { slug: 'does-not-exist' }
 
       expect(response).to redirect_to blog_posts_path
       expect(flash[:error]).to include("Oops! We can't seem to find that blog post.")
     end
 
     it 'should return the called blog post' do
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:blog_post)).to eq(blog_post)
     end
 
     it 'should redirect to blog post even if there are extra chars' do
-      get :show, slug: blog_post.slug + ')()('
+      get :show, params: { slug: blog_post.slug + ')()(' }
 
       expect(response).to redirect_to "/teacher-center/#{blog_post.slug}"
     end
 
     it 'should increment the blog post read count' do
-      expect { get :show, slug: blog_post.slug }.to change { blog_post.reload.read_count }.by(1)
+      expect { get :show, params: { slug: blog_post.slug } }.to change { blog_post.reload.read_count }.by(1)
     end
 
     it 'should return the blog post author' do
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:author)).to eq(blog_post.author)
     end
 
     it 'should return the three most recent posts' do
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:most_recent_posts)).to match_array(three_most_recent_posts)
     end
 
     it 'should return the title' do
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:title)).to eq(blog_post.title)
     end
 
     it 'should return the description' do
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:description)).to eq(blog_post.subtitle)
     end
 
     it 'should return the title as description if no subtitle exists' do
       blog_post = create(:blog_post, subtitle: nil)
-      get :show, slug: blog_post.slug
+      get :show, params: { slug: blog_post.slug }
       expect(assigns(:description)).to eq(blog_post.title)
     end
   end
@@ -87,13 +87,13 @@ describe BlogPostsController, type: :controller do
     let(:draft_post) { create(:blog_post, :draft, topic: topic) }
 
     it 'should redirect a legacy_url' do
-      get :show_topic, topic: 'param_with_underscores'
+      get :show_topic, params: { topic: 'param_with_underscores' }
 
       expect(response).to redirect_to '/teacher-center/topic/param-with-underscores'
     end
 
     it 'should redirect to teacher_center if topic slug is not found' do
-      get :show_topic, topic: 'does-not-exist'
+      get :show_topic, params: { topic: 'does-not-exist' }
 
       expect(response).to redirect_to '/teacher-center'
     end
@@ -101,25 +101,25 @@ describe BlogPostsController, type: :controller do
     it 'should redirect students to student_center if topic slug is not found' do
       allow(controller).to receive(:current_user) { create(:student) }
 
-      get :show_topic, topic: 'does-not-exist'
+      get :show_topic, params: { topic: 'does-not-exist' }
 
       expect(response).to redirect_to '/student-center'
     end
 
     it 'should never return a draft' do
       draft_post
-      get :show_topic, topic: topic.downcase.gsub(' ','-')
+      get :show_topic, params: { topic: topic.downcase.gsub(' ','-') }
       expect(assigns(:blog_posts)).not_to include(draft_post)
     end
 
     it 'should return all the posts associated with this topic' do
       blog_posts
-      get :show_topic, topic: topic.downcase.gsub(' ','-')
+      get :show_topic, params: { topic: topic.downcase.gsub(' ','-') }
       expect(assigns(:blog_posts)).to match_array(blog_posts)
     end
 
     it 'should return a title' do
-      get :show_topic, topic: topic.downcase.gsub(' ','-')
+      get :show_topic, params: { topic: topic.downcase.gsub(' ','-') }
       expect(assigns(:title)).to eq(topic)
     end
   end
@@ -136,13 +136,13 @@ describe BlogPostsController, type: :controller do
 
     it 'should return the proper title' do
       query = 'example query'
-      get :search, query: query
+      get :search, params: { query: query }
       expect(assigns(:title)).to eq("Search: #{query}")
     end
 
     it 'should not return a blog post with the topic "In the news"' do
       query = 'Press'
-      get :search, query: query
+      get :search, params: { query: query }
       expect(assigns(:blog_posts)).to eq([])
     end
   end

--- a/services/QuillLMS/spec/controllers/charges_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/charges_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ChargesController, type: :controller do
         email: teacher.email,
         metadata: { name: teacher.name, school: teacher.reload.school.name }
       )
-      post :create_customer_with_card, source: { id: 1 }
+      post :create_customer_with_card, params: { source: { id: 1 } }
       expect(teacher.reload.stripe_customer_id).to eq "42"
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe ChargesController, type: :controller do
       expect(sources).to receive(:create).with(source: "29")
       expect(customer).to receive("default_source=".to_sym).with(108)
       expect(customer).to receive(:save)
-      post :update_card, source: { id: 29 }
+      post :update_card, params: { source: { id: 29 } }
     end
   end
 

--- a/services/QuillLMS/spec/controllers/classrooms_teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/classrooms_teachers_controller_spec.rb
@@ -25,7 +25,7 @@ describe ClassroomsTeachersController, type: :controller do
     end
 
     it 'should set the classroom, coteachers, and selected teacher and classroom' do
-      get :edit_coteacher_form, classrooms_teacher_id: 45
+      get :edit_coteacher_form, params: { classrooms_teacher_id: 45 }
       expect(response).to redirect_to(teachers_classrooms_path)
     end
   end
@@ -55,7 +55,7 @@ describe ClassroomsTeachersController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :specific_coteacher_info, format: :json, coteacher_id: user.id
+      get :specific_coteacher_info, params: { format: :json, coteacher_id: user.id }
       expect(response.body).to eq({
       selectedTeachersClassroomIds: {
           is_coteacher: [classroom.id],
@@ -70,7 +70,7 @@ describe ClassroomsTeachersController, type: :controller do
     let!(:classroom_teacher) { create(:classrooms_teacher, user: user, classroom: classroom) }
 
     it 'should destroy the given classroom teacher' do
-      delete :destroy, classroom_id: classroom.id
+      delete :destroy, params: { classroom_id: classroom.id }
       expect{ ClassroomsTeacher.find(classroom_teacher.id) }.to raise_exception ActiveRecord::RecordNotFound
       expect(response.body).to eq({message: "Deletion Succeeded!"}.to_json)
     end

--- a/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
@@ -24,7 +24,7 @@ describe Cms::ActivitiesController, type: :controller do
 
     context 'when flag is archive' do
       it 'should set the flag and activities' do
-        get :index, activity_classification_id: classification.id, flag: :archive
+        get :index, params: { activity_classification_id: classification.id, flag: :archive }
         expect(assigns(:flag)).to eq :archived
         expect(assigns(:activities)).to eq "flagged set"
       end
@@ -32,7 +32,7 @@ describe Cms::ActivitiesController, type: :controller do
 
     context 'when flag is production' do
       it 'should set the flag and activities' do
-        get :index, activity_classification_id: classification.id
+        get :index, params: { activity_classification_id: classification.id }
         expect(assigns(:flag)).to eq :production
         expect(assigns(:activities)).to eq "production set"
       end
@@ -43,7 +43,7 @@ describe Cms::ActivitiesController, type: :controller do
     let!(:activity) { create(:activity, classification: classification) }
 
     it 'should find the activity' do
-      get :edit, activity_classification_id: classification.id, id: activity.id
+      get :edit, params: { activity_classification_id: classification.id, id: activity.id }
       activity_hash = {
         'id' => activity.id,
         'name' => activity.name,
@@ -82,7 +82,7 @@ describe Cms::ActivitiesController, type: :controller do
       selected_attributes[:topic_ids] = [topic.id]
       selected_attributes[:content_partner_ids] = [content_partner.id]
       selected_attributes[:activity_category_ids] = [activity_category.id]
-      post :create, activity_classification_id: classification.id, activity: selected_attributes, format: :json
+      post :create, params: { activity_classification_id: classification.id, activity: selected_attributes, format: :json }
       created_activity = Activity.find_by_name('Unique Name')
       expect(created_activity).to be
       expect(created_activity.topics).to eq([topic])
@@ -116,7 +116,7 @@ describe Cms::ActivitiesController, type: :controller do
       selected_attributes[:activity_category_ids] = [activity_category.id]
       selected_attributes[:standard_id] = standard.id
       selected_attributes[:raw_score_id] = raw_score.id
-      put :update, id: activity.id, activity_classification_id: classification.id, activity: selected_attributes
+      put :update, params: { id: activity.id, activity_classification_id: classification.id, activity: selected_attributes }
       updated_activity = Activity.find_by_name('Unique Name')
       expect(updated_activity.id).to eq activity.id
       expect(updated_activity.topics.to_a).to eq([topic])

--- a/services/QuillLMS/spec/controllers/cms/activity_categories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activity_categories_controller_spec.rb
@@ -101,7 +101,7 @@ describe Cms::ActivityCategoriesController, type: :controller do
 
   describe '#create' do
     it 'should create the activity category with the params' do
-      post :create, activity_category: { name: "test", order_number: 2 }
+      post :create, params: { activity_category: { name: "test", order_number: 2 } }
       expect(ActivityCategory.last.name).to eq "test"
       expect(ActivityCategory.last.order_number).to eq 2
     end

--- a/services/QuillLMS/spec/controllers/cms/activity_classifications_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activity_classifications_controller_spec.rb
@@ -23,7 +23,7 @@ describe Cms::ActivityClassificationsController, type: :controller do
     let(:classification) { build(:activity_classification) }
 
     it 'should create the activity classification with the given params' do
-      post :create, activity_classification: classification.attributes
+      post :create, params: { activity_classification: classification.attributes }
       expect(ActivityClassification.last.name).to eq classification.name
       expect(ActivityClassification.last.order_number).to eq classification.order_number
       expect(ActivityClassification.last.form_url).to eq classification.form_url
@@ -38,7 +38,7 @@ describe Cms::ActivityClassificationsController, type: :controller do
 
     it 'should update the classification with the params provided' do
       classification.update(order_number: 19)
-      put :update, id: classification.id, activity_classification: { id: classification.id, order_number: 20 }
+      put :update, params: { id: classification.id, activity_classification: { id: classification.id, order_number: 20 } }
       expect(classification.reload.order_number).to eq 20
     end
   end
@@ -48,7 +48,7 @@ describe Cms::ActivityClassificationsController, type: :controller do
 
     it 'should update the classification with the params provided' do
       classification.update(order_number: 19)
-      put :update_order_numbers, activity_classifications: [{ id: classification.id, order_number: 20 }]
+      put :update_order_numbers, params: { activity_classifications: [{ id: classification.id, order_number: 20 }] }
       expect(classification.reload.order_number).to eq 20
       expect(response.body).to eq({activity_classifications: ActivityClassification.order(order_number: :asc)}.to_json)
     end
@@ -58,7 +58,7 @@ describe Cms::ActivityClassificationsController, type: :controller do
     let!(:classification) { create(:activity_classification) }
 
     it 'should destroy the given classification' do
-      delete :destroy, id: classification.id
+      delete :destroy, params: { id: classification.id }
       expect{ActivityClassification.find(classification.id)}.to raise_exception(ActiveRecord::RecordNotFound)
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/announcements_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/announcements_controller_spec.rb
@@ -23,7 +23,7 @@ describe Cms::AnnouncementsController, type: :controller do
     let(:announcement) { build(:announcement) }
 
     it 'should create the announcement with the given params' do
-      post :create, announcement: announcement.attributes
+      post :create, params: { announcement: announcement.attributes }
       expect(flash[:success]).to eq "Announcement created successfully!"
       expect(response).to redirect_to cms_announcements_path
       expect(Announcement.last.link).to eq announcement.link
@@ -35,7 +35,7 @@ describe Cms::AnnouncementsController, type: :controller do
     let!(:announcement) { create(:announcement) }
 
     it 'should update the announcement with the params given' do
-      post :update, id: announcement.id, announcement: { link: "new_link.com" }
+      post :update, params: { id: announcement.id, announcement: { link: "new_link.com" } }
       expect(announcement.reload.link).to eq "new_link.com"
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/authors_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/authors_controller_spec.rb
@@ -21,7 +21,7 @@ describe Cms::AuthorsController, type: :controller do
     let(:author) { build(:author) }
 
     it 'should create the author with the params given' do
-      post :create, author: author.attributes
+      post :create, params: { author: author.attributes }
       expect(Author.last.name).to eq author.name
       expect(Author.last.avatar).to eq author.avatar
     end
@@ -31,7 +31,7 @@ describe Cms::AuthorsController, type: :controller do
     let!(:author) { create(:author) }
 
     it 'should find the author' do
-      get :edit, id: author.id
+      get :edit, params: { id: author.id }
       expect(assigns(:author)).to eq author
     end
   end
@@ -40,7 +40,7 @@ describe Cms::AuthorsController, type: :controller do
     let!(:author) { create(:author) }
 
     it 'should update the author with the params provided' do
-      post :update, id: author.id, author: { name: "test name" }
+      post :update, params: { id: author.id, author: { name: "test name" } }
       expect(response).to redirect_to cms_authors_path
       expect(flash[:success]).to eq "Updated successfully!"
       expect(author.reload.name).to eq "test name"

--- a/services/QuillLMS/spec/controllers/cms/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/blog_posts_controller_spec.rb
@@ -44,7 +44,7 @@ describe Cms::BlogPostsController, type: :controller do
     let!(:bpost) { create(:blog_post) }
 
     it 'should update the given blog post' do
-      post :update, id: bpost.id, blog_post: { title: "new test title" }
+      post :update, params: { id: bpost.id, blog_post: { title: "new test title" } }
       expect(bpost.reload.title).to eq "new test title"
     end
   end
@@ -53,7 +53,7 @@ describe Cms::BlogPostsController, type: :controller do
     let!(:bpost) { create(:blog_post) }
 
     it 'should destroy the given blog post' do
-      delete :destroy, id: bpost.id
+      delete :destroy, params: { id: bpost.id }
       expect{BlogPost.find(bpost.id)}.to raise_exception(ActiveRecord::RecordNotFound)
     end
   end
@@ -62,7 +62,7 @@ describe Cms::BlogPostsController, type: :controller do
     let!(:bpost) { create(:blog_post) }
 
     it 'should make draft true in the given blog post' do
-      get :unpublish, id: bpost.id
+      get :unpublish, params: { id: bpost.id }
       expect(bpost.reload.draft).to eq true
       expect(flash[:success]).to eq "Blog post successfully set to draft."
       expect(response).to redirect_to cms_blog_posts_path
@@ -74,7 +74,7 @@ describe Cms::BlogPostsController, type: :controller do
     let!(:bpost1) { create(:blog_post) }
 
     it 'should update the order number for all given blog posts' do
-      get :update_order_numbers, blog_posts: [{ id: bpost.id, order_number: 2 }, { id: bpost1.id, order_number: 4 }].to_json
+      get :update_order_numbers, params: { blog_posts: [{ id: bpost.id, order_number: 2 }, { id: bpost1.id, order_number: 4 }].to_json }
       expect(bpost.reload.order_number).to eq 2
       expect(bpost1.reload.order_number).to eq 4
     end
@@ -85,7 +85,7 @@ describe Cms::BlogPostsController, type: :controller do
     let!(:bpost1) { create(:blog_post) }
 
     it 'should update the order number for all given blog posts' do
-      get :update_featured_order_numbers, blog_posts: [{ id: bpost.id, featured_order_number: 2 }, { id: bpost1.id, featured_order_number: 4 }].to_json
+      get :update_featured_order_numbers, params: { blog_posts: [{ id: bpost.id, featured_order_number: 2 }, { id: bpost1.id, featured_order_number: 4 }].to_json }
       expect(bpost.reload.featured_order_number).to eq 2
       expect(bpost1.reload.featured_order_number).to eq 4
     end

--- a/services/QuillLMS/spec/controllers/cms/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/concepts_controller_spec.rb
@@ -23,7 +23,7 @@ describe Cms::ConceptsController do
 
   describe '#create' do
     it 'should create the concept with the params given' do
-      post :create, concept: { name: "test name", parent_id: 42 }
+      post :create, params: { concept: { name: "test name", parent_id: 42 } }
       expect(Concept.last.name).to eq "test name"
       expect(Concept.last.parent_id).to eq 42
     end

--- a/services/QuillLMS/spec/controllers/cms/content_partners_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/content_partners_controller_spec.rb
@@ -21,14 +21,12 @@ describe Cms::ContentPartnersController do
 
   describe '#create' do
     it 'creates a new content_partner' do
-      post :create, {
-        content_partner: {
+      post :create, params: { content_partner: {
           name: 'New ContentPartner',
           level: 3,
           visible: true,
           description: 'Blah da blah'
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["content_partner"]["id"]
       expect(id).to be
@@ -40,13 +38,10 @@ describe Cms::ContentPartnersController do
     it 'updates the content partner' do
       new_name = 'New Content Partner Name'
       id = content_partners[0].id
-      put :update, {
-        id: id,
-        content_partner: {
+      put :update, params: { id: id, content_partner: {
           name: new_name,
           id: id
-        }
-      }
+        } }
       expect(ContentPartner.find_by_id(id).name).to eq(new_name)
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/criteria_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/criteria_controller_spec.rb
@@ -23,10 +23,7 @@ describe Cms::CriteriaController do
     end
   
     it 'should give a new criteria' do
-      get :new, 
-        activity_classification_id: activity_classification.id,
-        activity_id: activity.id, 
-        recommendation_id: recommendation.id
+      get :new, params: { activity_classification_id: activity_classification.id, activity_id: activity.id, recommendation_id: recommendation.id }
       expect(assigns(:criterion)).to eq criteria
     end
   end
@@ -38,14 +35,11 @@ describe Cms::CriteriaController do
     let!(:concept) { create(:concept) }
 
     it 'should create the criteria with the given params' do
-      post :create, criterion: {
+      post :create, params: { criterion: {
         concept_id: concept.id, 
         count: 1, 
         no_incorrect: 0 
-      },
-      activity_classification_id: activity_classification.id,
-      activity_id: activity.id, 
-      recommendation_id: recommendation.id
+      }, activity_classification_id: activity_classification.id, activity_id: activity.id, recommendation_id: recommendation.id }
 
       expect(response).to redirect_to cms_activity_classification_activity_recommendation_path(
         activity_classification,
@@ -64,12 +58,7 @@ describe Cms::CriteriaController do
     let(:criterion) { create(:criterion, concept: concept, count: 1, no_incorrect: 0) }
 
     it 'should update the given criterion' do
-      post :update, 
-        activity_classification_id: activity_classification.id,
-        activity_id: activity.id, 
-        recommendation_id: recommendation.id,
-        id: criterion.id,
-        criterion: { count: 2 }
+      post :update, params: { activity_classification_id: activity_classification.id, activity_id: activity.id, recommendation_id: recommendation.id, id: criterion.id, criterion: { count: 2 } }
       expect(response).to redirect_to cms_activity_classification_activity_recommendation_path(
         activity_classification,
         activity,
@@ -89,11 +78,7 @@ describe Cms::CriteriaController do
 
 
     it 'should destroy the given criterion' do
-      delete :destroy, 
-        activity_classification_id: activity_classification.id,
-        activity_id: activity.id, 
-        recommendation_id: recommendation.id,
-        id: criterion.id
+      delete :destroy, params: { activity_classification_id: activity_classification.id, activity_id: activity.id, recommendation_id: recommendation.id, id: criterion.id }
       expect{ Criterion.find(criterion.id) }.to raise_exception ActiveRecord::RecordNotFound
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/raw_scores_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/raw_scores_controller_spec.rb
@@ -26,11 +26,9 @@ describe Cms::RawScoresController do
 
   describe '#create' do
     it 'creates a new raw score' do
-      post :create, {
-        raw_score: {
+      post :create, params: { raw_score: {
           name: 'New Raw Score',
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["raw_score"]["id"]
       expect(id).to be
@@ -42,12 +40,9 @@ describe Cms::RawScoresController do
     it 'creates a new raw_score with the nested change logs' do
       new_name = 'New RawScore Name'
       id = raw_scores[0].id
-      put :update, {
-        id: id,
-        raw_score: {
+      put :update, params: { id: id, raw_score: {
           name: new_name
-        }
-      }
+        } }
       expect(RawScore.find_by_id(id).name).to eq(new_name)
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/recommendations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/recommendations_controller_spec.rb
@@ -25,7 +25,7 @@ describe Cms::RecommendationsController do
     end
 
     it 'should assign the normal, independent, and group recommendations' do
-      get :index, activity_classification_id: activity_classification.id, activity_id: activity.id
+      get :index, params: { activity_classification_id: activity_classification.id, activity_id: activity.id }
       expect(assigns(:recommendations)).to eq recommendations
       expect(assigns(:independent_recommendations)).to eq independent_recommendations
       expect(assigns(:group_recommendations)).to eq group_recommendations
@@ -45,7 +45,7 @@ describe Cms::RecommendationsController do
     end
 
     it 'should assign the concepts and recommendation' do
-      get :new, activity_classification_id: activity_classification.id, activity_id: activity.id
+      get :new, params: { activity_classification_id: activity_classification.id, activity_id: activity.id }
       expect(assigns(:concepts)).to eq [concept]
       expect(assigns(:recommendation)).to eq recommendation
       expect(assigns(:unit_templates)).to eq [unit_template]
@@ -59,7 +59,7 @@ describe Cms::RecommendationsController do
 
 
     it 'should find the recommendation' do
-      get :show, id: recommendation.id, activity_id: activity.id, activity_classification_id: activity_classification.id
+      get :show, params: { id: recommendation.id, activity_id: activity.id, activity_classification_id: activity_classification.id }
       expect(assigns(:recommendation)).to eq recommendation
     end
   end
@@ -73,15 +73,11 @@ describe Cms::RecommendationsController do
       let!(:recommendation) { create(:recommendation, activity: activity, category: 0) }
 
       it 'should create the recommendation with the given activity and order number greater than that of the category' do
-        post :create,
-           activity_id: activity.id,
-           activity_classification_id: activity_classification.id,
-           category: "independent_practice",
-           recommendation: {
+        post :create, params: { activity_id: activity.id, activity_classification_id: activity_classification.id, category: "independent_practice", recommendation: {
              name: "some_name",
              unit_template_id: unit_template.id,
              category: "independent_practice"
-           }
+           } }
         expect(Recommendation.last.order).to eq recommendation.order + 1
         expect(Recommendation.last.activity).to eq activity
       end
@@ -89,27 +85,20 @@ describe Cms::RecommendationsController do
 
 
     it 'should create the recommendation with the given activity and next order number' do
-      post :create,
-           activity_id: activity.id,
-           activity_classification_id: activity_classification.id,
-           category: "independent_practice",
-           recommendation: {
+      post :create, params: { activity_id: activity.id, activity_classification_id: activity_classification.id, category: "independent_practice", recommendation: {
                name: "some_name",
                unit_template_id: unit_template.id,
                category: "independent_practice"
-           }
+           } }
       expect(Recommendation.last.order).to eq 0
       expect(Recommendation.last.activity).to eq activity
     end
 
     it 'should throw error if recommendation is not created' do
-      post :create,
-           activity_id: activity.id,
-           activity_classification_id: activity_classification.id,
-           recommendation: {
+      post :create, params: { activity_id: activity.id, activity_classification_id: activity_classification.id, recommendation: {
                unit_template_id: unit_template.id,
                category: "independent_practice"
-           }
+           } }
       expect(response).to render_template :new
       expect(flash[:error]).to eq "Unable to create recommendation."
     end
@@ -121,7 +110,7 @@ describe Cms::RecommendationsController do
     let!(:recommendation) { create(:recommendation) }
 
     it 'should destroy the recommendation' do
-      delete :destroy, id: recommendation.id, activity_id: activity.id, activity_classification_id: activity_classification.id
+      delete :destroy, params: { id: recommendation.id, activity_id: activity.id, activity_classification_id: activity_classification.id }
       expect{ Recommendation.find(recommendation.id) }.to raise_exception ActiveRecord::RecordNotFound
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -45,7 +45,7 @@ describe Cms::SchoolsController do
 
     it 'should assign the correct values' do
       allow_any_instance_of(Cms::TeacherSearchQuery).to receive(:run) { "teacher data" }
-      get :show, id: school.id
+      get :show, params: { id: school.id }
       expect(assigns(:subscription)).to eq school.subscription
       expect(assigns(:school_subscription_info)).to eq({
        'School Premium Type' => school&.subscription&.account_type,
@@ -78,7 +78,7 @@ describe Cms::SchoolsController do
     let!(:school) { create(:school) }
 
     it 'should assign the school and editable attributes' do
-      get :edit, id: school.id
+      get :edit, params: { id: school.id }
       expect(assigns(:school)).to eq school
       expect(assigns(:editable_attributes)).to eq({
           'School Name' => :name,
@@ -96,7 +96,7 @@ describe Cms::SchoolsController do
     let!(:school) { create(:school) }
 
     it 'should update the given school' do
-      post :update, id: school.id, school: { id: school.id, name: "test name" }
+      post :update, params: { id: school.id, school: { id: school.id, name: "test name" } }
       expect(school.reload.name).to eq "test name"
       expect(response).to redirect_to cms_school_path(school.id)
     end
@@ -106,21 +106,21 @@ describe Cms::SchoolsController do
     let!(:school) { create(:school) }
 
     it 'should assing the subscription' do
-      get :edit_subscription, id: school.id
+      get :edit_subscription, params: { id: school.id }
       expect(assigns(:subscription)).to eq school.subscription
     end
   end
 
   describe '#create' do
     it 'should create the school with the given params' do
-      post :create, school: {
+      post :create, params: { school: {
           name: "test",
           city: "test city",
           state: "test state",
           zipcode: "1100",
           leanm: "lean",
           free_lunches: 2
-      }
+      } }
       expect(School.last.name).to eq "test"
       expect(School.last.city).to eq "test city"
       expect(School.last.state).to eq "test state"
@@ -140,7 +140,7 @@ describe Cms::SchoolsController do
 
     describe 'when there is no existing subscription' do
       it 'should create a new subscription that starts today and ends at the promotional expiration date' do
-        get :new_subscription, id: school_with_no_subscription.id
+        get :new_subscription, params: { id: school_with_no_subscription.id }
         expect(assigns(:subscription).start_date).to eq Date.today
         expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
       end
@@ -148,7 +148,7 @@ describe Cms::SchoolsController do
 
     describe 'when there is an existing subscription' do
       it 'should create a new subscription with starting after the current subscription ends' do
-        get :new_subscription, id: school.id
+        get :new_subscription, params: { id: school.id }
         expect(assigns(:subscription).start_date).to eq subscription.expiration
         expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
       end
@@ -160,7 +160,7 @@ describe Cms::SchoolsController do
     let!(:school) { create(:school) }
 
     it 'should create the schools admin and redirect to cms school path' do
-      post :add_admin_by_email, email_address: another_user.email, id: school.id
+      post :add_admin_by_email, params: { email_address: another_user.email, id: school.id }
       expect(flash[:success]).to eq "Yay! It worked! 🎉"
       expect(response).to redirect_to cms_school_path(school.id)
       expect(SchoolsAdmins.last.user).to eq another_user
@@ -176,7 +176,7 @@ describe Cms::SchoolsController do
     end
 
     it 'should create the schools users and redirect to cms school path' do
-      post :add_existing_user_by_email, email_address: another_user.email, id: school.id
+      post :add_existing_user_by_email, params: { email_address: another_user.email, id: school.id }
       expect(flash[:success]).to eq "Yay! It worked! 🎉"
       expect(response).to redirect_to cms_school_path(school.id)
       expect(SchoolsUsers.last.user).to eq another_user
@@ -185,7 +185,7 @@ describe Cms::SchoolsController do
     end
 
     it 'should not create the schools users and redirect to cms school path if email is invalid' do
-      post :add_existing_user_by_email, email_address: 'random-invalid-email', id: school.id
+      post :add_existing_user_by_email, params: { email_address: 'random-invalid-email', id: school.id }
       expect(flash[:error]).to eq "It didn't work! Make sure the email you typed is correct."
     end
   end
@@ -199,7 +199,7 @@ describe Cms::SchoolsController do
 
     it 'should unlink the user and redirect to cms school path' do
       expect(SchoolsUsers.find_by(user: another_user.id, school: school)).to be
-      post :unlink, teacher_id: another_user.id, id: school.id
+      post :unlink, params: { teacher_id: another_user.id, id: school.id }
       expect(flash[:success]).to eq "Yay! It worked! 🎉"
       expect(response).to redirect_to cms_school_path(school.id)
       expect(SchoolsUsers.find_by(user: another_user.id, school: school)).not_to be

--- a/services/QuillLMS/spec/controllers/cms/standard_categories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/standard_categories_controller_spec.rb
@@ -23,8 +23,7 @@ describe Cms::StandardCategoriesController do
 
   describe '#create' do
     it 'creates a new standard with the nested change logs' do
-      post :create, {
-        standard_category: {
+      post :create, params: { standard_category: {
           name: 'New StandardCategory',
           level: 3,
           visible: true,
@@ -35,8 +34,7 @@ describe Cms::StandardCategoriesController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["standard_category"]["id"]
       expect(id).to be
@@ -49,9 +47,7 @@ describe Cms::StandardCategoriesController do
     it 'creates a new standard with the nested change logs' do
       new_name = 'New StandardCategory Name'
       id = standard_categories[0].id
-      put :update, {
-        id: id,
-        standard_category: {
+      put :update, params: { id: id, standard_category: {
           name: new_name,
           id: id,
           change_logs_attributes: [
@@ -62,8 +58,7 @@ describe Cms::StandardCategoriesController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       expect(StandardCategory.find_by_id(id).name).to eq(new_name)
       expect(ChangeLog.find_by(changed_record_id: id, changed_record_type: 'StandardCategory', action: 'Renamed')).to be
     end

--- a/services/QuillLMS/spec/controllers/cms/standard_level_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/standard_level_controller_spec.rb
@@ -23,8 +23,7 @@ describe Cms::StandardLevelsController do
 
   describe '#create' do
     it 'creates a new standard with the nested change logs' do
-      post :create, {
-        standard_level: {
+      post :create, params: { standard_level: {
           name: 'New StandardLevel',
           level: 3,
           visible: true,
@@ -35,8 +34,7 @@ describe Cms::StandardLevelsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["standard_level"]["id"]
       expect(id).to be
@@ -49,9 +47,7 @@ describe Cms::StandardLevelsController do
     it 'creates a new standard with the nested change logs' do
       new_name = 'New StandardLevel Name'
       id = standard_levels[0].id
-      put :update, {
-        id: id,
-        standard_level: {
+      put :update, params: { id: id, standard_level: {
           name: new_name,
           id: id,
           change_logs_attributes: [
@@ -62,8 +58,7 @@ describe Cms::StandardLevelsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       expect(StandardLevel.find_by_id(id).name).to eq(new_name)
       expect(ChangeLog.find_by(changed_record_id: id, changed_record_type: 'StandardLevel', action: 'Renamed')).to be
     end

--- a/services/QuillLMS/spec/controllers/cms/standards_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/standards_controller_spec.rb
@@ -25,8 +25,7 @@ describe Cms::StandardsController do
 
   describe '#create' do
     it 'creates a new standard with the nested change logs' do
-      post :create, {
-        standard: {
+      post :create, params: { standard: {
           name: 'New Standard',
           level: 3,
           visible: true,
@@ -39,8 +38,7 @@ describe Cms::StandardsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["standard"]["id"]
       expect(id).to be
@@ -53,9 +51,7 @@ describe Cms::StandardsController do
     it 'creates a new standard with the nested change logs' do
       new_name = 'New Standard Name'
       id = standards[0].id
-      put :update, {
-        id: id,
-        standard: {
+      put :update, params: { id: id, standard: {
           name: new_name,
           id: id,
           change_logs_attributes: [
@@ -66,8 +62,7 @@ describe Cms::StandardsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       expect(Standard.find_by_id(id).name).to eq(new_name)
       expect(ChangeLog.find_by(changed_record_id: id, changed_record_type: 'Standard', action: 'Renamed')).to be
     end

--- a/services/QuillLMS/spec/controllers/cms/student_feedback_responses_controller.rb
+++ b/services/QuillLMS/spec/controllers/cms/student_feedback_responses_controller.rb
@@ -3,13 +3,11 @@ require 'rails_helper'
 describe StudentFeedbackResponsesController do
   describe '#create' do
     it 'creates a new student_feedback_response' do
-      post :create, {
-        student_feedback_response: {
+      post :create, params: { student_feedback_response: {
           question: "What’s a part of your culture, upbringing, or background you’d like your classmates to learn more about in a Quill activity?",
           response: "I would like for them to learn about how Philadelphia is the greatest city on earth.",
           grade_levels: ["University", "9"],
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["student_feedback_response"]["id"]
       expect(id).to be

--- a/services/QuillLMS/spec/controllers/cms/subscription_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/subscription_controller_spec.rb
@@ -12,7 +12,7 @@ describe Cms::SubscriptionsController do
     let(:subscription) { build(:subscription) }
 
     it 'should create the subscription' do
-      post :create, school_or_user_id: school.id, school_or_user: "school", subscription: subscription.attributes
+      post :create, params: { school_or_user_id: school.id, school_or_user: "school", subscription: subscription.attributes }
       expect(school.reload.subscriptions.last.expiration).to eq subscription.expiration
       expect(school.reload.subscriptions.last.recurring).to eq subscription.recurring
       expect(school.reload.subscriptions.last.payment_method).to eq subscription.payment_method
@@ -23,7 +23,7 @@ describe Cms::SubscriptionsController do
       subscription = create(:subscription, recurring: true)
       create(:school_subscription, school: school, subscription: subscription)
       new_subscription = Subscription.new(start_date: Subscription.redemption_start_date(school), expiration: Subscription.redemption_start_date(school) + 1.year)
-      post :create, school_or_user_id: school.id, school_or_user: "school", subscription: new_subscription.attributes
+      post :create, params: { school_or_user_id: school.id, school_or_user: "school", subscription: new_subscription.attributes }
       expect(subscription.reload.recurring).to eq(false)
     end
   end
@@ -32,7 +32,7 @@ describe Cms::SubscriptionsController do
     let!(:subscription) { create(:subscription) }
 
     it 'should update the given subscription' do
-      post :update, id: subscription.id, subscription: { payment_amount: 100 }
+      post :update, params: { id: subscription.id, subscription: { payment_amount: 100 } }
       expect(subscription.reload.payment_amount).to eq 100
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/topics_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/topics_controller_spec.rb
@@ -23,8 +23,7 @@ describe Cms::TopicsController do
 
   describe '#create' do
     it 'creates a new topic with the nested change logs' do
-      post :create, {
-        topic: {
+      post :create, params: { topic: {
           name: 'New Topic',
           level: 3,
           visible: true,
@@ -35,8 +34,7 @@ describe Cms::TopicsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response["topic"]["id"]
       expect(id).to be
@@ -49,9 +47,7 @@ describe Cms::TopicsController do
     it 'creates a new topic with the nested change logs' do
       new_name = 'New Topic Name'
       id = topics[0].id
-      put :update, {
-        id: id,
-        topic: {
+      put :update, params: { id: id, topic: {
           name: new_name,
           id: id,
           change_logs_attributes: [
@@ -62,8 +58,7 @@ describe Cms::TopicsController do
               explanation: 'Here is an explanation'
             }
           ]
-        }
-      }
+        } }
       expect(Topic.find_by_id(id).name).to eq(new_name)
       expect(ChangeLog.find_by(changed_record_id: id, changed_record_type: 'Topic', action: 'Renamed')).to be
     end

--- a/services/QuillLMS/spec/controllers/cms/unit_template_categories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/unit_template_categories_controller_spec.rb
@@ -20,7 +20,7 @@ describe Cms::UnitTemplateCategoriesController do
 
   describe '#create' do
     it 'should create the unit template category with the given params' do
-      post :create, unit_template_category: { name: "test", primary_color: "primary", secondary_color: "secondary" }
+      post :create, params: { unit_template_category: { name: "test", primary_color: "primary", secondary_color: "secondary" } }
       expect(UnitTemplateCategory.last.name).to eq "test"
       expect(UnitTemplateCategory.last.primary_color).to eq "primary"
       expect(UnitTemplateCategory.last.secondary_color).to eq "secondary"
@@ -31,7 +31,7 @@ describe Cms::UnitTemplateCategoriesController do
     let(:category) { create(:unit_template_category) }
 
     it 'should update the given unit template category' do
-      post :update, id: category.id, unit_template_category: { name: "new name" }
+      post :update, params: { id: category.id, unit_template_category: { name: "new name" } }
       expect(category.reload.name).to eq "new name"
     end
   end
@@ -40,7 +40,7 @@ describe Cms::UnitTemplateCategoriesController do
     let(:category) { create(:unit_template_category) }
 
     it 'should destory the given category' do
-      delete :destroy, id: category.id
+      delete :destroy, params: { id: category.id }
       expect{ UnitTemplateCategory.find(category.id) }.to raise_exception ActiveRecord::RecordNotFound
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/unit_templates_controller_spec.rb
@@ -35,7 +35,7 @@ describe Cms::UnitTemplatesController, type: :controller do
     let(:template) { create(:unit_template) }
 
     it 'should update the given template' do
-      post :update, id: template.id, unit_template: { name: "new name" }
+      post :update, params: { id: template.id, unit_template: { name: "new name" } }
       expect(template.reload.name).to eq "new name"
     end
   end
@@ -44,7 +44,7 @@ describe Cms::UnitTemplatesController, type: :controller do
     let(:template) { create(:unit_template) }
 
     it 'should update the order number for the given unit templates' do
-      put :update_order_numbers, unit_templates: [{id: template.id, order_number: 47}]
+      put :update_order_numbers, params: { unit_templates: [{id: template.id, order_number: 47}] }
       expect(template.reload.order_number).to eq 47
     end
   end
@@ -53,7 +53,7 @@ describe Cms::UnitTemplatesController, type: :controller do
     let(:template) { create(:unit_template) }
 
     it 'should destroy the given unit template' do
-      delete :destroy, id: template.id
+      delete :destroy, params: { id: template.id }
       expect{ UnitTemplate.find(template.id) }.to raise_exception ActiveRecord::RecordNotFound
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -27,7 +27,7 @@ describe Cms::UsersController do
   describe '#search' do
 
     it 'should search for the users' do
-      get :search, user_flag: "auditor"
+      get :search, params: { user_flag: "auditor" }
       expect(response.body).to eq({numberOfPages: 0, userSearchQueryResults: [], userSearchQuery: {user_flag: "auditor"}}.to_json)
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:search])
       expect(ChangeLog.last.explanation).to include('auditor')
@@ -39,7 +39,7 @@ describe Cms::UsersController do
       classroom.teachers = [teacher]
       student = create(:student, classrooms: [classroom])
       class_code = classroom.code
-      get :search, class_code: class_code
+      get :search, params: { class_code: class_code }
       expect(JSON.parse(response.body)).to eq(
         {
           "numberOfPages"=> 1,
@@ -79,7 +79,7 @@ describe Cms::UsersController do
     let!(:school) { create(:school) }
 
     it 'should create the school users and kick of the syn sales contact worker' do
-      post :create_with_school, user: new_user.attributes.merge({password: "test123"}), school_id: school.id
+      post :create_with_school, params: { user: new_user.attributes.merge({password: "test123"}), school_id: school.id }
       expect(SchoolsUsers.last.school_id).to eq school.id
       expect(response).to redirect_to cms_school_path(school.id)
     end
@@ -99,7 +99,7 @@ describe Cms::UsersController do
     let(:another_user) { create(:user) }
 
     it 'should log when an admin visit the user admin page' do
-      get :show, id: another_user.id
+      get :show, params: { id: another_user.id }
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:show])
       expect(ChangeLog.last.changed_record_id).to eq(another_user.id)
     end
@@ -109,7 +109,7 @@ describe Cms::UsersController do
     let(:new_user) { build(:user) }
 
     it 'should create the user with the given params' do
-      post :create, user: new_user.attributes.merge({password: "test123"})
+      post :create, params: { user: new_user.attributes.merge({password: "test123"}) }
       expect(response).to redirect_to cms_users_path
       expect(User.last.email).to eq new_user.email
       expect(User.last.role).to eq new_user.role
@@ -120,7 +120,7 @@ describe Cms::UsersController do
     let(:another_user) { create(:user) }
 
     it 'should set the user id in session' do
-      put :sign_in, id: another_user.id
+      put :sign_in, params: { id: another_user.id }
       expect(session[:staff_id]).to eq user.id
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:sign_in])
       expect(ChangeLog.last.changed_record_id).to eq(another_user.id)
@@ -136,7 +136,7 @@ describe Cms::UsersController do
     end
 
     it 'should create a new schoolsadmin for the user given' do
-      put :make_admin, school_id: school.id, user_id: non_admin.id
+      put :make_admin, params: { school_id: school.id, user_id: non_admin.id }
       expect(SchoolsAdmins.last.school_id).to eq school.id
       expect(SchoolsAdmins.last.user_id).to eq non_admin.id
       expect(response).to redirect_to 'http://example.com'
@@ -153,7 +153,7 @@ describe Cms::UsersController do
     end
 
     it 'should destroy the schoolsadmins' do
-      put :remove_admin, user_id: admin.id, school_id: school.id
+      put :remove_admin, params: { user_id: admin.id, school_id: school.id }
       expect{SchoolsAdmins.find(schools_admin.id)}.to raise_exception ActiveRecord::RecordNotFound
       expect(response).to redirect_to "http://example.com"
     end
@@ -162,7 +162,7 @@ describe Cms::UsersController do
   describe '#edit' do
     let!(:another_user) { create(:user) }
     it 'should log when admin visits the edit page' do
-      get :edit, id: another_user.id
+      get :edit, params: { id: another_user.id }
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:edit])
       expect(ChangeLog.last.changed_record_id).to eq(another_user.id)
     end
@@ -172,7 +172,7 @@ describe Cms::UsersController do
     let!(:another_user) { create(:user) }
 
     it 'should assign the subscription' do
-      get :edit_subscription, id: another_user.id
+      get :edit_subscription, params: { id: another_user.id }
       expect(assigns(:subscription)).to eq another_user.subscription
     end
   end
@@ -185,7 +185,7 @@ describe Cms::UsersController do
 
     describe 'when there is no existing subscription' do
       it 'should create a new subscription that starts today and ends at the promotional expiration date' do
-        get :new_subscription, id: user_with_no_subscription.id
+        get :new_subscription, params: { id: user_with_no_subscription.id }
         expect(assigns(:subscription).start_date).to eq Date.today
         expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
       end
@@ -193,7 +193,7 @@ describe Cms::UsersController do
 
     describe 'when there is an existing subscription' do
       it 'should create a new subscription with starting after the current subscription ends' do
-        get :new_subscription, id: another_user.id
+        get :new_subscription, params: { id: another_user.id }
         expect(assigns(:subscription).start_date).to eq subscription.expiration
         expect(assigns(:subscription).expiration).to eq subscription.expiration + 1.year
       end
@@ -204,7 +204,7 @@ describe Cms::UsersController do
     let!(:another_user) { create(:user) }
 
     it 'should update the attributes for the given user and update change_log' do
-      post :update, id: another_user.id, user: { email: "new@test.com", flags: ["purchaser"] }
+      post :update, params: { id: another_user.id, user: { email: "new@test.com", flags: ["purchaser"] } }
       expect(another_user.reload.email).to eq "new@test.com"
       expect(response).to redirect_to cms_users_path
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
@@ -218,7 +218,7 @@ describe Cms::UsersController do
 
     it 'should clear the data' do
       expect_any_instance_of(User).to receive(:clear_data)
-      put :clear_data, id: another_user.id
+      put :clear_data, params: { id: another_user.id }
       expect(response).to redirect_to cms_users_path
     end
   end
@@ -244,7 +244,7 @@ describe Cms::UsersController do
     it 'should create the sales contact updater' do
       expect(UpdateSalesContact).to receive(:new).with(another_user.id, "2", user)
       expect(updater).to receive(:call)
-      post :complete_sales_stage, id: another_user.id, stage_number: 2
+      post :complete_sales_stage, params: { id: another_user.id, stage_number: 2 }
       expect(flash[:success]).to eq "Stage marked completed"
       expect(response).to redirect_to cms_user_path(another_user.id)
     end

--- a/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
@@ -17,13 +17,13 @@ describe CoteacherClassroomInvitationsController, type: :controller do
 
       context 'get' do
         it 'should accept one invitation' do
-          get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+          get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
           expect(invited_teacher.classrooms_i_coteach.map(&:id)).to match_array([invite_one.classroom_id])
           expect(response).to redirect_to dashboard_teachers_classrooms_path
         end
 
         it 'should accept multiple invitations' do
-          get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id, invite_two.id]
+          get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
           expect(invited_teacher.classrooms_i_coteach.map(&:id)).to match_array([invite_one.classroom_id, invite_two.classroom_id])
           expect(response).to redirect_to dashboard_teachers_classrooms_path
         end
@@ -35,25 +35,25 @@ describe CoteacherClassroomInvitationsController, type: :controller do
         end
 
         it 'should accept one invitation' do
-          get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+          get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
           expect(invited_teacher.classrooms_i_coteach.map(&:id)).to match_array([invite_one.classroom_id])
         end
 
         it 'should accept multiple invitations' do
-          get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id, invite_two.id]
+          get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
           expect(invited_teacher.classrooms_i_coteach.map(&:id)).to match_array([invite_one.classroom_id, invite_two.classroom_id])
         end
 
         it 'should track event' do
           expect(analyzer).to receive(:track).with(invited_teacher, SegmentIo::BackgroundEvents::COTEACHER_ACCEPTANCE)
-          get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id, invite_two.id]
+          get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
         end
       end
     end
 
     context 'user is not signed in' do
       it 'should redirect to the login page' do
-        get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+        get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
         expect(response).to redirect_to new_session_path
       end
     end
@@ -61,7 +61,7 @@ describe CoteacherClassroomInvitationsController, type: :controller do
     context 'user does not have access' do
       it 'should redirect to the login page' do
         session[:user_id] = unaffiliated_teacher.id
-        get :accept_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+        get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
         expect(response).to redirect_to new_session_path
       end
     end
@@ -75,13 +75,13 @@ describe CoteacherClassroomInvitationsController, type: :controller do
 
       context 'get' do
         it 'should reject one invitation' do
-          get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+          get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
           expect { invite_one.reload }.to raise_error ActiveRecord::RecordNotFound
           expect(response).to redirect_to dashboard_teachers_classrooms_path
         end
 
         it 'should reject multiple invitations' do
-          get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id, invite_two.id]
+          get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
           expect { invite_one.reload }.to raise_error ActiveRecord::RecordNotFound
           expect { invite_two.reload }.to raise_error ActiveRecord::RecordNotFound
           expect(response).to redirect_to dashboard_teachers_classrooms_path
@@ -90,12 +90,12 @@ describe CoteacherClassroomInvitationsController, type: :controller do
 
       context 'post' do
         it 'should reject one invitation' do
-          get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+          get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
           expect { invite_one.reload }.to raise_error ActiveRecord::RecordNotFound
         end
 
         it 'should reject multiple invitations' do
-          get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id, invite_two.id]
+          get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
           expect { invite_one.reload }.to raise_error ActiveRecord::RecordNotFound
           expect { invite_two.reload }.to raise_error ActiveRecord::RecordNotFound
         end
@@ -104,7 +104,7 @@ describe CoteacherClassroomInvitationsController, type: :controller do
 
     context 'user is not signed in' do
       it 'should redirect to the login page' do
-        get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+        get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
         expect(response).to redirect_to new_session_path
       end
     end
@@ -112,7 +112,7 @@ describe CoteacherClassroomInvitationsController, type: :controller do
     context 'user does not have access' do
       it 'should redirect to the login page' do
         session[:user_id] = unaffiliated_teacher.id
-        get :reject_pending_coteacher_invitations, coteacher_invitation_ids: [invite_one.id]
+        get :reject_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id] }
         expect(response).to redirect_to new_session_path
       end
     end

--- a/services/QuillLMS/spec/controllers/errors_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/errors_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ErrorsController do
   describe '#error_404' do
     it 'should set not found path' do
-      get :error_404, not_found: "www.test.com"
+      get :error_404, params: { not_found: "www.test.com" }
       expect(response).to have_http_status(404)
       assert_response :not_found
     end

--- a/services/QuillLMS/spec/controllers/feedback_history_ratings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/feedback_history_ratings_controller_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe FeedbackHistoryRatingsController, type: :controller do
           })
 
           expect do
-            post :create_or_update, {:feedback_history_rating => {
+            post :create_or_update, params: { :feedback_history_rating => {
               rating: nil,
               feedback_history_id: f_h.id
-            }}
+            } }
           end.to change(FeedbackHistoryRating, :count).by(0)
           expect(FeedbackHistoryRating.find_by(
             user_id: user.id,
@@ -44,10 +44,10 @@ RSpec.describe FeedbackHistoryRatingsController, type: :controller do
           })
 
           expect do
-            post :create_or_update, {:feedback_history_rating => {
+            post :create_or_update, params: { :feedback_history_rating => {
               rating: false,
               feedback_history_id: f_h.id
-            }}
+            } }
           end.to change(FeedbackHistoryRating, :count).by(0)
           expect(FeedbackHistoryRating.find_by(
             user_id: user.id,
@@ -68,7 +68,7 @@ RSpec.describe FeedbackHistoryRatingsController, type: :controller do
           }
 
           expect {
-            post :create_or_update, {:feedback_history_rating => valid_attributes}
+            post :create_or_update, params: { :feedback_history_rating => valid_attributes }
           }.to change(FeedbackHistoryRating, :count).by(1)
         end
       end
@@ -77,7 +77,7 @@ RSpec.describe FeedbackHistoryRatingsController, type: :controller do
       context "with invalid params" do
         it "should raise ParameterMissing" do
           expect do
-            post :create_or_update, {:feedback_history_rating => {}}
+            post :create_or_update, params: { :feedback_history_rating => {} }
           end.to raise_error(ActionController::ParameterMissing)
         end
       end
@@ -97,10 +97,7 @@ RSpec.describe FeedbackHistoryRatingsController, type: :controller do
       })
 
       expect do
-        post :mass_mark, {
-          rating: false,
-          feedback_history_ids: [f_h1.id, f_h2.id]
-        }
+        post :mass_mark, params: { rating: false, feedback_history_ids: [f_h1.id, f_h2.id] }
       end.to change(FeedbackHistoryRating, :count).by(1)
       expect(FeedbackHistoryRating.find_by(
         user_id: user.id,

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -20,7 +20,7 @@ describe GradesController do
     before { allow(RawSqlRunner).to receive(:execute) { result } }
 
     it 'should render the correct json' do
-      get :tooltip, user_id: teacher.id, completed: true, classroom_unit_id: "", activity_id: ""
+      get :tooltip, params: { user_id: teacher.id, completed: true, classroom_unit_id: "", activity_id: "" }
       expect(response.body).to eq({concept_results: result, scores: result}.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -21,17 +21,17 @@ describe InvitationsController, type: :controller do
 
   describe '#create_coteacher_invitation' do
     it 'should set the classroom ids' do
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@test.com"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@test.com" }
       expect(assigns(:classroom_ids)).to eq([classroom.id.to_s])
     end
 
     it 'should give error for invalid email format' do
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@testcom"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@testcom" }
       expect(response.body).to eq({error: "Please make sure you've entered a valid email."}.to_json)
     end
 
     it 'should give error for empty email' do
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: ""
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "" }
       expect(response.body).to eq({error: "Please make sure you've entered a valid email and selected at least one classroom."}.to_json)
     end
 
@@ -48,24 +48,24 @@ describe InvitationsController, type: :controller do
 
     it 'should give error when single class coteacher limit is exceeded' do
       stub_const("CoteacherClassroomInvitation::MAX_COTEACHER_INVITATIONS_PER_CLASS", 0)
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@test.com"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@test.com" }
       expect(response.body).to eq({error: "The maximum limit of #{CoteacherClassroomInvitation::MAX_COTEACHER_INVITATIONS_PER_CLASS} coteacher invitations have already been issued for class #{classroom.id}"}.to_json)
     end
 
     it 'should give error when user issues too many invites in a time period' do
       stub_const("Invitation::MAX_COTEACHER_INVITATIONS_PER_TIME", 0)
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@test.com"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@test.com" }
       expect(response.body).to eq({error: "User #{subject.current_user.id} has reached the maximum of #{Invitation::MAX_COTEACHER_INVITATIONS_PER_TIME} coteacher invitations that they can issue in a #{Invitation::MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS} hour period"}.to_json)
     end
 
     it 'should kick off the invitation email worker' do
       # only when environment is production or invite contains quill
       expect(InvitationEmailWorker).to receive(:perform_async)
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@quill.org"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@quill.org" }
     end
 
     it 'should render the correct json' do
-      post :create_coteacher_invitation, classroom_ids: [classroom.id], invitee_email: "test@test.com"
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@test.com" }
       expect(response.body).to eq ({invite_id: Invitation.last.id}.to_json)
       expect(Invitation.last.inviter).to eq user
       expect(Invitation.last.invitee_email).to eq "test@test.com"
@@ -83,14 +83,14 @@ describe InvitationsController, type: :controller do
       )}
 
       it 'should destroy the given invitation' do
-        delete :destroy_pending_invitations_to_specific_invitee, invitation_type: "some type", invitee_email: "test@test.com"
+        delete :destroy_pending_invitations_to_specific_invitee, params: { invitation_type: "some type", invitee_email: "test@test.com" }
         expect{ Invitation.find(invitation.id) }.to raise_exception ActiveRecord::RecordNotFound
       end
     end
 
     context 'when invitation does not exists' do
       it 'should respond with the error' do
-        delete :destroy_pending_invitations_to_specific_invitee, invitation_type: "anything", invitee_email: "some@test.com"
+        delete :destroy_pending_invitations_to_specific_invitee, params: { invitation_type: "anything", invitee_email: "some@test.com" }
         expect(response.body).to eq({error: "undefined method `destroy' for nil:NilClass"}.to_json)
       end
     end
@@ -107,14 +107,14 @@ describe InvitationsController, type: :controller do
       )}
 
       it 'should destroy the given invitation' do
-        delete :destroy_pending_invitations_from_specific_inviter, invitation_type: "some type", inviter_id: another_user.id
+        delete :destroy_pending_invitations_from_specific_inviter, params: { invitation_type: "some type", inviter_id: another_user.id }
         expect{ Invitation.find(invitation.id) }.to raise_exception ActiveRecord::RecordNotFound
       end
     end
 
     context 'when invitation does not exists' do
       it 'should respond with the error' do
-        delete :destroy_pending_invitations_from_specific_inviter,invitation_type: "some type", inviter_id: 1829
+        delete :destroy_pending_invitations_from_specific_inviter, params: { invitation_type: "some type", inviter_id: 1829 }
         expect(response.body).to eq({error: "undefined method `destroy' for nil:NilClass"}.to_json)
       end
     end

--- a/services/QuillLMS/spec/controllers/password_reset_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/password_reset_controller_spec.rb
@@ -27,7 +27,7 @@ describe PasswordResetController do
         expect_any_instance_of(User).to receive(:refresh_token!)
         expect(UserMailer).to receive(:password_reset_email).with(user)
         expect(ExpirePasswordTokenWorker).to receive(:perform_in).with(24.hours, user.id)
-        post :create, user: { email: user.email }
+        post :create, params: { user: { email: user.email } }
         expect(response.body).to eq ({ redirect: '/password_reset'}.to_json)
 
       end
@@ -35,7 +35,7 @@ describe PasswordResetController do
 
     context 'when user does not exist' do
       it 'should render the index page and show error' do
-        post :create, user: { email: "test@test.com" }
+        post :create, params: { user: { email: "test@test.com" } }
         expect(response.body).to eq ({ message: 'An account with this email does not exist. Try again.', type: 'email' }.to_json)
       end
     end
@@ -50,14 +50,14 @@ describe PasswordResetController do
       end
 
       it 'should set the user' do
-        get :show, id: user.token
+        get :show, params: { id: user.token }
         expect(assigns(:user)).to eq user
       end
     end
 
     context 'when user does not exists' do
       it 'should redirect to password reset index' do
-        get :show, id: 1234
+        get :show, params: { id: 1234 }
         expect(response).to redirect_to password_reset_index_path
       end
     end
@@ -71,7 +71,7 @@ describe PasswordResetController do
 
     it 'should update the sign the user in and redirect to profile path' do
       expect(@user.password).to_not eq "test123"
-      post :update, id: @user.token, user: { password: "test123" }
+      post :update, params: { id: @user.token, user: { password: "test123" } }
       expect(session[:user_id]).to eq @user.id
       expect(response.body).to eq({ redirect: '/profile'}.to_json)
       expect(@user.reload.token).to eq nil

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -119,7 +119,7 @@ describe ProfilesController, type: :controller do
       context 'when the student is in multiple classrooms' do
         it 'returns correct student, classrooms, and teachers info based on current_classroom_id' do
           classroom = student.classrooms.first
-          get :student_profile_data, current_classroom_id: classroom.id
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           response_body = JSON.parse(response.body)
           expect(response_body['student']).to eq({
             'name' => student.name,

--- a/services/QuillLMS/spec/controllers/referrals_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/referrals_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ReferralsController, type: :controller do
     inviting_teacher.update(email: 'current_user@quill.org')
     invitee_email = 'invitee@quill.org'
     session[:user_id] = inviting_teacher.id
-    post :invite, email: invitee_email
-    expect { post :invite, email: invitee_email }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    post :invite, params: { email: invitee_email }
+    expect { post :invite, params: { email: invitee_email } }.to change { ActionMailer::Base.deliveries.count }.by(1)
     expect(ActionMailer::Base.deliveries.last.subject).to eq("#{inviting_teacher.name} invites you to join Quill.org!")
     expect(ActionMailer::Base.deliveries.last.to).to eq([invitee_email])
   end

--- a/services/QuillLMS/spec/controllers/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/schools_controller_spec.rb
@@ -15,7 +15,7 @@ describe SchoolsController, type: :controller do
   end
 
   it 'fetches schools based on zipcode' do
-    get :index, search: '60657', format: 'json'
+    get :index, params: { search: '60657', format: 'json' }
 
     expect(response.status).to eq(200)
 
@@ -24,7 +24,7 @@ describe SchoolsController, type: :controller do
   end
 
   it 'fetches schools based on text string' do
-    get :index, search: 'Max A', format: 'json'
+    get :index, params: { search: 'Max A', format: 'json' }
 
     expect(response.status).to eq(200)
 
@@ -56,7 +56,7 @@ describe SchoolsController, type: :controller do
       end
 
       it 'should redirect to login' do
-        put :select_school, school_id_or_type: @school1.id, format: :json
+        put :select_school, params: { school_id_or_type: @school1.id, format: :json }
 
         response.should redirect_to '/session/new'
       end

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -14,7 +14,7 @@ describe SessionsController, type: :controller do
 
     context 'when user is nil' do
       it 'should report login failiure' do
-        post :create, user: { email: "test@whatever.com" }
+        post :create, params: { user: { email: "test@whatever.com" } }
         expect(response).to redirect_to "/session/new"
       end
     end
@@ -25,7 +25,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :create, user: { email: user.email }
+        post :create, params: { user: { email: user.email } }
         expect(flash[:error]).to eq 'You signed up with Google, please log in with Google using the link above.'
         expect(response).to redirect_to "/session/new"
       end
@@ -37,7 +37,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :create, user: { email: user.email }
+        post :create, params: { user: { email: user.email } }
         expect(flash[:error]).to eq 'Login failed. Did you sign up with Google? If so, please log in with Google using the link above.'
         expect(response).to redirect_to "/session/new"
       end
@@ -46,7 +46,7 @@ describe SessionsController, type: :controller do
     context 'when user is authenticated' do
       context 'when redirect present' do
         it 'should redirect to the given url' do
-          post :create, user: { email: user.email, password: "test123" }, redirect: root_path
+          post :create, params: { user: { email: user.email, password: "test123" }, redirect: root_path }
           expect(response).to redirect_to root_path
         end
       end
@@ -57,7 +57,7 @@ describe SessionsController, type: :controller do
         end
 
         it 'should redirect to profile path' do
-          post :create, user: { email: user.email, password: "test123" }
+          post :create, params: { user: { email: user.email, password: "test123" } }
           expect(response).to redirect_to profile_path
         end
       end
@@ -74,7 +74,7 @@ describe SessionsController, type: :controller do
 
     context 'when user is nil' do
       it 'should report login failiure' do
-        post :login_through_ajax, user: { email: "test@whatever.com" }, format: :json
+        post :login_through_ajax, params: { user: { email: "test@whatever.com" }, format: :json }
         expect(response.body).to eq({message: 'An account with this email or username does not exist. Try again.', type: 'email'}.to_json)
       end
     end
@@ -85,7 +85,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :login_through_ajax, user: { email: user.email }, format: :json
+        post :login_through_ajax, params: { user: { email: user.email }, format: :json }
         expect(response.body).to eq({message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}.to_json)
       end
     end
@@ -96,7 +96,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :login_through_ajax, user: { email: user.email }, format: :json
+        post :login_through_ajax, params: { user: { email: user.email }, format: :json }
         expect(response.body).to eq({message: 'Did you sign up with Google? If so, please log in with Google using the link above.', type: 'email'}.to_json)
       end
     end
@@ -108,7 +108,7 @@ describe SessionsController, type: :controller do
         end
 
         it 'should redirect to the value' do
-          post :login_through_ajax, user: { email: user.email, password: "test123" }, format: :json
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
           expect(response.body).to eq({redirect: root_path}.to_json)
           expect(session[ApplicationController::POST_AUTH_REDIRECT]).to eq nil
         end
@@ -116,7 +116,7 @@ describe SessionsController, type: :controller do
 
       context 'when params redirect present' do
         it 'should redirect to the value given' do
-          post :login_through_ajax, user: { email: user.email, password: "test123" }, redirect: root_path, format: :json
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, redirect: root_path, format: :json }
           expect(response.body).to eq({redirect: root_path}.to_json)
         end
       end
@@ -128,14 +128,14 @@ describe SessionsController, type: :controller do
         end
 
         it 'should redirect to subscriptions path' do
-          post :login_through_ajax, user: { email: user.email, password: "test123" }, format: :json
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
           expect(response.body).to eq({redirect: '/subscriptions'}.to_json)
         end
       end
 
       context 'when none of the above' do
         it 'should redirect to root path' do
-          post :login_through_ajax, user: { email: user.email, password: "test123" }, format: :json
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
           expect(response.body).to eq({redirect: '/'}.to_json)
         end
       end
@@ -195,7 +195,7 @@ describe SessionsController, type: :controller do
     it 'should set the js file, role in session  and post auth redirect in session' do
       session[:role] = "something"
       session[ApplicationController::POST_AUTH_REDIRECT] = "something else"
-      get :new, redirect: root_path
+      get :new, params: { redirect: root_path }
       expect(assigns(:js_file)).to eq "login"
       expect(session[:role]).to eq nil
       expect(session[ApplicationController::POST_AUTH_REDIRECT]).to eq root_path
@@ -205,7 +205,7 @@ describe SessionsController, type: :controller do
   describe '#set post_auth_redirect' do
     it 'should save the post_auth_redirect param to the session' do
       url = "/blah"
-      get :set_post_auth_redirect, post_auth_redirect: url
+      get :set_post_auth_redirect, params: { post_auth_redirect: url }
       expect(session[ApplicationController::POST_AUTH_REDIRECT]).to eq url
     end
   end

--- a/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
@@ -17,7 +17,7 @@ describe StatusesController, type: :controller do
         allow(resp).to receive(:status) { 200 }
         allow(Faraday).to receive(:post).and_return(resp)
 
-        post :deployment_notification, **params
+        post :deployment_notification, params: {  }
 
         expect(response.status).to eq 200
         expect(response.body).to eq 'OK'
@@ -29,7 +29,7 @@ describe StatusesController, type: :controller do
         allow(Faraday).to receive(:post).and_raise('Faraday exception')
 
         expect {
-          post :deployment_notification, **params
+          post :deployment_notification, params: {  }
         }.to raise_error(RuntimeError, 'Faraday exception')
       end
     end
@@ -41,7 +41,7 @@ describe StatusesController, type: :controller do
         allow(Faraday).to receive(:post).and_return(resp)
 
         expect {
-          post :deployment_notification, **params
+          post :deployment_notification, params: {  }
         }.to_not raise_error
 
         expect(response.status).to eq 400

--- a/services/QuillLMS/spec/controllers/students_classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/students_classrooms_controller_spec.rb
@@ -14,7 +14,7 @@ describe StudentsClassroomsController, type: :controller do
 
         it 'should kick off the students to classroom associator and join classroom worker' do
           expect(Associators::StudentsToClassrooms).to receive(:run).with(user, classroom)
-          post :create, classcode: classroom.code
+          post :create, params: { classcode: classroom.code }
           expect(response.body).to eq classroom.attributes.to_json
         end
       end
@@ -24,7 +24,7 @@ describe StudentsClassroomsController, type: :controller do
           let!(:classroom) { create(:classroom, visible: false) }
 
           it 'should return that class is archived' do
-            post :create, classcode: classroom.code
+            post :create, params: { classcode: classroom.code }
             expect(response.body).to eq({error: "Class is archived"}.to_json)
             expect(response.code).to eq "400"
           end
@@ -32,7 +32,7 @@ describe StudentsClassroomsController, type: :controller do
 
         context 'when classroom does not exist' do
           it 'should return the class does not exist' do
-            post :create, classcode: "some_code"
+            post :create, params: { classcode: "some_code" }
             expect(response.body).to eq({error: "No such classcode"}.to_json)
             expect(response.code).to eq "404"
           end
@@ -42,7 +42,7 @@ describe StudentsClassroomsController, type: :controller do
 
     context 'when current user does not exist' do
       it 'should return not logged in' do
-        post :create, classcode: "some_code"
+        post :create, params: { classcode: "some_code" }
         expect(response.body).to eq({error: "Student not logged in."}.to_json)
         expect(response.code).to eq "403"
       end

--- a/services/QuillLMS/spec/controllers/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/students_controller_spec.rb
@@ -21,7 +21,7 @@ describe StudentsController do
     end
 
     it 'should find the classroom and set flash' do
-      get :index, joined: "success", classroom: classroom.id
+      get :index, params: { joined: "success", classroom: classroom.id }
       expect(flash["join-class-notification"]).to eq "You have joined #{classroom.name} 🎉🎊"
     end
   end
@@ -34,7 +34,7 @@ describe StudentsController do
     end
 
     it 'should redirect for an invalid class_code' do
-      get :join_classroom, classcode: 'nonsense_doesnt_exist'
+      get :join_classroom, params: { classcode: 'nonsense_doesnt_exist' }
 
       expect(response).to redirect_to '/classes'
       expect(flash[:error]).to match("Oops! There is no class with the code nonsense_doesnt_exist. Ask your teacher for help.")
@@ -42,7 +42,7 @@ describe StudentsController do
 
     it 'should redirect for a valid class_code' do
       classroom = create(:classroom, code: 'existing_code')
-      get :join_classroom, classcode: classroom.code
+      get :join_classroom, params: { classcode: classroom.code }
 
       expect(response).to redirect_to "/classrooms/#{classroom.id}?joined=success"
     end
@@ -101,21 +101,21 @@ describe StudentsController do
     let!(:user) { create(:user, name: "Maya Angelou", email: 'maya_angelou_demo@quill.org', username: "maya-angelou", role: "student") }
     let!(:second_user) { create(:user, name: "Harvey Milk", email: 'harvey@quill.org', username: "harvey-milk", role: "student") }
     it 'should update the name, email and username' do
-      put :update_account, {email: "pablo@quill.org", username: "pabllo-vittar", name: "Pabllo Vittar"}
+      put :update_account, params: { email: "pablo@quill.org", username: "pabllo-vittar", name: "Pabllo Vittar" }
       expect(user.reload.email).to eq "pablo@quill.org"
       expect(user.reload.username).to eq "pabllo-vittar"
       expect(user.reload.name).to eq "Pabllo Vittar"
     end
     it 'should update only the fields that are changed' do
-      put :update_account, {email: "pablo@quill.org", username: "rainha-do-carnaval", name: "Pabllo Vittar"}
+      put :update_account, params: { email: "pablo@quill.org", username: "rainha-do-carnaval", name: "Pabllo Vittar" }
       expect(user.reload.email).to eq "pablo@quill.org"
       expect(user.reload.username).to eq "rainha-do-carnaval"
       expect(user.reload.name).to eq "Pabllo Vittar"
     end
     it 'should not update the email or username if already taken' do
-      put :update_account, {email: "harvey@quill.org", username: "pabllo-vittar", name: "Pabllo Vittar"}
+      put :update_account, params: { email: "harvey@quill.org", username: "pabllo-vittar", name: "Pabllo Vittar" }
       expect(user.reload.errors.messages[:email].first).to eq "That email is taken. Try another."
-      put :update_account, {email: "pablo@quill.org", username: "harvey-milk", name: "Pabllo Vittar"}
+      put :update_account, params: { email: "pablo@quill.org", username: "harvey-milk", name: "Pabllo Vittar" }
       expect(user.reload.errors.messages[:username].first).to eq "That username is taken. Try another."
     end
   end

--- a/services/QuillLMS/spec/controllers/subscriptions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/subscriptions_controller_spec.rb
@@ -41,7 +41,7 @@ describe SubscriptionsController do
         end
 
         it 'should sign the user out' do
-          get :purchaser_name, id: user.subscriptions.first.id
+          get :purchaser_name, params: { id: user.subscriptions.first.id }
           expect(session[:attempted_path]).to eq request.fullpath
           expect(response).to redirect_to new_session_path
         end
@@ -50,7 +50,7 @@ describe SubscriptionsController do
       context 'when subscription is associated with current user' do
         it 'should render the purchaser name' do
           user.subscriptions.first.update(purchaser: user)
-          get :purchaser_name, id: user.subscriptions.first.id
+          get :purchaser_name, params: { id: user.subscriptions.first.id }
           expect(response.body).to eq({name: user.name}.to_json)
         end
       end
@@ -58,7 +58,7 @@ describe SubscriptionsController do
 
     describe '#create' do
       it 'should create the subscription' do
-        post :create, subscription: { purchaser_id: user.id, expiration: Date.today+10.days, account_type: "some_type", recurring: false }
+        post :create, params: { subscription: { purchaser_id: user.id, expiration: Date.today+10.days, account_type: "some_type", recurring: false } }
         expect(user.reload.subscriptions.last.account_type).to eq "some_type"
         expect(user.reload.subscriptions.last.recurring).to eq false
       end
@@ -66,7 +66,7 @@ describe SubscriptionsController do
 
     describe '#update' do
       it 'should update the given subscription' do
-        post :update, id: user.subscriptions.first, subscription: { account_type: "some_type" }
+        post :update, params: { id: user.subscriptions.first, subscription: { account_type: "some_type" } }
         expect(user.reload.subscriptions.first.account_type).to eq "some_type"
       end
     end
@@ -74,7 +74,7 @@ describe SubscriptionsController do
     describe '#destroy' do
       it 'should destroy the given subscription' do
         subscription = user.subscriptions.first
-        delete :destroy, id: subscription.id
+        delete :destroy, params: { id: subscription.id }
         expect{ Subscription.find(subscription.id) }.to raise_exception ActiveRecord::RecordNotFound
       end
     end

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -12,7 +12,7 @@ describe TeacherFixController do
   describe '#archived_units' do
     context 'when user does not exist' do
       it 'should render no such user' do
-        get :archived_units, teacher_identifier: "new@email.com"
+        get :archived_units, params: { teacher_identifier: "new@email.com" }
         expect(response.body).to eq({error: "No such user."}.to_json)
       end
     end
@@ -21,7 +21,7 @@ describe TeacherFixController do
       let!(:user) { create(:student) }
 
       it 'should render user is not a teacher' do
-        get :archived_units, teacher_identifier: user.email
+        get :archived_units, params: { teacher_identifier: user.email }
         expect(response.body).to eq({error: "This user is not a teacher."}.to_json)
       end
     end
@@ -33,14 +33,14 @@ describe TeacherFixController do
         let!(:unit) { create(:unit, visible: false, user_id: user.id) }
 
         it 'should render the archived units' do
-          get :archived_units, teacher_identifier: user.email
+          get :archived_units, params: { teacher_identifier: user.email }
           expect(response.body).to eq({archived_units: [unit.attributes.merge({"shared_name" => false})]}.to_json)
         end
       end
 
       context 'when archived units are not present' do
         it 'should render the user has no archived units' do
-          get :archived_units, teacher_identifier: user.email
+          get :archived_units, params: { teacher_identifier: user.email }
           expect(response.body).to eq({error: "This user has no archived units."}.to_json)
         end
       end
@@ -106,7 +106,7 @@ describe TeacherFixController do
       let!(:classroom_unit) { create(:classroom_unit, visible: false,classroom_id: classroom.id, unit_id: unit.id) }
 
       it 'should mark the units and activit sessions visible' do
-        post :recover_classroom_units, class_code: classroom.code
+        post :recover_classroom_units, params: { class_code: classroom.code }
         expect(unit.reload.visible).to eq true
         expect(classroom_unit.reload.visible).to eq true
       end
@@ -114,7 +114,7 @@ describe TeacherFixController do
 
     context 'classroom does not exist' do
       it 'should render no such classroom' do
-        post :recover_classroom_units, class_code: "some code"
+        post :recover_classroom_units, params: { class_code: "some code" }
         expect(response.body).to eq({error: "No such classroom"}.to_json)
       end
     end
@@ -129,7 +129,7 @@ describe TeacherFixController do
       let!(:unit_activity) { create(:unit_activity, unit_id: unit.id, visible: false) }
 
       it 'should update all the unit activities' do
-        post :recover_unit_activities, email: user.email
+        post :recover_unit_activities, params: { email: user.email }
         expect(unit_activity.reload.visible).to eq true
         expect(response.code).to eq "200"
       end
@@ -147,7 +147,7 @@ describe TeacherFixController do
         let!(:activity_session) { create(:activity_session, visible: false, classroom_unit_id: classroom_unit.id, user_id: another_user.id) }
 
         it 'should update all the classroom activities' do
-          post :recover_activity_sessions, email: user.email, unit_name: "some name"
+          post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
           expect(activity_session.reload.visible).to eq true
           expect(classroom_unit.reload.visible).to eq true
           expect(classroom_unit.reload.assigned_student_ids).to eq [another_user.id]
@@ -157,7 +157,7 @@ describe TeacherFixController do
 
       context 'when unit does not exist' do
         it 'should render the user does not have a unit' do
-          post :recover_activity_sessions, email: user.email, unit_name: "test"
+          post :recover_activity_sessions, params: { email: user.email, unit_name: "test" }
           expect(response.body).to eq({error: "The user with the email #{user.email} does not have a unit named test"}.to_json)
         end
       end
@@ -167,14 +167,14 @@ describe TeacherFixController do
       let!(:user) { create(:user) }
 
       it 'should render cannot find teacher' do
-        post :recover_activity_sessions, email: user.email
+        post :recover_activity_sessions, params: { email: user.email }
         expect(response.body).to eq({error: "Cannot find a teacher with the email #{user.email}."}.to_json)
       end
     end
 
     context 'when user does not exist' do
       it 'should render cannot find teacher' do
-        post :recover_activity_sessions, email: "some@email.com"
+        post :recover_activity_sessions, params: { email: "some@email.com" }
         expect(response.body).to eq({error: "Cannot find a teacher with the email some@email.com."}.to_json)
       end
     end
@@ -189,7 +189,7 @@ describe TeacherFixController do
           let!(:student1) { create(:student, classrooms: [classroom]) }
 
           it 'should return a 200' do
-            post :merge_student_accounts, account_1_identifier: student.email, account_2_identifier: student1.email
+            post :merge_student_accounts, params: { account_1_identifier: student.email, account_2_identifier: student1.email }
             expect(response.status).to eq(200)
           end
         end
@@ -201,7 +201,7 @@ describe TeacherFixController do
           let!(:student1) { create(:student, classrooms: [classroom2] ) }
 
           it 'should return that students are not in the same classroom' do
-            post :merge_student_accounts, account_1_identifier: student.email, account_2_identifier: student1.email
+            post :merge_student_accounts, params: { account_1_identifier: student.email, account_2_identifier: student1.email }
             expect(response.body).to eq({error: "These students are not in the same classrooms."}.to_json)
           end
         end
@@ -212,7 +212,7 @@ describe TeacherFixController do
         let!(:user) { create(:user) }
 
         it 'should render that student is not a student' do
-          post :merge_student_accounts, account_1_identifier: student.email, account_2_identifier: user.email
+          post :merge_student_accounts, params: { account_1_identifier: student.email, account_2_identifier: user.email }
           expect(response.body).to eq({error: "#{user.email} is not a student."}.to_json)
         end
       end
@@ -222,7 +222,7 @@ describe TeacherFixController do
       let!(:student) { create(:student) }
 
       it 'should render that we do not have an account for the user' do
-        post :merge_student_accounts, account_1_identifier: student.email, account_2_identifier: "test@email.com"
+        post :merge_student_accounts, params: { account_1_identifier: student.email, account_2_identifier: "test@email.com" }
         expect(response.body).to eq({error: "We do not have an account for test@email.com"}.to_json)
 
       end
@@ -238,7 +238,7 @@ describe TeacherFixController do
         let!(:classrooms_teacher) { create(:classrooms_teacher, user_id: teacher.id) }
 
         it 'should update the classrooms teacher and unit' do
-          post :merge_teacher_accounts, account_1_identifier: teacher.email, account_2_identifier: teacher1.email
+          post :merge_teacher_accounts, params: { account_1_identifier: teacher.email, account_2_identifier: teacher1.email }
           expect(unit.reload.user_id).to eq teacher1.id
           expect(classrooms_teacher.reload.user_id).to eq teacher1.id
         end
@@ -249,7 +249,7 @@ describe TeacherFixController do
         let!(:user) { create(:user) }
 
         it 'should render that user is not a teacher' do
-          post :merge_teacher_accounts, account_1_identifier: teacher.email, account_2_identifier: user.email
+          post :merge_teacher_accounts, params: { account_1_identifier: teacher.email, account_2_identifier: user.email }
           expect(response.body).to eq({error: "#{user.email} is not a teacher."}.to_json)
         end
       end
@@ -259,7 +259,7 @@ describe TeacherFixController do
       let!(:teacher) { create(:teacher) }
 
       it 'should render that user does not exist' do
-        post :merge_teacher_accounts, account_1_identifier: teacher.email, account_2_identifier: "test@email.com"
+        post :merge_teacher_accounts, params: { account_1_identifier: teacher.email, account_2_identifier: "test@email.com" }
         expect(response.body).to eq( {error: "We do not have an account for test@email.com"}.to_json)
       end
     end
@@ -280,7 +280,7 @@ describe TeacherFixController do
 
             it 'should update the students classrooms, move the activity session and destroy the students classrooms' do
               # expect(user).to receive(:move_activity_sessions).with(classroom, classroom1)
-              post :move_student_from_one_class_to_another, class_code_1: classroom.code, class_code_2: classroom1.code, student_identifier: user.email
+              post :move_student_from_one_class_to_another, params: { class_code_1: classroom.code, class_code_2: classroom1.code, student_identifier: user.email }
               expect(students_classroom1.reload.visible).to eq true
               expect(StudentsClassrooms.unscoped.find(students_classroom.id).visible).not_to be
             end
@@ -288,7 +288,7 @@ describe TeacherFixController do
 
           context 'when students classrooms does not exist' do
             it 'should render student is not in any classrooms' do
-              post :move_student_from_one_class_to_another, class_code_1: classroom.code, class_code_2: classroom1.code, student_identifier: user.email
+              post :move_student_from_one_class_to_another, params: { class_code_1: classroom.code, class_code_2: classroom1.code, student_identifier: user.email }
               expect(response.body).to eq({error: "#{user.email} is not in a classroom with the code #{classroom.code}."}.to_json)
             end
           end
@@ -298,7 +298,7 @@ describe TeacherFixController do
           let!(:classroom) { create(:classroom) }
 
           it 'should render that classroom could not be found' do
-            post :move_student_from_one_class_to_another, class_code_1: classroom.code, class_code_2: "some_code", student_identifier: user.email
+            post :move_student_from_one_class_to_another, params: { class_code_1: classroom.code, class_code_2: "some_code", student_identifier: user.email }
             expect(response.body).to eq({error: "We cannot find a class with class code some_code."}.to_json)
           end
         end
@@ -308,7 +308,7 @@ describe TeacherFixController do
         let!(:user) { create(:user) }
 
         it 'should render user is not a student' do
-          post :move_student_from_one_class_to_another, student_identifier: user.email
+          post :move_student_from_one_class_to_another, params: { student_identifier: user.email }
           expect(response.body).to eq({error: "#{user.email} is not a student."}.to_json)
         end
       end
@@ -316,7 +316,7 @@ describe TeacherFixController do
 
     context 'when user does not exist' do
       it 'should render account does not exist' do
-        post :move_student_from_one_class_to_another, student_identifier: "non@user.com"
+        post :move_student_from_one_class_to_another, params: { student_identifier: "non@user.com" }
         expect(response.body).to eq({error: "We do not have an account for non@user.com"}.to_json)
       end
     end
@@ -328,7 +328,7 @@ describe TeacherFixController do
         let!(:user) { create(:student, :signed_up_with_google) }
 
         it 'should reset the google id and set the signed up with google flag' do
-          post :google_unsync_account, original_email: user.email, password: "test123"
+          post :google_unsync_account, params: { original_email: user.email, password: "test123" }
           expect(user.reload.signed_up_with_google).to eq false
           expect(user.reload.google_id).to eq nil
         end
@@ -338,7 +338,7 @@ describe TeacherFixController do
         let!(:user) { create(:student, :signed_up_with_google) }
 
         it 'should update the email, reset the google id and set the signed up with google flag' do
-          post :google_unsync_account, original_email: user.email, password: "test123", new_email: "new@email.com"
+          post :google_unsync_account, params: { original_email: user.email, password: "test123", new_email: "new@email.com" }
           expect(user.reload.email).to eq "new@email.com"
           expect(user.reload.signed_up_with_google).to eq false
           expect(user.reload.google_id).to eq nil
@@ -348,7 +348,7 @@ describe TeacherFixController do
 
     context 'when user does not exist' do
       it 'should render user does not exist' do
-        post :google_unsync_account, original_email: "some@email.com"
+        post :google_unsync_account, params: { original_email: "some@email.com" }
         expect(response.body).to eq({error: "We do not have a user registered with the email some@email.com"}.to_json)
       end
     end
@@ -358,7 +358,7 @@ describe TeacherFixController do
     context 'when to school id given' do
       it 'should not merge the schools' do
         expect(TeacherFixes).to_not receive(:merge_two_schools)
-        post :merge_two_schools, to_school_id: "to_id"
+        post :merge_two_schools, params: { to_school_id: "to_id" }
         expect(response.body).to eq({error: "Please specify a school ID."}.to_json)
       end
     end
@@ -366,7 +366,7 @@ describe TeacherFixController do
     context 'when from school id given' do
       it 'should not merge the schools' do
         expect(TeacherFixes).to_not receive(:merge_two_schools)
-        post :merge_two_schools, from_school_id: "from_id"
+        post :merge_two_schools, params: { from_school_id: "from_id" }
         expect(response.body).to eq({error: "Please specify a school ID."}.to_json)
       end
     end
@@ -374,7 +374,7 @@ describe TeacherFixController do
     context 'when both school ids given' do
       it 'should merge the two schools' do
         expect(TeacherFixes).to receive(:merge_two_schools).with("from_id", "to_id")
-        post :merge_two_schools, to_school_id: "to_id", from_school_id: "from_id"
+        post :merge_two_schools, params: { to_school_id: "to_id", from_school_id: "from_id" }
       end
     end
   end
@@ -388,7 +388,7 @@ describe TeacherFixController do
     context 'when one or more unit IDs are missing' do
       it 'should not merge activity packs' do
         expect(TeacherFixes).to_not receive(:merge_two_units)
-        post :merge_activity_packs, from_activity_pack_id: unit1.id
+        post :merge_activity_packs, params: { from_activity_pack_id: unit1.id }
         expect(response.body).to eq({error: "Please specify an activity pack ID."}.to_json)
       end
     end
@@ -396,7 +396,7 @@ describe TeacherFixController do
     context 'when one or more unit IDs are invalid' do
       it 'should not merge activity packs' do
         expect(TeacherFixes).to_not receive(:merge_two_units)
-        post :merge_activity_packs, from_activity_pack_id: unit1.id, to_activity_pack_id: 1000000000000
+        post :merge_activity_packs, params: { from_activity_pack_id: unit1.id, to_activity_pack_id: 1000000000000 }
         expect(response.body).to eq({error: "The second activity pack ID is invalid."}.to_json)
       end
     end
@@ -406,7 +406,7 @@ describe TeacherFixController do
         another_user = create(:user)
         unit3 = create(:unit, user: another_user)
         expect(TeacherFixes).to_not receive(:merge_two_units)
-        post :merge_activity_packs, from_activity_pack_id: unit1.id, to_activity_pack_id: unit3.id
+        post :merge_activity_packs, params: { from_activity_pack_id: unit1.id, to_activity_pack_id: unit3.id }
         expect(response.body).to eq({error: "The two activity packs must belong to the same teacher."}.to_json)
       end
     end
@@ -416,7 +416,7 @@ describe TeacherFixController do
         another_classroom = create(:classroom)
         unit3 = create(:unit, user: user, classrooms: [another_classroom])
         expect(TeacherFixes).to_not receive(:merge_two_units)
-        post :merge_activity_packs, from_activity_pack_id: unit1.id, to_activity_pack_id: unit3.id
+        post :merge_activity_packs, params: { from_activity_pack_id: unit1.id, to_activity_pack_id: unit3.id }
         expect(response.body).to eq({error: "The two activity packs must be assigned to the same classroom."}.to_json)
       end
     end
@@ -424,7 +424,7 @@ describe TeacherFixController do
     context 'when both activity packs are valid' do
       it 'should merge the activity packs' do
         expect(TeacherFixes).to receive(:merge_two_units).with(unit1, unit2)
-        post :merge_activity_packs, from_activity_pack_id: unit1.id, to_activity_pack_id: unit2.id
+        post :merge_activity_packs, params: { from_activity_pack_id: unit1.id, to_activity_pack_id: unit2.id }
       end
     end
   end
@@ -435,7 +435,7 @@ describe TeacherFixController do
 
       it 'should not merge the classrooms' do
         expect(TeacherFixes).to_not receive(:merge_two_classrooms)
-        post :merge_two_classrooms, class_code_1: classroom.code, class_code_2: "some_code"
+        post :merge_two_classrooms, params: { class_code_1: classroom.code, class_code_2: "some_code" }
         expect(response.body).to eq({error: "The second class code is invalid"}.to_json)
       end
     end
@@ -445,7 +445,7 @@ describe TeacherFixController do
 
       it 'should not merge the classrooms' do
         expect(TeacherFixes).to_not receive(:merge_two_classrooms)
-        post :merge_two_classrooms, class_code_2: classroom.code, class_code_1: "some_code"
+        post :merge_two_classrooms, params: { class_code_2: classroom.code, class_code_1: "some_code" }
         expect(response.body).to eq({error: "The first class code is invalid"}.to_json)
       end
     end
@@ -456,7 +456,7 @@ describe TeacherFixController do
 
       it 'should merge the two classrooms' do
         expect(TeacherFixes).to receive(:merge_two_classrooms).with(classroom.id, classroom1.id)
-        post :merge_two_classrooms, class_code_2: classroom1.code, class_code_1: classroom.code
+        post :merge_two_classrooms, params: { class_code_2: classroom1.code, class_code_1: classroom.code }
         expect(response.code).to eq "200"
       end
     end
@@ -467,7 +467,7 @@ describe TeacherFixController do
       let!(:activity) { create(:activity) }
 
       it 'should render no such student' do
-        post :delete_last_activity_session, student_identifier: "some@email.com", activity_name: activity.name
+        post :delete_last_activity_session, params: { student_identifier: "some@email.com", activity_name: activity.name }
         expect(response.body).to eq({error: "No such student"}.to_json)
       end
     end
@@ -476,7 +476,7 @@ describe TeacherFixController do
       let!(:user) { create(:user) }
 
       it 'should render no such activity' do
-        post :delete_last_activity_session, student_identifier: user.email, activity_name: "some_name"
+        post :delete_last_activity_session, params: { student_identifier: user.email, activity_name: "some_name" }
         expect(response.body).to eq({error: "No such activity"}.to_json)
       end
     end
@@ -487,7 +487,7 @@ describe TeacherFixController do
 
       it 'should delete the last activity session' do
         expect(TeacherFixes).to receive(:delete_last_activity_session).with(user.id, activity.id)
-        post :delete_last_activity_session, student_identifier: user.email, activity_name: activity.name
+        post :delete_last_activity_session, params: { student_identifier: user.email, activity_name: activity.name }
         expect(response.code).to eq "200"
       end
     end

--- a/services/QuillLMS/spec/controllers/teacher_saved_activities_controller.rb
+++ b/services/QuillLMS/spec/controllers/teacher_saved_activities_controller.rb
@@ -22,7 +22,7 @@ describe TeacherSavedActivitiesController do
   describe '#create_by_activity_id_for_current_user' do
     it 'should create a new teacher saved activity for that activity and the current user' do
       activity1 = create(:activity)
-      post :create_by_activity_id_for_current_user, { activity_id: activity1.id}
+      post :create_by_activity_id_for_current_user, params: { activity_id: activity1.id }
       expect(TeacherSavedActivity.find_by(teacher: user, activity: activity1)).to be
       expect(response.status).to be(200)
     end
@@ -33,7 +33,7 @@ describe TeacherSavedActivitiesController do
       it 'should destroy the teacher saved activity for that activity and the current user' do
         activity1 = create(:activity)
         TeacherSavedActivity.create(activity: activity1, teacher: user)
-        delete :destroy_by_activity_id_for_current_user, { activity_id: activity1.id}
+        delete :destroy_by_activity_id_for_current_user, params: { activity_id: activity1.id }
         expect(TeacherSavedActivity.find_by(teacher: user, activity: activity1)).not_to be
         expect(response.status).to be(200)
       end
@@ -42,7 +42,7 @@ describe TeacherSavedActivitiesController do
     describe 'when the teacher saved activity does not exist' do
       it 'should not error' do
         activity1 = create(:activity)
-        delete :destroy_by_activity_id_for_current_user, { activity_id: activity1.id}
+        delete :destroy_by_activity_id_for_current_user, params: { activity_id: activity1.id }
         expect(response.status).to be(200)
       end
     end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -14,7 +14,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should assign the tab, grade, students, last_classroom_name and last_lassroom_id' do
-      get :lesson_planner, id: teacher.id, tab: "test tab", grade: "test grade"
+      get :lesson_planner, params: { id: teacher.id, tab: "test tab", grade: "test grade" }
       expect(assigns(:tab)).to eq "test tab"
       expect(assigns(:grade)).to eq "test grade"
       expect(assigns(:students)).to eq user.students.any?
@@ -30,7 +30,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should assign the tab, grade, students, last_classroom_name and last_classroom_id' do
-      get :assign, tab: "test tab", grade: "test grade"
+      get :assign, params: { tab: "test tab", grade: "test grade" }
       expect(response.status).to eq(200)
     end
   end
@@ -50,7 +50,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
         end
 
         it 'should assign the tab, grade, students, last_classroom_name and last_classroom_id' do
-          get :assign, tab: "test tab", grade: "test grade"
+          get :assign, params: { tab: "test tab", grade: "test grade" }
           expect(assigns(:tab)).to eq "test tab"
           expect(assigns(:grade)).to eq "test grade"
           expect(assigns(:students)).to eq user.students.any?
@@ -61,7 +61,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
       context 'when user has classrooms i teach' do
         it 'should assign the tab, grade, students, last_classroom_name and last_classroom_id' do
-          get :assign, tab: "test tab", grade: "test grade"
+          get :assign, params: { tab: "test tab", grade: "test grade" }
           expect(assigns(:tab)).to eq "test tab"
           expect(assigns(:grade)).to eq "test grade"
           expect(assigns(:students)).to eq user.students.any?
@@ -135,12 +135,12 @@ describe Teachers::ClassroomManagerController, type: :controller do
         context 'on the /assign/diagnostic route' do
 
           it 'should create the Explore our library checkbox for the current user' do
-            get :assign, { tab: 'diagnostic' }
+            get :assign, params: { tab: 'diagnostic' }
             expect(Checkbox.find_by(objective_id: explore_our_library.id, user_id: user.id)).to be
           end
 
           it 'should create the Explore our diagnostics checkbox for the current user' do
-            get :assign, { tab: 'diagnostic' }
+            get :assign, params: { tab: 'diagnostic' }
             expect(Checkbox.find_by(objective_id: explore_our_diagnostics.id, user_id: user.id)).to be
           end
 
@@ -252,7 +252,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     context 'when classroom id is passed' do
       it 'should assign the classrooms and classroom' do
-        get :scorebook, classroom_id: classroom1.id
+        get :scorebook, params: { classroom_id: classroom1.id }
         expect(assigns(:classrooms)).to eq ([classroom, classroom1].as_json)
         expect(assigns(:classroom)).to eq (classroom1.as_json)
       end
@@ -356,7 +356,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should assign the classroom and render the correct json' do
-      get :students_list, id: classroom.id, format: :json
+      get :students_list, params: { id: classroom.id, format: :json }
       expect(assigns(:classroom)).to eq classroom
       expect(response.body).to eq({
         students: classroom.students.order("substring(users.name, '(?=\s).*') asc, users.name asc"),
@@ -473,7 +473,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
       create(:auth_credential, user: teacher)
 
       expect(GoogleStudentImporterWorker).to receive(:perform_async)
-      put :import_google_students, selected_classroom_ids: [1,2], format: :json
+      put :import_google_students, params: { selected_classroom_ids: [1,2], format: :json }
     end
   end
 
@@ -514,7 +514,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     it 'should return empty array with no classrooms' do
       expect(GoogleIntegration::Classroom::Creators::Classrooms).to receive(:run)
       classroom_json = [{id: 1}, {id: 2}].to_json
-      post :update_google_classrooms, selected_classrooms: classroom_json, format: :json
+      post :update_google_classrooms, params: { selected_classrooms: classroom_json, format: :json }
 
       expect(response.body).to eq({classrooms: []}.to_json)
    end
@@ -536,27 +536,27 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will call preview_student_id= if the student exists and is in one of the teachers classrooms' do
       expect(controller).to receive(:preview_student_id=).with(student1.id.to_s)
-      get :preview_as_student, student_id: student1.id
+      get :preview_as_student, params: { student_id: student1.id }
     end
 
     it 'will not call preview_student_id= if the student exists and is not in one of the teachers classrooms' do
       expect(controller).not_to receive(:preview_student_id=)
-      get :preview_as_student, student_id: student2.id
+      get :preview_as_student, params: { student_id: student2.id }
     end
 
     it 'will not call preview_student_id= if the student does not exist' do
       expect(controller).not_to receive(:preview_student_id=)
-      get :preview_as_student, student_id: 'random'
+      get :preview_as_student, params: { student_id: 'random' }
     end
 
     it 'will redirect to the profile path' do
-      get :preview_as_student, student_id: 'random'
+      get :preview_as_student, params: { student_id: 'random' }
       expect(response).to redirect_to profile_path
     end
 
     it 'will track event' do
       expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
-      get :preview_as_student, student_id: student1.id
+      get :preview_as_student, params: { student_id: student1.id }
     end
   end
 
@@ -569,7 +569,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will redirect to the redirect param if it exists' do
       redirect = '/teachers/classes'
-      get :unset_preview_as_student, redirect: redirect
+      get :unset_preview_as_student, params: { redirect: redirect }
       expect(response).to redirect_to redirect
     end
 

--- a/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
@@ -38,19 +38,19 @@ describe Teachers::ClassroomUnitsController, type: :controller do
           let(:teach_class_url) { "#{activity.classification_form_url}teach/class-lessons/#{activity.uid}?&classroom_unit_id=#{classroom_unit.id}" }
 
           it 'should redirect to teach class lessons url' do
-            get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid
+            get :launch_lesson, params: { id: classroom_unit.id, lesson_uid: activity.uid }
             expect(response).to redirect_to teach_class_url
           end
         end
 
         it 'should redirect_to customize lesson url' do
-          get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid
+          get :launch_lesson, params: { id: classroom_unit.id, lesson_uid: activity.uid }
           expect(response).to redirect_to customize_lesson_url
         end
 
         it 'should kick of the pusher lesson worker and update the classroom unit activity state' do
           expect(PusherLessonLaunched).to receive(:run).with(classroom_unit.classroom)
-          get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid
+          get :launch_lesson, params: { id: classroom_unit.id, lesson_uid: activity.uid }
           expect(cuas.reload.locked).to eq false
           expect(cuas.reload.pinned).to eq true
         end
@@ -65,7 +65,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
 
         it 'should redirect back to the referrer' do
           request.env["HTTP_REFERER"] = '/'
-          get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid
+          get :launch_lesson, params: { id: classroom_unit.id, lesson_uid: activity.uid }
           expect(response).to redirect_to '/'
         end
       end
@@ -124,7 +124,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
     describe '#launch_lesson' do
 
       it 'should redirect to login' do
-        get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid
+        get :launch_lesson, params: { id: classroom_unit.id, lesson_uid: activity.uid }
 
         response.should redirect_to '/session/new'
       end
@@ -133,7 +133,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
     describe '#mark_lesson_as_completed' do
 
       it 'should redirect to login' do
-        get :mark_lesson_as_completed, id: classroom_unit.id, lesson_uid: activity.uid
+        get :mark_lesson_as_completed, params: { id: classroom_unit.id, lesson_uid: activity.uid }
 
         response.should redirect_to '/session/new'
       end

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -73,7 +73,7 @@ describe Teachers::ClassroomsController, type: :controller do
         unauthorized_teacher = create(:teacher)
         unauthorized_student = { name: 'Fake Kid', password: 'Kid', username: "fake.kid@aol.com"}
         allow(controller).to receive(:current_user) { unauthorized_teacher }
-        post :create_students, classroom_id: classroom.id, students: [unauthorized_student], classroom: {}
+        post :create_students, params: { classroom_id: classroom.id, students: [unauthorized_student], classroom: {} }
 
         expect(response).to redirect_to(new_session_path)
         expect(User.find_by(name: 'Fake Kid')).to be nil
@@ -89,10 +89,7 @@ describe Teachers::ClassroomsController, type: :controller do
     before { session[:user_id] = teacher.id }
 
     it 'does not allow teacher unauthorized access to other PDFs' do
-      get :generate_login_pdf,
-        id: different_classroom.id,
-        format: :pdf,
-        only: [:pdf]
+      get :generate_login_pdf, params: { id: different_classroom.id, format: :pdf, only: [:pdf] }
 
       expect(response.status).to eq(303)
     end
@@ -119,20 +116,20 @@ describe Teachers::ClassroomsController, type: :controller do
 
     it 'does not allow transferring a classroom not owned by current user' do
       session[:user_id] = unaffiliated_user.id
-      post :transfer_ownership, id: classroom.id, requested_new_owner_id: subsequent_owner.id
+      post :transfer_ownership, params: { id: classroom.id, requested_new_owner_id: subsequent_owner.id }
       expect(response.status).to eq(303)
       expect(classroom.owner).to eq(current_owner)
     end
 
     it 'does not allow transferring a classroom to a teacher who is not already a coteacher' do
       session[:user_id] = current_owner.id
-      post :transfer_ownership, id: classroom.id, requested_new_owner_id: unaffiliated_user.id
+      post :transfer_ownership, params: { id: classroom.id, requested_new_owner_id: unaffiliated_user.id }
       expect(classroom.owner).to eq(current_owner)
     end
 
     it 'transfers ownership to a coteacher' do
       session[:user_id] = current_owner.id
-      post :transfer_ownership, id: classroom.id, requested_new_owner_id: subsequent_owner.id
+      post :transfer_ownership, params: { id: classroom.id, requested_new_owner_id: subsequent_owner.id }
 
       expect(classroom.owner).to eq(subsequent_owner)
       expect(classroom.coteachers.length).to eq(1)
@@ -153,7 +150,7 @@ describe Teachers::ClassroomsController, type: :controller do
           { properties: { new_owner_id: subsequent_owner.id.to_s } }
         )
         session[:user_id] = current_owner.id
-        post :transfer_ownership, id: classroom.id, requested_new_owner_id: subsequent_owner.id
+        post :transfer_ownership, params: { id: classroom.id, requested_new_owner_id: subsequent_owner.id }
       end
     end
   end
@@ -232,7 +229,7 @@ describe Teachers::ClassroomsController, type: :controller do
     end
 
     it 'should update the given classroom' do
-      post :update, id: classroom.id, classroom: { name: "new name" }
+      post :update, params: { id: classroom.id, classroom: { name: "new name" } }
       expect(classroom.reload.name).to eq "new name"
       expect(response).to redirect_to teachers_classroom_students_path(classroom.id)
     end
@@ -251,7 +248,7 @@ describe Teachers::ClassroomsController, type: :controller do
 
     it 'should destroy the given classroom' do
 
-      delete :destroy, id: classroom.id
+      delete :destroy, params: { id: classroom.id }
       expect{Classroom.find classroom.id}.to raise_exception ActiveRecord::RecordNotFound
       expect(response).to redirect_to teachers_classrooms_path
     end
@@ -266,7 +263,7 @@ describe Teachers::ClassroomsController, type: :controller do
     end
 
     it 'should hide the classroom' do
-      put :hide, id: classroom.id
+      put :hide, params: { id: classroom.id }
       expect(classroom.reload.visible).to eq false
       expect(response).to redirect_to teachers_classrooms_path
     end
@@ -285,7 +282,7 @@ describe Teachers::ClassroomsController, type: :controller do
     end
 
     it 'should hide the classrooms that are owned by the teacher and not hide the one that is not' do
-      put :bulk_archive, ids: [owned_classroom_1.id, owned_classroom_2.id, unowned_classroom.id]
+      put :bulk_archive, params: { ids: [owned_classroom_1.id, owned_classroom_2.id, unowned_classroom.id] }
       expect(owned_classroom_1.reload.visible).to eq false
       expect(owned_classroom_2.reload.visible).to eq false
       expect(unowned_classroom.reload.visible).to eq true
@@ -302,7 +299,7 @@ describe Teachers::ClassroomsController, type: :controller do
 
     it 'should unhide the classroom' do
       classroom.update(visible: false)
-      post :unhide, class_id: classroom.id
+      post :unhide, params: { class_id: classroom.id }
       expect(classroom.reload.visible).to eq true
     end
   end
@@ -317,7 +314,7 @@ describe Teachers::ClassroomsController, type: :controller do
     end
 
     it 'should give the correct json' do
-      get :units, id: classroom.id
+      get :units, params: { id: classroom.id }
       expect(response.body).to eq({units: "units"}.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -23,27 +23,27 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
       end
 
       it 'includes the serialized data for activity sessions' do
-        get :index, page: 1, format: :json
+        get :index, params: { page: 1, format: :json }
         expect(json['activity_sessions'][0]['activity_classification_name']).to_not be_nil
       end
 
       it 'includes the number of pages of results' do
-        get :index, {page: 1, format: :json}
+        get :index, params: { page: 1, format: :json }
         expect(json['page_count']).to eq(1)
       end
 
       it 'can filter by classroom' do
-        get :index, {classroom_id: empty_classroom.id, page: 1, format: :json}
+        get :index, params: { classroom_id: empty_classroom.id, page: 1, format: :json }
         expect(json['activity_sessions'].size).to eq(0)
       end
 
       it 'can filter by student' do
-        get :index, {student_id: zojirushi.id, page: 1, format: :json}
+        get :index, params: { student_id: zojirushi.id, page: 1, format: :json }
         expect(json['activity_sessions'].size).to eq(1)
       end
 
       it 'fetches classroom and student data for the filter options' do
-        get :index, page: 1, format: :json
+        get :index, params: { page: 1, format: :json }
         expect(json['classrooms']).to eq(teacher.ids_and_names_of_affiliated_classrooms)
         expect(json['students']).to eq(teacher.ids_and_names_of_affiliated_students)
         expect(json['units']).to eq(teacher.ids_and_names_of_affiliated_units)

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
@@ -10,7 +10,7 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
   end
 
   context 'GET #index' do
-    subject { get :index, student_id: student.id }
+    subject { get :index, params: { student_id: student.id } }
     before do
       session[:user_id] = teacher.id
     end
@@ -24,7 +24,7 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
   context 'GET #index json' do
     context 'when logged in' do
       let(:json) { JSON.parse(response.body) }
-      subject { get :index, student_id: student.id, format: :json }
+      subject { get :index, params: { student_id: student.id, format: :json } }
       before do
         session[:user_id] = teacher.id
       end
@@ -42,7 +42,7 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
       end
 
       context 'accessing another teacher\'s student data' do
-        subject { get :index, student_id: other_student.id, format: :json }
+        subject { get :index, params: { student_id: other_student.id, format: :json } }
 
         it 'raises error' do
           expect {

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/csv_exports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/csv_exports_controller_spec.rb
@@ -7,13 +7,10 @@ describe Teachers::ProgressReports::CsvExportsController, type: :controller do
     let(:export_type) { 'activity_sessions' }
     let(:filters) { { unit_id: '123' } }
     subject do
-      post :create, {
-        report_url: "/teachers/progress_reports/standards/classrooms/#{classroom_one.id}/students",
-        csv_export: {
+      post :create, params: { report_url: "/teachers/progress_reports/standards/classrooms/#{classroom_one.id}/students", csv_export: {
           export_type: export_type,
           filters: filters,
-        }
-      }
+        } }
     end
 
     context 'when authenticated as a teacher' do

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -17,7 +17,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
       it "redirects to the correct page" do
-        get :report_from_classroom_unit_activity_and_user, ({classroom_unit_id: classroom_unit.id, user_id: student.id, activity_id: activity.id})
+        get :report_from_classroom_unit_activity_and_user, params: ({classroom_unit_id: classroom_unit.id, user_id: student.id, activity_id: activity.id})
         expect(response).to redirect_to("/teachers/progress_reports/diagnostic_reports#/u/#{unit.id}/a/#{activity.id}/c/#{classroom.id}/student_report/#{student.id}")
       end
     end
@@ -31,15 +31,14 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     end
 
     it 'should not error with no activity_sessions' do
-      get :lesson_recommendations_for_classroom,
-        ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
+      get :lesson_recommendations_for_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
       expect(response).to be_success
     end
 
     it 'should not error with activity_sessions' do
       create(:activity_session, classroom_unit: @classroom_unit, activity: activity)
-      get :lesson_recommendations_for_classroom, ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
+      get :lesson_recommendations_for_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
       expect(response).to be_success
     end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
@@ -48,7 +48,7 @@ describe Teachers::ProgressReportsController do
         let!(:user) { create(:user, email: "hello+test@quill.org" ) }
 
         it 'should use the hello+test@quill account and redirect to scorebook teachers classrooms path' do
-          get :demo, name: "test"
+          get :demo, params: { name: "test" }
           expect(assigns(:user)).to eq User.find_by_email 'hello+test@quill.org'
           expect(response).to redirect_to scorebook_teachers_classrooms_path
         end
@@ -57,7 +57,7 @@ describe Teachers::ProgressReportsController do
           let!(:user) { create(:user, email: "hello+demoaccount@quill.org" ) }
 
           it 'should redirect to teachers_progress_reports_concepts_students_path path' do
-            get :demo, name: "demoaccount"
+            get :demo, params: { name: "demoaccount" }
             expect(response).to redirect_to teachers_progress_reports_concepts_students_path
           end
         end
@@ -66,7 +66,7 @@ describe Teachers::ProgressReportsController do
           let!(:user) { create(:user, email: "hello+admin_demo@quill.org" ) }
 
           it 'should redirect to profile path' do
-            get :demo, name: "admin_demo"
+            get :demo, params: { name: "admin_demo" }
             expect(response).to redirect_to profile_path
           end
         end
@@ -81,7 +81,7 @@ describe Teachers::ProgressReportsController do
         it 'should destroy the current demo and create a new demo' do
           expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with("test")
           expect(Demo::ReportDemoCreator).to receive(:create_demo).with("test")
-          get :demo, name: "test"
+          get :demo, params: { name: "test" }
         end
       end
     end
@@ -91,7 +91,7 @@ describe Teachers::ProgressReportsController do
     context 'when name given' do
       it 'sets the user and redirects to teacher_admin_dashboard path when user exists' do
         user = create(:user, email: "hello+demoadmin-test@quill.org")
-        get :admin_demo, name: "test"
+        get :admin_demo, params: { name: "test" }
         expect(assigns(:admin_user)).to eq user
       end
 
@@ -106,7 +106,7 @@ describe Teachers::ProgressReportsController do
           .with("test", "test", "hello+demoadmin-test@quill.org")
           .and_return(admin_report_service)
 
-        get :admin_demo, name: "test"
+        get :admin_demo, params: { name: "test" }
       end
     end
 

--- a/services/QuillLMS/spec/controllers/teachers/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/students_controller_spec.rb
@@ -11,7 +11,7 @@ describe Teachers::StudentsController, type: :controller do
 
     it 'kicks off a background job' do
       expect {
-        post :create, classroom_id: classroom.id, user: {first_name: 'Joe', last_name: 'Bob'}
+        post :create, params: { classroom_id: classroom.id, user: {first_name: 'Joe', last_name: 'Bob'} }
         expect(response.status).to eq(200) # Success
       }.to change(StudentJoinedClassroomWorker.jobs, :size).by(1)
     end

--- a/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
@@ -21,7 +21,7 @@ describe Teachers::UnitActivitiesController, type: :controller do
 
     it 'should hide the unit and kick off ResetLessonCacheWorker' do
       expect(ResetLessonCacheWorker).to receive_message_chain(:new, :perform).with(no_args).with(teacher.id)
-      put :hide, id: unit_activity.id
+      put :hide, params: { id: unit_activity.id }
       expect(unit_activity.reload.visible).to eq false
     end
   end
@@ -29,7 +29,7 @@ describe Teachers::UnitActivitiesController, type: :controller do
   describe '#update' do
     it 'should be able to update due dates' do
       new_due_date = '01-01-2020'
-      put :update, id: unit_activity.id, unit_activity: {due_date: new_due_date}
+      put :update, params: { id: unit_activity.id, unit_activity: {due_date: new_due_date} }
       expect(Date.parse(JSON.parse(response.body).first['due_date'])).to eq Date.parse(new_due_date)
     end
   end
@@ -37,7 +37,7 @@ describe Teachers::UnitActivitiesController, type: :controller do
   describe '#update_multiple_due_dates' do
     it 'should be able to update due dates for an array of unit_activity ids' do
       new_due_date = '01-01-2020'
-      put :update_multiple_due_dates, {unit_activity_ids: [unit_activity.id, unit_activity2.id, unit_activity3.id], due_date: new_due_date}
+      put :update_multiple_due_dates, params: { unit_activity_ids: [unit_activity.id, unit_activity2.id, unit_activity3.id], due_date: new_due_date }
       expect(unit_activity.reload.due_date).to eq new_due_date
       expect(unit_activity2.reload.due_date).to eq new_due_date
       expect(unit_activity3.reload.due_date).to eq new_due_date

--- a/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
@@ -24,7 +24,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
       it "can create new units and classroom activities" do
         data = {"id": unit_template1.id}
         current_jobs = FastAssignWorker.jobs.size
-        post "fast_assign", (data)
+        post "fast_assign", params: (data)
         expect(FastAssignWorker.jobs.size).to eq(current_jobs + 1)
       end
     end
@@ -44,7 +44,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :profile_info, id: unit_template1.id
+      get :profile_info, params: { id: unit_template1.id }
       expect(response.body).to eq({
         data: {
           non_authenticated: false,
@@ -57,7 +57,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
 
   describe '#assigned_info' do
     it 'should render the correct json' do
-      get :assigned_info , id: unit_template1.id, format: :json
+      get :assigned_info, params: { id: unit_template1.id, format: :json }
       expect(response.body).to eq({
         name: unit_template1.name,
         last_classroom_name: teacher.classrooms_i_teach.last.name,

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -73,14 +73,14 @@ describe TeachersController, type: :controller do
       it 'unlinks teacher from school' do
         expect(SchoolsUsers.find_by(user: teacher)).to be
         expect($redis).to receive(:del).with("SERIALIZED_ADMIN_USERS_FOR_#{teacher.id}")
-        post :unlink, teacher_id: teacher.id
+        post :unlink, params: { teacher_id: teacher.id }
         expect(SchoolsUsers.find_by(user: teacher)).not_to be
       end
 
       it 'returns 400 response if cannot unlink' do
         user2 = create(:teacher, school: nil)
         expect(SchoolsUsers.find_by(user: user2)).not_to be
-        post :unlink, teacher_id: user2.id
+        post :unlink, params: { teacher_id: user2.id }
         expect(response.status).to eq(400)
       end
     end

--- a/services/QuillLMS/spec/requests/sign_in_spec.rb
+++ b/services/QuillLMS/spec/requests/sign_in_spec.rb
@@ -12,12 +12,12 @@ describe 'Sign in', type: :request do
 
   describe 'POST /session' do
     it 'creates with valid attributes' do
-      post '/session', user: {email: 'student@quill.org', password: '12345'}
+      post '/session', params: { user: {email: 'student@quill.org', password: '12345'} }
       expect(response).to redirect_to(profile_path)
     end
 
     it 'does not create with invalid attributes' do
-      post '/session', user: {email: 'student@quill.org', password: 'wrong'}
+      post '/session', params: { user: {email: 'student@quill.org', password: 'wrong'} }
       expect(response).to_not redirect_to(profile_path)
     end
   end

--- a/services/QuillLMS/spec/requests/sign_up_spec.rb
+++ b/services/QuillLMS/spec/requests/sign_up_spec.rb
@@ -12,10 +12,10 @@ describe 'Sign up', type: :request do
 
   describe 'Create New Teacher Account' do
     it 'requires unique email' do
-      post '/account', user: user_params
+      post '/account', params: { user: user_params }
       sign_up_succeeds
 
-      post '/account', user: user_params
+      post '/account', params: { user: user_params }
       sign_up_fails
       expect(JSON.parse(response.body)['errors']['email']).to include("That email is taken. Try another.")
     end
@@ -23,16 +23,16 @@ describe 'Sign up', type: :request do
 
   describe 'Create New Student Account (from sign up)' do
     it 'requires unique username' do
-      post '/account', user: user_params(username: 'TestStudent', role: 'student')
+      post '/account', params: { user: user_params(username: 'TestStudent', role: 'student') }
       sign_up_succeeds
 
-      post '/account', user: user_params(username: 'TestStudent', role: 'student')
+      post '/account', params: { user: user_params(username: 'TestStudent', role: 'student') }
       sign_up_fails
       expect(JSON.parse(response.body)['errors']['username']).to include("That username is taken. Try another.")
     end
 
     it 'does not require email' do
-      post '/account', user: user_params(username: 'TestStudent', role: 'student').except(:email)
+      post '/account', params: { user: user_params(username: 'TestStudent', role: 'student').except(:email) }
       sign_up_succeeds
     end
   end
@@ -72,7 +72,7 @@ describe 'Sign up', type: :request do
 
     context "when the teacher enters the student's name correctly" do
       before do
-        post teachers_classroom_students_path(classroom), user: {first_name: student_first_name, last_name: student_last_name}
+        post teachers_classroom_students_path(classroom), params: { user: {first_name: student_first_name, last_name: student_last_name} }
       end
 
       it 'generates password' do

--- a/services/QuillLMS/spec/support/helpers/session_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/session_helper.rb
@@ -12,6 +12,6 @@ module SessionHelper
     user = args.first if args.length == 1
     email, password = user ? [user.email || user.username, user.password] : args
     password = password.presence || '123456'
-    post '/session', user: {email: email, password: password}
+    post '/session', params: { user: {email: email, password: password} }
   end
 end

--- a/services/QuillLMS/spec/support/shared/progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/progress_report.rb
@@ -7,7 +7,7 @@ shared_examples_for "Progress Report" do
   end
 
   describe 'GET #index HTML' do
-    subject { get :index, default_filters }
+    subject { get :index, params: default_filters }
 
     it 'requires an authenticated teacher' do
       subject
@@ -27,7 +27,7 @@ shared_examples_for "Progress Report" do
   end
 
   describe 'GET #index JSON' do
-    subject { get :index, default_filters.merge(format: :json) }
+    subject { get :index, params: default_filters.merge(format: :json) }
     let(:json) { JSON.parse(response.body) }
 
     it 'requires a logged-in teacher' do
@@ -95,7 +95,7 @@ shared_examples_for "exporting to CSV" do
     subject
   end
 
-  subject { get :index, default_filters.merge(format: :json) }
+  subject { get :index, params: default_filters.merge(format: :json) }
   let(:json) { JSON.parse(response.body) }
 
   it "includes the teacher data in the JSON response" do


### PR DESCRIPTION
## WHAT
Fix this deprecation:
```
DEPRECATION WARNING: Using positional arguments in functional tests has been deprecated,
in favor of keyword arguments, and will be removed in Rails 5.1.

Deprecated style:
get :show, { id: 1 }, nil, { notice: "This is a flash message" }

New keyword style:
get :show, params: { id: 1 }, flash: { notice: "This is a flash message" },
  session: nil # Can safely be omitted.
```

## WHY
We want controller specs to function properly.

## HOW
Locally, install a newer version of rubocop and run `bundle exec rubocop --only Rails/HttpPositionalArguments -a`
[more info here](https://stackoverflow.com/a/58095264)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
