### PR TITLE
lms/update-mastery-charter-clever-ids

### DIFF
--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -115,7 +115,7 @@ namespace :schools do
         original_id_holder = School.find_by(clever_id: school[CLEVER_ID_KEY])
         original_id_holder&.update(clever_id: nil)
         new_id_holder = School.find(school[QUILL_ID_KEY])
-        new_id_holder.update(clever_id: school[CLEVER_ID_KEY])
+        new_id_holder.update!(clever_id: school[CLEVER_ID_KEY])
       end
     end
   end

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -91,4 +91,29 @@ namespace :schools do
       school.save! 
     end  
   end
+
+  desc 'Update Clever IDs for existing schools based on a CSV file'
+  task :update_clever_ids => :environment do
+
+    QUILL_ID_KEY = 'Quill ID'
+    CLEVER_ID_KEY = 'Clever School ID'
+
+    pipe_data = STDIN.read unless STDIN.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake schools:update_clever_ids < path/to/local/file.csv'
+      exit 1
+    end
+
+    ActiveRecord::Base.transaction do
+      CSV.parse(pipe_data, headers: true) do |school|
+        # Just in case this CleverID was once assigned to a different school
+        original_id_holder = School.find_by(clever_id: school[CLEVER_ID_KEY])
+        original_id_holder&.update(clever_id: nil)
+        new_id_holder = School.find(school[QUILL_ID_KEY])
+        new_id_holder.update(clever_id: school[CLEVER_ID_KEY])
+      end
+    end
+  end
 end

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -103,6 +103,9 @@ namespace :schools do
     unless pipe_data
       puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
       puts '  rake schools:update_clever_ids < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake schools:update_clever_ids -a empirical-grammar --no-tty < path/to/local/file.csv'
       exit 1
     end
 


### PR DESCRIPTION
## WHAT
Add a rake task to update Mastery Charter Clever IDs
## WHY
They've changed some of the settings for some of their schools, and those changes need to be reflected in our system
## HOW
Add a task to the existing `schools.rake` file that reads the intended data from STDIN.  I was originally going to commit the CSV file and deploy it with the script to read from there, but realized that there is some information worth trying not to leak (the Clever IDs of some schools), so swapped to the STDIN approach.

### Notion Card Links
https://www.notion.so/quill/Mastery-Charter-School-Restructure-Clever-ID-c58c0e999932485daf2301bb82b0641c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
