### PR TITLE
Teacher Activity Feed - don’t show deleted users.

### DIFF
--- a/services/QuillLMS/app/models/teacher_activity_feed.rb
+++ b/services/QuillLMS/app/models/teacher_activity_feed.rb
@@ -18,6 +18,7 @@ class TeacherActivityFeed < RedisFeed
     sessions = ActivitySession
       .includes(:user, :classification, :classroom_unit)
       .where(id: ids)
+      .where.not(user_id: nil)
       .select(:id, :user_id, :classroom_unit_id, :activity_id, :percentage, :completed_at)
 
     # purposely avoiding the SQL sort on the large activity_sessions table

--- a/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
@@ -27,22 +27,6 @@ describe TeacherActivityFeed, type: :model do
       end
     end
 
-    context "activity_session without user" do
-      it 'shouldnt show in activity feed' do
-        TeacherActivityFeed.new(1).send(:delete_all)
-        activity_session_with_user = create(:activity_session, user: create(:user))
-        activity_session_without_user = create(:activity_session, user_id: nil)
-
-        TeacherActivityFeed.add(1, activity_session_with_user.id)
-        TeacherActivityFeed.add(1, activity_session_without_user.id)
-
-        feed = TeacherActivityFeed.get(1)
-
-        expect(feed.size).to eq(1)
-        expect(feed.first[:id]).to eq(activity_session_with_user.id)
-      end
-    end
-
     context "activity_session's user gets deleted after storage" do
       it 'should not show the activity session' do
         TeacherActivityFeed.new(1).send(:delete_all)

--- a/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
@@ -26,6 +26,25 @@ describe TeacherActivityFeed, type: :model do
         expect(feed.last[:score]).to eq("Proficient")
       end
     end
+
+    context "activity_session's user gets after storage" do
+      it 'should not show the activity session' do
+        TeacherActivityFeed.new(1).send(:delete_all)
+        TeacherActivityFeed.add(1, activity_session.id)
+        TeacherActivityFeed.add(1, activity_session2.id)
+        # delete the user after storage
+        activity_session2.update(user_id: nil)
+
+        feed = TeacherActivityFeed.get(1)
+
+        expect(feed.class).to eq(Array)
+        expect(feed.size).to eq(1)
+
+        expect(feed.first[:id]).to eq(activity_session.id)
+        expect(feed.first[:completed]).to eq("5 mins ago")
+        expect(feed.first[:score]).to eq("Proficient")
+      end
+    end
   end
 
   describe "feed integration test" do

--- a/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
@@ -27,7 +27,23 @@ describe TeacherActivityFeed, type: :model do
       end
     end
 
-    context "activity_session's user gets after storage" do
+    context "activity_session without user" do
+      it 'shouldnt show in activity feed' do
+        TeacherActivityFeed.new(1).send(:delete_all)
+        activity_session_with_user = create(:activity_session, user: create(:user))
+        activity_session_without_user = create(:activity_session, user_id: nil)
+
+        TeacherActivityFeed.add(1, activity_session_with_user.id)
+        TeacherActivityFeed.add(1, activity_session_without_user.id)
+
+        feed = TeacherActivityFeed.get(1)
+
+        expect(feed.size).to eq(1)
+        expect(feed.first[:id]).to eq(activity_session_with_user.id)
+      end
+    end
+
+    context "activity_session's user gets deleted after storage" do
       it 'should not show the activity session' do
         TeacherActivityFeed.new(1).send(:delete_all)
         TeacherActivityFeed.add(1, activity_session.id)


### PR DESCRIPTION
## WHAT
Tiny `nil` error fix. If a student is deleted, don't attempt to show their sessions in the Teacher Activity Feed. 

## WHY
If a student in your recent activity was deleted, the feed would error out. That's a bad experience. Also, to respect account deletion, we shouldn't show the record at all (even without the name). 
## HOW
Write a failing test, fix the test. Scope the session query to remove blank users.

### Notion Card Links
Sentry Error
https://sentry.io/organizations/quillorg-5s/issues/2512449125/?environment=production&project=11238&referrer=alert_email

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
