### PR TITLE
LMS - Refactor students_by_classroom Endpoint for Performance

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -132,7 +132,7 @@ class ActivitySession < ApplicationRecord
   # returns {user_id: average}
   def self.average_scores_by_student(user_ids)
     averages_for_user_ids(user_ids)
-    .map{|as| [as['user_id'], as['avg'].to_f * 100]}
+    .map{|as| [as['user_id'], (as['avg'].to_f * 100).to_i]}
     .to_h
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -89,6 +89,14 @@ class ActivitySession < ApplicationRecord
     joins(classroom_unit: {classroom: :teachers})
     .where(users: { id: teacher_id})
   }
+  scope :averages_for_user_ids, lambda {|user_ids|
+    select('user_id, AVG(percentage) as avg')
+    .joins(activity: :classification)
+    .where.not(activity_classifications: {key: ActivityClassification::UNSCORED_KEYS})
+    .where(user_id: user_ids)
+    .group(:user_id)
+  }
+
   # scope :started_or_better, -> { where("state != 'unstarted'") }
   #
   # scope :current_session, -> {
@@ -119,6 +127,13 @@ class ActivitySession < ApplicationRecord
 
   def self.with_best_scores
     where(is_final_score: true)
+  end
+
+  # returns {user_id: average}
+  def self.average_scores_by_student(user_ids)
+    averages_for_user_ids(user_ids)
+    .map{|as| [as['user_id'], as['avg'].to_f * 100]}
+    .to_h
   end
 
   def timespent

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -114,6 +114,7 @@ module PublicProgressReports
         unit_id: unit_id
       )
       activity = Activity.find_by_id_or_uid(activity_id)
+      classification_key = activity.classification.key
       unit_activity = UnitActivity.find_by(unit_id: unit_id, activity: activity)
       state = ClassroomUnitActivityState.find_by(
         unit_activity: unit_activity,
@@ -131,15 +132,16 @@ module PublicProgressReports
 
       students = User.includes(:students_classrooms).where(id: classroom_unit.assigned_student_ids)
 
-      finished_sessions = ActivitySession
-        .select("DISTINCT ON (user_id) user_id, *")
+      # Use DISTINCT ON to only pull one session per user
+      final_sessions_by_user = ActivitySession
+        .select("DISTINCT ON (activity_sessions.user_id) user_id, activity_sessions.*")
         .includes(concept_results: :concept)
         .where(
           user_id: students.map(&:id),
           is_final_score: true,
           classroom_unit_id: classroom_unit.id,
           activity_id: activity_id)
-        .order('user_id')
+        .order('activity_sessions.user_id')
         .group_by(&:user_id)
 
       average_scores = ActivitySession.average_scores_by_student(students.map(&:id))
@@ -147,9 +149,10 @@ module PublicProgressReports
       students.each do |student|
         next if !student.students_classrooms.map(&:classroom_id).include?(classroom.id)
 
-        finished_session = finished_sessions[student.id]&.first
+        finished_session = final_sessions_by_user[student.id]&.first
         if finished_session.present?
-          scores[:students].push(formatted_score_obj(finished_session, activity, student, average_scores[student.id]))
+          score_obj = formatted_score_obj(finished_session, classification_key, student, average_scores[student.id])
+          scores[:students].push(score_obj)
           next
         end
 
@@ -167,25 +170,24 @@ module PublicProgressReports
       :not_completed_names
     end
 
-    def formatted_score_obj(final_activity_session, activity, student, average_score_on_quill)
-      formatted_concept_results = get_concept_results(final_activity_session)
-      activity_classification_key = ActivityClassification.find(activity.activity_classification_id).key
-      if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(activity_classification_key)
+    def formatted_score_obj(final_activity_session, classification_key, student, average_score_on_quill)
+      formatted_concept_results = format_concept_results(final_activity_session.concept_results)
+      if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification_key)
         score = get_average_score(formatted_concept_results)
-      elsif [ActivityClassification::EVIDENCE_KEY].include?(activity_classification_key)
+      elsif [ActivityClassification::EVIDENCE_KEY].include?(classification_key)
         score = nil
       else
         score = (final_activity_session.percentage * 100).round
       end
       {
-        activity_classification: activity_classification_key,
+        activity_classification: classification_key,
         id: student.id,
         name: student.name,
         time: get_time_in_minutes(final_activity_session),
         number_of_questions: formatted_concept_results.length,
         concept_results: formatted_concept_results,
         score: score,
-        average_score_on_quill: average_score_on_quill || 0.0
+        average_score_on_quill: average_score_on_quill || 0
       }
     end
 
@@ -197,8 +199,8 @@ module PublicProgressReports
       time > 60 ? '> 60' : time
     end
 
-    def get_concept_results(activity_session)
-      activity_session.concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
+    def format_concept_results(concept_results)
+      concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
         # if we don't sort them, we can't rely on the first result being the first attemptNum
         # however, it would be more efficient to make them a hash with attempt numbers as keys
         cr.sort!{|x,y| (x[:metadata]['attemptNumber'] || 0) <=> (y[:metadata]['attemptNumber'] || 0)}

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -185,7 +185,7 @@ module PublicProgressReports
         number_of_questions: formatted_concept_results.length,
         concept_results: formatted_concept_results,
         score: score,
-        average_score_on_quill: average_score_on_quill
+        average_score_on_quill: average_score_on_quill || 0.0
       }
     end
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -184,14 +184,14 @@ module PublicProgressReports
     end
 
 
-    def get_time_in_minutes activity_session
+    def get_time_in_minutes(activity_session)
       return 'Untracked' if !(activity_session.started_at && activity_session.completed_at)
 
       time = ((activity_session.completed_at - activity_session.started_at) / 60).round()
       time > 60 ? '> 60' : time
     end
 
