### PR TITLE
comprehension/show-last-optimal-feedback

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/feedback.tsx
@@ -38,8 +38,6 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
         Feedback<span>{submittedResponses.length} of {prompt.max_attempts} attempts</span>
       </p>
       <ReactCSSTransitionReplace
-        transitionAppear={true}
-        transitionAppearTimeout={400}
         transitionEnterTimeout={1000}
         transitionLeaveTimeout={400}
         transitionName="fade"

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -256,8 +256,7 @@ exports[`PromptStep component active state when a profane response has been subm
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -272,8 +271,7 @@ exports[`PromptStep component active state when a profane response has been subm
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -453,8 +451,7 @@ exports[`PromptStep component active state when a response with multiple sentenc
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -469,8 +466,7 @@ exports[`PromptStep component active state when a response with multiple sentenc
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -679,8 +675,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -688,29 +683,14 @@ exports[`PromptStep component active state when a suboptimal response has been s
                 transitionName="fade"
               >
                 <div
-                  style={
-                    Object {
-                      "overflow": "hidden",
-                      "position": "relative",
-                    }
-                  }
+                  style={Object {}}
                 >
                   <span
                     key="1"
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                        "userSelect": "none",
-                      }
-                    }
+                    style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -890,8 +870,7 @@ exports[`PromptStep component active state when a too-long response has been sub
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -906,8 +885,7 @@ exports[`PromptStep component active state when a too-long response has been sub
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -1087,8 +1065,7 @@ exports[`PromptStep component active state when a too-short response has been su
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -1103,8 +1080,7 @@ exports[`PromptStep component active state when a too-short response has been su
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -1301,8 +1277,7 @@ exports[`PromptStep component active state when an optimal response has been sub
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -1310,29 +1285,14 @@ exports[`PromptStep component active state when an optimal response has been sub
                 transitionName="fade"
               >
                 <div
-                  style={
-                    Object {
-                      "overflow": "hidden",
-                      "position": "relative",
-                    }
-                  }
+                  style={Object {}}
                 >
                   <span
                     key="1"
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                        "userSelect": "none",
-                      }
-                    }
+                    style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -1585,8 +1545,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -1601,8 +1560,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}
@@ -1801,8 +1759,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                 component="div"
                 notifyLeaving={false}
                 overflowHidden={true}
-                transitionAppear={true}
-                transitionAppearTimeout={400}
+                transitionAppear={false}
                 transitionEnter={true}
                 transitionEnterTimeout={1000}
                 transitionLeave={true}
@@ -1817,8 +1774,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                     style={null}
                   >
                     <CSSTransitionGroupChild
-                      appear={true}
-                      appearTimeout={400}
+                      appear={false}
                       enter={true}
                       enterTimeout={1000}
                       leave={true}


### PR DESCRIPTION
## WHAT
Tweak fade-in animation to work properly with final prompt
## WHY
This was failing in for final prompt, failing to show the final optimal feedback for 20 seconds.  The delay was long enough to make it appear like the feedback was never appearing at all.  (Thanks for helping me chase this one down, @emilia-friedberg 
## HOW
Remove the `appear`-related attributes from the config of the `ReactCSSTransitionReplace` object.  This does make the animation slightly less smooth, but does seem to resolve the issue as multiple renders on the page don't seem to extend how long it takes before the item appears.

### Notion Card Links
https://www.notion.so/quill/Final-optimal-so-feedback-doesn-t-appear-47714eb22cc343c08cbdf3750292d6ad

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes