### PR TITLE
Fix user find_by bug

### DIFF
--- a/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
@@ -12,7 +12,7 @@ module GoogleIntegration
       end
 
       private def google_id?(user_id)
-        user_id && User.find_by(id: user_id)&.google_id
+        user_id && ::User.find_by(id: user_id)&.google_id
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix bug involving undefined method `find_by` for `GoogleIntegration::User:Class`

## WHY
It's preventing jobs from running.

## HOW
Add root namespace to `::User.find_by`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-NoMethodError-Sidekiq-GoogleIntegration-Users-UpdateImportedClassroomsWorker-ea4daac67a8246298fa0ea031f6a6a93

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.   Tiny change.
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
