### PR TITLE
fix Q&A file for Pre-AP page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
@@ -1589,7 +1589,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          What is the AP Writing Skills Survey?
+                          How is Quill.org used in Pre-AP English 1?
                         </button>
                       </div>
                       <div>
@@ -1615,7 +1615,33 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          For which AP courses is this practice most relevant?
+                          How is Quill.org used in Pre-AP English 2?
+                        </button>
+                      </div>
+                      <div>
+                        <button
+                          class="expand-collapse-button focus-on-light"
+                          type="button"
+                        >
+                          <img
+                            alt="expand-and-collapse"
+                            src="undefined/images/shared/expand.svg"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="qa-section"
+                    >
+                      <div
+                        class="qa"
+                      >
+                        <button
+                          class="question"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          Do I need to create an account on Quill.org?
                         </button>
                       </div>
                       <div>
@@ -1667,7 +1693,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          How long does the Survey take?
+                          How many activities are in each Pre-AP Writing Practice pack?
                         </button>
                       </div>
                       <div>
@@ -1693,7 +1719,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          What happens after I assign the Survey and my students complete it?
+                          How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                         </button>
                       </div>
                       <div>
@@ -1719,7 +1745,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                          Where can I track my students' completion of and performance on Quill activities?
                         </button>
                       </div>
                       <div>
@@ -1745,7 +1771,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          Can students complete the AP Writing Practice packs independently?
+                          What tools does Quill.org offer?
                         </button>
                       </div>
                       <div>
@@ -1771,189 +1797,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                           tabindex="-1"
                           type="button"
                         >
-                          How many activities are in each AP Writing Practice pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          What grade-level or reading level are the AP Activity Packs designed for?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
+                          I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                         </button>
                       </div>
                       <div>
@@ -4080,7 +3924,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
     <div>
       <QuestionsAndAnswers
         handleChange={[Function]}
-        questionsAndAnswersFile="ap"
+        questionsAndAnswersFile="preap"
         supportLink=""
       >
         <div
@@ -4115,12 +3959,12 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Quill is a writing tool that provides over 700 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
+                    Quill is a writing tool that provides over 600 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
                   </p>,
                   "question": "What is Quill.org?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4156,13 +4000,32 @@ exports[`PreAp component should render when it is not part of the assignment flo
               key="1"
               qa={
                 Object {
-                  "answer": <p>
-                    The AP Writing Skills Survey is a survey with 17 questions on a range of writing skills. The questions ask students to combine sentences, sometimes with a direction to use a specific strategy, and sometimes without any direction (other than to combine).
-                  </p>,
-                  "question": "What is the AP Writing Skills Survey?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 1, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the skills surveys and recommended practice activities, there are also sentence combining activities aligned to texts that are part of each unit’s instructional materials. These activities provide additional opportunities for students to practice their writing in context, combining sentences with a variety of skills and approaches that explore key ideas and themes from these texts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the previously mentioned tools and resources, you will also see direct links to Quill.org activities throughout English 1 lessons where specific grammar skills are addressed. The links will take students to independent practice activities that align with the writing goals of that particular lesson.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 1?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4176,7 +4039,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    What is the AP Writing Skills Survey?
+                    How is Quill.org used in Pre-AP English 1?
                   </button>
                 </div>
                 <div>
@@ -4198,13 +4061,27 @@ exports[`PreAp component should render when it is not part of the assignment flo
               key="2"
               qa={
                 Object {
-                  "answer": <p>
-                    Students in any AP course can benefit from the practice recommended by Quill's AP Writing Skills Survey, but the practice is probably of greatest interest to teachers of AP English Language and Composition and AP English Literature and Composition.
-                  </p>,
-                  "question": "For which AP courses is this practice most relevant?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 2, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      At this time, there are no sentence combining activities aligned to texts that are part of each unit’s instructional materials in Pre-AP English 2.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 2?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4218,7 +4095,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    For which AP courses is this practice most relevant?
+                    How is Quill.org used in Pre-AP English 2?
                   </button>
                 </div>
                 <div>
@@ -4240,20 +4117,85 @@ exports[`PreAp component should render when it is not part of the assignment flo
               key="3"
               qa={
                 Object {
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      <a
+                        href="https://www.quill.org/sign-up/teacher"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        sign-up page
+                      </a>
+                      .
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      If you do not want to create an account, the links provided throughout the English 1 lessons will allow you and your students to complete activities on Quill without Quill accounts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      Please note that if you do not create an account, you will not be able to use the skills surveys, access the recommended skills practice, track student progress, or view data reports.
+                    </p>
+                  </div>,
+                  "question": "Do I need to create an account on Quill.org?",
+                }
+              }
+              questionsAndAnswersFile="preap"
+            >
+              <div
+                className="qa-section"
+              >
+                <div
+                  className="qa"
+                >
+                  <button
+                    className="question"
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Do I need to create an account on Quill.org?
+                  </button>
+                </div>
+                <div>
+                  <button
+                    className="expand-collapse-button focus-on-light"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    type="button"
+                  >
+                    <img
+                      alt="expand-and-collapse"
+                      src="undefined/images/shared/expand.svg"
+                    />
+                  </button>
+                </div>
+              </div>
+            </QuestionAndAnswer>
+            <QuestionAndAnswer
+              key="4"
+              qa={
+                Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in AP courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
-                      href="ttps://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
+                      href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      This article explains the differences between Quill’s various diagnostics and surveys in more depth.
+                      This article explains the differences between Quill’s various diagnostics and surveys in more depth
                     </a>
+                    .
                   </p>,
                   "question": "Is a writing skills survey different than a diagnostic?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4286,64 +4228,23 @@ exports[`PreAp component should render when it is not part of the assignment flo
               </div>
             </QuestionAndAnswer>
             <QuestionAndAnswer
-              key="4"
-              qa={
-                Object {
-                  "answer": <p>
-                    The Survey contains 17 questions and is designed to take about 30 minutes for students to complete.
-                  </p>,
-                  "question": "How long does the Survey take?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How long does the Survey take?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
               key="5"
               qa={
                 Object {
                   "answer": <p>
-                    After you have assigned the Survey and your students have completed it, Quill will show you how your students performed and provide recommendations of personalized practice activities you can digitally assign to students who need further skill development. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
-                      href="https://support.quill.org/en/articles/1589522-how-do-i-assign-diagnostic-recommendations"
+                      href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      This article
+                      Learn how to find and assign those here.
                     </a>
-                     explains how to find and assign those recommendations.
                   </p>,
-                  "question": "What happens after I assign the Survey and my students complete it?",
+                  "question": "How many activities are in each Pre-AP Writing Practice pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4357,7 +4258,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    What happens after I assign the Survey and my students complete it?
+                    How many activities are in each Pre-AP Writing Practice pack?
                   </button>
                 </div>
                 <div>
@@ -4380,153 +4281,27 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Depending on their performance, students will be recommended some or all of the following AP Writing Practice packs. The packs provide practice through 
-                      <a
-                        href="https://www.quill.org/tools/connect"
-                      >
-                        Quill Connect
-                      </a>
-                      , 
-                      <a
-                        href="https://www.quill.org/teacher-center/-3"
-                      >
-                        Quill's sentence combining tool
-                      </a>
-                      . With the exception of the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                      >
-                        AP Writing - Advanced Sentence Combining pack
-                      </a>
-                      , the activities in each pack are scaffolded to build in complexity. Here are descriptions of the packs:
+                    <p>
+                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
+                    <p>
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                    </p>
+                    <p>
                       <a
-                        href="https://www.quill.org/activities/packs/139"
+                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        Complex Sentences
+                        This article
                       </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing complex sentences using subordinating conjunctions, such as even though, after, while, and because. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/140"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Relative Clauses
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students begin by using a provided relative pronoun, then progress to choosing between who, that, or which.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/143"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Appositive Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice describing nouns using appositive phrases at the beginning, middle, and end of sentences.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/144"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Participial Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences with -ing and -ed participial phrases at the beginning, middle, or end.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/192"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Parallel Structure
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences in parallel structure with correlative conjunctions like either/or, neither/nor, and both/and, and with subordinating conjunctions like although, because, and when. Students also practice constructing sentences with parallel clauses.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/141"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Compound-Complex Sentences
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing compound sentences with and, or, but, and so. Students also practice constructing complex sentences with subordinating conjunctions such as even though, after, while, and because. Finally, students practice constructing compound-complex sentences with coordinating and subordinating conjunctions. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Advanced Combining
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students apply their knowledge of multiple sentence structures to combine the sentences in the strongest way possible. Students practice constructing compound and complex sentences, using modifying phrases and clauses, and combining predicates.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
-                  "question": "What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?",
+                  "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4540,7 +4315,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                    How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                   </button>
                 </div>
                 <div>
@@ -4563,12 +4338,36 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Yes! From anywhere and at any time! Again though, please note that recommendations of the AP Writing Packs are generated after students complete the AP Writing Skills Survey. Please also note that students' performance on the AP Writing Practice packs will only be recorded if they are assigned to them by their teacher.
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    <a
+                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Activity Summary report
+                    </a>
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      This cheat sheet
+                    </a>
+                     shows you which report to go to for particular information, and 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      this video will walk you through 3 of Quill's student data reports
+                    </a>
+                    .
                   </p>,
-                  "question": "Can students complete the AP Writing Practice packs independently?",
+                  "question": "Where can I track my students' completion of and performance on Quill activities?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4582,7 +4381,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    Can students complete the AP Writing Practice packs independently?
+                    Where can I track my students' completion of and performance on Quill activities?
                   </button>
                 </div>
                 <div>
@@ -4608,26 +4407,69 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Each AP recommended pack* contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each.
+                      If you create a free account on Quill.org, you will be able to assign additional activities from any of Quill’s 5 tools:
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      *Please note that the activities in the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        AP Writing - Advanced Combining pack
-                      </a>
-                       are different as they are all uncued, meaning the feedback does not direct students to combine in a particular way. These are great for students who are ready to apply the strategies covered in the survey without suggestions or direction.
-                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Quill Connect
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students combine multiple ideas into a single sentence using the evidence-based strategy of sentence combining. Students receive instant feedback. *Note*: All activities recommended based on survey results are in Quill Connect.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Grammar
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice basic grammar skills, from using correct capitalization to correcting commonly confused words.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Proofreader
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice editing skills by correcting errors in passages. Students receive personalized follow-up activities based on their results.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Lessons
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Teachers lead whole-class writing instruction. Teachers control interactive slides that contain a mini-lesson and guided practice. Teachers can model writing strategies in real-time, present prompts to which students can respond, and then anonymously display student responses for discussion. Each Quill Lessons activity provides a lesson plan, writing prompts, discussion topics, and a follow-up independent practice activity. Teachers can also customize any lesson.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Diagnostic
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          <strong>
+                            Note
+                          </strong>
+                          : The writing skills surveys can be used in lieu of general Quill diagnostics.
+                        </p>
+                      </li>
+                    </ul>
                   </div>,
-                  "question": "How many activities are in each AP Writing Practice pack?",
+                  "question": "What tools does Quill.org offer?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4641,7 +4483,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    How many activities are in each AP Writing Practice pack?
+                    What tools does Quill.org offer?
                   </button>
                 </div>
                 <div>
@@ -4663,22 +4505,21 @@ exports[`PreAp component should render when it is not part of the assignment flo
               key="9"
               qa={
                 Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
+                  "answer": <p>
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    <a
+                      href="https://quillorg.canny.io/content-feedback"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      The focus in most of these activities is to build the target skill of the pack (appositives, relative clauses, etc.), so the vocabulary and reading level are intentionally designed to be accessible by all students.
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Teacher Tip: You can preview and play through any pack and its activities to get a sense of whether it's appropriate for your students.
-                    </p>
-                  </div>,
-                  "question": "What grade-level or reading level are the AP Activity Packs designed for?",
+                      here
+                    </a>
+                    !
+                  </p>,
+                  "question": "I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -4692,7 +4533,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     tabIndex={-1}
                     type="button"
                   >
-                    What grade-level or reading level are the AP Activity Packs designed for?
+                    I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                   </button>
                 </div>
                 <div>
@@ -4712,344 +4553,6 @@ exports[`PreAp component should render when it is not part of the assignment flo
             </QuestionAndAnswer>
             <QuestionAndAnswer
               key="10"
-              qa={
-                Object {
-                  "answer": "Yes! In each recommended practice activity, Quill provides students with immediate feedback on their writing that they can use to revise their responses up to 5 times. Through these rounds of feedback and revision, students improve the clarity and precision of their writing.",
-                  "question": "Will my students receive feedback as they work through the AP Writing Practice activity packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="11"
-              qa={
-                Object {
-                  "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
-                    <a
-                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Activity Summary report
-                    </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating their proficiency with each activity. Quill has several other reports as well. 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This Cheat Sheet
-                    </a>
-                     shows you which report to go to for particular information, and 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this video
-                    </a>
-                     will walk you through interpreting and utilizing three of Quill's student data reports.
-                  </p>,
-                  "question": "Where can I track my students' completion of and performance on the AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="12"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p>
-                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
-                    </p>
-                    <p>
-                      As Quill was designed to be a supplementary tool with each activity taking approximately 10-15 minutes, students are ideally completing an activity at least 1-2 times per week (at most completing one activity per day). Since each AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
-                    </p>
-                    <p>
-                      <a
-                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        This article
-                      </a>
-                       explains how you can use deadlines to help students pace themselves.
-                    </p>
-                  </div>,
-                  "question": "How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="13"
-              qa={
-                Object {
-                  "answer": <p>
-                    The activities in the AP Writing Practice packs are curated from existing Quill activities. While your students may encounter an activity they have already completed, the AP Writing Practice packs have been customized to target the skills students need to write successfully at the AP level. Given the quantity and variety of activities available on Quill, chances are that the AP Writing Practice packs will include plenty of new activities, even for students who have been using Quill for a while.
-                  </p>,
-                  "question": "If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="14"
-              qa={
-                Object {
-                  "answer": <p>
-                    Yes! Quill offers 
-                    <a
-                      href="https://support.quill.org/en/articles/1327607-what-are-each-of-the-different-quill-tools"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      5 different tools
-                    </a>
-                     with more than 700 writing, grammar, and proofreading activities designed to engage students in the writing process. 
-                    <a
-                      href="https://support.quill.org/en/articles/1049944-how-do-i-assign-a-featured-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This article
-                    </a>
-                     will show you how to explore and assign Quill’s featured activity packs, and 
-                    <a
-                      href="https://support.quill.org/en/articles/1049954-how-do-i-create-and-assign-a-new-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this article
-                    </a>
-                     will show you how to create a custom activity pack.
-                  </p>,
-                  "question": "Can I assign my students practice beyond the recommended AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="15"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the Survey and its recommended practice. Creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the 
-                      <a
-                        href="https://www.quill.org/account/new"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Quill sign-up page
-                      </a>
-                      .
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      If you do not want to create an account, you or your students can complete the Survey 
-                      <a
-                        href="https://quill.org/diagnostic/#/play/diagnostic/-L_wPCxbrT6toCb1fnYR?anonymous=true"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        here
-                      </a>
-                      . However, please note that if you do not create an account, your students’ performance on the Survey will not be saved or shared with you, and you will not have access to the recommended skills practice. You will also not be able to track student progress or view data reports.
-                    </p>
-                  </div>,
-                  "question": "Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="16"
               qa={
                 Object {
                   "answer": <div>
@@ -5100,16 +4603,11 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       </a>
                        or use the chat in the lower right corner of Quill to connect with a member of the Quill support team.
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      AP® is a registered trademark of the College Board.
-                    </p>
                   </div>,
                   "question": "What if I still have questions?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -6737,7 +6235,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          What is the AP Writing Skills Survey?
+                          How is Quill.org used in Pre-AP English 1?
                         </button>
                       </div>
                       <div>
@@ -6763,7 +6261,33 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          For which AP courses is this practice most relevant?
+                          How is Quill.org used in Pre-AP English 2?
+                        </button>
+                      </div>
+                      <div>
+                        <button
+                          class="expand-collapse-button focus-on-light"
+                          type="button"
+                        >
+                          <img
+                            alt="expand-and-collapse"
+                            src="undefined/images/shared/expand.svg"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="qa-section"
+                    >
+                      <div
+                        class="qa"
+                      >
+                        <button
+                          class="question"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          Do I need to create an account on Quill.org?
                         </button>
                       </div>
                       <div>
@@ -6815,7 +6339,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          How long does the Survey take?
+                          How many activities are in each Pre-AP Writing Practice pack?
                         </button>
                       </div>
                       <div>
@@ -6841,7 +6365,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          What happens after I assign the Survey and my students complete it?
+                          How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                         </button>
                       </div>
                       <div>
@@ -6867,7 +6391,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                          Where can I track my students' completion of and performance on Quill activities?
                         </button>
                       </div>
                       <div>
@@ -6893,7 +6417,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          Can students complete the AP Writing Practice packs independently?
+                          What tools does Quill.org offer?
                         </button>
                       </div>
                       <div>
@@ -6919,189 +6443,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                           tabindex="-1"
                           type="button"
                         >
-                          How many activities are in each AP Writing Practice pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          What grade-level or reading level are the AP Activity Packs designed for?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
+                          I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                         </button>
                       </div>
                       <div>
@@ -9232,7 +8574,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
     <div>
       <QuestionsAndAnswers
         handleChange={[Function]}
-        questionsAndAnswersFile="ap"
+        questionsAndAnswersFile="preap"
         supportLink=""
       >
         <div
@@ -9267,12 +8609,12 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Quill is a writing tool that provides over 700 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
+                    Quill is a writing tool that provides over 600 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
                   </p>,
                   "question": "What is Quill.org?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9308,13 +8650,32 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               key="1"
               qa={
                 Object {
-                  "answer": <p>
-                    The AP Writing Skills Survey is a survey with 17 questions on a range of writing skills. The questions ask students to combine sentences, sometimes with a direction to use a specific strategy, and sometimes without any direction (other than to combine).
-                  </p>,
-                  "question": "What is the AP Writing Skills Survey?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 1, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the skills surveys and recommended practice activities, there are also sentence combining activities aligned to texts that are part of each unit’s instructional materials. These activities provide additional opportunities for students to practice their writing in context, combining sentences with a variety of skills and approaches that explore key ideas and themes from these texts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the previously mentioned tools and resources, you will also see direct links to Quill.org activities throughout English 1 lessons where specific grammar skills are addressed. The links will take students to independent practice activities that align with the writing goals of that particular lesson.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 1?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9328,7 +8689,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    What is the AP Writing Skills Survey?
+                    How is Quill.org used in Pre-AP English 1?
                   </button>
                 </div>
                 <div>
@@ -9350,13 +8711,27 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               key="2"
               qa={
                 Object {
-                  "answer": <p>
-                    Students in any AP course can benefit from the practice recommended by Quill's AP Writing Skills Survey, but the practice is probably of greatest interest to teachers of AP English Language and Composition and AP English Literature and Composition.
-                  </p>,
-                  "question": "For which AP courses is this practice most relevant?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 2, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      At this time, there are no sentence combining activities aligned to texts that are part of each unit’s instructional materials in Pre-AP English 2.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 2?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9370,7 +8745,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    For which AP courses is this practice most relevant?
+                    How is Quill.org used in Pre-AP English 2?
                   </button>
                 </div>
                 <div>
@@ -9392,20 +8767,85 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               key="3"
               qa={
                 Object {
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      <a
+                        href="https://www.quill.org/sign-up/teacher"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        sign-up page
+                      </a>
+                      .
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      If you do not want to create an account, the links provided throughout the English 1 lessons will allow you and your students to complete activities on Quill without Quill accounts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      Please note that if you do not create an account, you will not be able to use the skills surveys, access the recommended skills practice, track student progress, or view data reports.
+                    </p>
+                  </div>,
+                  "question": "Do I need to create an account on Quill.org?",
+                }
+              }
+              questionsAndAnswersFile="preap"
+            >
+              <div
+                className="qa-section"
+              >
+                <div
+                  className="qa"
+                >
+                  <button
+                    className="question"
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Do I need to create an account on Quill.org?
+                  </button>
+                </div>
+                <div>
+                  <button
+                    className="expand-collapse-button focus-on-light"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    type="button"
+                  >
+                    <img
+                      alt="expand-and-collapse"
+                      src="undefined/images/shared/expand.svg"
+                    />
+                  </button>
+                </div>
+              </div>
+            </QuestionAndAnswer>
+            <QuestionAndAnswer
+              key="4"
+              qa={
+                Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in AP courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
-                      href="ttps://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
+                      href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      This article explains the differences between Quill’s various diagnostics and surveys in more depth.
+                      This article explains the differences between Quill’s various diagnostics and surveys in more depth
                     </a>
+                    .
                   </p>,
                   "question": "Is a writing skills survey different than a diagnostic?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9438,64 +8878,23 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               </div>
             </QuestionAndAnswer>
             <QuestionAndAnswer
-              key="4"
-              qa={
-                Object {
-                  "answer": <p>
-                    The Survey contains 17 questions and is designed to take about 30 minutes for students to complete.
-                  </p>,
-                  "question": "How long does the Survey take?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How long does the Survey take?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
               key="5"
               qa={
                 Object {
                   "answer": <p>
-                    After you have assigned the Survey and your students have completed it, Quill will show you how your students performed and provide recommendations of personalized practice activities you can digitally assign to students who need further skill development. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
-                      href="https://support.quill.org/en/articles/1589522-how-do-i-assign-diagnostic-recommendations"
+                      href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      This article
+                      Learn how to find and assign those here.
                     </a>
-                     explains how to find and assign those recommendations.
                   </p>,
-                  "question": "What happens after I assign the Survey and my students complete it?",
+                  "question": "How many activities are in each Pre-AP Writing Practice pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9509,7 +8908,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    What happens after I assign the Survey and my students complete it?
+                    How many activities are in each Pre-AP Writing Practice pack?
                   </button>
                 </div>
                 <div>
@@ -9532,153 +8931,27 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Depending on their performance, students will be recommended some or all of the following AP Writing Practice packs. The packs provide practice through 
-                      <a
-                        href="https://www.quill.org/tools/connect"
-                      >
-                        Quill Connect
-                      </a>
-                      , 
-                      <a
-                        href="https://www.quill.org/teacher-center/-3"
-                      >
-                        Quill's sentence combining tool
-                      </a>
-                      . With the exception of the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                      >
-                        AP Writing - Advanced Sentence Combining pack
-                      </a>
-                      , the activities in each pack are scaffolded to build in complexity. Here are descriptions of the packs:
+                    <p>
+                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
+                    <p>
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                    </p>
+                    <p>
                       <a
-                        href="https://www.quill.org/activities/packs/139"
+                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        Complex Sentences
+                        This article
                       </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing complex sentences using subordinating conjunctions, such as even though, after, while, and because. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/140"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Relative Clauses
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students begin by using a provided relative pronoun, then progress to choosing between who, that, or which.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/143"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Appositive Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice describing nouns using appositive phrases at the beginning, middle, and end of sentences.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/144"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Participial Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences with -ing and -ed participial phrases at the beginning, middle, or end.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/192"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Parallel Structure
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences in parallel structure with correlative conjunctions like either/or, neither/nor, and both/and, and with subordinating conjunctions like although, because, and when. Students also practice constructing sentences with parallel clauses.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/141"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Compound-Complex Sentences
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing compound sentences with and, or, but, and so. Students also practice constructing complex sentences with subordinating conjunctions such as even though, after, while, and because. Finally, students practice constructing compound-complex sentences with coordinating and subordinating conjunctions. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Advanced Combining
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students apply their knowledge of multiple sentence structures to combine the sentences in the strongest way possible. Students practice constructing compound and complex sentences, using modifying phrases and clauses, and combining predicates.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
-                  "question": "What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?",
+                  "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9692,7 +8965,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                    How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                   </button>
                 </div>
                 <div>
@@ -9715,12 +8988,36 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Yes! From anywhere and at any time! Again though, please note that recommendations of the AP Writing Packs are generated after students complete the AP Writing Skills Survey. Please also note that students' performance on the AP Writing Practice packs will only be recorded if they are assigned to them by their teacher.
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    <a
+                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Activity Summary report
+                    </a>
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      This cheat sheet
+                    </a>
+                     shows you which report to go to for particular information, and 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      this video will walk you through 3 of Quill's student data reports
+                    </a>
+                    .
                   </p>,
-                  "question": "Can students complete the AP Writing Practice packs independently?",
+                  "question": "Where can I track my students' completion of and performance on Quill activities?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9734,7 +9031,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    Can students complete the AP Writing Practice packs independently?
+                    Where can I track my students' completion of and performance on Quill activities?
                   </button>
                 </div>
                 <div>
@@ -9760,26 +9057,69 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Each AP recommended pack* contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each.
+                      If you create a free account on Quill.org, you will be able to assign additional activities from any of Quill’s 5 tools:
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      *Please note that the activities in the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        AP Writing - Advanced Combining pack
-                      </a>
-                       are different as they are all uncued, meaning the feedback does not direct students to combine in a particular way. These are great for students who are ready to apply the strategies covered in the survey without suggestions or direction.
-                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Quill Connect
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students combine multiple ideas into a single sentence using the evidence-based strategy of sentence combining. Students receive instant feedback. *Note*: All activities recommended based on survey results are in Quill Connect.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Grammar
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice basic grammar skills, from using correct capitalization to correcting commonly confused words.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Proofreader
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice editing skills by correcting errors in passages. Students receive personalized follow-up activities based on their results.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Lessons
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Teachers lead whole-class writing instruction. Teachers control interactive slides that contain a mini-lesson and guided practice. Teachers can model writing strategies in real-time, present prompts to which students can respond, and then anonymously display student responses for discussion. Each Quill Lessons activity provides a lesson plan, writing prompts, discussion topics, and a follow-up independent practice activity. Teachers can also customize any lesson.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Diagnostic
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          <strong>
+                            Note
+                          </strong>
+                          : The writing skills surveys can be used in lieu of general Quill diagnostics.
+                        </p>
+                      </li>
+                    </ul>
                   </div>,
-                  "question": "How many activities are in each AP Writing Practice pack?",
+                  "question": "What tools does Quill.org offer?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9793,7 +9133,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    How many activities are in each AP Writing Practice pack?
+                    What tools does Quill.org offer?
                   </button>
                 </div>
                 <div>
@@ -9815,22 +9155,21 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               key="9"
               qa={
                 Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
+                  "answer": <p>
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    <a
+                      href="https://quillorg.canny.io/content-feedback"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      The focus in most of these activities is to build the target skill of the pack (appositives, relative clauses, etc.), so the vocabulary and reading level are intentionally designed to be accessible by all students.
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Teacher Tip: You can preview and play through any pack and its activities to get a sense of whether it's appropriate for your students.
-                    </p>
-                  </div>,
-                  "question": "What grade-level or reading level are the AP Activity Packs designed for?",
+                      here
+                    </a>
+                    !
+                  </p>,
+                  "question": "I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -9844,7 +9183,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     tabIndex={-1}
                     type="button"
                   >
-                    What grade-level or reading level are the AP Activity Packs designed for?
+                    I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                   </button>
                 </div>
                 <div>
@@ -9864,344 +9203,6 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             </QuestionAndAnswer>
             <QuestionAndAnswer
               key="10"
-              qa={
-                Object {
-                  "answer": "Yes! In each recommended practice activity, Quill provides students with immediate feedback on their writing that they can use to revise their responses up to 5 times. Through these rounds of feedback and revision, students improve the clarity and precision of their writing.",
-                  "question": "Will my students receive feedback as they work through the AP Writing Practice activity packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="11"
-              qa={
-                Object {
-                  "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
-                    <a
-                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Activity Summary report
-                    </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating their proficiency with each activity. Quill has several other reports as well. 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This Cheat Sheet
-                    </a>
-                     shows you which report to go to for particular information, and 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this video
-                    </a>
-                     will walk you through interpreting and utilizing three of Quill's student data reports.
-                  </p>,
-                  "question": "Where can I track my students' completion of and performance on the AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="12"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p>
-                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
-                    </p>
-                    <p>
-                      As Quill was designed to be a supplementary tool with each activity taking approximately 10-15 minutes, students are ideally completing an activity at least 1-2 times per week (at most completing one activity per day). Since each AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
-                    </p>
-                    <p>
-                      <a
-                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        This article
-                      </a>
-                       explains how you can use deadlines to help students pace themselves.
-                    </p>
-                  </div>,
-                  "question": "How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="13"
-              qa={
-                Object {
-                  "answer": <p>
-                    The activities in the AP Writing Practice packs are curated from existing Quill activities. While your students may encounter an activity they have already completed, the AP Writing Practice packs have been customized to target the skills students need to write successfully at the AP level. Given the quantity and variety of activities available on Quill, chances are that the AP Writing Practice packs will include plenty of new activities, even for students who have been using Quill for a while.
-                  </p>,
-                  "question": "If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="14"
-              qa={
-                Object {
-                  "answer": <p>
-                    Yes! Quill offers 
-                    <a
-                      href="https://support.quill.org/en/articles/1327607-what-are-each-of-the-different-quill-tools"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      5 different tools
-                    </a>
-                     with more than 700 writing, grammar, and proofreading activities designed to engage students in the writing process. 
-                    <a
-                      href="https://support.quill.org/en/articles/1049944-how-do-i-assign-a-featured-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This article
-                    </a>
-                     will show you how to explore and assign Quill’s featured activity packs, and 
-                    <a
-                      href="https://support.quill.org/en/articles/1049954-how-do-i-create-and-assign-a-new-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this article
-                    </a>
-                     will show you how to create a custom activity pack.
-                  </p>,
-                  "question": "Can I assign my students practice beyond the recommended AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="15"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the Survey and its recommended practice. Creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the 
-                      <a
-                        href="https://www.quill.org/account/new"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Quill sign-up page
-                      </a>
-                      .
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      If you do not want to create an account, you or your students can complete the Survey 
-                      <a
-                        href="https://quill.org/diagnostic/#/play/diagnostic/-L_wPCxbrT6toCb1fnYR?anonymous=true"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        here
-                      </a>
-                      . However, please note that if you do not create an account, your students’ performance on the Survey will not be saved or shared with you, and you will not have access to the recommended skills practice. You will also not be able to track student progress or view data reports.
-                    </p>
-                  </div>,
-                  "question": "Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="16"
               qa={
                 Object {
                   "answer": <div>
@@ -10252,16 +9253,11 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       </a>
                        or use the chat in the lower right corner of Quill to connect with a member of the Quill support team.
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      AP® is a registered trademark of the College Board.
-                    </p>
                   </div>,
                   "question": "What if I still have questions?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -10669,7 +9665,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          What is the AP Writing Skills Survey?
+                          How is Quill.org used in Pre-AP English 1?
                         </button>
                       </div>
                       <div>
@@ -10695,7 +9691,33 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          For which AP courses is this practice most relevant?
+                          How is Quill.org used in Pre-AP English 2?
+                        </button>
+                      </div>
+                      <div>
+                        <button
+                          class="expand-collapse-button focus-on-light"
+                          type="button"
+                        >
+                          <img
+                            alt="expand-and-collapse"
+                            src="undefined/images/shared/expand.svg"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="qa-section"
+                    >
+                      <div
+                        class="qa"
+                      >
+                        <button
+                          class="question"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          Do I need to create an account on Quill.org?
                         </button>
                       </div>
                       <div>
@@ -10747,7 +9769,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          How long does the Survey take?
+                          How many activities are in each Pre-AP Writing Practice pack?
                         </button>
                       </div>
                       <div>
@@ -10773,7 +9795,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          What happens after I assign the Survey and my students complete it?
+                          How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                         </button>
                       </div>
                       <div>
@@ -10799,7 +9821,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                          Where can I track my students' completion of and performance on Quill activities?
                         </button>
                       </div>
                       <div>
@@ -10825,7 +9847,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          Can students complete the AP Writing Practice packs independently?
+                          What tools does Quill.org offer?
                         </button>
                       </div>
                       <div>
@@ -10851,189 +9873,7 @@ exports[`PreAp component should render with no units 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          How many activities are in each AP Writing Practice pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          What grade-level or reading level are the AP Activity Packs designed for?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                        </button>
-                      </div>
-                      <div>
-                        <button
-                          class="expand-collapse-button focus-on-light"
-                          type="button"
-                        >
-                          <img
-                            alt="expand-and-collapse"
-                            src="undefined/images/shared/expand.svg"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="qa-section"
-                    >
-                      <div
-                        class="qa"
-                      >
-                        <button
-                          class="question"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
+                          I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                         </button>
                       </div>
                       <div>
@@ -11887,7 +10727,7 @@ exports[`PreAp component should render with no units 1`] = `
     <div>
       <QuestionsAndAnswers
         handleChange={[Function]}
-        questionsAndAnswersFile="ap"
+        questionsAndAnswersFile="preap"
         supportLink=""
       >
         <div
@@ -11922,12 +10762,12 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Quill is a writing tool that provides over 700 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
+                    Quill is a writing tool that provides over 600 writing, grammar, and proofreading activities designed to engage students in the writing process. Quill provides practice in many areas of sentence writing, from comma placement and subject-verb agreement to the use of conjunctions to convey complex relationships between ideas. In the Quill Connect tool, students practice writing different types of sentences using the evidence-based strategy of sentence combining. Students receive specific, targeted feedback on their writing that they can use to revise their work. Through these activities, students practice writing a variety of sophisticated sentences and practice conveying complex ideas in clear, succinct, and grammatically strong ways. Most activities are designed to be completed in 10-15 minutes so that you have the freedom to use them in the way that works best for your classroom.
                   </p>,
                   "question": "What is Quill.org?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -11963,13 +10803,32 @@ exports[`PreAp component should render with no units 1`] = `
               key="1"
               qa={
                 Object {
-                  "answer": <p>
-                    The AP Writing Skills Survey is a survey with 17 questions on a range of writing skills. The questions ask students to combine sentences, sometimes with a direction to use a specific strategy, and sometimes without any direction (other than to combine).
-                  </p>,
-                  "question": "What is the AP Writing Skills Survey?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 1, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the skills surveys and recommended practice activities, there are also sentence combining activities aligned to texts that are part of each unit’s instructional materials. These activities provide additional opportunities for students to practice their writing in context, combining sentences with a variety of skills and approaches that explore key ideas and themes from these texts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      In addition to the previously mentioned tools and resources, you will also see direct links to Quill.org activities throughout English 1 lessons where specific grammar skills are addressed. The links will take students to independent practice activities that align with the writing goals of that particular lesson.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 1?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -11983,7 +10842,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    What is the AP Writing Skills Survey?
+                    How is Quill.org used in Pre-AP English 1?
                   </button>
                 </div>
                 <div>
@@ -12005,13 +10864,27 @@ exports[`PreAp component should render with no units 1`] = `
               key="2"
               qa={
                 Object {
-                  "answer": <p>
-                    Students in any AP course can benefit from the practice recommended by Quill's AP Writing Skills Survey, but the practice is probably of greatest interest to teachers of AP English Language and Composition and AP English Literature and Composition.
-                  </p>,
-                  "question": "For which AP courses is this practice most relevant?",
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      As part of the customized Pre-AP + Quill Offering for English 2, there are two distinct skills surveys. Pre-AP Skills Survey 1 addresses the basics of sentence patterns, while Pre-AP Skills Survey 2 engages with tools for sentence expansion. The skills featured as part of each survey are derived directly from the elements of grammar called out by the Pre-AP English High School Course Framework.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      You can use these skills surveys during the course to assess your students’ needs and to generate a sequence of recommended activities that provides targeted writing practice on the skills addressed instructionally in the Learning Cycles. In each of these recommended practice activities, students receive immediate feedback on their writing that they can use to revise their responses up to five times. Through these rounds of feedback and revision, students practice key writing skills.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      At this time, there are no sentence combining activities aligned to texts that are part of each unit’s instructional materials in Pre-AP English 2.
+                    </p>
+                  </div>,
+                  "question": "How is Quill.org used in Pre-AP English 2?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12025,7 +10898,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    For which AP courses is this practice most relevant?
+                    How is Quill.org used in Pre-AP English 2?
                   </button>
                 </div>
                 <div>
@@ -12047,20 +10920,85 @@ exports[`PreAp component should render with no units 1`] = `
               key="3"
               qa={
                 Object {
+                  "answer": <div>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      <a
+                        href="https://www.quill.org/sign-up/teacher"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        sign-up page
+                      </a>
+                      .
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      If you do not want to create an account, the links provided throughout the English 1 lessons will allow you and your students to complete activities on Quill without Quill accounts.
+                    </p>
+                    <p
+                      className="college-board-q-and-a-text"
+                    >
+                      Please note that if you do not create an account, you will not be able to use the skills surveys, access the recommended skills practice, track student progress, or view data reports.
+                    </p>
+                  </div>,
+                  "question": "Do I need to create an account on Quill.org?",
+                }
+              }
+              questionsAndAnswersFile="preap"
+            >
+              <div
+                className="qa-section"
+              >
+                <div
+                  className="qa"
+                >
+                  <button
+                    className="question"
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Do I need to create an account on Quill.org?
+                  </button>
+                </div>
+                <div>
+                  <button
+                    className="expand-collapse-button focus-on-light"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    type="button"
+                  >
+                    <img
+                      alt="expand-and-collapse"
+                      src="undefined/images/shared/expand.svg"
+                    />
+                  </button>
+                </div>
+              </div>
+            </QuestionAndAnswer>
+            <QuestionAndAnswer
+              key="4"
+              qa={
+                Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in AP courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
-                      href="ttps://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
+                      href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      This article explains the differences between Quill’s various diagnostics and surveys in more depth.
+                      This article explains the differences between Quill’s various diagnostics and surveys in more depth
                     </a>
+                    .
                   </p>,
                   "question": "Is a writing skills survey different than a diagnostic?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12093,64 +11031,23 @@ exports[`PreAp component should render with no units 1`] = `
               </div>
             </QuestionAndAnswer>
             <QuestionAndAnswer
-              key="4"
-              qa={
-                Object {
-                  "answer": <p>
-                    The Survey contains 17 questions and is designed to take about 30 minutes for students to complete.
-                  </p>,
-                  "question": "How long does the Survey take?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How long does the Survey take?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
               key="5"
               qa={
                 Object {
                   "answer": <p>
-                    After you have assigned the Survey and your students have completed it, Quill will show you how your students performed and provide recommendations of personalized practice activities you can digitally assign to students who need further skill development. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
-                      href="https://support.quill.org/en/articles/1589522-how-do-i-assign-diagnostic-recommendations"
+                      href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      This article
+                      Learn how to find and assign those here.
                     </a>
-                     explains how to find and assign those recommendations.
                   </p>,
-                  "question": "What happens after I assign the Survey and my students complete it?",
+                  "question": "How many activities are in each Pre-AP Writing Practice pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12164,7 +11061,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    What happens after I assign the Survey and my students complete it?
+                    How many activities are in each Pre-AP Writing Practice pack?
                   </button>
                 </div>
                 <div>
@@ -12187,153 +11084,27 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Depending on their performance, students will be recommended some or all of the following AP Writing Practice packs. The packs provide practice through 
-                      <a
-                        href="https://www.quill.org/tools/connect"
-                      >
-                        Quill Connect
-                      </a>
-                      , 
-                      <a
-                        href="https://www.quill.org/teacher-center/-3"
-                      >
-                        Quill's sentence combining tool
-                      </a>
-                      . With the exception of the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                      >
-                        AP Writing - Advanced Sentence Combining pack
-                      </a>
-                      , the activities in each pack are scaffolded to build in complexity. Here are descriptions of the packs:
+                    <p>
+                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
+                    <p>
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                    </p>
+                    <p>
                       <a
-                        href="https://www.quill.org/activities/packs/139"
+                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        Complex Sentences
+                        This article
                       </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing complex sentences using subordinating conjunctions, such as even though, after, while, and because. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/140"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Relative Clauses
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students begin by using a provided relative pronoun, then progress to choosing between who, that, or which.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/143"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Appositive Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice describing nouns using appositive phrases at the beginning, middle, and end of sentences.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/144"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Participial Phrases
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences with -ing and -ed participial phrases at the beginning, middle, or end.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/192"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Parallel Structure
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing sentences in parallel structure with correlative conjunctions like either/or, neither/nor, and both/and, and with subordinating conjunctions like although, because, and when. Students also practice constructing sentences with parallel clauses.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/141"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Compound-Complex Sentences
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students practice constructing compound sentences with and, or, but, and so. Students also practice constructing complex sentences with subordinating conjunctions such as even though, after, while, and because. Finally, students practice constructing compound-complex sentences with coordinating and subordinating conjunctions. Students also practice identifying time order, opposition, and cause/effect relationships.
-                    </p>
-                    <p
-                      className="college-board-sub-header"
-                    >
-                      AP Writing Practice - 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Advanced Combining
-                      </a>
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Students apply their knowledge of multiple sentence structures to combine the sentences in the strongest way possible. Students practice constructing compound and complex sentences, using modifying phrases and clauses, and combining predicates.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
-                  "question": "What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?",
+                  "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12347,7 +11118,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    What kind of activities will be recommended to my students after they take the AP Writing Skills Survey?
+                    How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
                   </button>
                 </div>
                 <div>
@@ -12370,12 +11141,36 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Yes! From anywhere and at any time! Again though, please note that recommendations of the AP Writing Packs are generated after students complete the AP Writing Skills Survey. Please also note that students' performance on the AP Writing Practice packs will only be recorded if they are assigned to them by their teacher.
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    <a
+                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Activity Summary report
+                    </a>
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      This cheat sheet
+                    </a>
+                     shows you which report to go to for particular information, and 
+                    <a
+                      href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      this video will walk you through 3 of Quill's student data reports
+                    </a>
+                    .
                   </p>,
-                  "question": "Can students complete the AP Writing Practice packs independently?",
+                  "question": "Where can I track my students' completion of and performance on Quill activities?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12389,7 +11184,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    Can students complete the AP Writing Practice packs independently?
+                    Where can I track my students' completion of and performance on Quill activities?
                   </button>
                 </div>
                 <div>
@@ -12415,26 +11210,69 @@ exports[`PreAp component should render with no units 1`] = `
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Each AP recommended pack* contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each.
+                      If you create a free account on Quill.org, you will be able to assign additional activities from any of Quill’s 5 tools:
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      *Please note that the activities in the 
-                      <a
-                        href="https://www.quill.org/activities/packs/142"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        AP Writing - Advanced Combining pack
-                      </a>
-                       are different as they are all uncued, meaning the feedback does not direct students to combine in a particular way. These are great for students who are ready to apply the strategies covered in the survey without suggestions or direction.
-                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Quill Connect
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students combine multiple ideas into a single sentence using the evidence-based strategy of sentence combining. Students receive instant feedback. *Note*: All activities recommended based on survey results are in Quill Connect.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Grammar
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice basic grammar skills, from using correct capitalization to correcting commonly confused words.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Proofreader
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students practice editing skills by correcting errors in passages. Students receive personalized follow-up activities based on their results.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Lessons
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Teachers lead whole-class writing instruction. Teachers control interactive slides that contain a mini-lesson and guided practice. Teachers can model writing strategies in real-time, present prompts to which students can respond, and then anonymously display student responses for discussion. Each Quill Lessons activity provides a lesson plan, writing prompts, discussion topics, and a follow-up independent practice activity. Teachers can also customize any lesson.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Quill Diagnostic
+                        </p>
+                        <p
+                          className="college-board-q-and-a-text"
+                        >
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          <strong>
+                            Note
+                          </strong>
+                          : The writing skills surveys can be used in lieu of general Quill diagnostics.
+                        </p>
+                      </li>
+                    </ul>
                   </div>,
-                  "question": "How many activities are in each AP Writing Practice pack?",
+                  "question": "What tools does Quill.org offer?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12448,7 +11286,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    How many activities are in each AP Writing Practice pack?
+                    What tools does Quill.org offer?
                   </button>
                 </div>
                 <div>
@@ -12470,22 +11308,21 @@ exports[`PreAp component should render with no units 1`] = `
               key="9"
               qa={
                 Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
+                  "answer": <p>
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    <a
+                      href="https://quillorg.canny.io/content-feedback"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
-                      The focus in most of these activities is to build the target skill of the pack (appositives, relative clauses, etc.), so the vocabulary and reading level are intentionally designed to be accessible by all students.
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      Teacher Tip: You can preview and play through any pack and its activities to get a sense of whether it's appropriate for your students.
-                    </p>
-                  </div>,
-                  "question": "What grade-level or reading level are the AP Activity Packs designed for?",
+                      here
+                    </a>
+                    !
+                  </p>,
+                  "question": "I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"
@@ -12499,7 +11336,7 @@ exports[`PreAp component should render with no units 1`] = `
                     tabIndex={-1}
                     type="button"
                   >
-                    What grade-level or reading level are the AP Activity Packs designed for?
+                    I see there are passage-aligned activities for Pre-AP English I. Are there passage-aligned activities for other Pre-AP courses?
                   </button>
                 </div>
                 <div>
@@ -12519,344 +11356,6 @@ exports[`PreAp component should render with no units 1`] = `
             </QuestionAndAnswer>
             <QuestionAndAnswer
               key="10"
-              qa={
-                Object {
-                  "answer": "Yes! In each recommended practice activity, Quill provides students with immediate feedback on their writing that they can use to revise their responses up to 5 times. Through these rounds of feedback and revision, students improve the clarity and precision of their writing.",
-                  "question": "Will my students receive feedback as they work through the AP Writing Practice activity packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Will my students receive feedback as they work through the AP Writing Practice activity packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="11"
-              qa={
-                Object {
-                  "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
-                    <a
-                      href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Activity Summary report
-                    </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating their proficiency with each activity. Quill has several other reports as well. 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This Cheat Sheet
-                    </a>
-                     shows you which report to go to for particular information, and 
-                    <a
-                      href="https://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this video
-                    </a>
-                     will walk you through interpreting and utilizing three of Quill's student data reports.
-                  </p>,
-                  "question": "Where can I track my students' completion of and performance on the AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Where can I track my students' completion of and performance on the AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="12"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p>
-                      You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
-                    </p>
-                    <p>
-                      As Quill was designed to be a supplementary tool with each activity taking approximately 10-15 minutes, students are ideally completing an activity at least 1-2 times per week (at most completing one activity per day). Since each AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
-                    </p>
-                    <p>
-                      <a
-                        href="https://support.quill.org/en/articles/1065187-can-i-assign-activities-in-a-specific-order"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        This article
-                      </a>
-                       explains how you can use deadlines to help students pace themselves.
-                    </p>
-                  </div>,
-                  "question": "How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    How many AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="13"
-              qa={
-                Object {
-                  "answer": <p>
-                    The activities in the AP Writing Practice packs are curated from existing Quill activities. While your students may encounter an activity they have already completed, the AP Writing Practice packs have been customized to target the skills students need to write successfully at the AP level. Given the quantity and variety of activities available on Quill, chances are that the AP Writing Practice packs will include plenty of new activities, even for students who have been using Quill for a while.
-                  </p>,
-                  "question": "If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    If my students have been using Quill for a while, will they encounter activities in the AP Writing Practice packs that they have completed before?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="14"
-              qa={
-                Object {
-                  "answer": <p>
-                    Yes! Quill offers 
-                    <a
-                      href="https://support.quill.org/en/articles/1327607-what-are-each-of-the-different-quill-tools"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      5 different tools
-                    </a>
-                     with more than 700 writing, grammar, and proofreading activities designed to engage students in the writing process. 
-                    <a
-                      href="https://support.quill.org/en/articles/1049944-how-do-i-assign-a-featured-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      This article
-                    </a>
-                     will show you how to explore and assign Quill’s featured activity packs, and 
-                    <a
-                      href="https://support.quill.org/en/articles/1049954-how-do-i-create-and-assign-a-new-activity-pack"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      this article
-                    </a>
-                     will show you how to create a custom activity pack.
-                  </p>,
-                  "question": "Can I assign my students practice beyond the recommended AP Writing Practice packs?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Can I assign my students practice beyond the recommended AP Writing Practice packs?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="15"
-              qa={
-                Object {
-                  "answer": <div>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the Survey and its recommended practice. Creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the 
-                      <a
-                        href="https://www.quill.org/account/new"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Quill sign-up page
-                      </a>
-                      .
-                    </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      If you do not want to create an account, you or your students can complete the Survey 
-                      <a
-                        href="https://quill.org/diagnostic/#/play/diagnostic/-L_wPCxbrT6toCb1fnYR?anonymous=true"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        here
-                      </a>
-                      . However, please note that if you do not create an account, your students’ performance on the Survey will not be saved or shared with you, and you will not have access to the recommended skills practice. You will also not be able to track student progress or view data reports.
-                    </p>
-                  </div>,
-                  "question": "Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?",
-                }
-              }
-              questionsAndAnswersFile="ap"
-            >
-              <div
-                className="qa-section"
-              >
-                <div
-                  className="qa"
-                >
-                  <button
-                    className="question"
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Do I need to create an account on Quill.org to assign the AP Writing Skills Survey?
-                  </button>
-                </div>
-                <div>
-                  <button
-                    className="expand-collapse-button focus-on-light"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    type="button"
-                  >
-                    <img
-                      alt="expand-and-collapse"
-                      src="undefined/images/shared/expand.svg"
-                    />
-                  </button>
-                </div>
-              </div>
-            </QuestionAndAnswer>
-            <QuestionAndAnswer
-              key="16"
               qa={
                 Object {
                   "answer": <div>
@@ -12907,16 +11406,11 @@ exports[`PreAp component should render with no units 1`] = `
                       </a>
                        or use the chat in the lower right corner of Quill to connect with a member of the Quill support team.
                     </p>
-                    <p
-                      className="college-board-q-and-a-text"
-                    >
-                      AP® is a registered trademark of the College Board.
-                    </p>
                   </div>,
                   "question": "What if I still have questions?",
                 }
               }
-              questionsAndAnswersFile="ap"
+              questionsAndAnswersFile="preap"
             >
               <div
                 className="qa-section"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/pre_ap.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/pre_ap.tsx
@@ -302,7 +302,7 @@ const PreAp = ({ units, isPartOfAssignmentFlow, }: PreApContainerProps) => {
       </div>
     </div>
     <div ref={questionAndAnswerRef}>
-      <QuestionsAndAnswers handleChange={handleChange} questionsAndAnswersFile="ap" supportLink="" />
+      <QuestionsAndAnswers handleChange={handleChange} questionsAndAnswersFile="preap" supportLink="" />
     </div>
   </div>
   )


### PR DESCRIPTION
## WHAT
fix Q&A file for Pre-AP page

## WHY
we want the correct Q&A section rendered

## HOW
just change the identifying prop being passed

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/FAQs-for-Pre-AP-landing-pg-are-not-for-Pre-AP-d09b1547d5e84f21af17c3a96ca14a04

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
