### PR TITLE
comprehension/strip-model-id-whitespace

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/automl_model.rb
@@ -21,6 +21,8 @@ module Comprehension
     validates :name, presence: true
     validates :state, inclusion: {in: ['active', 'inactive']}
 
+    before_validation :strip_whitespace
+
     def serializable_hash(options = nil)
       options ||= {}
 
@@ -83,6 +85,10 @@ module Comprehension
       name
     end
 
+    private def strip_whitespace
+      self.automl_model_id = automl_model_id.strip unless automl_model_id.nil?
+    end
+
     private def prompt_automl_rules
       prompt.rules.where(rule_type: Rule::TYPE_AUTOML)
     end
@@ -115,7 +121,7 @@ module Comprehension
     end
 
     private def automl_model_full_id
-      @model_full_id ||= automl_client.model_path(project: ENV['AUTOML_GOOGLE_PROJECT_ID'], location: ENV['AUTOML_GOOGLE_LOCATION'], model: automl_model_id)
+      @model_full_id ||= automl_client.model_path(project: ENV['AUTOML_GOOGLE_PROJECT_ID'], location: ENV['AUTOML_GOOGLE_LOCATION'], model: automl_model_id.strip)
     end
 
     private def automl_labels

--- a/services/QuillLMS/engines/comprehension/spec/models/comprehension/automl_model_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/models/comprehension/automl_model_spec.rb
@@ -44,9 +44,10 @@ module Comprehension
 
       context '#before_validation' do
         it 'should strip whitespace from "automl_model_id"' do
-          automl_model = build(:comprehension_automl_model, automl_model_id: '  HAS_SPACES   ')
+          model_id = '   STRIP_ME   '
+          automl_model = build(:comprehension_automl_model, automl_model_id: model_id)
           automl_model.valid?
-          expect(automl_model.automl_model_id).to eq('HAS_SPACES')
+          expect(automl_model.automl_model_id).to eq(model_id.strip)
         end
       end
 


### PR DESCRIPTION
## WHAT
Strip white space from automl_model_id

Both in validation and when populating data from Google (which happens pre-validation)
## WHY
Sometimes when copying and pasting from other places, a user might accidentally provide an AutoML Model ID with extraneous spaces around it.  We want to make sure that we don't store or use the extra spaces.
## HOW
Add a `before_validation` call to strip whitespace from the value, and then make sure to explicitly also call `strip` when sending the value to Google because we do that before validation during initial creation.

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-ArgumentError-Comprehension-AutomlModelsController-create-80c9a456e3d0409695186bad8d44803d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
