### PR TITLE
fix issue with nested html in comprehension highlight

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import queryString from 'query-string';
 import { connect } from "react-redux";
 import stripHtml from "string-strip-html";
-import ReactHtmlParser from 'react-html-parser'
+import ReactHtmlParser, { convertNodeToElement, } from 'react-html-parser'
 
 import PromptStep from './promptStep'
 import StepLink from './stepLink'
@@ -578,12 +578,13 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     const { studentHighlights, showReadTheDirectionsModal, doneHighlighting, hasStartedReadPassageStep, } = this.state
     if (node.name === 'mark') {
       const shouldBeHighlightable = !doneHighlighting && !showReadTheDirectionsModal && hasStartedReadPassageStep
-      const text = node.children[0].data
+      const innerElements = node.children.map((n, i) => convertNodeToElement(n, i, this.transformMarkTags))
+      const stringifiedInnerElements = node.children.map(n => n.data ? n.data : n.children[0].data).join('')
       let className = ''
-      className += studentHighlights.includes(text) ? ' highlighted' : ''
+      className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
       className += shouldBeHighlightable  ? ' highlightable' : ''
-      if (!shouldBeHighlightable) { return <mark className={className}>{text}</mark>}
-      return <mark className={className} onClick={this.handleHighlightClick} onKeyDown={this.handleHighlightKeyDown} tabIndex={0}>{text}</mark>
+      if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
+      return <mark className={className} onClick={this.handleHighlightClick} onKeyDown={this.handleHighlightKeyDown} tabIndex={0}>{innerElements}</mark>
     }
   }
 


### PR DESCRIPTION
## WHAT
Fix issue with nested HTML inside a `mark` tag in Comprehension.

## WHY
So that we can render italics, etc, correctly inside of the highlights.

## HOW
Make the logic for rendering the inside of the mark tags more sophisticated.

### Screenshots
<img width="1281" alt="Screen Shot 2021-08-05 at 3 38 28 PM" src="https://user-images.githubusercontent.com/18669014/128410873-d0407a7a-3310-42fe-9c58-5e1a36f41c0d.png">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Design Review: If applicable, have you compared the coded design to the mockups? | N/A