### PR TITLE
Add ProviderClassroomUser STI model, migration

### DIFF
--- a/services/QuillLMS/app/models/clever_classroom_user.rb
+++ b/services/QuillLMS/app/models/clever_classroom_user.rb
@@ -12,9 +12,7 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 class CleverClassroomUser < ProviderClassroomUser
   def clever_classroom_id

--- a/services/QuillLMS/app/models/clever_classroom_user.rb
+++ b/services/QuillLMS/app/models/clever_classroom_user.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+class CleverClassroomUser < ProviderClassroomUser
+  def clever_classroom_id
+    provider_classroom_id
+  end
+
+  def clever_user_id
+    provider_user_id
+  end
+end

--- a/services/QuillLMS/app/models/google_classroom_user.rb
+++ b/services/QuillLMS/app/models/google_classroom_user.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+class GoogleClassroomUser < ProviderClassroomUser
+  def google_classroom_id
+    provider_classroom_id
+  end
+
+  def google_id
+    provider_user_id
+  end
+end

--- a/services/QuillLMS/app/models/google_classroom_user.rb
+++ b/services/QuillLMS/app/models/google_classroom_user.rb
@@ -12,9 +12,7 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 class GoogleClassroomUser < ProviderClassroomUser
   def google_classroom_id

--- a/services/QuillLMS/app/models/provider_classroom_user.rb
+++ b/services/QuillLMS/app/models/provider_classroom_user.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+class ProviderClassroomUser < ApplicationRecord
+  scope :active, -> { where(deleted_at: nil) }
+  scope :deleted, -> { where.not(deleted_at: nil) }
+
+  ACTIVE = :active
+  DELETED = :deleted
+
+  def active?
+    deleted_at.nil?
+  end
+
+  def deleted?
+    !active?
+  end
+
+  def status
+    active? ? ACTIVE : DELETED
+  end
+
+  def soft_delete
+    update!(deleted_at: Time.now)
+  end
+end
+

--- a/services/QuillLMS/app/models/provider_classroom_user.rb
+++ b/services/QuillLMS/app/models/provider_classroom_user.rb
@@ -12,16 +12,24 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 class ProviderClassroomUser < ApplicationRecord
+  ACTIVE = :active
+  DELETED = :deleted
+
+  TYPES = %w[CleverClassroomUser GoogleClassroomUser].freeze
+
   scope :active, -> { where(deleted_at: nil) }
   scope :deleted, -> { where.not(deleted_at: nil) }
 
-  ACTIVE = :active
-  DELETED = :deleted
+  validates :type, inclusion: { in: TYPES }
+
+  # max_lengths: { clever_id: 24, google_classroom_id: 12 }
+  validates :provider_classroom_id, length: { maximum: 25 }
+
+  # max_lengths: { clever_id: 24, google_id: 21 }
+  validates :provider_user_id, length: { maximum: 25 }
 
   def active?
     deleted_at.nil?

--- a/services/QuillLMS/db/migrate/20210824114552_create_provider_classroom_user.rb
+++ b/services/QuillLMS/db/migrate/20210824114552_create_provider_classroom_user.rb
@@ -2,16 +2,16 @@ class CreateProviderClassroomUser < ActiveRecord::Migration[5.1]
   def change
     create_table :provider_classroom_users do |t|
       t.string :type, null: false
-      t.string :provider_classroom_id, index: true, null: false
-      t.string :provider_user_id, index: true, null: false
+      t.string :provider_classroom_id, null: false
+      t.string :provider_user_id, null: false
       t.timestamp :deleted_at
 
       t.timestamps
     end
 
     add_index :provider_classroom_users,
-      [:provider_user_id, :provider_classroom_id, :type],
-      name: :index_provider_user_id_and_provider_classroom_id_and_type,
+      [:type, :provider_classroom_id, :provider_user_id],
+      name: :index_provider_type_and_classroom_id_and_user_id,
       unique: true
   end
 end

--- a/services/QuillLMS/db/migrate/20210824114552_create_provider_classroom_user.rb
+++ b/services/QuillLMS/db/migrate/20210824114552_create_provider_classroom_user.rb
@@ -1,0 +1,17 @@
+class CreateProviderClassroomUser < ActiveRecord::Migration[5.1]
+  def change
+    create_table :provider_classroom_users do |t|
+      t.string :type, null: false
+      t.string :provider_classroom_id, index: true, null: false
+      t.string :provider_user_id, index: true, null: false
+      t.timestamp :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :provider_classroom_users,
+      [:provider_user_id, :provider_classroom_id, :type],
+      name: :index_provider_user_id_and_provider_classroom_id_and_type,
+      unique: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -6075,6 +6075,27 @@ CREATE INDEX index_partner_contents_on_partner ON public.partner_contents USING 
 
 
 --
