### PR TITLE
CMS - Add GradedResponses

### DIFF
--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -18,6 +18,7 @@ gem 'dotenv-rails', '~> 2.7'
 gem 'activerecord-import'
 gem 'bulk_insert'
 gem 'pg', '~> 1.2'
+gem 'scenic'
 
 # QUEUE/CACHING
 gem 'connection_pool'

--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -18,7 +18,7 @@ gem 'dotenv-rails', '~> 2.7'
 gem 'activerecord-import'
 gem 'bulk_insert'
 gem 'pg', '~> 1.2'
-gem 'scenic'
+gem 'scenic', '~> 1.5.4'
 
 # QUEUE/CACHING
 gem 'connection_pool'

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -249,6 +249,9 @@ GEM
     ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
+    scenic (1.5.4)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -317,6 +320,7 @@ DEPENDENCIES
   redis-namespace
   rspec-rails (~> 4.0)
   rubyzip
+  scenic
   sidekiq (~> 5.2.9)
   sidekiq-pro (= 5.0.0)!
   sinatra

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -320,7 +320,7 @@ DEPENDENCIES
   redis-namespace
   rspec-rails (~> 4.0)
   rubyzip
-  scenic
+  scenic (~> 1.5.4)
   sidekiq (~> 5.2.9)
   sidekiq-pro (= 5.0.0)!
   sinatra

--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -1,0 +1,16 @@
+class QuestionsController < ApplicationController
+  MULTIPLE_CHOICE_LIMIT = 2
+
+  def responses
+    render json: GradedResponse.no_parent.where(question_uid: params[:question_uid])
+  end
+
+  def multiple_choice_options
+    scope = GradedResponse.where(question_uid: params[:question_uid]).limit(MULTIPLE_CHOICE_LIMIT)
+
+    optimal = scope.optimal
+    nonoptimal = scope.nonoptimal.order('count DESC')
+
+    render json: optimal.to_a.concat(nonoptimal.to_a)
+  end
+end

--- a/services/QuillCMS/app/models/graded_response.rb
+++ b/services/QuillCMS/app/models/graded_response.rb
@@ -1,0 +1,11 @@
+class GradedResponse < ApplicationRecord
+  self.primary_key = :id
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
+  end
+
+  def readonly?
+    true
+  end
+end

--- a/services/QuillCMS/app/models/graded_response.rb
+++ b/services/QuillCMS/app/models/graded_response.rb
@@ -1,9 +1,9 @@
 class GradedResponse < ApplicationRecord
   self.primary_key = :id
 
-  scope :optimal,  -> { where(optimal: true) }
-  scope :nonoptimal,  -> { where(optimal: false) }
-  scope :no_parent,  -> { where(parent_id: nil) }
+  scope :optimal, -> { where(optimal: true) }
+  scope :nonoptimal, -> { where(optimal: false) }
+  scope :no_parent, -> { where(parent_id: nil) }
 
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)

--- a/services/QuillCMS/app/models/graded_response.rb
+++ b/services/QuillCMS/app/models/graded_response.rb
@@ -1,6 +1,10 @@
 class GradedResponse < ApplicationRecord
   self.primary_key = :id
 
+  scope :optimal,  -> { where(optimal: true) }
+  scope :nonoptimal,  -> { where(optimal: false) }
+  scope :no_parent,  -> { where(parent_id: nil) }
+
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end

--- a/services/QuillCMS/app/workers/refresh_graded_responses_worker.rb
+++ b/services/QuillCMS/app/workers/refresh_graded_responses_worker.rb
@@ -1,0 +1,26 @@
+class RefreshGradedResponsesWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+
+  REFRESH_TIMEOUT = ENV["VIEW_STATEMENT_TIMEOUT"] || '10min'
+
+  # Make the DB statement timeout longer while refreshing the materialized view
+  def perform
+    original_timeout = db_timeout
+    set_db_timeout(REFRESH_TIMEOUT)
+
+    GradedResponse.refresh
+  ensure
+    set_db_timeout(original_timeout)
+  end
+
+  private def set_db_timeout(time_string)
+    escaped_time_string = ActiveRecord::Base.connection.quote(time_string)
+
+    ActiveRecord::Base.connection.execute("SET statement_timeout = #{escaped_time_string}")
+  end
+
+  private def db_timeout
+    ActiveRecord::Base.connection.execute('SHOW statement_timeout').first['statement_timeout']
+  end
+end

