### PR TITLE
lms/fix-unit-template-admin-alignment

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/cms_unit_templates.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/cms_unit_templates.scss
@@ -22,6 +22,9 @@
     .list {
       background-color: white;
       .list-item {
+        display: inherit;
+        width: auto;
+        margin-left: 0px;
         padding: 6px;
         border-bottom: 1px solid #cecece;
         justify-content: space-between;


### PR DESCRIPTION
## WHAT
Have an override CSS specification for admin-only sortable lists
## WHY
We made these base changes to the `list-item` class because it's necessary for the styling we did for teacher sortable classrooms.  However, while this styling looks really good on those pages, it makes these pages look a lot worse.
## HOW
For technical reasons tied to the framework we're using, we can't modify the base class to resolve this issue and need to write a more specific selector to clobber the changes specifically in the CMS.

### Screenshots
Original code, with the issue
![image](https://user-images.githubusercontent.com/331565/127706839-7d08b312-3d6c-4a73-9588-9a584b2972ab.png)
New code, issue corrected
![image](https://user-images.githubusercontent.com/331565/127706881-d2c25445-9097-46a3-8fe5-e21fd14951a2.png)

### Notion Card Links
https://www.notion.so/quill/Activity-Pack-Editor-page-displaying-weirdly-7576190e644e46c5999f03ed89ad4621

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Style-only changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
