### PR TITLE
Warn admin if they are about to break a translation mapping

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -77,7 +77,10 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
   }
 
   warnTitleChange = (titleChanged) => {
-    if (titleChanged) {
+    const { match } = this.props
+    const { params } = match
+    const { titleCardID } = params
+    if (titleCardID && titleChanged) {
       return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
     }
     return true

--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -7,8 +7,7 @@ import _ from 'lodash'
 
 interface TitleCardFormState {
   title: string,
-  content: string,
-  titleChanged: boolean
+  content: string
 }
 
 export interface TitleCardFormProps {
@@ -31,14 +30,12 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
       const { title, content } = titleCard
       this.state = {
         content: content ? content : '',
-        title: title ? title : '',
-        titleChanged: false,
+        title: title ? title : ''
       }
     } else {
       this.state = {
         title: '',
-        content: '',
-        titleChanged: false
+        content: ''
       }
     }
   }
@@ -64,30 +61,17 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
     const { dispatch, match, submit } = this.props
     const { params } = match
     const { titleCardID } = params
-    const { titleChanged } = this.state
-    if (this.warnTitleChange(titleChanged)) {
-      if (submit) {
-        submit(this.state)
-      } else if (titleCardID) {
-        dispatch(titleCardActions.submitTitleCardEdit(titleCardID, this.state))
-      } else {
-        dispatch(titleCardActions.submitNewTitleCard(this.state))
-      }
+    if (submit) {
+      submit(this.state)
+    } else if (titleCardID) {
+      dispatch(titleCardActions.submitTitleCardEdit(titleCardID, this.state))
+    } else {
+      dispatch(titleCardActions.submitNewTitleCard(this.state))
     }
-  }
-
-  warnTitleChange = (titleChanged) => {
-    const { match } = this.props
-    const { params } = match
-    const { titleCardID } = params
-    if (titleCardID && titleChanged) {
-      return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
-    }
-    return true
   }
 
   handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    this.setState({title: e.target.value, titleChanged: true})
+    this.setState({title: e.target.value})
   }
 
   handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -7,7 +7,8 @@ import _ from 'lodash'
 
 interface TitleCardFormState {
   title: string,
-  content: string
+  content: string,
+  titleChanged: boolean
 }
 
 export interface TitleCardFormProps {
@@ -30,12 +31,14 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
       const { title, content } = titleCard
       this.state = {
         content: content ? content : '',
-        title: title ? title : ''
+        title: title ? title : '',
+        titleChanged: false,
       }
     } else {
       this.state = {
         title: '',
-        content: ''
+        content: '',
+        titleChanged: false
       }
     }
   }
@@ -61,17 +64,27 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
     const { dispatch, match, submit } = this.props
     const { params } = match
     const { titleCardID } = params
-    if (submit) {
-      submit(this.state)
-    } else if (titleCardID) {
-      dispatch(titleCardActions.submitTitleCardEdit(titleCardID, this.state))
-    } else {
-      dispatch(titleCardActions.submitNewTitleCard(this.state))
+    const { titleChanged } = this.state
+    if (this.warnTitleChange(titleChanged)) {
+      if (submit) {
+        submit(this.state)
+      } else if (titleCardID) {
+        dispatch(titleCardActions.submitTitleCardEdit(titleCardID, this.state))
+      } else {
+        dispatch(titleCardActions.submitNewTitleCard(this.state))
+      }
     }
   }
 
+  warnTitleChange = (titleChanged) => {
+    if (titleChanged) {
+      return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
+    }
+    return true
+  }
+
   handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    this.setState({title: e.target.value})
