### PR TITLE
Update Demo account with replay data and new Diagnostic data

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -134,7 +134,7 @@ module Demo::ReportDemoCreator
   def self.create_replayed_activity_session(student)
     replayed_session = ActivitySession.unscoped.where({activity_id: REPLAYED_ACTIVITY_ID, user_id: REPLAYED_SAMPLE_USER_ID, is_final_score: true}).first
     student_id = student.id
-    cu = ClassroomUnit.where(student_id: assigned_student_ids).to_a.first
+    cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids)").to_a.first
     act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: replayed_session&.percentage})
     replayed_session&.concept_results&.each do |cr|
       values = {

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -132,10 +132,11 @@ module Demo::ReportDemoCreator
   end
 
   def self.create_replayed_activity_session(student)
-    temp = ActivitySession.unscoped.where({activity_id: REPLAYED_ACTIVITY_ID, user_id: REPLAYED_SAMPLE_USER_ID, is_final_score: true}).first
-    cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids)").to_a.first
-    act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp&.percentage})
-    temp&.concept_results&.each do |cr|
+    replayed_session = ActivitySession.unscoped.where({activity_id: REPLAYED_ACTIVITY_ID, user_id: REPLAYED_SAMPLE_USER_ID, is_final_score: true}).first
+    student_id = student.id
+    cu = ClassroomUnit.where(student_id: assigned_student_ids).to_a.first
+    act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: replayed_session&.percentage})
+    replayed_session&.concept_results&.each do |cr|
       values = {
         activity_session_id: act_session.id,
         concept_id: cr.concept_id,

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -108,7 +108,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.create_unit_activities(unit)
-    activities = [849, 437, 434, 215, 41, 386, 289, 295, 418]
+    activities = [1663, 437, 434, 215, 41, 386, 289, 295, 418]
     unit_activities = []
     activities.each do |act_id|
       values = {
@@ -130,7 +130,7 @@ module Demo::ReportDemoCreator
 
   def self.create_activity_sessions(students)
     templates = [
-      {849 => 2949282,
+      {1663 => 9706466,
       437 => 313241,
       434 => 446637,
       215 => 369874,
@@ -141,7 +141,7 @@ module Demo::ReportDemoCreator
       418 => 662204},
 
 
-      {849 => 2949340,
+      {1663 => 9706465,
       437 => 409030,
       434 => 313319,
       215 => 370995,
@@ -152,7 +152,7 @@ module Demo::ReportDemoCreator
       418 => 662204},
 
 
-      {849 => 2949330,
+      {1663 => 9706463,
       437 => 446637,
       434 => 312664,
       215 => 369875,
@@ -163,7 +163,7 @@ module Demo::ReportDemoCreator
       418 => 662204},
 
 
-      {849 => 2949353,
+      {1663 => 9962415,
       437 => 312664,
       434 => 313241,
       215 => 369883,
@@ -173,7 +173,7 @@ module Demo::ReportDemoCreator
       295 => 442653,
       418 => 662204},
 
-      {849 => 3050346,
+      {1663 => 9962377,
       437 => 446641,
       434 => 446641,
       215 => 369872,


### PR DESCRIPTION
## WHAT
The Demo account has old data from the V1 Starter Diagnostic. We're removing that data and replacing it with new data from the new Starter Diagnostic.
We're also adding one replayed activity session so admin can demo what a "replay" looks like.

## WHY
We want an updated and functional demo account so that Partnerships can show off all of Quill's cool features in their webinars.

## HOW
For the Diagnostic reports, it's just hard coded data (activity ID and sample user IDs) so I replaced it with the new hard coded IDs that we want.
For the replayed activity session, I just added a method called `create_replayed_activity_session` that creates a (hard-coded) replay activity session with appropriate activity and user IDs.

### Screenshots
![Screen Shot 2021-08-04 at 1 56 29 PM](https://user-images.githubusercontent.com/57366100/128230723-5a06db0c-960a-4088-a0e2-c44286b64d4f.png)


### Notion Card Links
https://www.notion.so/quill/Change-Starter-Diagnostic-assignment-and-student-completion-data-in-quill-org-demo-to-new-version-ddeecd4a8e184fab921070e6fd013b79
https://www.notion.so/quill/Add-replayed-activity-to-quill-org-demo-account-fc0e951957c34b298ce64485283089f9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested manually
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
