### PR TITLE
Fix bug involving google imports of classes with existing with already existing names

### DIFF
--- a/services/QuillLMS/app/services/google_integration/classrooms/creator.rb
+++ b/services/QuillLMS/app/services/google_integration/classrooms/creator.rb
@@ -21,7 +21,7 @@ module GoogleIntegration
           teacher_id: teacher_id,
           classrooms_teachers_attributes: [
             {
-              user_id: user_id,
+              user_id: teacher_id,
               role: role
             }
           ]
@@ -29,19 +29,32 @@ module GoogleIntegration
       end
 
       private def name
-        data[:name].present? ? data[:name] : "Classroom #{google_classroom_id}"
+        data[:name].present? ? valid_name : "Classroom #{google_classroom_id}"
+      end
+
+      private def other_owned_classroom_names
+        @other_owned_classroom_names ||= teacher.classrooms_i_own.pluck(:name)
       end
 
       private def role
         'owner'
       end
 
+      private def teacher
+        ::User.find(teacher_id)
+      end
+
       private def synced_name
         data[:name]
       end
 
-      private def user_id
-        teacher_id
+      private def valid_name
+        temp_name = data[:name]
+
+        loop do
+          return temp_name unless other_owned_classroom_names.include?(temp_name)
+          temp_name += '_1'
+        end
       end
     end
   end

--- a/services/QuillLMS/spec/services/google_integration/classrooms/creator_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classrooms/creator_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe GoogleIntegration::Classrooms::Creator do
-  let(:teacher) { create(:teacher) }
+  let(:teacher_id) { create(:teacher).id }
 
   let(:data) do
     {
       google_classroom_id: google_classroom_id,
       name: name,
-      teacher_id: teacher.id
+      teacher_id: teacher_id
     }
   end
 
@@ -17,15 +17,15 @@ RSpec.describe GoogleIntegration::Classrooms::Creator do
 
   let(:google_classroom_id) { 123456 }
 
-  around { |example| expect { example.run }.to change(ClassroomsTeacher, :count).from(0).to(1) }
-
   context 'name present' do
     let(:name) { 'google classroom name'}
 
     it 'creates a new classroom object with synced_name attr initially set to name' do
+      expect(ClassroomsTeacher.count).to eq 0
       expect(classroom.google_classroom_id).to eq google_classroom_id
       expect(classroom.name).to eq name
       expect(classroom.synced_name).to eq name
+      expect(classroom.classrooms_teachers.count).to eq 1
     end
   end
 
@@ -36,6 +36,30 @@ RSpec.describe GoogleIntegration::Classrooms::Creator do
       expect(classroom.google_classroom_id).to eq google_classroom_id
       expect(classroom.name).to eq "Classroom #{google_classroom_id}"
       expect(classroom.synced_name).to eq nil
+    end
+  end
+
+  context "teacher owns another classroom with same name" do
+    let(:name) { 'google classroom name' }
+    let(:synced_name) { name }
+    let(:name_1) { name }
+    let(:classroom_1) { create(:classroom, :from_google, :with_no_teacher, name: name_1) }
+
+    before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_1) }
+
+    it 'creates a new classroom object with new name to avoid a naming collision' do
+      expect(classroom.name).to eq "#{name}_1"
+    end
+
+    context 'and another classroom as same name as a renamed collision' do
+      let(:name_2) { "#{name}_1"}
+      let(:classroom_2) { create(:classroom, :from_google, :with_no_teacher, name: name_2) }
+
+      before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_2) }
+
+      it 'creates a new classroom object with new name to avoid two naming collisions' do
+        expect(classroom.name).to eq "#{name}_1_1"
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug involving a teacher importing of google classrooms where there is a naming collision between an imported classroom and existing one owned by the teacher.

## WHY
During renaming of classrooms within the Quill UI, users will be warned dynamically when trying to update names to invalid ones.  
![Screen Shot 2021-08-13 at 3 26 40 PM](https://user-images.githubusercontent.com/2057805/129409367-9cc4c176-d519-42f6-a8ff-63a33d1e8779.png)
This validation also runs when teachers import from Google Classroom, however, when validation fails, the error message does not propagate to the UI and the import cycles indefinitely:
![Screen Shot 2021-08-13 at 3 41 15 PM](https://user-images.githubusercontent.com/2057805/129410623-721d93de-3605-44c5-bf4e-cc1e6b17b8a2.png)

## HOW
Simply append `_1` to the existing name if there is a collision.  In the unlikely event that rename collides with another owned classroom, the logic provides a [loop](https://github.com/empirical-org/Empirical-Core/pull/8087/files#diff-dd8e7d46eefefd3f89a7bb8ab5aa3c563de8e7b43ee0053ed1d96fca27275efaR59) that eventually settles on a temporary name.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-ActiveRecord-RecordInvalid-Teachers-ClassroomManagerController-update_google_classr-2b522bc57318430397f0272fdf0b743b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? |  YES


Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
