### PR TITLE
LMS - Refactor teachers::classrooms#index for Performance

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -163,6 +163,7 @@ class Teachers::ClassroomsController < ApplicationController
 
   private def format_coteacher_invitations_for_index
     coteacher_invitations = CoteacherClassroomInvitation.includes(invitation: :inviter).joins(:invitation, :classroom).where(invitations: {invitee_email: current_user.email}, classrooms: { visible: true})
+
     coteacher_invitations.map do |coteacher_invitation|
       coteacher_invitation_obj = coteacher_invitation.attributes
       coteacher_invitation_obj[:classroom_name] = Classroom.find(coteacher_invitation.classroom_id)&.name
@@ -174,11 +175,30 @@ class Teachers::ClassroomsController < ApplicationController
 
   private def format_classrooms_for_index
     has_classroom_order = ClassroomsTeacher.where(user_id: current_user.id).all? { |classroom| classroom.order }
-    classrooms = Classroom.unscoped.joins(:classrooms_teachers).where(classrooms_teachers: {user_id: current_user.id})
-    classrooms = has_classroom_order ? classrooms.includes(:classrooms_teachers).order('classrooms_teachers.order') : classrooms.order(created_at: :desc)
+
+    classrooms = Classroom.unscoped
+      .joins(:classrooms_teachers)
+      .where(classrooms_teachers: {user_id: current_user.id})
+      .includes(
+        :students,
+        coteacher_classroom_invitations: :invitation,
+        classrooms_teachers: :user,
+      )
+      .order(has_classroom_order ? 'classrooms_teachers.order' : 'created_at DESC')
+
+    student_ids = classrooms.flat_map(&:students).map(&:id)
+
+    # create a hash of the form {user_id: count}
+    activity_counts_by_student = ActivitySession
+      .select(:user_id, "count(activity_sessions.id) as total")
+      .where(user_id: student_ids, state: 'finished')
+      .group(:user_id)
+      .map{|r| [r.user_id, r.total]}
+      .to_h
+
     classrooms.compact.map do |classroom|
       classroom_obj = classroom.attributes
-      classroom_obj[:students] = format_students_for_classroom(classroom)
+      classroom_obj[:students] = format_students_for_classroom(classroom, activity_counts_by_student)
       classroom_teachers = format_teachers_for_classroom(classroom)
       pending_coteachers = format_pending_coteachers_for_classroom(classroom)
       classroom_obj[:teachers] = classroom_teachers.concat(pending_coteachers)
@@ -186,26 +206,16 @@ class Teachers::ClassroomsController < ApplicationController
     end.compact
   end
 
-  private def format_students_for_classroom(classroom)
-    sorted_students = classroom.students.sort_by { |s| s.last_name }
-    # create a hash of the form {user_id: count}
-    activity_counts_by_student = ActivitySession
-      .select(:user_id, "count(activity_sessions.id) as total")
-      .where(user_id: sorted_students.map(&:id), state: 'finished')
-      .group(:user_id)
-      .map{|r| [r.user_id, r.total]}
-      .to_h
+  private def format_students_for_classroom(classroom, activity_counts)
+    sorted_students = classroom.students.sort_by(&:last_name)
 
     sorted_students.map do |s|
-      student = s.attributes
-      student[:number_of_completed_activities] = activity_counts_by_student[s.id] || 0
-      student
+      s.attributes.merge(number_of_completed_activities: activity_counts[s.id] || 0)
     end
   end
 
   private def format_pending_coteachers_for_classroom(classroom)
-    coteacher_invitations = CoteacherClassroomInvitation.where(classroom_id: classroom.id)
-    coteacher_invitations.map do |cci|
+    classroom.coteacher_classroom_invitations.map do |cci|
       {
         email: cci.invitation.invitee_email,
         classroom_relation: 'coteacher',

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -182,7 +182,7 @@ class Teachers::ClassroomsController < ApplicationController
       .includes(
         :students,
         coteacher_classroom_invitations: :invitation,
-        classrooms_teachers: :user,
+        classrooms_teachers: :user
       )
       .order(has_classroom_order ? 'classrooms_teachers.order' : 'created_at DESC')
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -171,8 +171,7 @@ describe Teachers::ClassroomsController, type: :controller do
     context 'when current user has classrooms i teach' do
 
       it 'should return classrooms in order of creation date' do
-        request.accept = "application/json"
-        get :index
+        get :index, as: :json
 
         parsed_response = JSON.parse(response.body)
 
@@ -221,8 +220,7 @@ describe Teachers::ClassroomsController, type: :controller do
           ct1.order = 1
           ct1.save!
 
-          request.accept = "application/json"
-          get :index
+          get :index, as: :json
 
           parsed_response = JSON.parse(response.body)
           expect(parsed_response["classrooms"][0]["id"]).to eq(classroom3.id)
@@ -241,8 +239,7 @@ describe Teachers::ClassroomsController, type: :controller do
           ct3.order = 2
           ct3.save!
 
-          request.accept = "application/json"
-          get :index
+          get :index, as: :json
 
           parsed_response = JSON.parse(response.body)
           expect(parsed_response["classrooms"][0]["id"]).to eq(classroom2.id)


### PR DESCRIPTION
## WHAT
Refactor to speed up the  `Teachers::ClassroomsController#index`.
## WHY
It's one of our slowest pages for teachers with a lot of classrooms (See Notion card for more details)
## HOW
Use Eager loading and take an expensive query out a loop (perform it once, instead of multiple times). Note, there's more that could be cleaned up here, but I tried to be as light touch as possible and focus solely on the performance gains.
### Screenshots
Test logs Before/after
**Before**
<img width="1677" alt="Screen Shot 2021-08-31 at 10 43 00 AM" src="https://user-images.githubusercontent.com/1304933/131524521-bb6926bd-9be8-45c7-bed2-902572531f42.png">
**After**
<img width="1676" alt="Screen Shot 2021-08-31 at 10 39 26 AM" src="https://user-images.githubusercontent.com/1304933/131524582-dc013d87-a7e2-4fb4-aeb0-813b30f120f3.png">


### Notion Card Links
https://www.notion.so/quill/Speed-up-Teachers-ClassroomsController-index-view-960f49c7bf8c494c9f3626b5c3c00038

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, this is just a refactor.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A, it passes tests and shouldn't change functionality.