+    this.setState({title: e.target.value, titleChanged: true})
   }
 
   handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -78,7 +78,10 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
   }
 
   warnTitleChange = (titleChanged) => {
-    if (titleChanged) {
+    const { match } = this.props
+    const { params } = match
+    const { titleCardID } = params
+    if (titleCardID && titleChanged) {
       return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
     }
     return true

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -5,6 +5,7 @@ import {
   submitNewTitleCard,
   submitTitleCardEdit
 } from '../../actions/titleCards'
+import { commonText } from '../../modules/translation/commonText';
 import {
   hashToCollection,
   TextEditor
@@ -65,9 +66,9 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
     const { dispatch, history, match } = this.props
     const { params } = match
     const { titleCardID } = params
-    const { titleChanged } = this.state
+    const { title, titleChanged } = this.state
     // TODO: fix add/edit title card action to show new/updated title card without refreshing
-    if (this.warnTitleChange(titleChanged)) {
+    if (this.warnTitleChange(title, titleChanged)) {
       if (titleCardID) {
         dispatch(submitTitleCardEdit(titleCardID, this.state))
       } else {
@@ -77,12 +78,13 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
     }
   }
 
-  warnTitleChange = (titleChanged) => {
+  warnTitleChange = (title, titleChanged) => {
     const { match } = this.props
     const { params } = match
     const { titleCardID } = params
-    if (titleCardID && titleChanged) {
-      return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
+    const translationMappingMissing = commonText[title] == undefined
+    if (titleCardID && titleChanged && translationMappingMissing) {
+      return confirm(`Making this change will break the translation mapping because "${title}" does not yet exist on the mappings. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?`)
     }
     return true
   }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -14,7 +14,8 @@ import _ from 'lodash'
 
 interface TitleCardFormState {
   title: string,
-  content: string
+  content: string,
+  titleChanged: boolean
 }
 
 export interface TitleCardFormProps {
@@ -35,12 +36,14 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
       const titleCard = props.titleCards.data[titleCardID]
       this.state = {
         content: titleCard && titleCard.content ? titleCard.content : '',
-        title: titleCard && titleCard.title ? titleCard.title : ''
+        title: titleCard && titleCard.title ? titleCard.title : '',
+        titleChanged: false,
       }
     } else {
       this.state = {
         title: '',
-        content: ''
+        content: '',
+        titleChanged: false,
       }
     }
   }
@@ -62,17 +65,27 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
     const { dispatch, history, match } = this.props
     const { params } = match
     const { titleCardID } = params
+    const { titleChanged } = this.state
     // TODO: fix add/edit title card action to show new/updated title card without refreshing
-    if (titleCardID) {
-      dispatch(submitTitleCardEdit(titleCardID, this.state))
-    } else {
-      dispatch(submitNewTitleCard(this.state))
+    if (this.warnTitleChange(titleChanged)) {
+      if (titleCardID) {
+        dispatch(submitTitleCardEdit(titleCardID, this.state))
+      } else {
+        dispatch(submitNewTitleCard(this.state))
+      }
+      history.push(`/admin/title-cards`)
     }
-    history.push(`/admin/title-cards`)
+  }
+
+  warnTitleChange = (titleChanged) => {
+    if (titleChanged) {
+      return confirm("Making this change may break the translation mapping. Make a request on the support board to change the translation mapping before making this change. Are you sure you want to proceed?")
+    }
+    return true
   }
 
   handleTitleChange = (e) => {
-    this.setState({title: e.target.value})
+    this.setState({title: e.target.value, titleChanged: true})
   }
 
   handleContentChange = (e) => {


### PR DESCRIPTION
## WHAT
We [had a bug](https://www.notion.so/quill/ELL-Diagnostic-1-timeout-on-question-7-d8f8b3819f254b2089dc77a6148dc608) where admin changes to a Title Card title broke an activity. This is the long-term fix -- warn admin before they change a diagnostic activity's title. Direct them to work with Support Dev to update the translation mappings before they make a breaking change.

## WHY
To avoid this bug happening again.

## HOW
Before admin change the title of a Diagnostic activity, show them a warning that tells them this change will break the translation mapping. Direct them to engineering first to change the translation mappings.

### Screenshots
<img width="510" alt="Screen Shot 2021-07-30 at 10 53 13 AM" src="https://user-images.githubusercontent.com/57366100/127693377-59ca5493-828b-4197-84b9-430f8f931b5d.png">

### Notion Card Links
https://www.notion.so/quill/ELL-title-card-errors-New-Error-Message-to-Prevent-Activity-Title-Card-Errors-37790c0d807d48b3a31d9e9bb9f7c7a0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small change.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
