### PR TITLE
ci/fix-classroom-factory

### DIFF
--- a/services/QuillLMS/spec/factories/classroom.rb
+++ b/services/QuillLMS/spec/factories/classroom.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
   factory :classroom do
     name  { "#{['Period', 'Block', 'Class', 'Classroom'].sample} #{(1..100).to_a.sample}#{('A'..'Z').to_a.sample}" }
-    grade { [(1..12).to_a, 'University', 'Kindergarten', 'Other'].flatten.sample.to_s }
+    grade { [(1..12).to_a, 'University', 'Kindergarten'].flatten.sample.to_s }
 
     trait :from_google do
       google_classroom_id { (1..10).map { (1..9).to_a.sample }.join } # mock a google id


### PR DESCRIPTION
## WHAT
Remove "Other" grade option from Classroom factory
## WHY
This may have been a valid "grade" value at some point in the past, but it isn't anymore.  This can lead to the factory generating a value that we shouldn't expect in production which can lead to violated expectations about grades in the model
## HOW
Just remove `"Other"` from the list of options available for the `grade` value in the `Classroom` factory

### Notion Card Links
https://www.notion.so/quill/Fix-intermittent-CI-failure-spec-services-analytics-segment_analytics_spec-rb-16-4ba759ba5afb47629551cb20cecb52ae

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, CI only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
