### PR TITLE
rake task should select ids, not whole users

### DIFF
--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -24,8 +24,11 @@ namespace :app_settings do
     emails = CSV.parse(iostream, headers: true).map { |row| row['email'] }
     user_ids = emails.map do |email|
       user = User.find_by_email(email)
-      puts "User with email #{email} not found" unless user 
-      user
+      if !user 
+        puts "User with email #{email} not found"
+        next
+      end
+      user.id
     end.compact
 
     app_setting = AppSetting.find_by_name!(args[:name])


### PR DESCRIPTION
## WHAT
Fixes bug where script generated a list of users rather than user ids.

## WHY
The AppSetting expects ids, not users.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no; rake task
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | n/a
