### PR TITLE
make more space for important text on premium reports

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
@@ -13,6 +13,12 @@
   padding-top: 30px;
   padding-bottom: 180px;
 
+  &.data-export, &.concept-student-concepts {
+    .ReactTable .rt-td.show-overflow {
+      white-space: pre-wrap;
+    }
+  }
+
   .rt-table {
     border-radius: 6px;
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
@@ -88,7 +88,8 @@ export default createReactClass({
         accessor: 'student_id',
         resizeable: false,
         Cell: props => this.state.studentFilters.find(student => student.value == props.value).name,
-        className: this.nonPremiumBlur()
+        className: this.nonPremiumBlur(),
+        maxWidth: 200
       },
       {
         Header: 'Date',
@@ -101,6 +102,7 @@ export default createReactClass({
         Header: 'Activity',
         accessor: 'activity_name',
         resizeable: false,
+        className: 'show-overflow',
         Cell: props => props.value
       },
       {
@@ -234,7 +236,7 @@ export default createReactClass({
 
   render: function() {
     return (
-      <div className='progress-reports-2018'>
+      <div className='progress-reports-2018 data-export'>
         <div className='meta-overview flex-row space-between'>
           <div className='header-and-info'>
             <h1>Data Export</h1>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_concepts_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_concepts_progress_report.jsx
@@ -43,6 +43,7 @@ export default class extends React.Component {
       }, {
         Header: 'Name',
         accessor: 'concept_name',
+        className: 'show-overflow',
         resizable: false,
       }, {
         Header: 'Questions',
@@ -54,13 +55,13 @@ export default class extends React.Component {
         accessor: 'correct_result_count',
         resizable: false,
         className: blurIfNotPremium,
-        width: 120
+        width: 105
       }, {
         Header: 'Incorrect',
         accessor: 'incorrect_result_count',
         resizable: false,
         className: blurIfNotPremium,
-        width: 120
+        width: 115
       }, {
         Header: 'Percentage',
         accessor: 'percentage',


### PR DESCRIPTION
## WHAT
Downsize other columns and allow the text to wrap onto two lines in the two most important ones.

## WHY
Lindsey requested that we use tooltips here, but this table is built using `ReactTable` instead of our native `DataTable`, and our native `DataTable` doesn't have all the functionality `ReactTable` does. This seemed like the best interim fix.

## HOW
Just adjust the CSS for these two columns.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-tooltips-to-the-Data-Export-and-Concepts-Results-pages-45ade916f1ec4067bafc166a2e86f95f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES