### PR TITLE
do not automatically load all the schools for the school search index

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -17,7 +17,7 @@ class Cms::SchoolsController < Cms::CmsController
     @school_search_query = {
       'search_schools_with_zero_teachers' => true
     }
-    @school_search_query_results = school_query(school_query_params)
+    @school_search_query_results = []
     @number_of_pages = 0
   end
 

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -24,7 +24,7 @@ describe Cms::SchoolsController do
     it 'should allows staff memeber to view and search through school' do
       get :index
       expect(assigns(:school_search_query)).to eq({'search_schools_with_zero_teachers' => true})
-      expect(assigns(:school_search_query_results)).to eq [school_hash]
+      expect(assigns(:school_search_query_results)).to eq []
       expect(assigns(:number_of_pages)).to eq 0
     end
   end


### PR DESCRIPTION
## WHAT
Stop automatically loading all the schools for the CMS schools index page.

## WHY
This query, for every single school, is extremely slow (up to 82 seconds) and sometimes causes a timeout. When this happened with the users controller, we just stopped automatically loading all the data and waited until the user actually performed a search, so that's what I implemented here as well.

## HOW
Just stop actually calling the query function on the index page.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Schools-CMS-Index-page-timing-out-ad1d3d46bc064753a605f03cc7757623

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
