### PR TITLE
LMS Rails 5.1 Prework - Misc Rails 5.1 spec failures

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
@@ -1,19 +1,21 @@
 class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
-    def by_conjunction
-        raise ArgumentError unless params.include?('activity_id') && params.include?('conjunction')
-        report = RuleFeedbackHistory.generate_report(**params.permit(:conjunction, :activity_id, :start_date, :end_date).symbolize_keys)
-        render(json: report)
-    end
+  def by_conjunction
+    raise ArgumentError unless params.include?('activity_id') && params.include?('conjunction')
+    options = params.permit(:conjunction, :activity_id, :start_date, :end_date).to_h.symbolize_keys
+    report = RuleFeedbackHistory.generate_report(**options)
+    render json: report
+  end
 
-    def rule_detail
-        raise ArgumentError unless params.include?('rule_uid') && params.include?('prompt_id')
-        report = RuleFeedbackHistory.generate_rulewise_report(**params.permit(:rule_uid, :prompt_id, :start_date, :end_date).symbolize_keys)
-        render(json: report)
-    end
+  def rule_detail
+    raise ArgumentError unless params.include?('rule_uid') && params.include?('prompt_id')
+    options = params.permit(:rule_uid, :prompt_id, :start_date, :end_date).to_h.symbolize_keys
+    report = RuleFeedbackHistory.generate_rulewise_report(**options)
+    render json: report
+  end
 
-    def prompt_health
-        raise ArgumentError unless params.include?('activity_id')
-        report = PromptFeedbackHistory.run(params['activity_id'])
-        render(json: report)
-    end
+  def prompt_health
+    raise ArgumentError unless params.include?('activity_id')
+    report = PromptFeedbackHistory.run(params['activity_id'])
+    render json: report
+  end
 end

--- a/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::SessionFeedbackHistoriesController < Api::ApiController
     if results
       render json: results
     else
-      render text: "The resource you were looking for does not exist", status: 404
+      render plain: "The resource you were looking for does not exist", status: 404
     end
   end
 end

--- a/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::SessionFeedbackHistoriesController < Api::ApiController
   # GET /feedback_histories.json?page=1&activity_id=33&start_date=2021-04-18T03:00:00.000Z&end_date=2021-05-18T03:00:00.000Z
   def index
-    records = FeedbackHistory.list_by_activity_session(**params.permit(:page, :activity_id, :start_date, :end_date).symbolize_keys)
+    options = params.permit(:page, :activity_id, :start_date, :end_date).to_h.symbolize_keys
+    records = FeedbackHistory.list_by_activity_session(**options)
     count = FeedbackHistory.select(:feedback_session_uid).distinct.count
 
     render json: {

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -137,7 +137,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
         }
       end
     else
-      render text: csv_string(activity_sessions)
+      render plain: csv_string(activity_sessions)
     end
   end
 

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -4,9 +4,17 @@ module Student
   included do
     #TODO: move these relationships into the users model
 
-    has_many :students_classrooms, foreign_key: 'student_id', dependent: :destroy, class_name: "StudentsClassrooms"
+    has_many :students_classrooms,
+      foreign_key: 'student_id',
+      dependent: :destroy,
+      class_name: "StudentsClassrooms"
 
-    has_many :classrooms, through: :students_classrooms, source: :classroom, inverse_of: :students, class_name: "Classroom"
+    has_many :classrooms,
+      through: :students_classrooms,
+      source: :classroom,
+      inverse_of: :students,
+      class_name: "Classroom"
+
     has_many :activity_sessions, dependent: :destroy
     has_many :assigned_activities, through: :classrooms, source: :activities
     has_many :started_activities, through: :activity_sessions, source: :activity

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -99,7 +99,6 @@ class User < ApplicationRecord
   has_many :unit_activities, through: :units
   has_many :classroom_unit_activity_states, through: :unit_activities
 
