### PR TITLE
LMS - Fix broken activity test

### DIFF
--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -170,7 +170,7 @@ describe Activity, type: :model, redis: true do
       student = create(:student)
       activity_count = 2
       activity_count.times do
-        create(:activity_session, activity: classified_activity, user: student)
+        create(:activity_session, :finished, activity: classified_activity, user: student)
       end
 
       activity_session = student.activity_sessions.last

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -168,17 +168,21 @@ describe Activity, type: :model, redis: true do
       classification = create(:activity_classification, key: 'connect')
       classified_activity = create(:activity, classification: classification)
       student = create(:student)
-      uac = create(:user_activity_classification, user: student, activity_classification: classification, count: 4)
-      activity_session = create(:activity_session, activity: classified_activity, user: student)
+      activity_count = 2
+      activity_count.times do
+        create(:activity_session, activity: classified_activity, user: student)
+      end
 
-      expect(activity_session.user_activity_classifications.find_by(user_id: student.id)).to eq(uac)
-      expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{uac.count}")
+      activity_session = student.activity_sessions.last
+
+      expect(activity_session.user_activity_classifications.find_by(user_id: student.id).count).to eq(activity_count)
+      expect(classified_activity.module_url(activity_session).to_s).to include("activities=#{activity_count}")
     end
 
     it "must not add 'activities' param if the student has not completed any other activities of this classification" do
       classification = create(:activity_classification, key: 'connect')
       classified_activity = create(:activity, classification: classification)
-      activity_session = create(:activity_session, activity: classified_activity)
+      activity_session = create(:activity_session, :started, activity: classified_activity)
 
       expect(classified_activity.module_url(activity_session).to_s).to_not include("activities")
     end


### PR DESCRIPTION
## WHAT
Fix broken test setup. `UserActivityClassification`s  are created when the `ActivitySession` is completed now, use that for the test.
## WHY
Broken tests are annoying.
## HOW
Change the test setup to use the naturally created `UserActivityClassification` rather than a mocked one.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'. 
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
