### PR TITLE
make sure unit template is formatted properly

### DIFF
--- a/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
@@ -12,6 +12,7 @@ class Cms::UnitTemplatesController < Cms::CmsController
   end
 
   def edit
+    @unit_template = Cms::UnitTemplateSerializer.new(@unit_template).as_json(root: false)
   end
 
   def create


### PR DESCRIPTION
## WHAT
Make sure the `@unit_template` is formatted properly.

## WHY
So curriculum team members can see what activities are in a unit template.

## HOW
Just use the same serializer function we use for the index.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activities-in-a-pack-aren-t-displayed-in-the-activity-pack-editor-728a3f9a6b944d7d93187f2d0f772209

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
