### PR TITLE
Update controller specs to use as: :json instead of format: :json

### DIFF
--- a/services/QuillLMS/spec/controllers/api/v1/activity_flags_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_flags_controller_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe Api::V1::ActivityFlagsController, type: :controller do
   context '#index' do
     it 'returns appropriate flags' do
-      get :index
+      get :index, as: :json
+
       expect(JSON.parse(response.body)['activity_flags']).to match_array(
         ['production', 'archive', 'alpha', 'beta', 'private'])
     end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -18,12 +18,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         .and_return(service_instance)
       expect(service_instance).to receive(:call)
 
-      put :update,
-        params: {
-          id: activity_session.uid,
-          state: 'finished'
-        },
-        as: :json
+      put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
     end
 
     context 'default behavior' do
@@ -100,14 +95,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         results
       end
 
-      before do
-        put :update,
-          params: {
-            id: activity_session.uid,
-            concept_results: concept_results
-          },
-          as: :json
-      end
+      before { put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json }
 
       it 'succeeds' do
         expect(response.status).to eq(200)
@@ -138,7 +126,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
             }
           }
         ]
-        put :update, params: { id: activity_session.uid, concept_results: results }
+        put :update, params: { id: activity_session.uid, concept_results: results }, as: :json
       end
 
       # this is no longer the case, as results should not be saved with nonexistent concept tag
@@ -160,14 +148,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         }
       end
 
-      before do
-         put :update,
-          params: {
-           id: activity_session.uid,
-           data: data
-          },
-          as: :json
-      end
+      before { put :update, params: { id: activity_session.uid, data: data }, as: :json }
 
       it 'updates timespent on activity session' do
         activity_session.reload
@@ -182,7 +163,8 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     let!(:session) { create(:activity_session) }
 
     it 'renders the correct json' do
-      get :show, params: { id: session.uid }
+      get :show, params: { id: session.uid }, as: :json
+
       expect(JSON.parse(response.body)["meta"]).to eq({
           "status" => "success",
           "message" => nil,
@@ -208,14 +190,14 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     before { allow(controller).to receive(:doorkeeper_token) {token} }
 
     it 'returns a 422 error if activity session is already saved' do
-      put :update, params: { id: activity_session.uid }
+      put :update, params: { id: activity_session.uid }, as: :json
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Already Completed")
     end
 
     it 'returns a 200 if the activity session is not already finished and can be updated' do
       activity_session.update(completed_at: nil, state: 'started')
-      put :update, params: { id: activity_session.uid }
+      put :update, params: { id: activity_session.uid }, as: :json
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Updated")
     end
@@ -225,7 +207,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       activity_session = create(:activity_session, state: 'started', user: user)
       activity_session.stub(:update) { false }
 
-      put :update, params: { id: activity_session.uid }
+      put :update, params: { id: activity_session.uid }, as: :json
       parsed_body = JSON.parse(response.body)
       expect(parsed_body["meta"]["message"]).to eq("Activity Session Already Completed")
     end
@@ -252,7 +234,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     let!(:session) { create(:proofreader_activity_session) }
 
     it 'destroys the activity session' do
-      delete :destroy, params: { id: session.uid, format: :json }
+      delete :destroy, params: { id: session.uid }, as: :json
       expect(JSON.parse(response.body)["meta"]).to eq({
         "status" => "success",
         "message" => "Activity Session Destroy Successful",

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -2,19 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::AppSettingsController, type: :controller do
   let(:user) { create(:user) }
-  before do 
-    allow(controller).to receive(:current_user) { user }
-  end
+
+  before { allow(controller).to receive(:current_user) { user } }
 
   describe "GET #index" do
     it "returns a success response" do
-      
-      create(:app_setting, name: 'first', enabled: true) 
-      create(:app_setting, name: 'second', enabled: true) 
-      create(:app_setting, name: 'third', enabled: true) 
 
-      get(:index) 
-      
+      create(:app_setting, name: 'first', enabled: true)
+      create(:app_setting, name: 'second', enabled: true)
+      create(:app_setting, name: 'third', enabled: true)
+
+      get :index, as: :json
+
       expect(response).to be_success
       expected_keys = Set["first", "second", "third"]
       expect(Set[*JSON.parse(response.body).keys]).to eq expected_keys
@@ -24,9 +23,9 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       create(:app_setting, name: 'lorem', enabled: false)
-      
-      get(:show, params: { name: 'lorem' }) 
-      
+
+      get :show, params: { name: 'lorem' }, as: :json
+
       expect(response).to be_success
       expect(JSON.parse(response.body)).to eq({ "lorem" => false })
     end

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -25,26 +25,26 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   context '#student_names' do
     it 'does not authenticate a teacher who is not associated with the classroom activity' do
       session[:user_id] = other_teacher.id
-      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id }, as: :json
       expect(response.status).to be_in([303, 404])
     end
 
     it 'authenticates a teacher who is associated with the classroom activity classroom' do
       session[:user_id] = teacher.id
-      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id }, as: :json
       expect(response.status).not_to eq(303)
     end
 
     it 'returns JSON object with activity session name key values' do
       session[:user_id] = teacher.id
-      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id }, as: :json
       expect(JSON.parse(response.body)['activity_sessions_and_names'].keys.count)
         .to eq(5)
     end
 
     it 'returns JSON object with student id key values' do
       session[:user_id] = teacher.id
-      get(:student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :student_names, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id }, as: :json
       expect(JSON.parse(response.body)['student_ids'].keys.count).to eq(5)
     end
   end
@@ -52,19 +52,19 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   context '#teacher_and_classroom_name' do
     it 'does not authenticate a teacher who is not associated with the classroom activity' do
       session[:user_id] = other_teacher.id
-      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id }, as: :json
       expect(response.status).to be_in([303, 404])
     end
 
     it 'authenticates a teacher who is associated with the classroom activity classroom' do
       session[:user_id] = teacher.id
-      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id }, as: :json
       expect(response.status).not_to eq(303)
     end
 
     it 'returns JSON object with activity session name key values' do
       session[:user_id] = teacher.id
-      get(:teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id, format: 'json' })
+      get :teacher_and_classroom_name, params: { classroom_unit_id: classroom_unit.id }, as: :json
       expect(JSON.parse(response.body))
         .to eq({"teacher"=>teacher.name, "classroom"=>classroom.name})
     end
@@ -76,7 +76,15 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
 
     it 'does not authenticate a teacher who does not own the classroom activity' do
       session[:user_id] = other_teacher.id
-      put(:finish_lesson, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, concept_results: [], follow_up: true, format: 'json' })
+      put :finish_lesson,
+        params: {
+          activity_id: activity.uid,
+          classroom_unit_id: classroom_unit.id,
+          concept_results: [],
+          follow_up: true
+        },
+        as: :json
+
       expect(response.status).to be_in([303, 404])
     end
 
@@ -125,15 +133,12 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
         },
         as: :json
 
-      expect(JSON.parse(response.body))
-        .to eq({"follow_up_url"=> (ENV['DEFAULT_URL']).to_s})
+      expect(JSON.parse(response.body)).to eq({"follow_up_url"=> (ENV['DEFAULT_URL']).to_s})
     end
   end
 
   describe '#unpin_and_lock_activity' do
-    let(:unit_activity) do
-      UnitActivity.find_by(unit: classroom_unit.unit, activity: activity)
-    end
+    let(:unit_activity) { UnitActivity.find_by(unit: classroom_unit.unit, activity: activity) }
 
     let!(:classroom_unit_activity_state) do
       create(:classroom_unit_activity_state,
@@ -144,12 +149,15 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
       )
     end
 
-    before do
-      session[:user_id] = teacher.id
-    end
+    before { session[:user_id] = teacher.id }
 
     it 'should unpin and lock the state of classroom unit activity' do
