### PR TITLE
add question prefilter

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/modules/prefilters.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/modules/prefilters.ts
@@ -3,7 +3,6 @@ import { sentences } from 'sbd'
 
 const filter = new Filter()
 
-
 const MINIMUM_WORD_COUNT = 3
 const MAXIMUM_WORD_COUNT = 100
 
@@ -11,6 +10,7 @@ export const TOO_SHORT_FEEDBACK = "Whoops, it looks like you submitted your resp
 export const TOO_LONG_FEEDBACK = "Revise your work so it is shorter and more concise."
 export const PROFANITY_FEEDBACK = "Revise your work. When writing your response, make sure to use appropriate language."
 export const MULTIPLE_SENTENCES_FEEDBACK = "Revise your work. Your response should be only one sentence long."
+export const QUESTION_MARK_FEEDBACK = "Revise your response. Instead of using a question mark, write a statement that ends with a period. Remember, anytime you do an activity like this one on Quill, you'll write statements instead of questions."
 
 interface FilterResponse {
   matched: boolean,
@@ -24,6 +24,7 @@ const filters: PreFilter[] = [
   profanity,
   tooShort,
   multipleSentences,
+  endsWithQuestionMark,
   tooLong,
 ];
 
@@ -56,6 +57,11 @@ export function multipleSentences(str: string): FilterResponse {
 export function tooLong(str: string): FilterResponse {
   const matched = textWithoutStemArray(str).length > MAXIMUM_WORD_COUNT
   return { matched, feedback: TOO_LONG_FEEDBACK, feedbackKey: 'too-long' }
+}
+
+export function endsWithQuestionMark(str: string): FilterResponse {
+  const matched = !!str.match(/\?$/)
+  return { matched, feedback: QUESTION_MARK_FEEDBACK, feedbackKey: 'question-mark' }
 }
 
 function textWithoutStemArray(str: string): string[] {

--- a/services/QuillLMS/client/app/bundles/Comprehension/tests/modules/prefilters.spec.ts
+++ b/services/QuillLMS/client/app/bundles/Comprehension/tests/modules/prefilters.spec.ts
@@ -4,7 +4,8 @@ import preFilters, {
   profanity,
   tooShort,
   multipleSentences,
-  tooLong
+  tooLong,
+  endsWithQuestionMark
 } from '../../modules/prefilters'
 
 describe('#preFilters', () => {
@@ -53,6 +54,19 @@ describe("#multipleSentences", () => {
   it('returns matched: false if the string passed in includes an abbreviation at the end of the sentence', () => {
     expect(multipleSentences('because we should follow Martin Luther King Jr.').matched).toEqual(false)
   })
+})
+
+describe("#endsWithQuestionMark", () => {
+  it('returns matched: true if the string passed in ends with a question mark', () => {
+    const str = "Is this a question?"
+    expect(endsWithQuestionMark(str).matched).toEqual(true)
+  })
+
+  it('returns matched: false if the string passed in does not end with a question mark', () => {
+    const str = "This is not a question."
+    expect(endsWithQuestionMark(str).matched).toEqual(false)
+  })
+
 })
 
 describe("#tooLong", () => {


### PR DESCRIPTION
## WHAT
Add a new prefilter that checks for an ending question mark.

## WHY
So our curriculum team doesn't have to write the same regex for every prompt.

## HOW
Just add a new function to the existing prefilter framework.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-question-marks-to-pre-filter-37560770e60f47a286a9b3cb313c43c2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
