### PR TITLE
skip onboarding/highlights/reflection for turk workers and admin users

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -86,22 +86,24 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
   constructor(props: StudentViewContainerProps) {
     super(props)
 
+    const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts')
+
     this.state = {
-      activeStep: READ_PASSAGE_STEP,
+      activeStep: shouldSkipToPrompts ? READ_PASSAGE_STEP + 1: READ_PASSAGE_STEP,
       activityIsComplete: false,
       activityIsReadyForSubmission: false,
-      explanationSlidesCompleted: false,
+      explanationSlidesCompleted: shouldSkipToPrompts,
       explanationSlideStep: 0,
-      completedSteps: [],
+      completedSteps: shouldSkipToPrompts ? [READ_PASSAGE_STEP] : [],
       showFocusState: false,
       startTime: Date.now(),
       isIdle: false,
       studentHighlights: [],
-      scrolledToEndOfPassage: false,
+      scrolledToEndOfPassage: shouldSkipToPrompts,
       showReadTheDirectionsModal: false,
-      hasStartedReadPassageStep: false,
-      hasStartedPromptSteps: false,
-      doneHighlighting: false,
+      hasStartedReadPassageStep: shouldSkipToPrompts,
+      hasStartedPromptSteps: shouldSkipToPrompts,
+      doneHighlighting: shouldSkipToPrompts,
       timeTracking: {
         1: 0,
         2: 0,
@@ -878,7 +880,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
         <ExplanationSlide onHandleClick={this.handleExplanationSlideClick} slideData={explanationData[explanationSlideStep]} />
       );
     }
-    if(activityIsComplete) {
+    if(activityIsComplete && !window.location.href.includes('turk')) {
       return(
         <PostActivitySlide responses={submittedResponses} user={user} />
       );

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -9,11 +9,19 @@ exports[`Activity Form component should render Activities 1`] = `
   >
     <a
       className="quill-button fun secondary outlined"
-      href="/evidence/#/play?uid=undefined"
+      href="/evidence/#/play?uid=undefined&skipToPrompts=true"
       rel="noopener noreferrer"
       target="_blank"
     >
       Play Activity
+    </a>
+    <a
+      className="quill-button fun secondary outlined"
+      href="/evidence/#/play?uid=undefined"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Full Student Play
     </a>
     <button
       className="quill-button fun secondary outlined"

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
@@ -4,6 +4,14 @@ exports[`RegexRulesIndex component should render RegexRulesIndex 1`] = `
 <div
   className="rules-container"
 >
+  <a
+    className="quill-button fun secondary outlined focus-on-light play-activity-button"
+    href="/evidence/#/play?uid=1&skipToPrompts=true"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    Play Activity
+  </a>
   <section
     className="rules-based-section"
   >

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/configureSettings/activityForm.tsx
@@ -142,7 +142,8 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
   return(
     <div className="activity-form-container">
       <div className="button-container">
-        <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Play Activity</a>
+        <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Activity</a>
+        <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Full Student Play</a>
         {activity.parent_activity_id && <button className="quill-button fun secondary outlined" onClick={handleClickArchiveActivity} type="button">Archive Activity</button>}
         <button className="quill-button fun primary contained" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">Save</button>
       </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/comprehension/regexRules/regexRulesIndex.tsx
@@ -160,6 +160,7 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
   return(
     <div className="rules-container">
       {renderHeader(activityData, 'Regex Rules')}
+      <a className="quill-button fun secondary outlined focus-on-light play-activity-button" href={`/evidence/#/play?uid=${activityId}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Activity</a>
       <section className="rules-based-section">
         <button className="quill-button fun primary contained add-rule-button" type="submit">{addRulesBased1Link}</button>
         {renderTable(rulesBased1Rows, 'Sentence Structure')}

--- a/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/comprehension_manager.scss
@@ -431,6 +431,9 @@
   }
   .rules-container, .rule-container, .turk-sessions-container, .semantic-labels-container, .model-container {
     width: 80vw;
+    .play-activity-button {
+      margin-bottom: 20px;
+    }
     .semantic-rules-cheat-sheet {
       .data-table-row {
         height: min-content;


### PR DESCRIPTION
## WHAT
Skip onboarding/highlights/reflection for turk workers and admin users.

## WHY
To remove a lot of unnecessary clicks.

## HOW
Just update the default state based on whether it is a turk link or a link with the special queryString `skipToPrompts`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-the-Turk-flow-and-create-add-buttons-for-student-v-Turk-play-9bee5d0d2cf64decb393733d11b5a6db

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES