### PR TITLE
CMS - Add fallback for new questions added to system.

### DIFF
--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -1,8 +1,13 @@
 class QuestionsController < ApplicationController
   MULTIPLE_CHOICE_LIMIT = 2
+  CACHE_EXPIRY = 24.hours.to_i
 
   def responses
-    render json: GradedResponse.no_parent.where(question_uid: params[:question_uid])
+    graded = GradedResponse.no_parent.where(question_uid: params[:question_uid])
+
+    responses = graded.present? ? graded : graded_fallback
+
+    render json: responses
   end
 
   def multiple_choice_options
@@ -22,6 +27,17 @@ class QuestionsController < ApplicationController
     nonoptimal = nonoptimal_main.concat(nonoptimal_fallback(nonoptimal_main.count))
 
     render json: optimal.concat(nonoptimal)
+  end
+
+
+  # Newly added questions aren't in GradedResponse since that's only refreshed nightly
+  private def graded_fallback
+    ids = Rails.cache.fetch(Response.questions_cache_key(params[:question_uid]), expires_in: CACHE_EXPIRY) do
+      #NB, the result of this query is too large to store as objects in Memcached for some questions, so storing the ids then fetching them in a query.
+      Response.where(question_uid: params[:question_uid], parent_id: nil).where.not(optimal: nil).pluck(:id)
+    end
+
+    Response.where(id: ids)
   end
 
   # The MultipleChoiceResponse model contains responses
@@ -52,4 +68,6 @@ class QuestionsController < ApplicationController
       .limit(needed_count)
       .to_a
   end
+
+  private
 end

--- a/services/QuillCMS/app/controllers/questions_controller.rb
+++ b/services/QuillCMS/app/controllers/questions_controller.rb
@@ -68,6 +68,4 @@ class QuestionsController < ApplicationController
       .limit(needed_count)
       .to_a
   end
-
-  private
 end

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -5,7 +5,6 @@ class Response < ApplicationRecord
   include ResponseScopes
   after_create_commit :create_index_in_elastic_search
   after_update_commit :update_index_in_elastic_search
-  after_commit :clear_responses_route_cache
   before_destroy :destroy_index_in_elastic_search
 
   validates :question_uid, uniqueness: { scope: :text }
@@ -76,12 +75,6 @@ class Response < ApplicationRecord
 
   def destroy_index_in_elastic_search
     __elasticsearch__.delete_document
-  end
-
-  def clear_responses_route_cache
-    return if optimal.nil?
-
-    Rails.cache.delete(::Response.questions_cache_key(question_uid))
   end
 
   def self.questions_cache_key(question_uid)


### PR DESCRIPTION
## WHAT
The materialized view (`GradedResponse`) that serves question responses is refreshed nightly. If a question is added by our Curriculum Team during the day, the endpoint wouldn't find any responses.

This adds a fallback query on the `Response` table if no responses are found to handle this edge case.
## WHY
We want newly added questions to work immediately. Also, since this table is refreshed nightly, this issue was impossible to replicate the next day (since it only happens the first day of a live question).
## HOW
Use the old controller code as a fallback if no responses are found.
### Screenshots
Investigation into the support ticket found the activity and question were updated recently.
Activity
<img width="914" alt="Screen Shot 2021-09-03 at 10 28 25 AM" src="https://user-images.githubusercontent.com/1304933/132035322-25f1c61c-59e0-40c9-9fa1-476e74197ca3.png">
Question
<img width="1010" alt="Screen Shot 2021-09-03 at 12 07 02 PM" src="https://user-images.githubusercontent.com/1304933/132035323-3d054d4a-23e9-4b6a-a607-b14d6b3a88f8.png">




PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/a
