### PR TITLE
LMS Rails 5.1 Prework - Use ActiveSupport::HashWithIndifferentAccess instead of top-level constant

### DIFF
--- a/services/QuillLMS/app/models/csv_exporter/activity_session.rb
+++ b/services/QuillLMS/app/models/csv_exporter/activity_session.rb
@@ -33,7 +33,7 @@ module CsvExporter
 
     def model_data(teacher, filters)
       ::ProgressReports::ActivitySession.new(teacher)
-        .results(HashWithIndifferentAccess.new(filters) || {})
+        .results(ActiveSupport::HashWithIndifferentAccess.new(filters) || {})
     end
   end
 end

--- a/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
@@ -27,7 +27,7 @@ module CsvExporter::Standards
 
     def model_data(teacher, filters)
       ::ProgressReports::Standards::Classroom.new(teacher)
-        .results(HashWithIndifferentAccess.new(filters) || {})
+        .results(ActiveSupport::HashWithIndifferentAccess.new(filters) || {})
     end
   end
 end

--- a/services/QuillLMS/app/models/csv_exporter/standards/classroom_standard.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/classroom_standard.rb
@@ -27,7 +27,7 @@ module CsvExporter::Standards
 
     def model_data(teacher, filters)
       ::ProgressReports::Standards::Standard.new(teacher)
-        .results(HashWithIndifferentAccess.new(filters) || {})
+        .results(ActiveSupport::HashWithIndifferentAccess.new(filters) || {})
     end
 
     private def page_title(filters)

--- a/services/QuillLMS/app/models/csv_exporter/standards/standard_student.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/standard_student.rb
@@ -23,7 +23,7 @@ module CsvExporter::Standards
 
     def model_data(teacher, filters)
       ::ProgressReports::Standards::Student.new(teacher)
-        .results(HashWithIndifferentAccess.new(filters) || {})
+        .results(ActiveSupport::HashWithIndifferentAccess.new(filters) || {})
     end
 
     private def page_title(filters)

--- a/services/QuillLMS/app/models/csv_exporter/standards/student_standard.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/student_standard.rb
@@ -23,7 +23,7 @@ module CsvExporter::Standards
 
     def model_data(teacher, filters)
       ::ProgressReports::Standards::Standard.new(teacher)
-        .results(HashWithIndifferentAccess.new(filters) || {})
+        .results(ActiveSupport::HashWithIndifferentAccess.new(filters) || {})
     end
 
     private def page_title(filters)


### PR DESCRIPTION
## WHAT
The `HashWithIndifferentAccess` will be [soft-deprecated](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#top-level-hashwithindifferentaccess-is-soft-deprecated
) in Rails 5.1.  The new usage should: `ActiveSupport::HashWithIndifferentAccess`

## WHY
We need to get the codebase in proper shape before the Rails 5.1 upgrade

## HOW
Update necessary references to `HashWithIndifferentAccess` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Use-ActiveSupport-HashWithIndifferentAccess-instead-of-top-level-constant-0e277480d33047df86edda906a1ff4e0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is an upgrade.  No new functionality.
Have you deployed to Staging? | Not yet.  Deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? |  YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A