### PR TITLE
Tweak Increment Responses on CMS to update timestamp on increment

### DIFF
--- a/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
+++ b/services/QuillCMS/app/workers/create_or_increment_response_worker.rb
@@ -28,13 +28,13 @@ class CreateOrIncrementResponseWorker
   end
 
   def increment_counts(response, symbolized_vals)
-    response.increment!(:count)
+    response.increment!(:count, 1, touch: true)
     increment_first_attempt_count(response, symbolized_vals)
     increment_child_count_of_parent(response)
   end
 
   def increment_first_attempt_count(response, symbolized_vals)
-    symbolized_vals[:is_first_attempt] == "true" ? response.increment!(:first_attempt_count) : nil
+    symbolized_vals[:is_first_attempt] == "true" ? response.increment!(:first_attempt_count, 1, touch: true) : nil
   end
 
   def increment_child_count_of_parent(response)
@@ -46,7 +46,7 @@ class CreateOrIncrementResponseWorker
     # id is truthy and not 0
     if id && id != 0
       parent = Response.find_by_id_or_uid(id)
-      parent.increment!(:child_count) unless parent.nil?
+      parent.increment!(:child_count, 1, touch: true) unless parent.nil?
     end
   end
 

--- a/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
@@ -12,10 +12,12 @@ describe CreateOrIncrementResponseWorker do
 
   describe '#perform' do
     context 'if the response already exists' do
-      it 'should increment the count of the response' do
+      it 'should increment the count of the response and set updated at timestamp' do
         original_count = response.count
+        original_updated_at = response.updated_at
         subject.perform({ text: response.text, question_uid: response.question_uid })
         expect(response.reload.count).to eq(original_count + 1)
+        expect(response.reload.updated_at).to be > original_updated_at
       end
 
       it 'should increment the child count of the parent response if there is a parent id' do


### PR DESCRIPTION
## WHAT
We had a bug where Responses were being incremented in the database directly without changing their `updated_at` timestamp. Therefore the nightly `UpdateIndividualResponse` worker that reindexes all of that day's updated responses wasn't catching these responses, so they weren't being re-indexed.

## WHY
When responses are not reindexed, they get out of date in ElasticSearch and they are returned in the wrong order on the admin dashboard.

## HOW
Send a `touch: true` attribute to the `increment!` call, which tells SQL to update the `updated_at` column along with the increment update.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-sort-responses-by-submissions-in-Connect-or-Diagnostic-ae550c8f61824001917072d400854d91

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A