### PR TITLE
Refactor google integration namespace, part 1

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -42,7 +42,7 @@ class Auth::GoogleController < ApplicationController
 
   private def run_background_jobs
     if @user.teacher?
-      GoogleIntegration::Users::UpdateImportedClassroomsWorker.perform_async(@user.id)
+      GoogleIntegration::TeacherUpdateImportedClassroomsWorker.perform_async(@user.id)
       GoogleStudentImporterWorker.perform_async(@user.id, 'Auth::GoogleController')
     elsif @user.student?
       GoogleStudentClassroomWorker.perform_async(@user.id)

--- a/services/QuillLMS/app/services/google_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_creator.rb
@@ -1,0 +1,59 @@
+module GoogleIntegration
+  class ClassroomCreator
+    attr_reader :data, :google_classroom_id, :teacher_id
+
+    def initialize(data)
+      @data = data
+      @google_classroom_id = data[:google_classroom_id]
+      @teacher_id = data[:teacher_id]
+    end
+
+    def run
+      classroom
+    end
+
+    private def classroom
+      ::Classroom.create!(
+        google_classroom_id: google_classroom_id,
+        name: name,
+        synced_name: synced_name,
+        teacher_id: teacher_id,
+        classrooms_teachers_attributes: [
+          {
+            user_id: teacher_id,
+            role: role
+          }
+        ]
+      )
+    end
+
+    private def name
+      data[:name].present? ? valid_name : "Classroom #{google_classroom_id}"
+    end
+
+    private def other_owned_classroom_names
+      @other_owned_classroom_names ||= teacher.classrooms_i_own.pluck(:name)
+    end
+
+    private def role
+      'owner'
+    end
+
+    private def teacher
+      ::User.find(teacher_id)
+    end
+
+    private def synced_name
+      data[:name]
+    end
+
+    private def valid_name
+      temp_name = data[:name]
+
+      loop do
+        return temp_name unless other_owned_classroom_names.include?(temp_name)
+        temp_name += '_1'
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/classroom_importer.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_importer.rb
@@ -1,0 +1,23 @@
+module GoogleIntegration
+  class ClassroomImporter
+    attr_reader :data, :google_classroom_id, :teacher_id
+
+    def initialize(data)
+      @data = data
+      @google_classroom_id = data[:google_classroom_id]
+      @teacher_id = data[:teacher_id]
+    end
+
+    def run
+      importer_class.new(data).run
+    end
+
+    private def classroom
+      ::Classroom.unscoped.find_by(google_classroom_id: google_classroom_id, teacher_id: teacher_id)
+    end
+
+    private def importer_class
+      classroom.present? ? ClassroomUpdater : ClassroomCreator
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/classroom_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_updater.rb
@@ -1,0 +1,66 @@
+module GoogleIntegration
+  class ClassroomUpdater
+    attr_reader :data, :google_classroom_id, :teacher_id
+
+    def initialize(data)
+      @data = data
+      @google_classroom_id = data[:google_classroom_id]
+      @teacher_id = data[:teacher_id]
+    end
+
+    def run
+      update
+      classroom
+    end
+
+    private def classroom
+      @classroom ||= ::Classroom.unscoped.find_by!(google_classroom_id: google_classroom_id, teacher_id: teacher_id)
+    end
+
+    private def custom_name?
+      classroom.name != classroom.synced_name
+    end
+
+    private def grade
+      data.fetch(:grade, classroom.grade)
+    end
+
+    private def name
+      custom_name? ? classroom.name : valid_name
+    end
+
+    private def other_owned_classroom_names
+      @other_owned_classroom_names ||= teacher.classrooms_i_own.reject { |c| c.id == classroom.id }.pluck(:name)
+    end
+
+    private def synced_name
+      data[:name]
+    end
+
+    private def teacher
+      ::User.find(teacher_id)
+    end
+
+    private def update
+      classroom.update!(
+        name: name,
+        synced_name: synced_name,
+        grade: grade,
+        visible: visible
+      )
+    end
+
+    private def valid_name
+      temp_name = data[:name]
+
+      loop do
+        return temp_name unless other_owned_classroom_names.include?(temp_name)
+        temp_name += '_1'
+      end
+    end
+
+    private def visible
+      true
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/client.rb
+++ b/services/QuillLMS/app/services/google_integration/client.rb
@@ -1,44 +1,45 @@
 require 'google/api_client'
 
-class GoogleIntegration::Client
+module GoogleIntegration
+  class Client
+    class AccessTokenError < StandardError; end
 
-  class AccessTokenError < StandardError; end
+    def initialize(user, api_client = nil, token_refresher = nil, api_version = nil, os_version = nil)
+      @user            = user
+      @api_client      = api_client      || Google::APIClient
+      @token_refresher = token_refresher || GoogleIntegration::RefreshAccessToken
+      @api_version     = api_version     || Google::APIClient::VERSION::STRING
+      @os_version      = os_version      || Google::APIClient::ENV::OS_VERSION
+    end
 
-  def initialize(user, api_client = nil, token_refresher = nil, api_version = nil, os_version = nil)
-    @user            = user
-    @api_client      = api_client      || Google::APIClient
-    @token_refresher = token_refresher || GoogleIntegration::RefreshAccessToken
-    @api_version     = api_version     || Google::APIClient::VERSION::STRING
-    @os_version      = os_version      || Google::APIClient::ENV::OS_VERSION
-  end
+    def create
+      raise AccessTokenError, "No access token found" if !access_token
+      client.authorization.access_token = access_token
+      client
+    end
 