--- a/services/QuillCMS/app/workers/refresh_graded_responses_worker.rb
+++ b/services/QuillCMS/app/workers/refresh_graded_responses_worker.rb
@@ -7,14 +7,14 @@ class RefreshGradedResponsesWorker
   # Make the DB statement timeout longer while refreshing the materialized view
   def perform
     original_timeout = db_timeout
-    set_db_timeout(REFRESH_TIMEOUT)
+    db_set_timeout(REFRESH_TIMEOUT)
 
     GradedResponse.refresh
   ensure
-    set_db_timeout(original_timeout)
+    db_set_timeout(original_timeout)
   end
 
-  private def set_db_timeout(time_string)
+  private def db_set_timeout(time_string)
     escaped_time_string = ActiveRecord::Base.connection.quote(time_string)
 
     ActiveRecord::Base.connection.execute("SET statement_timeout = #{escaped_time_string}")

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -7,8 +7,10 @@ Rails.application.routes.draw do
 
   resources :responses, only: [:show, :create, :update, :destroy]
 
+  # TODO: remove these 2 routes to transition to GradedResponse setup
   get  'questions/:question_uid/responses' => 'responses#responses_for_question'
   get  'questions/:question_uid/multiple_choice_options' => 'responses#multiple_choice_options'
+  # END
   get  'questions/:question_uid/health' => 'responses#health_of_question'
   get  'questions/:question_uid/grade_breakdown' => 'responses#grade_breakdown'
   get  'questions/:question_uid/question_dashboard_data' => 'responses#question_dashboard'
@@ -34,7 +36,8 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :questions, only: [], param: :question_uid do
+  # TODO: remove path :graded to match routes used by frontend apps
+  resources :questions, only: [], param: :question_uid, path: :graded do
     get :responses, :multiple_choice_options, on: :member
   end
 

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -34,6 +34,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :questions, only: [], param: :question_uid do
+    get :responses, :multiple_choice_options, on: :member
+  end
+
   # Sidekiq web interface
   mount Sidekiq::Web => '/sidekiq'
 

--- a/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
+++ b/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
@@ -1,0 +1,9 @@
+class CreateGradedResponses < ActiveRecord::Migration[6.1]
+  def change
+    create_view :graded_responses, materialized: true
+
+    add_index :graded_responses, :id, unique: true
+    add_index :graded_responses, :question_uid
+    add_index :graded_responses, :optimal
+  end
+end

--- a/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
+++ b/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
@@ -1,9 +1,29 @@
 class CreateGradedResponses < ActiveRecord::Migration[6.1]
-  def change
+  def up
+    original_timeout = db_timeout
+    set_db_timeout(RefreshGradedResponsesWorker::REFRESH_TIMEOUT)
+
     create_view :graded_responses, materialized: true
 
     add_index :graded_responses, :id, unique: true
     add_index :graded_responses, :question_uid
     add_index :graded_responses, :optimal
+
+  ensure
+    set_db_timeout(original_timeout)
+  end
+
+  def down
+    drop_view :graded_responses, materialized: true
+  end
+
+  private def set_db_timeout(time_string)
+    escaped_time_string = quote(time_string)
+
+    execute("SET statement_timeout = #{escaped_time_string}")
+  end
+
+  private def db_timeout
+    execute('SHOW statement_timeout').first['statement_timeout']
   end
 end

--- a/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
+++ b/services/QuillCMS/db/migrate/20210809165937_create_graded_responses.rb
@@ -1,23 +1,22 @@
 class CreateGradedResponses < ActiveRecord::Migration[6.1]
   def up
     original_timeout = db_timeout
-    set_db_timeout(RefreshGradedResponsesWorker::REFRESH_TIMEOUT)
+    db_set_timeout(RefreshGradedResponsesWorker::REFRESH_TIMEOUT)
 
     create_view :graded_responses, materialized: true
 
     add_index :graded_responses, :id, unique: true
     add_index :graded_responses, :question_uid
     add_index :graded_responses, :optimal
-
   ensure
-    set_db_timeout(original_timeout)
+    db_set_timeout(original_timeout)
   end
 
   def down
     drop_view :graded_responses, materialized: true
   end
 
-  private def set_db_timeout(time_string)
+  private def db_set_timeout(time_string)
     escaped_time_string = quote(time_string)
 
     execute("SET statement_timeout = #{escaped_time_string}")

--- a/services/QuillCMS/db/schema.rb
+++ b/services/QuillCMS/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_18_231905) do
+ActiveRecord::Schema.define(version: 2021_08_09_165937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,10 +36,35 @@ ActiveRecord::Schema.define(version: 2019_12_18_231905) do
     t.index ["optimal"], name: "index_responses_on_optimal"
     t.index ["parent_id"], name: "index_responses_on_parent_id"
     t.index ["parent_uid"], name: "index_responses_on_parent_uid"
-    t.index ["question_uid", "text"], name: "index_responses_on_question_uid_and_text", unique: true
     t.index ["question_uid"], name: "index_responses_on_question_uid"
     t.index ["text"], name: "index_responses_on_text"
     t.index ["uid"], name: "index_responses_on_uid"
   end
+
+
+  create_view "graded_responses", materialized: true, sql_definition: <<-SQL
+      SELECT responses.id,
+      responses.uid,
+      responses.parent_id,
+      responses.parent_uid,
+      responses.question_uid,
+      responses.author,
+      responses.text,
+      responses.feedback,
+      responses.count,
+      responses.first_attempt_count,
+      responses.child_count,
+      responses.optimal,
+      responses.weak,
+      responses.concept_results,
+      responses.created_at,
+      responses.updated_at,
+      responses.spelling_error
+     FROM responses
+    WHERE (responses.optimal IS NOT NULL);
+  SQL
+  add_index "graded_responses", ["id"], name: "index_graded_responses_on_id", unique: true
+  add_index "graded_responses", ["optimal"], name: "index_graded_responses_on_optimal"
+  add_index "graded_responses", ["question_uid"], name: "index_graded_responses_on_question_uid"
 
 end

--- a/services/QuillCMS/db/views/graded_responses_v01.sql
+++ b/services/QuillCMS/db/views/graded_responses_v01.sql
@@ -1,0 +1,4 @@
+-- Note, if you add or remove columns for the tables, you'll need a migration
+SELECT *
+FROM responses
+WHERE optimal IS NOT NULL;

--- a/services/QuillCMS/db/views/graded_responses_v01.sql
+++ b/services/QuillCMS/db/views/graded_responses_v01.sql
@@ -1,4 +1,6 @@
 -- Note, if you add or remove columns for the tables, you'll need a migration
+-- To update this view use `rails generate scenic:view graded_responses`
+-- See documentation here: https://github.com/scenic-views/scenic#cool-but-what-if-i-need-to-change-that-view
 SELECT *
 FROM responses
 WHERE optimal IS NOT NULL;

--- a/services/QuillCMS/spec/controllers/questions_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/questions_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe QuestionsController, type: :controller do
       get :responses, params: {question_uid: '123'}
 
       expect(response.status).to eq 200
-
       expect(JSON.parse(response.body)).to be_empty
     end
 
@@ -43,7 +42,6 @@ RSpec.describe QuestionsController, type: :controller do
       get :multiple_choice_options, params: {question_uid: '123'}
 
       expect(response.status).to eq 200
-
       expect(JSON.parse(response.body)).to be_empty
     end
 

--- a/services/QuillCMS/spec/controllers/questions_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/questions_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe QuestionsController, type: :controller do
         GradedResponse.refresh
       end
 
+      # Note, this expectation is bound to QuestionsController::MULTIPLE_CHOICE_LIMIT
       it 'should return graded responses, 2 optimal, 2 nonoptimal' do
         get :multiple_choice_options, params: {question_uid: '123'}
 
@@ -84,6 +85,7 @@ RSpec.describe QuestionsController, type: :controller do
         GradedResponse.refresh
       end
 
+      # Note, this expectation is bound to QuestionsController::MULTIPLE_CHOICE_LIMIT
       it 'should return graded responses, 2 optimal' do
         get :multiple_choice_options, params: {question_uid: '123'}
 

--- a/services/QuillCMS/spec/controllers/questions_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/questions_controller_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe QuestionsController, type: :controller do
+  before(:each) do
+    allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
+  end
+
+  context '#responses' do
+    it 'should return empty array if nothing found' do
+      get :responses, params: {question_uid: '123'}
+
+      expect(response.status).to eq 200
+
+      expect(JSON.parse(response.body)).to be_empty
+    end
+
+    context 'with data' do
+      let!(:response_optimal) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_nonoptimal) {create(:response, question_uid: '123', optimal: false)}
+      let!(:response_ungraded) {create(:response, question_uid: '123', optimal: nil)}
+
+      before(:each) do
+        GradedResponse.refresh
+      end
+
+      it 'should return graded responses' do
+        get :responses, params: {question_uid: '123'}
+
+        expect(response.status).to eq 200
+        # sorting to make test consistent (order doesn't matter for this API)
+        json = JSON.parse(response.body).sort_by{|gr| gr['id']}
+
+        expect(json.count).to eq 2
+        expect(json.first['id']).to eq response_optimal.id
+        expect(json.second['id']).to eq response_nonoptimal.id
+      end
+    end
+  end
+
+  context '#multiple_choice_options' do
+
+    it 'should return empty array' do
+      get :multiple_choice_options, params: {question_uid: '123'}
+
+      expect(response.status).to eq 200
+
+      expect(JSON.parse(response.body)).to be_empty
+    end
+
+    context 'with all data' do
+      let!(:response_optimal1) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_optimal2) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_optimal3) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_nonoptimal1) {create(:response, question_uid: '123', optimal: false)}
+      let!(:response_nonoptimal2) {create(:response, question_uid: '123', optimal: false)}
+      let!(:response_nonoptimal3) {create(:response, question_uid: '123', optimal: false)}
+      let!(:response_ungraded) {create(:response, question_uid: '123', optimal: nil)}
+
+      before(:each) do
+        GradedResponse.refresh
+      end
+
+      it 'should return graded responses, 2 optimal, 2 nonoptimal' do
+        get :multiple_choice_options, params: {question_uid: '123'}
+
+        expect(response.status).to eq 200
+
+        json = JSON.parse(response.body)
+        optimal_count = json.count {|gr| gr['optimal']}
+        nonoptimal_count = json.count {|gr| !gr['optimal']}
+        null_optimal_count = json.count {|gr| gr['optimal'].nil?}
+
+        expect(json.count).to eq 4
+        expect(optimal_count).to eq 2
+        expect(nonoptimal_count).to eq 2
+        expect(null_optimal_count).to eq 0
+      end
+    end
+
+    context 'only optimal responses available' do
+      let!(:response_optimal1) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_optimal2) {create(:response, question_uid: '123', optimal: true)}
+      let!(:response_optimal3) {create(:response, question_uid: '123', optimal: true)}
+
+      before(:each) do
+        GradedResponse.refresh
+      end
+
+      it 'should return graded responses, 2 optimal' do
+        get :multiple_choice_options, params: {question_uid: '123'}
+
+        expect(response.status).to eq 200
+
+        json = JSON.parse(response.body)
+        optimal_count = json.count {|gr| gr['optimal']}
+        nonoptimal_count = json.count {|gr| !gr['optimal']}
+        null_optimal_count = json.count {|gr| gr['optimal'].nil?}
+
+        expect(json.count).to eq 2
+        expect(optimal_count).to eq 2
+        expect(nonoptimal_count).to eq 0
+        expect(null_optimal_count).to eq 0
+      end
+    end
+  end
+end

