### PR TITLE
redirect comprehension to evidence in case of existing links

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -621,6 +621,7 @@ EmpiricalGrammar::Application.routes.draw do
   end
 
   # These are legacy routes that we are redirecting for posterity.
+  get 'comprehension', to: redirect('evidence')
   get 'blog_posts', to: redirect('/news')
   get 'supporters', to: redirect('https://community.quill.org/')
   get 'story', to: redirect('/mission')


### PR DESCRIPTION
## WHAT
Redirect old `/comprehension` route to `/evidence`.

## WHY
In case there are existing links floating around that we want to work.

## HOW
Just add a line in the routes file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