-  def create
-    raise AccessTokenError, "No access token found" if !access_token
-    client.authorization.access_token = access_token
-    client
-  end
+    private def access_token
+      verified_credentials&.access_token
+    end
 
-  private def access_token
-    verified_credentials&.access_token
-  end
+    private def verified_credentials
+      @verified_credentials ||= @token_refresher.new(@user).refresh
+    end
 
-  private def verified_credentials
-    @verified_credentials ||= @token_refresher.new(@user).refresh
-  end
+    private def client
+      @client ||= @api_client.new(application_name: 'quill', user_agent: user_agent)
+    end
 
-  private def client
-    @client ||= @api_client.new(application_name: 'quill', user_agent: user_agent)
-  end
-
-  # Builds a custom user agent to prevent Google::APIClient to
-  # use an invalid auto-generated one
-  # @see https://github.com/google/google-api-ruby-client/blob/15853007bf1fc8ad000bb35dafdd3ca6bfa8ae26/lib/google/api_client.rb#L112
-  private def user_agent
-    [
-      "quill/0.0.0",
-      "google-api-ruby-client/#{@api_version}",
-      @os_version,
-      '(gzip)'
-    ].join(' ').delete("\n")
+    # Builds a custom user agent to prevent Google::APIClient to
+    # use an invalid auto-generated one
+    # @see https://github.com/google/google-api-ruby-client/blob/15853007bf1fc8ad000bb35dafdd3ca6bfa8ae26/lib/google/api_client.rb#L112
+    private def user_agent
+      [
+        "quill/0.0.0",
+        "google-api-ruby-client/#{@api_version}",
+        @os_version,
+        '(gzip)'
+      ].join(' ').delete("\n")
+    end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/lesson_announcement.rb
+++ b/services/QuillLMS/app/services/google_integration/lesson_announcement.rb
@@ -1,117 +1,119 @@
 require 'google/api_client'
 
-class GoogleIntegration::LessonAnnouncement
-  attr_reader :classroom_unit, :unit_activity
+module GoogleIntegration
+  class LessonAnnouncement
+    attr_reader :classroom_unit, :unit_activity
 
-  class GoogleApiError < StandardError; end
+    class GoogleApiError < StandardError; end
 
-  def initialize(classroom_unit, unit_activity, client = nil)
-    @classroom_unit = classroom_unit
-    @unit_activity = unit_activity
-    @client = client
-  end
-
-  def post
-    return unless can_post_to_google_classroom?
-
-    handle_response { request }
-  rescue GoogleApiError => e
-    NewRelic::Agent.add_custom_attributes({
-      classroom_unit_id: @classroom_unit.id,
-      unit_activity_id: @unit_activity.id
-    })
-    NewRelic::Agent.notice_error(e)
-    # If we get an error, report it to New Relic and bail
-    nil
-  end
-
-  private def request
-    client.execute(
-      api_method: api_method,
-      parameters: {
-        courseId: google_course_id,
-      },
-      body: body.to_json,
-      headers: {"Content-Type": 'application/json'}
-    )
-  end
-
-  private def handle_response(&request)
-    response = request.call
-    body = JSON.parse(response.body, symbolize_names: true)
-    raise(GoogleApiError, body) if response.status != 200
-    if body.dig(:error, :status) == 'UNAUTHENTICATED'
-      'UNAUTHENTICATED'
-    else
-      body
+    def initialize(classroom_unit, unit_activity, client = nil)
+      @classroom_unit = classroom_unit
+      @unit_activity = unit_activity
+      @client = client
     end
-  end
 
-  private def body
-    if individual_students?
-      base_body.merge(individual_students_body)
-    else
-      base_body
+    def post
+      return unless can_post_to_google_classroom?
+
+      handle_response { request }
+    rescue GoogleApiError => e
+      NewRelic::Agent.add_custom_attributes({
+        classroom_unit_id: @classroom_unit.id,
+        unit_activity_id: @unit_activity.id
+      })
+      NewRelic::Agent.notice_error(e)
+      # If we get an error, report it to New Relic and bail
+      nil
     end
-  end
 
-  private def base_body
-    {
-      text: announcement_text
-    }
-  end
+    private def request
+      client.execute(
+        api_method: api_method,
+        parameters: {
+          courseId: google_course_id,
+        },
+        body: body.to_json,
+        headers: {"Content-Type": 'application/json'}
+      )
+    end
 
-  private def classroom
-    classroom_unit.classroom
-  end
+    private def handle_response(&request)
+      response = request.call
+      body = JSON.parse(response.body, symbolize_names: true)
+      raise(GoogleApiError, body) if response.status != 200
+      if body.dig(:error, :status) == 'UNAUTHENTICATED'
+        'UNAUTHENTICATED'
+      else
+        body
+      end
+    end
 
-  private def user
-    classroom.owner
-  end
+    private def body
+      if individual_students?
+        base_body.merge(individual_students_body)
+      else
+        base_body
+      end
+    end
 
