### PR TITLE
add toggle button to show highlights on activity form

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -91,15 +91,27 @@ exports[`Activity Form component should render Activities 1`] = `
     <p
       className="text-editor-label has-text"
     >
-      Passage
+      <span>
+        Passage
+      </span>
+      <button
+        className="quill-button fun secondary outlined focus-on-light"
+        onClick={[Function]}
+      >
+        Hide highlights
+      </button>
     </p>
-    <TextEditor
-      ContentState={[Function]}
-      EditorState={[Function]}
-      handleTextChange={[Function]}
-      key="passage-description"
-      text="..."
-    />
+    <div
+      className=""
+    >
+      <TextEditor
+        ContentState={[Function]}
+        EditorState={[Function]}
+        handleTextChange={[Function]}
+        key="passage-description"
+        text="..."
+      />
+    </div>
     <p
       className="text-editor-label has-text"
     >

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`Activity Form component should render Activities 1`] = `
       <button
         className="quill-button fun secondary outlined focus-on-light"
         onClick={[Function]}
+        type="button"
       >
         Hide highlights
       </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -34,7 +34,6 @@ interface ActivityFormProps {
 const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences that explain "
 
 const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, submitActivity }: ActivityFormProps) => {
-
   const { parent_activity_id, passages, prompts, scored_level, target_level, title, notes, } = activity;
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
@@ -60,6 +59,9 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
   const [activityButPrompt, setActivityButPrompt] = React.useState<PromptInterface>(butPrompt);
   const [activitySoPrompt, setActivitySoPrompt] = React.useState<PromptInterface>(soPrompt);
   const [errors, setErrors] = React.useState<{}>({});
+  const [showHighlights, setShowHighlights] = React.useState(true)
+
+  function toggleShowHighlights(e: MouseEvent) { setShowHighlights(!showHighlights)}
 
   function handleSetActivityTitle(e: InputEvent){ setActivityTitle(e.target.value) };
 
@@ -189,14 +191,19 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
           label="Image Alt Text"
           value={activityPassages[0].image_alt_text}
         />
-        <p className={`text-editor-label ${passageLabelStyle}`}>Passage</p>
-        <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
-          handleTextChange={handleSetPassageText}
-          key="passage-description"
-          text={activityPassages[0].text}
-        />
+        <p className={`text-editor-label ${passageLabelStyle}`}>
+          <span>Passage</span>
+          <button className="quill-button fun secondary outlined focus-on-light" onClick={toggleShowHighlights} type="button">{showHighlights ? 'Hide highlights' : 'Show highlights'}</button>
+        </p>
+        <div className={showHighlights ? '' : 'hide-highlights'}>
+          <TextEditor
+            ContentState={ContentState}
+            EditorState={EditorState}
+            handleTextChange={handleSetPassageText}
+            key="passage-description"
+            text={activityPassages[0].text}
+          />
+        </div>
         {errors[PASSAGE] && <p className="error-message">{errors[PASSAGE]}</p>}
         <p className={`text-editor-label ${maxAttemptStyle}`}>Max Attempts Feedback</p>
         <TextEditor

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -288,13 +288,23 @@
         font-size: 16px;
         margin: 10px 0px -10px 0px;
         font-weight: normal;
+        display: flex;
+        align-items: center;
         &.has-text {
           font-size: 12px;
           font-weight: 600;
         }
+        .quill-button {
+          margin-left: 8px;
+        }
       }
       .text-editor-label:nth-of-type(2) {
         margin-top: 20px;
+      }
+      .hide-highlights {
+        span {
+          background-color: white !important;
+        }
       }
       #max-attempt-feedback {
         &.focus {


### PR DESCRIPTION
## WHAT
Add toggle to switch between highlighted and normal view on the activity form for Comprehension.

## WHY
The highlights are distracting and might make it harder to read the passage.

## HOW
Just add a button that adds and removes a class from the surrounding div.

### Screenshots
<img width="989" alt="Screen Shot 2021-08-09 at 11 12 31 AM" src="https://user-images.githubusercontent.com/18669014/128745209-833abc48-a3d9-4f8e-93c5-379e6c3f1edf.png"><img width="997" alt="Screen Shot 2021-08-09 at 11 12 18 AM" src="https://user-images.githubusercontent.com/18669014/128745211-fecfad81-3127-4d4d-a80c-c977ba69061e.png">


### Notion Card Links
https://www.notion.so/quill/V2-Features-for-Internal-Tool-Highlighting-a28e40044508428f9a775cee8a11bb8a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - waiting for Lindsey to be back to review it
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
