### PR TITLE
app setting script improvements

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::AppSettingsController < ApplicationController
+  before_action :staff!, only: [:admin_show]
+
   def index
     render(json: AppSetting.all_enabled_for_user(current_user))
   end
@@ -8,6 +10,21 @@ class Api::V1::AppSettingsController < ApplicationController
 
     render(json: {
       name => AppSetting.enabled?(name: name, user: current_user)
+    })
+  end
+
+  def admin_show
+    name = app_setting_show_params[:name] 
+    app_setting = AppSetting.find_by_name!(name)
+    user_ids = app_setting.user_ids_allow_list
+
+    emails = User.where(id: user_ids).pluck(:email).sort
+    render(json: {
+      name: name,
+      enabled: app_setting.enabled,
+      enabled_for_staff: app_setting.enabled_for_staff,
+      user_emails_in_allow_list: emails,
+      percent_active: app_setting.percent_active
     })
   end
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -390,7 +390,11 @@ EmpiricalGrammar::Application.routes.draw do
       end
 
       resources :users, only: [:index]
-      resources :app_settings, only: [:index, :show], param: :name
+      resources :app_settings, only: [:index, :show], param: :name do 
+          member do 
+            get :admin_show
+          end
+      end
 
       resources :classroom_units,         only: [] do
         collection do

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -12,24 +12,25 @@ namespace :app_settings do
     puts "AppSetting with name #{app_setting.name} created."
   end
 
-  desc 'Updates user allow list for existing AppSetting with inline args.'
-  # Example usage: rake 'app_settings:update_user_ids_allow_list[theName, a@b.com 4 5]'
-  task :update_user_ids_allow_list, [:name, :user_ids_allow_list] => :environment do |t, args|
+  desc 'Updates user allow list for existing AppSetting from a CSV file.'
+  # Example usage: rake 'app_settings:update_user_ids_allow_list_from_csv[theName, filename]'
+  task :update_user_ids_allow_list_from_csv, [:name, :filename] => :environment do |t, args|
+    iostream = File.open(args[:filename], 'r').read
+    if (CSV.parse(iostream, headers: true).headers & ["email", "flag"]).count != 2 
+      puts "Invalid headers. Exiting."
+      exit 1
+    end 
+    
+    emails = CSV.parse(iostream, headers: true).map { |row| row['email'] }
+    user_ids = emails.map do |email|
+      user = User.find_by_email(email)
+      puts "User with email #{email} not found" unless user 
+      user
+    end.compact
+
     app_setting = AppSetting.find_by_name!(args[:name])
-    user_ids = args[:user_ids_allow_list].split(' ')
-    app_setting.update!(user_ids_allow_list: user_ids)
-    puts "AppSetting #{app_setting.name} has been updated with user list: #{user_ids}."
-  end
 
-  desc 'Updates user allow list for existing AppSetting from file with emails.'
-  # Example usage: rake 'app_settings:update_user_ids_allow_list_from_file_by_email[theName, filename]'
-  task :update_user_ids_allow_list_from_file_by_email, [:name, :filename] => :environment do |t, args|
-    emails = File.open(args[:filename]).read.split(' ')
-    user_ids = emails.map {|e| User.find_by_email!(e).id}
-
-    app_setting = AppSetting.find_by_name!(args[:name])
-
-    app_setting.update!(user_ids_allow_list: user_ids)
+    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.concat(user_ids))
     puts "AppSetting #{app_setting.name} has been updated with user list: #{user_ids}."
   end
 end

--- a/services/QuillLMS/lib/tasks/flags.rake
+++ b/services/QuillLMS/lib/tasks/flags.rake
@@ -5,6 +5,11 @@ namespace :flags do
     desc 'Update User.flags from a CSV file'
     task :update_from_csv, [:filepath] => :environment do |t, args|
       iostream = File.open(args[:filepath], 'r').read
+      if (CSV.parse(iostream, headers: true).headers & ["email", "flag"]).count != 2 
+        puts "Invalid headers. Exiting."
+        exit 1
+      end 
+      
       CSV.parse(iostream, headers: true) do |row|
           user = User.find_by_email(row['email'])
           if user.nil?

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::AppSettingsController, type: :controller do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: 'staff') }
 
   before { allow(controller).to receive(:current_user) { user } }
 
@@ -19,6 +19,21 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       expect(Set[*JSON.parse(response.body).keys]).to eq expected_keys
     end
   end
+
+  describe 'GET #admin_show' do 
+    it "returns a success response" do
+      user1 = create(:user, email: 'a@b.com')
+      user2 = create(:user, email: 'c@d.com')
+
+      create(:app_setting, name: 'lorem', enabled: false, user_ids_allow_list: [user1.id, user2.id])
+
+      get :admin_show, params: { name: 'lorem' }, as: :json
+
+      expect(response).to be_success
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com c@d.com))
+    end
+  end
+
 
   describe "GET #show" do
     it "returns a success response" do


### PR DESCRIPTION
## WHAT
- adds extra input validation AppSetting user id ingestion script
- accepts csv rather than flat file
- appends user allowlist instead of overwriting
- 'best effort' strategy allows for successful script completion when Users do not exist
- creates admin-protected detail page for app settings, so that non-engineer admins can view allowlists easily

## WHY
These pain points arose after Lindsey and I started coordinating on AppSetting user-based rollouts last week. 

## HOW
- Adds JSON API endpoint for AppSetting status that is accessible to all staff
- rake task edits

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/AppSetting-system-enhancements-23699c437b46421e8903d83e68de4693

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes)
Have you deployed to Staging? |about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
