### PR TITLE
proofreader bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -138,9 +138,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const initialPassageData = formatInitialPassage(passage)
       const formattedPassage = initialPassageData.passage
       let currentPassage = formattedPassage
-      if (session.passageFromFirebase && typeof session.passageFromFirebase !== 'string') {
-        currentPassage = session.passageFromFirebase
-      }
+
       dispatch(setPassage(currentPassage))
       return { originalPassage: _.cloneDeep(formattedPassage), necessaryEdits: initialPassageData.necessaryEdits, edits: editCount(currentPassage), currentActivity: proofreaderActivities.currentActivity, loadingFirebaseSession: false }
     }


### PR DESCRIPTION
## WHAT
Fixes controller params permissioning broken by Rails 5.0, so that `passage` data is persisted to the database.

## WHY
So that students can resume editing their work after hitting `Save & Exit` or reloading.

## HOW

## DISCUSSION
Thomas's related PR: https://github.com/empirical-org/Empirical-Core/pull/8102

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=4622f65cdd714be08cf71f6f7fecdf3c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually. Creating a followup card for testing (we were not able to create an effective spec at this time)
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
