### PR TITLE
making rematch worker error handling more robust

### DIFF
--- a/services/QuillCMS/app/workers/rematch_response_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_response_worker.rb
@@ -60,11 +60,11 @@ class RematchResponseWorker
     resp = http.post(uri, lambda_payload.to_json, 'Content-Type' => 'application/json')
 
     if resp.is_a?(Net::HTTPGatewayTimeOut)
-      raise Net::HTTPRetriableError.new("Timed out rematching response #{lambda_payload[:response][:id]}", 504)
+      raise Net::HTTPRetriableError.new("Timed out rematching response #{lambda_payload.dig(:response)&.id}", 504)
     end
 
     if resp.code != '200'
-      raise RematchResponseWorker::LambdaHTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload[:response][:id]}: #{resp.message}", resp.code)
+      raise RematchResponseWorker::LambdaHTTPError.new("Got a #{resp.code} response trying to rematch #{lambda_payload.dig(:response)&.id}: #{resp.message}")
     end
 
     JSON.parse(resp.body)


### PR DESCRIPTION
## WHAT
- makes RematchResponseWorker error handling more robust

## WHY
During a recent Rematch jobset, LambdaHTTPError was itself raising an ArgumentError due to invalid args - its parent, StandardError, only takes one argument, not two.

This issue obfuscated the underlying error, hampering investigation.

Note: `Net::HTTPRetriableError` DOES take 2 args, which is why the argument count in that code path was not modified. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=dbd1f0e95dcc4b029760cc75e07a8d42

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes