### PR TITLE
Silence Segment ‘no user_id’ error until bug fix.

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -87,6 +87,11 @@ class SegmentAnalytics
   end
 
   def track_classroom_creation(classroom)
+    # TODO Remove early return once this bug is fixed
+    # https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
+    # https://www.notion.so/quill/Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d
+    return unless classroom&.owner&.id
+
     # first event is for Vitally, which does not show properties
     track({
       user_id: classroom&.owner&.id,

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -87,7 +87,7 @@ class SegmentAnalytics
   end
 
   def track_classroom_creation(classroom)
-    # TODO Remove early return once this bug is fixed
+    # TODO: Remove early return once this bug is fixed
     # https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
     # https://www.notion.so/quill/Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d
     return unless classroom&.owner&.id

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -10,6 +10,7 @@ describe 'SegmentAnalytics' do
 
   context 'tracking classroom creation' do
     let(:classroom) { create(:classroom) }
+    let(:classroom_with_no_teacher) { create(:classroom, :with_no_teacher) }
 
     it 'sends two events' do
       analytics.track_classroom_creation(classroom)
@@ -21,6 +22,12 @@ describe 'SegmentAnalytics' do
       expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
       expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
       expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
+    end
+
+    it 'should not send event if there is no owner' do
+      analytics.track_classroom_creation(classroom_with_no_teacher)
+      expect(identify_calls.size).to eq(0)
+      expect(track_calls.size).to eq(0)
     end
   end
 


### PR DESCRIPTION
## WHAT
Pulling out a common error from being reported that is a known bug (which should be fixed in the Google / Clever work). 
## WHY
I was hesitant to silence this error, since this is an issue we need to fix. But I think we have enough documentation of this error and it's throwing off our report and alerts, so I'm silencing it for now and leaving a TODO.
## HOW
Early return for `nil` case.


### Notion Card Links
https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
https://www.notion.so/quill/Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Design Review: If applicable, have you compared the coded design to the mockups? | N/A
