### PR TITLE
Comprehension internal tools/ add max-width to header images

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/activity.scss
@@ -34,7 +34,8 @@
     height: 100%;
     .header-image {
       height: auto;
-      max-width: 100%;
+      width: 100%;
+      max-width: 680px;
     }
     .passage p {
       margin-bottom: 40px;


### PR DESCRIPTION
## WHAT
add a width constraint to header images for Comprehension activities

## WHY
so that they don't distort the activity view

## HOW
just add a `max-width` value for `.header-image`

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1657" alt="Screen Shot 2021-07-22 at 1 52 36 PM" src="https://user-images.githubusercontent.com/25959584/126677852-55ad6496-c1cf-4c3b-b325-281fca9dd090.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Set-max-width-requirements-for-images-726759e5704640be96125609aa8d7af3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- small CSS change, manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
