### PR TITLE
Enable Focus Point/Incorrect Sequence Names

### DIFF
--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.15.0",
+    "quill-marking-logic": "0.15.3",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.15.3",
+    "quill-marking-logic": "0.15.5",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.4",
+  "version": "0.15.3",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.3",
+  "version": "0.15.5",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/interfaces/index.ts
+++ b/packages/quill-marking-logic/src/interfaces/index.ts
@@ -61,7 +61,8 @@ export interface FocusPoint {
   concept_uid?: string,
   concept_results?: Array<ConceptResult>,
   conceptResults?: Array<ConceptResult>,
-  key?: string
+  key?: string,
+  name?: string
 }
 
 export interface IncorrectSequence {

--- a/packages/quill-marking-logic/src/interfaces/index.ts
+++ b/packages/quill-marking-logic/src/interfaces/index.ts
@@ -69,7 +69,8 @@ export interface IncorrectSequence {
   feedback: string,
   concept_results?: Array<ConceptResult>,
   conceptResults?: Array<ConceptResult>,
-  caseInsensitive?: boolean|null
+  caseInsensitive?: boolean|null,
+  name?: string
 }
 
 export interface FeedbackObject {

--- a/packages/quill-marking-logic/src/libs/matchers/focus_point_match.spec.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/focus_point_match.spec.ts
@@ -42,8 +42,9 @@ const focusPoints = [
   {
     text: 'likes',
     feedback: "Use a word that conveys appreciation and starts with l.",
+    name: "Use the word likes",
     concept_results: [{correct: true, conceptUID: 'a'}]
-  },
+  }
 ]
 
 describe('focusPointMatch', () => {
@@ -85,6 +86,20 @@ describe('The focusPointChecker', () => {
         parent_id: getTopOptimalResponse(savedResponses).id,
         concept_results: focusPointMatch(responseString, focusPoints).concept_results
       }
+    assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).feedback, partialResponse.feedback);
+    assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).author, partialResponse.author);
+    assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).parent_id, partialResponse.parent_id);
+  });
+
+  it('Should return a partialResponse object if the response string matches a focus point', () => {
+    const responseString = "Jared loves edtech and startups.";
+    const partialResponse =  {
+        feedback: focusPointMatch(responseString, focusPoints).feedback,
+        author: 'Use the word likes',
+        parent_id: getTopOptimalResponse(savedResponses).id,
+        concept_results: focusPointMatch(responseString, focusPoints).concept_results
+      }
+
     assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).feedback, partialResponse.feedback);
     assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).author, partialResponse.author);
     assert.equal(focusPointChecker(responseString, focusPoints, savedResponses).parent_id, partialResponse.parent_id);

--- a/packages/quill-marking-logic/src/libs/matchers/focus_point_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/focus_point_match.ts
@@ -33,7 +33,7 @@ export function focusPointChecker(responseString: string, focusPoints:Array<Focu
 export function focusPointResponseBuilder(focusPointMatch:FocusPoint, responses:Array<Response>): PartialResponse {
   const res: PartialResponse = {
     feedback: focusPointMatch.feedback,
-    author: 'Focus Point Hint',
+    author: focusPointMatch.name || 'Focus Point Hint',
     parent_id: getTopOptimalResponse(responses).id
   }
 

--- a/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.spec.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.spec.ts
@@ -60,6 +60,12 @@ const incorrectSequences = [
     text: 'likes&&loves',
     feedback: 'Inc 7',
     concept_results: [{correct: true, conceptUID: 'a'}]
+  },
+  {
+    text: '^Cissy',
+    feedback: 'Inc 8',
+    name: 'do not mention Cissy',
+    concept_results: [{correct: true, conceptUID: 'a'}]
   }
 ]
 
@@ -133,5 +139,20 @@ describe('The incorrectSequenceChecker', () => {
   it('Should return undefined if the response string does not match an incorrect sequence', () => {
     const responseString = "Jared likes Edtech and startups.";
     assert.equal(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses), undefined);
+  });
+
+  it("Should return a partialResponse object with the incorrectSequence's name as the author if the response string matches an incorrect sequence with a name", () => {
+    const responseString = "Cissy likes some companies.";
+    const partialResponse =  {
+        feedback: incorrectSequenceMatch(responseString, incorrectSequences).feedback,
+        author: 'do not mention Cissy',
+        parent_id: getTopOptimalResponse(savedResponses).id,
+        concept_results: incorrectSequenceMatch(responseString, incorrectSequences).concept_results
+      }
+
+    assert.equal(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).feedback, partialResponse.feedback);
+    assert.equal(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).author, partialResponse.author);
+    assert.equal(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).parent_id, partialResponse.parent_id);
+    assert.equal(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).concept_results, partialResponse.concept_results);
   });
 })

