### PR TITLE
Add synced_name attr to classroom table

### DIFF
--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -7,6 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
+#  source              :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -7,7 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
-#  source              :string
+#  synced_name         :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime

--- a/services/QuillLMS/app/serializers/classroom_serializer.rb
+++ b/services/QuillLMS/app/serializers/classroom_serializer.rb
@@ -7,6 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
+#  source              :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime

--- a/services/QuillLMS/app/serializers/classroom_serializer.rb
+++ b/services/QuillLMS/app/serializers/classroom_serializer.rb
@@ -7,7 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
-#  source              :string
+#  synced_name         :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime

--- a/services/QuillLMS/db/migrate/20210803163028_add_source_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20210803163028_add_source_to_classrooms.rb
@@ -1,5 +1,0 @@
-class AddSourceToClassrooms < ActiveRecord::Migration[5.1]
-  def change
-    add_column :classrooms, :source, :string
-  end
-end

--- a/services/QuillLMS/db/migrate/20210803163028_add_source_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20210803163028_add_source_to_classrooms.rb
@@ -1,0 +1,5 @@
+class AddSourceToClassrooms < ActiveRecord::Migration[5.1]
+  def change
+    add_column :classrooms, :source, :string
+  end
+end

--- a/services/QuillLMS/db/migrate/20210803163028_add_synced_name_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20210803163028_add_synced_name_to_classrooms.rb
@@ -1,0 +1,5 @@
+class AddSyncedNameToClassrooms < ActiveRecord::Migration[5.1]
+  def change
+    add_column :classrooms, :synced_name, :string
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1131,7 +1131,7 @@ CREATE TABLE public.classrooms (
     visible boolean DEFAULT true NOT NULL,
     google_classroom_id bigint,
     grade_level integer,
-    source character varying
+    synced_name character varying
 );
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -938,7 +938,7 @@ CREATE TABLE public.change_logs (
     action character varying NOT NULL,
     changed_record_id integer,
     changed_record_type character varying NOT NULL,
-    user_id integer NOT NULL,
+    user_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     changed_attribute character varying,
@@ -1130,7 +1130,8 @@ CREATE TABLE public.classrooms (
     grade character varying,
     visible boolean DEFAULT true NOT NULL,
     google_classroom_id bigint,
-    grade_level integer
+    grade_level integer,
+    source character varying
 );
 
 
@@ -1166,7 +1167,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
-    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
+    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
 );
 
 
@@ -1377,7 +1378,8 @@ CREATE TABLE public.comprehension_passages (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     image_link character varying,
-    image_alt_text character varying DEFAULT ''::character varying
+    image_alt_text character varying DEFAULT ''::character varying,
+    highlight_prompt character varying
 );
 
 
@@ -7385,6 +7387,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210614205654'),
 ('20210709155935'),
 ('20210709161400'),
-('20210726193112');
+('20210712213724'),
+('20210722144950'),
+('20210726193112'),
+('20210803163028');
 
 

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -7,6 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
+#  source              :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -7,7 +7,7 @@
 #  grade               :string
 #  grade_level         :integer
 #  name                :string
-#  source              :string
+#  synced_name         :string
 #  visible             :boolean          default(TRUE), not null
 #  created_at          :datetime
 #  updated_at          :datetime


### PR DESCRIPTION
## WHAT
Add a new string attribute `synced_name` to the `classrooms` table.

## WHY
Teachers have the ability to rename a course on Quill but sometimes we'd like to keep track of the original name of the classroom if it's synced with Google Classroom or Clever.  This field will store the original 'synced_name' of the classroom.

## HOW
Add a migration file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
Preparation for: https://www.notion.so/quill/Google-Classroom-and-Clever-Standardize-and-improve-how-we-handle-renaming-of-classes-that-are-sync-fb81d68ded994f4cb76db9758f379704

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just a new column in database.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
