### PR TITLE
CMS - Missing files should 404 not error.

### DIFF
--- a/services/QuillCMS/app/controllers/application_controller.rb
+++ b/services/QuillCMS/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::API
+
+  def routing_error
+    render head: :not_found, body: nil, status: 404
+  end
 end

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   post 'cron' => 'cron#new'
 
   # catch-all 404
+  # DO NOT PLACE ROUTES BELOW THIS ONE, this catch-all must be last
   get '*path', to: 'application#routing_error'
 
 end

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -44,4 +44,7 @@ Rails.application.routes.draw do
   # cron controller runs a job in the last hour of the day
   post 'cron' => 'cron#new'
 
+  # catch-all 404
+  get '*path', to: 'application#routing_error'
+
 end

--- a/services/QuillCMS/spec/requests/file_not_found_spec.rb
+++ b/services/QuillCMS/spec/requests/file_not_found_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Missing files', type: :request do
+
+  it 'should return a 404' do
+    get '/file_does_not_exist.png'
+
+    expect(response.status).to eq 404
+  end
+end


### PR DESCRIPTION
## WHAT
Similar to the LMS fix, missing files in the CMS shouldn't 500, they should 404.
## WHY
500 errors for missing files throw off our error tracking and our alerts. Spurious alerts cause use to ignore alarms.
## HOW
Use a catch-all Rails route at the end of the `routes.rb` file, since if it makes it there, it is a routing error. Explicitly return a 404. 

Note, you can't use [rescue_from](https://guides.rubyonrails.org/v6.1.0/action_controller_overview.html#rescue-from) since the controller hasn't been instantiated at this part of the call.

### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=469e2a0c2d8c41539bbe1c8690c4afd7&p=92d8b965623240209ed6df55165d4e3d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | (Possible answers: YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
