### PR TITLE
LMS Rails 5.1 Prework - Fix comprehension tests for rails 5.1

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
@@ -10,7 +10,7 @@ module Comprehension
       @rules = @rules.where(rule_type: params[:rule_type]) if params[:rule_type]
 
       # some rules will apply to multiple prompts so we only want to return them once
-      render json: @rules.uniq.all
+      render json: @rules.distinct.all
     end
 
     # GET /rules/1.json

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/regex_rule.rb
@@ -50,7 +50,7 @@ module Comprehension
         Regexp.new(regex_text)
       rescue RegexpError => e
         rule.errors.add(:invalid_regex, e.to_s)
-        false
+        throw(:abort)
       end
     end
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200605133641_create_comprehension_activities.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200605133641_create_comprehension_activities.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionActivities < ActiveRecord::Migration
+class CreateComprehensionActivities < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_activities do |t|
       t.string :title, limit: 100

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200608233222_create_comprehension_passages.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200608233222_create_comprehension_passages.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionPassages < ActiveRecord::Migration
+class CreateComprehensionPassages < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_passages do |t|
       t.integer :activity_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200609005839_create_comprehension_prompts.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200609005839_create_comprehension_prompts.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionPrompts < ActiveRecord::Migration
+class CreateComprehensionPrompts < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts do |t|
       t.integer :activity_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200625222938_create_comprehension_rule_sets.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200625222938_create_comprehension_rule_sets.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionRuleSets < ActiveRecord::Migration
+class CreateComprehensionRuleSets < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rule_sets do |t|
       t.integer :activity_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200626160522_create_comprehension_rules.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200626160522_create_comprehension_rules.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionRules < ActiveRecord::Migration
+class CreateComprehensionRules < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rules do |t|
       t.integer :rule_set_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200626181312_create_comprehension_prompts_rule_sets_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200626181312_create_comprehension_prompts_rule_sets_table.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration
+class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts_rule_sets do |t|
       t.integer :prompt_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20200630161345_create_comprehension_turking_rounds.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20200630161345_create_comprehension_turking_rounds.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionTurkingRounds < ActiveRecord::Migration
+class CreateComprehensionTurkingRounds < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_turking_rounds do |t|
       t.integer :activity_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20201125161727_create_comprehension_turking_round_activity_sessions.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20201125161727_create_comprehension_turking_round_activity_sessions.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionTurkingRoundActivitySessions < ActiveRecord::Migration
+class CreateComprehensionTurkingRoundActivitySessions < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_turking_round_activity_sessions do |t|
       t.integer :turking_round_id

--- a/services/QuillLMS/engines/comprehension/db/migrate/20201202224853_add_plagiarism_columns_to_prompt.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20201202224853_add_plagiarism_columns_to_prompt.rb
@@ -1,4 +1,4 @@
-class AddPlagiarismColumnsToPrompt < ActiveRecord::Migration
+class AddPlagiarismColumnsToPrompt < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_prompts, :plagiarism_text, :text
     add_column :comprehension_prompts, :plagiarism_first_feedback, :text

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210114154926_create_regex_rules_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210114154926_create_regex_rules_table.rb
@@ -1,4 +1,4 @@
-class CreateRegexRulesTable < ActiveRecord::Migration
+class CreateRegexRulesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_regex_rules do |t|
       t.integer :rule_set_id, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210114164149_remove_rule_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210114164149_remove_rule_table.rb
@@ -1,4 +1,4 @@
-class RemoveRuleTable < ActiveRecord::Migration
+class RemoveRuleTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :comprehension_rules
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210114182832_create_comprehension_rules_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210114182832_create_comprehension_rules_table.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionRulesTable < ActiveRecord::Migration
+class CreateComprehensionRulesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rules do |t|
       t.string :uid, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210121200031_create_comprehension_feedbacks.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210121200031_create_comprehension_feedbacks.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionFeedbacks < ActiveRecord::Migration
+class CreateComprehensionFeedbacks < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_feedbacks do |t|
       t.references :rule, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210122144228_create_comprehension_prompts_rules.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210122144228_create_comprehension_prompts_rules.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionPromptsRules < ActiveRecord::Migration
+class CreateComprehensionPromptsRules < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts_rules do |t|
       t.references :prompt, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210122165204_create_plagiarism_text_table.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210122165204_create_plagiarism_text_table.rb
@@ -1,4 +1,4 @@
-class CreatePlagiarismTextTable < ActiveRecord::Migration
+class CreatePlagiarismTextTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_plagiarism_texts do |t|
       t.references :rule, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210122165328_create_comprehension_highlights.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210122165328_create_comprehension_highlights.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionHighlights < ActiveRecord::Migration
+class CreateComprehensionHighlights < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_highlights do |t|
       t.references :feedback, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210128152309_drop_plagiarism_columns_from_prompt.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210128152309_drop_plagiarism_columns_from_prompt.rb
