### PR TITLE
LMS Rails 5.1 Prework - Update Active Record Models which now inherit from ApplicationRecord by default

### DIFF
--- a/services/QuillLMS/app/models/active_activity_session.rb
+++ b/services/QuillLMS/app/models/active_activity_session.rb
@@ -12,7 +12,7 @@
 #
 #  index_active_activity_sessions_on_uid  (uid) UNIQUE
 #
-class ActiveActivitySession < ActiveRecord::Base
+class ActiveActivitySession < ApplicationRecord
   validates :data, presence: true
   validates :uid, presence: true, uniqueness: true
   validate :data_must_be_hash

--- a/services/QuillLMS/app/models/activities_unit_template.rb
+++ b/services/QuillLMS/app/models/activities_unit_template.rb
@@ -12,7 +12,7 @@
 #  aut  (activity_id,unit_template_id)
 #  uta  (unit_template_id,activity_id)
 #
-class ActivitiesUnitTemplate < ActiveRecord::Base
+class ActivitiesUnitTemplate < ApplicationRecord
   belongs_to :unit_template
   belongs_to :activity
 end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -30,7 +30,7 @@
 #  fk_rails_...  (raw_score_id => raw_scores.id)
 #  fk_rails_...  (standard_id => standards.id)
 #
-class Activity < ActiveRecord::Base
+class Activity < ApplicationRecord
   include Flags
   include Uid
 

--- a/services/QuillLMS/app/models/activity_category.rb
+++ b/services/QuillLMS/app/models/activity_category.rb
@@ -8,7 +8,7 @@
 #  created_at   :datetime
 #  updated_at   :datetime
 #
-class ActivityCategory < ActiveRecord::Base
+class ActivityCategory < ApplicationRecord
   has_many :activity_category_activities, dependent: :destroy
   has_many :activities, through: :activity_category_activities
 

--- a/services/QuillLMS/app/models/activity_category_activity.rb
+++ b/services/QuillLMS/app/models/activity_category_activity.rb
@@ -13,7 +13,7 @@
 #
 #  index_act_category_acts_on_act_id_and_act_cat_id  (activity_id,activity_category_id)
 #
-class ActivityCategoryActivity < ActiveRecord::Base
+class ActivityCategoryActivity < ApplicationRecord
   belongs_to :activity_category
   belongs_to :activity
 

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -20,7 +20,7 @@
 #
 #  index_activity_classifications_on_uid  (uid) UNIQUE
 #
-class ActivityClassification < ActiveRecord::Base
+class ActivityClassification < ApplicationRecord
 
   include Uid
 

--- a/services/QuillLMS/app/models/activity_health.rb
+++ b/services/QuillLMS/app/models/activity_health.rb
@@ -17,7 +17,7 @@
 #  tool                    :string
 #  url                     :string
 #
-class ActivityHealth < ActiveRecord::Base
+class ActivityHealth < ApplicationRecord
   ALLOWED_TOOLS = %w(connect grammar)
   FLAGS = %w(production archived alpha beta private)
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -37,7 +37,7 @@
 require 'newrelic_rpm'
 require 'new_relic/agent'
 
-class ActivitySession < ActiveRecord::Base
+class ActivitySession < ApplicationRecord
 
   include ::NewRelic::Agent
 

--- a/services/QuillLMS/app/models/activity_topic.rb
+++ b/services/QuillLMS/app/models/activity_topic.rb
@@ -16,7 +16,7 @@
 #  fk_rails_...  (activity_id => activities.id)
 #  fk_rails_...  (topic_id => topics.id)
 #
-class ActivityTopic < ActiveRecord::Base
+class ActivityTopic < ApplicationRecord
   belongs_to :activity
   belongs_to :topic
 

--- a/services/QuillLMS/app/models/announcement.rb
+++ b/services/QuillLMS/app/models/announcement.rb
@@ -13,7 +13,7 @@
 #
 #  index_announcements_on_start_and_end  (start,end)
 #
-class Announcement < ActiveRecord::Base
+class Announcement < ApplicationRecord
   TYPES = {
     webinar: 'webinar'
   }

--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -17,7 +17,7 @@
 #
 require 'zlib'
 
