### PR TITLE
Prevent default submission behavior on Comprehension Turk buttons

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1169,7 +1169,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               clickHandler={[Function]}
               id={1}
               label="copy"
-              value="undefined/comprehension/#/turk?uid=17&id=1"
+              value="undefined/evidence/#/turk?uid=17&id=1"
             />,
             "delete": <Unknown
               clickHandler={[Function]}
@@ -1185,11 +1185,11 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             "expiration": "December 7th, 2020",
             "id": "17-1",
             "turkLink": <a
-              href="undefined/comprehension/#/turk?uid=17&id=1"
+              href="undefined/evidence/#/turk?uid=17&id=1"
               rel="noopener noreferrer"
               target="_blank"
             >
-              undefined/comprehension/#/turk?uid=17&id=1
+              undefined/evidence/#/turk?uid=17&id=1
             </a>,
           },
         ]
@@ -1285,11 +1285,11 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <a
-                href="undefined/comprehension/#/turk?uid=17&id=1"
+                href="undefined/evidence/#/turk?uid=17&id=1"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                undefined/comprehension/#/turk?uid=17&id=1
+                undefined/evidence/#/turk?uid=17&id=1
               </a>
             </span>
             <span
@@ -1312,7 +1312,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   clickHandler={[Function]}
                   id={1}
                   label="copy"
-                  value="undefined/comprehension/#/turk?uid=17&id=1"
+                  value="undefined/evidence/#/turk?uid=17&id=1"
                 />
               }
               tooltipTriggerStyle={
@@ -1327,7 +1327,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   clickHandler={[Function]}
                   id={1}
                   label="copy"
-                  value="undefined/comprehension/#/turk?uid=17&id=1"
+                  value="undefined/evidence/#/turk?uid=17&id=1"
                 />
               }
               tooltipTriggerTextClass="data-table-row-section undefined"
@@ -1365,14 +1365,14 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                     clickHandler={[Function]}
                     id={1}
                     label="copy"
-                    value="undefined/comprehension/#/turk?uid=17&id=1"
+                    value="undefined/evidence/#/turk?uid=17&id=1"
                   >
                     <button
                       className="quill-button fun primary contained"
                       id="1"
                       onClick={[Function]}
                       type="submit"
-                      value="undefined/comprehension/#/turk?uid=17&id=1"
+                      value="undefined/evidence/#/turk?uid=17&id=1"
                     >
                       copy
                     </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1136,7 +1136,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
       headers={
         Array [
           Object {
-            "attribute": "link",
+            "attribute": "turkLink",
             "name": "Link",
             "width": "500px",
           },
@@ -1169,7 +1169,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               clickHandler={[Function]}
               id={1}
               label="copy"
-              value="undefined/evidence/#/turk?uid=17&id=1"
+              value="undefined/comprehension/#/turk?uid=17&id=1"
             />,
             "delete": <Unknown
               clickHandler={[Function]}
@@ -1184,6 +1184,13 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             />,
             "expiration": "December 7th, 2020",
             "id": "17-1",
+            "turkLink": <a
+              href="undefined/comprehension/#/turk?uid=17&id=1"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              undefined/comprehension/#/turk?uid=17&id=1
+            </a>,
           },
         ]
       }
@@ -1199,7 +1206,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             style={
               Object {
                 "minWidth": "500px",
-                "textAlign": "right",
+                "textAlign": "left",
                 "width": "500px",
               }
             }
@@ -1268,15 +1275,23 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
           >
             <span
               className="data-table-row-section undefined"
-              key="link-17-1"
+              key="turkLink-17-1"
               style={
                 Object {
                   "minWidth": "500px",
-                  "textAlign": "right",
+                  "textAlign": "left",
                   "width": "500px",
                 }
               }
-            />
+            >
+              <a
+                href="undefined/comprehension/#/turk?uid=17&id=1"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                undefined/comprehension/#/turk?uid=17&id=1
+              </a>
+            </span>
             <span
               className="data-table-row-section undefined"
               key="expiration-17-1"
@@ -1297,7 +1312,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   clickHandler={[Function]}
                   id={1}
                   label="copy"
-                  value="undefined/evidence/#/turk?uid=17&id=1"
+                  value="undefined/comprehension/#/turk?uid=17&id=1"
                 />
               }
               tooltipTriggerStyle={
@@ -1312,7 +1327,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   clickHandler={[Function]}
                   id={1}
                   label="copy"
-                  value="undefined/evidence/#/turk?uid=17&id=1"
+                  value="undefined/comprehension/#/turk?uid=17&id=1"
                 />
               }
               tooltipTriggerTextClass="data-table-row-section undefined"
@@ -1350,14 +1365,14 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                     clickHandler={[Function]}
                     id={1}
                     label="copy"
-                    value="undefined/evidence/#/turk?uid=17&id=1"
+                    value="undefined/comprehension/#/turk?uid=17&id=1"
                   >
                     <button
                       className="quill-button fun primary contained"
                       id="1"
                       onClick={[Function]}
                       type="submit"
-                      value="undefined/evidence/#/turk?uid=17&id=1"
+                      value="undefined/comprehension/#/turk?uid=17&id=1"
                     >
                       copy
                     </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1184,13 +1184,6 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             />,
             "expiration": "December 7th, 2020",
             "id": "17-1",
-            "link": <a
-              href="undefined/evidence/#/turk?uid=17&id=1"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              undefined/evidence/#/turk?uid=17&id=1
-            </a>,
           },
         ]
       }
