### PR TITLE
Comprehension/fix spelling feedback

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -49,7 +49,7 @@ module Comprehension
     end
 
     private def misspelled
-      bing_response['flaggedTokens']
+      bing_response['flaggedTokens'] || []
     end
 
     private def bing_response

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/spelling_check.rb
@@ -1,5 +1,6 @@
 module Comprehension
   class SpellingCheck
+    class BingRateLimitException < StandardError; end
 
     ALL_CORRECT_FEEDBACK = 'Correct spelling!'
     FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word(s).'
@@ -62,6 +63,10 @@ module Comprehension
           mode: "proof"
         }
       )
+      # The rest of this code basically swallows any errors, but we want
+      # to avoid swallowing errors around rate limiting, so raise those here
+      raise BingRateLimitException if @response.code == 429
+
       JSON.parse(@response.body)
     end
   end

--- a/services/QuillLMS/engines/comprehension/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/lib/spelling_check_spec.rb
@@ -33,6 +33,19 @@ module Comprehension
         expect(feedback[:concept_uid]).to(be_truthy)
       end
 
+      it 'should return appropriate feedback attributes if there is no spelling error even if Bing does not return a "flaggedTokens" value' do
+        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
+        entry = "there is no spelling error here"
+        spelling_check = Comprehension::SpellingCheck.new(entry)
+        feedback = spelling_check.feedback_object
+        expect(feedback[:feedback]).to(be_truthy)
+        expect(feedback[:feedback_type]).to(be_truthy)
+        expect(feedback[:optimal]).to(be_truthy)
+        expect(feedback[:entry]).to(be_truthy)
+        expect(feedback[:rule_uid]).to(be_truthy)
+        expect(feedback[:concept_uid]).to(be_truthy)
+      end
+
       it 'should return appropriate error if the endpoint returns an error' do
         stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"

--- a/services/QuillLMS/engines/comprehension/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/lib/spelling_check_spec.rb
@@ -69,5 +69,14 @@ module Comprehension
         expect(feedback.text).to(eq(spelling_check.non_optimal_feedback_string))
       end
     end
+
+    context 'should handle appropriate Bing API errors' do
+      it 'should raise exception if the endpoint returns a rate-limit error' do
+        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        entry = "there is no spelling error here"
+        spelling_check = Comprehension::SpellingCheck.new(entry)
+        expect { spelling_check.feedback_object }.to raise_error(Comprehension::SpellingCheck::BingRateLimitException)
+      end
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a `nil` error that came up in Sentry caused when the Bing spelling API errors

At the same time, add a small tweak so that we don't swallow Bing API rate limit errors since those are things we'll want to know about
## WHY
We want to make sure that the our API doesn't error just because Bing's might.  However, we do want to record errors in cases where we're running into Bing rate-limiting
## HOW
The initial problem is solved by making sure we provide an empty array for the rest of our code to work with when we don't get the expected response payload shape back from Bing.  Then we check for the explicit HTTP status code that Bing documentation says they'll use to indicate rate limit violations and raise a custom exception that should report to Sentry and other systems.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-NoMethodError-Comprehension-FeedbackController-spelling-664d69d67f1a43fd9e33a5680469dabd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