-class AppSetting < ActiveRecord::Base
+class AppSetting < ApplicationRecord
   validates :percent_active, numericality: {
     only_integer: true,
     greater_than_or_equal_to: 0,

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -22,6 +22,6 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class AuthCredential < ActiveRecord::Base
+class AuthCredential < ApplicationRecord
   belongs_to :user
 end

--- a/services/QuillLMS/app/models/author.rb
+++ b/services/QuillLMS/app/models/author.rb
@@ -6,7 +6,7 @@
 #  avatar :text
 #  name   :string
 #
-class Author < ActiveRecord::Base
+class Author < ApplicationRecord
   has_many :unit_templates
   after_commit :delete_relevant_caches
 

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -33,7 +33,7 @@
 #  index_blog_posts_on_topic       (topic)
 #  tsv_idx                         (tsv) USING gin
 #
-class BlogPost < ActiveRecord::Base
+class BlogPost < ApplicationRecord
   GETTING_STARTED = "Getting started"
   TEACHER_STORIES = "Teacher stories"
   WRITING_INSTRUCTION_RESEARCH = "Writing instruction research"

--- a/services/QuillLMS/app/models/blog_post_user_rating.rb
+++ b/services/QuillLMS/app/models/blog_post_user_rating.rb
@@ -9,7 +9,7 @@
 #  blog_post_id :integer
 #  user_id      :integer
 #
-class BlogPostUserRating < ActiveRecord::Base
+class BlogPostUserRating < ApplicationRecord
   belongs_to :user
   belongs_to :blog_post
 

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -23,7 +23,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class ChangeLog < ActiveRecord::Base
+class ChangeLog < ApplicationRecord
   RENAMED = 'Renamed'
   UNARCHIVED = 'Unarchived'
   ARCHIVED = 'Archived'

--- a/services/QuillLMS/app/models/checkbox.rb
+++ b/services/QuillLMS/app/models/checkbox.rb
@@ -13,7 +13,7 @@
 #
 #  index_checkboxes_on_user_id_and_objective_id  (user_id,objective_id) UNIQUE
 #
-class Checkbox < ActiveRecord::Base
+class Checkbox < ApplicationRecord
   belongs_to :objective
   belongs_to :user
   validates :objective_id, uniqueness: { scope: :user_id, message: "should only be checked once per user" }

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -21,7 +21,7 @@
 #  index_classrooms_on_grade_level  (grade_level)
 #  index_classrooms_on_teacher_id   (teacher_id)
 #
-class Classroom < ActiveRecord::Base
+class Classroom < ApplicationRecord
   include CheckboxCallback
 
   GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)

--- a/services/QuillLMS/app/models/classroom_activity.rb
+++ b/services/QuillLMS/app/models/classroom_activity.rb
@@ -24,7 +24,7 @@
 #  index_classroom_activities_on_unit_id                  (unit_id)
 #  index_classroom_activities_on_updated_at               (updated_at)
 #
-class ClassroomActivity < ActiveRecord::Base
+class ClassroomActivity < ApplicationRecord
   has_many :activity_sessions
   belongs_to :activity
 end

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -22,7 +22,7 @@
 #  fk_rails_...  (classroom_id => classrooms.id)
 #  fk_rails_...  (unit_id => units.id)
 #
-class ClassroomUnit < ActiveRecord::Base
+class ClassroomUnit < ApplicationRecord
   include ::NewRelic::Agent
   include AtomicArrays
 

--- a/services/QuillLMS/app/models/classroom_unit_activity_state.rb
+++ b/services/QuillLMS/app/models/classroom_unit_activity_state.rb
@@ -23,7 +23,7 @@
 #  fk_rails_...  (classroom_unit_id => classroom_units.id)
 #  fk_rails_...  (unit_activity_id => unit_activities.id)
 #
-class ClassroomUnitActivityState < ActiveRecord::Base
+class ClassroomUnitActivityState < ApplicationRecord
   include ::NewRelic::Agent
   include LessonsCache
 

--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -17,7 +17,7 @@
 #  index_classrooms_teachers_on_user_id                  (user_id)
 #  unique_classroom_and_user_ids_on_classrooms_teachers  (user_id,classroom_id) UNIQUE
 #
-class ClassroomsTeacher < ActiveRecord::Base
+class ClassroomsTeacher < ApplicationRecord
   belongs_to :user
   belongs_to :classroom
 

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -13,7 +13,7 @@
 #  parent_id      :integer
 #  replacement_id :integer
 #
-class Concept < ActiveRecord::Base
+class Concept < ApplicationRecord
   include Uid
   belongs_to :parent, class_name: 'Concept', foreign_key: :parent_id
   belongs_to :replacement, class_name: 'Concept', foreign_key: :replacement_id

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -14,7 +14,7 @@
 #  index_concept_feedbacks_on_activity_type          (activity_type)
 #  index_concept_feedbacks_on_uid_and_activity_type  (uid,activity_type) UNIQUE
 #
