### PR TITLE
have grammar focus go back to main container between questions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
@@ -206,6 +206,9 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
       goToNextQuestion();
       this.setState({ response: '', questionStatus: UNANSWERED, responses: {} })
     }
+    const element = document.getElementById("main-content")
+    if (!element) { return }
+    element.focus()
   }
 
   handleExampleButtonClick = () => this.setState(prevState => ({ showExample: !prevState.showExample }))


### PR DESCRIPTION
## WHAT
Have Grammar focus go back to the main container when a user clicks "Next question".

## WHY
This is how it works in Connect, and is a better user experience for keyboard navigators.

## HOW
Just assign focus to the main container.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Mixed-up-keyboard-focus-order-in-Grammar-activities-211d408adecf41febc67831fc89806fd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