-      put(:unpin_and_lock_activity, params: { activity_id: activity.uid, classroom_unit_id: classroom_unit.id, format: :json })
+      put :unpin_and_lock_activity,
+        params: {
+          activity_id: activity.uid,
+          classroom_unit_id: classroom_unit.id
+        },
+        as: :json
 
       expect(classroom_unit_activity_state.reload).to have_attributes(
         pinned: false,
@@ -161,12 +169,10 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   describe '#classroom_teacher_and_coteacher_ids' do
     let(:teacher_ids) { Hash[classroom.teacher_ids.collect {|i| [i, true]}] }
 
-    before do
-      session[:user_id] = teacher.id
-    end
+    before { session[:user_id] = teacher.id }
 
     it 'should return the teacher ids in the classroom' do
-      get(:classroom_teacher_and_coteacher_ids, params: { format: :json, classroom_unit_id: classroom_unit.id })
+      get :classroom_teacher_and_coteacher_ids, params: { classroom_unit_id: classroom_unit.id }, as: :json
       expect(response.body).to eq({ teacher_ids: teacher_ids }.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/comprehension_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/comprehension_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Comprehension::ActivitiesController, :type => :controller do
   it "hits the correct engine endpoint and renders json" do
     activity = Comprehension::Activity.create(notes: "some notes", title: "some title", target_level: 5, parent_activity_id: 1)
 
-    get :show, params: { id: activity.id }
+    get :show, params: { id: activity.id }, as: :json
     expect(response.status).to eq(200)
 
     parsed_response = JSON.parse(response.body)

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -6,24 +6,24 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
 
   describe "#index" do
     it "should return a list of ConceptFeedbacks" do
-      get :index, params: { activity_type: concept_feedback.activity_type }
+      get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should include the response from the db" do
-      get :index, params: { activity_type: concept_feedback.activity_type }
+      get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
     end
   end
 
   describe "#show" do
     it "should return the specified concept_feedback" do
-      get :show, params: { activity_type: concept_feedback.activity_type, id: concept_feedback.uid }
+      get :show, params: { activity_type: concept_feedback.activity_type, id: concept_feedback.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(concept_feedback.data)
     end
 
     it "should return a 404 if the requested ConceptFeedback is not found" do
-      get :show, params: { activity_type: concept_feedback.activity_type, id: 'doesnotexist' }
+      get :show, params: { activity_type: concept_feedback.activity_type, id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -35,7 +35,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       data = {foo: "bar"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = ConceptFeedback.count
-      post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: data }
+      post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: data }, as: :json
       expect(ConceptFeedback.count).to eq(pre_create_count + 1)
     end
   end
@@ -43,7 +43,14 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, params: { activity_type: concept_feedback.activity_type, id: concept_feedback.uid, concept_feedback: data }
+      put :update,
+        params: {
+          activity_type: concept_feedback.activity_type,
+          id: concept_feedback.uid,
+          concept_feedback: data
+        },
+        as: :json
+
       concept_feedback.reload
       expect(concept_feedback.data).to eq(data)
     end
@@ -52,7 +59,14 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       data = {"foo" => "bar"}
       uid = SecureRandom.uuid
       expect(ConceptFeedback.find_by(uid: uid)).to be_nil
-      put :update, params: { activity_type: concept_feedback.activity_type, id: uid, concept_feedback: data }
+      put :update,
+        params: {
+          activity_type: concept_feedback.activity_type,
+          id: uid,
+          concept_feedback: data
+        },
+        as: :json
+
       expect(ConceptFeedback.find_by(uid: uid)).to be
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V1::ConceptsController, type: :controller do
     let!(:parent_concept) { create(:concept) }
 
     def subject
-      post :create, params: { concept: {name: concept_name, parent_uid: parent_concept.uid} }
+      post :create, params: { concept: {name: concept_name, parent_uid: parent_concept.uid} }, as: :json
     end
 
     it_behaves_like 'protected endpoint'
@@ -43,12 +43,10 @@ describe Api::V1::ConceptsController, type: :controller do
     let(:parsed_body) { JSON.parse(response.body) }
 
     def subject
-      get :index
+      get :index, as: :json
     end
 
-    before do
-      subject
-    end
+    before { subject }
 
     it 'returns all concepts' do
       expect(parsed_body['concepts'].length).to eq(2)
@@ -68,9 +66,7 @@ describe Api::V1::ConceptsController, type: :controller do
       get :level_zero_concepts_with_lineage
     end
 
-    before do
-      subject
-    end
+    before { subject }
 
     it 'returns a row for each level 0 concept' do
       expect(parsed_body['concepts'].length).to eq(2)

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::FeedbackHistoriesController, type: :controller do
   context "index" do
     it "should return successfully - no history" do
-      get :index
+      get :index, as: :json
 
       parsed_response = JSON.parse(response.body)['feedback_histories']
 
@@ -19,7 +19,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       end
 
       it "should return successfully" do
-        get :index
+        get :index, as: :json
 
         parsed_response = JSON.parse(response.body)['feedback_histories']
 
@@ -35,10 +35,23 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
 
   context "create" do
     it "should create a valid record and return it as json" do
-      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                        time: DateTime.now, entry: 'This is the entry provided by the student',
-                                        feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: {foo: 'bar'} } }
+      post :create,
+        params: {
+          feedback_history: {
+            feedback_session_uid: '1',
+            attempt: 1,
+            optimal: false,
+            used: true,
+            time: DateTime.now,
+            entry: 'This is the entry provided by the student',
+            feedback_text: 'This is the feedback provided by the algorithm',
+            feedback_type: 'autoML',
+            metadata: {
+              foo: 'bar'
+            }
+          }
+        },
+        as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -57,10 +70,21 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
         ]
       }
 
-      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                        time: DateTime.now, entry: 'This is the entry provided by the student',
-                                        feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: metadata } }
+      post :create,
+        params: {
+          feedback_history: {
+            feedback_session_uid: '1',
+            attempt: 1,
+            optimal: false,
+            used: true,
+            time: DateTime.now,
+            entry: 'This is the entry provided by the student',
+            feedback_text: 'This is the feedback provided by the algorithm',
+            feedback_type: 'autoML',
+            metadata: metadata
+          }
+        },
+        as: :json
 
       parsed_response = JSON.parse(response.body)
       expect(parsed_response['metadata']['highlight'].first.keys).to eq metadata['highlight'].first.keys
@@ -69,10 +93,24 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     it "should set prompt_type to Comprehension::Prompt if prompt_id is provided" do
       activity = Comprehension::Activity.create(target_level: 1, title: 'Test Activity Title')
       prompt = Comprehension::Prompt.create(activity: activity, text: 'Test prompt text', conjunction: 'but')
-      post :create, params: { feedback_history: { feedback_session_uid: '1', attempt: 1, optimal: false, used: true,
-                                        time: DateTime.now, entry: 'This is the entry provided by the student',
-                                        feedback_text: 'This is the feedback provided by the algorithm',
-                                        feedback_type: 'autoML', metadata: {foo: 'bar'}, prompt_id: prompt.id } }
+      post :create,
+        params: {
+          feedback_history: {
+            feedback_session_uid: '1',
+            attempt: 1,
+            optimal: false,
+            used: true,
+            time: DateTime.now,
+            entry: 'This is the entry provided by the student',
+            feedback_text: 'This is the feedback provided by the algorithm',
+            feedback_type: 'autoML',
+            prompt_id: prompt.id,
+            metadata: {
+              foo: 'bar'
+            }
+          },
+        },
+        as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -82,7 +120,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should not create an invalid record and return errors as json" do
-      post :create, params: { feedback_history: { entry: nil } }
+      post :create, params: { feedback_history: { entry: nil } }, as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -126,7 +164,8 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
               }
             }
           ]
-        }
+        },
+        as: :json
 
       expect(201).to eq(response.code.to_i)
       expect(2).to eq(FeedbackHistory.count)
@@ -162,7 +201,8 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
               }
             }
           ]
-        }
+        },
+        as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -175,12 +215,10 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
   end
 
   context "show" do
-    setup do
-      @feedback_history = create(:feedback_history, entry: 'This is the first entry in history')
-    end
+    setup { @feedback_history = create(:feedback_history, entry: 'This is the first entry in history') }
 
     it "should return json if found" do
-      get :show, params: { id: @feedback_history.id }
+      get :show, params: { id: @feedback_history.id }, as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -189,7 +227,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should raise if not found (to be handled by parent app)" do
-      get :show, params: { id: 99999 }
+      get :show, params: { id: 99999 }, as: :json
       expect(404).to eq(response.status)
       expect(response.body.include?("The resource you were looking for does not exist")).to be
     end
@@ -201,7 +239,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
       feedback_history.prompt = prompt
       feedback_history.save
 
-      get :show, params: { id: feedback_history.id }
+      get :show, params: { id: feedback_history.id }, as: :json
 
       parsed_response = JSON.parse(response.body)
 

--- a/services/QuillLMS/spec/controllers/api/v1/firebase_tokens_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/firebase_tokens_controller_spec.rb
@@ -7,13 +7,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
     let!(:user) { create(:student) }
 
     context 'when accessing anonymously' do
-      before do
-        subject
-      end
-
-      def subject
-        post :create, params: { app: 'foobar' }
-      end
+      before { post :create, params: { app: 'foobar' }, as: :json }
 
       it 'responds with 200' do
         expect(response.status).to eq(200)
@@ -34,7 +28,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
       end
 
       def subject
-        post :create, params: { app: 'foobar' }
+        post :create, params: { app: 'foobar' }, as: :json
       end
 
       it 'responds with 200' do
@@ -49,9 +43,7 @@ describe Api::V1::FirebaseTokensController, type: :controller do
     end
 
     context 'when the firebase app does not exist' do
-      subject do
-        post :create, params: { app: 'nonexistent' }
-      end
+      subject { post :create, params: { app: 'nonexistent' }, as: :json }
 
       it 'responds with 404' do
         subject
@@ -70,13 +62,11 @@ describe Api::V1::FirebaseTokensController, type: :controller do
     end
 
     def subject
