### PR TITLE
Skip authenticity token verification on UnitTemplates controller

### DIFF
--- a/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
@@ -1,4 +1,5 @@
 class Cms::UnitTemplatesController < Cms::CmsController
+  skip_before_action :verify_authenticity_token
   before_action :set_unit_template, only: [:update, :destroy]
 
   def index


### PR DESCRIPTION
## WHAT
Skip the authenticity token verification on this controller, because they become stale after a period of time and admin are unable to send API requests after they are stale. 

## WHY
We want admin to always be able to send API requests on this page. The page is staff-only, so the risk of bad agents sending bad data (the purpose of having this authenticity token) is low. 

## HOW
Add a `skip_before_action` on this controller.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Packs-don-t-always-save-in-Activity-Packs-Editor-4b9356d6b76e41e7b85f0f60465a52ee

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
