### PR TITLE
Comprehension/ strip html from entry before submission

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -249,11 +249,13 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { sessionID, } = session
     const activityUID = this.activityUID()
     const previousFeedback = session.submittedResponses[promptID] || [];
+    // strip any HTML injected by browser extensions (such as Chrome highlight)
+    const strippedEntry = stripHtml(entry);
     if (activityUID) {
       const args = {
         sessionID,
         activityUID,
-        entry,
+        entry: strippedEntry,
         promptID,
         promptText,
         attempt,


### PR DESCRIPTION
## WHAT
strip html from student entry before submission for Comprehension

## WHY
some browser extensions were injecting HTML which was causing some incorrect feedback to be served

## HOW
just use `stripHtml` function before passing the entry text to the submitting function

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Remove-HTML-markdown-from-user-responses-c862fcbbcd2645b6a5e6166c40b849fc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