-      post :create_for_connect, params: { "json" => { "app" => 'foobar' }.to_json, format: :json }
+      post :create_for_connect, params: { "json" => { "app" => 'foobar' }.to_json, as: :json }
     end
 
     it 'should respond with the connect token' do
-      expect(response.body).to eq({
-        token: "connect token"
-      }.to_json)
+      expect(response.body).to eq({ token: "connect token" }.to_json)
     end
   end
 end

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -19,12 +19,12 @@ describe Api::V1::FocusPointsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Question Focus Points" do
-      get :index, params: { question_id: question.uid }
+      get :index, params: { question_id: question.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data["focusPoints"])
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, params: { question_id: 'doesnotexist' }
+      get :index, params: { question_id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -33,19 +33,19 @@ describe Api::V1::FocusPointsController, type: :controller do
   describe "#show" do
     it "should return the containing focus points object" do
       fp_id = question.data["focusPoints"].keys.first
-      get :show, params: { question_id: question.uid, id: fp_id }
+      get :show, params: { question_id: question.uid, id: fp_id }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data["focusPoints"][fp_id])
     end
 
     it "should return a 404 if the requested Question is not found" do
       fp_id = question.data["focusPoints"].keys.first
-      get :show, params: { question_id: 'doesnotexist', id: fp_id }
+      get :show, params: { question_id: 'doesnotexist', id: fp_id }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested FocusPoint is not found" do
-      get :show, params: { question_id: question.id, id: "doesnotexist" }
+      get :show, params: { question_id: question.id, id: "doesnotexist" }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -55,13 +55,13 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should add a new focus point to the question data" do
       data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_count = question.data["focusPoints"].keys.length
-      post :create, params: { question_id: question.uid, focus_point: data }
+      post :create, params: { question_id: question.uid, focus_point: data }, as: :json
       question.reload
       expect(question.data["focusPoints"].keys.length).to eq(focus_point_count + 1)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, params: { question_id: 'doesnotexist' }
