### PR TITLE
fix bug with putting space at start of sentence

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/promptStep.tsx
@@ -139,17 +139,18 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     } else if (!text.length) {
       this.resetText()
     } else {
+      const htmlStrippedPrompt = this.htmlStrippedPrompt()
       const splitSubmission = text.split('&nbsp;')
 
       // handles case where change is only in the formatted prompt part
       if (splitSubmission.length > 1) {
-        const newValue = `${this.htmlStrippedPrompt()}${splitSubmission[1]}`
+        const newValue = `${htmlStrippedPrompt}${splitSubmission[splitSubmission.length - 1]}`
         this.setState({ html: newValue}, () => {
           this.editor.innerHTML = newValue
         })
       // student overwrote or deleted both part of their submission and the formatted prompt and the solution is much more complicated
       } else {
-        const formattedPromptWordArray = this.htmlStrippedPrompt().split(' ')
+        const formattedPromptWordArray = htmlStrippedPrompt.split(' ')
         const textWordArray = text.replace(/&nbsp;/g, ' ').split(' ')
 
         // if the user has tried to edit part of the original prompt, we find the words in their submission that are different from the original prompt


### PR DESCRIPTION
## WHAT
Fix bug where putting a space at the start of the sentence resulted in the prompt duplicating itself.

## WHY
We don't want this behavior.

## HOW
Just update the function that handles text input to append the part of the student's submission after the last `&nbsp;`, instead of whatever the second element in the array is, in cases where the array is longer than two elements.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Pressing-the-spacebar-duplicates-the-stem-e81566ecb6fd40dc9219cbb9bfcadf9c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
