### PR TITLE
Evidence/ add check for response highlights

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -596,7 +596,6 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
   formatHtmlForPassage = () => {
     const { activeStep, studentHighlights, } = this.state
     const { activities, session, } = this.props
-    console.log("🚀 ~ file: container.tsx ~ line 599 ~ StudentViewContainer ~ session", session)
     const { currentActivity, } = activities
 
     if (!currentActivity) { return }

--- a/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Comprehension/components/studentView/container.tsx
@@ -596,6 +596,7 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
   formatHtmlForPassage = () => {
     const { activeStep, studentHighlights, } = this.state
     const { activities, session, } = this.props
+    console.log("🚀 ~ file: container.tsx ~ line 599 ~ StudentViewContainer ~ session", session)
     const { currentActivity, } = activities
 
     if (!currentActivity) { return }
@@ -614,8 +615,9 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
     if (!(submittedResponsesForActivePrompt && submittedResponsesForActivePrompt.length)) { return passagesWithoutSpanTags }
 
     const lastSubmittedResponse = submittedResponsesForActivePrompt[submittedResponsesForActivePrompt.length - 1]
-
-    if (!lastSubmittedResponse.highlight || (lastSubmittedResponse.highlight && !lastSubmittedResponse.highlight.length)) { return passagesWithoutSpanTags }
+    const noPassageHighlights = !lastSubmittedResponse.highlight || (lastSubmittedResponse.highlight && !lastSubmittedResponse.highlight.length);
+    const isResponseHighlight = lastSubmittedResponse.highlight && lastSubmittedResponse.highlight[0] && lastSubmittedResponse.highlight[0].type === 'response';
+    if (noPassageHighlights || isResponseHighlight) { return passagesWithoutSpanTags }
 
     const passageHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === "passage")
 


### PR DESCRIPTION
## WHAT
add a check for response highlights in the latest attempt when returning passage

## WHY
we don't want to return passage highlights if the latest attempt has response highlights

## HOW
just add a conditional check for stripping passage highlights

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Highlighting-from-earlier-in-comprehension-activity-reappearing-94c678e02c8644ea9164386647931c54

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