-  private def google_course_id
-    classroom.google_classroom_id
-  end
-
-  private def announcement_text
-    activity_url  = ActivitySession.generate_activity_url(
-      classroom_unit.id,
-      unit_activity.activity.id
-    )
-    activity_name = unit_activity.activity.name
-
-    "New Activity: #{activity_name} #{activity_url}"
-  end
-
-  private def individual_students?
-    classroom_unit.assigned_student_ids.any? &&
-    !classroom_unit.assign_on_join
-  end
-
-  private def individual_students_body
-    {
-      assigneeMode: "INDIVIDUAL_STUDENTS",
-      individualStudentsOptions: {
-        studentIds: assigned_student_ids_as_google_ids
+    private def base_body
+      {
+        text: announcement_text
       }
-    }
-  end
+    end
 
-  private def assigned_student_ids_as_google_ids
-    User.where(id: classroom_unit.assigned_student_ids)
-      .pluck(:google_id)
-      .compact
-  end
+    private def classroom
+      classroom_unit.classroom
+    end
 
-  private def client
-    @client ||= GoogleIntegration::Client.new(user).create
-  end
+    private def user
+      classroom.owner
+    end
 
-  private def api_method
-    client.discovered_api('classroom', 'v1').courses.announcements.create
-  end
+    private def google_course_id
+      classroom.google_classroom_id
+    end
 
-  private def can_post_to_google_classroom?
-    classroom.google_classroom_id.present? && classroom.owner.post_google_classroom_assignments
+    private def announcement_text
+      activity_url  = ActivitySession.generate_activity_url(
+        classroom_unit.id,
+        unit_activity.activity.id
+      )
+      activity_name = unit_activity.activity.name
+
+      "New Activity: #{activity_name} #{activity_url}"
+    end
+
+    private def individual_students?
+      classroom_unit.assigned_student_ids.any? &&
+      !classroom_unit.assign_on_join
+    end
+
+    private def individual_students_body
+      {
+        assigneeMode: "INDIVIDUAL_STUDENTS",
+        individualStudentsOptions: {
+          studentIds: assigned_student_ids_as_google_ids
+        }
+      }
+    end
+
+    private def assigned_student_ids_as_google_ids
+      User.where(id: classroom_unit.assigned_student_ids)
+        .pluck(:google_id)
+        .compact
+    end
+
+    private def client
+      @client ||= Client.new(user).create
+    end
+
+    private def api_method
+      client.discovered_api('classroom', 'v1').courses.announcements.create
+    end
+
+    private def can_post_to_google_classroom?
+      classroom.google_classroom_id.present? && classroom.owner.post_google_classroom_assignments
+    end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/profile.rb
+++ b/services/QuillLMS/app/services/google_integration/profile.rb
@@ -1,53 +1,54 @@
-class GoogleIntegration::Profile
-
-  def initialize(request, session)
-    @session = session
-    @request = request
-  end
-
-  def name
-    info.name if info.present?
-  end
-
-  def email
-    info.email if info.present?
-  end
-
-  def google_id
-    omniauth_data.uid if omniauth_data.present?
-  end
-
-  def refresh_token
-    credentials.refresh_token if credentials.present?
-  end
-
-  def access_token
-    credentials.token if credentials.present?
-  end
-
-  def expires_at
-    Time.at(expiration_in_epoch_time) if expiration_in_epoch_time.present?
-  end
-
-  def role
-    @session['role']
-  end
-
-  def info
-    omniauth_data.info if omniauth_data.present?
-  end
-
-  private def expiration_in_epoch_time
-    if credentials.present?
-      credentials.expires_at || credentials.expires_in
+module GoogleIntegration
+  class Profile
+    def initialize(request, session)
+      @session = session
+      @request = request
     end
-  end
 
-  private def credentials
-    omniauth_data.credentials if omniauth_data.present?
-  end
+    def name
+      info.name if info.present?
+    end
 
-  private def omniauth_data
-    @request.env['omniauth.auth']
+    def email
+      info.email if info.present?
+    end
+
+    def google_id
+      omniauth_data.uid if omniauth_data.present?
+    end
+
+    def refresh_token
+      credentials.refresh_token if credentials.present?
+    end
+
+    def access_token
+      credentials.token if credentials.present?
+    end
+
+    def expires_at
+      Time.at(expiration_in_epoch_time) if expiration_in_epoch_time.present?
+    end
+
+    def role
+      @session['role']
+    end
+
+    def info
+      omniauth_data.info if omniauth_data.present?
+    end
+
+    private def expiration_in_epoch_time
+      if credentials.present?
+        credentials.expires_at || credentials.expires_in
+      end
+    end
+
+    private def credentials
+      omniauth_data.credentials if omniauth_data.present?
+    end
+
+    private def omniauth_data
+      @request.env['omniauth.auth']
+    end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
+++ b/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
@@ -1,115 +1,116 @@
-class GoogleIntegration::RefreshAccessToken
+module GoogleIntegration
+  class RefreshAccessToken
+    class RefreshAccessTokenError < StandardError; end
 
-  class RefreshAccessTokenError < StandardError; end
-
-  class NoRefreshTokenError < RefreshAccessTokenError
-    def message
-      "No existing Google Refresh Token available to submit"
+    class NoRefreshTokenError < RefreshAccessTokenError
+      def message
+        "No existing Google Refresh Token available to submit"
+      end
     end
-  end
 
-  class TokenTooOldToRefreshError < RefreshAccessTokenError
-    def message
-      "Existing Google Access Token is too old to refresh"
+    class TokenTooOldToRefreshError < RefreshAccessTokenError
+      def message
+        "Existing Google Access Token is too old to refresh"
+      end
     end
-  end
 
-  class FailedToRefreshTokenError < RefreshAccessTokenError; end
+    class FailedToRefreshTokenError < RefreshAccessTokenError; end
 
-  class FailedToSaveRefreshedTokenError < RefreshAccessTokenError; end
+    class FailedToSaveRefreshedTokenError < RefreshAccessTokenError; end
 
-  TOKEN_ENDPOINT = 'https://accounts.google.com/o/oauth2/token'
+    TOKEN_ENDPOINT = 'https://accounts.google.com/o/oauth2/token'
 
-  def initialize(user, http_client = nil)
-    @user        = user
-    @http_client = http_client || HTTParty
-  end
-
-  def refresh
-    if should_refresh?
-      raise NoRefreshTokenError if !current_credentials&.refresh_token
-      # According to Google documentation, refresh tokens older than
-      # 6 months can not be refreshed:
-      # https://developers.google.com/identity/protocols/OAuth2#expiration
-      raise TokenTooOldToRefreshError if token_too_old_to_refresh?
-      handle_response(make_request)
-    else
-      current_credentials
+    def initialize(user, http_client = nil)
+      @user        = user
+      @http_client = http_client || HTTParty
     end
-  end
 
-  private def make_request
-    @http_client.post(TOKEN_ENDPOINT, refresh_token_options)
-  end
-
-  private def handle_response(response)
-    if response.code == 200
-      store_credentials(response)
-    else
-      msg = "Non-200 response when attempting to refresh access token: '#{response.parsed_response['error']}'"
-      # delete current_credentials so that user is forced to login again
-      current_credentials.destroy!
-      raise FailedToRefreshTokenError, msg
+    def refresh
+      if should_refresh?
+        raise NoRefreshTokenError if !current_credentials&.refresh_token
+        # According to Google documentation, refresh tokens older than
+        # 6 months can not be refreshed:
+        # https://developers.google.com/identity/protocols/OAuth2#expiration
+        raise TokenTooOldToRefreshError if token_too_old_to_refresh?
+        handle_response(make_request)
+      else
+        current_credentials
+      end
     end
-  end
 
-  private def store_credentials(response)
-    data       = response.parsed_response
-    attributes = parse_attributes(data)
-
-    if current_credentials.update(attributes)
-      current_credentials.reload
-    else
-      msg = "Failed to save updated access token: '#{current_credentials.errors.messages}'"
-      raise FailedToSaveRefreshedTokenError, msg
+    private def make_request
+      @http_client.post(TOKEN_ENDPOINT, refresh_token_options)
     end
-  end
 
-  private def parse_attributes(data)
-    {}.tap do |attributes|
-      attributes[:access_token] = data['access_token'] if data['access_token'].present?
-      attributes[:expires_at] = data['expires_in'] if data['expires_in'].present?
-      attributes[:timestamp] = data['issued_at'] if data['issued_at'].present?
+    private def handle_response(response)
+      if response.code == 200
+        store_credentials(response)
+      else
+        msg = "Non-200 response when attempting to refresh access token: '#{response.parsed_response['error']}'"
+        # delete current_credentials so that user is forced to login again
+        current_credentials.destroy!
+        raise FailedToRefreshTokenError, msg
+      end
     end
-  end
 
-  private def refresh_token
-    current_credentials.refresh_token
-  end
+    private def store_credentials(response)
+      data       = response.parsed_response
+      attributes = parse_attributes(data)
 
-  private def current_credentials
-    @current_credentials ||= @user.auth_credential
-  end
+      if current_credentials.update(attributes)
+        current_credentials.reload
+      else
+        msg = "Failed to save updated access token: '#{current_credentials.errors.messages}'"
+        raise FailedToSaveRefreshedTokenError, msg
+      end
+    end
 
-  private def should_refresh?
-    current_credentials && ( nil_access_token_expiration? || access_token_expired? )
-  end
+    private def parse_attributes(data)
+      {}.tap do |attributes|
+        attributes[:access_token] = data['access_token'] if data['access_token'].present?
+        attributes[:expires_at] = data['expires_in'] if data['expires_in'].present?
+        attributes[:timestamp] = data['issued_at'] if data['issued_at'].present?
+      end
+    end
 
-  private def nil_access_token_expiration?
-    current_credentials.expires_at.nil?
-  end
+    private def refresh_token
+      current_credentials.refresh_token
+    end
 
-  private def access_token_expired?
-    Time.now > current_credentials.expires_at
-  end
+    private def current_credentials
+      @current_credentials ||= @user.auth_credential
+    end
 
-  private def token_too_old_to_refresh?
-    return false if nil_access_token_expiration?
+    private def should_refresh?
+      current_credentials && ( nil_access_token_expiration? || access_token_expired? )
+    end
 
-    Time.now >= current_credentials.refresh_token_expires_at
-  end
+    private def nil_access_token_expiration?
+      current_credentials.expires_at.nil?
+    end
 
-  private def refresh_token_options
-    {
-      body: {
-        client_id: ENV["GOOGLE_CLIENT_ID"],
-        client_secret: ENV["GOOGLE_CLIENT_SECRET"],
-        refresh_token: refresh_token,
-        grant_type: 'refresh_token'
-      },
-      headers: {
-        'Content-Type' => 'application/x-www-form-urlencoded'
+    private def access_token_expired?
+      Time.now > current_credentials.expires_at
+    end
+
+    private def token_too_old_to_refresh?
+      return false if nil_access_token_expiration?
+
+      Time.now >= current_credentials.refresh_token_expires_at
+    end
+
+    private def refresh_token_options
+      {
+        body: {
+          client_id: ENV["GOOGLE_CLIENT_ID"],
+          client_secret: ENV["GOOGLE_CLIENT_SECRET"],
+          refresh_token: refresh_token,
+          grant_type: 'refresh_token'
+        },
+        headers: {
+          'Content-Type' => 'application/x-www-form-urlencoded'
+        }
       }
-    }
+    end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/teacher_classroom_data_adapter.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classroom_data_adapter.rb
@@ -1,0 +1,26 @@
+module GoogleIntegration
+  class TeacherClassroomDataAdapter
+    attr_reader :user, :data
+
+    def initialize(user, data)
+      @user = user
+      @data = data
+    end
+
+    def run
+      clean_data
+    end
+
+    private def clean_data
+      data.tap do |cleaned_data|
+        cleaned_data[:google_classroom_id] = data.fetch(:id)
+        cleaned_data[user_role_id_key] = user.id
+      end
+    end
+
+    private def user_role_id_key
+      "#{user.role}_id".to_sym
+    end
+  end
+end
+

--- a/services/QuillLMS/app/services/google_integration/teacher_classrooms_cache.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classrooms_cache.rb
@@ -1,0 +1,26 @@
+module GoogleIntegration
+  class TeacherClassroomsCache
+    SERIALIZED_GOOGLE_CLASSROOMS_FOR_ = 'SERIALIZED_GOOGLE_CLASSROOMS_FOR_'.freeze
+    SERIALIZED_GOOGLE_CLASSROOMS_CACHE_LIFE = 300
+
+    def self.cache_key(teacher_id)
+      "#{SERIALIZED_GOOGLE_CLASSROOMS_FOR_}#{teacher_id}"
+    end
+
+    def self.get(teacher_id)
+      $redis.get(cache_key(teacher_id))
+    end
+
+    def self.expire(teacher_id, expires_in=SERIALIZED_GOOGLE_CLASSROOMS_CACHE_LIFE)
+      $redis.expire(cache_key(teacher_id), expires_in)
+    end
+
+    def self.del(teacher_id)
+      $redis.del(cache_key(teacher_id))
+    end
+
+    def self.set(teacher_id, data)
+      $redis.set(cache_key(teacher_id), data)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/teacher_classrooms_data.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classrooms_data.rb
@@ -1,0 +1,27 @@
+module GoogleIntegration
+  class TeacherClassroomsData
+    include Enumerable
+
+    attr_reader :user, :serialized_classrooms_data
+
+    def initialize(user, serialized_classrooms_data)
+      @user = user
+      @serialized_classrooms_data = serialized_classrooms_data
+    end
+
+    def each
+      classrooms_data.each { |classroom_data| yield classroom_data }
+    end
+
+    private def classrooms_data
+      deserialized_classrooms_data.map { |data| TeacherClassroomDataAdapter.new(user, data).run }
+    end
+
+    private def deserialized_classrooms_data
+      JSON
+        .parse(serialized_classrooms_data)
+        .deep_symbolize_keys
+        .fetch(:classrooms)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
@@ -1,0 +1,54 @@
+module GoogleIntegration
+  class TeacherClassroomsRetriever
+    ACCESS_TOKEN_ERRORS = [
+      RefreshAccessToken::RefreshAccessTokenError,
+      Client::AccessTokenError
+    ].freeze
+
+    UNAUTHENTICATED_RESPONSE = 'UNAUTHENTICATED'.freeze
+
+    attr_reader :user_id
+
+    def initialize(user_id)
+      @user_id = user_id
+    end
+
+    def run
+      cache_classrooms_data
+      set_cache_expiration
+      notify_pusher
+    rescue *ACCESS_TOKEN_ERRORS => e
+      NewRelic::Agent.add_custom_attributes({user_id: user_id})
+      NewRelic::Agent.notice_error(e)
+      e.message
+    end
+
+    private def cache_classrooms_data
+      TeacherClassroomsCache.set(user_id, data.to_json)
+    end
+
+    private def data
+      unauthenticated_response? ? { errors: google_response } : { classrooms: google_response }
+    end
+
+    private def unauthenticated_response?
+      google_response == UNAUTHENTICATED_RESPONSE
+    end
+
+    private def google_response
+      @google_response ||= Classroom::Main.pull_data(user)
+    end
+
+    private def notify_pusher
+      PusherTrigger.run(user_id, 'google-classrooms-retrieved', "Google classrooms found for #{user_id}.")
+    end
+
+    private def set_cache_expiration
+      TeacherClassroomsCache.expire(user_id)
+    end
+
+    private def user
+      ::User.find(user_id)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/teacher_imported_classrooms_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_imported_classrooms_updater.rb
@@ -1,0 +1,39 @@
+module GoogleIntegration
+  class TeacherImportedClassroomsUpdater
+    attr_reader :user_id
+
+    def initialize(user_id)
+      @user_id = user_id
+    end
+
+    def run
+      update_classrooms
+    end
+
+    private def cached_data
+      TeacherClassroomsCache.get(user_id)
+    end
+
+    private def classrooms_data
+      TeacherClassroomsData.new(user, cached_data)
+    end
+
+    private def imported_classrooms_data
+      classrooms_data.select do |classroom_data|
+        ::Classroom.unscoped.exists?(
+          google_classroom_id: classroom_data[:google_classroom_id],
+          teacher_id: user_id,
+          visible: true
+        )
+      end
+    end
+
+    private def update_classrooms
+      imported_classrooms_data.each { |data| ClassroomUpdater.new(data).run }
+    end
+
+    private def user
+      ::User.find(user_id)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/google_integration/update_teacher_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/update_teacher_imported_classrooms_worker.rb
@@ -1,0 +1,17 @@
+module GoogleIntegration
+  class UpdateTeacherImportedClassroomsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+    def perform(user_id)
+      return unless google_id?(user_id)
+
+      TeacherClassroomsRetriever.new(user_id).run
+      TeacherImportedClassroomsUpdater.new(user_id).run
+    end
+
+    private def google_id?(user_id)
+      user_id && ::User.find_by(id: user_id)&.google_id&.present?
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/users/update_imported_classrooms_worker.rb
@@ -12,7 +12,7 @@ module GoogleIntegration
       end
 
       private def google_id?(user_id)
-        user_id && ::User.find_by(id: user_id)&.google_id
+        user_id && ::User.find_by(id: user_id)&.google_id&.present?
       end
     end
   end

--- a/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/retrieve_google_classrooms_worker.rb
@@ -5,6 +5,6 @@ class RetrieveGoogleClassroomsWorker
   def perform(user_id)
     return unless user_id
 
-    GoogleIntegration::Users::ClassroomsRetriever.new(user_id).run
+    GoogleIntegration::TeacherClassroomsRetriever.new(user_id).run
   end
 end

--- a/services/QuillLMS/spec/services/google_integration/classroom_creator_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_creator_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::ClassroomCreator do
+  let(:teacher_id) { create(:teacher).id }
+
+  let(:data) do
+    {
+      google_classroom_id: google_classroom_id,
+      name: name,
+      teacher_id: teacher_id
+    }
+  end
+
+  subject { described_class.new(data) }
+
+  let(:classroom) { subject.run }
+
+  let(:google_classroom_id) { 123456 }
+
+  context 'name present' do
+    let(:name) { 'google classroom name'}
+
+    it 'creates a new classroom object with synced_name attr initially set to name' do
+      expect(ClassroomsTeacher.count).to eq 0
+      expect(classroom.google_classroom_id).to eq google_classroom_id
+      expect(classroom.name).to eq name
+      expect(classroom.synced_name).to eq name
+      expect(classroom.classrooms_teachers.count).to eq 1
+    end
+  end
+
+  context 'blank name' do
+    let(:name) { nil }
+
+    it 'creates a new classroom object with synced_name attr initially set to name' do
+      expect(classroom.google_classroom_id).to eq google_classroom_id
+      expect(classroom.name).to eq "Classroom #{google_classroom_id}"
+      expect(classroom.synced_name).to eq nil
+    end
+  end
+
+  context "teacher owns another classroom with same name" do
+    let(:name) { 'google classroom name' }
+    let(:synced_name) { name }
+    let(:name_1) { name }
+    let(:classroom_1) { create(:classroom, :from_google, :with_no_teacher, name: name_1) }
+
+    before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_1) }
+
+    it 'creates a new classroom object with new name to avoid a naming collision' do
+      expect(classroom.name).to eq "#{name}_1"
+    end
+
+    context 'and another classroom as same name as a renamed collision' do
+      let(:name_2) { "#{name}_1"}
+      let(:classroom_2) { create(:classroom, :from_google, :with_no_teacher, name: name_2) }
+
+      before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_2) }
+
+      it 'creates a new classroom object with new name to avoid two naming collisions' do
+        expect(classroom.name).to eq "#{name}_1_1"
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/classroom_importer_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_importer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::ClassroomImporter do
+  let(:teacher) { create(:teacher) }
+
+  let(:data) do
+    {
+      google_classroom_id: google_classroom_id,
+      name: 'Google classroom',
+      teacher_id: teacher.id
+    }
+  end
+
+  subject { described_class.new(data) }
+
+  context 'classroom exists with google_classroom_id' do
+    let(:google_classroom_id) { 123456 }
+
+    before { create(:classroom, google_classroom_id: google_classroom_id, teacher_id: teacher.id) }
+
+    it 'runs classroom updater' do
+      expect { subject.run }.to_not change(Classroom, :count)
+    end
+  end
+
+  context 'classroom does not exist with google_classroom_id' do
+    let(:google_classroom_id) { 987654 }
+
+    it 'creates a new classroom' do
+      expect { subject.run }.to change(Classroom, :count).from(0).to(1)
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::ClassroomUpdater do
+  let(:google_classroom_id) { 123456 }
+  let(:teacher_id) { create(:teacher).id }
+
+  let!(:classroom) do
+    create(:classroom,
+      :with_no_teacher,
+      google_classroom_id: google_classroom_id,
+      name: name,
+      synced_name: synced_name,
+      teacher_id: teacher_id
+    )
+  end
+
+  let(:data) do
+    {
+      google_classroom_id: google_classroom_id,
+      name: data_name,
+      grade: '100',
+      teacher_id: teacher_id
+    }
+  end
+
+  before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom) }
+
+  subject { described_class.new(data) }
+
+  let(:updated_classroom) { subject.run }
+
+  context 'no custom classroom name' do
+    let(:name) { 'google_classroom classroom' }
+    let(:synced_name) { name }
+
+    context 'name on google_classroom has not changed' do
+      let(:data_name) { synced_name }
+
+      it 'no attributes are changed' do
+        expect(updated_classroom.name).to eq classroom.name
+        expect(updated_classroom.synced_name).to eq classroom.synced_name
+      end
+
+      it 'updates grade' do
+        expect(updated_classroom.grade).to_not eq classroom.grade
+      end
+    end
+
+    context 'name on google_classroom changed' do
+      let(:data_name) { 'Renamed on Quill' + synced_name }
+
+      it 'updates name and synced name with data_name' do
+        expect(updated_classroom.name).to eq data_name
+        expect(updated_classroom.synced_name).to eq data_name
+      end
+    end
+  end
+
+  context 'custom classroom name' do
+    let(:name) { 'Renamed on Quill' + synced_name }
+    let(:synced_name) { 'google_classroom Classroom' }
+
+    context 'name on google_classroom has not changed' do
+      let(:data_name) { synced_name }
+
+      it 'no attributes are changed' do
+        expect(updated_classroom.name).to eq classroom.name
+        expect(updated_classroom.synced_name).to eq classroom.synced_name
+      end
+    end
+
+    context 'name on google_classroom has changed' do
+      let(:data_name) { 'renamed on google_classroom ' + synced_name }
+
+      it 'updates synced name with data_name' do
+        expect(updated_classroom.name).to eq classroom.name
+        expect(updated_classroom.synced_name).to eq data_name
+      end
+    end
+  end
+
+  context "teacher owns another classroom with same name" do
+    let(:name_1) { 'other google_classroom classroom' }
+    let(:classroom_1) { create(:classroom, :from_google, :with_no_teacher, name: name_1) }
+
+    let(:name) { 'google_classroom classroom'}
+    let(:synced_name) { name }
+    let(:data_name) { name_1 }
+
+    before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_1) }
+
+    it 'creates a new classroom object with new name to avoid a naming collision' do
+      expect(updated_classroom.name).to eq "#{name_1}_1"
+    end
+
+    context 'and another classroom as same name as renamed collision' do
+      let(:name_2) { "#{name_1}_1"}
+      let(:classroom_2) { create(:classroom, :from_google, :with_no_teacher, name: name_2) }
+
+      before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom_2) }
+
+      it 'creates a new classroom object with new name to avoid two naming collisions' do
+        expect(updated_classroom.name).to eq "#{name_2}_1"
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/teacher_classroom_cache_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classroom_cache_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::TeacherClassroomsCache do
+  let(:user_id) { create(:user).id }
+  let(:data) { { "classrooms" => [] }.to_json }
+  let(:cache) { described_class }
+
+  context 'key is not cached' do
+    it 'returns OK message after caching' do
+      expect(cache.set(user_id, data)).to eq "OK"
+    end
+
+    it 'nothing will retrieved from cache' do
+      expect(cache.get(user_id)).to eq nil
+    end
+  end
+
+  context 'key is already cached' do
+    before { cache.set(user_id, data) }
+
+    it 'allows retrieval' do
+      expect(cache.get(user_id)).to eq data
+    end
+
+    it 'allows for expiration' do
+      cache.expire(user_id, 0.1)
+      sleep 0.1
+      expect(cache.get(user_id)).to eq nil
+    end
+
+    it 'deletes data' do
+      expect { cache.del(user_id) }.to change { cache.get(user_id) }.from(data).to(nil)
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/teacher_classroom_data_adapter_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classroom_data_adapter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::TeacherClassroomDataAdapter do
+  subject { described_class.new(user, data) }
+
+  let(:updated_data) { subject.run }
+  let(:user) { create(:user, role: role) }
+
+  context 'valid data' do
+    let(:google_classroom_id) { 32432423 }
+    let(:data) { { id: google_classroom_id } }
+
+    context 'teacher' do
+      let(:role) { 'teacher' }
+
+      it 'correctly updates data' do
+        expect(updated_data[:google_classroom_id]).to eq google_classroom_id
+        expect(updated_data[:teacher_id]).to eq user.id
+      end
+    end
+
+    context 'student' do
+      let(:role) { 'student' }
+
+      it 'correctly updates data' do
+        expect(updated_data[:google_classroom_id]).to eq google_classroom_id
+        expect(updated_data[:student_id]).to eq user.id
+      end
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/services/google_integration/teacher_classrooms_data_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classrooms_data_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::TeacherClassroomsData do
+  let(:teacher) { create(:teacher) }
+
+  subject { described_class.new(teacher, serialized_classrooms_data) }
+
+  context 'no classrooms' do
+    let(:serialized_classrooms_data) { { classrooms: [] }.to_json }
+
+    it 'has no elements' do
+      expect(subject.count).to eq 0
+    end
+  end
+
+  context 'two classrooms' do
+    let(:google_classroom_id_1) { 123 }
+    let(:google_classroom_id_2) { 456 }
+
+    let(:serialized_classrooms_data) do
+      {
+        classrooms: [
+          { id: google_classroom_id_1 },
+          { id: google_classroom_id_2 }
+        ]
+      }.to_json
+    end
+
+    let(:expected_classrooms_data) do
+      [
+        { id: google_classroom_id_1, google_classroom_id: google_classroom_id_1, teacher_id: teacher.id },
+        { id: google_classroom_id_2, google_classroom_id: google_classroom_id_2, teacher_id: teacher.id }
+      ]
+    end
+
+    it 'has two elements' do
+      subject.each_with_index { |classroom_data, index| expect(classroom_data).to eq expected_classrooms_data[index] }
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/teacher_classrooms_retriever_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classrooms_retriever_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe GoogleIntegration::TeacherClassroomsRetriever do
+  let(:user) { create(:user) }
+
+  subject { described_class.new(user.id) }
+
+  it 'should trigger a pusher notification when now errors are raised' do
+    expect(GoogleIntegration::Classroom::Main)
+      .to receive(:pull_data)
+      .with(user)
+      .and_return({})
+
+    expect(PusherTrigger).to receive(:run)
+    subject.run
+  end
+
+  it 'should rescue GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError in the Google integration' do
+    expect(GoogleIntegration::Classroom::Main)
+      .to receive(:pull_data)
+      .with(user)
+      .and_raise(GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError)
+
+    subject.run
+  end
+
+  it 'should rescue GoogleIntegration::Client::AccessTokenError in the Google integration' do
+    expect(GoogleIntegration::Classroom::Main)
+      .to receive(:pull_data)
+      .with(user)
+      .and_raise(GoogleIntegration::Client::AccessTokenError)
+
+    subject.run
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/teacher_imported_classrooms_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_imported_classrooms_updater_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe GoogleIntegration::TeacherImportedClassroomsUpdater do
+  let(:user_id) { create(:teacher).id }
+
+  let(:google_classroom_id_1) { 123 }
+  let(:google_classroom_id_2) { 345 }
+
+  let!(:imported_classroom) { create(:classroom, google_classroom_id: google_classroom_id_1, teacher_id: user_id) }
+  let(:name) { 'new_' + imported_classroom.name}
+
+  let(:data) do
+    {
+      classrooms: [
+        { id: google_classroom_id_1, name: name },
+        { id: google_classroom_id_2 }
+      ]
+    }.to_json
+  end
+
+  let(:subject) { described_class.new(user_id) }
+
+  it 'updates only previously imported classrooms that have google_classroom_id' do
+    expect(GoogleIntegration::TeacherClassroomsCache)
+      .to receive(:get)
+      .with(user_id)
+      .and_return(data)
+
+    subject.run
+
+    expect(Classroom.count).to eq 1
+    expect(imported_classroom.reload.synced_name).to eq name
+  end
+end

