### PR TITLE
Bug/proofread

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -33,6 +33,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
   end
 
   private def working_params
+    return valid_params unless params.dig(:active_activity_session, :passage)
     permitted_passage_object = params[:active_activity_session][:passage].map do |paragraph| 
       paragraph.map do |word_object|
         word_object.permit!

--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
     begin
       @activity_session = ActiveActivitySession.find_or_initialize_by(uid: params[:id])
       @activity_session.data ||= {}
-      @activity_session.data = @activity_session.data.merge(valid_params)
+      @activity_session.data = @activity_session.data.merge(working_params)
       @activity_session.save!
     rescue ActiveRecord::RecordNotUnique => e
       # Due to the way that ActiveRecord handles unique validations such as the one on UID,
@@ -30,6 +30,15 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
   def destroy
     @activity_session.destroy
     render(plain: 'OK')
+  end
+
+  private def working_params
+    permitted_passage_object = params[:active_activity_session][:passage].map do |paragraph| 
+      paragraph.map do |word_object|
+        word_object.permit!
+      end
+    end
+    valid_params.merge({ passage: permitted_passage_object })
   end
 
   private def valid_params

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -138,7 +138,9 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const initialPassageData = formatInitialPassage(passage)
       const formattedPassage = initialPassageData.passage
       let currentPassage = formattedPassage
-
+      if (session.passageFromFirebase && typeof session.passageFromFirebase !== 'string') {
+        currentPassage = session.passageFromFirebase
+      }
       dispatch(setPassage(currentPassage))
       return { originalPassage: _.cloneDeep(formattedPassage), necessaryEdits: initialPassageData.necessaryEdits, edits: editCount(currentPassage), currentActivity: proofreaderActivities.currentActivity, loadingFirebaseSession: false }
     }

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -138,9 +138,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const initialPassageData = formatInitialPassage(passage)
       const formattedPassage = initialPassageData.passage
       let currentPassage = formattedPassage
-      if (session.passageFromFirebase && typeof session.passageFromFirebase !== 'string') {
-        currentPassage = session.passageFromFirebase
-      }
+
       dispatch(setPassage(currentPassage))
       return { originalPassage: _.cloneDeep(formattedPassage), necessaryEdits: initialPassageData.necessaryEdits, edits: editCount(currentPassage), currentActivity: proofreaderActivities.currentActivity, loadingFirebaseSession: false }
     }


### PR DESCRIPTION
## WHAT
Fixes controller params permissioning broken by Rails 5.0, so that `passage` data is persisted to the database.

## WHY
So that students can resume editing their work after hitting `Save & Exit` or reloading.

## HOW

## DISCUSSION
Thomas's related PR: https://github.com/empirical-org/Empirical-Core/pull/8102

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=4622f65cdd714be08cf71f6f7fecdf3c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually. Creating a followup card for testing (we were not able to create an effective spec at this time)
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
