### PR TITLE
CMS - Enable new response and multiple_choice_options endpoints

### DIFF
--- a/services/QuillCMS/app/models/cron.rb
+++ b/services/QuillCMS/app/models/cron.rb
@@ -24,7 +24,7 @@ class Cron
     timeout = RefreshResponsesViewWorker::REFRESH_TIMEOUT
     default_interval = 600 # 10 minutes
 
-    interval = minute_string.in?(timeout) ? (timeout.gsub(minute_string,'').to_i * 60) : default_inteveral
+    interval = minute_string.in?(timeout) ? (timeout.gsub(minute_string,'').to_i * 60) : default_interval
 
     RefreshResponsesViewWorker::VIEWS.each.with_index do |view, index|
       RefreshResponsesViewWorker.perform_in(index * interval, view)

--- a/services/QuillCMS/app/models/cron.rb
+++ b/services/QuillCMS/app/models/cron.rb
@@ -2,11 +2,32 @@ class Cron
 
   def self.run
     current_time = Time.zone.now
-    if current_time.hour == 3
-      beginning_of_yesterday = current_time.yesterday.beginning_of_day
-      end_of_yesterday = current_time.yesterday.end_of_day
-      UpdateElasticsearchWorker.perform_async(beginning_of_yesterday, end_of_yesterday)
-      UpdateElasticsearchWorker.perform_async(current_time.beginning_of_day, current_time)
+
+    return unless current_time.hour == 3
+
+    update_elasticsearch(current_time)
+    refresh_response_views
+  end
+
+  private_class_method def self.update_elasticsearch(time)
+    beginning_of_yesterday = time.yesterday.beginning_of_day
+    end_of_yesterday = time.yesterday.end_of_day
+
+    UpdateElasticsearchWorker.perform_async(beginning_of_yesterday, end_of_yesterday)
+    UpdateElasticsearchWorker.perform_async(time.beginning_of_day, time)
+  end
+
+  private_class_method def self.refresh_response_views
+    # spread out run by the length of timeout to run them separately
+    # default to 10 minutes
+    minute_string = 'min'
+    timeout = RefreshResponsesViewWorker::REFRESH_TIMEOUT
+    default_interval = 600 # 10 minutes
+
+    interval = minute_string.in?(timeout) ? (timeout.gsub(minute_string,'').to_i * 60) : default_inteveral
+
+    RefreshResponsesViewWorker::VIEWS.each.with_index do |view, index|
+      RefreshResponsesViewWorker.perform_in(index * interval, view)
     end
   end
 end

--- a/services/QuillCMS/app/models/cron.rb
+++ b/services/QuillCMS/app/models/cron.rb
@@ -5,29 +5,11 @@ class Cron
 
     return unless current_time.hour == 3
 
-    update_elasticsearch(current_time)
-    refresh_response_views
-  end
-
-  private_class_method def self.update_elasticsearch(time)
-    beginning_of_yesterday = time.yesterday.beginning_of_day
-    end_of_yesterday = time.yesterday.end_of_day
+    beginning_of_yesterday = current_time.yesterday.beginning_of_day
+    end_of_yesterday = current_time.yesterday.end_of_day
 
     UpdateElasticsearchWorker.perform_async(beginning_of_yesterday, end_of_yesterday)
-    UpdateElasticsearchWorker.perform_async(time.beginning_of_day, time)
-  end
-
-  private_class_method def self.refresh_response_views
-    # spread out run by the length of timeout to run them separately
-    # default to 10 minutes
-    minute_string = 'min'
-    timeout = RefreshResponsesViewWorker::REFRESH_TIMEOUT
-    default_interval = 600 # 10 minutes
-
-    interval = minute_string.in?(timeout) ? (timeout.gsub(minute_string,'').to_i * 60) : default_interval
-
-    RefreshResponsesViewWorker::VIEWS.each.with_index do |view, index|
-      RefreshResponsesViewWorker.perform_in(index * interval, view)
-    end
+    UpdateElasticsearchWorker.perform_async(current_time.beginning_of_day, current_time)
+    RefreshAllResponsesViewsWorker.perform_async
   end
 end

