### PR TITLE
don't apply bolding or highlighting when user is out of attempts

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -463,6 +463,9 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
 
     if (!activeStep || activeStep === READ_PASSAGE_STEP) { return passagesWithPTags }
 
+    // we return the unhighlighted text when an active response has maxed attempts
+    if (this.outOfAttemptsForActivePrompt()) { return passagesWithoutSpanTags }
+
     const promptIndex = activeStep - 2 // have to subtract 2 because the prompts array index starts at 0 but the prompt numbers in the state are 2..4
     const activePromptId = currentActivity.prompts[promptIndex].id
     const submittedResponsesForActivePrompt = session.submittedResponses[activePromptId]

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -89,10 +89,10 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   }
 
   formatStudentResponse = (str: string) => {
-    const { prompt, } = this.props
+    const { prompt, submittedResponses, } = this.props
     const lastSubmittedResponse = this.lastSubmittedResponse()
 
-    if (!lastSubmittedResponse || !lastSubmittedResponse.highlight || !lastSubmittedResponse.entry) { return str }
+    if (!lastSubmittedResponse || !lastSubmittedResponse.highlight || !lastSubmittedResponse.entry || submittedResponses.length === prompt.max_attempts) { return str }
 
     const thereAreResponseHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).length
     const lastSubmittedResponseWithoutStem = lastSubmittedResponse.entry.replace(prompt.text, '').trim()


### PR DESCRIPTION
## WHAT
Don't apply either passage or response highlighting when a user is out of attempts.

## WHY
To avoid confusing them when they can't make further revisions.

## HOW
Just check to see if a user is on their last attempt and, if they are, don't add highlighting to the passage or the response.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fifth-attempt-sub-optimal-feedback-should-not-have-bolding-or-highlighting-f1d64c54cc944e53b8770d2d1f7afda8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
