### PR TITLE
lms/fix-homepage-spacing-for-phones

### DIFF
--- a/services/QuillLMS/client/app/assets/styles/home.scss
+++ b/services/QuillLMS/client/app/assets/styles/home.scss
@@ -291,7 +291,7 @@ $background-images-list: (diagnostic-pattern-magnifier connect-pattern-bullseye 
 
 section.q-hero {
   width: 100%;
-  height: 530px;
+  min-height: 530px;
   background-image: url(../../../../public/images/homepage/homepage_pattern.png);
   background-position: center center;
   .navbar {


### PR DESCRIPTION
## WHAT
Tweak style for homepage to work on very narrow screens
## WHY
As we've added more buttons for users to click on at the top of the web page ("student", "teacher", "guardian", "administrator"), they take up more vertical space on narrow (phone) screens when they move from a row to a stack.  The old style had a maximum height that we now exceed in specific cases.
## HOW
Change the `height` style to `min-height` instead.

### Screenshots
Connect animation box pushed up into the sections counting students and sentences:
![image](https://user-images.githubusercontent.com/331565/127712040-a1d84ed0-9286-442c-b898-707ab7bd49d1.png)
Connect animation properly staying in its separate section even when the viewport is very narrow:
![image](https://user-images.githubusercontent.com/331565/127712591-520b360b-f2e7-4b8c-bf4d-858ecdd7349a.png)

### Notion Card Links
https://www.notion.so/quill/Home-page-style-is-messed-up-on-Mobile-1817e93a1b8146f99190019447592a3f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just a style change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
