### PR TITLE
PR template - Change design review to spec review.

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,4 +15,4 @@ PR Checklist | Your Answer
 Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
 Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
 Self-Review: Have you done an initial self-review of the code below on Github? |
-Design Review: If applicable, have you compared the coded design to the mockups? | (N/A or Yes)
+Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)


### PR DESCRIPTION
## WHAT
Update the PR template to change 'design review' to 'spec review'.
## WHY
Design Review is a subset of Spec review. Making this check more generic makes it more applicable to more projects. 

A self-review of the code against the spec requirements is an important step that we should codify.
## HOW
Update PR template


### Notion Card Links
N/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no, documentation
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 