### PR TITLE
LMS Rails 5.1 Prework - Replace ActiveRecord::Base.sanitize calls with ActiveRecord::Base.connection.quote

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -68,8 +68,8 @@ class BlogPostsController < ApplicationController
         FROM blog_posts
         WHERE draft IS false
           AND topic != '#{BlogPost::IN_THE_NEWS}'
-          AND tsv @@ plainto_tsquery(#{ActiveRecord::Base.sanitize(@query)})
-        ORDER BY ts_rank(tsv, plainto_tsquery(#{ActiveRecord::Base.sanitize(@query)}))
+          AND tsv @@ plainto_tsquery(#{ActiveRecord::Base.connection.quote(@query)})
+        ORDER BY ts_rank(tsv, plainto_tsquery(#{ActiveRecord::Base.connection.quote(@query)}))
       SQL
     ).to_a
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -259,8 +259,8 @@ class Cms::SchoolsController < Cms::CmsController
     # School zip: schools.zipcode or schools.mail_zipcode
     # District name: schools.leanm
     # Premium status: subscriptions.account_type
-    sanitized_fuzzy_param_value = ActiveRecord::Base.sanitize('%' + param_value + '%')
-    sanitized_param_value = ActiveRecord::Base.sanitize(param_value)
+    sanitized_fuzzy_param_value = ActiveRecord::Base.connection.quote('%' + param_value + '%')
+    sanitized_param_value = ActiveRecord::Base.connection.quote(param_value)
 
     case param
     when 'school_name'
@@ -343,7 +343,7 @@ class Cms::SchoolsController < Cms::CmsController
   private def teacher_search_query_for_school(school_id)
     Cms::TeacherSearchQuery.new(school_id).run
   end
-  
+
   def fallback_location
     cms_school_path(params[:id].to_i)
   end

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -224,9 +224,9 @@ class Cms::UsersController < Cms::CmsController
     # School name: schools.name
     # User flag: user.flags
     # Premium status: subscriptions.account_type
-    sanitized_fuzzy_param_value = ActiveRecord::Base.sanitize('%' + param_value + '%')
-    sanitized_param_value = ActiveRecord::Base.sanitize(param_value)
-    # sanitized_and_joined_param_value = ActiveRecord::Base.sanitize(param_value.join('\',\''))
+    sanitized_fuzzy_param_value = ActiveRecord::Base.connection.quote('%' + param_value + '%')
+    sanitized_param_value = ActiveRecord::Base.connection.quote(param_value)
+    # sanitized_and_joined_param_value = ActiveRecord::Base.connection.quote(param_value.join('\',\''))
 
     case param
     when 'user_name'
@@ -253,7 +253,7 @@ class Cms::UsersController < Cms::CmsController
   protected def class_code_string_builder
     class_code = user_query_params["class_code"]
     if class_code.present?
-      sanitized_class_code = ActiveRecord::Base.sanitize(class_code)
+      sanitized_class_code = ActiveRecord::Base.connection.quote(class_code)
       query = """AND users.id IN
         (( SELECT user_id FROM classrooms_teachers
         JOIN classrooms ON classrooms.id = classrooms_teachers.classroom_id

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -226,7 +226,6 @@ class Cms::UsersController < Cms::CmsController
     # Premium status: subscriptions.account_type
     sanitized_fuzzy_param_value = ActiveRecord::Base.connection.quote('%' + param_value + '%')
     sanitized_param_value = ActiveRecord::Base.connection.quote(param_value)
-    # sanitized_and_joined_param_value = ActiveRecord::Base.connection.quote(param_value.join('\',\''))
 
     case param
     when 'user_name'

--- a/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
@@ -11,7 +11,7 @@ class CoteacherClassroomInvitationsController < ApplicationController
         FROM coteacher_classroom_invitations
         JOIN invitations
           ON invitations.invitation_type = '#{Invitation::TYPES[:coteacher]}'
-          AND invitations.invitee_email = #{ActiveRecord::Base.sanitize(current_user.email)}
+          AND invitations.invitee_email = #{ActiveRecord::Base.connection.quote(current_user.email)}
           AND invitations.archived = false
         WHERE coteacher_classroom_invitations.id IN (#{coteacher_invitations_to_accept.join(', ')})
       SQL

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -37,9 +37,9 @@ class GradesController < ApplicationController
           JOIN unit_activities
             ON activities.id = unit_activities.activity_id
             AND unit_activities.unit_id = classroom_units.unit_id
-          WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.sanitize(tooltip_params[:classroom_unit_id].to_i)}
-            AND activity_sessions.user_id = #{ActiveRecord::Base.sanitize(tooltip_params[:user_id].to_i)}
-            AND activity_sessions.activity_id = #{ActiveRecord::Base.sanitize(tooltip_params[:activity_id].to_i)}
+          WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:classroom_unit_id].to_i)}
+            AND activity_sessions.user_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:user_id].to_i)}
+            AND activity_sessions.activity_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:activity_id].to_i)}
             AND activity_sessions.is_final_score IS true
             AND activity_sessions.visible
         SQL
@@ -55,9 +55,9 @@ class GradesController < ApplicationController
           activity_sessions.percentage,
           activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS completed_at
         FROM activity_sessions
-        WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.sanitize(tooltip_params[:classroom_unit_id].to_i)}
-          AND activity_sessions.user_id = #{ActiveRecord::Base.sanitize(tooltip_params[:user_id].to_i)}
-          AND activity_sessions.activity_id = #{ActiveRecord::Base.sanitize(tooltip_params[:activity_id].to_i)}
+        WHERE activity_sessions.classroom_unit_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:classroom_unit_id].to_i)}
+          AND activity_sessions.user_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:user_id].to_i)}
+          AND activity_sessions.activity_id = #{ActiveRecord::Base.connection.quote(tooltip_params[:activity_id].to_i)}
           AND (activity_sessions.percentage IS NOT NULL
             OR activity_sessions.state = 'finished'
           )

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -177,7 +177,7 @@ class Teachers::UnitsController < ApplicationController
         JOIN unit_activities
           ON unit_activities.unit_id = units.id
         WHERE classrooms_teachers.user_id = #{current_user.id.to_i}
-          AND unit_activities.activity_id = #{ActiveRecord::Base.sanitize(params[:activity_id])}
+          AND unit_activities.activity_id = #{ActiveRecord::Base.connection.quote(params[:activity_id])}
           AND classroom_units.visible IS true
       SQL
     ).to_a
@@ -251,7 +251,7 @@ class Teachers::UnitsController < ApplicationController
           #{scores}
           EXTRACT(EPOCH FROM units.created_at) AS unit_created_at,
           EXTRACT(EPOCH FROM ua.created_at) AS unit_activity_created_at,
-          #{ActiveRecord::Base.sanitize(teach_own_or_coteach)} AS teach_own_or_coteach,
+          #{ActiveRecord::Base.connection.quote(teach_own_or_coteach)} AS teach_own_or_coteach,
           unit_owner.name AS owner_name,
           ua.id AS unit_activity_id,
           CASE

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -145,7 +145,7 @@ class BlogPost < ActiveRecord::Base
       <<-SQL
         SELECT slug
         FROM blog_posts
-        WHERE slug ~* CONCAT(#{ActiveRecord::Base.sanitize(slug)}, '-\\d$')
+        WHERE slug ~* CONCAT(#{ActiveRecord::Base.connection.quote(slug)}, '-\\d$')
       SQL
     ).values.flatten
 

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -172,8 +172,8 @@ module Student
         FROM
           students_classrooms A,
           students_classrooms B
-        WHERE A.student_id = #{ActiveRecord::Base.sanitize(id)}
-          AND B.student_id = #{ActiveRecord::Base.sanitize(other_student_id)}
+        WHERE A.student_id = #{ActiveRecord::Base.connection.quote(id)}
+          AND B.student_id = #{ActiveRecord::Base.connection.quote(other_student_id)}
           AND A.classroom_id = B.classroom_id
       SQL
     ).to_a

--- a/services/QuillLMS/app/queries/cms/teacher_search_query.rb
+++ b/services/QuillLMS/app/queries/cms/teacher_search_query.rb
@@ -35,7 +35,7 @@ class Cms::TeacherSearchQuery
           ON subscriptions.id = user_subscriptions.subscription_id
         LEFT JOIN schools_admins
           ON users.id = schools_admins.user_id
-        WHERE schools_users.school_id = #{ActiveRecord::Base.sanitize(school_id)}
+        WHERE schools_users.school_id = #{ActiveRecord::Base.connection.quote(school_id)}
         GROUP BY
           users.name,
           users.last_sign_in,

--- a/services/QuillLMS/app/queries/progress_reports/student_overview.rb
+++ b/services/QuillLMS/app/queries/progress_reports/student_overview.rb
@@ -15,7 +15,7 @@ class ProgressReports::StudentOverview
         FROM classroom_units
         LEFT JOIN activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
-          AND activity_sessions.user_id = #{ActiveRecord::Base.sanitize(student_id)}
+          AND activity_sessions.user_id = #{ActiveRecord::Base.connection.quote(student_id)}
           AND activity_sessions.visible = true
           AND activity_sessions.is_final_score = true
         JOIN units
@@ -28,8 +28,8 @@ class ProgressReports::StudentOverview
         LEFT JOIN classroom_unit_activity_states AS cuas
           ON cuas.unit_activity_id = unit_activities.id
           AND cuas.classroom_unit_id = classroom_units.id
-        WHERE classroom_units.classroom_id = #{ActiveRecord::Base.sanitize(classroom_id)}
-          AND #{ActiveRecord::Base.sanitize(student_id)} = ANY (classroom_units.assigned_student_ids::int[])
+        WHERE classroom_units.classroom_id = #{ActiveRecord::Base.connection.quote(classroom_id)}
+          AND #{ActiveRecord::Base.connection.quote(student_id)} = ANY (classroom_units.assigned_student_ids::int[])
           AND classroom_units.visible = true
           AND units.visible = true
         GROUP BY

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -68,12 +68,12 @@ class Scorebook::Query
 
   def self.units(unit_id)
     if unit_id && !unit_id.blank?
-      ["JOIN units ON cu.unit_id = units.id", "AND units.id = #{ActiveRecord::Base.sanitize(unit_id)}"]
+      ["JOIN units ON cu.unit_id = units.id", "AND units.id = #{ActiveRecord::Base.connection.quote(unit_id)}"]
     end
   end
 
   def self.sanitize_date(date)
-    return ActiveRecord::Base.sanitize(date) if date && !date.blank?
+    return ActiveRecord::Base.connection.quote(date) if date && !date.blank?
   end
 
   def self.date_conditional_string(begin_date, end_date, offset)


### PR DESCRIPTION
## WHAT
Replace all calls to `ActiveRecord::Base.sanitize` with `ActiveRecord::Base.connection.quote`.

## WHY
`sanitize` is [deprecated](https://github.com/rails/rails/issues/28947) in Rails 5.1.

## HOW
Replace all occurrences of `sanitize` with `connection.quote`.  Solution was suggested [here](https://github.com/rails/rails/issues/28947#issuecomment-310733481)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/LMS-Rails-5-1-Prework-Replace-ActiveRecord-Base-sanitize-calls-with-ActiveRecord-Base-connection-a707c934443c464c9806f2e7bfc46874
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  No new functionality.
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