--- a/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
@@ -29,7 +29,7 @@ export function incorrectSequenceChecker(responseString: string, incorrectSequen
 export function incorrectSequenceResponseBuilder(incorrectSequenceMatch:IncorrectSequence, responses:Array<Response>): PartialResponse {
   const res: PartialResponse = {
     feedback: incorrectSequenceMatch.feedback,
-    author: 'Incorrect Sequence Hint',
+    author: incorrectSequenceMatch.name || 'Incorrect Sequence Hint',
     parent_id: getTopOptimalResponse(responses).id
   }
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -133,6 +133,12 @@ export class FocusPointsContainer extends Component {
     this.setState({focusPoints: focusPoints})
   }
 
+  handleNameChange = (e, key) => {
+    const { focusPoints } = this.state
+    focusPoints[key].name = e.target.value
+    this.setState({focusPoints: focusPoints})
+  }
+
   handleFocusPointChange = (e, key) => {
     const { focusPoints } = this.state
     const className = `regex-${key}`
@@ -173,6 +179,9 @@ export class FocusPointsContainer extends Component {
     const components = this.fPsortedByOrder().map((fp) => {
       return (
         <div className="card is-fullwidth has-bottom-margin" key={fp.key}>
+          <header className="card-header">
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, s.key)} placeholder="Name" type="text" value={fp.name || ''} />
+          </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>
               {this.renderTextInputFields(fp.text, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -180,7 +180,7 @@ export class FocusPointsContainer extends Component {
       return (
         <div className="card is-fullwidth has-bottom-margin" key={fp.key}>
           <header className="card-header">
-            <input className="regex-name" onChange={(e) => this.handleNameChange(e, s.key)} placeholder="Name" type="text" value={fp.name || ''} />
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, fp.key)} placeholder="Name" type="text" value={fp.name || ''} />
           </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -146,6 +146,12 @@ class IncorrectSequencesContainer extends Component {
     this.setState({incorrectSequences: incorrectSequences})
   }
 
+  handleNameChange = (e, key) => {
+    const { incorrectSequences } = this.state
+    incorrectSequences[key].name = e.target.value
+    this.setState({incorrectSequences: incorrectSequences})
+  }
+
   handleFeedbackChange = (e, key) => {
     const { incorrectSequences } = this.state
     incorrectSequences[key].feedback = e
@@ -176,6 +182,9 @@ class IncorrectSequencesContainer extends Component {
     const components = this.sequencesSortedByOrder().map((s) => {
       return (
         <div className="card is-fullwidth has-bottom-margin" key={s.key}>
+          <header className="card-header">
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, s.key)} placeholder="Name" type="text" value={s.name || ''} />
+          </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>
               {this.renderTextInputFields(s.text, s.key)}

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
@@ -344,6 +344,32 @@ class ResponseComponent extends React.Component {
     this.props.dispatch(submitResponseEdit(rid, vals, this.props.questionID));
   };
 
+  incorrectSequenceNames = () => {
+    const { question } = this.props
+    const { incorrectSequences } = question
+
+    let incorrectSequenceNames = []
+    if (Array.isArray(incorrectSequences)) {
+      incorrectSequenceNames = incorrectSequences.map(i => i.name)
+    } else {
+      incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
+    }
+    return incorrectSequenceNames.filter(f => f !== undefined)
+  }
+
+  focusPointNames = () => {
+    const { question } = this.props
+    const { focusPoints } = question
+
+    let focusPointNames = []
+    if (Array.isArray(focusPoints)) {
+      focusPointNames = focusPoints.map(fp => fp.name)
+    } else {
+      focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
+    }
+    return focusPointNames.filter(f => f !== undefined)
+  }
+
   renderDeselectAllFiltersButton = () => {
     return (
       <div className="column">
@@ -498,15 +524,18 @@ class ResponseComponent extends React.Component {
   renderStatusToggleMenu = () => {
     let usedQualityLabels = qualityLabels
     const { mode } = this.props
+    const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
     if (mode === 'questions') {
       usedQualityLabels = _.without(qualityLabels, 'Algorithm Optimal')
     }
+
     return (
       <ResponseToggleFields
         deselectFields={this.deselectFields}
         excludeMisspellings={this.props.filters.formattedFilterData.filters.excludeMisspellings}
         labels={labels}
         qualityLabels={usedQualityLabels}
+        regexLabels={regexLabels}
         resetFields={this.resetFields}
         resetPageNumber={this.resetPageNumber}
         toggleExcludeMisspellings={this.toggleExcludeMisspellings}

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
@@ -523,8 +523,13 @@ class ResponseComponent extends React.Component {
 
   renderStatusToggleMenu = () => {
     let usedQualityLabels = qualityLabels
-    const { mode } = this.props
+    const { mode, filters } = this.props
+    const { visibleStatuses } = filters
     const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
+    regexLabels.forEach(author =>
+      visibleStatuses[author] = true
+    );
+
     if (mode === 'questions') {
       usedQualityLabels = _.without(qualityLabels, 'Algorithm Optimal')
     }
@@ -540,7 +545,7 @@ class ResponseComponent extends React.Component {
         resetPageNumber={this.resetPageNumber}
         toggleExcludeMisspellings={this.toggleExcludeMisspellings}
         toggleField={this.toggleField}
-        visibleStatuses={this.props.filters.visibleStatuses}
+        visibleStatuses={visibleStatuses}
       />
     );
   };

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
@@ -526,9 +526,6 @@ class ResponseComponent extends React.Component {
     const { mode, filters } = this.props
     const { visibleStatuses } = filters
     const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
-    regexLabels.forEach(author =>
-      visibleStatuses[author] = true
-    );
 
     if (mode === 'questions') {
       usedQualityLabels = _.without(qualityLabels, 'Algorithm Optimal')

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
@@ -351,7 +351,7 @@ class ResponseComponent extends React.Component {
     let incorrectSequenceNames = []
     if (Array.isArray(incorrectSequences)) {
       incorrectSequenceNames = incorrectSequences.map(i => i.name)
-    } else {
+    } else if (incorrectSequences) {
       incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
     }
     return incorrectSequenceNames.filter(f => f !== undefined)
@@ -364,7 +364,7 @@ class ResponseComponent extends React.Component {
     let focusPointNames = []
     if (Array.isArray(focusPoints)) {
       focusPointNames = focusPoints.map(fp => fp.name)
-    } else {
+    } else if (focusPoints) {
       focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
     }
     return focusPointNames.filter(f => f !== undefined)

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -13,6 +13,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
 
     const item = this.props.item;
     this.state = {
+      name: item && item.name ? item.name : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item && item.conceptResults ? item.conceptResults : {},
@@ -44,6 +45,10 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
     const newConceptResults = Object.assign({}, this.state.itemConcepts)
     delete newConceptResults[key]
     this.setState({itemConcepts: newConceptResults})
+  }
+
+  handleNameChange = e => {
+    this.setState({name: e.target.value})
   }
 
   handleChange = (stateKey, e) => {
@@ -85,10 +90,12 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   }
 
   submit = (focusPoint) => {
+    const { name } = this.state
     const focusPoints = this.state.itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
     if (focusPoints.every(fp => isValidRegex(fp))) {
       const focusPointString = focusPoints.join('|||')
       const data = {
+        name: name,
         text: focusPointString,
         feedback: this.state.itemFeedback,
         conceptResults: this.state.itemConcepts,
@@ -160,12 +167,15 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
+    const { name } = this.state
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -12,6 +12,7 @@ export default class extends React.Component {
     const item = props.item;
 
     this.state = {
+      name: item ? (item.name ? item.name : '') : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item ? (item.conceptResults ? item.conceptResults : {}) : {},
@@ -40,6 +41,10 @@ export default class extends React.Component {
       );
     };
 
+  handleNameChange = (e) => {
+    this.setState({name: e.target.value})
+  }
+
   handleChange = (stateKey, e) => {
     const obj = {};
     let value = e.target.value;
@@ -65,10 +70,12 @@ export default class extends React.Component {
   };
 
   submit = (incorrectSequence) => {
+    const { name } = this.state
     const incorrectSequences = this.state.itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
     if (incorrectSequences.every(is => isValidRegex(is))) {
       const incorrectSequenceString = incorrectSequences.join('|||')
       const data = {
+        name: name,
         text: incorrectSequenceString,
         feedback: this.state.itemFeedback,
         conceptResults: this.state.itemConcepts,
@@ -141,13 +148,15 @@ export default class extends React.Component {
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
-    const { caseInsensitive } = this.state;
+    const { caseInsensitive, name } = this.state;
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Connect/styles/components/_admin-regex-rules.scss
+++ b/services/QuillLMS/client/app/bundles/Connect/styles/components/_admin-regex-rules.scss
@@ -20,3 +20,12 @@
   color: #404040;
   margin-top: 12px;
 }
+
+.regex-name {
+  margin-bottom: 5px;
+  min-width: 400px;
+  margin-left: 12px;
+  border: none;
+  padding: 10px;
+  font-size: 15px;
+}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -105,6 +105,12 @@ export class FocusPointsContainer extends Component {
     this.setState({focusPoints: focusPoints})
   }
 
+  handleNameChange = (e, key) => {
+    const { focusPoints } = this.state
+    focusPoints[key].name = e.target.value
+    this.setState({focusPoints: focusPoints})
+  }
+
   handleFocusPointChange = (e, key) => {
     const { focusPoints } = this.state
     const className = `regex-${key}`
@@ -172,6 +178,9 @@ export class FocusPointsContainer extends Component {
       const { conceptResults, feedback, key, order, text } = fp;
       return (
         <div className="card is-fullwidth has-bottom-margin" key={key}>
+          <header className="card-header">
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, key)} placeholder="Name" type="text" value={fp.name || ''} />
+          </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>
               {this.renderTextInputFields(text, key)}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -111,6 +111,12 @@ class IncorrectSequencesContainer extends Component {
     this.setState({incorrectSequences: incorrectSequences})
   }
 
+  handleNameChange = (e, key) => {
+    const { incorrectSequences } = this.state
+    incorrectSequences[key].name = e.target.value
+    this.setState({incorrectSequences: incorrectSequences})
+  }
+
   handleSequenceChange = (e, key) => {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
@@ -180,6 +186,9 @@ class IncorrectSequencesContainer extends Component {
     const components = this.sequencesSortedByOrder().map((seq) => {
       return (
         <div className="card is-fullwidth has-bottom-margin" key={seq.key}>
+          <header className="card-header">
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, seq.key)} placeholder="Name" type="text" value={seq.name || ''} />
+          </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>
               {this.renderTextInputFields(seq.text, seq.key)}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -342,7 +342,7 @@ class ResponseComponent extends React.Component {
     let incorrectSequenceNames = []
     if (Array.isArray(incorrectSequences)) {
       incorrectSequenceNames = incorrectSequences.map(i => i.name)
-    } else {
+    } else if (incorrectSequences) {
       incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
     }
     return incorrectSequenceNames.filter(f => f !== undefined)
@@ -355,7 +355,7 @@ class ResponseComponent extends React.Component {
     let focusPointNames = []
     if (Array.isArray(focusPoints)) {
       focusPointNames = focusPoints.map(fp => fp.name)
-    } else {
+    } else if (focusPoints) {
       focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
     }
     return focusPointNames.filter(f => f !== undefined)

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -292,17 +292,24 @@ class ResponseComponent extends React.Component {
   };
 
   renderStatusToggleMenu = () => {
+    const { filters } = this.props
+    const { visibleStatuses } = filters
+    const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
+    regexLabels.forEach(author =>
+      visibleStatuses[author] = true
+    );
     return (
       <ResponseToggleFields
         deselectFields={this.deselectFields}
         excludeMisspellings={this.props.filters.formattedFilterData.filters.excludeMisspellings}
         labels={labels}
         qualityLabels={qualityLabels}
+        regexLabels={regexLabels}
         resetFields={this.resetFields}
         resetPageNumber={this.resetPageNumber}
         toggleExcludeMisspellings={this.toggleExcludeMisspellings}
         toggleField={this.toggleField}
-        visibleStatuses={this.props.filters.visibleStatuses}
+        visibleStatuses={visibleStatuses}
       />
     );
   };
@@ -327,6 +334,32 @@ class ResponseComponent extends React.Component {
     }
     return true;
   };
+
+  incorrectSequenceNames = () => {
+    const { question } = this.props
+    const { incorrectSequences } = question
+
+    let incorrectSequenceNames = []
+    if (Array.isArray(incorrectSequences)) {
+      incorrectSequenceNames = incorrectSequences.map(i => i.name)
+    } else {
+      incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
+    }
+    return incorrectSequenceNames.filter(f => f !== undefined)
+  }
+
+  focusPointNames = () => {
+    const { question } = this.props
+    const { focusPoints } = question
+
+    let focusPointNames = []
+    if (Array.isArray(focusPoints)) {
+      focusPointNames = focusPoints.map(fp => fp.name)
+    } else {
+      focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
+    }
+    return focusPointNames.filter(f => f !== undefined)
+  }
 
   renderExpandCollapseAll = () => {
     let text,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -295,9 +295,7 @@ class ResponseComponent extends React.Component {
     const { filters } = this.props
     const { visibleStatuses } = filters
     const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
-    regexLabels.forEach(author =>
-      visibleStatuses[author] = true
-    );
+
     return (
       <ResponseToggleFields
         deselectFields={this.deselectFields}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -41,7 +41,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
       );
     };
 
-  handleName = e => {
+  handleNameChange = e => {
     this.setState({name: e.target.value})
   }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -14,6 +14,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
     const item = this.props.item;
 
     this.state = {
+      name: item && item.name ? item.name : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item && item.conceptResults ? item.conceptResults : {},
@@ -40,6 +41,10 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
       );
     };
 
+  handleName = e => {
+    this.setState({name: e.target.value})
+  }
+
   handleChange = (stateKey, e) => {
     const obj = {};
     let value = e.target.value;
@@ -65,10 +70,12 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   };
 
   submit(focusPoint) {
+    const { name } = this.state
     const focusPoints = this.state.itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
     if (focusPoints.every(fp => isValidRegex(fp))) {
       const incorrectSequenceString = focusPoints.join('|||')
       const data = {
+        name: name,
         text: incorrectSequenceString,
         feedback: this.state.itemFeedback,
         conceptResults: this.state.itemConcepts,
@@ -160,12 +167,15 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
+    const { name } = this.state
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -14,6 +14,7 @@ export default class extends React.Component {
     const { item } = props;
 
     this.state = {
+      name: item ? (item.name ? item.name : '') : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item ? (item.conceptResults ? item.conceptResults : {}) : {},
@@ -42,6 +43,10 @@ export default class extends React.Component {
       );
     };
 
+  handleNameChange = (e) => {
+    this.setState({name: e.target.value})
+  }
+
   handleChange = (stateKey, e) => {
     const obj = {};
     let value = e.target.value;
@@ -67,10 +72,12 @@ export default class extends React.Component {
   };
 
   submit = (incorrectSequence) => {
+    const { name } = this.state
     const incorrectSequences = this.state.itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
     if (incorrectSequences.every(is => isValidRegex(is))) {
       const incorrectSequenceString = incorrectSequences.join('|||')
       const data = {
+        name: name,
         text: incorrectSequenceString,
         feedback: this.state.itemFeedback,
         conceptResults: this.state.itemConcepts,
@@ -143,13 +150,15 @@ export default class extends React.Component {
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
-    const { caseInsensitive } = this.state;
+    const { caseInsensitive, name } = this.state;
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_admin-regex-rules.scss
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_admin-regex-rules.scss
@@ -20,3 +20,12 @@
   color: #404040;
   margin-top: 12px;
 }
+
+.regex-name {
+  margin-bottom: 5px;
+  min-width: 400px;
+  margin-left: 12px;
+  border: none;
+  padding: 10px;
+  font-size: 15px;
+}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -88,6 +88,12 @@ export class FocusPointsContainer extends React.Component {
     this.setState({focusPoints: focusPoints})
   }
 
+  handleNameChange = (e, key) => {
+    const { focusPoints } = this.state
+    focusPoints[key].name = e.target.value
+    this.setState({focusPoints: focusPoints})
+  }
+
   handleFocusPointChange = (e, key) => {
     const { focusPoints } = this.state
     const className = `regex-${key}`
@@ -134,6 +140,9 @@ export class FocusPointsContainer extends React.Component {
     const components = this.fPsortedByOrder().map((fp) => {
       return (
         <div className="card is-fullwidth has-bottom-margin" key={fp.key}>
+          <header className="card-header">
+            <input className="regex-name" onChange={(e) => this.handleNameChange(e, fp.key)} placeholder="Name" type="text" value={fp.name || ''} />
+          </header>
           <header className="card-header">
             <p className="card-header-title" style={{ display: 'inline-block', }}>
               {this.renderTextInputFields(fp.text, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -85,6 +85,12 @@ class IncorrectSequencesContainer extends React.Component {
     this.setState({incorrectSequences: incorrectSequences})
   }
 
+  handleNameChange = (e, key) => {
+    const { incorrectSequences } = this.state
+    incorrectSequences[key].name = e.target.value
+    this.setState({incorrectSequences: incorrectSequences})
+  }
+
   handleSequenceChange = (e, key) => {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
@@ -155,6 +161,9 @@ class IncorrectSequencesContainer extends React.Component {
     const components = this.sequencesSortedByOrder().map((seq) => {
       const onClickDelete = () => { this.handleDeleteSequence(seq.key) }
       return (<div className="card is-fullwidth has-bottom-margin" key={seq.key}>
+        <header className="card-header">
+          <input className="regex-name" onChange={(e) => this.handleNameChange(e, seq.key)} placeholder="Name" type="text" value={seq.name || ''} />
+        </header>
         <header className="card-header">
           <p className="card-header-title" style={{ display: 'inline-block', }}>
             {this.renderTextInputFields(seq.text, seq.key)}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
@@ -391,7 +391,7 @@ class ResponseComponent extends React.Component {
     let incorrectSequenceNames = []
     if (Array.isArray(incorrectSequences)) {
       incorrectSequenceNames = incorrectSequences.map(i => i.name)
-    } else {
+    } else if (incorrectSequences) {
       incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
     }
     return incorrectSequenceNames.filter(f => f !== undefined)
@@ -404,7 +404,7 @@ class ResponseComponent extends React.Component {
     let focusPointNames = []
     if (Array.isArray(focusPoints)) {
       focusPointNames = focusPoints.map(fp => fp.name)
-    } else {
+    } else if (focusPoints) {
       focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
     }
     return focusPointNames.filter(f => f !== undefined)

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
@@ -343,9 +343,6 @@ class ResponseComponent extends React.Component {
     const { filters } = this.props
     const { visibleStatuses } = filters
     const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
-    regexLabels.forEach(author =>
-      visibleStatuses[author] = true
-    );
 
     return (
       <ResponseToggleFields

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
@@ -340,17 +340,25 @@ class ResponseComponent extends React.Component {
   }
 
   renderStatusToggleMenu() {
+    const { filters } = this.props
+    const { visibleStatuses } = filters
+    const regexLabels = this.incorrectSequenceNames().concat(this.focusPointNames())
+    regexLabels.forEach(author =>
+      visibleStatuses[author] = true
+    );
+
     return (
       <ResponseToggleFields
         deselectFields={this.deselectFields}
         excludeMisspellings={this.props.filters.formattedFilterData.filters.excludeMisspellings}
         labels={labels}
         qualityLabels={qualityLabels}
+        regexLabels={regexLabels}
         resetFields={this.resetFields}
         resetPageNumber={this.resetPageNumber}
         toggleExcludeMisspellings={this.toggleExcludeMisspellings}
         toggleField={this.toggleField}
-        visibleStatuses={this.props.filters.visibleStatuses}
+        visibleStatuses={visibleStatuses}
       />
     );
   }
@@ -374,6 +382,32 @@ class ResponseComponent extends React.Component {
       if (expanded[i] === true) { return false; }
     }
     return true;
+  }
+
+  incorrectSequenceNames = () => {
+    const { question } = this.props
+    const { incorrectSequences } = question
+
+    let incorrectSequenceNames = []
+    if (Array.isArray(incorrectSequences)) {
+      incorrectSequenceNames = incorrectSequences.map(i => i.name)
+    } else {
+      incorrectSequenceNames = Object.keys(incorrectSequences).map((key) => incorrectSequences[key].name)
+    }
+    return incorrectSequenceNames.filter(f => f !== undefined)
+  }
+
+  focusPointNames = () => {
+    const { question } = this.props
+    const { focusPoints } = question
+
+    let focusPointNames = []
+    if (Array.isArray(focusPoints)) {
+      focusPointNames = focusPoints.map(fp => fp.name)
+    } else {
+      focusPointNames = Object.keys(focusPoints).map((key) => focusPoints[key].name)
+    }
+    return focusPointNames.filter(f => f !== undefined)
   }
 
   renderExpandCollapseAll() {

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -14,12 +14,14 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
 
     const item = this.props.item;
     this.state = {
+      name: item && item.name ? item.name : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item && item.conceptResults ? item.conceptResults : {},
       matchedCount: 0
     }
 
+    this.handleNameChange = this.handleNameChange.bind(this)
     this.handleChange = this.handleChange.bind(this)
     this.handleFeedbackChange = this.handleFeedbackChange.bind(this)
     this.handleConceptChange = this.handleConceptChange.bind(this)
@@ -44,6 +46,10 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
         }
       );
     }
+
+  handleNameChange(e) {
+    this.setState({name: e.target.value})
+  }
 
   handleChange(stateKey, e) {
     const obj = {};
@@ -70,10 +76,12 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   }
 
   submit(focusPoint) {
+    const { name } = this.state
     const focusPoints = this.state.itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
     if (focusPoints.every(fp => isValidRegex(fp))) {
       const incorrectSequenceString = focusPoints.join('|||')
       const data = {
+        name: name,
         text: incorrectSequenceString,
         feedback: this.state.itemFeedback,
         conceptResults: this.state.itemConcepts,
@@ -158,12 +166,15 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
+    const { name } = this.state
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -15,6 +15,7 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
     const { item } = props
 
     this.state = {
+      name: item ? (item.name ? item.name : '') : '',
       itemText: item ? `${item.text}|||` : '',
       itemFeedback: item ? item.feedback : '',
       itemConcepts: item ? (item.conceptResults ? item.conceptResults : {}) : {},
@@ -43,6 +44,10 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
     );
   }
 
+  handleNameChange = (e) => {
+    this.setState({name: e.target.value})
+  }
+
   handleChange = (stateKey, e) => {
     const obj = {};
     let value = e.target.value;
@@ -68,12 +73,13 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
   }
 
   submit(incorrectSequence) {
-    const { itemFeedback, itemConcepts, caseInsensitive, itemText } = this.state
+    const { name, itemFeedback, itemConcepts, caseInsensitive, itemText } = this.state
     const incorrectSequences = itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
 
     if (incorrectSequences.every(is => isValidRegex(is))) {
       const incorrectSequenceString = incorrectSequences.join('|||')
       const data = {
+        name: name,
         text: incorrectSequenceString,
         feedback: itemFeedback,
         conceptResults: itemConcepts,
@@ -141,13 +147,15 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
   render() {
     const appropriateData = this.returnAppropriateDataset();
     const { dataset, mode, } = appropriateData;
-    const { caseInsensitive } = this.state;
+    const { caseInsensitive, name } = this.state;
     return (
       <div>
         <div className="box add-incorrect-sequence">
           <h4 className="title">{this.addOrEditItemLabel()}</h4>
           {this.renderExplanatoryNote()}
           <div className="control">
+            <label className="label">Name</label>
+            <input className="input" onChange={this.handleNameChange} type="text" value={name || ''} />
             <label className="label">{this.props.itemLabel} Text</label>
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/styles/admin-regex-rules.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/admin-regex-rules.scss
@@ -20,3 +20,12 @@
   color: #404040;
   margin-top: 12px;
 }
+
+.regex-name {
+  margin-bottom: 5px;
+  min-width: 400px;
+  margin-left: 12px;
+  border: none;
+  padding: 10px;
+  font-size: 15px;
+}

--- a/services/QuillLMS/client/app/bundles/Shared/components/questions/responseToggleFields.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questions/responseToggleFields.tsx
@@ -61,6 +61,9 @@ class ResponseToggleFields extends React.Component<any, any> {
         <div style={{ margin: '10 0 0 0', display: 'flex', flexWrap: 'wrap', }}>
           {this.props.labels.map((label: string, i: number) => this.renderToggleField(label, i))}
         </div>
+        <div style={{ margin: '10 0', display: 'flex', flexWrap: 'wrap', }}>
+          {this.props.regexLabels.map((label: string, i: number) => this.renderToggleField(label, i))}
+        </div>
       </div>
     );
   }

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -6819,13 +6819,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
@@ -6835,7 +6835,7 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "optional": true
         },
@@ -6847,7 +6847,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
@@ -6865,7 +6865,7 @@
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "resolved": false,
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "optional": true,
           "requires": {
@@ -6874,7 +6874,7 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
@@ -6886,13 +6886,13 @@
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "resolved": false,
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "optional": true,
           "requires": {
@@ -6901,7 +6901,7 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
@@ -6923,7 +6923,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "resolved": false,
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "optional": true,
           "requires": {
@@ -6943,7 +6943,7 @@
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -6952,7 +6952,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "optional": true,
           "requires": {
@@ -6961,7 +6961,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -6971,13 +6971,13 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
@@ -6998,7 +6998,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
@@ -7007,13 +7007,13 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "optional": true,
           "requires": {
@@ -7023,7 +7023,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "resolved": false,
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "optional": true,
           "requires": {
@@ -7032,7 +7032,7 @@
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+          "resolved": false,
           "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
           "optional": true,
           "requires": {
@@ -7041,13 +7041,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "optional": true
         },
         "needle": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+          "resolved": false,
           "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
           "optional": true,
           "requires": {
@@ -7058,7 +7058,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+          "resolved": false,
           "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "optional": true,
           "requires": {
@@ -7076,7 +7076,7 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "optional": true,
           "requires": {
@@ -7086,7 +7086,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "optional": true,
           "requires": {
@@ -7095,13 +7095,13 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "optional": true,
           "requires": {
@@ -7136,7 +7136,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
@@ -7145,19 +7145,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -7167,7 +7167,7 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
@@ -7179,7 +7179,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -7206,7 +7206,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "resolved": false,
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "optional": true,
           "requires": {
@@ -7215,25 +7215,25 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "resolved": false,
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "optional": true
         },
@@ -7280,13 +7280,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "resolved": false,
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "optional": true,
           "requires": {
@@ -7316,13 +7316,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "optional": true
         }
@@ -11752,9 +11752,9 @@
       "dev": true
     },
     "quill-marking-logic": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.4.tgz",
-      "integrity": "sha512-PEZb6sDKoYwBO88wHvD5S897L9XyzlqkYgCj0tvVZ0j8cMg5BLXJ8DEwqmMoMm5nRCqOBgXiitVURDQWsKm5iQ==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.5.tgz",
+      "integrity": "sha512-k8XvGsRMAiIdzQ1hoAYFaZXW/w0g0AebAn0HUxx2SL8hWKZ1ow+HawNFSGKFkusFZo+35f6q5OTzIWxn7apUAg==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -72,7 +72,7 @@
     "pusher-js": "^5.0.1",
     "qs": "^6.9.2",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "^0.15.3",
+    "quill-marking-logic": "^0.15.5",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^16.13.1",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -72,7 +72,7 @@
     "pusher-js": "^5.0.1",
     "qs": "^6.9.2",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "^0.15.4",
+    "quill-marking-logic": "^0.15.3",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^16.13.1",

--- a/services/QuillLMS/package-lock.json
+++ b/services/QuillLMS/package-lock.json
@@ -13,8 +13,8 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
       "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
       "requires": {
-        "@types/prop-types": "15.7.3",
-        "csstype": "3.0.3"
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
       }
     },
     "@types/react-table": {
@@ -22,7 +22,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-6.8.7.tgz",
       "integrity": "sha512-1U0xl47jk0BzE+HNHgxZYSLvtybSvnlLhOpW9Mfqf9iuRm/fGqgRab3TKivPCY6Tl7WPFM2hWEJ1GnsuSFc9AQ==",
       "requires": {
-        "@types/react": "16.9.49"
+        "@types/react": "*"
       }
     },
     "acorn": {
@@ -45,9 +45,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.3",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "js-tokens": {
@@ -62,9 +62,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.3"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -72,10 +72,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -83,10 +83,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.21"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-function-name": {
@@ -94,11 +94,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -106,8 +106,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -115,8 +115,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -124,8 +124,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -133,9 +133,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.21"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-replace-supers": {
@@ -143,12 +143,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -156,7 +156,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -164,7 +164,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-dynamic-import": {
@@ -192,7 +192,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -200,7 +200,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -208,11 +208,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.21"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -220,15 +220,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -236,8 +236,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -245,7 +245,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -253,8 +253,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -262,7 +262,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -270,9 +270,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -280,7 +280,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -288,9 +288,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -298,10 +298,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -309,9 +309,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -319,9 +319,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -329,8 +329,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -338,12 +338,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -351,8 +351,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -360,7 +360,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -368,9 +368,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -378,7 +378,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -386,7 +386,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -394,9 +394,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -404,8 +404,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -413,8 +413,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -422,7 +422,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -430,9 +430,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -440,8 +440,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -449,8 +449,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -458,7 +458,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -466,8 +466,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015": {
@@ -475,30 +475,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-flow": {
@@ -506,7 +506,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
     },
     "babel-preset-react": {
@@ -514,12 +514,12 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       }
     },
     "babel-runtime": {
@@ -527,8 +527,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.6.12",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -536,11 +536,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.21"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -548,15 +548,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.21"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -564,10 +564,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.3",
-        "lodash": "4.17.21",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -595,11 +595,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "classnames": {
@@ -665,10 +665,10 @@
       "resolved": "https://registry.npmjs.org/foreman/-/foreman-3.0.1.tgz",
       "integrity": "sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==",
       "requires": {
-        "commander": "2.20.3",
-        "http-proxy": "1.18.1",
-        "mustache": "2.3.2",
-        "shell-quote": "1.7.2"
+        "commander": "^2.15.1",
+        "http-proxy": "^1.17.0",
+        "mustache": "^2.2.1",
+        "shell-quote": "^1.6.1"
       }
     },
     "function-bind": {
@@ -686,7 +686,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -694,7 +694,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "http-proxy": {
@@ -702,9 +702,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
-        "eventemitter3": "4.0.7",
-        "follow-redirects": "1.13.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "immutable": {
@@ -717,15 +717,15 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-module": {
@@ -763,7 +763,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "magic-string": {
@@ -771,7 +771,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "^0.2.2"
       }
     },
     "ms": {
@@ -790,9 +790,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "pos": {
       "version": "0.4.2",
@@ -814,9 +814,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.13.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "psl": {
@@ -836,26 +836,26 @@
       "dev": true
     },
     "quill-marking-logic": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.14.7.tgz",
-      "integrity": "sha512-/vc9JCddyhD5D28GYm5Ghbm2rT/M8pDqzUKIE0PkJjc/jnO+UQFxZd7Nv8ei/c6vmAZbD+mFLUkRRY0CSpMgJA==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.5.tgz",
+      "integrity": "sha512-k8XvGsRMAiIdzQ1hoAYFaZXW/w0g0AebAn0HUxx2SL8hWKZ1ow+HawNFSGKFkusFZo+35f6q5OTzIWxn7apUAg==",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-react": "6.24.1",
-        "diff": "3.5.0",
-        "immutable": "3.8.2",
-        "levenshtein": "1.0.5",
-        "lodash": "4.17.21",
-        "pos": "0.4.2",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0",
+        "babel-preset-es2015": "^6.24.1",
+        "babel-preset-react": "^6.24.1",
+        "diff": "^3.2.0",
+        "immutable": "^3.8.2",
+        "levenshtein": "^1.0.5",
+        "lodash": "^4.17.20",
+        "pos": "^0.4.2",
         "quill-string-normalizer": "0.0.9",
-        "request-promise": "4.2.6",
-        "rollup-plugin-commonjs": "8.4.1",
-        "rollup-plugin-json": "2.3.1",
-        "rollup-plugin-node-globals": "1.4.0",
-        "rollup-plugin-node-resolve": "3.4.0",
-        "underscore": "1.13.1"
+        "request-promise": "^4.2.5",
+        "rollup-plugin-commonjs": "^8.3.0",
+        "rollup-plugin-json": "^2.3.0",
+        "rollup-plugin-node-globals": "^1.4.0",
+        "rollup-plugin-node-resolve": "^3.4.0",
+        "underscore": "^1.8.3"
       }
     },
     "quill-string-normalizer": {
@@ -873,7 +873,7 @@
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
       "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
       "requires": {
-        "prop-types": "15.7.2"
+        "prop-types": "^15.5.8"
       }
     },
     "react-is": {
@@ -886,9 +886,9 @@
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
       "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
       "requires": {
-        "classnames": "2.2.6",
-        "prop-types": "15.7.2",
-        "react-input-autosize": "2.2.2"
+        "classnames": "^2.2.4",
+        "prop-types": "^15.5.8",
+        "react-input-autosize": "^2.1.2"
       }
     },
     "react-table": {
@@ -896,9 +896,9 @@
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.11.5.tgz",
       "integrity": "sha512-LM+AS9v//7Y7lAlgTWW/cW6Sn5VOb3EsSkKQfQTzOW8FngB1FUskLLNEVkAYsTX9LjOWR3QlGjykJqCE6eXT/g==",
       "requires": {
-        "@types/react-table": "6.8.7",
-        "classnames": "2.2.6",
-        "react-is": "16.13.1"
+        "@types/react-table": "^6.8.5",
+        "classnames": "^2.2.5",
+        "react-is": "^16.8.1"
       }
     },
     "redux-test-utils": {
@@ -922,9 +922,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regexpu-core": {
@@ -932,9 +932,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.4.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -947,7 +947,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "request-promise": {
@@ -955,10 +955,10 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
       "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
       "requires": {
-        "bluebird": "3.7.2",
+        "bluebird": "^3.5.0",
         "request-promise-core": "1.1.4",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "request-promise-core": {
@@ -966,7 +966,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "4.17.21"
+        "lodash": "^4.17.19"
       }
     },
     "requires-port": {
@@ -979,8 +979,8 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "requires": {
-        "is-core-module": "2.2.0",
-        "path-parse": "1.0.6"
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
       }
     },
     "rollup-plugin-commonjs": {
@@ -988,11 +988,11 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
       "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
       "requires": {
-        "acorn": "5.7.4",
-        "estree-walker": "0.5.2",
-        "magic-string": "0.22.5",
-        "resolve": "1.20.0",
-        "rollup-pluginutils": "2.8.2"
+        "acorn": "^5.2.1",
+        "estree-walker": "^0.5.0",
+        "magic-string": "^0.22.4",
+        "resolve": "^1.4.0",
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "rollup-plugin-json": {
@@ -1000,7 +1000,7 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-2.3.1.tgz",
       "integrity": "sha512-alQQQVPo2z9pl6LSK8QqyDlWwCH5KeE8YxgQv7fa/SeTxz+gQe36jBjcha7hQW68MrVh9Ms71EQaMZDAG3w2yw==",
       "requires": {
-        "rollup-pluginutils": "2.8.2"
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "rollup-plugin-node-globals": {
@@ -1008,12 +1008,12 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.4.0.tgz",
       "integrity": "sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==",
       "requires": {
-        "acorn": "5.7.4",
-        "buffer-es6": "4.9.3",
-        "estree-walker": "0.5.2",
-        "magic-string": "0.22.5",
-        "process-es6": "0.11.6",
-        "rollup-pluginutils": "2.8.2"
+        "acorn": "^5.7.3",
+        "buffer-es6": "^4.9.3",
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.22.5",
+        "process-es6": "^0.11.6",
+        "rollup-pluginutils": "^2.3.1"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -1021,9 +1021,9 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
       "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
       "requires": {
-        "builtin-modules": "2.0.0",
-        "is-module": "1.0.0",
-        "resolve": "1.20.0"
+        "builtin-modules": "^2.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.1.6"
       }
     },
     "rollup-pluginutils": {
@@ -1031,7 +1031,7 @@
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "requires": {
-        "estree-walker": "0.6.1"
+        "estree-walker": "^0.6.1"
       },
       "dependencies": {
         "estree-walker": {
@@ -1056,7 +1056,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -1074,8 +1074,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "1.8.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "underscore": {

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.14.7",
+    "quill-marking-logic": "0.15.3",
     "react-csv": "^1.1.2",
     "react-select": "^1.1.0",
     "react-table": "^6.10.3"

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.15.3",
+    "quill-marking-logic": "0.15.5",
     "react-csv": "^1.1.2",
     "react-select": "^1.1.0",
     "react-table": "^6.10.3"


### PR DESCRIPTION
## WHAT
Admin requested the ability to name focus points and incorrect sequences. They want to be able to
1) Assign a name (e.g. "Do not start a sentence with a conjunction.") to a Focus Point or an Incorrect Sequence.
2) Use that name as the "author" label for that response, instead of the current "Focus Point Hint" / "Incorrect Sequence Hint".
3) See that name in the list of response filters.

## WHY
This allows admin to label and analyze their focus points and incorrect sequences more granularly and see which exact focus points and incorrect sequences are giving feedback on responses.

## HOW
1. Add UI/UX for assigning names to focus points and incorrect sequences across all 3 apps.
2. Edit grading logic to use a sequence's name as the "author" of a response feedback, when a name exists.
3. In the response component, fetch a list of incorrect sequence and focus point names and add them as labels to the filter labels.

### Screenshots
<img width="505" alt="Screen Shot 2021-07-27 at 1 42 07 PM" src="https://user-images.githubusercontent.com/57366100/127225091-3bfa95b6-e08f-43fc-8eee-9b9384676e86.png">
<img width="529" alt="Screen Shot 2021-07-27 at 1 42 18 PM" src="https://user-images.githubusercontent.com/57366100/127225095-ca9ebd1e-cc83-4191-8314-278218da4f51.png">
<img width="718" alt="Screen Shot 2021-07-27 at 1 46 15 PM" src="https://user-images.githubusercontent.com/57366100/127225104-bfcdd772-2557-4314-9760-4e16137de06b.png">


### Notion Card Links
https://www.notion.so/quill/Ability-to-name-Incorrect-Sequences-and-Focus-Points-d5c6e5aa52234a918f7f275993cb4a4b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
