### PR TITLE
don't allow users to move on in Evidence til they have scrolled to the end of the passage

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/bottomNavigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/bottomNavigation.tsx
@@ -7,7 +7,7 @@ const MINIMUM_STUDENT_HIGHLIGHT_COUNT = 2
 const ReadAndHighlightTracker = ({ scrolledToEndOfPassage, studentHighlights, onMobile, handleClickDoneHighlighting, }) => {
   const minimumMet = studentHighlights.length >= MINIMUM_STUDENT_HIGHLIGHT_COUNT
   let doneButton = <button className="quill-button contained primary large focus-on-light disabled" type="button">Done</button>
-  if (minimumMet) {
+  if (scrolledToEndOfPassage && minimumMet) {
     doneButton = <button className="quill-button contained primary large focus-on-light" onClick={handleClickDoneHighlighting} type="button">Done</button>
   }
   return (


### PR DESCRIPTION
## WHAT
Don't allow Evidence users to move on until they have scrolled to the end of the passage, not just made two highlights.

## WHY
To force them to scroll to the end.

## HOW
Just add it as part of the conditional that determines whether the "Done" button is disabled or not.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/The-student-app-doesn-t-require-you-to-scroll-to-the-bottom-of-the-text-ed2fd31228cb44f9903a91e3813d89f9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
