### PR TITLE
Catch nil error edge case in ActivityHealth Serializer

### DIFF
--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -32,10 +32,10 @@ class SerializeActivityHealth
     questions = @activity.data["questions"]
     return [] if !questions.present?
 
-    @questions_arr ||= questions.each.with_index(1).map do |q, question_number|
+    @questions_arr ||= questions.each.with_index(1).map { |q, question_number|
       question = Question.find_by(uid: q["key"])
-      question.present? ? QuestionHealthObj.new(@activity, question, question_number, tool).run : {}
-    end
+      question.present? ? QuestionHealthObj.new(@activity, question, question_number, tool).run : nil
+    }.compact
   end
 
   private def tool

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -173,4 +173,22 @@ describe 'SerializeActivityHealth' do
     expect(data[:standard_dev_difficulty]).to eq(0)
   end
 
+  it 'calculates the data without erroring for an activity with one question uid that does not exist' do
+    missing_question_activity =
+      create(:activity,
+        activity_classification_id: connect.id,
+        data: {
+          questions: [
+            {key: question.uid},
+            {key: 'not-a-real-uid'}
+          ]
+        }
+      )
+
+    data = SerializeActivityHealth.new(missing_question_activity).data
+
+    expect(data[:avg_difficulty]).to eq(0)
+    expect(data[:avg_common_unmatched]).to eq(50)
+    expect(data[:standard_dev_difficulty]).to eq(0)
+  end
 end


### PR DESCRIPTION
## WHAT
Fix an edge case where some activities were throwing errors on invalid question UIDs (e.g. question UIDs belong to Title Cards, or deleted questions). 

## WHY
So we stop getting sentry errors every time PopulateActivityHealthWorker is run for all the activities.

## HOW
Return `nil` in the question data array for invalid question UIDs, then call `.compact` on the question data array to get rid of these nil values before we calculate the averages and standard deviations.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Sidekiq-PopulateActivityHealthWorker-TypeError-0952aa55784d4ca0843745343d303ff6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
