### PR TITLE
lms/count-activity-completeions-on-session-finish

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -20,8 +20,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       message = "Activity Session Updated"
       NotifyOfCompletedActivity.new(@activity_session).call if @activity_session.classroom_unit_id
       handle_concept_results
-      # TODO: turn this next line back on once we've backfilled the data
-      # count_completed_activity
+      count_completed_activity
     else
       status = :unprocessable_entity
       message = "Activity Session Update Failed"

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -4,7 +4,9 @@ describe Api::V1::ActivitySessionsController, type: :controller do
   describe '#update' do
     let(:token) { double :acceptable? => true, resource_owner_id: user.id }
     let(:user) { create(:student) }
-    let!(:activity_session) { create(:activity_session, state: 'started', user: user, completed_at: nil) }
+    let(:activity_classification) { create(:activity_classification) }
+    let(:activity) { create(:activity, classification: activity_classification) }
+    let!(:activity_session) { create(:activity_session, state: 'started', user: user, completed_at: nil, activity: activity) }
 
     before { allow(controller).to receive(:doorkeeper_token) { token } }
 
@@ -36,6 +38,27 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       it 'responds with the updated activity session' do
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['activity_session']['uid']).to eq(activity_session.uid)
+      end
+    end
+
+    context 'user_activity_classification counts increment when they should' do
+      it 'should create a new user_activity_classification row if necessary' do
+        records = UserActivityClassification.count
+        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
+        expect(UserActivityClassification.count).to eq(records + 1)
+      end
+
+      it 'should increment an existing user_activity_classification row if one exists' do
+        start_count = 10
+        UserActivityClassification.create(user: user, activity_classification: activity_classification, count: start_count)
+        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
+        expect(UserActivityClassification.find_by(user: user, activity_classification: activity_classification).count).to eq(start_count + 1)
+      end
+
+      it 'should not touch user_activity_classification counts if the state of the session is not "finished"' do
+        records = UserActivityClassification.count
+        put :update, params: { id: activity_session.uid }, as: :json
+        expect(UserActivityClassification.count).to eq(records)
       end
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -44,21 +44,25 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     context 'user_activity_classification counts increment when they should' do
       it 'should create a new user_activity_classification row if necessary' do
         records = UserActivityClassification.count
-        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
-        expect(UserActivityClassification.count).to eq(records + 1)
+        expect do
+          put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
+        end.to change { UserActivityClassification.count }.by(1)
       end
 
       it 'should increment an existing user_activity_classification row if one exists' do
         start_count = 10
-        UserActivityClassification.create(user: user, activity_classification: activity_classification, count: start_count)
-        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
-        expect(UserActivityClassification.find_by(user: user, activity_classification: activity_classification).count).to eq(start_count + 1)
+        uac = UserActivityClassification.create(user: user, activity_classification: activity_classification, count: start_count)
+
+        expect do
+          put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
+          uac.reload
+        end.to change { uac.count }.to(start_count + 1)
       end
 
       it 'should not touch user_activity_classification counts if the state of the session is not "finished"' do
-        records = UserActivityClassification.count
-        put :update, params: { id: activity_session.uid }, as: :json
-        expect(UserActivityClassification.count).to eq(records)
+        expect do
+          put :update, params: { id: activity_session.uid }, as: :json
+        end.to_not change { UserActivityClassification.count }
       end
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -62,7 +62,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       it 'should not touch user_activity_classification counts if the state of the session is not "finished"' do
         expect do
           put :update, params: { id: activity_session.uid }, as: :json
-        end.to_not change { UserActivityClassification.count }
+        end.to_not(change { UserActivityClassification.count })
       end
     end
 


### PR DESCRIPTION
## WHAT
Turn on updated tracking of activity classification on session update
## WHY
We want to track this data as it updates once we've backfilled it
## HOW
Hook into the `ActivitySession` completion flow to increment this counter whenever a user completes a sesison

### Notion Card Links
https://www.notion.so/quill/Quill-LMS-shares-number-of-previously-completed-activities-per-tool-at-the-start-of-the-activity-de4db8fbe1c34664a4de189fca935eb4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
