### PR TITLE
adding nil guard to address sentry error

### DIFF
--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -44,6 +44,7 @@ class AppSetting < ApplicationRecord
 
   def enabled_for_user?(user)
     return false unless enabled
+    return false unless user
 
     return true if enabled_for_staff && user.staff?
 

--- a/services/QuillLMS/spec/models/app_setting_spec.rb
+++ b/services/QuillLMS/spec/models/app_setting_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe AppSetting, type: :model do
 
     end
 
+    context 'user is nil' do 
+      let(:app_setting_1) { create(:app_setting, percent_active: 100, enabled: true) }
+
+      it 'should return false' do
+        expect(app_setting_1.enabled_for_user?(nil)).to be false
+      end
+    end
+
     context 'override is true, staff is true' do
       let(:app_setting_1) { create(:app_setting, percent_active: 0, enabled: true, enabled_for_staff: true) }
 


### PR DESCRIPTION
## WHAT
Addresses sentry error 

## WHY
We don't want spurious errors or impeded functionality due to errors.

## HOW
Adds nil guard around current user for `AppSetting#enabled_for_user`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Api-V1-AppSettingsController-show-NoMethodError-235c43c345d84230b7dcfd992419883d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | (N/A
