### PR TITLE
CMS Graded Responses - Apply sort to optimal multiple choice options.

### DIFF
--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -6,11 +6,11 @@ class QuestionsController < ApplicationController
   end
 
   def multiple_choice_options
-    scope = GradedResponse.where(question_uid: params[:question_uid]).limit(MULTIPLE_CHOICE_LIMIT)
+    scope = GradedResponse
+      .where(question_uid: params[:question_uid])
+      .limit(MULTIPLE_CHOICE_LIMIT)
+      .order('count DESC')
 
-    optimal = scope.optimal
-    nonoptimal = scope.nonoptimal.order('count DESC')
-
-    render json: optimal.to_a.concat(nonoptimal.to_a)
+    render json: scope.optimal.to_a.concat(scope.nonoptimal.to_a)
   end
 end

--- a/services/QuillCMS/spec/controllers/questions_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/questions_controller_spec.rb
@@ -46,13 +46,15 @@ RSpec.describe QuestionsController, type: :controller do
     end
 
     context 'with all data' do
-      let!(:response_optimal1) {create(:response, question_uid: '123', optimal: true)}
-      let!(:response_optimal2) {create(:response, question_uid: '123', optimal: true)}
-      let!(:response_optimal3) {create(:response, question_uid: '123', optimal: true)}
-      let!(:response_nonoptimal1) {create(:response, question_uid: '123', optimal: false)}
-      let!(:response_nonoptimal2) {create(:response, question_uid: '123', optimal: false)}
-      let!(:response_nonoptimal3) {create(:response, question_uid: '123', optimal: false)}
-      let!(:response_ungraded) {create(:response, question_uid: '123', optimal: nil)}
+      let!(:optimal1) {create(:response, question_uid: '123', optimal: true, count: 5)}
+      let!(:optimal2) {create(:response, question_uid: '123', optimal: true, count: 7)}
+      let!(:optimal3) {create(:response, question_uid: '123', optimal: true, count: 9)}
+
+      let!(:nonoptimal1) {create(:response, question_uid: '123', optimal: false, count: 7)}
+      let!(:nonoptimal2) {create(:response, question_uid: '123', optimal: false, count: 5)}
+      let!(:nonoptimal3) {create(:response, question_uid: '123', optimal: false, count: 9)}
+
+      let!(:ungraded) {create(:response, question_uid: '123', optimal: nil, count: 1000)}
 
       before(:each) do
         GradedResponse.refresh
@@ -74,12 +76,24 @@ RSpec.describe QuestionsController, type: :controller do
         expect(nonoptimal_count).to eq 2
         expect(null_optimal_count).to eq 0
       end
+
+      it 'should return responses with the highest counts' do
+        get :multiple_choice_options, params: {question_uid: '123'}
+
+        expect(response.status).to eq 200
+
+        json = JSON.parse(response.body)
+        response_ids = json.map{|r| r['id']}.sort
+        highest_count_ids = [optimal2.id, optimal3.id, nonoptimal1.id, nonoptimal3.id].sort
+
+        expect(response_ids).to eq highest_count_ids
+      end
     end
 
     context 'only optimal responses available' do
-      let!(:response_optimal1) {create(:response, question_uid: '123', optimal: true)}
-      let!(:response_optimal2) {create(:response, question_uid: '123', optimal: true)}
-      let!(:response_optimal3) {create(:response, question_uid: '123', optimal: true)}
+      let!(:optimal1) {create(:response, question_uid: '123', optimal: true)}
+      let!(:optimal2) {create(:response, question_uid: '123', optimal: true)}
+      let!(:optimal3) {create(:response, question_uid: '123', optimal: true)}
 
       before(:each) do
         GradedResponse.refresh


### PR DESCRIPTION
## WHAT
In testing the old endpoints vs. the new ones, I found that the `optimal` responses should be sorted by count. This PR correctly sorts both the `optimal` and `nonoptimal`  by count for the `multiple_choice_options` endpoint.
## WHY
This should be a pure refactor and match the previous logic.
## HOW
Add a failing test, fix that test.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'. If you answer
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
