### PR TITLE
CMS - Record POST missing routes as 404s

### DIFF
--- a/services/QuillCMS/config/environments/production.rb
+++ b/services/QuillCMS/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -47,5 +47,7 @@ Rails.application.routes.draw do
   # catch-all 404
   # DO NOT PLACE ROUTES BELOW THIS ONE, this catch-all must be last
   get '*path', to: 'application#routing_error'
+  post '/', to: 'application#routing_error'
+  post '*path', to: 'application#routing_error'
 
 end

--- a/services/QuillCMS/spec/requests/file_not_found_spec.rb
+++ b/services/QuillCMS/spec/requests/file_not_found_spec.rb
@@ -2,8 +2,20 @@ require 'rails_helper'
 
 describe 'Missing files', type: :request do
 
-  it 'should return a 404' do
+  it 'should return a 404 for non-existent asset' do
     get '/file_does_not_exist.png'
+
+    expect(response.status).to eq 404
+  end
+
+  it 'should return a 404 for a post to root' do
+    post '/'
+
+    expect(response.status).to eq 404
+  end
+
+  it 'should return a 404 for a post to random endpoint' do
+    post '/hello'
 
     expect(response.status).to eq 404
   end


### PR DESCRIPTION
## WHAT
Similar to #8042 return 404s for missing POST routes. I also changed our production logging to `info`, since we don't need the volume of `debug` in production
## WHY
So scrappers don't affect our error logs and alerting.
## HOW
Catch-all route for POST requests.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'. 
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
