### PR TITLE
Fix reordering bug involving unit activities

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -49,7 +49,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def update_classroom_unit_assigned_students
-    activities_data = UnitActivity.where(unit_id: params[:id]).pluck(:activity_id).map{|id| {id: id}}
+    activities_data = UnitActivity.where(unit_id: params[:id]).order(:order_number).pluck(:activity_id).map { |id| { id: id } }
     if activities_data.any?
       classroom_data = JSON.parse(params[:unit][:classrooms], symbolize_names: true)
       Units::Updater.run(params[:id], activities_data, classroom_data, current_user.id)


### PR DESCRIPTION
## WHAT
Fix a bug involving reordering of unit activities

## WHY
We want the reordering functionality to be predictable.

## HOW
When using the Activity Packs 'adding / removing students assigned' flow, a call is made to `teacher/units#update_classroom_unit_assigned_students` which queries unit activities without preserving order.  This effectively gives a random order when `Units::Updater.run` is called.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Reordering-feature-not-working-properly-556aab8bd26e4f0d9fce12d0b8e59344

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | No.  Deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
