### PR TITLE
Remove "View Story" links from home page

### DIFF
--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -335,7 +335,6 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           "I started using Quill because it fit right into my daily curriculum."
 
           <p class="quote-author">ROXANNA BUTKUS, RANGEVIEW ELEMENTARY</p>
-          <a href="/activities/packs/2" class="q-button cta-button bg-white text-quillblue">View my story</a>
 
         </div>
       </div>
@@ -344,7 +343,6 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           "With interesting passages and immediate feedback, my students really feel like they’re learning."
 
           <p class="quote-author">SARA ANGEL, KIPP LA</p>
-          <a href="/activities/packs/5" class="q-button cta-button bg-white text-quillblue">View my story</a>
 
         </div>
       </div>
@@ -353,7 +351,6 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           "Using Quill has opened up more conversations between me and my students, in terms of how to write better and what the student needs to practice."
 
           <p class="quote-author">COLETTE KANG, EAST BAY INNOVATION ACADEMY</p>
-          <a href="/activities/packs/8" class="q-button cta-button bg-white text-quillblue">View my story</a>
 
         </div>
       </div>
@@ -362,7 +359,6 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           "I've seen tremendous improvement in the proficiency of my students and the quality of their writing."
 
           <p class="quote-author">DANIEL SCIBIENSKI, PRINCETON PUBLIC SCHOOLS</p>
-          <a href="/activities/packs/6" class="q-button cta-button bg-white text-quillblue">View my story</a>
 
         </div>
       </div>

--- a/services/QuillLMS/client/app/assets/styles/teacher-stories.scss
+++ b/services/QuillLMS/client/app/assets/styles/teacher-stories.scss
@@ -138,7 +138,6 @@
       .tab-content {
         font-size: 21px;
         color: $white;
-        margin-bottom: 75px;
         min-height: 196px;
       }
       .quote-author {


### PR DESCRIPTION
## WHAT
Remove the "View Story" buttons from the home page.

## WHY
So there are no broken or outdated links on our homepage.

## HOW
Just remove the button elements, then adjust the styling on that page so there's no big blank spot.

### Screenshots
![Screen Shot 2021-08-04 at 2 44 20 PM](https://user-images.githubusercontent.com/57366100/128240639-1d64196b-9ac6-45cb-adf4-96615f95bb0f.png)


### Notion Card Links
https://www.notion.so/quill/Remove-Homepage-View-my-story-links-since-some-are-archived-2ca9ea5be6c54b7a8028ae8131d9a4e5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested this small change manually.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | Yes
