### PR TITLE
Evidence/ fix view for onboarding slides for shorter screen sizes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/explanationSlide.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/explanationSlide.scss
@@ -161,9 +161,12 @@
 
 @media (max-height: 670px) {
   .explanation-slide-container {
+    height: min-content;
+    padding-top: 16px;
     #information-section {
       #instructions-container {
         margin-top: 40px;
+        padding-bottom: 16px;
       }
     }
   }

--- a/services/QuillLMS/client/app/bundles/Comprehension/styles/explanationSlide.scss
+++ b/services/QuillLMS/client/app/bundles/Comprehension/styles/explanationSlide.scss
@@ -158,3 +158,13 @@
     }
   }
 }
+
+@media (max-height: 670px) {
+  .explanation-slide-container {
+    #information-section {
+      #instructions-container {
+        margin-top: 40px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## WHAT
fix view for onboarding slides for shorter screen sizes

## WHY
it was causing some of the image to be cut off and display weird

## HOW
just added a media query for the relevant height

### Screenshots
(If applicable. Also, please censor any sensitive data)
https://recordit.co/BT4BluXZ9l

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Onboarding-offboarding-slides-get-squished-on-smaller-screen-heights-30b5352a9d054a3e931f04afce72ecb5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
