### PR TITLE
Bug-fix/ incorrect sequences

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -19,7 +19,7 @@ class IncorrectSequencesContainer extends Component {
     const question = props[questionType].data[props.match.params.questionID]
     const incorrectSequences = this.getSequences(question)
 
-    this.state = { orderedIds: null, questionType, actionFile, questionTypeLink, incorrectSequences, newSequenceSet: false };
+    this.state = { orderedIds: null, questionType, actionFile, questionTypeLink, incorrectSequences };
   }
 
   componentDidMount() {
@@ -126,7 +126,6 @@ class IncorrectSequencesContainer extends Component {
   }
 
   addNewSequence = (e, key) => {
-    console.log('adding new sequence')
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}|||`;

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -19,7 +19,7 @@ class IncorrectSequencesContainer extends Component {
     const question = props[questionType].data[props.match.params.questionID]
     const incorrectSequences = this.getSequences(question)
 
-    this.state = { orderedIds: null, questionType, actionFile, questionTypeLink, incorrectSequences };
+    this.state = { orderedIds: null, questionType, actionFile, questionTypeLink, incorrectSequences, newSequenceSet: false };
   }
 
   componentDidMount() {
@@ -37,7 +37,7 @@ class IncorrectSequencesContainer extends Component {
     const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
     const incorrectSequences = this.getSequences(question)
 
-    if (previousState.incorrectSequences === incorrectSequences) return;
+    if (_.isEqual(previousState.incorrectSequences, incorrectSequences)) return;
 
     this.setState({ incorrectSequences, });
   }
@@ -126,6 +126,7 @@ class IncorrectSequencesContainer extends Component {
   }
 
   addNewSequence = (e, key) => {
+    console.log('adding new sequence')
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}|||`;

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -37,9 +37,9 @@ class IncorrectSequencesContainer extends Component {
     const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
     const incorrectSequences = this.getSequences(question)
 
-    if (_.isEqual(previousState.incorrectSequences, incorrectSequences)) return;
-
-    this.setState({ incorrectSequences, });
+    if (!_.isEqual(previousState.incorrectSequences, incorrectSequences)) {
+      this.setState({ incorrectSequences, });
+    };
   }
 
   getSequences = (question) => {


### PR DESCRIPTION
## WHAT
fix an issue with the incorrect sequences section not loading in Connect

## WHY
so Curriculum can access this part of the tool

## HOW
wrap setState in conditional and use lodash to do deep equality check of `previousState.incorrectSequences` and `incorrectSequences`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Incorrect-Sequence-page-is-blank-2e592547bfb64a01a2ac967e2b069fd9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