--- a/services/QuillCMS/spec/models/graded_response_spec.rb
+++ b/services/QuillCMS/spec/models/graded_response_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GradedResponse, type: :model do
       expect(GradedResponse.count).to be 2
     end
 
-    it 'should return responses for queries' do
+    it 'should return response objects for queries' do
       GradedResponse.refresh
       graded_responses = GradedResponse.where(question_uid: '123').sort_by(&:id)
 

--- a/services/QuillCMS/spec/models/graded_response_spec.rb
+++ b/services/QuillCMS/spec/models/graded_response_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe GradedResponse, type: :model do
     let!(:response_nonoptimal) {create(:response, question_uid: '123', optimal: false)}
     let!(:response_ungraded) {create(:response, question_uid: '123', optimal: nil)}
 
-
     it 'should return no records if refresh is not run' do
       expect(GradedResponse.count).to be 0
     end

--- a/services/QuillCMS/spec/models/graded_response_spec.rb
+++ b/services/QuillCMS/spec/models/graded_response_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe GradedResponse, type: :model do
+  context 'basic queries' do
+    let!(:response_optimal) {create(:response, question_uid: '123', optimal: true)}
+    let!(:response_nonoptimal) {create(:response, question_uid: '123', optimal: false)}
+    let!(:response_ungraded) {create(:response, question_uid: '123', optimal: nil)}
+
+
+    it 'should return no records if refresh is not run' do
+      expect(GradedResponse.count).to be 0
+    end
+
+    it 'should return 2 records when refreshed' do
+      GradedResponse.refresh
+      expect(GradedResponse.count).to be 2
+    end
+
+    it 'should return responses for queries' do
+      GradedResponse.refresh
+      graded_responses = GradedResponse.where(question_uid: '123').sort_by(&:id)
+
+      expect(graded_responses.first.id).to be response_optimal.id
+      expect(graded_responses.second.id).to be response_nonoptimal.id
+    end
+  end
+end

