### PR TITLE
put version of draft-js back the way it was

### DIFF
--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -4703,21 +4703,6 @@
         "gud": "^1.0.0"
       }
     },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "requires": {
-        "node-fetch": "2.6.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
-      }
-    },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -5287,35 +5272,15 @@
       }
     },
     "draft-js": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
-      "integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
+      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
       "requires": {
-        "fbjs": "^2.0.0",
+        "fbjs": "^0.8.15",
         "immutable": "~3.7.4",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.16.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-          "integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw=="
-        },
-        "fbjs": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
-          "integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
-          "requires": {
-            "core-js": "^3.6.4",
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
         "immutable": {
           "version": "3.7.6",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
@@ -6499,11 +6464,6 @@
         }
       }
     },
-    "fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
     "fetch-defaults": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fetch-defaults/-/fetch-defaults-1.0.0.tgz",
@@ -7022,7 +6982,8 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -36,7 +36,7 @@
     "css-loader": "^3.2.0",
     "diff": "^3.5.0",
     "draft-convert": "^2.1.10",
-    "draft-js": "^0.11.7",
+    "draft-js": "^0.10.4",
     "draft-js-export-html": "^0.6.0",
     "draft-js-plugins-editor": "^2.1.1",
     "draft-js-richbuttons-plugin": "^2.2.0",


### PR DESCRIPTION
## WHAT
Revert to previous version of draft-js.

## WHY
There is some issue in the previous version that makes some editors unusable.

## HOW
Just go back to the version we had before last week's PR.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/You-can-t-delete-or-update-any-text-in-the-Evidence-internal-tool-7c4a9d77d34545a8a9a3a210e7db3e15

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