-class ConceptFeedback < ActiveRecord::Base
+class ConceptFeedback < ApplicationRecord
   TYPES = [
     TYPE_CONNECT = 'connect',
     TYPE_GRAMMAR = 'grammar'

--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -18,7 +18,7 @@
 #
 #  fk_rails_...  (activity_classification_id => activity_classifications.id)
 #
-class ConceptResult < ActiveRecord::Base
+class ConceptResult < ApplicationRecord
 
   belongs_to :concept
   belongs_to :activity_session

--- a/services/QuillLMS/app/models/content_partner.rb
+++ b/services/QuillLMS/app/models/content_partner.rb
@@ -9,7 +9,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
-class ContentPartner < ActiveRecord::Base
+class ContentPartner < ApplicationRecord
   has_many :content_partner_activities, dependent: :destroy
   has_many :activities, :through => :content_partner_activities
 

--- a/services/QuillLMS/app/models/content_partner_activity.rb
+++ b/services/QuillLMS/app/models/content_partner_activity.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (activity_id => activities.id)
 #  fk_rails_...  (content_partner_id => content_partners.id)
 #
-class ContentPartnerActivity < ActiveRecord::Base
+class ContentPartnerActivity < ApplicationRecord
   belongs_to :content_partner
   belongs_to :activity
 end

--- a/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
@@ -14,7 +14,7 @@
 #  index_coteacher_classroom_invitations_on_classroom_id   (classroom_id)
 #  index_coteacher_classroom_invitations_on_invitation_id  (invitation_id)
 #
-class CoteacherClassroomInvitation < ActiveRecord::Base
+class CoteacherClassroomInvitation < ApplicationRecord
   belongs_to :invitation
   belongs_to :classroom
 

--- a/services/QuillLMS/app/models/credit_transaction.rb
+++ b/services/QuillLMS/app/models/credit_transaction.rb
@@ -15,7 +15,7 @@
 #  index_credit_transactions_on_source_type_and_source_id  (source_type,source_id)
 #  index_credit_transactions_on_user_id                    (user_id)
 #
-class CreditTransaction < ActiveRecord::Base
+class CreditTransaction < ApplicationRecord
   belongs_to :user
   belongs_to :source, polymorphic: true
 

--- a/services/QuillLMS/app/models/criterion.rb
+++ b/services/QuillLMS/app/models/criterion.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (concept_id => concepts.id)
 #  fk_rails_...  (recommendation_id => recommendations.id)
 #
-class Criterion < ActiveRecord::Base
+class Criterion < ApplicationRecord
   belongs_to :recommendation
   belongs_to :concept
   validates :recommendation, :concept, :count, presence: true

--- a/services/QuillLMS/app/models/csv_export.rb
+++ b/services/QuillLMS/app/models/csv_export.rb
@@ -13,7 +13,7 @@
 #
 require 'csv'
 
-class CsvExport < ActiveRecord::Base
+class CsvExport < ApplicationRecord
   EXPORT_TYPE_OPTIONS = %w(activity_sessions
                            standards_classrooms
                            standards_classroom_students

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -9,7 +9,7 @@
 #  updated_at :datetime
 #  clever_id  :string
 #
-class District < ActiveRecord::Base
+class District < ApplicationRecord
   
   has_and_belongs_to_many :users
 end

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -26,7 +26,7 @@
 #  index_feedback_histories_on_prompt_type_and_id    (prompt_type,prompt_id)
 #  index_feedback_histories_on_rule_uid              (rule_uid)
 #
-class FeedbackHistory < ActiveRecord::Base
+class FeedbackHistory < ApplicationRecord
   CONCEPT_UID_LENGTH = 22
   DEFAULT_PAGE_SIZE = 25
   DEFAULT_PROMPT_TYPE = "Comprehension::Prompt"

--- a/services/QuillLMS/app/models/feedback_history_flag.rb
+++ b/services/QuillLMS/app/models/feedback_history_flag.rb
@@ -8,7 +8,7 @@
 #  updated_at          :datetime         not null
 #  feedback_history_id :integer          not null
 #
-class FeedbackHistoryFlag < ActiveRecord::Base
+class FeedbackHistoryFlag < ApplicationRecord
   FLAG_TYPES = [
     FLAG_REPEATED_RULE_NON_CONSECUTIVE = 'repeated-non-consecutive',
     FLAG_REPEATED_RULE_CONSECUTIVE = 'repeated-consecutive'

--- a/services/QuillLMS/app/models/feedback_history_rating.rb
+++ b/services/QuillLMS/app/models/feedback_history_rating.rb
@@ -17,7 +17,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class FeedbackHistoryRating < ActiveRecord::Base
-    belongs_to :feedback_history 
+class FeedbackHistoryRating < ApplicationRecord
+    belongs_to :feedback_history
     belongs_to :user
 end

--- a/services/QuillLMS/app/models/feedback_session.rb
+++ b/services/QuillLMS/app/models/feedback_session.rb
@@ -11,7 +11,7 @@
 #  index_feedback_sessions_on_activity_session_uid  (activity_session_uid) UNIQUE
 #  index_feedback_sessions_on_uid                   (uid) UNIQUE
 #
-class FeedbackSession < ActiveRecord::Base
+class FeedbackSession < ApplicationRecord
   has_one :activity_session, foreign_key: :uid, primary_key: :activity_session_uid
   has_many :feedback_history, foreign_key: :feedback_session_uid, primary_key: :uid
 

--- a/services/QuillLMS/app/models/firebase_app.rb
+++ b/services/QuillLMS/app/models/firebase_app.rb
@@ -12,7 +12,7 @@
 require 'firebase_token_generator'
 require "jwt"
 
-class FirebaseApp < ActiveRecord::Base
+class FirebaseApp < ApplicationRecord
 
   def token_for(user)
     payload = create_payload(user)

--- a/services/QuillLMS/app/models/image.rb
+++ b/services/QuillLMS/app/models/image.rb
@@ -7,7 +7,6 @@
 #  created_at :datetime
 #  updated_at :datetime
 #
-class Image < ActiveRecord::Base
+class Image < ApplicationRecord
   mount_uploader :file, FileUploader
-
 end

--- a/services/QuillLMS/app/models/invitation.rb
+++ b/services/QuillLMS/app/models/invitation.rb
@@ -15,7 +15,7 @@
 #  index_invitations_on_invitee_email  (invitee_email)
 #  index_invitations_on_inviter_id     (inviter_id)
 #
-class Invitation < ActiveRecord::Base
+class Invitation < ApplicationRecord
 
   belongs_to :inviter, class_name: 'User', foreign_key: 'inviter_id'
   has_many :coteacher_classroom_invitations, dependent: :destroy

--- a/services/QuillLMS/app/models/ip_location.rb
+++ b/services/QuillLMS/app/models/ip_location.rb
@@ -16,7 +16,7 @@
 #  index_ip_locations_on_user_id  (user_id)
 #  index_ip_locations_on_zip      (zip)
 #
-class IpLocation < ActiveRecord::Base
+class IpLocation < ApplicationRecord
 
   belongs_to :user
 

--- a/services/QuillLMS/app/models/milestone.rb
+++ b/services/QuillLMS/app/models/milestone.rb
@@ -11,7 +11,7 @@
 #
 #  index_milestones_on_name  (name)
 #
-class Milestone < ActiveRecord::Base
+class Milestone < ApplicationRecord
   has_many :user_milestones
   has_many :users, through: :user_milestones
 

--- a/services/QuillLMS/app/models/notification.rb
+++ b/services/QuillLMS/app/models/notification.rb
@@ -17,7 +17,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class Notification < ActiveRecord::Base
+class Notification < ApplicationRecord
   belongs_to :user
 
   validates :text, presence: true, length: { maximum: 500 }

--- a/services/QuillLMS/app/models/objective.rb
+++ b/services/QuillLMS/app/models/objective.rb
@@ -12,7 +12,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #
-class Objective < ActiveRecord::Base
+class Objective < ApplicationRecord
   has_many :checkboxes
   has_many :users, through: :checkboxes
 

--- a/services/QuillLMS/app/models/partner_content.rb
+++ b/services/QuillLMS/app/models/partner_content.rb
@@ -15,7 +15,7 @@
 #  index_partner_contents_on_content_type_and_content_id  (content_type,content_id)
 #  index_partner_contents_on_partner                      (partner)
 #
-class PartnerContent < ActiveRecord::Base
+class PartnerContent < ApplicationRecord
   PARTNERS = [
     AMPLIFY = 'amplify'
   ]

--- a/services/QuillLMS/app/models/prompt_health.rb
+++ b/services/QuillLMS/app/models/prompt_health.rb
@@ -18,7 +18,7 @@
 #
 #  fk_rails_...  (activity_health_id => activity_healths.id) ON DELETE => cascade
 #
-class PromptHealth < ActiveRecord::Base
+class PromptHealth < ApplicationRecord
   FLAGS = %w(production archived alpha beta private)
 
   belongs_to :activity_health

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -14,7 +14,7 @@
 #  index_questions_on_question_type  (question_type)
 #  index_questions_on_uid            (uid) UNIQUE
 #
-class Question < ActiveRecord::Base
+class Question < ApplicationRecord
   TYPES = [
     TYPE_CONNECT_SENTENCE_COMBINING = 'connect_sentence_combining',
     TYPE_CONNECT_SENTENCE_FRAGMENTS = 'connect_sentence_fragments',

--- a/services/QuillLMS/app/models/raw_score.rb
+++ b/services/QuillLMS/app/models/raw_score.rb
@@ -7,7 +7,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-class RawScore < ActiveRecord::Base
+class RawScore < ApplicationRecord
   validates :name, presence: true
 
   def self.order_by_name

--- a/services/QuillLMS/app/models/recommendation.rb
+++ b/services/QuillLMS/app/models/recommendation.rb
@@ -19,7 +19,7 @@
 #  fk_rails_...  (activity_id => activities.id)
 #  fk_rails_...  (unit_template_id => unit_templates.id)
 #
-class Recommendation < ActiveRecord::Base
+class Recommendation < ApplicationRecord
   belongs_to :activity
   belongs_to :unit_template
   has_many :criteria, dependent: :destroy

--- a/services/QuillLMS/app/models/referrals_user.rb
+++ b/services/QuillLMS/app/models/referrals_user.rb
@@ -15,7 +15,7 @@
 #  index_referrals_users_on_referred_user_id  (referred_user_id) UNIQUE
 #  index_referrals_users_on_user_id           (user_id)
 #
-class ReferralsUser < ActiveRecord::Base
+class ReferralsUser < ApplicationRecord
   belongs_to :user
   has_one :referred_user, class_name: 'User', foreign_key: :id, primary_key: :referred_user_id
 

--- a/services/QuillLMS/app/models/referrer_user.rb
+++ b/services/QuillLMS/app/models/referrer_user.rb
@@ -13,7 +13,6 @@
 #  index_referrer_users_on_referral_code  (referral_code) UNIQUE
 #  index_referrer_users_on_user_id        (user_id) UNIQUE
 #
-class ReferrerUser < ActiveRecord::Base
+class ReferrerUser < ApplicationRecord
   belongs_to :user
-
 end

--- a/services/QuillLMS/app/models/sales_contact.rb
+++ b/services/QuillLMS/app/models/sales_contact.rb
@@ -15,7 +15,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class SalesContact < ActiveRecord::Base
+class SalesContact < ApplicationRecord
   belongs_to :user
   has_many :stages, class_name: "SalesStage", dependent: :destroy
 end

--- a/services/QuillLMS/app/models/sales_stage.rb
+++ b/services/QuillLMS/app/models/sales_stage.rb
@@ -22,7 +22,7 @@
 #  fk_rails_...  (sales_stage_type_id => sales_stage_types.id)
 #  fk_rails_...  (user_id => users.id)
 #
-class SalesStage < ActiveRecord::Base
+class SalesStage < ApplicationRecord
   validates :sales_stage_type, uniqueness: { scope: :sales_contact }
   validates :sales_stage_type, presence: true
   validates :sales_contact, presence: true

--- a/services/QuillLMS/app/models/sales_stage_type.rb
+++ b/services/QuillLMS/app/models/sales_stage_type.rb
@@ -14,7 +14,7 @@
 #
 #  index_sales_stage_types_on_name_and_order  (name,order) UNIQUE
 #
-class SalesStageType < ActiveRecord::Base
+class SalesStageType < ApplicationRecord
   validates :name, uniqueness: true
   validates :order, uniqueness: true
 

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -47,7 +47,7 @@
 #  unique_index_schools_on_nces_id  (nces_id) UNIQUE WHERE ((nces_id)::text <> ''::text)
 #  unique_index_schools_on_ppin     (ppin) UNIQUE WHERE ((ppin)::text <> ''::text)
 #
-class School < ActiveRecord::Base
+class School < ApplicationRecord
   has_many :school_subscription
   has_many :subscriptions, through: :school_subscription
   has_many :schools_users,  class_name: 'SchoolsUsers'

--- a/services/QuillLMS/app/models/school_subscription.rb
+++ b/services/QuillLMS/app/models/school_subscription.rb
@@ -13,7 +13,7 @@
 #  index_school_subscriptions_on_school_id        (school_id)
 #  index_school_subscriptions_on_subscription_id  (subscription_id)
 #
-class SchoolSubscription < ActiveRecord::Base
+class SchoolSubscription < ApplicationRecord
   validates :school_id, :subscription_id, presence: true
   belongs_to :school
   belongs_to :subscription

--- a/services/QuillLMS/app/models/schools_admins.rb
+++ b/services/QuillLMS/app/models/schools_admins.rb
@@ -14,7 +14,7 @@
 #  index_schools_admins_on_school_id_and_user_id  (school_id,user_id) UNIQUE
 #  index_schools_admins_on_user_id                (user_id)
 #
-class SchoolsAdmins < ActiveRecord::Base
+class SchoolsAdmins < ApplicationRecord
   belongs_to :school
   belongs_to :user
 

--- a/services/QuillLMS/app/models/schools_users.rb
+++ b/services/QuillLMS/app/models/schools_users.rb
@@ -12,7 +12,7 @@
 #  index_schools_users_on_school_id_and_user_id  (school_id,user_id)
 #  index_schools_users_on_user_id                (user_id) UNIQUE
 #
-class SchoolsUsers < ActiveRecord::Base
+class SchoolsUsers < ApplicationRecord
   belongs_to :school
   belongs_to :user
 

--- a/services/QuillLMS/app/models/standard.rb
+++ b/services/QuillLMS/app/models/standard.rb
@@ -16,7 +16,7 @@
 #  fk_rails_...  (standard_category_id => standard_categories.id)
 #  fk_rails_...  (standard_level_id => standard_levels.id)
 #
-class Standard < ActiveRecord::Base
+class Standard < ApplicationRecord
   include Uid
 
   belongs_to :standard_level

--- a/services/QuillLMS/app/models/standard_category.rb
+++ b/services/QuillLMS/app/models/standard_category.rb
@@ -9,7 +9,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-class StandardCategory < ActiveRecord::Base
+class StandardCategory < ApplicationRecord
   include Uid
   include ArchiveAssociatedStandards
 

--- a/services/QuillLMS/app/models/standard_level.rb
+++ b/services/QuillLMS/app/models/standard_level.rb
@@ -10,7 +10,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-class StandardLevel < ActiveRecord::Base
+class StandardLevel < ApplicationRecord
   include Uid
   include RankedModel
   include ArchiveAssociatedStandards

--- a/services/QuillLMS/app/models/student_feedback_response.rb
+++ b/services/QuillLMS/app/models/student_feedback_response.rb
@@ -9,7 +9,7 @@
 #  created_at   :datetime
 #  updated_at   :datetime
 #
-class StudentFeedbackResponse < ActiveRecord::Base
+class StudentFeedbackResponse < ApplicationRecord
   validates_presence_of :question, :response
   validates :response, length: { maximum: 1000 }
 end

--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -15,7 +15,7 @@
 #  index_students_classrooms_on_student_id                   (student_id)
 #  index_students_classrooms_on_student_id_and_classroom_id  (student_id,classroom_id) UNIQUE
 #
-class StudentsClassrooms < ActiveRecord::Base
+class StudentsClassrooms < ApplicationRecord
   include CheckboxCallback
   belongs_to :student, class_name: "User"
   belongs_to :classroom, class_name: "Classroom"

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -27,7 +27,7 @@
 require 'newrelic_rpm'
 require 'new_relic/agent'
 
-class Subscription < ActiveRecord::Base
+class Subscription < ApplicationRecord
   has_many :user_subscriptions
   has_many :users, through: :user_subscriptions
   has_many :school_subscriptions

--- a/services/QuillLMS/app/models/subscription_type.rb
+++ b/services/QuillLMS/app/models/subscription_type.rb
@@ -16,7 +16,7 @@
 require 'newrelic_rpm'
 require 'new_relic/agent'
 
-class SubscriptionType < ActiveRecord::Base
+class SubscriptionType < ApplicationRecord
 
   has_many :subscriptions
   validates :name, presence: true

--- a/services/QuillLMS/app/models/teacher_saved_activity.rb
+++ b/services/QuillLMS/app/models/teacher_saved_activity.rb
@@ -19,7 +19,7 @@
 #  fk_rails_...  (activity_id => activities.id)
 #  fk_rails_...  (teacher_id => users.id)
 #
-class TeacherSavedActivity < ActiveRecord::Base
+class TeacherSavedActivity < ApplicationRecord
   belongs_to :activity
   belongs_to :teacher, class_name: "User"
 

--- a/services/QuillLMS/app/models/third_party_user_id.rb
+++ b/services/QuillLMS/app/models/third_party_user_id.rb
@@ -17,7 +17,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-class ThirdPartyUserId < ActiveRecord::Base
+class ThirdPartyUserId < ApplicationRecord
 
   module SOURCES
     LEAP ||= "LEAP"

--- a/services/QuillLMS/app/models/title_card.rb
+++ b/services/QuillLMS/app/models/title_card.rb
@@ -15,7 +15,7 @@
 #  index_title_cards_on_title_card_type  (title_card_type)
 #  index_title_cards_on_uid              (uid) UNIQUE
 #
-class TitleCard < ActiveRecord::Base
+class TitleCard < ApplicationRecord
   TYPES = [
     TYPE_CONNECT = 'connect_title_card',
     TYPE_DIAGNOSTIC = 'diagnostic_title_card'

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -14,7 +14,7 @@
 #
 #  fk_rails_...  (parent_id => topics.id)
 #
-class Topic < ActiveRecord::Base
+class Topic < ApplicationRecord
   validates :name, presence: true
   validates :visible, :inclusion => { :in => [true, false] } # presence: true doesn't work for booleans because false will fail
   validates_inclusion_of :level, :in => 0..3

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -30,7 +30,7 @@ class UniqueNameWhenVisible < ActiveModel::Validator
 end
 
 
-class Unit < ActiveRecord::Base
+class Unit < ApplicationRecord
   include ActiveModel::Validations
   validates_with UniqueNameWhenVisible
   belongs_to :user

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -22,7 +22,7 @@
 #  fk_rails_...  (activity_id => activities.id)
 #  fk_rails_...  (unit_id => units.id)
 #
-class UnitActivity < ActiveRecord::Base
+class UnitActivity < ApplicationRecord
   include ::NewRelic::Agent
   include CheckboxCallback
 

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -21,7 +21,7 @@
 #  index_unit_templates_on_author_id                  (author_id)
 #  index_unit_templates_on_unit_template_category_id  (unit_template_category_id)
 #
-class UnitTemplate < ActiveRecord::Base
+class UnitTemplate < ApplicationRecord
   belongs_to :unit_template_category
   belongs_to :author
   has_many :activities_unit_templates, -> { order('order_number ASC') }

--- a/services/QuillLMS/app/models/unit_template_category.rb
+++ b/services/QuillLMS/app/models/unit_template_category.rb
@@ -7,7 +7,7 @@
 #  primary_color   :string
 #  secondary_color :string
 #
-class UnitTemplateCategory < ActiveRecord::Base
+class UnitTemplateCategory < ApplicationRecord
   has_many :unit_templates, dependent: :nullify
   validates :name, presence: true, uniqueness: true
 end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -53,7 +53,7 @@
 #  users_to_tsvector_idx4             (to_tsvector('english'::regconfig, (username)::text)) USING gin
 #  users_to_tsvector_idx5             (to_tsvector('english'::regconfig, split_part((ip_address)::text, '/'::text, 1))) USING gin
 #
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   include Student
   include Teacher
   include CheckboxCallback

--- a/services/QuillLMS/app/models/user_milestone.rb
+++ b/services/QuillLMS/app/models/user_milestone.rb
@@ -14,7 +14,7 @@
 #  index_user_milestones_on_user_id                   (user_id)
 #  index_user_milestones_on_user_id_and_milestone_id  (user_id,milestone_id) UNIQUE
 #
-class UserMilestone < ActiveRecord::Base
+class UserMilestone < ApplicationRecord
   belongs_to :user
   belongs_to :milestone
 end

--- a/services/QuillLMS/app/models/user_subscription.rb
+++ b/services/QuillLMS/app/models/user_subscription.rb
@@ -13,7 +13,7 @@
 #  index_user_subscriptions_on_subscription_id  (subscription_id)
 #  index_user_subscriptions_on_user_id          (user_id)
 #
-class UserSubscription < ActiveRecord::Base
+class UserSubscription < ApplicationRecord
   validates :user_id, :subscription_id, presence: true
   belongs_to :user
   belongs_to :subscription

--- a/services/QuillLMS/app/models/zipcode_info.rb
+++ b/services/QuillLMS/app/models/zipcode_info.rb
@@ -20,7 +20,7 @@
 #
 #  index_zipcode_infos_on_zipcode  (zipcode) UNIQUE
 #
-class ZipcodeInfo < ActiveRecord::Base
+class ZipcodeInfo < ApplicationRecord
 
   
   # Takes a tuple of (lat, lng) where lng and lat are floats, and a distance in

--- a/services/QuillLMS/config/initializers/ownable.rb
+++ b/services/QuillLMS/config/initializers/ownable.rb
@@ -1,2 +1,1 @@
-ActiveRecord::Base.include Owner
-
+ApplicationRecord.include(Owner)

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Activity < ActiveRecord::Base
+  class Activity < ApplicationRecord
     MIN_TARGET_LEVEL = 1
     MAX_TARGET_LEVEL = 12
     MIN_TITLE_LENGTH = 5

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/application_record.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/application_record.rb
@@ -1,0 +1,5 @@
+module Comprehension
+  class ApplicationRecord < ::ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
@@ -2,7 +2,7 @@ require "google/cloud/automl"
 
 
 module Comprehension
-  class AutomlModel < ActiveRecord::Base
+  class AutomlModel < ApplicationRecord
     MIN_LABELS_LENGTH = 1
     STATES = [
       STATE_ACTIVE = 'active',

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/feedback.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/feedback.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Feedback < ActiveRecord::Base
+  class Feedback < ApplicationRecord
     MIN_FEEDBACK_LENGTH = 10 
     MAX_FEEDBACK_LENGTH = 500
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/highlight.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/highlight.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Highlight < ActiveRecord::Base
+  class Highlight < ApplicationRecord
     MIN_TEXT_LENGTH = 1
     MAX_TEXT_LENGTH = 5000
     TYPES= [

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/label.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/label.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Label < ActiveRecord::Base
+  class Label < ApplicationRecord
     NAME_MIN_LENGTH = 3
     NAME_MAX_LENGTH = 50
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/passage.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/passage.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Passage < ActiveRecord::Base
+  class Passage < ApplicationRecord
     MIN_TEXT_LENGTH = 50
 
     belongs_to :activity, inverse_of: :passages

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/plagiarism_text.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/plagiarism_text.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class PlagiarismText < ActiveRecord::Base
+  class PlagiarismText < ApplicationRecord
 
     belongs_to :rule, inverse_of: :plagiarism_text
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompt.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class Prompt < ActiveRecord::Base
+  class Prompt < ApplicationRecord
     MIN_TEXT_LENGTH = 10
     MAX_TEXT_LENGTH = 255
     CONJUNCTIONS = %w(because but so)

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/prompts_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/prompts_rule.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class PromptsRule < ActiveRecord::Base
+  class PromptsRule < ApplicationRecord
     belongs_to :prompt
     belongs_to :rule
 

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class RegexRule < ActiveRecord::Base
+  class RegexRule < ApplicationRecord
     DEFAULT_CASE_SENSITIVITY = true
     MAX_REGEX_TEXT_LENGTH = 200
     CASE_SENSITIVE_ALLOWED_VALUES = [true, false]

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/rule.rb
@@ -1,6 +1,7 @@
 module Comprehension
-  class Rule < ActiveRecord::Base
+  class Rule < ApplicationRecord
     attr_accessor :first_feedback
+
     MAX_NAME_LENGTH = 250
     ALLOWED_BOOLEANS = [true, false]
     STATES = [

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class TurkingRound < ActiveRecord::Base
+  class TurkingRound < ApplicationRecord
     attr_readonly :uuid
 
     before_validation :set_default_uuid, on: :create

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round_activity_session.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/turking_round_activity_session.rb
@@ -1,5 +1,5 @@
 module Comprehension
-  class TurkingRoundActivitySession < ActiveRecord::Base
+  class TurkingRoundActivitySession < ApplicationRecord
     belongs_to :turking_round
 
     validates :activity_session_uid, presence: true, uniqueness: true

--- a/services/QuillLMS/engines/comprehension/lib/generators/quill_model/templates/model.rb
+++ b/services/QuillLMS/engines/comprehension/lib/generators/quill_model/templates/model.rb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %> < ActiveRecord::Base
+class <%= class_name %> < ApplicationRecord
   # FIXME, add relationships
 
   # FIXME, add validations

--- a/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity.rb
@@ -1,2 +1,2 @@
-class Activity < ActiveRecord::Base
+class Activity < ApplicationRecord
 end

--- a/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity_classification.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/app/models/activity_classification.rb
@@ -1,4 +1,4 @@
-class ActivityClassification < ActiveRecord::Base
+class ActivityClassification < ApplicationRecord
   COMPREHENSION_KEY = 'comprehension'
 
   def self.comprehension

--- a/services/QuillLMS/engines/comprehension/test/dummy/app/models/application_record.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ::ActiveRecord::Base
+  self.abstract_class = true
+end


### PR DESCRIPTION
## WHAT
Update the parent model on ActiveRecord models from `ActiveRecord::Base` to `ApplicationRecord`

## WHY 
As of Rails 5.0, there's a new [default](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-models-now-inherit-from-applicationrecord-by-default
) for ActiveRecord models inheriting from`ApplicationRecord`, which can be a single point of entry for all the customizations and extensions needed for an application, instead of monkey patching `ActiveRecord::Base`.

A more extensive writeup is [here](https://www.bigbinary.com/blog/application-record-in-rails-5)

## HOW
Update the necessary ActiveRecord files and create the ApplicationRecord model

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  No new functionality.  
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
