### PR TITLE
CMS - Performance Optimizations for multiple_choice_options endpoint

### DIFF
--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -37,12 +37,14 @@ class QuestionsController < ApplicationController
     graded_nonoptimal = GradedResponse
       .graded_nonoptimal
       .where(question_uid: params[:question_uid])
-      .where("count > 1 AND count <= #{MultipleChoiceResponse::MIN_COUNT}")
+      .where("count <= #{MultipleChoiceResponse::MIN_COUNT}")
       .limit(needed_count)
       .to_a
 
     return graded_nonoptimal if graded_nonoptimal.count == needed_count
 
+    # otherwise pull any nonoptimal answer
+    # ignore responses with count = 1 to avoid junk responses
     Response
       .nonoptimal
       .where(question_uid: params[:question_uid])

--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -35,8 +35,7 @@ class QuestionsController < ApplicationController
       .where(question_uid: params[:question_uid])
       .nonoptimal
       .where("count > 1 AND count <= #{MultipleChoiceResponse::MIN_COUNT}")
-      .limit(MULTIPLE_CHOICE_LIMIT - nonoptimal_count)
-      .order('count DESC')
+      .limit(needed_count)
       .to_a
   end
 end

--- a/services/QuillCMS/app/models/concerns/response_scopes.rb
+++ b/services/QuillCMS/app/models/concerns/response_scopes.rb
@@ -1,0 +1,14 @@
+require "active_support/concern"
+
+module ResponseScopes
+  extend ActiveSupport::Concern
+
+  included do
+    scope :optimal, -> { where(optimal: true) }
+    scope :graded_nonoptimal, -> { where(optimal: false) }
+    scope :ungraded, -> { where(optimal: nil) }
+    scope :nonoptimal, -> { where(optimal: [false, nil]) }
+
+    scope :no_parent, -> { where(parent_id: nil) }
+  end
+end

--- a/services/QuillCMS/app/models/concerns/response_view.rb
+++ b/services/QuillCMS/app/models/concerns/response_view.rb
@@ -1,15 +1,10 @@
 require "active_support/concern"
 
-module ResponsesView
+module ResponseView
   extend ActiveSupport::Concern
 
   included do
     self.primary_key = :id
-
-    scope :optimal, -> { where(optimal: true) }
-    scope :nonoptimal, -> { where(optimal: [false, nil]) }
-    scope :graded_nonoptimal, -> { where(optimal: false) }
-    scope :no_parent, -> { where(parent_id: nil) }
 
     def self.refresh
       Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)

--- a/services/QuillCMS/app/models/concerns/responses_view.rb
+++ b/services/QuillCMS/app/models/concerns/responses_view.rb
@@ -8,6 +8,7 @@ module ResponsesView
 
     scope :optimal, -> { where(optimal: true) }
     scope :nonoptimal, -> { where(optimal: [false, nil]) }
+    scope :graded_nonoptimal, -> { where(optimal: false) }
     scope :no_parent, -> { where(parent_id: nil) }
 
     def self.refresh

--- a/services/QuillCMS/app/models/graded_response.rb
+++ b/services/QuillCMS/app/models/graded_response.rb
@@ -1,3 +1,4 @@
 class GradedResponse < ApplicationRecord
-  include ResponsesView
+  include ResponseView
+  include ResponseScopes
 end

--- a/services/QuillCMS/app/models/multiple_choice_response.rb
+++ b/services/QuillCMS/app/models/multiple_choice_response.rb
@@ -1,4 +1,5 @@
 class MultipleChoiceResponse < ApplicationRecord
   MIN_COUNT = 10
-  include ResponsesView
+  include ResponseView
+  include ResponseScopes
 end

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -2,14 +2,13 @@ require 'elasticsearch/model'
 
 class Response < ApplicationRecord
   include Elasticsearch::Model
+  include ResponseScopes
   after_create_commit :create_index_in_elastic_search
   after_update_commit :update_index_in_elastic_search
   after_commit :clear_responses_route_cache
   before_destroy :destroy_index_in_elastic_search
 
   validates :question_uid, uniqueness: { scope: :text }
-
-  scope :nonoptimal, -> { where(optimal: [false, nil]) }
 
   settings analysis: {
     analyzer: {

--- a/services/QuillCMS/spec/controllers/questions_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/questions_controller_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe QuestionsController, type: :controller do
       end
 
       # Note, this expectation is bound to QuestionsController::MULTIPLE_CHOICE_LIMIT
-      it 'should return graded responses, 1 from MultipleChoiceResponse and 1 from ungraded responses )if there are no more graded responses' do
+      it 'should return graded responses, 1 from MultipleChoiceResponse and 1 from ungraded responses since there are no more graded responses' do
         get :multiple_choice_options, params: {question_uid: '123'}
 
         expect(response.status).to eq 200

--- a/services/QuillCMS/spec/models/graded_response_spec.rb
+++ b/services/QuillCMS/spec/models/graded_response_spec.rb
@@ -22,7 +22,17 @@ RSpec.describe GradedResponse, type: :model do
       graded_ids = [optimal.id, graded_nonoptimal.id].sort
 
       expect(response_ids).to eq graded_ids
-      expect(responses.first.attributes.keys.sort).to eq graded_nonoptimal.attributes.keys.sort
+    end
+
+
+    # Note, if this test fails, you might need a migration for this view
+    # Scenic View attributes are locked at the time of the view migration
+    # So a query for responses.* doesn't update as you add fields
+    # https://github.com/scenic-views/scenic#faqs
+    it 'should have the same attributes as Response' do
+      GradedResponse.refresh
+
+      expect(GradedResponse.first.attributes.keys.sort).to eq Response.first.attributes.keys.sort
     end
   end
 end

--- a/services/QuillCMS/spec/models/graded_response_spec.rb
+++ b/services/QuillCMS/spec/models/graded_response_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe GradedResponse, type: :model do
       expect(response_ids).to eq graded_ids
     end
 
-
     # Note, if this test fails, you might need a migration for this view
     # Scenic View attributes are locked at the time of the view migration
     # So a query for responses.* doesn't update as you add fields

--- a/services/QuillCMS/spec/models/multiple_choice_response_spec.rb
+++ b/services/QuillCMS/spec/models/multiple_choice_response_spec.rb
@@ -23,7 +23,16 @@ RSpec.describe MultipleChoiceResponse, type: :model do
       highest_two_count_ids = [graded_nonoptimal.id, ungraded2.id].sort
 
       expect(response_ids).to eq highest_two_count_ids
-      expect(responses.first.attributes.keys.sort).to eq graded_nonoptimal.attributes.keys.sort
+    end
+
+    # Note, if this test fails, you might need a migration for this view
+    # Scenic View attributes are locked at the time of the view migration
+    # So a query for responses.* doesn't update as you add fields
+    # https://github.com/scenic-views/scenic#faqs
+    it 'should have the same attributes as Response' do
+      MultipleChoiceResponse.refresh
+
+      expect(MultipleChoiceResponse.first.attributes.keys.sort).to eq Response.first.attributes.keys.sort
     end
   end
 


### PR DESCRIPTION
## WHAT
This is a follow-on PR for #8078. Making some changes based on performance testing. Mainly:
1. Removing `.order('count DESC')` from fallback in multiple choice
2. Checking `GradedResponse` for fallback multiple choice options first (faster)

I also broke our shared `response` scopes in a separate concern, and cleaned up some tests.
## WHY
Purely performance reasons.
## HOW
Removing a scope, adding cascading logic.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
