### PR TITLE
setting more secure HTTP cache headers

### DIFF
--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -1,6 +1,5 @@
 class AccountsController < ApplicationController
   before_action :signed_in!, only: [:edit, :update]
-  before_action :set_cache_buster, only: [:new]
   before_action :set_user, only: [:create]
 
   def new

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   end
 
   def show_errors
-    status = env["PATH_INFO"][1..-1]
+    status = env['PATH_INFO'][1..-1]
     render_error(status)
   end
 
@@ -61,7 +61,7 @@ class ApplicationController < ActionController::Base
       # So technically we shouldn't really be setting the content-type header
       # in a content-less error response at all, but CORS security logic in Rails
       # falsely flags lack of content-type headers in responses to routes that end
-      # in ".js" as a class of responses that need CORS protection and 500s when
+      # in '.js' as a class of responses that need CORS protection and 500s when
       # attempting to serve a 404.  So, we set the content_type to 'text/html'.
       format.js { render head: :not_found, body: nil, status: status, content_type: 'text/html' }
       format.any { render head: :not_found, body: nil, status: status }
@@ -76,7 +76,7 @@ class ApplicationController < ActionController::Base
   def login_failure(error)
     @user = User.new
     flash[:error] = error
-    redirect_to "/session/new"
+    redirect_to '/session/new'
   end
 
   def default_params
@@ -113,9 +113,9 @@ class ApplicationController < ActionController::Base
   end
 
   protected def set_default_cache_security_headers
-    response.headers['Cache-Control'] = "no-cache, no-store, max-age=0, must-revalidate"
-    response.headers['Pragma'] = "no-cache"
-    response.headers['Expires'] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end
 
   protected def set_raven_context

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -17,10 +17,9 @@ class ApplicationController < ActionController::Base
   #helper CMS::Helper
   helper SegmentioHelper
 
-  # FIXME: disabled till it's clear what this does
-  # before_action :setup_visitor
   before_action :set_raven_context
   before_action :confirm_valid_session
+  before_action :set_default_cache_security_headers
 
   def admin!
     return if current_user.try(:admin?)
@@ -69,13 +68,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def setup_visitor
-    return true if signed_in?
-
-    # FIXME: ??
-    # sign_in(User.create_visitor)
-  end
-
   def login_failure_message
     login_failure 'Incorrect username/email or password'
   end
@@ -120,10 +112,10 @@ class ApplicationController < ActionController::Base
      response.headers['Vary'] = 'Accept'
   end
 
-  protected def set_cache_buster
-    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  protected def set_default_cache_security_headers
+    response.headers['Cache-Control'] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers['Pragma'] = "no-cache"
+    response.headers['Expires'] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
   protected def set_raven_context
@@ -176,4 +168,5 @@ class ApplicationController < ActionController::Base
     diff = now - timestamp
     diff.round.abs
   end
+
 end

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -5,7 +5,6 @@ class SessionsController < ApplicationController
   CLEAR_ANALYTICS_SESSION_KEY = "clear_analytics_session"
 
   before_action :signed_in!, only: [:destroy]
-  before_action :set_cache_buster, only: [:new]
 
   def create
     email_or_username = params[:user][:email].downcase.strip unless params[:user][:email].nil?

--- a/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/accounts_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe AccountsController, type: :controller do
   it { should use_before_action :signed_in! }
-  it { should use_before_action :set_cache_buster }
 
   let(:user) { create(:user) }
 

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe SessionsController, type: :controller do
   it { should use_before_action :signed_in! }
-  it { should use_before_action :set_cache_buster }
 
   describe '#create' do
     let!(:user) { create(:user) }

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -22,4 +22,10 @@ describe DummyController, type: :request do
     get '/dummy'
     expect(response.header['Set-Cookie']).to match('HttpOnly')
   end
+
+  it 'should set cache control headers' do 
+    get '/dummy'
+    expect(response.header['Cache-Control']).to match('no-cache, no-store, max-age=0, must-revalidate')
+    expect(response.header['Pragma']).to match('no-cache')
+  end
 end


### PR DESCRIPTION
## WHAT
Aligns LMS with CB's caching recommendation. Because our assets are served by a webserver and not Rails, our asset routes implicitly avoid these new cache controls, which is the desired behavior.

## WHY
So that private information does not get stored in user browsers (an attack vector)

## HOW
Set stricter cache headers for all non-asset requests. 


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Cacheable-HTTPS-Content-e35a42c3ffef4e0994be33399ab014de

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A