-    def get_concept_results activity_session
+    def get_concept_results(activity_session)
       activity_session.concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
         # if we don't sort them, we can't rely on the first result being the first attemptNum
         # however, it would be more efficient to make them a hash with attempt numbers as keys
@@ -223,7 +223,7 @@ module PublicProgressReports
       }
     end
 
-    def get_score_for_question concept_results
+    def get_score_for_question(concept_results)
       if !concept_results.empty? && concept_results.first[:metadata]['questionScore']
         concept_results.first[:metadata]['questionScore'] * 100
       else
@@ -231,7 +231,7 @@ module PublicProgressReports
       end
     end
 
-    def get_average_score formatted_results
+    def get_average_score(formatted_results)
       if formatted_results.empty?
         100
       else
@@ -276,7 +276,7 @@ module PublicProgressReports
       }
     end
 
-    def return_value_for_recommendation students, activity_pack_recommendation
+    def return_value_for_recommendation(students, activity_pack_recommendation)
       {
         activity_pack_id: activity_pack_recommendation[:activityPackId],
         name: activity_pack_recommendation[:recommendation],
@@ -311,7 +311,7 @@ module PublicProgressReports
       }
     end
 
-    def activity_sessions_with_counted_concepts activity_sessions
+    def activity_sessions_with_counted_concepts(activity_sessions)
       activity_sessions.map do |activity_session|
         {
           user_id: activity_session.user_id,
@@ -320,7 +320,7 @@ module PublicProgressReports
       end
     end
 
-    def concept_results_by_count activity_session
+    def concept_results_by_count(activity_session)
       hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
       activity_session.concept_results.each do |concept_result|
         hash[concept_result.concept.uid]["correct"] += concept_result["metadata"]["correct"]

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -52,7 +52,6 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       end
 
       it 'should return report data for students and not_completed_name' do
-        Rails.logger.info "\n\n\n***********START TEST********\n\n\n"
         get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
         expect(response).to be_success
@@ -97,20 +96,23 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         end
       end
 
-      context 'with graded activities' do
+      context 'with multiple graded and non-graded activities' do
         before do
           create(:grammar_activity_session, :finished, user: student1, percentage: 0.60)
           create(:grammar_activity_session, :finished, user: student1, percentage: 0.50)
+
+          create(:activity_session, :finished, user: student2, activity: activity, classroom_unit: cu)
+          create(:activity_session, :finished, user: student3, activity: activity, classroom_unit: cu)
         end
 
-        it 'should return average score' do
+        it 'should return all 3 records and average score' do
           get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
           expect(response).to be_success
 
           json = JSON.parse(response.body)
 
-          expect(json['students'].count).to eq(1)
+          expect(json['students'].count).to eq(3)
           expect(json['students'].first['average_score_on_quill']).to eq(55)
         end
       end

--- a/services/QuillLMS/spec/factories/activity_session.rb
+++ b/services/QuillLMS/spec/factories/activity_session.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :simple_activity_session, class: 'ActivitySession' do; end
 
+  # TODO: don't make all activity_sessions finished, used :finished trait
   factory :activity_session do
     activity            { create(:activity, :production) }
     uid                 { SecureRandom.urlsafe_base64 }
@@ -52,6 +53,13 @@ FactoryBot.define do
       state 'started'
       completed_at {nil}
       is_final_score false
+    end
+
+    trait :finished do
+      percentage {0.50}
+      state 'finished'
+      completed_at { Time.now }
+      is_final_score true
     end
 
     factory :diagnostic_activity_session do

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -159,6 +159,41 @@ describe ActivitySession, type: :model, redis: true do
     end
   end
 
+  describe "self.average_scores_by_student" do
+    let(:student) { create(:student) }
+
+    it 'should return empty hash for no sessions' do
+      averages = ActivitySession.average_scores_by_student(student.id)
+      expect(averages).to be_empty
+      expect(averages.class).to be Hash
+    end
+
+    context 'with non-graded sessions' do
+      before do
+        create(:diagnostic_activity_session, :finished, user: student)
+      end
+
+      it 'should return empty hash for non-graded sessions' do
+        averages = ActivitySession.average_scores_by_student(student.id)
+        expect(averages).to be_empty
+        expect(averages.class).to be Hash
+      end
+    end
+
+    context 'with graded sessions' do
+      before do
+        create(:grammar_activity_session, :finished, user: student, percentage: 0.60)
+        create(:grammar_activity_session, :finished, user: student, percentage: 0.50)
+      end
+
+      it 'should return average of scores' do
+        averages = ActivitySession.average_scores_by_student(student.id)
+
+        expect(averages[student.id]).to eq(55)
+      end
+    end
+  end
+
   describe '#classroom_owner' do
     let(:classroom) { build(:classroom) }
     let(:owner) { build(:teacher) }


### PR DESCRIPTION
## WHAT
Performance refactor for `Teachers::ProgressReports::DiagnosticReportsController#students_by_classroom`.
## WHY
This endpoint is slow for many users. See Notion Card for details
## HOW
Created some backing tests to start. Added eager loading and moving queries out of a loop and into a batch query.

Note, I scoped the refactor to performance issues and test backing. There's more that could be refactored here.
### Screenshots
Test log showing no queries running within the inner loop.
<img width="1680" alt="Screen Shot 2021-09-01 at 10 13 57 AM" src="https://user-images.githubusercontent.com/1304933/131687195-dc16a1dd-7ef5-4f7b-89bf-2d77a8f41dfc.png">


### Notion Card Links
https://www.notion.so/quill/Speed-up-students_by_classroom-report-d27b43f7905d457cbfb58c94e9aa223b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes, this was an untested endpoint.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A. Kept functionality the same.