@@ -1,4 +1,4 @@
-class DropPlagiarismColumnsFromPrompt < ActiveRecord::Migration
+class DropPlagiarismColumnsFromPrompt < ActiveRecord::Migration[4.2]
   def change
     remove_column :comprehension_prompts, :plagiarism_text
     remove_column :comprehension_prompts, :plagiarism_first_feedback

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210128155938_associate_regex_rule_with_rule.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210128155938_associate_regex_rule_with_rule.rb
@@ -1,4 +1,4 @@
-class AssociateRegexRuleWithRule < ActiveRecord::Migration
+class AssociateRegexRuleWithRule < ActiveRecord::Migration[4.2]
   def change
     add_reference :comprehension_regex_rules, :rule, index: true
     add_foreign_key :comprehension_regex_rules, :comprehension_rules, column: :rule_id, on_delete: :cascade

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210129184505_delete_rule_sets.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210129184505_delete_rule_sets.rb
@@ -1,4 +1,4 @@
-class DeleteRuleSets < ActiveRecord::Migration
+class DeleteRuleSets < ActiveRecord::Migration[4.2]
   def change
     drop_table :comprehension_rule_sets
     drop_table :comprehension_prompts_rule_sets

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210209200555_create_comprehension_automl_models.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210209200555_create_comprehension_automl_models.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionAutomlModels < ActiveRecord::Migration
+class CreateComprehensionAutomlModels < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_automl_models do |t|
       t.string :automl_model_id, null: false, unique: true

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210212194127_create_comprehension_labels.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210212194127_create_comprehension_labels.rb
@@ -1,4 +1,4 @@
-class CreateComprehensionLabels < ActiveRecord::Migration
+class CreateComprehensionLabels < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_labels do |t|
       t.string :name, null: false

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210218195536_add_state_column_to_rule.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210218195536_add_state_column_to_rule.rb
@@ -1,4 +1,4 @@
-class AddStateColumnToRule < ActiveRecord::Migration
+class AddStateColumnToRule < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_rules, :state, :string
     Comprehension::Rule.update_all(state: Comprehension::Rule::STATE_ACTIVE)

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210218213618_add_sequence_type_to_regex_rules.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210218213618_add_sequence_type_to_regex_rules.rb
@@ -1,4 +1,4 @@
-class AddSequenceTypeToRegexRules < ActiveRecord::Migration
+class AddSequenceTypeToRegexRules < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_regex_rules, :sequence_type, :text, null: false, default: "incorrect"
     change_column :comprehension_rules, :suborder, :text, null: true

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210219163806_add_image_link_and_image_alt_text_to_passages.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210219163806_add_image_link_and_image_alt_text_to_passages.rb
@@ -1,4 +1,4 @@
-class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration
+class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_passages, :image_link, :string
     add_column :comprehension_passages, :image_alt_text, :string, default: ''

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210316160648_add_name_to_comprehension_activities.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210316160648_add_name_to_comprehension_activities.rb
@@ -1,4 +1,4 @@
-class AddNameToComprehensionActivities < ActiveRecord::Migration
+class AddNameToComprehensionActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_activities, :name, :string
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210429144611_rename_rule_description_to_rule_note.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210429144611_rename_rule_description_to_rule_note.rb
@@ -1,4 +1,4 @@
-class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration
+class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration[4.2]
   def change
     rename_column :comprehension_rules, :description, :note
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210511160025_update_comprehension_rule_suborder_type_to_integer.rb
@@ -1,4 +1,4 @@
-class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
+class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration[4.2]
   def change
     change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210525194626_add_notes_to_auto_ml_model.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210525194626_add_notes_to_auto_ml_model.rb
@@ -1,4 +1,4 @@
-class AddNotesToAutoMlModel < ActiveRecord::Migration
+class AddNotesToAutoMlModel < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_automl_models, :notes, :text, default: ''
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210614190110_update_activity_name_to_notes.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210614190110_update_activity_name_to_notes.rb
@@ -1,4 +1,4 @@
-class UpdateActivityNameToNotes < ActiveRecord::Migration
+class UpdateActivityNameToNotes < ActiveRecord::Migration[4.2]
   def change
     rename_column :comprehension_activities, :name, :notes
   end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/activities_controller_test.rb
@@ -73,7 +73,16 @@ module Comprehension
       end
 
       should "create a valid record and return it as json" do
