### PR TITLE
comprehension/update-rules-report

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -25,7 +25,7 @@ class RuleFeedbackHistory
         .joins('LEFT JOIN feedback_histories ON feedback_histories.rule_uid = comprehension_rules.uid AND feedback_histories.prompt_id = prompts.id')
         .joins('LEFT JOIN feedback_history_ratings ON feedback_histories.id = feedback_history_ratings.feedback_history_id')
         .joins('LEFT JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
-        .where("feedback_histories.used = ?", true)
+        .where("(feedback_histories.used = ? OR feedback_histories.id IS NULL)", true)
         .where("prompts.conjunction = ? AND activity_id = ?", conjunction, activity_id)
         .group('comprehension_rules.id, rules_uid, activity_id, rule_type, rule_suborder, rule_name, rule_note')
         .includes(:feedbacks)

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -189,6 +189,23 @@ RSpec.describe RuleFeedbackHistory, type: :model do
 
     end
 
+    it 'should include rules that have no related FeedbackHistory records' do
+      so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
+
+      result = RuleFeedbackHistory.generate_rulewise_report(
+        rule_uid: so_rule1.uid,
+        prompt_id: 1,
+        start_date: nil,
+        end_date: nil)
+
+      expect(result.keys.length).to eq 1
+      expect(result.keys.first.to_s).to eq so_rule1.uid
+
+      responses = result[so_rule1.uid.to_sym][:responses]
+
+      expect(responses.length).to eq(0)
+    end
+
     it 'should filter feedback histories by prompt id, used=true, time params and turk session ID' do
       so_rule1 = rule_factory { { name: 'so_rule1', rule_type: 'autoML'} }
       unused_rule = rule_factory { { name: 'unused', rule_type: 'autoML'} }


### PR DESCRIPTION
## WHAT
Provide roll-up Rule data even for Rules with no FeedbackHistory
## WHY
This way we can see rules in the report even if they've never been triggered (and can see the fact that they haven't)
## HOW
Add an `OR feedback_histories.id IS NULL` to the conditions for items to include in the query so that we don't exclude `Rules` that don't cleanly `JOIN` to any `FeedbackHistory` records.  The roll-ups still count matching `FeedbackHistory` rows, so there'll be a lot of `0` counts for `Rules` with no associated `FeedbackHistory`.

### Notion Card Links
https://www.notion.so/quill/Rules-Analysis-Add-Spelling-API-and-rules-based-2-API-to-Rules-Analysis-Add-them-as-Universal-Ru-47d2a4c1b8b340c2887377c0773cf53e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
