### PR TITLE
blur and scroll passage to top between reflection and prompt steps

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -447,6 +447,8 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
 
   handleDoneReadingClick = () => {
     this.completeStep(READ_PASSAGE_STEP)
+    const scrollContainer = document.getElementsByClassName("read-passage-container")[0]
+    scrollContainer.scrollTo(0, 0)
     this.trackPassageReadEvent();
   }
 
@@ -769,7 +771,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
 
     const headerImage = passages[0].image_link && <img alt={passages[0].image_alt_text} className="header-image" src={passages[0].image_link} />
     let innerContainerClassName = "read-passage-inner-container "
-    innerContainerClassName += !hasStartedReadPassageStep || showReadTheDirectionsModal ? 'blur' : ''
+    innerContainerClassName += !hasStartedReadPassageStep || showReadTheDirectionsModal || (activeStep > READ_PASSAGE_STEP && !hasStartedPromptSteps) ? 'blur' : ''
 
     if ((!hasStartedReadPassageStep || (activeStep > READ_PASSAGE_STEP && !hasStartedPromptSteps)) && this.onMobile()) {
       return


### PR DESCRIPTION
## WHAT
Blur and scroll the passage to the the top for the view between finishing the reflection and starting the prompt steps.

## WHY
So students start the prompt steps with the passage at the top.

## HOW
Just update the conditional and add a scroll.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Upon-completing-the-reflection-move-back-to-the-top-of-the-text-96369d4fc1d94758a29f8ef1e8421726

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES