### PR TITLE
LMS - Refactor Classrooms Index 2: The Revenge.

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -20,7 +20,6 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       message = "Activity Session Updated"
       NotifyOfCompletedActivity.new(@activity_session).call if @activity_session.classroom_unit_id
       handle_concept_results
-      count_completed_activity
     else
       status = :unprocessable_entity
       message = "Activity Session Update Failed"
@@ -96,12 +95,6 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
   private def find_activity_session
     @activity_session = ActivitySession.unscoped.find_by_uid!(params[:id])
-  end
-
-  private def count_completed_activity
-    return unless @activity_session.finished?
-
-    UserActivityClassification.count_for(@activity_session.user, @activity_session.classification)
   end
 
   private def activity_session_params

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -188,13 +188,7 @@ class Teachers::ClassroomsController < ApplicationController
 
     student_ids = classrooms.flat_map(&:students).map(&:id)
 
-    # create a hash of the form {user_id: count}
-    activity_counts_by_student = ActivitySession
-      .select(:user_id, "count(activity_sessions.id) as total")
-      .where(user_id: student_ids, state: 'finished')
-      .group(:user_id)
-      .map{|r| [r.user_id, r.total]}
-      .to_h
+    activity_counts_by_student = UserActivityClassification.completed_activities_by_student(student_ids)
 
     classrooms.compact.map do |classroom|
       classroom_obj = classroom.attributes

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -70,7 +70,7 @@ class ActivitySession < ApplicationRecord
   before_create :set_state
   before_save   :set_completed_at, :set_activity_id
 
-  after_save    :determine_if_final_score, :update_milestones
+  after_save    :determine_if_final_score, :update_milestones, :increment_counts
   after_save :record_teacher_activity_feed, if: [:completed_at_changed?, :completed?]
 
   after_commit :invalidate_activity_session_count_if_completed
@@ -580,6 +580,13 @@ class ActivitySession < ApplicationRecord
     if self.state == 'finished'
       UpdateMilestonesWorker.perform_async(uid)
     end
+  end
+
+  private def increment_counts
+    return unless finished?
+    return unless saved_change_to_completed_at?
+
+    UserActivityClassification.count_for(user, classification)
   end
 
   def self.has_a_completed_session?(activity_id_or_ids, classroom_unit_id_or_ids)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -607,6 +607,11 @@ class User < ApplicationRecord
     auth_credential.google_authorized?
   end
 
+  # Note this is an incremented count, so could be off.
+  def completed_activity_count
+    user_activity_classifications.sum(:count)
+  end
+
   private def validate_flags
     # ensures there are no items in the flags array that are not in the VALID_FLAGS const
     invalid_flags = flags - VALID_FLAGS

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -45,7 +45,6 @@ class UserActivityClassification < ApplicationRecord
     .to_h
   end
 
-
   def self.count_for(user, activity_classification)
     begin
       transaction(requires_new: true) do

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -32,6 +32,20 @@ class UserActivityClassification < ApplicationRecord
       greater_than_or_equal_to: 0
     }
 
+  scope :completed_activities_for_user_ids, lambda {|user_ids|
+    select('user_id, SUM(count) as total')
+    .where(user_id: user_ids)
+    .group(:user_id)
+  }
+
+  # returns {user_id: total}
+  def self.completed_activities_by_student(user_ids)
+    completed_activities_for_user_ids(user_ids)
+    .map{|r| [r['user_id'], r['total'].to_i]}
+    .to_h
+  end
+
+
   def self.count_for(user, activity_classification)
     begin
       transaction(requires_new: true) do


### PR DESCRIPTION
## WHAT
This is a second pass at performance improvements for `Teachers::ClassroomsController#index` using `UserActivityClassification` for activity_counts instead of `ActivitySession`. 
## WHY
The last PR #8171 was a [mild performance improvement](https://one.newrelic.com/launcher/nr1-core.explorer?platform[timeRange][duration]=21600000&pane=eyJ0cmFuc2FjdGlvbklkIjoiNWIyMjQzNmY2ZTc0NzI2ZjZjNmM2NTcyMmY3NDY1NjE2MzY4NjU3MjczMmY2MzZjNjE3MzczNzI2ZjZmNmQ3MzJmNjk2ZTY0NjU3ODIyMmMyMjIyNWQiLCJzb3J0QnkiOiJhcGRleF9kaXNzYXRpc2Z5aW5nIiwibmVyZGxldElkIjoiYXBtLW5lcmRsZXRzLnRyYW5zYWN0aW9ucyIsImVudGl0eUd1aWQiOiJNall6T1RFeE0zeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5UUTRPRFUyT0RjMSJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1qWXpPVEV4TTN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRRNE9EVTJPRGMxIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImFwbS1uZXJkbGV0cy50cmFuc2FjdGlvbnMifX0=&state=29e7722c-c057-23b7-605b-dc19862fb467), but the session counts are still slow, even in a rolled-up query. Using a different source to get the counts with the hope that it is more performent.
## HOW
Use `UserActivityClassification` to get a sum of completed activities. I also moved the counter increment-or to the model to make testing easier (and that feels where it belongs).

### Notion Card Links
https://www.notion.so/quill/Speed-up-Teachers-ClassroomsController-index-view-960f49c7bf8c494c9f3626b5c3c00038

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yuppers
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