--- a/services/QuillCMS/spec/workers/refresh_graded_responses_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/refresh_graded_responses_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe RefreshGradedResponsesWorker do
+  let(:worker) { described_class.new }
+
+  describe '#perform' do
+    it 'should call refresh' do
+
+      expect(GradedResponse).to receive(:refresh)
+
+      worker.perform
+    end
+  end
+end

--- a/services/QuillCMS/spec/workers/rematch_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/rematch_response_worker_spec.rb
@@ -119,13 +119,16 @@ describe RematchResponseWorker do
       "spelling_error":false
     }]
   }.stringify_keys
-  reference_responses = []
-  sample_payload["referenceResponses"].each do |r|
-    reference_responses.push(Response.create_with(r).find_or_create_by(id: r[:id]))
-  end
+
 
   describe '#perform' do
     let(:response) { Response.create(sample_payload['response']) }
+    let(:reference_responses) do
+      sample_payload["referenceResponses"].map do |params|
+        create(:response, params)
+      end
+    end
+
     it 'should update the response based on the lambda payload' do
       stub_request(:post, /#{ENV['REMATCH_LAMBDA_URL']}/)
         .to_return(status: 200, body: sample_lambda_response.to_json, headers: {})


### PR DESCRIPTION
## WHAT
In an effort to improve CMS performance, this PR creates a new model called `GradedResponses` which is backed by a materialized view (not a table) of graded responses set up using the `scenic` gem  that will be refreshed once a day. This will power the `responses_for_question` and `multiple_choice_options` endpoints

Note, since there needs to be testing of this set-up with `production` data, this PR doesn't make any of the endpoints 'live'. If testing goes well, that would be the next step.
## WHY
Right now, these are slow endpoints that need to be cached heavily in order to function. I originally was going to move these to the LMS, but based on feedback from the [RFC](https://www.notion.so/quill/RFC-Move-CMS-activity-endpoints-to-the-LMS-733daebd1dae4a51a3263bba1f900079), some research, and self-reflection, I think it's worth trying a more lightweight version of this in the CMS for now.
## HOW
Uses a materialized view generated using the [scenic gem](https://github.com/scenic-views/scenic). The view acts exactly like a regular active_record table. Both endpoints are powered by the `GradedResponse` model for now.

### Notion Card Links
https://www.notion.so/quill/RFC-Move-CMS-activity-endpoints-to-the-LMS-733daebd1dae4a51a3263bba1f900079

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