-  has_many :students_classrooms, class_name: 'StudentsClassrooms', foreign_key: 'student_id'
   has_many :student_in_classroom, through: :students_classrooms, source: :classroom
 
   has_and_belongs_to_many :districts

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -8,12 +8,12 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
   describe '#by_conjunction' do
     it 'should return successfully' do
-        get :by_conjunction, params: { conjunction: 'so', activity_id: 1 }
+      get :by_conjunction, params: { conjunction: 'so', activity_id: 1 }
 
-        expect(response.status).to eq 200
-        expect(JSON.parse(response.body)).to eq(
-            {"rule_feedback_histories"=>[]}
-        )
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)).to eq(
+        {"rule_feedback_histories"=>[]}
+      )
     end
 
     it 'should pass conjunction, activity_id, start_date and end_date through to #generate_report' do
@@ -28,7 +28,14 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
         start_date: START_DATE,
         end_date: END_DATE,
       })
-      get :by_conjunction, params: { conjunction: CONJUNCTION, activity_id: ACTIVITY_ID, start_date: START_DATE, end_date: END_DATE }
+
+      get :by_conjunction,
+        params: {
+          conjunction: CONJUNCTION,
+          activity_id: ACTIVITY_ID,
+          start_date: START_DATE,
+          end_date: END_DATE
+        }
     end
   end
 

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -18,9 +18,7 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
     context 'when logged in' do
       let(:json) { JSON.parse(response.body) }
 
-      before do
-        session[:user_id] = teacher.id
-      end
+      before { session[:user_id] = teacher.id }
 
       it 'includes the serialized data for activity sessions' do
         get :index, params: { page: 1, format: :json }

--- a/services/QuillLMS/spec/support/shared/progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/progress_report.rb
@@ -15,9 +15,7 @@ shared_examples_for "Progress Report" do
     end
 
     describe 'when the teacher is logged in' do
-      before do
-        login
-      end
+      before { login }
 
       it 'renders the view' do
         subject
@@ -28,6 +26,7 @@ shared_examples_for "Progress Report" do
 
   describe 'GET #index JSON' do
     subject { get :index, params: default_filters.merge(format: :json) }
+
     let(:json) { JSON.parse(response.body) }
 
     it 'requires a logged-in teacher' do
@@ -36,9 +35,7 @@ shared_examples_for "Progress Report" do
     end
 
     describe 'when the teacher is logged in' do
-      before do
-        login
-      end
+      before { login }
 
       it 'sends a Vary: Accept header (for Chrome caching issues)' do
         subject
@@ -65,15 +62,13 @@ shared_examples_for "Progress Report" do
 end
 
 shared_examples_for "filtering progress reports by Unit" do
-
-  let(:filters) { default_filters.merge({unit_id: filter_value, format: :json})}
+  let(:filters) { { unit_id: filter_value, xhr: true, format: :json } }
 
   describe 'GET #index JSON' do
-    before do
-      login
-    end
+    before { login }
 
-    subject { xhr :get, :index, filters }
+    subject { get :index, params: default_filters.merge(filters) }
+
     let(:json) { JSON.parse(response.body) }
 
     it "can filter the progress report by unit" do
@@ -96,6 +91,7 @@ shared_examples_for "exporting to CSV" do
   end
 
   subject { get :index, params: default_filters.merge(format: :json) }
+
   let(:json) { JSON.parse(response.body) }
 
   it "includes the teacher data in the JSON response" do


### PR DESCRIPTION
## WHAT
1) Fix calls to `symbolize_keys` on `ActionController::Parameters` object
2) Rewrite `xhr` controller spec requests
3) Remove duplicate `has_many` declarations
4) Update `render :text` calls due to [deprecation](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#removed-deprecated-support-to-text-and-nothing-in-render)

## WHY
These items are all spec failures when upgrading to Rails 5.1.  Fixing them before the actual upgrade makes the eventual upgrade diff more manageable.

## HOW
1) Add `to_h` before calling `symbolize_keys`
2) change verb from `xhr :get :index` to `get :index, xhr: true`
3) Remove duplicate
4) Update `render :text` to `render :plain`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
