### PR TITLE
Add Hover Text over Google/Clever classrooms name

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom.tsx
@@ -57,15 +57,28 @@ export default class Classroom extends React.Component<ClassroomProps, Classroom
 
   renderClassType() {
     const { classroom } = this.props
-    if (!classroom.google_classroom_id && !classroom.clever_id) { return }
+    const { name, synced_name } = classroom
 
     const text = classroom.google_classroom_id ? 'Google Classroom' : 'Clever Classroom'
 
-    return (<React.Fragment>
-      <span className="item">{text}</span>
-      <span className="bullet item">•</span>
-    </React.Fragment>)
+    if (synced_name === null || synced_name === name) {  return text }
+
+    return (
+      <Tooltip
+        tooltipText={`Source: ${synced_name}`}
+        tooltipTriggerText={
+          <div className="text-and-icon-wrapper">
+            <span>{text}&nbsp;</span>
+            <img
+              alt={helpIcon.alt}
+              src={helpIcon.src}
+            />
+          </div>
+        }
+      />
+    )
   }
+
 
   renderClassCode() {
     const { classroom } = this.props
@@ -98,18 +111,20 @@ export default class Classroom extends React.Component<ClassroomProps, Classroom
 
   renderClassroomData() {
     const { classroom } = this.props
+    const { clever_id, google_classroom_id } = classroom
     const numberOfStudents = classroom.students.length
     const numberOfTeachers = classroom.teachers.length
     const createdAt = moment(classroom.created_at).format('MMM D, YYYY')
     const updatedAt = moment(classroom.updated_at).format('MMM D, YYYY')
     const archivedDate = classroom.visible ? null : [<span className="bullet item">•</span>, <span className="item">Archived {updatedAt}</span>]
     const coteachers = numberOfTeachers > 1 ? [<span className="item">{numberOfTeachers - 1} {numberOfTeachers === 2 ? 'co-teacher' : 'co-teachers'}</span>, <span className="bullet item">•</span>] : null
+    const classType = (google_classroom_id || clever_id) ? [<span className="item">{this.renderClassType()}</span>, <span className="bullet item">•</span>] : null
 
     return (<div className="classroom-data">
       <span className="item">{numberOfStudents} {numberOfStudents === 1 ? 'student' : 'students'}</span>
       <span className="bullet item">•</span>
       {coteachers}
-      {this.renderClassType()}
+      {classType}
       <span className="item">{this.renderClassCode()}</span>
       <span className="bullet item">•</span>
       <span className="item">{this.renderGrade()}</span>


### PR DESCRIPTION
## WHAT
Add hover text over classrooms that have a different name than the one found on Google Classroom or Clever servers.

## WHY
For greater visibility, teachers should be able to see the original name of the classroom.

## HOW
Add hover text over Google Classroom or Clever Classroom text by checking if synced_name and name are different on a particular classroom.

### Screenshots
![Screen Shot 2021-08-13 at 11 09 48 AM](https://user-images.githubusercontent.com/2057805/129379206-15e21f70-1da5-49c5-8032-d4ca18097e85.png)

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-and-Clever-Standardize-and-improve-how-we-handle-renaming-of-classes-that-are-sync-fb81d68ded994f4cb76db9758f379704

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested.  Extensive backend tests in #8054 and #8044
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | YES
