### PR TITLE
Add apple icon to site

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -19,7 +19,7 @@
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">
-  <link rel="apple-touch-icon" href=<%= ENV['CDN_URL'].tr("‘", "").tr("’", "") + "/images/logos/apple-touch-icon.png" %>>
+  <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].tr("‘", "").tr("’", "") + "/images/logos/apple-touch-icon.png" %>">
 
   <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -19,7 +19,7 @@
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">
-  <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].tr("‘", "").tr("’", "") + "/images/logos/apple-touch-icon.png" %>">
+  <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
 
   <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -19,7 +19,7 @@
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href=<%= ENV['CDN_URL'].tr("‘", "").tr("’", "") + "/images/logos/apple-touch-icon.png" %>>
 
   <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -19,6 +19,7 @@
     <meta property="og:title"       content="<%= @title %>" />
     <meta property="og:description" content="<%= @description %>" />
     <meta property="og:image"       content=<%= image_url('share/facebook.png') %> />
+    <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
 
     <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>


### PR DESCRIPTION
## WHAT
Add a link to `apple-touch-icon.png` so that we don't get errors for missing this icon. It will direct the user to an image that their iPhone or iPad can use as the Quill icon if they bookmark our app to the home page.

## WHY
So users can see a nice logo if they bookmark our website.

## HOW
Add the link to the icon in the head HTML.

### Screenshots
![IMG_1742](https://user-images.githubusercontent.com/57366100/129373841-1d82b5b9-f7eb-40b6-8dbd-e577d99c7b3c.PNG)


### Notion Card Links
https://www.notion.so/quill/Add-Apple-Touch-Icons-b461983e9466451ba0d8861b10181d3e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
