### PR TITLE
Add configuration for logging verbose assets:precompile

### DIFF
--- a/services/QuillLMS/lib/tasks/assets.rake
+++ b/services/QuillLMS/lib/tasks/assets.rake
@@ -13,6 +13,11 @@ if defined?(Sprockets)
         # Use open3 so an error aborts the build (backticks `` swallow the error)
         stdout, stderr, status = Open3.capture3(npm_build)
 
+        if ENV.fetch('VERBOSE_ASSETS_PRECOMPILE', false) == 'true'
+          puts "stdout:\n#{stdout}" if stdout.present?
+          puts "stderr:\n#{stderr}" if stderr.present?
+        end
+
         if !status.success?
           # print everything in the case of an error
           puts stdout


### PR DESCRIPTION
## WHAT
Add a configuration that toggles verbose logging of `stderr` and `stdout` when running `assets:precompile` (e.g. see this [build](https://dashboard.heroku.com/apps/empirical-grammar-staging/activity/builds/dcb8a919-a443-4913-8ced-ca0474f6ef1f))

## WHY
A [build](https://dashboard.heroku.com/apps/empirical-grammar/activity/builds/4b8044f8-e3e0-430d-8df3-17cc13309719) completed without properly building the file.  Since there were no errors, `stdout` was not outputted and there wasn't any logging to inspect.

## HOW
Add a conditional that checks to see if environment variable `VERBOSE_ASSETS_PRECOMPILE` is set.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO.  This is adding logging.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
