### PR TITLE
Comprehension/ add caption, author and source image properties to passages (backend)

### DIFF
--- a/services/QuillLMS/db/migrate/20210811130155_add_comprehension_passage_image_properties.rb
+++ b/services/QuillLMS/db/migrate/20210811130155_add_comprehension_passage_image_properties.rb
@@ -1,0 +1,7 @@
+class AddComprehensionPassageImageProperties < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comprehension_passages, :image_caption, :string, default: ''
+    add_column :comprehension_passages, :image_author, :string, default: ''
+    add_column :comprehension_passages, :image_source, :string, default: ''
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1167,7 +1167,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
-    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
+    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
 );
 
 
@@ -1379,7 +1379,10 @@ CREATE TABLE public.comprehension_passages (
     updated_at timestamp without time zone NOT NULL,
     image_link character varying,
     image_alt_text character varying DEFAULT ''::character varying,
-    highlight_prompt character varying
+    highlight_prompt character varying,
+    image_caption character varying DEFAULT ''::character varying,
+    image_author character varying DEFAULT ''::character varying,
+    image_source character varying DEFAULT ''::character varying
 );
 
 
@@ -1511,8 +1514,8 @@ ALTER SEQUENCE public.comprehension_prompts_rules_id_seq OWNED BY public.compreh
 
 CREATE TABLE public.comprehension_regex_rules (
     id integer NOT NULL,
-    regex_text character varying(200),
-    case_sensitive boolean,
+    regex_text character varying(200) NOT NULL,
+    case_sensitive boolean NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rule_id integer,
@@ -1553,9 +1556,10 @@ CREATE TABLE public.comprehension_rules (
     rule_type character varying NOT NULL,
     optimal boolean NOT NULL,
     suborder integer,
-    concept_uid character varying,
+    concept_uid character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
+    sequence_type character varying,
     state character varying NOT NULL
 );
 
@@ -7390,6 +7394,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210712213724'),
 ('20210722144950'),
 ('20210726193112'),
-('20210803163028');
+('20210803163028'),
+('20210811130155');
 
 

--- a/services/QuillLMS/engines/comprehension/db/migrate/20210811130211_add_comprehension_passage_image_properties.rb
+++ b/services/QuillLMS/engines/comprehension/db/migrate/20210811130211_add_comprehension_passage_image_properties.rb
@@ -1,0 +1,7 @@
+class AddComprehensionPassageImageProperties < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comprehension_passages, :image_caption, :string, default: ''
+    add_column :comprehension_passages, :image_author, :string, default: ''
+    add_column :comprehension_passages, :image_source, :string, default: ''
+  end
+end

--- a/services/QuillLMS/engines/comprehension/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/comprehension/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210722143752) do
+ActiveRecord::Schema.define(version: 20210811130211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,9 @@ ActiveRecord::Schema.define(version: 20210722143752) do
     t.string "image_link"
     t.string "image_alt_text", default: ""
     t.string "highlight_prompt"
+    t.string "image_caption", default: ""
+    t.string "image_author", default: ""
+    t.string "image_source", default: ""
     t.index ["activity_id"], name: "index_comprehension_passages_on_activity_id"
   end
 


### PR DESCRIPTION
## WHAT
add migrations for adding new image properties to Comprehension passages

## WHY
Curriculum will need to be able to add captions and image attributions

## HOW
add migrations to add `image_caption`, `image_author` and `image_source` to `Comprehension::Passages` table

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Caption-and-attribution-feature-5ac5e5dcbc3441c686dff5f47efbe46b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No-- only has migration files
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
