### PR TITLE
Fix bug with unpermitted attributes for active activity sessions update

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
   end
 
   private def valid_params
-    params.require(:active_activity_session).except(:uid)
+    params.require(:active_activity_session).except(:uid).permit!
   end
 
   private def activity_session_by_uid

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -1,0 +1,99 @@
+require 'json'
+require 'rails_helper'
+
+describe Api::V1::ActiveActivitySessionsController, type: :controller do
+  let!(:active_activity_session) { create(:active_activity_session) }
+
+  describe "#show" do
+    it "should return the specified active_activity_session" do
+      get :show, params: { id: active_activity_session.uid }
+      expect(JSON.parse(response.body)).to eq(active_activity_session.data)
+    end
+
+    it "should return a 404 if the requested activity session is not found" do
+      get :show, params: { id: 'doesnotexist' }
+      expect(response.status).to eq(404)
+      expect(response.body).to include("The resource you were looking for does not exist")
+    end
+  end
+
+  describe "#update" do
+    it "should update the existing record" do
+      data = {"foo" => "bar"}
+      put :update, params: { id: active_activity_session.uid, active_activity_session: data }
+      active_activity_session.reload
+      expect(active_activity_session.data).to eq(data)
+    end
+
+    it "should handle nested data" do
+      old_data = active_activity_session.data
+
+      new_data = {
+        "answeredQuestions" => [
+          {
+            "attempts" => [
+              {
+                "response" => "{\"child_count\":2468}"
+              }
+            ],
+            "question" => "-LOKpH-21lwuPa"
+          }
+        ]
+      }
+
+      put :update, params: { id: active_activity_session.uid, active_activity_session: new_data }
+      active_activity_session.reload
+      expect(active_activity_session.data).to eq(old_data.merge(new_data))
+    end
+
+
+    it "should create a new session if the requested activity session is not found" do
+      data = {"foo" => "bar"}
+      put :update, params: { id: 'doesnotexist', active_activity_session: data }
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(data.to_json)
+      new_activity_session = ActiveActivitySession.find_by(uid: 'doesnotexist')
+      expect(new_activity_session).to be
+      expect(new_activity_session.data).to eq(data)
+    end
+
+    it "should retain the values in keys not updated in the payload" do
+      old_data = active_activity_session.data
+      new_data = {"newkey" => "newvalue"}
+      put :update, params: { id: active_activity_session.uid, active_activity_session: new_data }
+      active_activity_session.reload
+      expect(active_activity_session.data.keys).to eq(old_data.keys + new_data.keys)
+    end
+
+    it "should not raise an ActiveRecord::RecordNotUnique error if that is raised during the first save attempt but not raised on retry" do
+      call_count = 0
+      allow_any_instance_of(ActiveActivitySession).to receive(:save!) do
+        call_count += 1
+        raise(ActiveRecord::RecordNotUnique, 'Error') if call_count == 1
+        true
+      end
+      put :update, params: { id: active_activity_session.uid, active_activity_session: active_activity_session.data }
+    end
+
+    it "should raise an ActiveRecord::RecordNotUnique error if that is raised both during save and on retry" do
+      err = ActiveRecord::RecordNotUnique.new('Error')
+      allow_any_instance_of(ActiveActivitySession).to receive(:save!).and_raise(err)
+      expect do
+        put :update, params: { id: active_activity_session.uid, active_activity_session: active_activity_session.data }
+      end.to raise_error(err)
+    end
+  end
+
+  describe "#destroy" do
+    it "should destroy the existing record" do
+      delete :destroy, params: { id: active_activity_session.uid }
+      expect(ActiveActivitySession.where(uid: active_activity_session.uid).count).to eq(0)
+    end
+
+    it "should return a 404 if the requested activity session is not found" do
+      delete :destroy, params: { id: 'doesnotexist' }
+      expect(response.status).to eq(404)
+      expect(response.body).to include("The resource you were looking for does not exist")
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Fix a bug involving nested parameters in an `update` action for active activity sessions.

## WHY
This bug will materialize when we upgrade to Rails 5.1, so it's better to deal with it now.

## HOW
Add `permit!` call on the params hash.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/SentryError-Api-V1-ActiveActivitySessionsController-update-ActionController-UnfilteredParamet-d4e5b636581e43d9a1c5d11fab66db42

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
