### PR TITLE
ci/public-progress-report-intermittent-failure

### DIFF
--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -79,10 +79,18 @@ describe PublicProgressReports, type: :model do
           instance = FakeReports.new
           instance.session = { user_id: teacher.id }
           classrooms = instance.classrooms_with_students_for_report(unit.id, diagnostic_activity.id)
-          expect(classrooms[0]['id']).to eq(classroom_1.id)
-          expect(classrooms[1]['id']).to eq(classroom_2.id)
-          expect(classrooms[0][:classroom_unit_id]).to eq(classroom_unit_1.id)
-          expect(classrooms[1][:classroom_unit_id]).to eq(classroom_unit_2.id)
+
+          classroom_ids = classrooms.map { |c| c['id'] }
+          expect(classroom_ids).to include(classroom_1.id)
+          expect(classroom_ids).to include(classroom_2.id)
+
+          c1_index = classroom_ids.index(classroom_1.id)
+          c2_index = classroom_ids.index(classroom_2.id)
+
+          expect(classrooms[c1_index][:classroom_unit_id]).to eq(classroom_unit_1.id)
+          expect(classrooms[c2_index][:classroom_unit_id]).to eq(classroom_unit_2.id)
+
+      
         end
       end
     end


### PR DESCRIPTION
## WHAT
Update test conditions to not assume order of responses
## WHY
Because the underlying function can be arbitrary in its return order
## HOW
Test to ensure that the `classroom_id` values we care about are in the response payload, and then confirm that they are associated with the expected `classroom_unit_id`s values

### Notion Card Links
https://www.notion.so/quill/Fix-intermittent-CircleCI-failure-bb314a2c8f734bc28ea3612d72a18609

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No.  CI fix only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
