### PR TITLE
add internal tool for highlights (#7968)

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/interfaces/activities.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/interfaces/activities.ts
@@ -19,5 +19,6 @@ export interface Passage {
   id: number,
   text: string,
   image_link?: string,
-  image_alt_text?: string
+  image_alt_text?: string,
+  highlight_prompt?: string,
 }

--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/activity.scss
@@ -37,8 +37,13 @@
       width: 100%;
       max-width: 680px;
     }
-    .passage p {
-      margin-bottom: 40px;
+    .passage {
+      p {
+        margin-bottom: 40px;
+      }
+      mark {
+        background-color: inherit;
+      }
     }
     .passage-highlight {
       background-color: #fff6e4;

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
+import * as Draft from 'draft-js';
 import Editor from 'draft-js-plugins-editor'
 import { convertFromHTML, convertToHTML } from 'draft-convert'
 import createRichButtonsPlugin from 'draft-js-richbuttons-plugin'
 import * as Immutable from 'immutable'
+
+const HIGHLIGHT = 'highlight'
+const HIGHLIGHTABLE = 'HIGHLIGHTABLE'
 
 // interface TextEditorProps {
 //   text: string;
@@ -14,50 +18,105 @@ import * as Immutable from 'immutable'
 //   text: any;
 // }
 //
-const customRenderMap = Immutable.Map({
-  unstyled: {
-    element: 'div',
-    // will be used in convertFromHTMLtoContentBlocks
-    aliasedElements: ['p'],
-  },
-})
+const customRenderMap = Draft.DefaultDraftBlockRenderMap.merge(
+  Immutable.Map({
+    unstyled: {
+      element: 'div',
+      // will be used in convertFromHTMLtoContentBlocks
+      aliasedElements: ['p'],
+    },
+  })
+)
 
 class TextEditor extends React.Component <any, any> {
   constructor(props: any) {
     super(props)
 
     this.state = {
-      text: this.props.EditorState.createWithContent(convertFromHTML(this.props.text || '')),
+      text: props.EditorState.createWithContent(this.contentState(props.text || '')),
       richButtonsPlugin: createRichButtonsPlugin()
     }
-
-    this.handleTextChange = this.handleTextChange.bind(this)
   }
 
   componentWillReceiveProps(nextProps: any) {
-    if (nextProps.boilerplate !== this.props.boilerplate) {
-      this.setState({text: this.props.EditorState.createWithContent(this.props.ContentState.createFromBlockArray(convertFromHTML(nextProps.boilerplate)))},
+    const { boilerplate, EditorState, handleTextChange, ContentState, } = this.props
+    if (nextProps.boilerplate !== boilerplate) {
+      this.setState({text: EditorState.createWithContent(ContentState.createFromBlockArray(this.contentState(nextProps.boilerplate)))},
       () => {
-        this.props.handleTextChange(convertToHTML(this.state.text.getCurrentContent()))
+        handleTextChange(this.html())
       }
     )
     }
   }
 
-  handleTextChange(e: Event) {
+  html = () => {
+    const { text, } = this.state
+    return convertToHTML({
+      styleToHTML: (style) => {
+        if (style === HIGHLIGHTABLE) {
+          return <mark />;
+        }
+      },
+    })(text.getCurrentContent());
+  }
+
+  contentState = (html) => {
+    return convertFromHTML({
+      htmlToStyle: (nodeName, node, currentStyle) => {
+        if (nodeName === 'mark') {
+          return currentStyle.add(HIGHLIGHTABLE);
+        } else {
+          return currentStyle;
+        }
+      },
+    })(html);
+  }
+
+  handleTextChange = (e: Event) => {
+    const { handleTextChange, } = this.props
     this.setState({text: e}, () => {
-      this.props.handleTextChange(convertToHTML(this.state.text.getCurrentContent()).replace(/<p><\/p>/g, '<br/>').replace(/&nbsp;/g, '<br/>'))
+      handleTextChange(this.html().replace(/<p><\/p>/g, '<br/>').replace(/&nbsp;/g, '<br/>'))
     });
   }
 
+  keyBindingFn = (event) => {
+    if (Draft.KeyBindingUtil.hasCommandModifier(event) && event.keyCode === 72) { return HIGHLIGHT; }
+    return Draft.getDefaultKeyBinding(event);
+  }
+
+  // command: string returned from this.keyBidingFn(event)
+  // if this function returns 'handled' string, all ends here.
+  // if it return 'not-handled', handling of :command will be delegated to Editor's default handling.
+  onKeyCommand = (command) => {
+    const { text, } = this.state
+    let newState;
+    if (command === HIGHLIGHT) {
+      newState = Draft.RichUtils.toggleInlineStyle(text, HIGHLIGHTABLE);
+    }
+
+    if (newState) {
+      this.setState({ text: newState });
+      return 'handled';
+    }
+    return 'not-handled';
+}
+
   render() {
-    const { richButtonsPlugin, } = this.state
+    const { richButtonsPlugin, text, } = this.state
     const {
       // inline buttons
-      ItalicButton, BoldButton, UnderlineButton,
+      ItalicButton, BoldButton, UnderlineButton, createStyleButton,
       // block buttons
-      BlockquoteButton, ULButton, H3Button
+      BlockquoteButton, ULButton, H3Button,
     } = richButtonsPlugin;
+
+    const HighlightButton = createStyleButton({ style: HIGHLIGHTABLE, label: 'Highlight', });
+
+    const styleMap = {
+      HIGHLIGHTABLE: {
+        'background-color': '#FFFF00',
+      },
+    };
 
     return (
       <div className="card is-fullwidth">
@@ -69,13 +128,17 @@ class TextEditor extends React.Component <any, any> {
             <UnderlineButton />
             <BlockquoteButton />
             <ULButton />
+            <HighlightButton />
           </div>
         </header>
         <div className="card-content">
           <div className="content landing-page-html-editor">
             <Editor
               blockRenderMap={customRenderMap}
-              editorState={this.state.text}
+              customStyleMap={styleMap}
+              editorState={text}
+              handleKeyCommand={this.onKeyCommand}
+              keyBindingFn={this.keyBindingFn}
               onChange={this.handleTextChange}
               plugins={[richButtonsPlugin]}
             />

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -97,6 +97,13 @@ exports[`Activity Form component should render Activities 1`] = `
       key="max-attempt-feedback"
       text="At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul."
     />
+    <Input
+      autoComplete="on"
+      className="highlight-prompt-input"
+      handleChange={[Function]}
+      label="Highlight Prompt: \\"As you read, highlight two sentences that explain ...\\""
+      value="As you read, highlight two sentences that explain "
+    />
     <PromptsForm
       activityBecausePrompt={
         Object {

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -18,7 +18,8 @@ import {
   PASSAGE,
   IMAGE_LINK,
   IMAGE_ALT_TEXT,
-  PARENT_ACTIVITY_ID
+  PARENT_ACTIVITY_ID,
+  HIGHLIGHT_PROMPT
 } from '../../../../../constants/comprehension';
 import { ActivityInterface, PromptInterface, PassagesInterface, InputEvent } from '../../../interfaces/comprehensionInterfaces';
 import { Input, TextEditor, } from '../../../../Shared/index'
@@ -30,13 +31,15 @@ interface ActivityFormProps {
   submitActivity: (activity: object) => void
 }
 
+const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences that explain "
+
 const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: ActivityFormProps) => {
 
   const { parent_activity_id, passages, prompts, scored_level, target_level, title, notes, } = activity;
   // const formattedFlag = flag ? { label: flag, value: flag } : flagOptions[0];
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
-  const formattedPassage = passages && passages.length ? passages : [{ text: ''}];
+  const formattedPassage = passages && passages.length ? passages : [{ text: '', highlight_prompt: DEFAULT_HIGHLIGHT_PROMPT }];
   let formattedMaxFeedback;
   if(prompts && prompts[0] && prompts[0].max_attempts_feedback) {
     formattedMaxFeedback = prompts[0].max_attempts_feedback
@@ -72,6 +75,8 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
 
   function handleSetActivityTargetReadingLevel(e: InputEvent){ setActivityTargetReadingLevel(e.target.value) };
 
+  function handleSetHighlightPrompt(e: InputEvent){ handleSetActivityPassages('highlight_prompt', e.target.value) };
+
   function handleSetImageLink(e: InputEvent){ handleSetActivityPassages('image_link', e.target.value) };
 
   function handleSetImageAltText(e: InputEvent){ handleSetActivityPassages('image_alt_text', e.target.value) };
@@ -104,7 +109,7 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
       activityMaxFeedback,
       activityBecausePrompt,
       activityButPrompt,
-      activitySoPrompt
+      activitySoPrompt,
     });
     const state = [
       activityTitle,
@@ -117,7 +122,8 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
       activityButPrompt.text,
       activitySoPrompt.text,
       activityPassages[0].image_link,
-      activityPassages[0].image_alt_text
+      activityPassages[0].image_alt_text,
+      activityPassages[0].highlight_prompt
     ];
     const validationErrors = validateForm(activityFormKeys, state);
     if(validationErrors && Object.keys(validationErrors).length !== 0) {
@@ -207,6 +213,13 @@ const ActivityForm = ({ activity, closeModal, requestErrors, submitActivity }: A
           handleTextChange={handleSetActivityMaxFeedback}
           key="max-attempt-feedback"
           text={activityMaxFeedback}
+        />
+        <Input
+          className="highlight-prompt-input"
+          error={errors[HIGHLIGHT_PROMPT]}
+          handleChange={handleSetHighlightPrompt}
+          label={`Highlight Prompt: "${DEFAULT_HIGHLIGHT_PROMPT}..."`}
+          value={activityPassages[0].highlight_prompt || DEFAULT_HIGHLIGHT_PROMPT}
         />
         {errors[MAX_ATTEMPTS_FEEDBACK] && <p className="error-message">{errors[MAX_ATTEMPTS_FEEDBACK]}</p>}
         <PromptsForm

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/comprehension.tsx
@@ -13,6 +13,7 @@ import {
   SCORED_READING_LEVEL,
   IMAGE_LINK,
   IMAGE_ALT_TEXT,
+  HIGHLIGHT_PROMPT,
   PLAGIARISM,
   ALL
 } from '../../../constants/comprehension';
@@ -121,7 +122,8 @@ export const buildActivity = ({
   activityMaxFeedback,
   activityBecausePrompt,
   activityButPrompt,
-  activitySoPrompt
+  activitySoPrompt,
+  highlightPrompt,
 }) => {
   // const { label } = activityFlag;
   const prompts = [activityBecausePrompt, activityButPrompt, activitySoPrompt];
@@ -135,6 +137,7 @@ export const buildActivity = ({
       // flag: label,
       scored_level: activityScoredReadingLevel,
       target_level: parseInt(activityTargetReadingLevel),
+      highlight_prompt: highlightPrompt,
       passages_attributes: activityPassages,
       prompts_attributes: prompts
     }
@@ -337,6 +340,7 @@ export const validateForm = (keys: string[], state: any[], ruleType?: string) =>
     switch(keys[i]) {
       case IMAGE_LINK:
       case IMAGE_ALT_TEXT:
+      case HIGHLIGHT_PROMPT:
         break;
       case TARGET_READING_LEVEL:
         const targetError = targetReadingLevelError(value);

--- a/services/QuillLMS/client/app/bundles/Staff/interfaces/comprehensionInterfaces.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/interfaces/comprehensionInterfaces.ts
@@ -55,7 +55,8 @@ export interface PassagesInterface {
   id?: number,
   text: string,
   image_link?: string,
-  image_alt_text?: string
+  image_alt_text?: string,
+  highlight_prompt?: string
 }
 
 export interface RuleInterface {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -268,7 +268,7 @@
     .activity-form , .rule-form, .semantic-rule-form {
       padding: 0px 30px 0px 30px;
       .title-input, .course-input, .flag-input, .reading-level-input,
-      .reading-score-input, .because-input, .but-input {
+      .reading-score-input, .because-input, .but-input, .highlight-prompt-input {
         margin-top: 20px;
         max-width: 650px;
       }

--- a/services/QuillLMS/client/app/constants/comprehension.ts
+++ b/services/QuillLMS/client/app/constants/comprehension.ts
@@ -245,6 +245,7 @@ export const NOTES = 'Notes';
 export const SCORED_READING_LEVEL = 'Scored reading level';
 export const TARGET_READING_LEVEL = 'Target reading level';
 export const PARENT_ACTIVITY_ID = 'Parent Activity ID'
+export const HIGHLIGHT_PROMPT = 'Highlight Prompt'
 export const PASSAGE = 'Passage';
 export const MAX_ATTEMPTS_FEEDBACK = 'Max attempts feedback';
 export const BECAUSE_STEM = 'Because stem';

--- a/services/QuillLMS/db/migrate/20210722144950_add_highlight_prompt_to_passages.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210722144950_add_highlight_prompt_to_passages.comprehension.rb
@@ -1,0 +1,6 @@
+# This migration comes from comprehension (originally 20210722143752)
+class AddHighlightPromptToPassages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :comprehension_passages, :highlight_prompt, :string
+  end
+end

--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/activities_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/activities_controller.rb
@@ -59,7 +59,7 @@ module Comprehension
         :parent_activity_id,
         :target_level,
         :scored_level,
-        passages_attributes: [:id, :text, :image_link, :image_alt_text],
+        passages_attributes: [:id, :text, :image_link, :image_alt_text, :highlight_prompt],
         prompts_attributes: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback]
       )
     end

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/passage.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/passage.rb
@@ -10,7 +10,7 @@ module Comprehension
     def serializable_hash(options = nil)
       options ||= {}
       super(options.reverse_merge(
-        only: [:id, :text, :image_link, :image_alt_text]
+        only: [:id, :text, :image_link, :image_alt_text, :highlight_prompt]
       ))
     end
   end

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210722143752_add_highlight_prompt_to_passages.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210722143752_add_highlight_prompt_to_passages.rb
@@ -1,0 +1,5 @@
+class AddHighlightPromptToPassages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :comprehension_passages, :highlight_prompt, :string
+  end
+end

--- a/services/QuillLMS/engines/comprehension/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210614190110) do
+ActiveRecord::Schema.define(version: 20210722143752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,10 +76,11 @@ ActiveRecord::Schema.define(version: 20210614190110) do
   create_table "comprehension_passages", force: :cascade do |t|
     t.integer  "activity_id"
     t.text     "text"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.string   "image_link"
-    t.string   "image_alt_text", default: ""
+    t.string   "image_alt_text",   default: ""
+    t.string   "highlight_prompt"
     t.index ["activity_id"], name: "index_comprehension_passages_on_activity_id", using: :btree
   end
 


### PR DESCRIPTION
* make it possible to add mark elements and highlight prompts to comprehension passages

* tests

* css

* autofill base

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
