### PR TITLE
Security/ prevent 404 rule error

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureRules/rule.tsx
@@ -189,26 +189,31 @@ const Rule = ({ history, match }) => {
       </div>
     );
   }
+  const validRule = ruleData && ruleData.rule;
 
   return(
     <div className="rule-container">
       {showDeleteRuleModal && renderDeleteRuleModal()}
       {showEditRuleModal && renderRuleForm()}
       {renderHeader(activityData, 'View All Rules - View Individual Rule')}
-      <Link className="data-link" to={`/activities/${activityId}/rules`}>← Return to Rules Index</Link>
-      <DataTable
-        className="rule-table"
-        headers={dataTableFields}
-        rows={ruleRows(ruleData)}
-      />
-      <div className="button-container">
-        <button className="quill-button fun primary contained" id="edit-rule-button" onClick={toggleShowEditRuleModal} type="button">
-          Configure
-        </button>
-        <button className="quill-button fun primary contained" id="delete-rule-button" onClick={toggleShowDeleteRuleModal} type="button">
-          Delete
-        </button>
-      </div>
+      <Link className="data-link" to={`/activities/${activityId}/rules-index`}>← Return to Rules Index</Link>
+      {validRule &&
+      <React.Fragment>
+        <DataTable
+          className="rule-table"
+          headers={dataTableFields}
+          rows={ruleRows(ruleData)}
+        />
+        <div className="button-container">
+          <button className="quill-button fun primary contained" id="edit-rule-button" onClick={toggleShowEditRuleModal} type="button">
+            Configure
+          </button>
+          <button className="quill-button fun primary contained" id="delete-rule-button" onClick={toggleShowDeleteRuleModal} type="button">
+            Delete
+          </button>
+        </div>
+      </React.Fragment>}
+      {!validRule && <p className="invalid-rule-text">{`Rule with id ${ruleId} does not exist.`}</p>}
     </div>
   );
 }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -643,6 +643,10 @@
         }
       }
     }
+    .invalid-rule-text {
+      margin: 22px 0px;
+      color: red;
+    }
   }
   .rule-form-container {
     .delete-rule-container {

--- a/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
+++ b/services/QuillLMS/engines/comprehension/app/controllers/comprehension/rules_controller.rb
@@ -62,7 +62,7 @@ module Comprehension
 
     private def set_rule
       # warning - the id param is getting used as both an id and a uid, which is an antipattern
-      @rule = Comprehension::Rule.find_by_uid(params[:id]) || Comprehension::Rule.find(params[:id])
+      @rule = Comprehension::Rule.find_by_uid(params[:id]) || Comprehension::Rule.find_by_id(params[:id])
     end
 
     private def rule_params

--- a/services/QuillLMS/engines/comprehension/spec/controllers/comprehension/rules_controller_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/controllers/comprehension/rules_controller_spec.rb
@@ -15,7 +15,7 @@ module Comprehension
       end
 
       context 'should with rules' do
-        let!(:rule) { create(:comprehension_rule) } 
+        let!(:rule) { create(:comprehension_rule) }
 
         it 'should return successfully' do
           get(:index)
@@ -176,7 +176,7 @@ module Comprehension
     end
 
     context 'should show' do
-      let!(:rule) { create(:comprehension_rule) } 
+      let!(:rule) { create(:comprehension_rule) }
 
       it 'should return json if found by id' do
         get(:show, :params => ({ :id => rule.id }))
@@ -206,8 +206,10 @@ module Comprehension
         expect(parsed_response["concept_uid"]).to(eq(rule.concept_uid))
       end
 
-      it 'should raise if not found (to be handled by parent app)' do
-        expect { get(:show, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+      it 'should not raise exception if not found (to be handled by parent app)' do
+        get(:show, :params => ({ :id => 99999 }))
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to eq(nil)
       end
     end
 
@@ -287,7 +289,7 @@ module Comprehension
     end
 
     context 'should destroy' do
-      let!(:rule) { create(:comprehension_rule) } 
+      let!(:rule) { create(:comprehension_rule) }
 
       it 'should destroy record at id' do
         delete(:destroy, :params => ({ :id => rule.id }))


### PR DESCRIPTION
## WHAT
prevent set_rule function from raising argument error

## WHY
we don't want to get these alerts, we can just have the controller return nil if the rule for that ID doesn't exist

## HOW
swap out `find` with `find_by_id`; this also adds a few small frontend tweaks to handle the case

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1306" alt="Screen Shot 2021-07-27 at 6 11 31 PM" src="https://user-images.githubusercontent.com/25959584/127239099-7944a5b9-26db-4fe8-a9c1-743bb6808ef5.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Error-api-v1-comprehension-rules-null-ActiveRecord-RecordNotFound-d46f65b71bdf4ac9bb4c1e527899b09c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