-        post :create, activity: { parent_activity_id: @activity.parent_activity_id, scored_level: @activity.scored_level, target_level: @activity.target_level, title: @activity.title, notes: @activity.notes }
+        post :create,
+          params: {
+            activity: {
+              parent_activity_id: @activity.parent_activity_id,
+              scored_level: @activity.scored_level,
+              target_level: @activity.target_level,
+              title: @activity.title,
+              notes: @activity.notes
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -84,7 +93,12 @@ module Comprehension
       end
 
       should "not create an invalid record and return errors as json" do
-        post :create, activity: { parent_activity_id: @activity.parent_activity_id }
+        post :create,
+          params: {
+            activity: {
+              parent_activity_id: @activity.parent_activity_id
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -94,7 +108,21 @@ module Comprehension
       end
 
       should "create a valid record with passage attributes" do
-        post :create, activity: { parent_activity_id: @activity.parent_activity_id, scored_level: @activity.scored_level, target_level: @activity.target_level, title: @activity.title, notes: @activity.notes, passages_attributes: [{text: ("Hello " * 20) }] }
+        post :create,
+          params: {
+            activity: {
+              parent_activity_id: @activity.parent_activity_id,
+              scored_level: @activity.scored_level,
+              target_level: @activity.target_level,
+              title: @activity.title,
+              notes: @activity.notes,
+              passages_attributes: [
+                {
+                  text: ("Hello " * 20)
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -107,7 +135,22 @@ module Comprehension
       end
 
       should "create a valid record with prompt attributes" do
-        post :create, activity: { parent_activity_id: @activity.parent_activity_id, scored_level: @activity.scored_level, target_level: @activity.target_level, title: @activity.title, notes: @activity.notes, prompts_attributes: [{text: "meat is bad for you.", conjunction: "because"}] }
+        post :create,
+          params: {
+            activity: {
+              parent_activity_id: @activity.parent_activity_id,
+              scored_level: @activity.scored_level,
+              target_level: @activity.target_level,
+              title: @activity.title,
+              notes: @activity.notes,
+              prompts_attributes: [
+                {
+                  text: "meat is bad for you.",
+                  conjunction: "because"
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -120,7 +163,22 @@ module Comprehension
       end
 
       should "create a new parent activity and activity if no parent_activity_id is passed" do
-        post :create, activity: { parent_activity_id: nil, scored_level: @activity.scored_level, target_level: @activity.target_level, title: @activity.title, notes: @activity.notes, prompts_attributes: [{text: "meat is bad for you.", conjunction: "because"}] }
+        post :create,
+          params: {
+            activity: {
+              parent_activity_id: nil,
+              scored_level: @activity.scored_level,
+              target_level: @activity.target_level,
+              title: @activity.title,
+              notes: @activity.notes,
+              prompts_attributes: [
+                {
+                  text: "meat is bad for you.",
+                  conjunction: "because"
+                }
+              ]
+            }
+          }
         parent_activity = Comprehension.parent_activity_class.find_by_name(@activity.title)
         new_activity = Activity.find_by_title(@activity.title)
         assert parent_activity.present?
@@ -137,7 +195,7 @@ module Comprehension
       end
 
       should "return json if found" do
-        get :show, id: @activity.id
+        get :show, params: { id: @activity.id }
 
         parsed_response = JSON.parse(response.body)
 
@@ -149,7 +207,7 @@ module Comprehension
 
       should "raise if not found (to be handled by parent app)" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, id: 99999
+          get :show, params: { id: 99999 }
         end
       end
     end
@@ -162,7 +220,17 @@ module Comprehension
       end
 
       should "update record if valid, return nothing" do
-        put :update, id: @activity.id, activity: { parent_activity_id: 2, scored_level: "5th grade", target_level: 9, title: "New title" }
+        put :update,
+          params: {
+            id: @activity.id,
+            activity: {
+              parent_activity_id: 2,
+              scored_level: "5th grade",
+              target_level: 9,
+              title: "New title"
+            }
+          }
+
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -176,7 +244,18 @@ module Comprehension
       end
 
       should "update passage if valid, return nothing" do
-        put :update, id: @activity.id, activity: { passages_attributes: [{id: @passage.id, text: ('Goodbye' * 20)}] }
+        put :update,
+          params: {
+            id: @activity.id,
+            activity: {
+              passages_attributes: [
+                {
+                  id: @passage.id,
+                  text: ('Goodbye' * 20)
+                }
+              ]
+            }
+          }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -187,7 +266,18 @@ module Comprehension
       end
 
       should "update prompt if valid, return nothing" do
-        put :update, id: @activity.id, activity: { prompts_attributes: [{id: @prompt.id, text: "this is a good thing."}] }
+        put :update,
+          params: {
+            id: @activity.id,
+            activity: {
+              prompts_attributes: [
+                {
+                  id: @prompt.id,
+                  text: "this is a good thing."
+                }
+              ]
+            }
+          }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -199,7 +289,16 @@ module Comprehension
 
 
       should "not update record and return errors as json" do
-        put :update, id: @activity.id, activity: { parent_activity_id: 2, scored_level: "5th grade", target_level: 99999999, title: "New title" }
+        put :update,
+          params: {
+            id: @activity.id,
+            activity: {
+              parent_activity_id: 2,
+              scored_level: "5th grade",
+              target_level: 99999999,
+              title: "New title"
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -215,7 +314,7 @@ module Comprehension
       end
 
       should "destroy record at id" do
-        delete :destroy, id: @activity.id
+        delete :destroy, params: { id: @activity.id }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -235,7 +334,7 @@ module Comprehension
       end
 
       should "return rules" do
-        get :rules, id: @activity.id
+        get :rules, params: { id: @activity.id }
 
         parsed_response = JSON.parse(response.body)
 
@@ -245,7 +344,7 @@ module Comprehension
 
       should "404 if activity is invalid" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :rules, id: 99999
+          get :rules, params: { id: 99999 }
         end
       end
     end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/automl_models_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/automl_models_controller_test.rb
@@ -53,7 +53,13 @@ module Comprehension
       should "create a valid record and return it as json" do
         AutomlModel.stub_any_instance(:automl_name, @automl_model.name) do
           AutomlModel.stub_any_instance(:automl_labels, @automl_model.labels) do
-            post :create, automl_model: { prompt_id: @automl_model.prompt_id, automl_model_id: @automl_model.automl_model_id }
+            post :create,
+              params: {
+                automl_model: {
+                  prompt_id: @automl_model.prompt_id,
+                  automl_model_id: @automl_model.automl_model_id
+                }
+              }
           end
         end
 
@@ -77,7 +83,14 @@ module Comprehension
       should "create new records with state = inactive no matter what is passed in" do
         AutomlModel.stub_any_instance(:automl_name, @automl_model.name) do
           AutomlModel.stub_any_instance(:automl_labels, @automl_model.labels) do
-            post :create, automl_model: { prompt_id: @automl_model.prompt_id, automl_model_id: @automl_model.automl_model_id, state: AutomlModel::STATE_ACTIVE }
+            post :create,
+              params: {
+                automl_model: {
+                  prompt_id: @automl_model.prompt_id,
+                  automl_model_id: @automl_model.automl_model_id,
+                  state: AutomlModel::STATE_ACTIVE
+                }
+              }
           end
         end
 
@@ -91,7 +104,13 @@ module Comprehension
       should "not create an invalid record and return errors as json" do
         AutomlModel.stub_any_instance(:automl_name, @automl_model.name) do
           AutomlModel.stub_any_instance(:automl_labels, @automl_model.labels) do
-            post :create, automl_model: { prompt_id: @automl_model.prompt_id, automl_model_id: '' }
+            post :create,
+              params: {
+                automl_model: {
+                  prompt_id: @automl_model.prompt_id,
+                  automl_model_id: ''
+                }
+              }
           end
         end
 
@@ -109,7 +128,7 @@ module Comprehension
       end
 
       should "return json if found" do
-        get :show, id: @automl_model.id
+        get :show, params: { id: @automl_model.id }
 
         parsed_response = JSON.parse(response.body)
 
@@ -129,7 +148,7 @@ module Comprehension
 
       should "raise if not found (to be handled by parent app)" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, id: 99999
+          get :show, params: { id: 99999 }
         end
       end
     end
@@ -143,7 +162,13 @@ module Comprehension
         # NOTE: Only prompt_id is available to change during an update call
         @new_prompt = create(:comprehension_prompt)
         new_prompt_id = @new_prompt_id
-        patch :update, id: @automl_model.id, automl_model: { prompt_id: new_prompt_id }
+        patch :update,
+          params: {
+            id: @automl_model.id,
+            automl_model: {
+              prompt_id: new_prompt_id
+            }
+          }
 
         assert_equal 200, response.code.to_i
         assert_equal JSON.parse(response.body)['id'], @automl_model.id
@@ -155,7 +180,15 @@ module Comprehension
 
       should "not update read-only attributes return 200" do
         old_id = @automl_model.automl_model_id
-        patch :update, id: @automl_model.id, automl_model: { automl_model_id: 'anything', name: 'anything', labels: ['anything'] }
+        patch :update,
+          params: {
+            id: @automl_model.id,
+            automl_model: {
+              automl_model_id: 'anything',
+              name: 'anything',
+              labels: ['anything']
+            }
+          }
 
         assert_equal 200, response.code.to_i
         assert_equal JSON.parse(response.body)['id'], @automl_model.id
@@ -172,7 +205,7 @@ module Comprehension
 
       should 'return an empty 200 response if activation is successful' do
         AutomlModel.stub_any_instance(:activate, true) do
-          patch :activate, id: @automl_model.id
+          patch :activate, params: { id: @automl_model.id }
 
           assert_equal "", response.body
           assert_equal 204, response.code.to_i
@@ -181,7 +214,7 @@ module Comprehension
 
       should 'return a 422 with the unmodified object if activation fails' do
         AutomlModel.stub_any_instance(:activate, false) do
-          patch :activate, id: @automl_model.id
+          patch :activate, params: { id: @automl_model.id }
 
           parsed_response = JSON.parse(response.body)
 
@@ -197,7 +230,7 @@ module Comprehension
       end
 
       should "destroy record at id" do
-        delete :destroy, id: @automl_model.id
+        delete :destroy, params: { id: @automl_model.id }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/rules_controller_test.rb
@@ -66,7 +66,7 @@ module Comprehension
         end
 
         should 'only get Rules for specified prompt when provided' do
-          get :index, prompt_id: @prompt1.id
+          get :index, params: { prompt_id: @prompt1.id }
 
           parsed_response = JSON.parse(response.body)
 
@@ -77,7 +77,7 @@ module Comprehension
         end
 
         should 'only get unique Rules for specified prompts when provided' do
-          get :index, prompt_id: "#{@prompt1.id}, #{@prompt2.id}"
+          get :index, params: { prompt_id: "#{@prompt1.id}, #{@prompt2.id}" }
 
           parsed_response = JSON.parse(response.body)
 
@@ -85,7 +85,7 @@ module Comprehension
         end
 
         should 'only get Rules for specified rule type when provided' do
-          get :index, rule_type: Rule::TYPE_AUTOML
+          get :index, params: { rule_type: Rule::TYPE_AUTOML }
 
           parsed_response = JSON.parse(response.body)
 
@@ -96,7 +96,11 @@ module Comprehension
         end
 
         should 'only get Rules for the intersection of prompt and rule type when both are provided' do
-          get :index, prompt_id: @prompt1.id, rule_type: Rule::TYPE_AUTOML
+          get :index,
+            params: {
+              prompt_id: @prompt1.id,
+              rule_type: Rule::TYPE_AUTOML
+            }
 
           parsed_response = JSON.parse(response.body)
 
@@ -116,7 +120,20 @@ module Comprehension
       should "create a valid record and return it as json" do
         assert_equal 0, Rule.count
 
-        post :create, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: @rule.prompt_ids }
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              prompt_ids: @rule.prompt_ids
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -143,7 +160,19 @@ module Comprehension
       end
 
       should "not create an invalid record and return errors as json" do
-        post :create, rule: { concept_uid: @rule.uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: nil, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: nil,
+              suborder: -1,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -153,14 +182,25 @@ module Comprehension
       end
 
       should "return an error if regex is invalid" do
-        post :create, rule: { concept_uid: @rule.uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, suborder: 1, rule_type: @rule.rule_type, universal: @rule.universal, state: Rule::STATE_INACTIVE,
-          regex_rules_attributes:
-            [
-              {
-                regex_text: '(invalid|',
-                case_sensitive: false
-              }
-            ]}
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              suborder: 1,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              state: Rule::STATE_INACTIVE,
+              regex_rules_attributes: [
+                {
+                  regex_text: '(invalid|',
+                  case_sensitive: false
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -170,7 +210,9 @@ module Comprehension
 
       should "create a valid record with plagiarism_text attributes" do
         plagiarism_text = "Here is some text to be checked for plagiarism."
-        post :create, rule: {
+        post :create,
+          params: {
+            rule: {
               concept_uid: @rule.concept_uid,
               note: @rule.note,
               name: @rule.name,
@@ -183,6 +225,7 @@ module Comprehension
                 text: plagiarism_text
               }
             }
+          }
 
         parsed_response = JSON.parse(response.body)
         assert_equal @rule.name, parsed_response['name']
@@ -191,7 +234,20 @@ module Comprehension
 
       should "return an error if plagiarism rule already exists for prompt" do
         plagiarism_rule = create(:comprehension_rule, prompt_ids: [@prompt.id], rule_type: Rule::TYPE_PLAGIARISM)
-        post :create, rule: { concept_uid: @rule.uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, suborder: 1, rule_type: Rule::TYPE_PLAGIARISM, universal: false, state: Rule::STATE_ACTIVE, prompt_ids: [@prompt.id]}
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              suborder: 1,
+              rule_type: Rule::TYPE_PLAGIARISM,
+              universal: false,
+              state: Rule::STATE_ACTIVE,
+              prompt_ids: [@prompt.id]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -203,24 +259,26 @@ module Comprehension
         assert_equal 0, Feedback.count
 
         feedback = build(:comprehension_feedback)
-        post :create, rule: {
-          concept_uid: @rule.concept_uid,
-          note: @rule.note,
-          name: @rule.name,
-          optimal: @rule.optimal,
-          state: @rule.state,
-          suborder: @rule.suborder,
-          rule_type: @rule.rule_type,
-          universal: @rule.universal,
-          feedbacks_attributes:
-            [
-              {
-                text: feedback.text,
-                description: feedback.description,
-                order: feedback.order
-              }
-            ]
-        }
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              feedbacks_attributes: [
+                {
+                  text: feedback.text,
+                  description: feedback.description,
+                  order: feedback.order
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -237,7 +295,33 @@ module Comprehension
 
         feedback = create(:comprehension_feedback, rule: @rule)
         highlight = build(:comprehension_highlight, starting_index: 2)
-        post :create, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, feedbacks_attributes: [{text: feedback.text, description: feedback.description, order: feedback.order, highlights_attributes: [{text: highlight.text, highlight_type: highlight.highlight_type, starting_index: highlight.starting_index }]}]}
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              feedbacks_attributes: [
+                {
+                  text: feedback.text,
+                  description: feedback.description,
+                  order: feedback.order,
+                  highlights_attributes: [
+                    {
+                      text: highlight.text,
+                      highlight_type: highlight.highlight_type,
+                      starting_index: highlight.starting_index
+                    }
+                  ]
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -253,19 +337,22 @@ module Comprehension
         assert_equal 0, Label.count
 
         label = build(:comprehension_label)
-        post :create, rule: {
-          concept_uid: @rule.concept_uid,
-          note: @rule.note,
-          name: @rule.name,
-          optimal: @rule.optimal,
-          state: @rule.state,
-          suborder: @rule.suborder,
-          rule_type: @rule.rule_type,
-          universal: @rule.universal,
-          label_attributes: {
-            name: label.name
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              label_attributes: {
+                name: label.name
+              }
+            }
           }
-        }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -279,23 +366,25 @@ module Comprehension
         assert_equal 0, RegexRule.count
 
         regex_rule = build(:comprehension_regex_rule)
-        post :create, rule: {
-          concept_uid: @rule.concept_uid,
-          note: @rule.note,
-          name: @rule.name,
-          optimal: @rule.optimal,
-          state: @rule.state,
-          suborder: @rule.suborder,
-          rule_type: @rule.rule_type,
-          universal: @rule.universal,
-          regex_rules_attributes:
-            [
-              {
-                regex_text: regex_rule.regex_text,
-                case_sensitive: regex_rule.case_sensitive
-              }
-            ]
-        }
+        post :create,
+          params: {
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              regex_rules_attributes: [
+                {
+                  regex_text: regex_rule.regex_text,
+                  case_sensitive: regex_rule.case_sensitive
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
         assert_equal 201, response.code.to_i
@@ -313,7 +402,7 @@ module Comprehension
       end
 
       should "return json if found by id" do
-        get :show, id: @rule.id
+        get :show, params: { id: @rule.id }
 
         parsed_response = JSON.parse(response.body)
 
@@ -337,7 +426,7 @@ module Comprehension
       end
 
       should "return json if found by uid" do
-        get :show, id: @rule.uid
+        get :show, params: { id: @rule.uid }
 
         parsed_response = JSON.parse(response.body)
 
@@ -362,7 +451,7 @@ module Comprehension
 
       should "raise if not found (to be handled by parent app)" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, id: 99999
+          get :show, params: { id: 99999 }
         end
       end
     end
@@ -375,7 +464,21 @@ module Comprehension
 
       should "update record if valid, return nothing" do
         new_prompt = create(:comprehension_prompt)
-        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: @rule.suborder, rule_type: @rule.rule_type, universal: @rule.universal, prompt_ids: [new_prompt.id] }
+        patch :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: @rule.suborder,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal,
+              prompt_ids: [new_prompt.id]
+            }
+          }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -384,7 +487,20 @@ module Comprehension
       end
 
       should "not update record and return errors as json" do
-        patch :update, id: @rule.id, rule: { concept_uid: @rule.concept_uid, note: @rule.note, name: @rule.name, optimal: @rule.optimal, state: @rule.state, suborder: -1, rule_type: @rule.rule_type, universal: @rule.universal }
+        patch :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              concept_uid: @rule.concept_uid,
+              note: @rule.note,
+              name: @rule.name,
+              optimal: @rule.optimal,
+              state: @rule.state,
+              suborder: -1,
+              rule_type: @rule.rule_type,
+              universal: @rule.universal
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -394,7 +510,15 @@ module Comprehension
 
       should "update a valid record with plagiarism_text attributes" do
         plagiarism_text = "New plagiarism text"
-        patch :update, id: @rule.id, rule: { plagiarism_text_attributes: {text: plagiarism_text}}
+        patch :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              plagiarism_text_attributes: {
+                text: plagiarism_text
+              }
+            }
+          }
 
         assert_equal @rule.reload.plagiarism_text.text, plagiarism_text
       end
@@ -402,7 +526,18 @@ module Comprehension
       should "update nested feedback attributes if present" do
         feedback = create(:comprehension_feedback, rule: @rule)
         new_text = 'new text for the feedbacks object'
-        patch :update, id: @rule.id, rule: { feedbacks_attributes: [{id: feedback.id, text: new_text}]}
+        patch :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              feedbacks_attributes: [
+                {
+                  id: feedback.id,
+                  text: new_text
+                }
+              ]
+            }
+          }
 
         assert_equal 204, response.code.to_i
         assert_equal "", response.body
@@ -416,7 +551,23 @@ module Comprehension
         highlight = create(:comprehension_highlight, feedback: feedback)
         new_text = "New text to highlight"
 
-        post :update, id: @rule.id, rule: { feedbacks_attributes: [{id: feedback.id, highlights_attributes: [{id: highlight.id, text: new_text}]}]}
+        post :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              feedbacks_attributes: [
+                {
+                  id: feedback.id,
+                  highlights_attributes: [
+                    {
+                      id: highlight.id,
+                      text: new_text
+                    }
+                  ]
+                }
+              ]
+            }
+          }
 
         assert_equal 204, response.code.to_i
         assert_equal "", response.body
@@ -429,8 +580,16 @@ module Comprehension
         label = create(:comprehension_label, rule: @rule)
         new_name = 'can not be updated'
 
-        post :update, id: @rule.id, rule: { label_attributes: {id: label.id, name: new_name}}
-
+        post :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              label_attributes: {
+                id: label.id,
+                name: new_name
+              }
+            }
+          }
 
         assert_equal 204, response.code.to_i
 
@@ -442,7 +601,18 @@ module Comprehension
         regex_rule = create(:comprehension_regex_rule, rule: @rule)
         new_text = "new regex text"
 
-        post :update, id: @rule.id, rule: { regex_rules_attributes: [{id: regex_rule.id, regex_text: new_text}]}
+        post :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              regex_rules_attributes: [
+                {
+                  id: regex_rule.id,
+                  regex_text: new_text
+                }
+              ]
+            }
+          }
 
         assert_equal 204, response.code.to_i
         assert_equal "", response.body
@@ -455,7 +625,18 @@ module Comprehension
         regex_rule = create(:comprehension_regex_rule, rule: @rule)
         new_text = "(invalid|"
 
-        post :update, id: @rule.id, rule: { regex_rules_attributes: [{id: regex_rule.id, regex_text: new_text}]}
+        post :update,
+          params: {
+            id: @rule.id,
+            rule: {
+              regex_rules_attributes: [
+                {
+                  id: regex_rule.id,
+                  regex_text: new_text
+                }
+              ]
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -471,7 +652,7 @@ module Comprehension
       end
 
       should "destroy record at id" do
-        delete :destroy, id: @rule.id
+        delete :destroy, params: { id: @rule.id }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -488,7 +669,14 @@ module Comprehension
       end
 
       should "update the rules to have the suborders in the order of their ids" do
-        put :update_rule_order, ordered_rule_ids: [@rule2.id, @rule3.id, @rule1.id]
+        put :update_rule_order,
+          params: {
+            ordered_rule_ids: [
+              @rule2.id,
+              @rule3.id,
+              @rule1.id
+            ]
+          }
 
         assert_equal 200, response.code.to_i
         assert_equal @rule2.reload.suborder, 0
@@ -497,7 +685,14 @@ module Comprehension
       end
 
       should "return an error if any of the updated rules are invalid" do
-        put :update_rule_order, ordered_rule_ids: [@rule2.id, nil, @rule1.id]
+        put :update_rule_order,
+          params: {
+            ordered_rule_ids: [
+              @rule2.id,
+              nil,
+              @rule1.id
+            ]
+          }
 
         assert_equal 422, response.code.to_i
       end

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/turking_round_activity_sessions_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/turking_round_activity_sessions_controller_test.rb
@@ -30,7 +30,7 @@ module Comprehension
           assert_response :success
           assert_equal Array, parsed_response.class
           refute parsed_response.empty?
-      
+
         end
       end
     end
@@ -42,17 +42,23 @@ module Comprehension
 
       should "create a valid record and return it as json" do
         turking_round = create(:comprehension_turking_round)
-        post :create, turking_round_activity_session: { turking_round_id: turking_round.id, activity_session_uid: SecureRandom.uuid }
+        post :create,
+          params: {
+            turking_round_activity_session: {
+              turking_round_id: turking_round.id,
+              activity_session_uid: SecureRandom.uuid
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
         assert_equal 201, response.code.to_i
-    
+
         assert_equal 1, TurkingRoundActivitySession.count
       end
 
       should "not create an invalid record and return errors as json" do
-        post :create, turking_round_activity_session: { activity_session_uid: nil }
+        post :create, params: { turking_round_activity_session: { activity_session_uid: nil } }
 
         parsed_response = JSON.parse(response.body)
 
@@ -68,17 +74,17 @@ module Comprehension
       end
 
       should "return json if found" do
-        get :show, id: @turking_round_activity_session.id
+        get :show, params: { id: @turking_round_activity_session.id }
 
         parsed_response = JSON.parse(response.body)
 
         assert_equal 200, response.code.to_i
-    
+
       end
 
       should "raise if not found (to be handled by parent app)" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, id: 99999
+          get :show, params: { id: 99999 }
         end
       end
     end
@@ -90,7 +96,13 @@ module Comprehension
 
       should "update record if valid, return nothing" do
         new_session_uid = SecureRandom.uuid
-        patch :update, id: @turking_round_activity_session.id, turking_round_activity_session: { activity_session_uid: new_session_uid }
+        patch :update,
+          params: {
+            id: @turking_round_activity_session.id,
+            turking_round_activity_session: {
+              activity_session_uid: new_session_uid
+            }
+          }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -100,7 +112,13 @@ module Comprehension
       end
 
       should "not update record and return errors as json" do
-        patch :update, id: @turking_round_activity_session.id, turking_round_activity_session: { activity_session_uid: nil }
+        patch :update,
+          params: {
+            id: @turking_round_activity_session.id,
+            turking_round_activity_session: {
+              activity_session_uid: nil
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -115,7 +133,7 @@ module Comprehension
       end
 
       should "destroy record at id" do
-        delete :destroy, id: @turking_round_activity_session.id
+        delete :destroy, params: { id: @turking_round_activity_session.id }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i

--- a/services/QuillLMS/engines/comprehension/test/controllers/comprehension/turking_rounds_controller_test.rb
+++ b/services/QuillLMS/engines/comprehension/test/controllers/comprehension/turking_rounds_controller_test.rb
@@ -44,7 +44,14 @@ module Comprehension
       end
 
       should "create a valid record and return it as json" do
-        post :create, turking_round: { activity_id: @activity.id, uuid: @turking_round.uuid, expires_at: @turking_round.expires_at.iso8601(3) }
+        post :create,
+          params: {
+            turking_round: {
+              activity_id: @activity.id,
+              uuid: @turking_round.uuid,
+              expires_at: @turking_round.expires_at.iso8601(3)
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -56,7 +63,7 @@ module Comprehension
       end
 
       should "not create an invalid record and return errors as json" do
-        post :create, turking_round: { activity_id: nil, expires_at: nil }
+        post :create, params: { turking_round: { activity_id: nil, expires_at: nil } }
 
         parsed_response = JSON.parse(response.body)
 
@@ -73,7 +80,7 @@ module Comprehension
       end
 
       should "return json if found" do
-        get :show, id: @turking_round.id
+        get :show, params: { id: @turking_round.id }
 
         parsed_response = JSON.parse(response.body)
 
@@ -85,7 +92,7 @@ module Comprehension
 
       should "raise if not found (to be handled by parent app)" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, id: 99999
+          get :show, params: { id: 99999 }
         end
       end
     end
@@ -98,7 +105,14 @@ module Comprehension
       should "update record if valid, return nothing" do
         new_activity = create(:comprehension_activity)
         new_datetime = DateTime.now.utc
-        patch :update, id: @turking_round.id, turking_round: { activity_id: new_activity.id, expires_at: new_datetime }
+        patch :update,
+          params: {
+            id: @turking_round.id,
+            turking_round: {
+              activity_id: new_activity.id,
+              expires_at: new_datetime
+            }
+          }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i
@@ -109,7 +123,15 @@ module Comprehension
       end
 
       should "not update record and return errors as json" do
-        patch :update, id: @turking_round.id, turking_round: { activity_id: nil, uuid: nil, expires_at: nil }
+        patch :update,
+          params: {
+            id: @turking_round.id,
+            turking_round: {
+              activity_id: nil,
+              uuid: nil,
+              expires_at: nil
+            }
+          }
 
         parsed_response = JSON.parse(response.body)
 
@@ -126,7 +148,7 @@ module Comprehension
       end
 
       should "destroy record at id" do
-        delete :destroy, id: @turking_round.id
+        delete :destroy, params: { id: @turking_round.id }
 
         assert_equal "", response.body
         assert_equal 204, response.code.to_i

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200004_add_parent_activity.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200004_add_parent_activity.rb
@@ -1,4 +1,4 @@
-class AddParentActivity < ActiveRecord::Migration
+class AddParentActivity < ActiveRecord::Migration[4.2]
   def change
     create_table :activities do |t|
       t.string :name

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200005_add_parent_activity_classification.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200005_add_parent_activity_classification.rb
@@ -1,4 +1,4 @@
-class AddParentActivityClassification < ActiveRecord::Migration
+class AddParentActivityClassification < ActiveRecord::Migration[4.2]
   def change
     create_table :activity_classifications do |t|
       t.string :key

--- a/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200006_add_flags_to_activities.rb
+++ b/services/QuillLMS/engines/comprehension/test/dummy/db/migrate/20210317200006_add_flags_to_activities.rb
@@ -1,4 +1,4 @@
-class AddFlagsToActivities < ActiveRecord::Migration
+class AddFlagsToActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :activities, :flags, :string, array: true, default: [], null: false
   end


### PR DESCRIPTION
## WHAT
1.  Fix deprecation for inheriting directly from ActiveRecord::Migration:
```
Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. 
Please specify the Rails release the migration was written for
```
2. Fix positional params in comprehension controller specs 
3. Fix [deprecation](https://github.com/empirical-org/Empirical-Core/pull/7935) in a spec using `return false` in a callback
4. Fix model using `uniq` on an ActiveRecord:Relation


## WHY
Before upgrading LMS and Comprehension engine to Rails 5.1, various pieces of code need to be updated. 

## HOW
1.  Add `ActiveRecord::Migration[4.2]` to each migration file.
2. See https://github.com/empirical-org/Empirical-Core/pull/7919
3. Add `throw(:abort)` in places where we used to return false to halt the callback chain
4. Replace Relation#uniq calls with Relation#distinct 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/LMS-Rails-5-1-Prework-Fix-comprehension-tests-d98b1b41ca924268bc1236204e6ce7f5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
