### PR TITLE
remove default X-Frame-Options behavior in secure_headers

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,5 +1,6 @@
 SecureHeaders::Configuration.default do |config|
   config.csp = SecureHeaders::OPT_OUT
+  config.x_frame_options = SecureHeaders::OPT_OUT
   config.cookies = {
     secure: true, 
     httponly: true, 


### PR DESCRIPTION
## WHAT
Removes the default, strict X-Frame-Options header, because this breaks Nearpod, which relies on iframe embedding of LMS  endpoints. 

## WHY
We want our Nearpod content to work.

## HOW
Untoggle secure_headers gem default behavior. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=eb485d5f6fbd4e57b8331cbeb55b56b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no app code change
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes