### PR TITLE
lms/fix-activity-count-race-condition

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -101,8 +101,12 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   private def count_completed_activity
     return unless @activity_session.finished?
 
-    counter = UserActivityClassification.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
-    counter.increment_count
+    begin
+      counter = UserActivityClassification.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
+      counter.increment_count
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
   end
 
   private def activity_session_params

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -101,12 +101,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   private def count_completed_activity
     return unless @activity_session.finished?
 
-    begin
-      counter = UserActivityClassification.find_or_create_by(user: @activity_session.user, activity_classification: @activity_session.classification)
-      counter.increment_count
-    rescue ActiveRecord::RecordNotUnique
-      retry
-    end
+    UserActivityClassification.count_for(@activity_session.user, @activity_session.classification)
   end
 
   private def activity_session_params

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -32,6 +32,17 @@ class UserActivityClassification < ApplicationRecord
       greater_than_or_equal_to: 0
     }
 
+  def self.count_for(user, activity_classification)
+    begin
+      transaction(requires_new: true) do
+        instance = find_or_create_by(user: user, activity_classification: activity_classification)
+        instance.increment_count
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
+  end
+
   def increment_count
     # Note that this could theoretically be susceptible to race conditions
     # if two calls are made at the same time, but since we only intend to

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -42,27 +42,14 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     end
 
     context 'user_activity_classification counts increment when they should' do
-      it 'should create a new user_activity_classification row if necessary' do
-        records = UserActivityClassification.count
-        expect do
-          put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
-        end.to change { UserActivityClassification.count }.by(1)
+      it 'should count_for if the state of the session is "finished"' do
+        expect(UserActivityClassification).to receive(:count_for).with(user, activity_classification)
+        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
       end
 
-      it 'should increment an existing user_activity_classification row if one exists' do
-        start_count = 10
-        uac = UserActivityClassification.create(user: user, activity_classification: activity_classification, count: start_count)
-
-        expect do
-          put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
-          uac.reload
-        end.to change { uac.count }.to(start_count + 1)
-      end
-
-      it 'should not touch user_activity_classification counts if the state of the session is not "finished"' do
-        expect do
-          put :update, params: { id: activity_session.uid }, as: :json
-        end.to_not(change { UserActivityClassification.count })
+      it 'should not count_for if the state of the session is not "finished"' do
+        expect(UserActivityClassification).not_to receive(:count_for)
+        put :update, params: { id: activity_session.uid }, as: :json
       end
     end
 

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -43,6 +43,52 @@ RSpec.describe UserActivityClassification, type: :model do
     end
   end
 
+  context '#self.count_for' do
+    let(:user) { create(:user) }
+    let(:activity_classification) { create(:activity_classification) }
+
+    it 'should create a new record if none exists' do
+      expect do
+        UserActivityClassification.count_for(user, activity_classification)
+      end.to change { UserActivityClassification.count }.by(1)
+    end
+
+    it 'should increment an existing record if it exists' do
+      existing_record = UserActivityClassification.create(user: user, activity_classification: activity_classification, count: 10)
+      expect do
+        UserActivityClassification.count_for(user, activity_classification)
+        existing_record.reload
+      end.to change { existing_record.count }.by(1)
+    end
+
+    it 'should handle race conditions gracefully' do
+      begin
+        call_count = 2
+        wait_to_start = true
+        failure_in_thread = false
+
+        threads = call_count.times.map do |i|
+          Thread.new do
+            true while wait_to_start
+            begin
+              UserActivityClassification.count_for(user, activity_classification)
+            rescue ActiveRecord::RecordNotUnique
+              failure_in_thread = true
+            end
+          end
+        end
+        wait_to_start = false
+        threads.each(&:join)
+
+        expect(failure_in_thread).to be(false)
+        record = UserActivityClassification.find_by(user: user, activity_classification: activity_classification)
+        expect(record.count).to eq(call_count)
+      ensure
+        ActiveRecord::Base.connection_pool.disconnect!
+      end
+    end
+  end
+
   context '#increment_count' do
     let(:start_count) { 10 }
     let(:user_activity_classification) { create(:user_activity_classification, count: start_count) }


### PR DESCRIPTION
## WHAT
Wrap activity count in a retry block to avoid race conditions
## WHY
I don't know how this happens, but sometimes a user triggers `ActivitySession.update` twice in parallel with both payloads trying to mark the session as `complete`.  When this happens, if the user doesn't already have a `UserActivityClassification` record for the activity classification of the referenced activity, there can be a race condition about which thread gets to create the record for the first time.
## HOW
Just wrap the block that does the creation in a `begin` block and retry in cases where the race condition is detected.

### Notion Card Links
https://www.notion.so/quill/Race-Condition-in-User-completed-activity-counts-8c234b1100a048399d6819c47cbbd5fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  I don't actually know of a good way to simulate a race condition.
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