--- a/services/QuillLMS/spec/workers/google_integration/update_teacher_imported_classrooms_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/google_integration/update_teacher_imported_classrooms_worker_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe GoogleIntegration::UpdateTeacherImportedClassroomsWorker do
+  let(:worker) { described_class.new }
+
+  let(:retriever_class) { GoogleIntegration::TeacherClassroomsRetriever}
+  let(:updater_class) { GoogleIntegration::TeacherImportedClassroomsUpdater }
+
+  subject { worker.perform(user_id) }
+
+  context 'nil user_id' do
+    let(:user_id) { nil }
+
+    it { should_not_call_service_objects }
+  end
+
+  context 'user does not exist' do
+    let(:user_id) { 0 }
+
+    it { should_not_call_service_objects }
+  end
+
+  context 'user exists' do
+    context 'that does not have google_id' do
+      let(:user_id) { create(:teacher).id }
+
+      it { should_not_call_service_objects }
+    end
+
+    context 'that has google_id' do
+      let(:updater) { instance_double(updater_class, run: nil) }
+      let(:retriever) { instance_double(retriever_class, run: nil) }
+
+      let(:user_id) { create(:teacher, google_id: 123).id }
+
+      it { should_call_service_objects }
+    end
+  end
+
+  def should_not_call_service_objects
+    expect(retriever_class).to_not receive(:new)
+    expect(updater_class).to_not receive(:new)
+    subject
+  end
+
+  def should_call_service_objects
+    expect(retriever_class).to receive(:new).with(user_id).and_return(retriever)
+    expect(updater_class).to receive(:new).with(user_id).and_return(updater)
+    subject
+  end
+end


### PR DESCRIPTION
## WHAT
1.  Flatten out the namespaces `GoogleIntegration::Classrooms` and `GoogleIntegration::Users`.  
2.  Change compact style module-class declarations for some of the GoogleIntegration classes to the nested form.

Per @dandrabik [insight](https://github.com/empirical-org/Empirical-Core/pull/8218#pullrequestreview-750576772), I'm breaking this up into two parts

## WHY
1.  I recently created a couple namespaces `GoogleIntegration::Classrooms` and `GoogleIntegration::Users`.  However, after getting deeper into the code, there was sometimes a use for `classrooms_[object]` and `classroom_[object]`.  Removing this extra layer of hierarchy allows for precise, unambiguous naming of classes.

2.  As far as the nested class declaration, it's better to have nested reasons due to constant resolution. For example, see this [post](https://github.com/rubocop/ruby-style-guide#namespace-definition)

## HOW
1.  Rename classes with appropriate prefix (e.g. Classroom, Classrooms, Teacher) and move respective tests and references.
2. Wrap classes in `module GoogleIntegration`

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-and-Clever-Refactor-google-integration-namespace-6dc6ecc026954b7f880445bb7916ca57

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet, deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
