### PR TITLE
Fix bug with updating imported google classrooms

### DIFF
--- a/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
@@ -5,10 +5,14 @@ module GoogleIntegration
       sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
       def perform(user_id)
-        return unless user_id
+        return unless google_id?(user_id)
 
         ClassroomsRetriever.new(user_id).run
         ImportedClassroomsUpdater.new(user_id).run
+      end
+
+      private def google_id?(user_id)
+        user_id && User.find_by(id: user_id)&.google_id
       end
     end
   end

--- a/services/QuillLMS/spec/workers/google_integration/users/update_imported_classrooms_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/google_integration/users/update_imported_classrooms_worker_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe GoogleIntegration::Users::UpdateImportedClassroomsWorker do
+  let(:worker) { described_class.new }
+
+  let(:retriever_class) { GoogleIntegration::Users::ClassroomsRetriever}
+  let(:updater_class) { GoogleIntegration::Users::ImportedClassroomsUpdater }
+
+  subject { worker.perform(user_id) }
+
+  context 'nil user_id' do
+    let(:user_id) { nil }
+
+    it { should_not_call_service_objects }
+  end
+
+  context 'user does not exist' do
+    let(:user_id) { 0 }
+
+    it { should_not_call_service_objects }
+  end
+
+  context 'user exists' do
+    context 'that does not have google_id' do
+      let(:user_id) { create(:teacher).id }
+
+      it { should_not_call_service_objects }
+    end
+
+    context 'that has google_id' do
+      let(:updater) { instance_double(updater_class, run: nil) }
+      let(:retriever) { instance_double(retriever_class, run: nil) }
+
+      let(:user_id) { create(:teacher, google_id: 123).id }
+
+      it { should_call_service_objects }
+    end
+  end
+
+  def should_not_call_service_objects
+    expect(retriever_class).to_not receive(:new)
+    expect(updater_class).to_not receive(:new)
+    subject
+  end
+
+  def should_call_service_objects
+    expect(retriever_class).to receive(:new).with(user_id).and_return(retriever)
+    expect(updater_class).to receive(:new).with(user_id).and_return(updater)
+    subject
+  end
+end


### PR DESCRIPTION
## WHAT
Fix an error where a background job is calling methods on a teacher who doesn't have a `google_id`.

## WHY
The job does not apply to these teachers.

## HOW
Add a guard clause to only run classroom retrieval and updating when the teacher has a `google_id`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-TypeError-Sidekiq-GoogleIntegration-Users-UpdateImportedClassroomsWorker-f4e210140f674a2aafa566f41cce0614

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