+-- Name: index_provider_classroom_users_on_provider_classroom_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_provider_classroom_users_on_provider_classroom_id ON public.provider_classroom_users USING btree (provider_classroom_id);
+
+
+--
+-- Name: index_provider_classroom_users_on_provider_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_provider_classroom_users_on_provider_user_id ON public.provider_classroom_users USING btree (provider_user_id);
+
+
+--
+-- Name: index_provider_user_id_and_provider_classroom_id_and_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_provider_user_id_and_provider_classroom_id_and_type ON public.provider_classroom_users USING btree (provider_user_id, provider_classroom_id, type);
+
+
+--
 -- Name: index_questions_on_question_type; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -6075,24 +6075,10 @@ CREATE INDEX index_partner_contents_on_partner ON public.partner_contents USING 
 
 
 --
--- Name: index_provider_classroom_users_on_provider_classroom_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_provider_type_and_classroom_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_provider_classroom_users_on_provider_classroom_id ON public.provider_classroom_users USING btree (provider_classroom_id);
-
-
---
--- Name: index_provider_classroom_users_on_provider_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_provider_classroom_users_on_provider_user_id ON public.provider_classroom_users USING btree (provider_user_id);
-
-
---
--- Name: index_provider_user_id_and_provider_classroom_id_and_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_provider_user_id_and_provider_classroom_id_and_type ON public.provider_classroom_users USING btree (provider_user_id, provider_classroom_id, type);
+CREATE UNIQUE INDEX index_provider_type_and_classroom_id_and_user_id ON public.provider_classroom_users USING btree (type, provider_classroom_id, provider_user_id);
 
 
 --

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1167,7 +1167,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
-    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
+    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
 );
 
 
@@ -2647,6 +2647,40 @@ CREATE SEQUENCE public.prompt_healths_id_seq
 --
 
 ALTER SEQUENCE public.prompt_healths_id_seq OWNED BY public.prompt_healths.id;
