### PR TITLE
comprehension/view-sessions-report-fix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/activitySessions/sessionOverview.tsx
@@ -7,7 +7,7 @@ import { DataTable, Error, Spinner } from '../../../../Shared/index';
 import { getPromptForActivitySession } from "../../../helpers/comprehension";
 import { BECAUSE, BUT, SO } from '../../../../../constants/comprehension';
 
-const SessionOverview = ({ activity, sessionData }) => {
+const SessionOverview = ({ activity, rules, sessionData }) => {
 
   function sessionRows({ activitySession }) {
     if(!activitySession) {
@@ -78,9 +78,9 @@ const SessionOverview = ({ activity, sessionData }) => {
         headers={dataTableFields}
         rows={sessionRows(sessionData)}
       />
-      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, BECAUSE)} sessionId={sessionId} showHeader={true} />
-      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, BUT)} sessionId={sessionId} showHeader={true} />
-      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, SO)} sessionId={sessionId} showHeader={true} />
+      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, BECAUSE)} rules={rules} sessionId={sessionId} showHeader={true} />
+      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, BUT)} rules={rules} sessionId={sessionId} showHeader={true} />
+      <PromptTable activity={activity} prompt={getPromptForActivitySession(sessionData, SO)} rules={rules} sessionId={sessionId} showHeader={true} />
     </div>
   );
 }


### PR DESCRIPTION
## WHAT
Pass `rules` object through the overview to the prompt tables
## WHY
So that it displays Rule names even on the "overview" page
## HOW
The "overview" page just reproduces the components that are used on the conjunction-specific pages, but does so sequentially.  It needs to have the Rule names passed through if it's going to pass them through in turn.  We were passing the value to the overview component, but it wasn't properly passing them through to the nested conjunction-specific components.  This fixes that.

### Notion Card Links
https://www.notion.so/quill/View-Sessions-rules-display-null-instead-of-rule-names-4801a9bab6bc4407b657b2cd3d2e5f2d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Our snapshots don't capture this level of detail
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
