### PR TITLE
Home/ explore curriculum mobile optimization

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
@@ -82,12 +82,21 @@
       display: none;
     }
   }
-}
-
-@media only screen and (max-width: 500px) {
   .related-activity-packs {
     .small-screen-unit-template-container {
         padding: 0px !important;
     }
+  }
+  .filter-options {
+    flex-direction: column;
+    .dropdown-container {
+      width: 100% !important;
+    }
+    .dropdown-container:first-of-type {
+      margin-bottom: 24px;
+    }
+  }
+  .unit-template-minis {
+    justify-content: center !important;
   }
 }

--- a/services/QuillLMS/app/helpers/application_helper.rb
+++ b/services/QuillLMS/app/helpers/application_helper.rb
@@ -77,4 +77,10 @@ module ApplicationHelper
     "u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/student_report/" \
     "#{user_id}"
   end
+
+  def device
+    agent = request.user_agent
+    return "mobile" if agent =~ /Mobile/
+    return "desktop"
+  end
 end

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -75,7 +75,7 @@ module TeacherCenterHelper
       {name: large ? 'AP Activities' : 'AP', url: 'ap'},
       {name: large ? 'Pre-AP Activities' : 'Pre-AP', url: 'preap'},
       {name: large ? 'SpringBoard Activities' : 'SpringBoard', url: 'springboard'},
-      {name: large ? 'ELA Standards' : 'Standards', url: 'activities/standard_level/7'},
+      {name: large ? 'ELA Standards' : 'Standards', url: 'activities/standard_level/7'}
     ]
   end
 end

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -68,4 +68,14 @@ module TeacherCenterHelper
       }
     ]
   end
+
+  def explore_curriculum_tabs(large: true)
+    [
+      {name: large ? 'Featured Activities' : 'Featured', url: 'activities/packs'},
+      {name: large ? 'AP Activities' : 'AP', url: 'ap'},
+      {name: large ? 'Pre-AP Activities' : 'Pre-AP', url: 'preap'},
+      {name: large ? 'SpringBoard Activities' : 'SpringBoard', url: 'springboard'},
+      {name: large ? 'ELA Standards' : 'Standards', url: 'activities/standard_level/7'},
+    ]
+  end
 end

--- a/services/QuillLMS/app/views/pages/activities.html.erb
+++ b/services/QuillLMS/app/views/pages/activities.html.erb
@@ -1,4 +1,4 @@
-<% @active_tab = 'ELA Standards' %>
+<% @active_tab = device == 'mobile' ? 'Standards' : 'ELA Standards' %>
 <%= render partial: 'pages/shared/explore_curriculum_navbar', active_tab: @active_tab  %>
 
 <div class="container pages-activities">

--- a/services/QuillLMS/app/views/pages/ap.html.erb
+++ b/services/QuillLMS/app/views/pages/ap.html.erb
@@ -1,4 +1,4 @@
-<% @active_tab = 'AP Activities'
+<% @active_tab = device == 'mobile' ? 'AP' : 'AP Activities'
   @title = 'AP® English Practice'
 %>
 <%= render partial: 'pages/shared/explore_curriculum_navbar', active_tab: @active_tab  %>

--- a/services/QuillLMS/app/views/pages/preap.html.erb
+++ b/services/QuillLMS/app/views/pages/preap.html.erb
@@ -1,4 +1,4 @@
-<% @active_tab = 'Pre-AP Activities'
+<% @active_tab = device == 'mobile' ? 'Pre-AP' : 'Pre-AP Activities'
   @title = 'Pre-AP® English Practice'
   @units = preap_and_springboard_content
 %>

--- a/services/QuillLMS/app/views/pages/shared/_explore_curriculum_navbar.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_explore_curriculum_navbar.html.erb
@@ -1,23 +1,14 @@
 <div class="subnav">
   <div class="container">
-  <% tabs = [
-    {name: 'Featured Activities', url: 'activities/packs'},
-    {name: 'AP Activities', url: 'ap'},
-    {name: 'Pre-AP Activities', url: 'preap'},
-    {name: 'SpringBoard Activities', url: 'springboard'},
-    {name: 'ELA Standards', url: 'activities/standard_level/7'},
-  ]
-    @tabs = tabs
-    @mobile = false
-  %>
+  <% @mobile = false %>
 
   <div class="full-screen">
-    <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab: @active_tab, mobile: @mobile } %>
+    <%= render partial: "pages/shared/generic_tabs", locals: { tabs: explore_curriculum_tabs(large: true), active_tab: @active_tab, mobile: @mobile } %>
   </div>
 
 
   <div class="small-screen">
-    <%= render partial: "pages/shared/generic_tabs", locals: { tabs: @tabs, active_tab:  @active_tab, mobile: @mobile} %>
+    <%= render partial: "pages/shared/generic_tabs", locals: { tabs: explore_curriculum_tabs(large: false), active_tab:  @active_tab, mobile: @mobile} %>
   </div>
 
   </div>

--- a/services/QuillLMS/app/views/pages/springboard.html.erb
+++ b/services/QuillLMS/app/views/pages/springboard.html.erb
@@ -1,4 +1,5 @@
-<% @active_tab = 'SpringBoard Activities'
+<% @active_tab = device == 'mobile' ? 'SpringBoard' : 'SpringBoard Activities'
+
   @title = 'SpringBoard English Practice'
 %>
 <%= render partial: 'pages/shared/explore_curriculum_navbar', active_tab: @active_tab  %>

--- a/services/QuillLMS/app/views/teachers/unit_templates/index.html.erb
+++ b/services/QuillLMS/app/views/teachers/unit_templates/index.html.erb
@@ -1,5 +1,5 @@
 <!-- this is the public facing index, for signed-in-teacher facing index, see lesson planner -->
-<% @active_tab = 'Featured Activities' %>
+<% @active_tab = device == 'mobile' ? 'Featured' : 'Featured Activities' %>
 <%= render partial: 'pages/shared/explore_curriculum_navbar', active_tab: @active_tab %>
 
 <div class="tab-pane" id="public-activity-packs" data-authenticated=<%=@is_teacher%>>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
@@ -1,5 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UnitTemplateMinis component should render dropdowns when on mobile 1`] = `
+<div
+  className="unit-template-minis-container"
+  key="always-display"
+>
+  <AssignmentFlowNavigation />
+  <div
+    className="container"
+  >
+    <div>
+      <h1>
+        Select an activity pack for your students
+      </h1>
+      <div>
+        <div
+          className="filter-options"
+        >
+          <DropdownInput
+            handleChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "label": "All packs",
+                  "value": "/activities/packs",
+                },
+                Object {
+                  "label": "Diagnostic",
+                  "value": "/assign/featured-activity-packs?type=diagnostic",
+                },
+              ]
+            }
+            value={
+              Object {
+                "label": "All packs",
+                "value": "/activities/packs",
+              }
+            }
+          />
+          <DropdownInput
+            options={
+              Array [
+                Object {
+                  "label": "All levels",
+                  "link": "/assign/featured-activity-packs",
+                  "value": null,
+                },
+                Object {
+                  "label": "Starter",
+                  "link": "/assign/featured-activity-packs",
+                  "value": null,
+                },
+                Object {
+                  "label": "Intermediate",
+                  "link": "/assign/featured-activity-packs",
+                  "value": null,
+                },
+                Object {
+                  "label": "Advanced",
+                  "link": "/assign/featured-activity-packs",
+                  "value": null,
+                },
+                Object {
+                  "label": "ELL",
+                  "link": "/assign/featured-activity-packs",
+                  "value": null,
+                },
+              ]
+            }
+            value={
+              Object {
+                "label": "All levels",
+                "link": "/assign/featured-activity-packs",
+                "value": null,
+              }
+            }
+          />
+        </div>
+        <div
+          className="unit-template-minis"
+        >
+          <UnitTemplateMini
+            data={
+              Object {
+                "activities": Array [],
+                "activity_info": "test activity",
+                "author": Object {
+                  "avatar_url": "avatar",
+                  "name": "author",
+                },
+                "created_at": 0,
+                "grades": Array [
+                  "1",
+                  "2",
+                ],
+                "id": 20,
+                "name": "Sentence Structure Diagnostic",
+                "number_of_standards": 1,
+                "order_number": 0,
+                "time": 30,
+                "type": Object {
+                  "name": "Diagnostic",
+                  "primary_color": "#ea9a1a",
+                },
+                "unit_template_category": Object {
+                  "id": 9,
+                  "name": "Diagnostic",
+                  "primary_color": "#00c2a2",
+                  "secondary_color": "#027360",
+                },
+              }
+            }
+            index={0}
+            key="20"
+            signedInTeacher={true}
+          />
+          <UnitTemplateMini
+            data={
+              Object {
+                "id": "createYourOwn",
+                "non_authenticated": undefined,
+              }
+            }
+            index={1}
+            key="createYourOwn"
+            signedInTeacher={true}
+          />
+        </div>
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`UnitTemplateMinis component should render without createYourOwn mini when teacher not signed in 1`] = `
 <div
   className="unit-template-minis-container"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/unit_template_minis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/unit_template_minis.test.jsx
@@ -82,5 +82,10 @@ describe('UnitTemplateMinis component', () => {
     const wrapper = shallow(<UnitTemplateMinis {...sharedProps} signedInTeacher={true} />)
     expect(wrapper.find('UnitTemplateMini').findWhere(n => n.prop('data').id === 'createYourOwn')).toHaveLength(1)
   })
+  it('should render dropdowns when on mobile', () => {
+    const wrapper = shallow(<UnitTemplateMinis {...sharedProps} signedInTeacher={true} />)
+    wrapper.setState({ onMobile: true });
+    expect(wrapper).toMatchSnapshot();
+  })
 
 });

--- a/services/QuillLMS/spec/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper.rb
@@ -39,7 +39,7 @@ describe TeacherCenterHelper do
         {name: 'AP Activities', url: 'ap'},
         {name: 'Pre-AP Activities', url: 'preap'},
         {name: 'SpringBoard Activities', url: 'springboard'},
-        {name: 'ELA Standards', url: 'activities/standard_level/7'},
+        {name: 'ELA Standards', url: 'activities/standard_level/7'}
       ]
     }
     let(:small_tabs) {
@@ -48,7 +48,7 @@ describe TeacherCenterHelper do
         {name: 'AP', url: 'ap'},
         {name: 'Pre-AP', url: 'preap'},
         {name: 'SpringBoard', url: 'springboard'},
-        {name: 'Standards', url: 'activities/standard_level/7'},
+        {name: 'Standards', url: 'activities/standard_level/7'}
       ]
     }
     it 'should return large_tabs if large is true' do

--- a/services/QuillLMS/spec/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper.rb
@@ -6,12 +6,11 @@ describe TeacherCenterHelper do
     let(:app_setting) { create(:app_setting, name: "comprehension") }
     let(:tabs) {
       [
-        { id: "All resources", name: "All resources", url: "teacher-center" },
+        { id: "All resources", name: "All", url: "teacher-center" },
         { id: "Getting started", name: "Getting started", url: "teacher-center/topic/getting-started" },
-        { id: "Teacher stories", name: "Teacher stories", url: "teacher-center/topic/teacher-stories" },
-        { id: "Writing instruction research", name: "Writing instruction research", url: "teacher-center/topic/writing-instruction-research" },
-        { id: "FAQ", name: "FAQ", url: "faq" },
-        { id: "Premium", name: "Premium", url: "premium" }
+        { id: "Best practices", name: "Best practices", url: "teacher-center/topic/best-practices" },
+        { id: "Writing instruction research", name: "Research", url: "teacher-center/topic/writing-instruction-research" },
+        { id: "FAQ", name: "FAQ", url: "faq" }
       ]
     }
 
@@ -24,12 +23,39 @@ describe TeacherCenterHelper do
       expect(helper.teacher_center_tabs).to eq tabs
     end
     it 'should return the tabs with comprehension if app setting is true' do
-      comprehension_tab = { id: "Using quill for reading comprehension", name: "Using Quill for reading comprehension", url: "teacher-center/topic/using-quill-for-reading-comprehension" }
+      comprehension_tab = { id: "Using quill for reading comprehension", name: "Reading comprehension", url: "teacher-center/topic/using-quill-for-reading-comprehension" }
       app_setting.enabled = true
       app_setting.user_ids_allow_list = [current_user.id]
       app_setting.save!
       tabs.insert(1, comprehension_tab)
       expect(helper.teacher_center_tabs).to eq tabs
+    end
+  end
+
+  describe `#explore_curriculum_tabs` do
+    let(:large_tabs) {
+      [
+        {name: 'Featured Activities', url: 'activities/packs'},
+        {name: 'AP Activities', url: 'ap'},
+        {name: 'Pre-AP Activities', url: 'preap'},
+        {name: 'SpringBoard Activities', url: 'springboard'},
+        {name: 'ELA Standards', url: 'activities/standard_level/7'},
+      ]
+    }
+    let(:small_tabs) {
+      [
+        {name: 'Featured', url: 'activities/packs'},
+        {name: 'AP', url: 'ap'},
+        {name: 'Pre-AP', url: 'preap'},
+        {name: 'SpringBoard', url: 'springboard'},
+        {name: 'Standards', url: 'activities/standard_level/7'},
+      ]
+    }
+    it 'should return large_tabs if large is true' do
+      expect(helper.explore_curriculum_tabs(large: true)).to eq large_tabs
+    end
+    it 'should return small_tabs if large is false' do
+      expect(helper.explore_curriculum_tabs(large: false)).to eq small_tabs
     end
   end
 end


### PR DESCRIPTION
## WHAT
various changes to optimize mobile views for the Explore Curriculum section of our home page

## WHY
we want mobile users to have a good experiencing browsing this section on mobile

## HOW
add helper class function for render tab text; conditionally render dropdown in `UnitTemplateMinis` if on mobile
### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="416" alt="Screen Shot 2021-08-25 at 1 14 44 PM" src="https://user-images.githubusercontent.com/25959584/130843823-7c9eb4fc-e1ea-4286-942b-dcb7c91b89f6.png">
<img width="419" alt="Screen Shot 2021-08-25 at 1 14 20 PM" src="https://user-images.githubusercontent.com/25959584/130843827-1d920ed4-fb11-4942-82cf-c11be5c60a42.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Update-the-Explore-Curriculum-mobile-menus-60b626f5fcb4415caa6de86fbd031085

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
