### PR TITLE
Allow students to be imported if they were previously imported and their email changed

### DIFF
--- a/services/QuillLMS/app/services/google_integration/classroom/creators/classrooms.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/creators/classrooms.rb
@@ -1,8 +1,9 @@
 module GoogleIntegration::Classroom::Creators::Classrooms
 
   def self.run(teacher, courses)
-    courses.map{ |course| create_classroom(teacher, course) }
-           .compact
+    courses
+      .map { |course| create_classroom(teacher, course) }
+      .compact
   end
 
   def self.create_classroom(teacher, course)
@@ -16,5 +17,4 @@ module GoogleIntegration::Classroom::Creators::Classrooms
       classroom.reload
     classroom
   end
-
 end

--- a/services/QuillLMS/spec/services/google_integration/classroom/creators/students_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom/creators/students_spec.rb
@@ -1,52 +1,103 @@
 require 'rails_helper'
 
-describe 'GoogleIntegration::Classroom::Creators::Students' do
+describe GoogleIntegration::Classroom::Creators::Students do
 
-  def subject(classrooms, students_requester)
-    x = GoogleIntegration::Classroom::Creators::Students.run(classrooms, students_requester)
-    x.map(&:reload).map{ |y| { name: y.name, email: y.email } }
-  end
+  context '.run' do
+    def subject(classrooms, students_requester)
+      profiles = GoogleIntegration::Classroom::Creators::Students.run(classrooms, students_requester)
+      profiles.map(&:reload).map { |profile| { name: profile.name, email: profile.email } }
+    end
 
-  let!(:classroom) { create(:classroom) }
-  let!(:classrooms) { [classroom] }
+    let!(:classroom) { create(:classroom) }
+    let!(:classrooms) { [classroom] }
 
-  let!(:students_requester) do
-    lambda do |course_id|
-      x = [{
-          "profile": {
-              "id": "107708392406225674265",
-              "name": {
-                  "givenName": "test1_s1",
-                  "familyName": "s1",
-                  "fullName": "test1_s1 s1"
-              },
-              "emailAddress": "test1_s1@gedu.demo.rockerz.xyz"
-          }
-      }, {
-          "profile": {
-              "id": "2",
-              "name": {
-                  "givenName": "test1_s2",
-                  "familyName": "s2",
-                  "fullName": "test1_s2 s2"
-              },
-              "emailAddress": "test1_s2@gedu.demo.rockerz.xyz"
-          }
-      }]
-      body = JSON.parse(x.to_json)
+    let!(:students_requester) do
+      lambda do |course_id|
+        x = [{
+            "profile": {
+                "id": "107708392406225674265",
+                "name": {
+                    "givenName": "test1_s1",
+                    "familyName": "s1",
+                    "fullName": "test1_s1 s1"
+                },
+                "emailAddress": "test1_s1@gedu.demo.rockerz.xyz"
+            }
+        }, {
+            "profile": {
+                "id": "2",
+                "name": {
+                    "givenName": "test1_s2",
+                    "familyName": "s2",
+                    "fullName": "test1_s2 s2"
+                },
+                "emailAddress": "test1_s2@gedu.demo.rockerz.xyz"
+            }
+        }]
+        body = JSON.parse(x.to_json)
+      end
+    end
+
+    context 'no students have been previously created' do
+      let!(:expected) do
+        [
+          { name: 'Test1_s1 S1', email: 'test1_s1@gedu.demo.rockerz.xyz'},
+          { name: 'Test1_s2 S2', email: 'test1_s2@gedu.demo.rockerz.xyz'}
+        ]
+      end
+
+      it 'creates all the students' do
+        expect(subject(classrooms, students_requester)).to eq(expected)
+      end
     end
   end
 
-  context 'no students have been previously created' do
-    let!(:expected) do
-      [
-        { name: 'Test1_s1 S1', email: 'test1_s1@gedu.demo.rockerz.xyz'},
-        { name: 'Test1_s2 S2', email: 'test1_s2@gedu.demo.rockerz.xyz'}
-      ]
+  context '.update_existing_student_with_google_id_and_different_email' do
+    let!(:student) { create :student, google_id: '123' }
+    let(:orig_email) { student.email }
+    let(:data) { { email: email, google_id: google_id } }
+
+    subject do
+      described_class.update_existing_student_with_google_id_and_different_email(data)
+      student.reload
     end
 
-    it 'creates all the students' do
-      expect(subject(classrooms, students_requester)).to eq(expected)
+    context 'no student exists with google_id' do
+      let(:google_id) { '456' }
+      let(:email) { orig_email }
+
+      it 'does not update the email' do
+        expect { subject }.to_not change(student, :email)
+      end
+    end
+
+    context 'student exists with google_id and same email as data[:email]' do
+      let(:google_id) { '123' }
+      let(:email) { orig_email }
+
+      it 'does not update the email' do
+        expect { subject }.to_not change(student, :email)
+      end
+    end
+
+    context 'student exists with google_id but different email than data[:email]' do
+      let(:different_email) { 'different_' + orig_email }
+      let(:google_id) { '123' }
+      let(:email) { different_email }
+
+      it 'updates the email' do
+        expect { subject }.to change(student, :email).from(orig_email).to(different_email)
+      end
+
+      context 'a different user exists with data[:email]' do
+        let!(:another_student) { create :student, email: different_email }
+
+        it 'does not update the email' do
+          expect { subject }.to_not change(student, :email)
+        end
+      end
     end
   end
 end
+
+


### PR DESCRIPTION
## WHAT
If a student's email address is changed but their google_id is not, our system will not import that student into newer classrooms since there will be a uniqueness violation with the google_id.

## WHY
We'd like to be able to import students into classrooms even when their email domain changes.

## HOW
The [edge case](https://github.com/empirical-org/Empirical-Core/blob/bs-google-classroom-student-email-change/services/QuillLMS/app/services/google_integration/classroom/creators/students.rb#L78) that needs to be handled before proceeding with pre-existing code is if a user exists in the database with the the given google_id given and a different email than the given email address, then update the email address with the given one.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-Previously-imported-students-can-t-be-added-to-a-new-classroom-if-their-email-was--74b24a813ed5477cbaf32387ac4a3cc6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