+      get :index, params: { question_id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -71,19 +71,26 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should update an existing focus point in the question data" do
       data = {"text" => "foo", "feedback"=>"bar"}
       focus_point_uid = question.data["focusPoints"].keys.first
-      put :update, params: { question_id: question.uid, id: focus_point_uid, focus_point: data }
+      put :update,
+        params: {
+          question_id: question.uid,
+          id: focus_point_uid,
+          focus_point: data
+        },
+        as: :json
+
       question.reload
       expect(question.data["focusPoints"][focus_point_uid]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
+      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified focusPoint" do
-      put :update, params: { question_id: question.uid, id: 'doesnotexist' }
+      put :update, params: { question_id: question.uid, id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -93,7 +100,13 @@ describe Api::V1::FocusPointsController, type: :controller do
 
       focus_point_uid = new_q.data["focusPoints"].keys.first
 
-      put :update, params: { question_id: new_q.uid, id: focus_point_uid, focus_point: data }
+      put :update,
+        params: {
+          question_id: new_q.uid,
+          id: focus_point_uid,
+          focus_point: data
+        },
+        as: :json
 
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)["data"]).to include("There is incorrectly formatted regex: (and|")
@@ -104,7 +117,7 @@ describe Api::V1::FocusPointsController, type: :controller do
     it "should delete the focus point" do
       focus_point_uid = question.data["focusPoints"].keys.first
       pre_delete_count = question.data["focusPoints"].keys.length
-      delete :destroy, params: { question_id: question.uid, id: focus_point_uid }
+      delete :destroy, params: { question_id: question.uid, id: focus_point_uid }, as: :json
       question.reload
       expect(question.data["focusPoints"].keys.length).to eq(pre_delete_count - 1)
     end
@@ -119,13 +132,13 @@ describe Api::V1::FocusPointsController, type: :controller do
   describe "#update_all" do
     it "should replace all focusPoints" do
       data = {"0" => {"text"=>"text", "feedback"=>"feedback"}}
-      put :update_all, params: { question_id: question.uid, focus_point: data }
+      put :update_all, params: { question_id: question.uid, focus_point: data }, as: :json
       question.reload
       expect(question.data["focusPoints"]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_all, params: { question_id: 'doesnotexist' }
+      put :update_all, params: { question_id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
@@ -6,12 +6,12 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
 
   describe "#index" do
     it "should include the response from the db" do
-      get :index, params: { question_id: question.uid }
+      get :index, params: { question_id: question.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data["incorrectSequences"])
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :index, params: { question_id: 'doesnotexist' }
+      get :index, params: { question_id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -20,19 +20,19 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
   describe "#show" do
     it "should return the specified question" do
       is_id = question.data["incorrectSequences"].keys.first
-      get :show, params: { question_id: question.uid, id: is_id }
+      get :show, params: { question_id: question.uid, id: is_id }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data["incorrectSequences"][is_id])
     end
 
     it "should return a 404 if the requested Question is not found" do
       is_id = question.data["incorrectSequences"].keys.first
-      get :show, params: { question_id: 'doesnotexist', id: is_id }
+      get :show, params: { question_id: 'doesnotexist', id: is_id }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified incorrectSequence" do
-      put :show, params: { question_id: question.uid, id: 'doesnotexist' }
+      put :show, params: { question_id: question.uid, id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -42,7 +42,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should add a new incorrect sequence to the question data" do
       data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_count = question.data["incorrectSequences"].keys.length
-      post :create, params: { question_id: question.uid, incorrect_sequence: data }
+      post :create, params: { question_id: question.uid, incorrect_sequence: data }, as: :json
       question.reload
       expect(question.data["incorrectSequences"].keys.length).to eq(incorrect_sequence_count + 1)
     end
@@ -52,19 +52,26 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should update an existing incorrect sequence in the question data" do
       data = {"text" => "text", "feedback"=>"feedback"}
       incorrect_sequence_uid = question.data["incorrectSequences"].keys.first
-      put :update, params: { question_id: question.uid, id: incorrect_sequence_uid, incorrect_sequence: data }
+      put :update,
+       params: {
+         question_id: question.uid,
+         id: incorrect_sequence_uid,
+         incorrect_sequence: data
+        },
+        as: :json
+
       question.reload
       expect(question.data["incorrectSequences"][incorrect_sequence_uid]).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
+      put :update, params: { question_id: 'doesnotexist', id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 404 if the requested Question does not have the specified incorrectSequence" do
-      put :update, params: { question_id: question.uid, id: 'doesnotexist' }
+      put :update, params: { question_id: question.uid, id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -74,13 +81,13 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     it "should delete the incorrect sequence" do
       incorrect_sequence_uid = question.data["incorrectSequences"].keys.first
       pre_delete_count = question.data["incorrectSequences"].keys.length
-      delete :destroy, params: { question_id: question.uid, id: incorrect_sequence_uid }
+      delete :destroy, params: { question_id: question.uid, id: incorrect_sequence_uid }, as: :json
       question.reload
       expect(question.data["incorrectSequences"].keys.length).to eq(pre_delete_count - 1)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      delete :destroy, params: { question_id: 'doesnotexist', id: 'doesnotexist' }
+      delete :destroy, params: { question_id: 'doesnotexist', id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -89,7 +96,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
   describe "#update_all" do
     it "should replace all incorrectSequences" do
       data = {"0"=>{"text" => "text", "feedback"=>"feedback"}}
-      put :update_all, params: { question_id: question.uid, incorrect_sequence: data }
+      put :update_all, params: { question_id: question.uid, incorrect_sequence: data }, as: :json
       question.reload
       expect(question.data["incorrectSequences"]).to eq(data)
     end
@@ -108,7 +115,7 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_all, params: { question_id: 'doesnotexist' }
+      put :update_all, params: { question_id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/lessons_controller_spec.rb
@@ -7,24 +7,24 @@ describe Api::V1::LessonsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Lessons" do
-      get :index, params: { lesson_type: "connect_lesson" }
+      get :index, params: { lesson_type: "connect_lesson" }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should include the response from the db" do
-      get :index, params: { lesson_type: "connect_lesson" }
+      get :index, params: { lesson_type: "connect_lesson" }, as: :json
       expect(JSON.parse(response.body).keys.first).to eq(activity.uid)
     end
   end
 
   describe "#show" do
     it "should return the specified lesson" do
-      get :show, params: { id: activity.uid }
+      get :show, params: { id: activity.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(activity.data)
     end
 
     it "should return a 404 if the requested Lesson is not found" do
-      get :show, params: { id: 'doesnotexist' }
+      get :show, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -36,7 +36,7 @@ describe Api::V1::LessonsController, type: :controller do
       data = {foo: "bar", name: "name", flag: "alpha"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = Activity.count
-      post :create, params: { lesson_type: "connect_lesson", lesson: data }
+      post :create, params: { lesson_type: "connect_lesson", lesson: data }, as: :json
       expect(Activity.count).to eq(pre_create_count + 1)
       expect(Activity.find_by(name: data[:name]).flag = data[:flag])
     end
@@ -45,14 +45,14 @@ describe Api::V1::LessonsController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar", "flag" => "alpha", "name" => "new name"}
-      put :update, params: { id: activity.uid, lesson: data }
+      put :update, params: { id: activity.uid, lesson: data }, as: :json
       activity.reload
       expect(activity.data).to eq(data)
       expect(Activity.find_by(name: data["name"]).flag = data["flag"])
     end
 
     it "should return a 404 if the requested Lesson is not found" do
-      get :update, params: { id: 'doesnotexist' }
+      get :update, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -64,20 +64,20 @@ describe Api::V1::LessonsController, type: :controller do
 
     it "should destroy the existing record if the current user is staff" do
       allow(controller).to receive(:current_user).and_return(staff)
-      delete :destroy, params: { id: activity.uid }
+      delete :destroy, params: { id: activity.uid }, as: :json
       expect(Activity.where(uid: activity.uid).count).to eq(0)
     end
 
     it "should return a 404 if the requested Lesson is not found if the current user is staff" do
       allow(controller).to receive(:current_user).and_return(staff)
-      delete :destroy, params: { id: 'doesnotexist' }
+      delete :destroy, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return a 403 if the current user is not staff" do
       allow(controller).to receive(:current_user).and_return(teacher)
-      delete :destroy, params: { id: activity.uid }
+      delete :destroy, params: { id: activity.uid }, as: :json
       expect(response.status).to eq(403)
       expect(response.body).to include("You are not authorized to access this resource")
     end
@@ -86,14 +86,14 @@ describe Api::V1::LessonsController, type: :controller do
   describe "#add_question" do
     it "should add a question to the existing record" do
       data = {"key" => question.uid, "questionType" => "questions"}
-      put :add_question, params: { id: activity.uid, question: data }
+      put :add_question, params: { id: activity.uid, question: data }, as: :json
       activity.reload
       expect(activity.data["questions"]).to include(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
       data = {"question" => {"key" => "notarealID", "questionType" => "question"}}
-      put :add_question, params: { id: activity.uid, question: data }
+      put :add_question, params: { id: activity.uid, question: data }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/lessons_tokens_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/lessons_tokens_controller_spec.rb
@@ -3,12 +3,10 @@ require 'rails_helper'
 describe Api::V1::LessonsTokensController do
   describe '#create' do
 
-    before do
-      allow_any_instance_of(CreateLessonsToken).to receive(:call) { "token" }
-    end
+    before { allow_any_instance_of(CreateLessonsToken).to receive(:call) { "token" } }
 
     it 'should render the token' do
-      post :create, format: :json
+      post :create, as: :json
       expect(response.body).to eq({token: "token"}.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
   context '#activities_scores_by_classroom_data' do
     it 'should return ProgressReports::ActivitiesScoresByClassroom for my classes' do
       session[:user_id] = teacher.id
-      get :activities_scores_by_classroom_data
+      get :activities_scores_by_classroom_data, as: :json
       expect(response.body).to eq({
         data: ProgressReports::ActivitiesScoresByClassroom.results(teacher.classrooms_i_teach.map(&:id))
       }.to_json)
@@ -21,25 +21,25 @@ describe Api::V1::ProgressReportsController, type: :controller do
   context '#student_overview_data' do
     it 'should not allow access if no teacher classroom relationship exists' do
       session[:user_id] = unaffiliated_teacher.id
-      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }, as: :json
       expect(response).to redirect_to new_session_path
     end
 
     it 'should not allow access if student is not in classroom' do
       session[:user_id] = teacher.id
-      get :student_overview_data, params: { student_id: unaffiliated_student.id, classroom_id: classroom.id }
+      get :student_overview_data, params: { student_id: unaffiliated_student.id, classroom_id: classroom.id }, as: :json
       expect(response).to redirect_to new_session_path
     end
 
     it 'should not allow access if teacher is admin but not admin of that school' do
       session[:user_id] = admin.id
-      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }, as: :json
       expect(response).to redirect_to new_session_path
     end
 
     it 'should return appropriate data' do
       session[:user_id] = teacher.id
-      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }
+      get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }, as: :json
       expect(response.body).to eq({
         report_data: ProgressReports::StudentOverview.results(classroom.id, student.id),
         student_data: {
@@ -60,7 +60,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
     end
 
     it 'should return the district activit scores progress reports' do
-      get :district_activity_scores, format: :json
+      get :district_activity_scores, as: :json
       expect(response.body).to eq({id: teacher.id}.to_json)
     end
   end
@@ -73,7 +73,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
     end
 
     it 'should return the district activity scores progress reports' do
-      get :district_concept_reports, format: :json
+      get :district_concept_reports, as: :json
       expect(response.body).to eq({id: teacher.id}.to_json)
     end
   end
@@ -86,7 +86,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
     end
 
     it 'should return the district activit scores progress reports' do
-      get :district_standards_reports, format: :json
+      get :district_standards_reports, as: :json
       expect(response.body).to eq({id: teacher.id}.to_json)
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -7,26 +7,26 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#index" do
     it "should return a list of Questions" do
       expect($redis).to receive(:get).and_return(nil)
-      get :index, params: { question_type: 'connect_sentence_combining' }
+      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)
     end
 
     it "should set cache if it is empty" do
       expect($redis).to receive(:get).and_return(nil)
       expect($redis).to receive(:set)
-      get :index, params: { question_type: 'connect_sentence_combining' }
+      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
     end
 
     it "should not set cache if there is a cache hit" do
       mock_cached_data = {"foo" => "bar"}
       expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
       expect($redis).not_to receive(:set)
-      get :index, params: { question_type: 'connect_sentence_combining' }
+      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
       expect(JSON.parse(response.body)).to eq(mock_cached_data)
     end
 
     it "should include the response from the db" do
-      get :index, params: { question_type: 'connect_sentence_combining' }
+      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
       puts response.body
       expect(JSON.parse(response.body).keys.first).to eq(question.uid)
     end
@@ -34,26 +34,26 @@ describe Api::V1::QuestionsController, type: :controller do
 
   describe "#show" do
     it "should return the specified question" do
-      get :show, params: { id: question.uid }
+      get :show, params: { id: question.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data)
     end
 
     it "should set cache if it is empty" do
       expect($redis).to receive(:get).and_return(nil)
       expect($redis).to receive(:set)
-      get :show, params: { id: question.uid }
+      get :show, params: { id: question.uid }, as: :json
     end
 
     it "should not set cache if there is a cache hit" do
       mock_cached_data = {"foo" => "bar"}
       expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
       expect($redis).not_to receive(:set)
-      get :show, params: { id: question.uid }
+      get :show, params: { id: question.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(mock_cached_data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :show, params: { id: 'doesnotexist' }
+      get :show, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -65,7 +65,7 @@ describe Api::V1::QuestionsController, type: :controller do
       data = {foo: "bar"}
       expect(SecureRandom).to receive(:uuid).and_return(uuid)
       pre_create_count = Question.count
-      post :create, params: { question_type: 'connect_sentence_combining', question: data }
+      post :create, params: { question_type: 'connect_sentence_combining', question: data }, as: :json
       expect(Question.count).to eq(pre_create_count + 1)
     end
   end
@@ -73,42 +73,28 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#update" do
     it "should update the existing record" do
       data = {"foo" => "bar"}
-      put :update, params: { id: question.uid, question: data }
+      put :update, params: { id: question.uid, question: data }, as: :json
       question.reload
       expect(question.data).to eq(data)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      get :update, params: { id: 'doesnotexist' }
+      get :update, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
   end
 
-  # Disabling these since we have no working auth
-  #describe "#destroy" do
-  #  it "should delete the existing record" do
-  #    delete :destroy, id: question.uid
-  #    expect(Question.find_by(uid: question.uid)).to be_nil
-  #  end
-
-  #  it "should return a 404 if the requested Question is not found" do
-  #    delete :destroy, id: 'doesnotexist'
-  #    expect(response.status).to eq(404)
-  #    expect(response.body).to include("The resource you were looking for does not exist")
-  #  end
-  #end
-
   describe "#update_flag" do
     it "should update the flag attribute in the data" do
       new_flag = 'newflag'
-      put :update_flag, params: { id: question.uid, question: {flag: new_flag} }
+      put :update_flag, params: { id: question.uid, question: { flag: new_flag } }, as: :json
       question.reload
       expect(question.data["flag"]).to eq(new_flag)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_flag, params: { id: 'doesnotexist', question: {flag: nil} }
+      put :update_flag, params: { id: 'doesnotexist', question: { flag: nil } }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -117,13 +103,13 @@ describe Api::V1::QuestionsController, type: :controller do
   describe "#update_model_concept" do
     it "should update the model concept uid attribute in the data" do
       new_model_concept = SecureRandom.uuid
-      put :update_model_concept, params: { id: question.uid, question: {modelConcept: new_model_concept} }
+      put :update_model_concept, params: { id: question.uid, question: { modelConcept: new_model_concept } }, as: :json
       question.reload
       expect(question.data["modelConceptUID"]).to eq(new_model_concept)
     end
 
     it "should return a 404 if the requested Question is not found" do
-      put :update_model_concept, params: { id: 'doesnotexist', question: {flag: nil} }
+      put :update_model_concept, params: { id: 'doesnotexist', question: { flag: nil } }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
   describe '#by_conjunction' do
     it 'should return successfully' do
-      get :by_conjunction, params: { conjunction: 'so', activity_id: 1 }
+      get :by_conjunction, params: { conjunction: 'so', activity_id: 1 }, as: :json
 
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)).to eq(
@@ -44,7 +44,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
   describe '#rule_detail' do
     it 'should return successfully' do
-      get :rule_detail, params: { rule_uid: 1, prompt_id: 1 }
+      get :rule_detail, params: { rule_uid: 1, prompt_id: 1 }, as: :json
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)).to eq({"1"=>{"responses"=>[]}})
     end
@@ -53,7 +53,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
   describe '#prompt_health' do
     context 'no associated feedback sessions' do
       it 'should return successfully' do
-        get :prompt_health, params: { activity_id: 1 }
+        get :prompt_health, params: { activity_id: 1 }, as: :json
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq({})
       end
@@ -74,7 +74,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
 
         f_h1 = create(:feedback_history, feedback_session_uid: as1.uid, attempt: 1, optimal: false, prompt_id: prompt.id)
 
-        get :prompt_health, params: { activity_id: main_activity.id }
+        get :prompt_health, params: { activity_id: main_activity.id }, as: :json
         expect(response.status).to eq 200
         expect(JSON.parse(response.body).keys.length).to eq 1
       end

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
   context "index" do
     it "should return successfully - no history" do
-      get :index
+      get :index, as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -21,7 +21,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         create(:feedback_history, entry: 'This is the first entry in history')
         create(:feedback_history, entry: 'This is the second entry in history')
 
-        get :index
+        get :index, as: :json
 
         parsed_response = JSON.parse(response.body)
 
@@ -36,7 +36,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it "should return 2 records at a time" do
-          get :index
+          get :index, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -45,7 +45,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it "should skip pages if specified" do
-          get :index, params: { page: 2 }
+          get :index, params: { page: 2 }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -63,7 +63,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified activity' do
-          get :index, params: { activity_id: @activity.id }
+          get :index, params: { activity_id: @activity.id }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -72,7 +72,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve all items if no activity_id is specified' do
-          get :index
+          get :index, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -92,7 +92,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified time constraints' do
-          get :index, params: { start_date: '2021-04-06T20:43:27.698Z' }
+          get :index, params: { start_date: '2021-04-06T20:43:27.698Z' }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -101,7 +101,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items from the specified time constraints' do
-          get :index, params: { start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z' }
+          get :index, params: { start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z' }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -120,7 +120,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only items with the specified turk_session_uid' do
-          get :index, params: { turk_session_id: @comprehension_turking_round.turking_round_id }
+          get :index, params: { turk_session_id: @comprehension_turking_round.turking_round_id }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -141,7 +141,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve all sessions when filter_type is all' do
-          get :index, params: { filter_type: "all" }
+          get :index, params: { filter_type: "all" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -153,7 +153,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only scored sessions when filter_type is scored' do
-          get :index, params: { filter_type: "scored" }
+          get :index, params: { filter_type: "scored" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -164,7 +164,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only unscored sessions when filter_type is unscored' do
-          get :index, params: { filter_type: "unscored" }
+          get :index, params: { filter_type: "unscored" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -174,7 +174,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only weak sessions when filter_type is weak' do
-          get :index, params: { filter_type: "weak" }
+          get :index, params: { filter_type: "weak" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -184,7 +184,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only incomplete sessions when filter_type is incomplete' do
-          get :index, params: { filter_type: "incomplete" }
+          get :index, params: { filter_type: "incomplete" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -202,7 +202,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
           feedback_history4 = create(:feedback_history, feedback_session_uid: activity_session.uid, prompt: but_prompt, optimal: true)
           feedback_history5 = create(:feedback_history, feedback_session_uid: activity_session.uid, prompt: so_prompt, optimal: true)
 
-          get :index, params: { filter_type: "complete" }
+          get :index, params: { filter_type: "complete" }, as: :json
 
           parsed_response = JSON.parse(response.body)
 
@@ -214,12 +214,10 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
   end
 
   context "show" do
-    setup do
-      @feedback_history = create(:feedback_history, entry: 'This is the first entry in history')
-    end
+    setup { @feedback_history = create(:feedback_history, entry: 'This is the first entry in history') }
 
     it "should return json if found" do
-      get :show, params: { id: @feedback_history.feedback_session_uid }
+      get :show, params: { id: @feedback_history.feedback_session_uid }, as: :json
 
       parsed_response = JSON.parse(response.body)
 
@@ -228,7 +226,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
     end
 
     it "should raise if not found (to be handled by parent app)" do
-      get :show, params: { id: 99999 }
+      get :show, params: { id: 99999 }, as: :json
       expect(404).to eq(response.status)
       expect(response.body.include?("The resource you were looking for does not exist")).to be
     end

--- a/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::SharedCacheController, type: :controller do
   describe "#show" do
     it "should return a 404 if the custom cache key isn't set" do
       expect($redis).to receive(:get).with(COMBINED_KEY).and_return(nil)
-      get :show, params: { id: KEY }
+      get :show, params: { id: KEY }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
@@ -18,7 +18,7 @@ describe Api::V1::SharedCacheController, type: :controller do
         foo: 'bar'
       }
       expect($redis).to receive(:get).with(COMBINED_KEY).and_return(CACHED_DATA.to_json)
-      get :show, params: { id: KEY, data: CACHED_DATA }
+      get :show, params: { id: KEY, data: CACHED_DATA }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to eq(CACHED_DATA.to_json)
     end
@@ -28,7 +28,7 @@ describe Api::V1::SharedCacheController, type: :controller do
     it "should set the cache for the specified key" do
       SET_DATA = {"foo" => "bar"}
       expect($redis).to receive(:set).with(COMBINED_KEY, SET_DATA.to_json, {ex: Api::V1::SharedCacheController::SHARED_CACHE_EXPIRY})
-      put :update, params: { id: KEY, data: SET_DATA }
+      put :update, params: { id: KEY, data: SET_DATA }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to eq(SET_DATA.to_json)
     end
@@ -37,7 +37,7 @@ describe Api::V1::SharedCacheController, type: :controller do
   describe "#destroy" do
     it "should delete the existing record" do
       expect($redis).to receive(:del).with(COMBINED_KEY)
-      delete :destroy, params: { id: KEY }
+      delete :destroy, params: { id: KEY }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to eq("OK")
     end

--- a/services/QuillLMS/spec/controllers/api/v1/title_cards_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/title_cards_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::TitleCardsController, type: :controller do
     it 'should render TitleCard objects if they exist' do
       # Persist the factory-generated TitleCard so that .all works in the controller
       title_card.save
-      get :index, params: { title_card_type: 'connect_title_card' }
+      get :index, params: { title_card_type: 'connect_title_card' }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to include(title_card.uid)
       expect(response.body).to include(title_card.content)
@@ -17,7 +17,7 @@ describe Api::V1::TitleCardsController, type: :controller do
 
     it 'should render an empty array if no TitleCards exist' do
       title_card.delete
-      get :index, params: { title_card_type: 'connect_title_card' }
+      get :index, params: { title_card_type: 'connect_title_card' }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to eq('{"title_cards":[]}')
     end
@@ -25,7 +25,7 @@ describe Api::V1::TitleCardsController, type: :controller do
 
   describe "#show" do
     it 'should render the requested TitleCard object if it exists' do
-      get :show, params: { title_card_type: 'connect_title_card', id: title_card.uid }
+      get :show, params: { title_card_type: 'connect_title_card', id: title_card.uid }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to include(title_card.uid)
       expect(response.body).to include(title_card.content)
@@ -33,33 +33,49 @@ describe Api::V1::TitleCardsController, type: :controller do
     end
 
     it 'should return a 404 if the requested TitleCard is not found' do
-      get :show, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }
+      get :show, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
   end
 
   describe "#update" do
-    before do
-      @request.session['user_id'] = staff.id
-    end
+    before { @request.session['user_id'] = staff.id }
 
     it 'should update the specified TitleCard if all data is valid and return it' do
       new_content = 'updated content'
-      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: new_content} }
+      put :update,
+        params: {
+          title_card_type: 'connect_title_card',
+          id: title_card.uid,
+          title_card: {
+            content: new_content
+          }
+        },
+        as: :json
+
       expect(response.status).to eq(200)
       expect(title_card.reload.content).to eq(new_content)
     end
 
     it 'should 404 NOT FOUND if the provided UID does not match a known TitleCard' do
-      put :update, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }
+      put :update, params: { title_card_type: 'connect_title_card', id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the posted data is invalid' do
       invalid_content = nil
-      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {content: invalid_content} }
+      put :update,
+        params: {
+          title_card_type: 'connect_title_card',
+          id: title_card.uid,
+          title_card: {
+            content: invalid_content
+          }
+        },
+        as: :json
+
       expect(response.status).to eq(422)
       expect(response.body).to match(/content.*can't be blank/)
     end
@@ -67,7 +83,16 @@ describe Api::V1::TitleCardsController, type: :controller do
     it 'should 422 UNPROCESSABLE ENTITY if the provided UID already belongs to an existing TitleCard' do
       used_uid = SecureRandom.uuid
       create(:title_card, uid: used_uid)
-      put :update, params: { title_card_type: 'connect_title_card', id: title_card.uid, title_card: {uid: used_uid} }
+      put :update,
+        params: {
+          title_card_type: 'connect_title_card',
+          id: title_card.uid,
+          title_card: {
+            uid: used_uid
+          }
+        },
+        as: :json
+
       expect(response.status).to eq(422)
       expect(response.body).to match(/uid.*has already been taken/)
     end
@@ -91,31 +116,47 @@ describe Api::V1::TitleCardsController, type: :controller do
       }
     end
 
-    before do
-      @request.session['user_id'] = staff.id
-    end
+    before { @request.session['user_id'] = staff.id }
 
     it 'should create a new TitleCard if all data is valid and return it' do
-      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params }
+      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params }, as: :json
       expect(response.status).to eq(200)
       expect(TitleCard.find_by(uid: create_params[:uid])).not_to be_nil
     end
 
     it 'should provide a UID automatically if we do not set one explicitly' do
-      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.except(:uid) }
+      post :create,
+        params: {
+          title_card_type: 'connect_title_card',
+          title_card: create_params.except(:uid)
+        },
+        as: :json
+
       expect(response.status).to eq(200)
       expect(response.body).to include(create_params[:content])
       expect(response.body).to include(create_params[:title])
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the posted data is invalid' do
-      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.except(:content) }
+      post :create,
+        params: {
+          title_card_type: 'connect_title_card',
+          title_card: create_params.except(:content)
+        },
+        as: :json
+
       expect(response.status).to eq(422)
       expect(response.body).to match(/content.*can't be blank/)
     end
 
     it 'should 422 UNPROCESSABLE ENTITY if the provided UID already belongs to an existing TitleCard' do
-      post :create, params: { title_card_type: 'connect_title_card', title_card: create_params.update({uid: title_card.uid}) }
+      post :create,
+        params: {
+          title_card_type: 'connect_title_card',
+          title_card: create_params.update(uid: title_card.uid)
+        },
+        as: :json
+
       expect(response.status).to eq(422)
       expect(response.body).to match(/uid.*has already been taken/)
     end

--- a/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
@@ -7,7 +7,7 @@ describe Api::V1::UsersController do
     let(:user) { create(:user) }
 
     it 'should return the correct json' do
-      get :index, format: :json
+      get :index, as: :json
 
       expect(response.body).to eq({
         user: user,
@@ -23,7 +23,7 @@ describe Api::V1::UsersController do
       let(:user) { nil }
 
       it 'should return the correct json' do
-        get :current_user_and_coteachers, format: :json
+        get :current_user_and_coteachers, as: :json
 
         expect(response.body).to eq({
           user: user,
@@ -38,7 +38,7 @@ describe Api::V1::UsersController do
       let!(:coteachers) { classroom.coteachers.map { |ct| ct.attributes.slice('id', 'name') } }
 
       it 'should return the correct json' do
-        get :current_user_and_coteachers, format: :json
+        get :current_user_and_coteachers, as: :json
 
         expect(response.body).to eq({
           user: user,
@@ -53,7 +53,7 @@ describe Api::V1::UsersController do
       let(:user) { create(:teacher) }
 
       it 'should return teacher for teacher users' do
-        get :current_user_role, format: :json
+        get :current_user_role, as: :json
 
         expect(response.body).to eq({ role: "teacher" }.to_json)
       end
@@ -63,7 +63,7 @@ describe Api::V1::UsersController do
       let(:user) { create(:admin) }
 
       it 'should return admin for admin users' do
-        get :current_user_role, format: :json
+        get :current_user_role, as: :json
         expect(response.body).to eq({ role: "admin" }.to_json)
       end
     end
@@ -72,7 +72,7 @@ describe Api::V1::UsersController do
       let(:user)  { create(:student) }
 
       it 'should return student for student users' do
-        get :current_user_role, format: :json
+        get :current_user_role, as: :json
         expect(response.body).to eq({ role: "student" }.to_json)
       end
     end
@@ -81,7 +81,7 @@ describe Api::V1::UsersController do
       let(:user) { nil }
 
       it 'should return nil if current_user is nil' do
-        get :current_user_role, format: :json
+        get :current_user_role, as: :json
         expect(response.body).to eq({ role: nil }.to_json)
       end
     end

--- a/services/QuillLMS/spec/controllers/classrooms_teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/classrooms_teachers_controller_spec.rb
@@ -77,7 +77,7 @@ describe ClassroomsTeachersController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :specific_coteacher_info, params: { format: :json, coteacher_id: user.id }
+      get :specific_coteacher_info, params: { coteacher_id: user.id }, as: :json
       expect(response.body).to eq({
       selectedTeachersClassroomIds: {
           is_coteacher: [classroom.id],

--- a/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
@@ -82,7 +82,7 @@ describe Cms::ActivitiesController, type: :controller do
       selected_attributes[:topic_ids] = [topic.id]
       selected_attributes[:content_partner_ids] = [content_partner.id]
       selected_attributes[:activity_category_ids] = [activity_category.id]
-      post :create, params: { activity_classification_id: classification.id, activity: selected_attributes, format: :json }
+      post :create, params: { activity_classification_id: classification.id, activity: selected_attributes }, as: :json
       created_activity = Activity.find_by_name('Unique Name')
       expect(created_activity).to be
       expect(created_activity.topics).to eq([topic])

--- a/services/QuillLMS/spec/controllers/cms/activity_classifications_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activity_classifications_controller_spec.rb
@@ -12,7 +12,7 @@ describe Cms::ActivityClassificationsController, type: :controller do
     let!(:classification1) { create(:activity_classification) }
 
     it 'should return all the activity classifications' do
-      get :index, format: :json
+      get :index, as: :json
       expect(response.body).to eq({
         activity_classifications: ActivityClassification.order(order_number: :asc)
       }.to_json)

--- a/services/QuillLMS/spec/controllers/cms/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/unit_templates_controller_spec.rb
@@ -9,13 +9,13 @@ describe Cms::UnitTemplatesController, type: :controller do
     allow(controller).to receive(:current_user) { staff }
   end
 
-  describe '#index, format: :json' do
-    let!(:author) {create(:author)}
+  describe '#index, as: :json' do
+    let!(:author) { create(:author) }
     let!(:unit_template1) { create(:unit_template, author_id: author.id) }
     let!(:unit_template2) { create(:unit_template, author_id: author.id) }
 
     it 'responds with list of unit_templates' do
-      get :index, format: :json
+      get :index, as: :json
       expect(parsed_body['unit_templates'].length).to eq(2)
     end
   end

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -85,16 +85,6 @@ describe Cms::UsersController do
     end
   end
 
-  # there is no route for this action, not sure if its used
-  # describe '#show_json' do
-  #   let!(:another_user) { create(:user) }
-  #
-  #   it 'should give the correct json' do
-  #     get :show_json, format: :json
-  #     expect(JSON.parse(response.body)).to eq(another_user.generate_teacher_account_info)
-  #   end
-  # end
-
   describe 'show' do
     let(:another_user) { create(:user) }
 

--- a/services/QuillLMS/spec/controllers/notifications_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/notifications_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NotificationsController do
       user = create(:simple_user)
       allow(controller).to receive(:current_user).and_return(user)
 
-      get :index, format: :json
+      get :index, as: :json
 
       expect(response).to have_http_status(:ok)
     end
@@ -15,7 +15,7 @@ RSpec.describe NotificationsController do
       user = create(:simple_user)
       allow(controller).to receive(:current_user).and_return(user)
 
-      get :index, format: :json
+      get :index, as: :json
 
       expect(response).to render_template(:index)
     end
@@ -25,7 +25,7 @@ RSpec.describe NotificationsController do
       notification = create(:notification, user: student)
 
       allow(controller).to receive(:current_user).and_return(student)
-      get :index, format: :json
+      get :index, as: :json
 
       expect(assigns(:notifications)).to eq([notification])
     end

--- a/services/QuillLMS/spec/controllers/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/schools_controller_spec.rb
@@ -15,7 +15,7 @@ describe SchoolsController, type: :controller do
   end
 
   it 'fetches schools based on zipcode' do
-    get :index, params: { search: '60657', format: 'json' }
+    get :index, params: { search: '60657' }, as: :json
 
     expect(response.status).to eq(200)
 
@@ -24,7 +24,7 @@ describe SchoolsController, type: :controller do
   end
 
   it 'fetches schools based on text string' do
-    get :index, params: { search: 'Max A', format: 'json' }
+    get :index, params: { search: 'Max A' }, as: :json
 
     expect(response.status).to eq(200)
 
@@ -32,18 +32,6 @@ describe SchoolsController, type: :controller do
     expect(json['data'].first['id']).to eq(@school2.id)
   end
 
-  context "there is a current user" do
-
-    describe '#select_school' do
-      let(:user) { create(:user) }
-      let(:school_user) { create(:school_user, user: user) }
-
-      before do
-        allow(controller).to receive(:current_user) { user }
-      end
-    end
-
-  end
 
   context "there is no current user" do
 
@@ -51,12 +39,10 @@ describe SchoolsController, type: :controller do
       let(:user) { create(:user) }
       let(:school_user) { create(:school_user, user: user) }
 
-      before do
-        allow(controller).to receive(:current_user) { nil }
-      end
+      before { allow(controller).to receive(:current_user) { nil } }
 
       it 'should redirect to login' do
-        put :select_school, params: { school_id_or_type: @school1.id, format: :json }
+        put :select_school, params: { school_id_or_type: @school1.id }, as: :json
 
         response.should redirect_to '/session/new'
       end

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -73,7 +73,7 @@ describe SessionsController, type: :controller do
 
     context 'when user is nil' do
       it 'should report login failiure' do
-        post :login_through_ajax, params: { user: { email: "test@whatever.com" }, format: :json }
+        post :login_through_ajax, params: { user: { email: "test@whatever.com" } }, as: :json
         expect(response.body).to eq({message: 'An account with this email or username does not exist. Try again.', type: 'email'}.to_json)
       end
     end
@@ -84,7 +84,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :login_through_ajax, params: { user: { email: user.email }, format: :json }
+        post :login_through_ajax, params: { user: { email: user.email } }, as: :json
         expect(response.body).to eq({message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}.to_json)
       end
     end
@@ -95,7 +95,7 @@ describe SessionsController, type: :controller do
       end
 
       it 'should report login failiure' do
-        post :login_through_ajax, params: { user: { email: user.email }, format: :json }
+        post :login_through_ajax, params: { user: { email: user.email } }, as: :json
         expect(response.body).to eq({message: 'Did you sign up with Google? If so, please log in with Google using the link above.', type: 'email'}.to_json)
       end
     end
@@ -107,7 +107,7 @@ describe SessionsController, type: :controller do
         end
 
         it 'should redirect to the value' do
-          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" } }, as: :json
           expect(response.body).to eq({redirect: root_path}.to_json)
           expect(session[ApplicationController::POST_AUTH_REDIRECT]).to eq nil
         end
@@ -115,7 +115,16 @@ describe SessionsController, type: :controller do
 
       context 'when params redirect present' do
         it 'should redirect to the value given' do
-          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, redirect: root_path, format: :json }
+          post :login_through_ajax,
+            params: {
+              user: {
+                email: user.email,
+                password: "test123"
+              },
+              redirect: root_path,
+            },
+            as: :json
+
           expect(response.body).to eq({redirect: root_path}.to_json)
         end
       end
@@ -127,14 +136,14 @@ describe SessionsController, type: :controller do
         end
 
         it 'should redirect to subscriptions path' do
-          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" } }, as: :json
           expect(response.body).to eq({redirect: '/subscriptions'}.to_json)
         end
       end
 
       context 'when none of the above' do
         it 'should redirect to root path' do
-          post :login_through_ajax, params: { user: { email: user.email, password: "test123" }, format: :json }
+          post :login_through_ajax, params: { user: { email: user.email, password: "test123" } }, as: :json
           expect(response.body).to eq({redirect: '/'}.to_json)
         end
       end
@@ -144,16 +153,12 @@ describe SessionsController, type: :controller do
   describe '#destroy' do
     let(:user) { create(:user ) }
 
-    before do
-      allow(controller).to receive(:current_user) { user }
-    end
+    before { allow(controller).to receive(:current_user) { user } }
 
     context 'when session admin id present' do
       let!(:admin) { create(:admin) }
 
-      before do
-        session[:admin_id] = admin.id
-      end
+      before { session[:admin_id] = admin.id }
 
       it 'should login the admin and redirect to profile path' do
         delete :destroy
@@ -166,9 +171,7 @@ describe SessionsController, type: :controller do
       context 'when staff exists' do
         let!(:staff) { create(:staff) }
 
-        before do
-          session[:staff_id] = staff.id
-        end
+        before { session[:staff_id] = staff.id }
 
         it 'should sign the staff in and redirect to cms users path' do
           delete :destroy
@@ -178,9 +181,7 @@ describe SessionsController, type: :controller do
       end
 
       context 'when staff does not exist' do
-        before do
-          session[:staff_id] = 12
-        end
+        before { session[:staff_id] = 12 }
 
         it 'should redirect to signed out path' do
           delete :destroy

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -182,7 +182,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
             students: classroom.students.sort_by(&:sorting_name)
         }
       }
-      get :retrieve_classrooms_for_assigning_activities, format: :json
+      get :retrieve_classrooms_for_assigning_activities, as: :json
       expect(response.body).to eq ({
           classrooms_and_their_students: json
       }).to_json
@@ -205,7 +205,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
             students: classroom.students.sort_by(&:sorting_name)
         }
       }
-      get :retrieve_classrooms_i_teach_for_custom_assigning_activities, format: :json
+      get :retrieve_classrooms_i_teach_for_custom_assigning_activities, as: :json
       expect(response.body).to eq ({
           classrooms_and_their_students: json
       }).to_json
@@ -344,7 +344,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should assign the classroom and render the correct json' do
-      get :students_list, params: { id: classroom.id, format: :json }
+      get :students_list, params: { id: classroom.id }, as: :json
       expect(assigns(:classroom)).to eq classroom
       expect(response.body).to eq({
         students: classroom.students.order("substring(users.name, '(?=\s).*') asc, users.name asc"),
@@ -382,7 +382,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :classroom_mini, format: :json
+      get :classroom_mini, as: :json
       expect(response.body).to eq({
         classes: "some class info"
       }.to_json)
@@ -413,7 +413,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :getting_started, format: :json
+      get :getting_started, as: :json
       expect(response.body).to eq(teacher.getting_started_info.to_json)
     end
   end
@@ -427,7 +427,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should render the correct json' do
-      get :scores, format: :json
+      get :scores, as: :json
       expect(response.body).to eq({
         scores: [1, 2, 3],
         is_last_page: true
@@ -461,7 +461,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
       create(:auth_credential, user: teacher)
 
       expect(GoogleStudentImporterWorker).to receive(:perform_async)
-      put :import_google_students, params: { selected_classroom_ids: [1,2], format: :json }
+      put :import_google_students, params: { selected_classroom_ids: [1,2], as: :json }
     end
   end
 
@@ -507,7 +507,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     before { allow(controller).to receive(:current_user) { teacher } }
 
     it 'should return an array with two classrooms' do
-      post :update_google_classrooms, params: { selected_classrooms: selected_classrooms, format: :json }
+      post :update_google_classrooms, params: { selected_classrooms: selected_classrooms }, as: :json
 
       classrooms = JSON.parse(response.body).deep_symbolize_keys.fetch(:classrooms)
 

--- a/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
@@ -59,9 +59,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
       context 'when milestone exists and activity could not get updated' do
         let!(:user_milestone) { create(:user_milestone, milestone: milestone, user: teacher) }
 
-        before do
-          allow_any_instance_of(ClassroomUnit).to receive(:update) { false }
-        end
+        before { allow_any_instance_of(ClassroomUnit).to receive(:update) { false } }
 
         it 'should redirect back to the referrer' do
           request.env["HTTP_REFERER"] = '/'
@@ -69,34 +67,23 @@ describe Teachers::ClassroomUnitsController, type: :controller do
           expect(response).to redirect_to '/'
         end
       end
-
-      # setting flash value without redirecting is throwing a missing partial error
-      # context 'when milestone does not exist' do
-        # it 'should set flash error' do
-        #   get :launch_lesson, id: classroom_unit.id, lesson_uid: activity.uid, format: :json
-        #   expect(flash[:error]).to eq "We cannot launch this lesson. If the problem persists, please contact support."
-        # end
-      # end
     end
+
     describe '#lessons_activities_cache' do
-      before do
-        allow(teacher).to receive(:set_and_return_lessons_cache_data) { {id: "not 10"} }
-      end
+      before { allow(teacher).to receive(:set_and_return_lessons_cache_data) { { id: "not 10" } } }
 
       context 'when value is present in the cache' do
-        before do
-          $redis.set("user_id:#{teacher.id}_lessons_array", {id: 10}.to_json)
-        end
+        before { $redis.set("user_id:#{teacher.id}_lessons_array", { id: 10 }.to_json) }
 
         it 'should render the redis cache' do
-          get :lessons_activities_cache, format: :json
-          expect(response.body).to eq({data: {id: 10}}.to_json)
+          get :lessons_activities_cache, as: :json
+          expect(response.body).to eq({data: { id: 10 } }.to_json)
         end
       end
 
       it 'should render the current users lesson cache data' do
-        get :lessons_activities_cache, format: :json
-        expect(response.body).to eq({data: { id: "not 10"}}.to_json)
+        get :lessons_activities_cache, as: :json
+        expect(response.body).to eq({data: { id: "not 10" }}.to_json)
       end
     end
 
@@ -116,10 +103,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
   end
 
   context "without user" do
-
-    before(:each) do
-      allow(controller).to receive(:current_user) { nil }
-    end
+    before { allow(controller).to receive(:current_user) { nil } }
 
     describe '#launch_lesson' do
 

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -21,27 +21,27 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
       before { session[:user_id] = teacher.id }
 
       it 'includes the serialized data for activity sessions' do
-        get :index, params: { page: 1, format: :json }
+        get :index, params: { page: 1 }, as: :json
         expect(json['activity_sessions'][0]['activity_classification_name']).to_not be_nil
       end
 
       it 'includes the number of pages of results' do
-        get :index, params: { page: 1, format: :json }
+        get :index, params: { page: 1 }, as: :json
         expect(json['page_count']).to eq(1)
       end
 
       it 'can filter by classroom' do
-        get :index, params: { classroom_id: empty_classroom.id, page: 1, format: :json }
+        get :index, params: { classroom_id: empty_classroom.id, page: 1}, as: :json
         expect(json['activity_sessions'].size).to eq(0)
       end
 
       it 'can filter by student' do
-        get :index, params: { student_id: zojirushi.id, page: 1, format: :json }
+        get :index, params: { student_id: zojirushi.id, page: 1 }, as: :json
         expect(json['activity_sessions'].size).to eq(1)
       end
 
       it 'fetches classroom and student data for the filter options' do
-        get :index, params: { page: 1, format: :json }
+        get :index, params: { page: 1 }, as: :json
         expect(json['classrooms']).to eq(teacher.ids_and_names_of_affiliated_classrooms)
         expect(json['students']).to eq(teacher.ids_and_names_of_affiliated_students)
         expect(json['units']).to eq(teacher.ids_and_names_of_affiliated_units)

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/concepts_controller_spec.rb
@@ -13,9 +13,8 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
 
   context 'GET #index' do
     subject { get :index, params: { student_id: student.id } }
-    before do
-      session[:user_id] = teacher.id
-    end
+
+    before { session[:user_id] = teacher.id }
 
     it 'assigns the student to the view' do
       subject
@@ -26,10 +25,10 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
   context 'GET #index json' do
     context 'when logged in' do
       let(:json) { JSON.parse(response.body) }
-      subject { get :index, params: { student_id: student.id, format: :json } }
-      before do
-        session[:user_id] = teacher.id
-      end
+
+      subject { get :index, params: { student_id: student.id }, as: :json }
+
+      before { session[:user_id] = teacher.id }
 
       it 'includes a list of concepts in the JSON' do
         subject
@@ -44,12 +43,10 @@ describe Teachers::ProgressReports::Concepts::ConceptsController, type: :control
       end
 
       context 'accessing another teacher\'s student data' do
-        subject { get :index, params: { student_id: other_student.id, format: :json } }
+        subject { get :index, params: { student_id: other_student.id }, as: :json }
 
         it 'raises error' do
-          expect {
-            subject
-          }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
@@ -10,10 +10,10 @@ describe Teachers::ProgressReports::Concepts::StudentsController, type: :control
   context 'GET #index json' do
     context 'when logged in' do
       let(:json) { JSON.parse(response.body) }
-      subject { get :index, format: :json }
-      before do
-        session[:user_id] = teacher.id
-      end
+
+      subject { get :index, as: :json }
+
+      before { session[:user_id] = teacher.id }
 
       it 'includes a list of students in the JSON' do
         crs = alice.activity_sessions.map(&:concept_results).flatten.map(&:metadata)

--- a/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
@@ -12,9 +12,9 @@ describe Teachers::UnitTemplatesController, type: :controller do
 
   let(:parsed_body) { JSON.parse(response.body) }
 
-  describe '#index, format: :json' do
+  describe '#index, as: :json' do
     it 'responds with list of unit_templates' do
-      get :index, format: :json
+      get :index, as: :json
       expect(parsed_body['unit_templates'].length).to eq(4)
     end
   end
@@ -32,7 +32,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
 
   describe '#count' do
     it 'should set the count' do
-      get :count, format: :json
+      get :count, as: :json
       expect(assigns(:count)).to eq UnitTemplate.count
       expect(response.body).to eq({count: UnitTemplate.count}.to_json)
     end
@@ -57,7 +57,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
 
   describe '#assigned_info' do
     it 'should render the correct json' do
-      get :assigned_info, params: { id: unit_template1.id, format: :json }
+      get :assigned_info, params: { id: unit_template1.id }, as: :json
       expect(response.body).to eq({
         name: unit_template1.name,
         last_classroom_name: teacher.classrooms_i_teach.last.name,

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -49,7 +49,7 @@ describe Teachers::UnitsController, type: :controller do
     let(:unit_template_names) { UnitTemplate.pluck(:name).map(&:downcase) }
 
     it 'should render the correct json' do
-      get :prohibited_unit_names, format: :json
+      get :prohibited_unit_names, as: :json
       expect(response.body).to eq({
           prohibitedUnitNames: unit_names.concat(unit_template_names)
       }.to_json)
@@ -58,7 +58,7 @@ describe Teachers::UnitsController, type: :controller do
 
   describe '#last_assigned_unit_id' do
     it 'should render the current json' do
-      get :last_assigned_unit_id, format: :json
+      get :last_assigned_unit_id, as: :json
       expect(response.body).to eq({
         id: Unit.where(user: teacher).last.id,
         referral_code: teacher.referral_code
@@ -75,7 +75,7 @@ describe Teachers::UnitsController, type: :controller do
       end
 
       it 'should render the correct json' do
-        get :lesson_info_for_activity, params: { activity_id: activities.first.id, format: :json }
+        get :lesson_info_for_activity, params: { activity_id: activities.first.id }, as: :json
         expect(response.body).to eq({
           classroom_units: activities,
           activity_name: Activity.select('name').where("id = #{activities.first.id}")
@@ -89,7 +89,7 @@ describe Teachers::UnitsController, type: :controller do
       end
 
       it 'should render the correct json' do
-        get :lesson_info_for_activity, params: { activity_id: classroom.activities.first.id, format: :json }
+        get :lesson_info_for_activity, params: { activity_id: classroom.activities.first.id }, as: :json
         expect(response.body).to eq({
           errors: "No activities found"
         }.to_json)

--- a/services/QuillLMS/spec/support/shared/api_request.rb
+++ b/services/QuillLMS/spec/support/shared/api_request.rb
@@ -16,7 +16,7 @@ shared_examples "a simple api request" do
 
   before do
     create_list(lwc_model_name.to_sym, 3)
-    get :index
+    get :index, as: :json
   end
 
   it 'sends a list' do

--- a/services/QuillLMS/spec/support/shared/progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/progress_report.rb
@@ -25,7 +25,7 @@ shared_examples_for "Progress Report" do
   end
 
   describe 'GET #index JSON' do
-    subject { get :index, params: default_filters.merge(format: :json) }
+    subject { get :index, params: default_filters, as: :json }
 
     let(:json) { JSON.parse(response.body) }
 
@@ -62,12 +62,12 @@ shared_examples_for "Progress Report" do
 end
 
 shared_examples_for "filtering progress reports by Unit" do
-  let(:filters) { { unit_id: filter_value, xhr: true, format: :json } }
+  let(:filters) { { unit_id: filter_value, xhr: true } }
 
   describe 'GET #index JSON' do
     before { login }
 
-    subject { get :index, params: default_filters.merge(filters) }
+    subject { get :index, params: default_filters.merge(filters), as: :json }
 
     let(:json) { JSON.parse(response.body) }
 
@@ -90,7 +90,7 @@ shared_examples_for "exporting to CSV" do
     subject
   end
 
-  subject { get :index, params: default_filters.merge(format: :json) }
+  subject { get :index, params: default_filters, as: :json }
 
   let(:json) { JSON.parse(response.body) }
 


### PR DESCRIPTION
## WHAT
Update active_activity_controller_spec to include a test for proofreader passage data.

## WHY
Rails 4.2 controller specs did not encode parameters, instead simply passing the hash through directly.  In Rails 5, the parameters are now encoded.  When attempting to write a new [spec](https://github.com/empirical-org/Empirical-Core/pull/8109/files#diff-5db7248663d966b06cb1a05f339a2966e93a71b9a64f05dc619c3d213e2624dbR52) for a recent regression, the params coming in were not as expected until the request included `as: :json`.

## HOW
Add `as: :json` to the appropriate spec.

I've also added this `as: :json` to appropriate specs in `spec/api/v1/controller/` and few other specs to ensure the intended params are being received by the controller.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-spec-for-proofreading-bug-719d4b75cacb401b8f24b42b58d886b6
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO these is just updated specs.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A