### PR TITLE
lms/update-diagnostic-copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
+              "text": "Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
             },
             Object {
               "key": "When",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
+              "text": "What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
             },
             Object {
               "key": "When",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
+              "text": "What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
             },
             Object {
               "key": "When",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AssignADiagnostic component should render 1`] = `
           Array [
             Object {
               "key": "What",
-              "text": "What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
+              "text": "Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
             },
             Object {
               "key": "When",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -49,7 +49,7 @@ const selectCard = (history: any, unitTemplateName: string, activityIdsArray: st
 const minis = ({ history }) => [
   (<AssignmentCard
     bodyArray={[
-      { key: 'What', text: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization', },
+      { key: 'What', text: 'What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words', },
       { key: 'When', text: 'Your students are working on basic grammar concepts.', }
     ]}
     buttonLink={`/activity_sessions/anonymous?activity_id=${STARTER_DIAGNOSTIC_ACTIVITY_ID}`}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -49,7 +49,7 @@ const selectCard = (history: any, unitTemplateName: string, activityIdsArray: st
 const minis = ({ history }) => [
   (<AssignmentCard
     bodyArray={[
-      { key: 'What', text: 'What: Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words', },
+      { key: 'What', text: 'Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words', },
       { key: 'When', text: 'Your students are working on basic grammar concepts.', }
     ]}
     buttonLink={`/activity_sessions/anonymous?activity_id=${STARTER_DIAGNOSTIC_ACTIVITY_ID}`}


### PR DESCRIPTION
## WHAT
Tweak Starter Diagnostic copy that was wrong
## WHY
Somehow we assigned the copy for the Intermediate diagnostic to both Intermediate and Starter when what we really wanted was this copy for Starter
## HOW
Just update the copy in the `AssignmentCard` for the starter diagnostic

### Screenshots
![image](https://user-images.githubusercontent.com/331565/128041664-47780217-6471-4ad0-8dd4-0317e89f4702.png)

### Notion Card Links
https://www.notion.so/quill/Copy-Request-Update-Diagnostic-assigning-flow-512f762f37604a1092ee08950bdc7416

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
