### PR TITLE
Go Endpoint - Synchronous version

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -148,7 +148,6 @@ func Endpoint(context *gin.Context) {
 	context.JSON(200, returnable_result)
 
 	wg.Wait()
-	close(channel)
 }
 // returns a typle of results index and that should be returned.
 func processResults(results map[int]InternalAPIResponse, length int) (int, bool) {

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -104,18 +104,11 @@ func Endpoint(context *gin.Context) {
 	}
 
 	results := map[int]InternalAPIResponse{}
-	responses := make([]InternalAPIResponse, api_count)
-
-	for priority, url := range urls {
-
-		responses[priority] = getAPIResponse(url, priority, request_body)
-	}
-
 
 	var returnable_result APIResponse
 
-	for _, response := range responses {
-		results[response.Priority] = response
+	for index, url := range urls {
+		results[index] = getAPIResponse(url, index, request_body)
 		return_index, finished := processResults(results, len(urls))
 
 		if finished {

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -148,6 +148,7 @@ func Endpoint(context *gin.Context) {
 	context.JSON(200, returnable_result)
 
 	wg.Wait()
+	close(channel)
 }
 // returns a typle of results index and that should be returned.
 func processResults(results map[int]InternalAPIResponse, length int) (int, bool) {


### PR DESCRIPTION
## WHAT
This is a synchronous version of the go endpoint that runs the sub-API requests one at a time.

## WHY
We are debugging a `goroutine` leak, which we believe is caused by the way we are closing/not closing `channels` (the core of the concurrency/async code). 

The Curriculum Team needs to turk some new activities, so while we debug the issues, I'm converting this endpoint to not use `channel`s, and run the sub-API requests synchronously, one-at-a-time. Running this for turkers will also help us understand if `channels` are the issue (or it's something else, like the way we use the `gin` framework).
## HOW
Convert to `goroutines` to standard functions that have return values. Run them in a `for` loop.

### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=5c9c8e0172ec46499385d655b9e1d9de&p=b5bb5d3a07614e27ad488929f88edbb3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', same functionality
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/S