--- a/services/QuillCMS/app/workers/refresh_all_responses_views_worker.rb
+++ b/services/QuillCMS/app/workers/refresh_all_responses_views_worker.rb
@@ -1,0 +1,18 @@
+class RefreshAllResponsesViewsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+
+  MINUTE_STRING = 'min'
+  DEFAULT_INTERVAL = 600 # 10 minutes
+  MINUTES_IN_HOUR = 60
+
+  def perform
+    timeout = RefreshResponsesViewWorker::REFRESH_TIMEOUT
+
+    interval = MINUTE_STRING.in?(timeout) ? (timeout.gsub(MINUTE_STRING,'').to_i * MINUTES_IN_HOUR) : DEFAULT_INTERVAL
+
+    RefreshResponsesViewWorker::VIEWS.each.with_index do |view, index|
+      RefreshResponsesViewWorker.perform_in(index * interval, view)
+    end
+  end
+end

--- a/services/QuillCMS/config/routes.rb
+++ b/services/QuillCMS/config/routes.rb
@@ -7,10 +7,6 @@ Rails.application.routes.draw do
 
   resources :responses, only: [:show, :create, :update, :destroy]
 
-  # TODO: remove these 2 routes to transition to GradedResponse setup
-  get  'questions/:question_uid/responses' => 'responses#responses_for_question'
-  get  'questions/:question_uid/multiple_choice_options' => 'responses#multiple_choice_options'
-  # END
   get  'questions/:question_uid/health' => 'responses#health_of_question'
   get  'questions/:question_uid/grade_breakdown' => 'responses#grade_breakdown'
   get  'questions/:question_uid/question_dashboard_data' => 'responses#question_dashboard'
@@ -36,8 +32,7 @@ Rails.application.routes.draw do
     end
   end
 
-  # TODO: remove path :graded to match routes used by frontend apps
-  resources :questions, only: [], param: :question_uid, path: :graded do
+  resources :questions, only: [], param: :question_uid do
     get :responses, :multiple_choice_options, on: :member
   end
 

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -137,41 +137,6 @@ RSpec.describe ResponsesController, type: :controller do
     end
   end
 
-  describe '#responses_for_question' do
-    let(:q_response) { create(:response, question_uid: '123456') }
-
-    before do
-      allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
-    end
-
-    it 'should return 200 for found' do
-      get :responses_for_question, params: { question_uid: q_response.question_uid}
-
-      expect(response.status).to eq(200)
-    end
-
-    it 'should return 200 for not-found' do
-      get :responses_for_question, params: { question_uid: 'adsfdsf'}
-
-      expect(response.status).to eq(200)
-    end
-  end
-
-  describe '#multiple_choice_options' do
-    let(:q_response) { create(:response, question_uid: '123456') }
-    let(:q_response_optimal) { create(:response, question_uid: '123456', optimal: true) }
-
-    before do
-      allow_any_instance_of(Response).to receive(:create_index_in_elastic_search)
-    end
-
-    it 'should return 200 for found' do
-      get :multiple_choice_options, params: { question_uid: q_response.question_uid}
-
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe 'POST #batch_responses_for_lesson' do
 
     it 'returns an object with question uids as keys and an array of responses as values' do

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -16,13 +16,26 @@ RSpec.describe Cron do
       Cron.run
     end
 
-    it "should run a refresh responsee view job if the hour is 3AM" do
-      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
+    context 'refresh response views' do
+      before do
+        allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
+      end
 
-      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
-      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(600, 'MultipleChoiceResponse')
-      Cron.run
+      it "should run a refresh responsee view job if the hour is 3AM" do
+        stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '1min')
+
+        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
+        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(60, 'MultipleChoiceResponse')
+        Cron.run
+      end
+
+      it "should spread out jobs by default if REFRESH_TIMEOUT is not in minutes" do
+        stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '999999999999999999s')
+
+        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
+        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(600, 'MultipleChoiceResponse')
+        Cron.run
+      end
     end
