### PR TITLE
Comprehension internal tools/ regex semantic formatting issue

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -262,6 +262,9 @@
         }
       }
     }
+    .activity-form {
+      max-height: 80vh;
+    }
     .activity-form , .rule-form, .semantic-rule-form {
       padding: 0px 30px 0px 30px;
       .title-input, .course-input, .flag-input, .reading-level-input,

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -264,7 +264,6 @@
     }
     .activity-form , .rule-form, .semantic-rule-form {
       padding: 0px 30px 0px 30px;
-      max-height: 80vh;
       .title-input, .course-input, .flag-input, .reading-level-input,
       .reading-score-input, .because-input, .but-input {
         margin-top: 20px;


### PR DESCRIPTION
## WHAT
fix regex rule/ semantic label form formatting issue

## WHY
it was making it harder for Curriculum to develop

## HOW
just a small CSS fix; only the activity form needs a max height limit because it's the only modal now

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Regex-Rules-and-Semantic-Labels-pages-formatting-issue-cf4c6810abac40b8ba6e66ec42d9c6ab

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
