### PR TITLE
fix edge case where the text to-be-bolded doesn't actually appear in the response

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/libs/stringFormatting.ts
@@ -3,8 +3,10 @@ export const highlightSpellingGrammar = (str: string, wordsToFormat: string | st
   let newString = str
   wordArray.forEach((word) => {
     const matched = newString.match(`${word}[\\w\']*`)
-    const augmentedRegex = new RegExp(`${matched[0]}`, 'g')
-    newString = newString.replace(augmentedRegex, `<b>${matched[0]}</b>`)
+    if (matched) {
+      const augmentedRegex = new RegExp(`${matched[0]}`, 'g')
+      newString = newString.replace(augmentedRegex, `<b>${matched[0]}</b>`)
+    }
   })
   return newString
 }


### PR DESCRIPTION
## WHAT
Fix edge case where the text to be bolded doesn't actually appear in the response.

## WHY
Though this is unusual, we don't want the page to totally error out when it happens.

## HOW
Just wrap the part that actually uses `matched` in a conditional.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