@@ -1206,7 +1199,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             style={
               Object {
                 "minWidth": "500px",
-                "textAlign": "left",
+                "textAlign": "right",
                 "width": "500px",
               }
             }
@@ -1269,17 +1262,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
         <div
           className="data-table-body"
         >
-          <a
+          <div
             className="data-table-row  "
-            href={
-              <a
-                href="undefined/evidence/#/turk?uid=17&id=1"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                undefined/evidence/#/turk?uid=17&id=1
-              </a>
-            }
             key="17-1"
           >
             <span
@@ -1288,19 +1272,11 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               style={
                 Object {
                   "minWidth": "500px",
-                  "textAlign": "left",
+                  "textAlign": "right",
                   "width": "500px",
                 }
               }
-            >
-              <a
-                href="undefined/evidence/#/turk?uid=17&id=1"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                undefined/evidence/#/turk?uid=17&id=1
-              </a>
-            </span>
+            />
             <span
               className="data-table-row-section undefined"
               key="expiration-17-1"
@@ -1559,7 +1535,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
             <span
               className="removable data-table-row-section"
             />
-          </a>
+          </div>
         </div>
       </div>
     </DataTable>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
@@ -60,6 +60,7 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   }
 
   function handleEditOrDeleteTurkSession (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
+    e.preventDefault();
     const target  = e.target as HTMLButtonElement;
     const { id, value } = target;
     setEditTurkSessionId(id);
@@ -95,6 +96,7 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   }
 
   function handleCopyTurkLink (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
+    e.preventDefault();
     copyToClipboard(e, setSnackBarVisible);
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
@@ -60,7 +60,6 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   }
 
   function handleEditOrDeleteTurkSession (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    e.preventDefault();
     const target  = e.target as HTMLButtonElement;
     const { id, value } = target;
     setEditTurkSessionId(id);
@@ -96,17 +95,14 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   }
 
   function handleCopyTurkLink (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    e.preventDefault();
     copyToClipboard(e, setSnackBarVisible);
   }
 
   const turkSessionsRows = turkSessionsData && turkSessionsData.turkSessions && turkSessionsData.turkSessions.map((turkSession: TurkSessionInterface) => {
     const { activity_id, expires_at, id } = turkSession;
     const url = `${process.env.DEFAULT_URL}/evidence/#/turk?uid=${activity_id}&id=${id}`;
-    const link = <a href={url} rel="noopener noreferrer" target="_blank">{url}</a>;
     return {
       id: `${activity_id}-${id}`,
-      link,
       expiration: moment(expires_at).format('MMMM Do, YYYY'),
       copy: <TurkSessionButton clickHandler={handleCopyTurkLink} id={id} label="copy" value={url} />,
       edit: <TurkSessionButton clickHandler={handleEditOrDeleteTurkSession} id={id} label="edit" value={expires_at} />,

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
@@ -100,7 +100,7 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
 
   const turkSessionsRows = turkSessionsData && turkSessionsData.turkSessions && turkSessionsData.turkSessions.map((turkSession: TurkSessionInterface) => {
     const { activity_id, expires_at, id } = turkSession;
-    const url = `${process.env.DEFAULT_URL}/comprehension/#/turk?uid=${activity_id}&id=${id}`;
+    const url = `${process.env.DEFAULT_URL}/evidence/#/turk?uid=${activity_id}&id=${id}`;
     const turkLink = <a href={url} rel="noopener noreferrer" target="_blank">{url}</a>;
     return {
       id: `${activity_id}-${id}`,

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/gatherResponses/turkSessions.tsx
@@ -100,9 +100,11 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
 
   const turkSessionsRows = turkSessionsData && turkSessionsData.turkSessions && turkSessionsData.turkSessions.map((turkSession: TurkSessionInterface) => {
     const { activity_id, expires_at, id } = turkSession;
-    const url = `${process.env.DEFAULT_URL}/evidence/#/turk?uid=${activity_id}&id=${id}`;
+    const url = `${process.env.DEFAULT_URL}/comprehension/#/turk?uid=${activity_id}&id=${id}`;
+    const turkLink = <a href={url} rel="noopener noreferrer" target="_blank">{url}</a>;
     return {
       id: `${activity_id}-${id}`,
+      turkLink,
       expiration: moment(expires_at).format('MMMM Do, YYYY'),
       copy: <TurkSessionButton clickHandler={handleCopyTurkLink} id={id} label="copy" value={url} />,
       edit: <TurkSessionButton clickHandler={handleEditOrDeleteTurkSession} id={id} label="edit" value={expires_at} />,
@@ -138,7 +140,7 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   }
 
   const dataTableFields = [
-    { name: "Link", attribute:"link", width: "500px" },
+    { name: "Link", attribute:"turkLink", width: "500px" },
     { name: "Expiration Date", attribute:"expiration", width: "200px" },
     { name: "", attribute:"copy", width: "100px" },
     { name: "", attribute:"edit", width: "100px" },


### PR DESCRIPTION
## WHAT
The "copy", "edit" and "delete" buttons on the admin Comprehension Turk Sessions page were submitting by default and redirecting the user to a 404 page because the submission would take them to a broken link. This fixes that by preventing the default submission behavior.

## WHY
We don't want admin to go to a broken page when they click these links.

## HOW
Add a line to prevent the default event behavior on button click.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Broken-buttons-in-Comprehension-internal-tool-a5a55e8a87c14a538f797fb5050ac4e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
