### PR TITLE
make background for connect activities extend to the bottom of the page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Connect/styles/style.scss
@@ -22,6 +22,10 @@ body {
   font-feature-settings: "ss04";
 }
 
+.activity-container {
+  background-color: #eee;
+}
+
 .button-group {
   .button {
     margin-right: 5px;


### PR DESCRIPTION
## WHAT
Make background for Connect activities extend to the bottom of the page.

## WHY
So we don't get an awkward gray/white cutoff partway down.

## HOW
Just apply the background color to the full container.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Missing-background-gray-when-getting-hints-in-Quill-Grammar-4f3c71749b46499489ec348919d54856 (note that the card says Grammar, but this is actually a Connect activity)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
