### PR TITLE
Lms/security headers

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -69,6 +69,7 @@ gem 'intercom', '~> 3.5.23'
 gem 'haversine'
 gem 'configs'
 gem 'rack-test', '~> 0.6.3'
+gem 'secure_headers', '5.2.0'
 
 # Engines
 gem 'comprehension', path: 'engines/comprehension'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -659,6 +659,8 @@ GEM
       sprockets-rails
       tilt
     scout_apm (2.4.21)
+    secure_headers (5.2.0)
+      useragent (>= 0.15.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.142.7)
@@ -755,6 +757,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode_utils (1.4.0)
     uniform_notifier (1.12.1)
+    useragent (0.16.10)
     validates_email_format_of (1.6.3)
       i18n
     vcr (4.0.0)
@@ -889,6 +892,7 @@ DEPENDENCIES
   sass-rails
   sassc-rails (>= 2.1.0)
   scout_apm
+  secure_headers (= 5.2.0)
   select2-rails
   selenium-webdriver
   sentry-raven (>= 0.12.2)

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,0 +1,9 @@
+SecureHeaders::Configuration.default do |config|
+  config.cookies = {
+    secure: true, # mark all cookies as "Secure"
+    httponly: true, # mark all cookies as "HttpOnly"
+    samesite: {
+      lax: true # mark all cookies as SameSite=lax
+    }
+  }
+end

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,9 +1,10 @@
 SecureHeaders::Configuration.default do |config|
+  config.csp = SecureHeaders::OPT_OUT
   config.cookies = {
-    secure: true, # mark all cookies as "Secure"
-    httponly: true, # mark all cookies as "HttpOnly"
+    secure: true, 
+    httponly: true, 
     samesite: {
-      lax: true # mark all cookies as SameSite=lax
+      lax: true 
     }
   }
 end

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+class DummyController < ApplicationController
+  def index 
+    cookies['foo'] = 'bar'
+    render json: {}
+  end
+end
+
+describe DummyController, type: :request do
+  before do 
+    Rails.application.routes.draw do
+      get '/dummy', to: 'dummy#index'
+    end
+  end 
+
+  after do 
+    Rails.application.reload_routes!
+  end
+
+  it 'should flag all cookies as HttpOnly' do 
+    get '/dummy'
+    expect(response.header['Set-Cookie']).to match('HttpOnly')
+  end
+end


### PR DESCRIPTION
## WHAT
- includes `secure_headers` gem in LMS
- enables HttpOnly and Secure flags for LMS-managed cookies
- I audited all instances of client-side scripts reading cookies, and all of them are set by client-side scripts, so HttpOnly will not break existing features.

## DISCUSSION
- I notice that we use two third-party non-Secure cookies: Google Analytics and Amplitude. I confirmed they do not contain sensitive information (they are counters/hashed data).
- We should minimize attack vectors in general, apart from the details of the CB review. We should consider implementing a security checklist whenever a new tracker is added to the app.

## WHY
- college board requirement 
- reduces possibility of leaking sensitive cookie data

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/HttpOnly-Cookie-Attribute-Not-Set-0659fd9e4e8a446fac89cfc40f3dc4ce
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=d1aa65095bd24bf58e9fe455c94754b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A 
