### PR TITLE
Lms/count user activity completions

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -102,7 +102,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   private def count_completed_activity
     return unless @activity_session.finished?
 
-    counter = UserActivityClassificationCount.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
+    counter = UserActivityClassification.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
     counter.increment_count
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -20,6 +20,8 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       message = "Activity Session Updated"
       NotifyOfCompletedActivity.new(@activity_session).call if @activity_session.classroom_unit_id
       handle_concept_results
+      # TODO: turn this next line back on once we've backfilled the data
+      # count_completed_activity
     else
       status = :unprocessable_entity
       message = "Activity Session Update Failed"
@@ -95,6 +97,13 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
   private def find_activity_session
     @activity_session = ActivitySession.unscoped.find_by_uid!(params[:id])
+  end
+
+  private def count_completed_activity
+    return unless @activity_session.finished?
+
+    counter = UserActivityClassificationCount.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
+    counter.increment_count
   end
 
   private def activity_session_params

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -136,7 +136,7 @@ class Activity < ApplicationRecord
 
   def module_url(activity_session)
     @activity_session = activity_session
-    classification_count = @activity_session&.classification&.user_activity_classifications&.where(user: @activity_session.user_id)&.first&.count
+    classification_count = @activity_session&.user_activity_classifications&.find_by(user_id: @activity_session.user_id)&.count
     initial_params = {student: activity_session.uid}
     initial_params[:activities] = classification_count if classification_count
     module_url_helper(initial_params)

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -136,7 +136,9 @@ class Activity < ApplicationRecord
 
   def module_url(activity_session)
     @activity_session = activity_session
+    classification_count = @activity_session&.classification&.user_activity_classifications&.where(user: @activity_session.user_id)&.first&.count
     initial_params = {student: activity_session.uid}
+    initial_params[:activities] = classification_count if classification_count
     module_url_helper(initial_params)
   end
 

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -26,6 +26,7 @@ class ActivityClassification < ApplicationRecord
 
   has_many :activities, dependent: :destroy
   has_many :concept_results
+  has_many :user_activity_classifications, dependent: :destroy
 
   validates :key, presence: true
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -54,6 +54,7 @@ class ActivitySession < ApplicationRecord
   belongs_to :classroom_unit
   belongs_to :activity
   has_one :classification, through: :activity
+  has_many :user_activity_classifications, through: :classification
   has_one :classroom, through: :classroom_unit
   has_one :unit, through: :classroom_unit
   has_many :concept_results

--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  enabled             :boolean          default(FALSE), not null
-#  enabled_for_staff  :boolean          default(FALSE), not null
+#  enabled_for_staff   :boolean          default(FALSE), not null
 #  name                :string           not null
 #  percent_active      :integer          default(0), not null
 #  user_ids_allow_list :integer          default([]), not null, is an Array

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -76,6 +76,7 @@ class User < ApplicationRecord
   has_many :credit_transactions
   has_many :invitations, foreign_key: 'inviter_id'
   has_many :objectives, through: :checkboxes
+  has_many :user_activity_classifications, dependent: :destroy
   has_many :user_subscriptions
   has_many :subscriptions, through: :user_subscriptions
   has_many :activity_sessions

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: user_activity_classifications
+#
+#  id                         :bigint           not null, primary key
+#  count                      :integer          default(0)
+#  activity_classification_id :bigint
+#  user_id                    :bigint
+#
+# Indexes
+#
+#  index_user_activity_classifications_on_classifications  (activity_classification_id)
+#  index_user_activity_classifications_on_user_id          (user_id)
+#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (activity_classification_id => activity_classifications.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class UserActivityClassification < ApplicationRecord
+  belongs_to :user
+  belongs_to :activity_classification
+
+  attribute :count, :integer, default: 0
+
+  validates_presence_of :user
+  validates_presence_of :activity_classification
+  validates :count, presence: true,
+    numericality: {
+      only_integer: true,
+      greater_than_or_equal_to: 0
+    }
+
+  def increment_count
+    # Note that this could theoretically be susceptible to race conditions
+    # if two calls are made at the same time, but since we only intend to
+    # count these when activity sessions complete, and don't expect that to
+    # happen more than once, and not close together, we should be safe
+    update(count: count + 1)
+  end
+end

--- a/services/QuillLMS/db/migrate/20210726193112_create_user_activity_classification.rb
+++ b/services/QuillLMS/db/migrate/20210726193112_create_user_activity_classification.rb
@@ -1,0 +1,10 @@
+class CreateUserActivityClassification < ActiveRecord::Migration[5.1]
+  def change
+    create_table :user_activity_classifications do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :activity_classification, index: { name: 'index_user_activity_classifications_on_classifications' }, foreign_key: true
+      t.integer :count, default: 0 
+    end
+    add_index :user_activity_classifications, [:user_id, :activity_classification_id], unique: true, name: 'user_activity_classification_unique_index'
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1,10 +1,3 @@
---
--- PostgreSQL database dump
---
-
--- Dumped from database version 10.16
--- Dumped by pg_dump version 10.16
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -712,7 +705,7 @@ CREATE TABLE public.app_settings (
     id integer NOT NULL,
     name character varying NOT NULL,
     user_ids_allow_list integer[] DEFAULT '{}'::integer[] NOT NULL,
-    enabled_for_admins boolean DEFAULT false NOT NULL,
+    enabled_for_staff boolean DEFAULT false NOT NULL,
     enabled boolean DEFAULT false NOT NULL,
     percent_active integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -1516,8 +1509,8 @@ ALTER SEQUENCE public.comprehension_prompts_rules_id_seq OWNED BY public.compreh
 
 CREATE TABLE public.comprehension_regex_rules (
     id integer NOT NULL,
-    regex_text character varying(200) NOT NULL,
-    case_sensitive boolean NOT NULL,
+    regex_text character varying(200),
+    case_sensitive boolean,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rule_id integer,
@@ -1558,10 +1551,9 @@ CREATE TABLE public.comprehension_rules (
     rule_type character varying NOT NULL,
     optimal boolean NOT NULL,
     suborder integer,
-    concept_uid character varying NOT NULL,
+    concept_uid character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    sequence_type character varying,
     state character varying NOT NULL
 );
 
@@ -3618,6 +3610,37 @@ ALTER SEQUENCE public.units_id_seq OWNED BY public.units.id;
 
 
 --
+-- Name: user_activity_classifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_activity_classifications (
+    id bigint NOT NULL,
+    user_id bigint,
+    activity_classification_id bigint,
+    count integer DEFAULT 0
+);
+
+
+--
+-- Name: user_activity_classifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_activity_classifications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_activity_classifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_activity_classifications_id_seq OWNED BY public.user_activity_classifications.id;
+
+
+--
 -- Name: user_milestones; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4435,6 +4458,13 @@ ALTER TABLE ONLY public.units ALTER COLUMN id SET DEFAULT nextval('public.units_
 
 
 --
+-- Name: user_activity_classifications id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_activity_classifications ALTER COLUMN id SET DEFAULT nextval('public.user_activity_classifications_id_seq'::regclass);
+
+
+--
 -- Name: user_milestones id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5220,6 +5250,14 @@ ALTER TABLE ONLY public.unit_templates
 
 ALTER TABLE ONLY public.units
     ADD CONSTRAINT units_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_activity_classifications user_activity_classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_activity_classifications
+    ADD CONSTRAINT user_activity_classifications_pkey PRIMARY KEY (id);
 
 
 --
@@ -6333,6 +6371,20 @@ CREATE INDEX index_units_on_user_id ON public.units USING btree (user_id);
 
 
 --
+-- Name: index_user_activity_classifications_on_classifications; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_activity_classifications_on_classifications ON public.user_activity_classifications USING btree (activity_classification_id);
+
+
+--
+-- Name: index_user_activity_classifications_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_activity_classifications_on_user_id ON public.user_activity_classifications USING btree (user_id);
+
+
+--
 -- Name: index_user_milestones_on_milestone_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6522,6 +6574,13 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 
 
 --
+-- Name: user_activity_classification_unique_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX user_activity_classification_unique_index ON public.user_activity_classifications USING btree (user_id, activity_classification_id);
+
+
+--
 -- Name: username_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6630,6 +6689,14 @@ ALTER TABLE ONLY public.comprehension_automl_models
 
 ALTER TABLE ONLY public.classroom_units
     ADD CONSTRAINT fk_rails_3e1ff09783 FOREIGN KEY (unit_id) REFERENCES public.units(id);
+
+
+--
+-- Name: user_activity_classifications fk_rails_3ef65d581c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_activity_classifications
+    ADD CONSTRAINT fk_rails_3ef65d581c FOREIGN KEY (activity_classification_id) REFERENCES public.activity_classifications(id);
 
 
 --
@@ -6838,6 +6905,14 @@ ALTER TABLE ONLY public.teacher_saved_activities
 
 ALTER TABLE ONLY public.content_partner_activities
     ADD CONSTRAINT fk_rails_d292764f4f FOREIGN KEY (activity_id) REFERENCES public.activities(id);
+
+
+--
+-- Name: user_activity_classifications fk_rails_d544d0cd3e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_activity_classifications
+    ADD CONSTRAINT fk_rails_d544d0cd3e FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -7308,6 +7383,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210528142650'),
 ('20210614190031'),
 ('20210614205654'),
-('20210709161400');
+('20210709155935'),
+('20210709161400'),
+('20210726193112');
 
 

--- a/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
+++ b/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
@@ -1,18 +1,19 @@
 namespace :migrate_backfill_user_activity_classifications do
   desc 'Establish initial values for UserActivityClassification counts'
   task :run => :environment do
-    User.select(<<-SELECT
+    records = User.select(<<-SELECT
         users.id AS user_id,
         activity_classifications.id AS activity_classification_id,
         COUNT(*) AS count
       SELECT
     )
-      .joins('activity_sessions ON users.id = activity_sessions.user_id')
-      .joins('activities ON activity_sessions.activity_id = activities.id')
-      .joins('join activity_classifications ON activities.activity_classification_id = activity_classifications.id')
+      .joins('JOIN activity_sessions ON users.id = activity_sessions.user_id')
+      .joins('JOIN activities ON activity_sessions.activity_id = activities.id')
+      .joins('JOIN activity_classifications ON activities.activity_classification_id = activity_classifications.id')
+      .where("activity_sessions.state = 'finished'")
       .group('users.id, activity_classifications.id')
-      .each do |data|
-        UserActivityClassification.create(user_id: data.user_id, activity_classification_id: data.activity_classification_id, count: data.count)
-      end
+    records.each do |data|
+      UserActivityClassification.create(user_id: data.user_id, activity_classification_id: data.activity_classification_id, count: data.count)
+    end
   end
 end

--- a/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
+++ b/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
@@ -1,23 +1,23 @@
 namespace :migrate_backfill_user_activity_classifications do
-  # NOTE: In production environments, this task requires more memory
-  # than is available in via a default `heroku run` command.
-  # You'll need to run this with the `--size=` flag.  I've tested it
-  # in staging with `--size=performance-l`
   desc 'Establish initial values for UserActivityClassification counts'
   task :run => :environment do
-    records = User.select(<<-SELECT
-        users.id AS user_id,
-        activity_classifications.id AS activity_classification_id,
-        COUNT(*) AS count
-      SELECT
-    )
-      .joins('JOIN activity_sessions ON users.id = activity_sessions.user_id')
-      .joins('JOIN activities ON activity_sessions.activity_id = activities.id')
-      .joins('JOIN activity_classifications ON activities.activity_classification_id = activity_classifications.id')
-      .where("activity_sessions.state = 'finished'")
-      .group('users.id, activity_classifications.id')
-    records.each do |data|
-      UserActivityClassification.create(user_id: data.user_id, activity_classification_id: data.activity_classification_id, count: data.count)
-    end
+    # Running this as a raw SQL command in order to avoid spending any
+    # CPU or RAM on interpreting the data across the ORM which could
+    # get very expensive and time-consuming, especially iterating over
+    # a bunch of records.
+    sql = <<-SQL
+      INSERT INTO user_activity_classifications (user_id, activity_classification_id, count)
+      SELECT users.id, activity_classifications.id, COUNT(*)
+      FROM users
+        JOIN activity_sessions
+          ON users.id = activity_sessions.user_id
+        JOIN activities
+          ON activity_sessions.activity_id = activities.id
+        JOIN activity_classifications
+          ON activities.activity_classification_id = activity_classifications.id
+      WHERE activity_sessions.state = 'finished'
+      GROUP BY users.id, activity_classifications.id
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
+++ b/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
@@ -1,4 +1,8 @@
 namespace :migrate_backfill_user_activity_classifications do
+  # NOTE: In production environments, this task requires more memory
+  # than is available in via a default `heroku run` command.
+  # You'll need to run this with the `--size=` flag.  I've tested it
+  # in staging with `--size=performance-l`
   desc 'Establish initial values for UserActivityClassification counts'
   task :run => :environment do
     records = User.select(<<-SELECT

--- a/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
+++ b/services/QuillLMS/lib/tasks/migrate_backfill_user_activity_classifications.rake
@@ -1,0 +1,18 @@
+namespace :migrate_backfill_user_activity_classifications do
+  desc 'Establish initial values for UserActivityClassification counts'
+  task :run => :environment do
+    User.select(<<-SELECT
+        users.id AS user_id,
+        activity_classifications.id AS activity_classification_id,
+        COUNT(*) AS count
+      SELECT
+    )
+      .joins('activity_sessions ON users.id = activity_sessions.user_id')
+      .joins('activities ON activity_sessions.activity_id = activities.id')
+      .joins('join activity_classifications ON activities.activity_classification_id = activity_classifications.id')
+      .group('users.id, activity_classifications.id')
+      .each do |data|
+        UserActivityClassification.create(user_id: data.user_id, activity_classification_id: data.activity_classification_id, count: data.count)
+      end
+  end
+end

--- a/services/QuillLMS/spec/factories/user_activity_classification.rb
+++ b/services/QuillLMS/spec/factories/user_activity_classification.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user_activity_classification, class: 'UserActivityClassification' do
+    user                       { create(:user) }
+    activity_classification    { create(:activity_classification) }
+    count                      { 0 }
+  end
+end
+

--- a/services/QuillLMS/spec/models/activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/activity_classification_spec.rb
@@ -25,6 +25,7 @@ require 'rails_helper'
 describe ActivityClassification, type: :model, redis: true do
   it { should have_many(:activities) }
   it { should have_many(:concept_results) }
+  it { should have_many(:user_activity_classifications).dependent(:destroy) }
 
   it_behaves_like "uid"
 

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -41,6 +41,8 @@ describe ActivitySession, type: :model, redis: true do
 
   it { should belong_to(:classroom_unit) }
   it { should belong_to(:activity) }
+  it { should have_one(:classification).through(:activity) }
+  it { should have_many(:user_activity_classifications).through(:classification) }
   it { should have_many(:feedback_sessions) }
   it { should have_many(:feedback_histories).through(:feedback_sessions) }
   it { should have_one(:classroom).through(:classroom_unit) }

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -164,16 +164,14 @@ describe Activity, type: :model, redis: true do
       expect(activity.module_url(student.activity_sessions.build()).to_s).to include "student"
     end
 
-    it "must add 'activities' param if it the student has completed previous sessions of this activity classification" do
+    it "must add 'activities' param if the student has completed previous sessions of this activity classification" do
       classification = create(:activity_classification, key: 'connect')
       classified_activity = create(:activity, classification: classification)
       student = create(:student)
       uac = create(:user_activity_classification, user: student, activity_classification: classification, count: 4)
       activity_session = create(:activity_session, activity: classified_activity, user: student)
 
-      activity_session.reload
-
-      expect(activity_session.classification.user_activity_classifications.where(id: student.id).first.count).to eq(4)
+      expect(activity_session.user_activity_classifications.find_by(user_id: student.id)).to eq(uac)
       expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{uac.count}")
     end
 

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -164,6 +164,26 @@ describe Activity, type: :model, redis: true do
       expect(activity.module_url(student.activity_sessions.build()).to_s).to include "student"
     end
 
+    it "must add 'activities' param if it the student has completed previous sessions of this activity classification" do
+      classification = create(:activity_classification, key: 'connect')
+      classified_activity = create(:activity, classification: classification)
+      student = create(:student)
+      activity_session = create(:activity_session, activity: classified_activity, user: student)
+      uac = create(:user_activity_classification, user: student, activity_classification: classification, count: 4)
+
+      activity_session.classification.user_activity_classifications.reload
+      expect(activity_session.classification.user_activity_classifications.where(id: student.id).first.count).to eq(4)
+      expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{uac.count}")
+    end
+
+    it "must not add 'activities' param if the student has not completed any other activities of this classification" do
+      classification = create(:activity_classification, key: 'connect')
+      classified_activity = create(:activity, classification: classification)
+      activity_session = create(:activity_session, activity: classified_activity)
+
+      expect(classified_activity.module_url(activity_session).to_s).to_not include("activities")
+    end
+
     it "must use the connect_url_helper when the classification.key is 'connect'" do
       classification = build(:activity_classification, key: 'connect')
       classified_activity = build(:activity, classification: classification)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -168,10 +168,11 @@ describe Activity, type: :model, redis: true do
       classification = create(:activity_classification, key: 'connect')
       classified_activity = create(:activity, classification: classification)
       student = create(:student)
-      activity_session = create(:activity_session, activity: classified_activity, user: student)
       uac = create(:user_activity_classification, user: student, activity_classification: classification, count: 4)
+      activity_session = create(:activity_session, activity: classified_activity, user: student)
 
-      activity_session.classification.user_activity_classifications.reload
+      classification.reload
+
       expect(activity_session.classification.user_activity_classifications.where(id: student.id).first.count).to eq(4)
       expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{uac.count}")
     end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -171,7 +171,7 @@ describe Activity, type: :model, redis: true do
       uac = create(:user_activity_classification, user: student, activity_classification: classification, count: 4)
       activity_session = create(:activity_session, activity: classified_activity, user: student)
 
-      classification.reload
+      activity_session.reload
 
       expect(activity_session.classification.user_activity_classifications.where(id: student.id).first.count).to eq(4)
       expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{uac.count}")

--- a/services/QuillLMS/spec/models/app_setting_spec.rb
+++ b/services/QuillLMS/spec/models/app_setting_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  enabled             :boolean          default(FALSE), not null
-#  enabled_for_staff  :boolean          default(FALSE), not null
+#  enabled_for_staff   :boolean          default(FALSE), not null
 #  name                :string           not null
 #  percent_active      :integer          default(0), not null
 #  user_ids_allow_list :integer          default([]), not null, is an Array

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: auth_credentials
+#
+#  id            :integer          not null, primary key
+#  access_token  :string           not null
+#  expires_at    :datetime
+#  provider      :string           not null
+#  refresh_token :string
+#  timestamp     :datetime
+#  created_at    :datetime
+#  updated_at    :datetime
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_auth_credentials_on_provider       (provider)
+#  index_auth_credentials_on_refresh_token  (refresh_token)
+#  index_auth_credentials_on_user_id        (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 describe AuthCredential, type: :model do

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -2,17 +2,17 @@
 #
 # Table name: questions
 #
-#  id            :integer
-#  data          :jsonb
-#  question_type :string
-#  uid           :string
-#  created_at    :datetime
-#  updated_at    :datetime
-#  temp_id       :integer          not null, primary key
+#  id            :integer          not null, primary key
+#  data          :jsonb            not null
+#  question_type :string           not null
+#  uid           :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
 #
 # Indexes
 #
 #  index_questions_on_question_type  (question_type)
+#  index_questions_on_uid            (uid) UNIQUE
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -1,0 +1,57 @@
+# == Schema Information
+#
+# Table name: user_activity_classifications
+#
+#  id                         :bigint           not null, primary key
+#  count                      :integer          default(0)
+#  activity_classification_id :bigint
+#  user_id                    :bigint
+#
+# Indexes
+#
+#  index_user_activity_classifications_on_classifications  (activity_classification_id)
+#  index_user_activity_classifications_on_user_id          (user_id)
+#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (activity_classification_id => activity_classifications.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+
+RSpec.describe UserActivityClassification, type: :model do
+
+  context 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:activity_classification) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:activity_classification) }
+    it { should validate_presence_of(:count) }
+
+    it { should validate_numericality_of(:count).only_integer.is_greater_than_or_equal_to(0) }
+  end
+
+  context '#new' do
+    it 'should default count to 0' do
+      new = UserActivityClassification.new()
+      expect(new.count).to be(0)
+    end
+  end
+
+  context '#increment_count' do
+    START_COUNT = 10
+    let(:user_activity_classification) { create(:user_activity_classification, count: START_COUNT) }
+
+    it 'should increment the value of count by 1' do
+
+      user_activity_classification.increment_count
+      user_activity_classification.reload
+      expect(user_activity_classification.count).to eq(START_COUNT + 1)
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe UserActivityClassification, type: :model do
 
   context '#new' do
     it 'should default count to 0' do
-      user_activity_classification = UserActivityClassification.new()
+      user_activity_classification = UserActivityClassification.new
       expect(user_activity_classification.count).to be(0)
     end
   end

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -38,20 +38,20 @@ RSpec.describe UserActivityClassification, type: :model do
 
   context '#new' do
     it 'should default count to 0' do
-      new = UserActivityClassification.new()
-      expect(new.count).to be(0)
+      user_activity_classification = UserActivityClassification.new()
+      expect(user_activity_classification.count).to be(0)
     end
   end
 
   context '#increment_count' do
-    START_COUNT = 10
-    let(:user_activity_classification) { create(:user_activity_classification, count: START_COUNT) }
+    let(:start_count) { 10 }
+    let(:user_activity_classification) { create(:user_activity_classification, count: start_count) }
 
     it 'should increment the value of count by 1' do
 
       user_activity_classification.increment_count
       user_activity_classification.reload
-      expect(user_activity_classification.count).to eq(START_COUNT + 1)
+      expect(user_activity_classification.count).to eq(start_count + 1)
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -79,6 +79,7 @@ describe User, type: :model do
   it { should have_many(:classrooms_i_teach).through(:classrooms_teachers).source(:classroom) }
   it { should have_and_belong_to_many(:districts) }
   it { should have_one(:ip_location) }
+  it { should have_many(:user_activity_classifications).dependent(:destroy) }
   it { should have_many(:user_milestones) }
   it { should have_many(:milestones).through(:user_milestones) }
 


### PR DESCRIPTION
## WHAT
Start counting the each time a user completes an activity by classification.  This will also allow us to pass that value on to activities so that individual clients can change behavior based on it if they want to.
## WHY
Ultimately we want to start using this value to decide how much of a tutorial to show to a user, but for now we're just collecting and passing this data on without actually using it.
## HOW
Hook into the `ActivitySession` completion workflow to increment counts in `UserActivityClassification` whenever a user completes a session.

### Notion Card Links
https://www.notion.so/quill/Quill-LMS-shares-number-of-previously-completed-activities-per-tool-at-the-start-of-the-activity-de4db8fbe1c34664a4de189fca935eb4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
