### PR TITLE
Stop highlighting misspelled words when the student has a Missing Word Hint

### DIFF
--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.15.5",
+    "quill-marking-logic": "0.15.6",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.15.6",
+    "quill-marking-logic": "0.15.7",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
@@ -23,6 +23,8 @@ import {caseStartChecker} from '../matchers/case_start_match';
 import {punctuationEndChecker} from '../matchers/punctuation_end_match';
 import {spellingFeedbackStrings} from '../constants/feedback_strings';
 
+const MISSING_WORD_HINT = 'Missing Word Hint'
+
 export function checkSentenceCombining(
   question_uid: string,
   response: string,
@@ -66,11 +68,8 @@ export function checkSentenceCombining(
       spellingPass.concept_results.push(conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
     }
     const spellingAwareFeedback = getSpellingFeedback(spellingPass);
-    const spellingFeedbackObj = {
-      text: data.response,
-      spelling_error: true,
-      misspelled_words: misspelledWords
-    }
+    const spellingFeedbackObj = getSpellingFeedbackObj(spellingPass, data, misspelledWords)
+
     return Object.assign(responseTemplate, spellingAwareFeedback, spellingFeedbackObj);
   };
 
@@ -155,4 +154,20 @@ function getMisspelledWords(text: string, spellCheckedText: string) {
   const spellCheckedTextArray: Array<string> = removePunctuation(spellCheckedText).split(' ')
   const misspelledWords = textArray.filter(word => !spellCheckedTextArray.includes(word))
   return misspelledWords
+}
+
+function getSpellingFeedbackObj(spellingPass, data, misspelledWords) {
+  // missing word hint should not return any highlighted words
+  if (spellingPass.author == MISSING_WORD_HINT) {
+    return {
+      text: data.response,
+      spelling_error: true
+    }
+  } else {
+    return {
+      text: data.response,
+      spelling_error: true,
+      misspelled_words: misspelledWords
+    }
+  }
 }

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
@@ -92,14 +92,14 @@ describe('The checking a sentence combining question', () => {
     });
 
     it('should add spelling concept result to concept results', () => {
-      const questionString = "Batss wings, so they can fly."
+      const questionString = "Batss have wi ngs, so they can fly."
       const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
       assert.equal(matchedResponse.spelling_error, true);
       assert.include(matchedResponse.concept_results, conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
     });
 
     it('should add spelling concept result to concept results if there are two or more spelling errors', () => {
-      const questionString = "Batss wingss, so they can fly."
+      const questionString = "Batss have wi ngss, so they can fly."
       const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
       assert.equal(matchedResponse.spelling_error, true);
       assert.include(matchedResponse.concept_results, conceptResultTemplate('H-2lrblngQAQ8_s-ctye4g'));
@@ -163,7 +163,7 @@ describe('The checking a sentence combining question', () => {
       const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
       assert.equal(matchedResponse.feedback, spellingFeedbackStrings[matchedResponse.author]);
       assert.equal(matchedResponse.spelling_error, true);
-      assert.equal(matchedResponse.misspelled_words[0], 'zings')
+      assert.equal(matchedResponse.misspelled_words, undefined)
     });
 
     it('should be able to find a flexible change match', () => {
@@ -173,6 +173,14 @@ describe('The checking a sentence combining question', () => {
       assert.equal(matchedResponse.spelling_error, true);
       assert.equal(matchedResponse.misspelled_words[0], 'shave')
     });
+
+    it('should be able to find a missing word match but not return spelling errors', () => {
+      const questionString = "Batss have, so they can fly."
+      const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
+      assert.equal(matchedResponse.author, 'Missing Word Hint');
+      assert.equal(matchedResponse.spelling_error, true);
+      assert.equal(matchedResponse.misspelled_words, undefined)
+    })
 
   })
 

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
@@ -174,14 +174,6 @@ describe('The checking a sentence combining question', () => {
       assert.equal(matchedResponse.misspelled_words[0], 'shave')
     });
 
-    it('should be able to find a missing word match but not return spelling errors', () => {
-      const questionString = "Batss have, so they can fly."
-      const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
-      assert.equal(matchedResponse.author, 'Missing Word Hint');
-      assert.equal(matchedResponse.spelling_error, true);
-      assert.equal(matchedResponse.misspelled_words, undefined)
-    })
-
   })
 
   describe('second matchers - original sentence', () => {

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -11752,9 +11752,9 @@
       "dev": true
     },
     "quill-marking-logic": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.5.tgz",
-      "integrity": "sha512-k8XvGsRMAiIdzQ1hoAYFaZXW/w0g0AebAn0HUxx2SL8hWKZ1ow+HawNFSGKFkusFZo+35f6q5OTzIWxn7apUAg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.7.tgz",
+      "integrity": "sha512-jyk8wEC/VF6XzRCjXPDIT2+yj0Vtik8tFFU5rXFqf9zymiHUzCaqQkVUj1mXpXwniIS2fh0slxhETgIpTQ9kwg==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -72,7 +72,7 @@
     "pusher-js": "^5.0.1",
     "qs": "^6.9.2",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "^0.15.5",
+    "quill-marking-logic": "^0.15.6",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^16.13.1",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -72,7 +72,7 @@
     "pusher-js": "^5.0.1",
     "qs": "^6.9.2",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "^0.15.6",
+    "quill-marking-logic": "^0.15.7",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^16.13.1",

--- a/services/QuillLMS/package-lock.json
+++ b/services/QuillLMS/package-lock.json
@@ -836,9 +836,9 @@
       "dev": true
     },
     "quill-marking-logic": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.5.tgz",
-      "integrity": "sha512-k8XvGsRMAiIdzQ1hoAYFaZXW/w0g0AebAn0HUxx2SL8hWKZ1ow+HawNFSGKFkusFZo+35f6q5OTzIWxn7apUAg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.7.tgz",
+      "integrity": "sha512-jyk8wEC/VF6XzRCjXPDIT2+yj0Vtik8tFFU5rXFqf9zymiHUzCaqQkVUj1mXpXwniIS2fh0slxhETgIpTQ9kwg==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.15.5",
+    "quill-marking-logic": "0.15.6",
     "react-csv": "^1.1.2",
     "react-select": "^1.1.0",
     "react-table": "^6.10.3"

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.15.6",
+    "quill-marking-logic": "0.15.7",
     "react-csv": "^1.1.2",
     "react-select": "^1.1.0",
     "react-table": "^6.10.3"


### PR DESCRIPTION
## WHAT
As of now, we automatically highlight misspelled words on all algorithmic feedback. However, this is misleading for the Missing Word Hint feedback because it makes the student think the highlighted misspelled word has something to do with the missing word (which is not the case).

So Curriculum has asked us to stop highlighting misspellings on this algorithm, specifically.

## WHY
This will make feedback easier to understand.

## HOW
We currently add the spelling concept results and misspelled words array after we process the response algorithms. So, at this last step, just add an edge case to catch when the author is "Misspelled Words Hint" and omit the misspelled_words array if this is the case.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-the-required-words-algorithm-to-no-longer-use-bolding-3defd347fa5f474da8b728b05362d98f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
