### PR TITLE
LMS Rails 5.1 Prework - misc spec failures part 2

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -318,7 +318,7 @@ class Cms::UsersController < Cms::CmsController
       new_user_params = user_params.except("password_confirmation")
     end
 
-    difference = Hash[new_user_params.to_a - previous_user_params.to_a]
+    difference = Hash[new_user_params.to_h.to_a - previous_user_params.to_h.to_a]
     difference.each_key do |field|
       new_value = field == 'password' ? nil : difference[field]
       log_change(params[:action].to_sym, @user.id.to_s, nil, field, previous_user_params[field], new_value)

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -82,7 +82,7 @@ class Teachers::ClassroomsController < ApplicationController
   def destroy
     authorize_owner! { params[:id] }
     Classroom.find(params[:id]).destroy
-    # we need a performed? check here to avoid a double render, since 
+    # we need a performed? check here to avoid a double render, since
     # authorize_owner can trigger a render, which is an anti-pattern
     # more info: https://medium.com/cedarcode/abstractcontroller-doublerendererror-fix-d18881b80476
     redirect_to teachers_classrooms_path unless performed?
@@ -225,7 +225,18 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   private def create_students_params
-    params.permit(:classroom_id, :students => [:name, :username, :password, :account_type], :classroom => classroom_params)
+    params
+      .permit(
+        :classroom_id,
+        classroom: classroom_params,
+        students: [
+          :name,
+          :username,
+          :password,
+          :account_type
+        ]
+      )
+      .to_h
   end
 
   private def classroom_params

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -552,7 +552,8 @@ class ActivitySession < ApplicationRecord
   end
 
   private def set_completed_at
-    return true if state != 'finished'
+    return unless state == 'finished'
+
     self.completed_at ||= Time.current
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -58,7 +58,7 @@ class ActivitySession < ApplicationRecord
   has_one :unit, through: :classroom_unit
   has_many :concept_results
   has_many :teachers, through: :classroom
-  has_many :concepts, -> { uniq }, through: :concept_results
+  has_many :concepts, -> { distinct }, through: :concept_results
 
   validate :correctly_assigned, :on => :create
 

--- a/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
@@ -45,7 +45,7 @@ class CoteacherClassroomInvitation < ApplicationRecord
       SQL
     ).to_a
 
-    return false if classrooms_teachers.any?
+    throw(:abort) if classrooms_teachers.any?
   end
 
   private def trigger_analytics

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -123,7 +123,7 @@ class School < ApplicationRecord
   end
 
   def students
-    User.joins(student_in_classroom: {teachers: :school}).where(schools: {id: id}).uniq
+    User.joins(student_in_classroom: {teachers: :school}).where(schools: {id: id}).distinct
   end
 
   def self.school_year_start(time)

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -30,11 +30,30 @@ class Topic < ApplicationRecord
   before_save :validate_parent_by_level
 
   def validate_parent_by_level
-    # level 2s must have level 3 parent. all other levels must not have parent.
-    if parent_id.present?
-      return level == 2 && Topic.find(parent_id)&.level == 3
-    else
-      return level != 2
-    end
+    throw(:abort) unless valid_parent_structure?
+  end
+
+  def level_two?
+    level == 2
+  end
+
+  def level_three?
+    level == 3
+  end
+
+  private def level_three_parent?
+    parent? && Topic.find(parent_id).level_three?
+  end
+
+  private def no_parent?
+    !parent?
+  end
+
+  private def parent?
+    parent_id.present? && Topic.exists?(parent_id)
+  end
+
+  private def valid_parent_structure?
+    level_two? ? level_three_parent? : no_parent?
   end
 end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 describe Teachers::ProgressReports::Concepts::ConceptsController, type: :controller do
   include_context 'Concept Progress Report'
+
   let!(:teacher) { classroom.owner }
+
   it_behaves_like 'Progress Report' do
     let(:result_key) { 'concepts' }
     let(:default_filters) { { student_id: student.id } }

--- a/services/QuillLMS/spec/models/topic_spec.rb
+++ b/services/QuillLMS/spec/models/topic_spec.rb
@@ -34,31 +34,31 @@ describe Topic, type: :model do
 
   describe 'saving a topic with parent id' do
     it 'should raise error if level is not 2' do
-      level_one_topic = Topic.new(name: 'test', level: 1, parent_id: level_three_topic.id,visible: true)
-      expect{ level_one_topic.save! }.to raise_error
+      level_one_topic = Topic.new(name: 'test', level: 1, parent_id: level_three_topic.id, visible: true)
+      expect { level_one_topic.save! }.to raise_error(ActiveRecord::RecordNotSaved)
     end
 
     it 'should raise error if level is 2 and parent is not level 3' do
       level_one_topic = Topic.create(name: 'test', level: 1, visible: true)
       level_two_topic = Topic.new(name: 'test', level: 2, visible: true, parent_id: level_one_topic.id)
-      expect{ level_two_topic.save! }.to raise_error
+      expect { level_two_topic.save! }.to raise_error(ActiveRecord::RecordNotSaved)
     end
 
     it 'should not raise error if level is 2 and parent is 3' do
       level_two_topic = Topic.new(name: 'test', level: 2, visible: true, parent_id: level_three_topic.id)
-      expect{ level_two_topic.save! }.not_to raise_error
+      expect { level_two_topic.save! }.not_to raise_error
     end
   end
 
   describe 'saving a topic without parent id' do
     it 'should raise error if level is 2' do
       level_two_topic = Topic.new(name: 'test', level: 2, visible: true)
-      expect{ level_two_topic.save! }.to raise_error
+      expect { level_two_topic.save! }.to raise_error(ActiveRecord::RecordNotSaved)
     end
 
     it 'should not raise error if level is not 2' do
       level_one_topic = Topic.new(name: 'test', level: 1, visible: true)
-      expect{ level_one_topic.save! }.not_to raise_error
+      expect { level_one_topic.save! }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
## WHAT
1.  Fix Rail 5.1 [deprecation](https://github.com/rails/rails/commit/adfab2dcf4003ca564d78d4425566dd2d9cd8b4f) involving Relation#uniq relation call to Relation#distinct
2.  Fix `to_a` call on `ActionController::Parameters`
3.  Fix halted active record callbacks due to Rails 5.1 [deprecation](https://github.com/rails/rails/pull/17227)
4.  Fix failure involving `ActionController::Parameters` object

## WHY
Before upgrading to Rails 5.1, it's helpful to fix any deprecations ahead of time in order to make the upgrade diff small.

## HOW
1.  Replace Relation#uniq calls with Relation#distinct
2.  First convert `ActionController::Parameters` to a hash before calling `to_a`
3.  Add `throw(:abort)` in places where we  used to `return false` to halt the callback chain
4.  Convert  `ActionController::Parameters` to a hash to fix spec

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet, deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
