### PR TITLE
lms/new-connect-regex-same-page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -22,6 +22,15 @@ export class FocusPointsContainer extends Component {
     this.state = { fpOrderedIds: null, questionType, actionFile, questionTypeLink, focusPoints };
   }
 
+  componentDidUpdate(previousProps, previousState) {
+    const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
+    const focusPoints = this.getFocusPoints(question)
+
+    if (previousState.focusPoints === focusPoints) return;
+
+    this.setState({ focusPoints, });
+  }
+
   getFocusPoints = (question) => {
     return question.focusPoints;
   }
@@ -218,7 +227,7 @@ export class FocusPointsContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Focus Points</h1>
-          <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Focus Point</a>
+          <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Focus Point</a>
           {this.renderfPButton()}
         </div>
         {this.renderFocusPointsList()}

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -33,6 +33,15 @@ class IncorrectSequencesContainer extends Component {
     }
   }
 
+  componentDidUpdate(previousProps, previousState) {
+    const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
+    const incorrectSequences = this.getSequences(question)
+
+    if (previousState.incorrectSequences === incorrectSequences) return;
+
+    this.setState({ incorrectSequences, });
+  }
+
   getSequences = (question) => {
     const sequences = question.incorrectSequences;
     if(sequences && sequences.length) {
@@ -213,7 +222,7 @@ class IncorrectSequencesContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -22,6 +22,15 @@ export class FocusPointsContainer extends Component {
     this.state = { fpOrderedIds: null, questionType, actionFile, questionTypeLink, focusPoints };
   }
 
+  componentDidUpdate(previousProps, previousState) {
+    const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
+    const focusPoints = this.getFocusPoints(question)
+
+    if (previousState.focusPoints === focusPoints) return;
+
+    this.setState({ focusPoints, });
+  }
+
   getFocusPoints = (question) => {
     return question.focusPoints;
   }
@@ -217,7 +226,7 @@ export class FocusPointsContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Focus Points</h1>
-          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${questionTypeLink}/${questionID}/focus-points/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Focus Point</a>
+          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${questionTypeLink}/${questionID}/focus-points/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Focus Point</a>
           {this.renderfPButton()}
         </div>
         {this.renderFocusPointsList()}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -38,6 +38,15 @@ class IncorrectSequencesContainer extends Component {
     dispatch(actionFile.getUsedSequences(questionID, type))
   }
 
+  componentDidUpdate(previousProps, previousState) {
+    const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
+    const incorrectSequences = this.getSequences(question)
+
+    if (previousState.incorrectSequences === incorrectSequences) return;
+
+    this.setState({ incorrectSequences, });
+  }
+
   getSequences(question) {
     return question.incorrectSequences;
   }
@@ -220,7 +229,7 @@ class IncorrectSequencesContainer extends Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
         </div>
         {this.renderSequenceList()}
       </div>


### PR DESCRIPTION
Update sequences and focus points on creation
And don't open up the creation interface in a new window

## WHAT
Tweak the interface for creating Incorrect Sequences and Focus Points for both Connect and Diagnostic so that:
1. The "create new" interface doesn't open in a new tab (resulting in a bunch of tabs opening up and confusing Curriculum developers about which one is "current")
2. When you create a new Incorrect Sequence of Focus Point and then get navigated back to the list, it is updated with the most recently-created item.  This should simplify things for curriculum developers so they don't have to constantly refresh this page to see the current state of things.
## WHY
This came in as a bug report about confusing behavior, but it turned out to just be that it's super easy to get confused about the state of Incorrect Sequences and Focus Points with the old workflows.  This should be a lot cleaner.
## HOW
Removed the `target="_blank"` attribute from the link to the "new" interface, and then added a `componentDidUpdate` function to all of the handlers to make sure that they reflect the most recently known set of Focus Points and Incorrect Sequences.

### Notion Card Links
https://www.notion.so/quill/Diagnostic-grading-isn-t-saving-correctly-23b5034f2fbf4e588a015fa756b03437

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No major changes to behavior
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
