### PR TITLE
Comprehension internal tools/ refactor activity form into page view

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -5,19 +5,34 @@ exports[`Activity Form component should render Activities 1`] = `
   className="activity-form-container"
 >
   <div
-    className="close-button-container"
+    className="button-container"
   >
+    <a
+      className="quill-button fun secondary outlined"
+      href="/comprehension/#/play?uid=undefined"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Play Activity
+    </a>
     <button
-      className="quill-button fun primary contained"
-      id="activity-close-button"
+      className="quill-button fun secondary outlined"
       onClick={[MockFunction]}
       type="button"
     >
-      x
+      Archive Activity
+    </button>
+    <button
+      className="quill-button fun primary contained"
+      id="activity-submit-button"
+      onClick={[Function]}
+      type="submit"
+    >
+      Save
     </button>
   </div>
   <form
-    className="activity-form"
+    className="comprehension-activity-form"
   >
     <Input
       autoComplete="on"
@@ -128,26 +143,6 @@ exports[`Activity Form component should render Activities 1`] = `
       errors={Object {}}
       handleSetPrompt={[Function]}
     />
-    <div
-      className="submit-button-container"
-    >
-      <button
-        className="quill-button fun primary contained"
-        id="activity-submit-button"
-        onClick={[Function]}
-        type="submit"
-      >
-        Submit
-      </button>
-      <button
-        className="quill-button fun primary contained"
-        id="activity-cancel-button"
-        onClick={[MockFunction]}
-        type="button"
-      >
-        Cancel
-      </button>
-    </div>
   </form>
 </div>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activitySettings.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activitySettings.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActivitySettings component should render ActivitySettings 1`] = `
-<div
-  className="loading-spinner-container"
->
-  <Spinner />
-</div>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activity.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activity.test.tsx
@@ -13,6 +13,6 @@ describe('Activity component', () => {
   );
 
   it('should render 2 NavLinks', () => {
-    expect(container.find(NavLink).length).toEqual(2);
+    expect(container.find(NavLink).length).toEqual(3);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activityForm.test.tsx
@@ -10,7 +10,7 @@ jest.mock('string-strip-html', () => ({
 
 const mockProps = {
   activity: mockActivity,
-  closeModal: jest.fn(),
+  handleClickArchiveActivity: jest.fn(),
   requestErrors: [],
   submitActivity: jest.fn()
 };
@@ -20,15 +20,6 @@ describe('Activity Form component', () => {
 
   it('should render Activities', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('clicking the "x" button or "close" button should call closeModal prop', () => {
-    container.find('#activity-close-button').simulate('click');
-    container.find('#activity-cancel-button').simulate('click');
-    expect(mockProps.closeModal).toHaveBeenCalledTimes(2);
-  });
-  it('clicking submit button should submit activity', () => {
-    container.find('#activity-submit-button').simulate('click');
-    expect(mockProps.closeModal).toHaveBeenCalled();
   });
   it('should render request errors if present', () => {
     mockProps.requestErrors = ['passage.text: passage text is too short'];

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activitySettingsWrapper.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/activitySettingsWrapper.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+
+import ActivitySettingsWrapper from '../configureSettings/activitySettingsWrapper';
+
+const mockActivity = [{ id: 1, title: 'First' }]
+jest.mock("react-query", () => ({
+  useQuery: jest.fn(() => ({
+    data: { activity: mockActivity},
+    error: null,
+    status: "success",
+    isFetching: true,
+  })),
+}));
+
+const mockProps = {
+  match: {
+    params: {
+      activityId: 1
+    },
+    isExact: true,
+    path: '',
+    url:''
+  }
+}
+
+describe('ActivitySettingsWrapper component', () => {
+  const container = mount(
+    <MemoryRouter>
+      <ActivitySettingsWrapper {...mockProps} />
+    </MemoryRouter>
+  );
+  it('should render ActivitySettingsWrapper', () => {
+    expect(container.find(ActivitySettingsWrapper).length).toEqual(1);
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activity.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Redirect, Route, RouteComponentProps, Switch, withRouter } from 'react-router-dom';
 
 import Navigation from './navigation'
-import ActivitySettings from './configureSettings/activitySettings';
+import ActivitySettingsWrapper from './configureSettings/activitySettingsWrapper';
 import RulesIndexRouter from './configureRules/rulesIndexRouter';
 import Rule from './configureRules/rule';
 import RulesAnalysis from './rulesAnalysis/rulesAnalysis';
@@ -24,7 +24,8 @@ const Activity: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match, lo
       <div className="activity-container">
         <Switch>
           <Redirect exact from='/activities/:activityId' to='/activities/:activityId/settings' />
-          <Route component={ActivitySettings} path='/activities/:activityId/settings' />
+          <Route component={ActivitySettingsWrapper} path='/activities/new/settings' />
+          <Route component={ActivitySettingsWrapper} path='/activities/:activityId/settings' />
           <Route component={Rule} path='/activities/:activityId/rules/:ruleId' />
           <Route component={RulesIndexRouter} path='/activities/:activityId/rules-index' />
           <Route component={ActivityStats} path='/activities/:activityId/stats' />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -3,7 +3,6 @@ import { EditorState, ContentState } from 'draft-js';
 
 import PromptsForm from './promptsForm';
 
-// import { flagOptions } from '../../../../../constants/comprehension'
 import { validateForm, buildActivity, buildBlankPrompt, promptsByConjunction, getActivityPrompt, getActivityPromptSetter, renderErrorsContainer, renderIDorUID } from '../../../helpers/comprehension';
 import {
   BECAUSE,
@@ -25,15 +24,14 @@ import { Input, TextEditor, } from '../../../../Shared/index'
 
 interface ActivityFormProps {
   activity: ActivityInterface,
-  closeModal: (event: React.MouseEvent) => void,
+  handleClickArchiveActivity: (any) => void,
   requestErrors: string[],
   submitActivity: (activity: object) => void
 }
 
-const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: ActivityFormProps) => {
+const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, submitActivity }: ActivityFormProps) => {
 
   const { parent_activity_id, passages, prompts, scored_level, target_level, title, notes, } = activity;
-  // const formattedFlag = flag ? { label: flag, value: flag } : flagOptions[0];
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
   const formattedPassage = passages && passages.length ? passages : [{ text: ''}];
@@ -50,7 +48,6 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
 
   const [activityTitle, setActivityTitle] = React.useState<string>(title || '');
   const [activityNotes, setActivityNotes] = React.useState<string>(notes || '');
-  // const [activityFlag, setActivityFlag] = React.useState<FlagInterface>(formattedFlag);
   const [activityScoredReadingLevel, setActivityScoredReadingLevel] = React.useState<string>(formattedScoredLevel);
   const [activityTargetReadingLevel, setActivityTargetReadingLevel] = React.useState<string>(formattedTargetLevel);
   const [activityPassages, setActivityPassages] = React.useState<PassagesInterface[]>(formattedPassage);
@@ -63,8 +60,6 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
   function handleSetActivityTitle(e: InputEvent){ setActivityTitle(e.target.value) };
 
   function handleSetActivityNotes(e: InputEvent){ setActivityNotes(e.target.value) };
-
-  // const handleSetActivityFlag = (flag: FlagInterface) => { setActivityFlag(flag) };
 
   function handleSetActivityMaxFeedback(text: string){ setActivityMaxFeedback(text) };
 
@@ -136,10 +131,13 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
 
   return(
     <div className="activity-form-container">
-      <div className="close-button-container">
-        <button className="quill-button fun primary contained" id="activity-close-button" onClick={closeModal} type="button">x</button>
+      <div className="button-container">
+        <a className="quill-button fun secondary outlined" href={`/comprehension/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Play Activity</a>
+        {activity.parent_activity_id && <button className="quill-button fun secondary outlined" onClick={handleClickArchiveActivity} type="button">Archive Activity</button>}
+        <button className="quill-button fun primary contained" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">Save</button>
       </div>
-      <form className="activity-form">
+      {showErrorsContainer && renderErrorsContainer(formErrorsPresent, requestErrors)}
+      <form className="comprehension-activity-form">
         <Input
           className="title-input"
           error={errors[TITLE]}
@@ -154,14 +152,6 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
           label="Activity Notes"
           value={activityNotes}
         />
-        {/* <DropdownInput
-          className="flag-input"
-          handleChange={handleSetActivityFlag}
-          isSearchable={true}
-          label="Development Stage"
-          options={flagOptions}
-          value={activityFlag}
-        /> */}
         <Input
           className="scored-reading-level-input"
           error={errors[SCORED_READING_LEVEL]}
@@ -216,15 +206,6 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
           errors={errors}
           handleSetPrompt={handleSetPrompt}
         />
-        <div className="submit-button-container">
-          {showErrorsContainer && renderErrorsContainer(formErrorsPresent, requestErrors)}
-          <button className="quill-button fun primary contained" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">
-            Submit
-          </button>
-          <button className="quill-button fun primary contained" id="activity-cancel-button" onClick={closeModal} type="button">
-            Cancel
-          </button>
-        </div>
       </form>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettings.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettings.tsx
@@ -1,42 +1,28 @@
 import * as React from "react";
-import { RouteComponentProps } from 'react-router-dom';
-import { queryCache, useQuery } from 'react-query'
+import { queryCache } from 'react-query';
+import { withRouter } from 'react-router-dom';
 
 import ActivityForm from './activityForm';
 
-import { ActivityInterface, ActivityRouteProps } from '../../../interfaces/comprehensionInterfaces';
-import { BECAUSE, BUT, SO } from '../../../../../constants/comprehension';
+import { ActivityInterface } from '../../../interfaces/comprehensionInterfaces';
 import SubmissionModal from '../shared/submissionModal';
-// import { flagOptions } from '../../../../../constants/comprehension';
-import { fetchActivity, updateActivity, archiveParentActivity } from '../../../utils/comprehension/activityAPIs';
-import { promptsByConjunction } from "../../../helpers/comprehension";
-import { DataTable, Error, Modal, Spinner } from '../../../../Shared/index';
+import { createActivity, updateActivity, archiveParentActivity } from '../../../utils/comprehension/activityAPIs';
+import { renderHeader } from "../../../helpers/comprehension";
+import { Spinner } from '../../../../Shared/index';
 
-const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match }) => {
-
+const ActivitySettings = ({ activity, history }: {activity: ActivityInterface, history: any}) => {
+  const { id } = activity;
   const [errorOrSuccessMessage, setErrorOrSuccessMessage] = React.useState<string>(null);
-  // const [activityFlag, setActivityFlag] = React.useState<FlagInterface>(null);
-  const [showEditActivityModal, setShowEditActivityModal] = React.useState<boolean>(false);
-  // const [showEditFlagModal, setShowEditFlagModal] = React.useState<boolean>(false);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
-  const { params } = match;
-  const { activityId } = params;
 
-  // cache activity data for updates
-  const { data } = useQuery({
-    queryKey: [`activity-${activityId}`, activityId],
-    queryFn: fetchActivity
-  });
-
-  const handleClickArchiveActivity = () => {
+  function handleClickArchiveActivity() {
     if (window.confirm('Are you sure you want to archive? If you archive, it will not be displayed on the "View Activities" page. Please also make sure that the activity has the correct parent activity id, because the parent activity will be archived as well.')) {
-      archiveParentActivity(data.activity.parent_activity_id).then((response) => {
+      archiveParentActivity(activity.parent_activity_id).then((response) => {
         const { error } = response;
         error && setErrorOrSuccessMessage(error);
-        queryCache.refetchQueries(`activity-${activityId}`)
+        queryCache.refetchQueries(`activity-${id}`)
         if(!error) {
-          setShowEditActivityModal(false);
           // reset errorOrSuccessMessage in case of subsequent submission
           setErrorOrSuccessMessage('Activity successfully archived!');
         }
@@ -46,15 +32,14 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
     }
   }
 
-  const handleUpdateActivity = (activity: ActivityInterface) => {
-    updateActivity(activity, activityId).then((response) => {
+  function handleUpdateActivity (activity: ActivityInterface) {
+    updateActivity(activity, id).then((response) => {
       const { errors } = response;
       if(errors && errors.length) {
         setErrors(errors);
       } else {
-        queryCache.refetchQueries(`activity-${activityId}`)
+        queryCache.refetchQueries(`activity-${id}`)
         setErrors([]);
-        setShowEditActivityModal(false);
         // reset errorOrSuccessMessage in case of subsequent submission
         setErrorOrSuccessMessage('Activity successfully updated!');
         toggleSubmissionModal();
@@ -62,144 +47,34 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
     });
   }
 
-  // const handleUpdateFlag = () => {
-  //   let updatedActivity: any = data.activity;
-  //   updatedActivity.flag = activityFlag.value;
-  //   handleUpdateActivity(updatedActivity);
-  //   setShowEditFlagModal(false);
-  // }
-
-  // const handleFlagChange = (flag: { label: string, value: {}}) => {
-  //   setActivityFlag(flag);
-  // }
-
-
-  const toggleEditActivityModal = () => {
-    setShowEditActivityModal(!showEditActivityModal);
+  function handleSubmitActivity(activity: ActivityInterface) {
+    createActivity(activity).then((response) => {
+      const { errors, activityId } = response;
+      if(errors && errors.length) {
+        setErrors(errors);
+      } else {
+        // update activities cache to display newly created activity
+        queryCache.refetchQueries('activities');
+        setErrors([]);
+        setErrorOrSuccessMessage('Activity successfully created!');
+        toggleSubmissionModal();
+        history.push(`/activities/${activityId}/settings`)
+      }
+    });
   }
 
-  // const toggleFlagModal = () => {
-  //   // only update flag if submit button is clicked
-  //   if(activityFlag !== data.flag) {
-  //     setActivityFlag(data.flag);
-  //   }
-  //   setShowEditFlagModal(!showEditFlagModal);
-  // }
-
-  const toggleSubmissionModal = () => {
+  function toggleSubmissionModal() {
     setShowSubmissionModal(!showSubmissionModal);
   }
 
-  // const flagModal = (
-  //   <button className="quill-button fun primary outlined" id="edit-flag-button" onClick={toggleFlagModal} type="submit">
-  //     {data && data.flag ? data.flag.label : ''}
-  //   </button>
-  // );
-
-  const renderActivityForm = () => {
-    return(
-      <Modal>
-        <ActivityForm activity={data && data.activity} closeModal={toggleEditActivityModal} requestErrors={errors} submitActivity={handleUpdateActivity} />
-      </Modal>
-    );
-  }
-
-  // const renderFlagEditModal = () => {
-  //   return(
-  //     <Modal>
-  //       <div className="edit-flag-container">
-  //         <div className="close-button-container">
-  //           <button className="quill-button fun primary contained" id="flag-close-button" onClick={toggleFlagModal} type="submit">x</button>
-  //         </div>
-  //         <DropdownInput
-  //           className="flag-dropdown"
-  //           handleChange={handleFlagChange}
-  //           isSearchable={true}
-  //           label="Development Stage"
-  //           options={flagOptions}
-  //           value={activityFlag ? activityFlag : data.flag}
-  //         />
-  //         <div className="submit-button-container">
-  //           <button className="quill-button fun primary contained" id="flag-submit-button" onClick={handleUpdateFlag} type="submit">
-  //             Submit
-  //           </button>
-  //           <button className="quill-button fun primary contained" id="flag-cancel-button" onClick={toggleFlagModal} type="submit">
-  //             Cancel
-  //           </button>
-  //         </div>
-  //       </div>
-  //     </Modal>
-  //   )
-  // }
-
-  const renderSubmissionModal = () => {
+  function renderSubmissionModal() {
     const message = errorOrSuccessMessage ? errorOrSuccessMessage : 'Activity successfully updated!';
     return <SubmissionModal close={toggleSubmissionModal} message={message} />;
   }
 
-  const generalSettingsRows = ({ activity }) => {
-    if(!activity) {
-      return [];
-    } else {
-      // format for DataTable to display labels on left side and values on right
-      const { passages, prompts, title, scored_level, target_level, name, notes } = activity
+  const submitFunction = id ? handleUpdateActivity : handleSubmitActivity;
 
-      const passageLength = passages && passages[0] ? `${passages[0].text.split(' ').length} words` : null;
-      const formattedPrompts = promptsByConjunction(prompts);
-      const becauseText = formattedPrompts && formattedPrompts[BECAUSE] ? formattedPrompts[BECAUSE].text : null;
-      const butText = formattedPrompts && formattedPrompts[BUT] ? formattedPrompts[BUT].text : null;
-      const soText = formattedPrompts && formattedPrompts[SO] ? formattedPrompts[SO].text : null;
-
-      const fields = [
-        {
-          label: 'Activity Title',
-          value: title
-        },
-        {
-          label: 'Activity Notes',
-          value: notes
-        },
-        // {
-        //   label: 'Development Stage',
-        //   value: flagModal
-        // },
-        {
-          label: 'Scored Reading Level',
-          value: scored_level || 'not set'
-        },
-        {
-          label: 'Target Reading Level',
-          value: target_level || 'not set'
-        },
-        {
-          label: 'Passage Length',
-          value: passageLength
-        },
-        {
-          label: "Because",
-          value: becauseText
-        },
-        {
-          label: "But",
-          value: butText
-        },
-        {
-          label: "So",
-          value: soText
-        },
-      ];
-      return fields.map((field, i) => {
-        const { label, value } = field
-        return {
-          id: `${field}-${i}`,
-          field: label,
-          value
-        }
-      });
-    }
-  }
-
-  if(!data) {
+  if(!activity) {
     return(
       <div className="loading-spinner-container">
         <Spinner />
@@ -207,39 +82,13 @@ const ActivitySettings: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ m
     );
   }
 
-  if(data && data.error) {
-    return(
-      <div className="error-container">
-        <Error error={`${data.error}`} />
-      </div>
-    );
-  }
-
-  // Header labels are redundant so passing empty strings and hiding header display
-  const dataTableFields = [
-    { name: "", attribute:"field", width: "200px" },
-    { name: "", attribute:"value", width: "400px" }
-  ];
-
   return(
     <div className="activity-settings-container">
-      {showEditActivityModal && renderActivityForm()}
-      {/* {showEditFlagModal && renderFlagEditModal()} */}
       {showSubmissionModal && renderSubmissionModal()}
-      <DataTable
-        className="activity-general-settings-table"
-        headers={dataTableFields}
-        rows={generalSettingsRows(data)}
-      />
-      <div className="button-container">
-        <div>
-          <a className="quill-button fun secondary outlined" href={`/comprehension/#/play?uid=${activityId}`} rel="noopener noreferrer" target="_blank">Play Activity</a>
-          {data.activity.parent_activity_id && <button className="quill-button fun secondary outlined" onClick={handleClickArchiveActivity} type="button">Archive Activity</button>}
-        </div>
-        <button className="quill-button fun primary contained" id="edit-activity-button" onClick={toggleEditActivityModal} type="submit">Configure</button>
-      </div>
+      {activity && renderHeader({activity: activity}, 'Activity Settings')}
+      <ActivityForm activity={activity} handleClickArchiveActivity={handleClickArchiveActivity} requestErrors={errors} submitActivity={submitFunction} />
     </div>
   );
 }
 
-export default ActivitySettings;
+export default withRouter<any, any>(ActivitySettings);

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettingsWrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettingsWrapper.tsx
@@ -9,7 +9,7 @@ import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
 import { blankActivity } from '../../../../../constants/comprehension';
 import { Spinner } from '../../../../Shared/index';
 
-const ActivityFormWrapper = ({ match }) => {
+const ActivitySettingsWrapper = ({ match }) => {
   const { params } = match;
   const { activityId} = params;
 
@@ -38,4 +38,4 @@ const ActivityFormWrapper = ({ match }) => {
   );
 }
 
-export default withRouter<any, any>(ActivityFormWrapper)
+export default withRouter<any, any>(ActivitySettingsWrapper)

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettingsWrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activitySettingsWrapper.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { useQuery } from 'react-query';
+import { withRouter } from 'react-router-dom';
+
+import ActivitySettings from './activitySettings';
+
+import { ActivityInterface } from '../../../interfaces/comprehensionInterfaces';
+import { fetchActivity } from '../../../utils/comprehension/activityAPIs';
+import { blankActivity } from '../../../../../constants/comprehension';
+import { Spinner } from '../../../../Shared/index';
+
+const ActivityFormWrapper = ({ match }) => {
+  const { params } = match;
+  const { activityId} = params;
+
+  let activity: ActivityInterface;
+
+  if(!activityId) {
+    activity = blankActivity
+  } else {
+    const { data: activityData } = useQuery({
+      queryKey: [`activity-${activityId}`, activityId],
+      queryFn: fetchActivity
+    });
+    activity = activityData && activityData.activity;
+  }
+
+  if(!activity) {
+    return(
+      <div className="loading-spinner-container">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return(
+    <ActivitySettings activity={activity} />
+  );
+}
+
+export default withRouter<any, any>(ActivityFormWrapper)

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/navigation.tsx
@@ -7,8 +7,6 @@ import ActivityForm from './configureSettings/activityForm';
 
 import { ActivityInterface } from '../../interfaces/comprehensionInterfaces';
 import { createActivity } from '../../utils/comprehension/activityAPIs';
-import { Modal } from '../../../Shared/index';
-import { blankActivity } from '../../../../constants/comprehension';
 import { getCsrfToken } from "../../helpers/comprehension";
 
 const Navigation = ({ location, match }) => {
@@ -48,14 +46,6 @@ const Navigation = ({ location, match }) => {
         setShowSubmissionModal(true);
       }
     });
-  }
-
-  function renderActivityForm() {
-    return(
-      <Modal>
-        <ActivityForm activity={blankActivity} closeModal={toggleCreateActivityModal} requestErrors={errors} submitActivity={submitActivity} />
-      </Modal>
-    );
   }
 
   function renderSubmissionModal () {
@@ -110,7 +100,7 @@ const Navigation = ({ location, match }) => {
 
   let activityEditorAndResults
 
-  if (activityId) {
+  if (activityId && activityId !== 'new') {
     activityEditorAndResults = (<React.Fragment>
       <p className="menu-label">
         Activity Editor
@@ -155,27 +145,28 @@ const Navigation = ({ location, match }) => {
     </React.Fragment>)
   }
 
-  return(<React.Fragment>
-    <section className="left-side-menu">
-      <p className="menu-label">
-        Tool Views
-      </p>
-      <ul className="menu-list">
-        <NavLink activeClassName='is-active' isActive={checkOverviewActive} to="/activities">
-          View Activities
-        </NavLink>
-        <button className={`create-activity-button ${showCreateActivityModal ? 'is-active' :''}`} onClick={toggleCreateActivityModal} type="submit">
-          Create New Activity
-        </button>
-        <NavLink activeClassName={!showCreateActivityModal ? 'is-active' :''} to="/universal-rules">
-          View Universal Rules
-        </NavLink>
-      </ul>
-      {activityEditorAndResults}
-    </section>
-    {showCreateActivityModal && renderActivityForm()}
-    {showSubmissionModal && renderSubmissionModal()}
-  </React.Fragment>)
+  return(
+    <React.Fragment>
+      <section className="left-side-menu">
+        <p className="menu-label">
+          Tool Views
+        </p>
+        <ul className="menu-list">
+          <NavLink activeClassName='is-active' isActive={checkOverviewActive} to="/activities">
+            View Activities
+          </NavLink>
+          <NavLink activeClassName='is-active' to="/activities/new">
+            Create New Activity
+          </NavLink>
+          <NavLink activeClassName='is-active' to="/universal-rules">
+            View Universal Rules
+          </NavLink>
+        </ul>
+        {activityEditorAndResults}
+      </section>
+      {showSubmissionModal && renderSubmissionModal()}
+    </React.Fragment>
+  )
 }
 
 export default Navigation

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -246,7 +246,7 @@
         color: #29d8bc;
       }
     }
-    .activity-form {
+    .comprehension-activity-form {
       .label-status-container {
         min-height: 58px;
         margin-top: 8px;
@@ -262,15 +262,15 @@
         }
       }
     }
-    .activity-form {
-      max-height: 80vh;
+    .comprehension-activity-form {
+      max-width: none !important;
     }
-    .activity-form , .rule-form, .semantic-rule-form {
+    .comprehension-activity-form , .rule-form, .semantic-rule-form {
       padding: 0px 30px 0px 30px;
       .title-input, .course-input, .flag-input, .reading-level-input,
-      .reading-score-input, .because-input, .but-input {
+      .reading-score-input, .because-input, .but-input, .name-input {
         margin-top: 20px;
-        max-width: 650px;
+        // max-width: 650px;
       }
       .so-input {
         margin: 20px 0px 20px 0px;
@@ -377,6 +377,42 @@
               border: none;
             }
           }
+        }
+      }
+    }
+  }
+  .rule-container {
+    .modal {
+      .rule-form {
+        max-height: 80vh;
+      }
+    }
+  }
+  .activity-settings-container {
+    width: 80vw;
+    .comprehension-page-header-container, .button-container {
+      width: 100%;
+    }
+    .button-container {
+      justify-content: flex-start;
+      a, button {
+        margin: 0px 8px 0px 8px;
+      }
+    }
+    .activity-form-container {
+      width: 100%;
+      .card {
+        max-width: unset !important;
+      }
+      .error-message-container {
+        width: 100%;
+        .all-errors-message {
+          font-size: 12px;
+          font-weight: 600;
+          letter-spacing: normal;
+          color: #ff0000;
+          display: flex;
+          text-align: left;
         }
       }
     }

--- a/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/comprehension/activityAPIs.ts
@@ -39,7 +39,8 @@ export const createActivity = async (activity: object) => {
     const returnedErrors = await handleRequestErrors(errors);
     return { errors: returnedErrors };
   }
-  return { errors: [] };
+  const newActivity = await response.json();
+  return { errors: [], activityId: newActivity.id };
 }
 
 export const updateActivity = async (activity: object, activityId: string) => {


### PR DESCRIPTION
## WHAT
refactor activity form into full page view for Comprehension

## WHY
this will be a better workflow for Curriculum

## HOW
refactored `ActivityForm` and `ActivitySettings` to handle new data flow; add `ActivitySettingsWrapper` to handle create/update activity logic

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1581" alt="Screen Shot 2021-07-26 at 5 07 42 PM" src="https://user-images.githubusercontent.com/25959584/127052125-2e9a49ac-e4d3-40b3-bf45-dcbd38cc2e28.png">
<img width="1646" alt="Screen Shot 2021-07-26 at 5 07 28 PM" src="https://user-images.githubusercontent.com/25959584/127052130-444723ec-e299-447c-a42f-4d42d246a1ae.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Update-Activity-Settings-Page-to-Show-all-Info-f3594c42fead4b968c4a17d2cdf18b89

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
