### PR TITLE
display regex character limit

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/regexRules.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/regexRules.test.tsx.snap
@@ -18,6 +18,12 @@ exports[`RegexRules component should render RegexRules 1`] = `
         id="regex-rule-0"
         value="it contain(s)? methane gas"
       />
+      <p
+        className="characters-remaining"
+      >
+        174
+         characters remaining
+      </p>
       <div
         className="checkbox-container"
       >
@@ -86,6 +92,12 @@ exports[`RegexRules component should render RegexRules 1`] = `
         id="regex-rule-1"
         value="another reg(ex) line"
       />
+      <p
+        className="characters-remaining"
+      >
+        180
+         characters remaining
+      </p>
       <div
         className="checkbox-container"
       >
@@ -154,6 +166,12 @@ exports[`RegexRules component should render RegexRules 1`] = `
         id="regex-rule-2"
         value="some m?ore reg(ex"
       />
+      <p
+        className="characters-remaining"
+      >
+        183
+         characters remaining
+      </p>
       <div
         className="checkbox-container"
       >

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/regexRules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/regexRules.tsx
@@ -5,6 +5,8 @@ import { regexRuleSequenceOptions } from '../../../../../constants/comprehension
 import { DropdownObjectInterface } from '../../../interfaces/comprehensionInterfaces';
 import { getSequenceType } from "../../../helpers/comprehension/ruleHelpers";
 
+const MAX_REGEX_LENGTH = 200
+
 interface RegexRulesProps {
   errors: {},
   handleAddRegexInput: (event: React.MouseEvent) => void,
@@ -28,6 +30,7 @@ const RegexRules = ({ errors, handleAddRegexInput, handleDeleteRegexRule, handle
     const regexRuleKeys = Object.keys(regexRules);
     return !!regexRuleKeys.length && regexRuleKeys.map((ruleKey, i) => {
       const sequenceType = getInitialSequenceType(regexRules[ruleKey]);
+      const charactersRemaining = MAX_REGEX_LENGTH - regexRules[ruleKey].regex_text.length
       return(
         <div className="regex-rule-container" key={`regex-rule-container-${i}`}>
           <div className="regex-input-container">
@@ -38,6 +41,7 @@ const RegexRules = ({ errors, handleAddRegexInput, handleDeleteRegexRule, handle
               id={ruleKey}
               value={regexRules[ruleKey].regex_text}
             />
+            <p className="characters-remaining">{charactersRemaining} characters remaining</p>
             <div className="checkbox-container">
               <DropdownInput
                 className='rule-type-input'


### PR DESCRIPTION
## WHAT
Display character limit for regex rules.

## WHY
So curriculum team members don't type the whole thing out just to get an error message.

## HOW
Just add a counter.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/When-writing-a-Regex-string-provide-a-character-countdown-11581311bcfd4b9c8e5e5cb0a5d0fb19

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
