### PR TITLE
fix issue with summing timestamps

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -151,7 +151,7 @@ class ActivitySession < ApplicationRecord
   end
 
   def self.calculate_timespent(time_tracking)
-    time_tracking&.values&.sum
+    time_tracking&.values&.compact&.sum
   end
 
   def eligible_for_tracking?

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -910,6 +910,13 @@ end
     end
   end
 
+  describe '#calculate_timespent' do
+    it 'should save timetracking data even if one of the values is nil' do
+      time_tracking = {"1"=>188484, "2"=>94405, "3"=>89076, "4"=>120504, "onboarding"=>nil}
+      expect(ActivitySession.calculate_timespent(time_tracking)).to eq(492469)
+    end
+  end
+
   describe '#has_a_completed_session?' do
     context 'when session exists' do
       let(:activity_session) { create(:activity_session, state: "finished") }


### PR DESCRIPTION
## WHAT
Fix issue where one of the timestamp keys has a nil value.

## WHY
So that this operation doesn't error and the session can save.

## HOW
Just remove nil values before summing.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/ActivitySession-TimeSpent-nil-error-fc693b5055d741768c6d3316721179f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
