### PR TITLE
update default highlight instructions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/directionsSectionAndModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/directionsSectionAndModal.tsx
@@ -16,7 +16,7 @@ const DirectionsSectionAndModal = ({ className, closeReadTheDirectionsModal, pas
     return (<div className={className}>
       <section className="reflection-section">
         <h3>Directions</h3>
-        <p>Great! <u>Now take a moment to reflect.</u> Look back at what you highlighted to think about reasons {uniquePartOfHighlightPrompt}</p>
+        <p>Great! <u>Now take a moment to reflect on the sentences you highlighted.</u></p>
       </section>
     </div>)
   }

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
@@ -25,9 +25,8 @@ exports[`DirectionsSectionAndModal component when the student is in reflection r
       <p>
         Great! 
         <u>
-          Now take a moment to reflect.
+          Now take a moment to reflect on the sentences you highlighted.
         </u>
-         Look back at what you highlighted to think about reasons 
       </p>
     </section>
   </div>
@@ -58,7 +57,7 @@ exports[`DirectionsSectionAndModal component when the student is on the read pas
         Directions
       </h3>
       <p>
-        As you read, highlight two sentences that explain 
+        As you read, highlight two sentences 
         <u />
       </p>
     </section>
@@ -140,7 +139,7 @@ exports[`DirectionsSectionAndModal component when the student should see the mod
         Directions
       </h3>
       <p>
-        As you read, highlight two sentences that explain 
+        As you read, highlight two sentences 
         <u />
       </p>
     </section>

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ReadAndHighlightInstructions component when the student has not started
             Directions
           </h3>
           <p>
-            As you read, highlight two sentences that explain 
+            As you read, highlight two sentences 
             <u />
           </p>
         </section>
@@ -166,7 +166,7 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
             Directions
           </h3>
           <p>
-            As you read, highlight two sentences that explain 
+            As you read, highlight two sentences 
             <u />
           </p>
         </section>

--- a/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences that explain "
+export const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences "

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -116,8 +116,8 @@ exports[`Activity Form component should render Activities 1`] = `
       autoComplete="on"
       className="highlight-prompt-input"
       handleChange={[Function]}
-      label="Highlight Prompt: \\"As you read, highlight two sentences that explain ...\\""
-      value="As you read, highlight two sentences that explain "
+      label="Highlight Prompt: \\"As you read, highlight two sentences ...\\""
+      value="As you read, highlight two sentences "
     />
     <PromptsForm
       activityBecausePrompt={

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -31,7 +31,7 @@ interface ActivityFormProps {
   submitActivity: (activity: object) => void
 }
 
-const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences that explain "
+const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences "
 
 const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, submitActivity }: ActivityFormProps) => {
 


### PR DESCRIPTION
## WHAT
Update default highlight instructions for highlight prompt in Evidence.

## WHY
The curriculum team wants more flexibility here.

## HOW
Update the default highlight prompt, and update the text on the reflection page to be generic.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-COA-question-template-f00f6786f3cb4759ad17594b6b83da59

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO -  tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES