### PR TITLE
proofreader/no-override-with-empty-passage

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -138,7 +138,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const initialPassageData = formatInitialPassage(passage)
       const formattedPassage = initialPassageData.passage
       let currentPassage = formattedPassage
-      if (session.passageFromFirebase && typeof session.passageFromFirebase !== 'string') {
+      if (session.passageFromFirebase && typeof session.passageFromFirebase !== 'string' && session.passageFromFirebase.length) {
         currentPassage = session.passageFromFirebase
       }
       dispatch(setPassage(currentPassage))


### PR DESCRIPTION
## WHAT
Do not clobber Passages with empty arrays from Active Sessions
## WHY
We've found a bug that mistakenly saves empty arrays to the `passage` key of ActiveActivitySession for Proofreader activities, and that empty value is clobbering the actual intended `passage` value rendering activities unplayable on reload
## HOW
Ignore the `passage` key from `ActiveActivitySession` if it is an empty array (which can be caused by a bug we are working on fixing now).  That lets the activity play through as expected, even if it doesn't persist.

### Notion Card Links
https://www.notion.so/quill/Quill-Proofreader-passage-not-loading-for-students-4622f65cdd714be08cf71f6f7fecdf3c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this very specific edge case on the front-end
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