+
+
+--
+-- Name: provider_classroom_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.provider_classroom_users (
+    id bigint NOT NULL,
+    type character varying NOT NULL,
+    provider_classroom_id character varying NOT NULL,
+    provider_user_id character varying NOT NULL,
+    deleted_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: provider_classroom_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.provider_classroom_users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: provider_classroom_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.provider_classroom_users_id_seq OWNED BY public.provider_classroom_users.id;
 
 
 --
@@ -4274,6 +4308,13 @@ ALTER TABLE ONLY public.prompt_healths ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: provider_classroom_users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classroom_users ALTER COLUMN id SET DEFAULT nextval('public.provider_classroom_users_id_seq'::regclass);
+
+
+--
 -- Name: questions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5039,6 +5080,14 @@ ALTER TABLE ONLY public.partner_contents
 
 ALTER TABLE ONLY public.prompt_healths
     ADD CONSTRAINT prompt_healths_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: provider_classroom_users provider_classroom_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classroom_users
+    ADD CONSTRAINT provider_classroom_users_pkey PRIMARY KEY (id);
 
 
 --
@@ -7395,6 +7444,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210726193112'),
 ('20210803163028'),
 ('20210811130155'),
-('20210816195838');
+('20210816195838'),
+('20210824114552');
 
 

--- a/services/QuillLMS/spec/factories/provider_classroom_users.rb
+++ b/services/QuillLMS/spec/factories/provider_classroom_users.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: provider_classroom_user_imports
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+FactoryBot.define do
+  factory :provider_classroom_user, class: 'ProviderClassroomUser' do
+    provider_classroom_id { (1..10).map { (1..9).to_a.sample }.join }
+    provider_user_id { (1..21).map{(1..9).to_a.sample}.join }
+
+    trait(:active) { deleted_at { nil } }
+    trait(:deleted) { deleted_at { Time.now } }
+
+    factory :google_classroom_user, parent: :provider_classroom_user, class: 'GoogleClassroomUser'
+    factory :clever_classroom_user, parent: :provider_classroom_user, class: 'CleverClassroomUser'
+  end
+end

--- a/services/QuillLMS/spec/factories/provider_classroom_users.rb
+++ b/services/QuillLMS/spec/factories/provider_classroom_users.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: provider_classroom_user_imports
+# Table name: provider_classroom_users
 #
 #  id                    :bigint           not null, primary key
 #  deleted_at            :datetime
@@ -9,6 +9,10 @@
 #  updated_at            :datetime         not null
 #  provider_classroom_id :string           not null
 #  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 FactoryBot.define do
   factory :provider_classroom_user, class: 'ProviderClassroomUser' do

--- a/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe CleverClassroomUser, type: :model do
+  let(:clever_classroom_id) { '67890' }
+  let(:clever_user_id) { '12345' }
+
+  subject do
+    create(:clever_classroom_user, provider_classroom_id: clever_classroom_id, provider_user_id: clever_user_id)
+  end
+
+  it { expect(subject.clever_classroom_id).to eq clever_classroom_id }
+  it { expect(subject.clever_user_id).to eq clever_user_id }
+  it { expect(subject.type).to eq described_class.to_s }
+end

--- a/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
@@ -12,9 +12,7 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/google_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/google_classroom_user_spec.rb
@@ -12,9 +12,7 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/google_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/google_classroom_user_spec.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe GoogleClassroomUser, type: :model do
+  let(:google_id) { '12345' }
+  let(:google_classroom_id) { '67890' }
+
+  subject do
+    create(:google_classroom_user,
+      provider_user_id: google_id,
+      provider_classroom_id: google_classroom_id
+    )
+  end
+
+  it { expect(subject.google_classroom_id).to eq google_classroom_id }
+  it { expect(subject.google_id).to eq google_id }
+  it { expect(subject.type).to eq described_class.to_s }
+end

--- a/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
@@ -12,21 +12,43 @@
 #
 # Indexes
 #
-#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
-#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
-#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
 #
 require 'rails_helper'
 
 RSpec.describe ProviderClassroomUser, type: :model do
-  let(:type) { described_class.to_s }
+  let(:type) { ProviderClassroomUser::TYPES.sample }
+  let(:klass) { type.constantize }
+  let(:factory) { type.underscore }
 
   context 'attributes' do
-    subject { create(:provider_classroom_user, type: type) }
+    subject { create(factory) }
 
     it { expect(subject.provider_classroom_id).to_not be_nil }
     it { expect(subject.provider_user_id).to_not be_nil }
     it { expect(subject.type).to eq type }
+  end
+
+  context 'validations' do
+    describe 'type' do
+      let(:provider_classroom_user) { create(:provider_classroom_user, type: 'NotApprovedType') }
+
+      it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
+    end
+
+    describe 'provider_classroom_id length' do
+      let(:too_long_id) { 'a' * 26 }
+      let(:provider_classroom_user) { create(factory, provider_classroom_id: too_long_id) }
+
+      it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
+    end
+
+    describe 'provider_user_id length' do
+      let(:too_long_id) { 'a' * 26 }
+      let(:provider_classroom_user) { create(factory, provider_user_id: too_long_id) }
+
+      it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
+    end
   end
 
   context 'uniqueness' do
@@ -34,7 +56,7 @@ RSpec.describe ProviderClassroomUser, type: :model do
     let(:provider_user_id) { '123' }
 
     let!(:provider_classroom_user) do
-      create(:provider_classroom_user,
+      create(factory,
         provider_classroom_id: provider_classroom_id,
         provider_user_id: provider_user_id,
         type: type

--- a/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
@@ -1,0 +1,46 @@
+# == Schema Information
+#
+# Table name: provider_classroom_users
+#
+#  id                    :bigint           not null, primary key
+#  deleted_at            :datetime
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  provider_classroom_id :string           not null
+#  provider_user_id      :string           not null
+#
+# Indexes
+#
+#  index_provider_classroom_users_on_provider_classroom_id    (provider_classroom_id)
+#  index_provider_classroom_users_on_provider_user_id         (provider_user_id)
+#  index_provider_user_id_and_provider_classroom_id_and_type  (provider_user_id,provider_classroom_id,type) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe ProviderClassroomUser, type: :model do
+  let(:type) { described_class.to_s }
+
+  context 'attributes' do
+    subject { create(:provider_classroom_user, type: type) }
+
+    it { expect(subject.provider_classroom_id).to_not be_nil }
+    it { expect(subject.provider_user_id).to_not be_nil }
+    it { expect(subject.type).to eq type }
+  end
+
+  context 'uniqueness' do
+    let(:provider_classroom_id) { '987' }
+    let(:provider_user_id) { '123' }
+
+    let!(:provider_classroom_user) do
+      create(:provider_classroom_user,
+        provider_classroom_id: provider_classroom_id,
+        provider_user_id: provider_user_id,
+        type: type
+       )
+    end
+
+    it { expect(provider_classroom_user.dup.save!).to raise_error ActiveRecord::RecordNotUnique }
+  end
+end

--- a/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe ProviderClassroomUser, type: :model do
        )
     end
 
-    it { expect(provider_classroom_user.dup.save!).to raise_error ActiveRecord::RecordNotUnique }
+    it { expect { provider_classroom_user.dup.save!}.to raise_error ActiveRecord::RecordNotUnique }
   end
 end


### PR DESCRIPTION
## WHAT
Add a STI join table `ProviderClassroomUser` along with subtypes `GoogleClassroomUser` and `CleverClassroomUser`

## WHY
In order to display what students are in a classroom on one of our third party providers, we need a model to track their status.  
More details in [RFC](https://www.notion.so/quill/RFC-Google-Classroom-and-Clever-Import-Object-291c61b3d05a46c3834c5621ef222a0e)

## HOW
Create the requisite migration and model files.  There's also a timestamp attribute `deleted_at` which will keep track of when a student is removed from a classroom on one of the providers.

### Notion Card Links
https://www.notion.so/quill/Add-ProviderClassroomUser-STI-model-migration-97991855dab6443cb2325df044ca406f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A