### PR TITLE
LMS - Fix 500s that should be 404s

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -53,8 +53,6 @@ class ApplicationController < ActionController::Base
   end
 
   def routing_error(error = 'Routing error', status = :not_found, exception=nil)
-    @current_user = current_user
-    #if current_user == nil render_error(404) : render_error()
     render_error(404)
   end
 
@@ -66,8 +64,8 @@ class ApplicationController < ActionController::Base
       # falsely flags lack of content-type headers in responses to routes that end
       # in ".js" as a class of responses that need CORS protection and 500s when
       # attempting to serve a 404.  So, we set the content_type to 'text/html'.
-      format.js { render nothing: true, status: status, content_type: 'text/html' }
-      format.all { render nothing: true, status: status }
+      format.js { render head: :not_found, body: nil, status: status, content_type: 'text/html' }
+      format.any { render head: :not_found, body: nil, status: status }
     end
   end
 

--- a/services/QuillLMS/spec/requests/file_not_found_spec.rb
+++ b/services/QuillLMS/spec/requests/file_not_found_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Missing files', type: :request do
+
+  it 'should return a 404' do
+    get '/file_does_not_exist.php'
+
+    expect(response.status).to eq 404
+  end
+end


### PR DESCRIPTION
## WHAT
Since we upgraded to Rails 5.1, we've been returning a `500` for files that aren't found when it should be a `404`. This is a fix to return the correct status.
## WHY
These additional `500`s are throwing off our error reporting and causing spurious alarms. Using the proper status code of `404` will stop that.
## HOW
Rails deprecated `render nothing: true`, changing to `head: :not_found, body: nil`
```
DEPRECATION WARNING: :nothing option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.
```

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
