### PR TITLE
Evidence/link activity title to lms

### DIFF
--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -15,7 +15,7 @@ module Comprehension
     has_many :passages, inverse_of: :activity, dependent: :destroy
     has_many :prompts, inverse_of: :activity, dependent: :destroy
     has_many :turking_rounds, inverse_of: :activity
-    belongs_to :parent_activity, class_name: Comprehension.parent_activity_class
+    belongs_to :parent_activity, class_name: "::#{Comprehension.parent_activity_class}"
 
     accepts_nested_attributes_for :passages, reject_if: proc { |p| p['text'].blank? }
     accepts_nested_attributes_for :prompts

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -10,6 +10,7 @@ module Comprehension
 
     before_destroy :expire_turking_rounds
     before_validation :set_parent_activity, on: :create
+    after_save :update_parent_activity_name, if: :title_changed?
 
     has_many :passages, inverse_of: :activity, dependent: :destroy
     has_many :prompts, inverse_of: :activity, dependent: :destroy
@@ -56,6 +57,10 @@ module Comprehension
 
     def url
       "comprehension/#/activities/#{id}/settings"
+    end
+
+    private def update_parent_activity_name
+      parent_activity&.update(name: title)
     end
 
     private def expire_turking_rounds

--- a/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
+++ b/services/QuillLMS/engines/comprehension/app/models/comprehension/activity.rb
@@ -15,7 +15,7 @@ module Comprehension
     has_many :passages, inverse_of: :activity, dependent: :destroy
     has_many :prompts, inverse_of: :activity, dependent: :destroy
     has_many :turking_rounds, inverse_of: :activity
-    belongs_to :parent_activity, class_name: "::#{Comprehension.parent_activity_class}"
+    belongs_to :parent_activity, class_name: Comprehension.parent_activity_classname
 
     accepts_nested_attributes_for :passages, reject_if: proc { |p| p['text'].blank? }
     accepts_nested_attributes_for :prompts

--- a/services/QuillLMS/engines/comprehension/lib/comprehension.rb
+++ b/services/QuillLMS/engines/comprehension/lib/comprehension.rb
@@ -10,6 +10,10 @@ module Comprehension
     @@parent_activity_class.constantize
   end
 
+  def self.parent_activity_classname
+    @@parent_activity_class
+  end
+
   def self.parent_activity_classification_class
     @@parent_activity_classification_class.constantize
   end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -563,4 +563,18 @@ describe Activity, type: :model, redis: true do
       expect { activity.update(name: 'New name') }.not_to raise_error(NoMethodError)
     end
   end
+
+  context 'a test that belongs in Comprehension that we need here because the engine stubs the LMS Activity model, and we need them both to behave as if real' do
+    describe '#Comprehension::Activity.update_parent_activity_name' do
+      let(:activity) { create(:activity) }
+      let(:comp_activity) { Comprehension::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id) }
+
+      it 'should update the parent_activity.name when the comprehension activity.title is updated' do
+        new_title = 'New Title'
+        comp_activity.update(title: new_title)
+        activity.reload
+        expect(activity.name).to eq(new_title)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -571,6 +571,7 @@ describe Activity, type: :model, redis: true do
 
       it 'should update the parent_activity.name when the comprehension activity.title is updated' do
         new_title = 'New Title'
+        expect(activity.name).not_to eq(new_title)
         comp_activity.update(title: new_title)
         activity.reload
         expect(activity.name).to eq(new_title)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -483,4 +483,84 @@ describe Activity, type: :model, redis: true do
       refute connect_activity.is_diagnostic?
     end
   end
+
+  describe '#update_evidence_title?' do
+    let(:evidence) { create(:evidence) }
+    let(:activity) { create(:activity, classification: evidence) }
+
+    it 'should return true if both is_evidence? and name_changed?' do
+      activity.name = 'New Name'
+
+      expect(activity.send(:update_evidence_title?)).to eq(true)
+    end
+
+    it 'should return false if activity is not an evidence activity' do
+      activity.classification = create(:connect)
+      activity.name = 'New Name'
+
+      expect(activity.send(:update_evidence_title?)).to eq(false)
+    end
+
+    it 'should return false if name has not been changed on activity' do
+      activity.supporting_info = 'Name not changed'
+      expect(activity.send(:update_evidence_title?)).to eq(false)
+    end
+  end
+
+  describe '#after_save' do
+    let(:evidence) { create(:evidence) }
+    let(:activity) { create(:activity, classification: evidence) }
+
+    it 'should call update_evidence_child_title if update_evidence_title? is true' do
+      expect(activity).to receive(:update_evidence_child_title)
+      activity.update(name: 'New name')
+    end
+
+    it 'should not call update_evidence_child_title if update_evidence_title? is false' do
+      expect(activity).to receive(:update_evidence_title?).and_return(false)
+      activity.update(supporting_info: 'No name change')
+    end
+  end
+
+  describe '#child_activity' do
+    let(:evidence) { create(:evidence) }
+    let(:activity) { create(:activity, classification: evidence) }
+
+    it 'should do nothing if is_evidence? is false' do
+      activity.classification = create(:connect)
+      expect(Comprehension::Activity).not_to receive(:find_by)
+      activity.update(supporting_info: 'No name change')
+    end
+
+    it 'should call Comprehension::Activity.find_by if is_evidence? is true' do
+      expect(Comprehension::Activity).to receive(:find_by).with(parent_activity_id: activity.id)
+      activity.update(name: 'New name')
+    end
+
+    it 'should return nil if there is no child activity' do
+      expect(activity.child_activity).to be_nil
+    end
+
+    it 'should return a Comprehension::Activity if one has the LMS Activity.id as its parent_activity_id' do
+      comp_activity = Comprehension::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
+      expect(activity.child_activity).to eq(comp_activity)
+    end
+  end
+
+  describe '#update_evidence_child_title' do
+    let(:evidence) { create(:evidence) }
+    let(:activity) { create(:activity, classification: evidence) }
+
+    it 'should update the child activity title to the name value' do
+      new_name = 'A new name'
+      comp_activity = Comprehension::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
+      activity.update(name: new_name)
+      comp_activity.reload
+      expect(comp_activity.title).to eq(new_name)
+    end
+
+    it 'should not error if there is no child activity' do
+      expect { activity.update(name: 'New name') }.not_to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Add `after_save` hooks to both base `Activity` and `Comprehension::Activity` so that when you change a specific value in one model, it updates the corresponding value in the other.  Specifically, we are linking `Activity.name` and `Comprehension::Activity.title`.  This allows Curriculum developers to edit the value via either the Evidence admin interface OR the LMS Activity editing interface and not have to worry about updating the corresponding value in the other place.
## WHY
We were running into instances where Curriculum would update the `Comprehension::Activity.title` value in the Evidence admin tool, but forgetting to update the LMS value which resulted in students and teachers seeing one name when looking at their dashboards, and a different name when actually playing the activity.
## HOW
Use `after_save` hooks in both models to update the value in the associated parent/child model when the relevant values are changed.
Note, we also tweaked the way that we defined the `Comprehension::Activity.parent_activity` relationship so that it namespaces properly.  (I'll leave an in-line note in the PR with more detail.)

### Notion Card Links
https://www.notion.so/quill/Display-a-warning-when-changing-the-activity-title-in-the-Activity-Settings-c5eac6ea4eaa44aeb9e0e972d01a97db

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
