### PR TITLE
comprehension/provide-highlights-for-regex

### DIFF
--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
@@ -50,7 +50,7 @@ module Comprehension
     private def highlights
       return [] unless feedback&.highlights
 
-      feedback&.highlights.map do |h|
+      feedback&.highlights&.map do |h|
         {
           type: h.highlight_type,
           text: h.text,

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
@@ -20,7 +20,7 @@ module Comprehension
         entry: @entry,
         concept_uid: matched_rule&.concept_uid || '',
         rule_uid: matched_rule&.uid || optimal_rule_uid,
-        highlight: feedback&.highlights || []
+        highlight: highlights
       }
     end
 
@@ -45,6 +45,18 @@ module Comprehension
 
     private def matched_rule
       @matched_rule ||= first_failing_regex_rule
+    end
+
+    private def highlights
+      return [] unless feedback&.highlights
+
+      feedback&.highlights.map do |h|
+        {
+          type: h.highlight_type,
+          text: h.text,
+          category: ''
+        }
+      end
     end
 
     private def first_failing_regex_rule

--- a/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension/comprehension/regex_check.rb
@@ -13,14 +13,14 @@ module Comprehension
 
     def feedback_object
       {
-        feedback: feedback,
+        feedback: feedback_text,
         feedback_type: @rule_type,
         optimal: matched_rule.blank?,
         response_id: '',
         entry: @entry,
         concept_uid: matched_rule&.concept_uid || '',
         rule_uid: matched_rule&.uid || optimal_rule_uid,
-        highlight: []
+        highlight: feedback&.highlights || []
       }
     end
 
@@ -35,8 +35,12 @@ module Comprehension
     end
 
     private def feedback
+      matched_rule&.feedbacks&.first
+    end
+
+    private def feedback_text
       return ALL_CORRECT_FEEDBACK unless matched_rule
-      matched_rule&.feedbacks&.first&.text
+      feedback&.text
     end
 
     private def matched_rule

--- a/services/QuillLMS/engines/comprehension/spec/lib/regex_check_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/lib/regex_check_spec.rb
@@ -52,6 +52,21 @@ module Comprehension
         feedback = regex_check.feedback_object
         expect(rule.uid).to(eq(feedback[:rule_uid]))
       end
+
+      it 'should include any highlights that are attached to the feedback it returns' do
+        highlight = create(:comprehension_highlight, feedback: feedback)
+        entry = "Test this is a good regex match"
+        regex_check = Comprehension::RegexCheck.new(entry, prompt, rule.rule_type)
+        local_feedback = regex_check.feedback_object
+        expect(feedback.text).to(eq(local_feedback[:feedback]))
+        expect(rule.rule_type).to(eq(local_feedback[:feedback_type]))
+        expect(local_feedback[:optimal]).to(be_falsey)
+        expect(entry).to(eq(local_feedback[:entry]))
+        expect(rule.concept_uid).to(eq(local_feedback[:concept_uid]))
+        expect(rule.uid).to(eq(local_feedback[:rule_uid]))
+        expect(local_feedback[:highlight].length).to eq(1)
+        expect(local_feedback[:highlight].first.text).to eq(highlight.text)
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/comprehension/spec/lib/regex_check_spec.rb
+++ b/services/QuillLMS/engines/comprehension/spec/lib/regex_check_spec.rb
@@ -65,7 +65,8 @@ module Comprehension
         expect(rule.concept_uid).to(eq(local_feedback[:concept_uid]))
         expect(rule.uid).to(eq(local_feedback[:rule_uid]))
         expect(local_feedback[:highlight].length).to eq(1)
-        expect(local_feedback[:highlight].first.text).to eq(highlight.text)
+        expect(local_feedback[:highlight].first[:text]).to eq(highlight.text)
+        expect(local_feedback[:highlight].first[:type]).to eq(highlight.highlight_type)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Refactor Regex rule API to return Highlights if they exist
## WHY
While originally we didn't have any need for Highlights attached to Regex rules, we now have a couple of edge cases that we're trying to use Regex rules for in which Highlights would be useful.  We already allow users to store Highlights on Regex Feedback objects, we just don't pass them to the front-end during Comprehension.  So now we do.
## HOW
Just attach the `Highlight` objects related to the `Feedback` that we return with Regex instead of always returning an empty array.

### Notion Card Links
https://www.notion.so/quill/Highlighting-not-appearing-with-regex-feedback-974422b11d2345cfa3438adf29d03ded

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
