### PR TITLE
Lms/update diagnostic copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Plural and possessive nouns, pronouns, verbs, adjectives, adverbs of manner, commas, prepositions, and capitalization",
+              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
             },
             Object {
               "key": "When",
@@ -28,7 +28,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=849"
+        buttonLink="/activity_sessions/anonymous?activity_id=1663"
         buttonText="Preview"
         header="Starter Diagnostic"
         imgAlt="page with a little writing"
@@ -40,7 +40,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and commonly confused words",
+              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
             },
             Object {
               "key": "When",
@@ -48,7 +48,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=850"
+        buttonLink="/activity_sessions/anonymous?activity_id=1668"
         buttonText="Preview"
         header="Intermediate Diagnostic"
         imgAlt="page with a medium amount of writing"
@@ -68,7 +68,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=888"
+        buttonLink="/activity_sessions/anonymous?activity_id=1678"
         buttonText="Preview"
         header="Advanced Diagnostic"
         imgAlt="page with a large amount of writing"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Plural and possessive nouns, pronouns, verbs, adjectives, adverbs of manner, commas, prepositions, and capitalization",
+              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
             },
             Object {
               "key": "When",
@@ -28,7 +28,7 @@ exports[`AssignADiagnostic component should render 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=849"
+        buttonLink="/activity_sessions/anonymous?activity_id=1663"
         buttonText="Preview"
         header="Starter Diagnostic"
         imgAlt="page with a little writing"
@@ -40,7 +40,7 @@ exports[`AssignADiagnostic component should render 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and commonly confused words",
+              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
             },
             Object {
               "key": "When",
@@ -48,7 +48,7 @@ exports[`AssignADiagnostic component should render 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=850"
+        buttonLink="/activity_sessions/anonymous?activity_id=1668"
         buttonText="Preview"
         header="Intermediate Diagnostic"
         imgAlt="page with a medium amount of writing"
@@ -68,7 +68,7 @@ exports[`AssignADiagnostic component should render 1`] = `
             },
           ]
         }
-        buttonLink="/activity_sessions/anonymous?activity_id=888"
+        buttonLink="/activity_sessions/anonymous?activity_id=1678"
         buttonText="Preview"
         header="Advanced Diagnostic"
         imgAlt="page with a large amount of writing"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -26,9 +26,9 @@ const PRE_AP_WRITINGS_SKILLS_2 = 'Pre-AP Writing Skills Survey 2'
 const AP_WRITINGS_SKILLS = 'AP Writing Skills Survey'
 const SPRING_BOARD_WRITINGS_SKILLS = 'SpringBoard Writing Skills Survey'
 
-const STARTER_DIAGNOSTIC_ACTIVITY_ID = 849
-const INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID = 850
-const ADVANCED_DIAGNOSTIC_ACTIVITY_ID = 888
+const STARTER_DIAGNOSTIC_ACTIVITY_ID = 1663
+const INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID = 1668
+const ADVANCED_DIAGNOSTIC_ACTIVITY_ID = 1678
 const ELL_STARTER_DIAGNOSTIC_ACTIVITY_ID = 1161
 const ELL_INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID = 1568
 const ELL_ADVANCED_DIAGNOSTIC_ACTIVITY_ID = 1590
@@ -49,7 +49,7 @@ const selectCard = (history: any, unitTemplateName: string, activityIdsArray: st
 const minis = ({ history }) => [
   (<AssignmentCard
     bodyArray={[
-      { key: 'What', text: 'Plural and possessive nouns, pronouns, verbs, adjectives, adverbs of manner, commas, prepositions, and capitalization', },
+      { key: 'What', text: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization', },
       { key: 'When', text: 'Your students are working on basic grammar concepts.', }
     ]}
     buttonLink={`/activity_sessions/anonymous?activity_id=${STARTER_DIAGNOSTIC_ACTIVITY_ID}`}
@@ -61,7 +61,7 @@ const minis = ({ history }) => [
   />),
   (<AssignmentCard
     bodyArray={[
-      { key: 'What', text: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and commonly confused words', },
+      { key: 'What', text: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization', },
       { key: 'When', text: 'Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.', }
     ]}
     buttonLink={`/activity_sessions/anonymous?activity_id=${INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID}`}


### PR DESCRIPTION
## WHAT
Change the `Activity` IDs and some minor copy around the three basic diagnostics since Curriculum has finished designing and grading new ones.
## WHY
We want teachers to assign the best Diagnostics we know how to make.
## HOW
Just swap out IDs and tweak copy, the rest relies on work that Curriculum has already done creating the diagnostics in question.

### Screenshots
![Screenshot 2021-07-29 163238](https://user-images.githubusercontent.com/331565/127561865-2a017d75-3ee3-4a50-9c0e-d24d03beb1c9.png)

### Notion Card Links
https://www.notion.so/quill/Copy-Request-Update-Diagnostic-assigning-flow-512f762f37604a1092ee08950bdc7416

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? |  Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