-
   end
 end

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -15,5 +15,14 @@ RSpec.describe Cron do
       expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.beginning_of_day, Time.zone.now.beginning_of_day + 3.hour)
       Cron.run
     end
+
+    it "should run a refresh responsee view job if the hour is 3AM" do
+      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
+
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(600, 'MultipleChoiceResponse')
+      Cron.run
+    end
+
   end
 end

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Cron do
   describe "kicks off appropriate jobs at the appropriate time" do
 
-    context 'update elasticsearch' do
+    context 'UpdateElasticsearchWorker' do
       it "should not kick off jobs if the hour is not 3AM" do
         allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day)
         expect(UpdateIndividualResponseWorker).to_not receive(:perform_async)
@@ -18,24 +18,11 @@ RSpec.describe Cron do
       end
     end
 
-    context 'refresh response views' do
-      before do
+    context 'RefreshAllResponsesViewsWorker' do
+      it "should run a refresh response view job if the hour is 3AM" do
         allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
-      end
+        expect(RefreshAllResponsesViewsWorker).to receive(:perform_async)
 
-      it "should run a refresh responsee view job if the hour is 3AM" do
-        stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '1min')
-
-        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
-        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(60, 'MultipleChoiceResponse')
-        Cron.run
-      end
-
-      it "should spread out jobs by default if REFRESH_TIMEOUT is not in minutes" do
-        stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '999999999999999999s')
-
-        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
-        expect(RefreshResponsesViewWorker).to receive(:perform_in).with(600, 'MultipleChoiceResponse')
         Cron.run
       end
     end

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -3,17 +3,19 @@ require "rails_helper"
 RSpec.describe Cron do
   describe "kicks off appropriate jobs at the appropriate time" do
 
-    it "should not kick off jobs if the hour is not 3AM" do
-      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day)
-      expect(UpdateIndividualResponseWorker).to_not receive(:perform_async)
-      Cron.run
-    end
+    context 'update elasticsearch' do
+      it "should not kick off jobs if the hour is not 3AM" do
+        allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day)
+        expect(UpdateIndividualResponseWorker).to_not receive(:perform_async)
+        Cron.run
+      end
 
-    it "should kick off job if the hour is 3AM" do
-      allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
-      expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.yesterday.beginning_of_day, Time.zone.now.yesterday.end_of_day)
-      expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.beginning_of_day, Time.zone.now.beginning_of_day + 3.hour)
-      Cron.run
+      it "should kick off job if the hour is 3AM" do
+        allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
+        expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.yesterday.beginning_of_day, Time.zone.now.yesterday.end_of_day)
+        expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.beginning_of_day, Time.zone.now.beginning_of_day + 3.hour)
+        Cron.run
+      end
     end
 
     context 'refresh response views' do

--- a/services/QuillCMS/spec/spec_helper.rb
+++ b/services/QuillCMS/spec/spec_helper.rb
@@ -13,6 +13,10 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -43,6 +47,10 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.

--- a/services/QuillCMS/spec/workers/refresh_all_responses_views_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/refresh_all_responses_views_worker_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe RefreshAllResponsesViewsWorker do
+  let(:worker) { described_class.new }
+
+  describe '#perform' do
+    it "should run a refresh responsee view job for each view" do
+      stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '1min')
+
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(60, 'MultipleChoiceResponse')
+
+      worker.perform
+    end
+
+    it "should spread out jobs by default if REFRESH_TIMEOUT is not in minutes" do
+      stub_const("RefreshResponsesViewWorker::REFRESH_TIMEOUT", '999999999999999999s')
+
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(0, 'GradedResponse')
+      expect(RefreshResponsesViewWorker).to receive(:perform_in).with(600, 'MultipleChoiceResponse')
+
+      worker.perform
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Testing of the new endpoints powered by views looks good on `production`, so putting them in place.
## WHY
These are much more performant than the current endpoints, without even using caching.
## HOW
Removing old routes, controller endpoints, and tests.  Since these are materialized views that need to be refreshed, queueing a job to refresh each view over night.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | YES 
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A