### PR TITLE
assigning previously archived recommendations

### DIFF
--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -48,8 +48,8 @@ class AssignRecommendationsWorker
   end
 
   def show_classroom_units(unit_id, classroom_id)
-    ClassroomUnit.unscoped.where(unit_id: unit_id, classroom_id: classroom_id).each do |classroom_unit|
-      classroom_unit.update(visible: true)
+    ClassroomUnit.unscoped.where(unit_id: unit_id, classroom_id: classroom_id, visible: false).each do |classroom_unit|
+      classroom_unit.update(visible: true, assigned_student_ids: [])
     end
   end
 


### PR DESCRIPTION
## WHAT
Wipe the array of `assigned_student_ids` when unarchiving an archived classroom unit in order to assign a recommendation.

## WHY
We've been having an issue with teachers assigning recommendations, then deleting the pack, and then reassigning them to only some of the students, where all the students that had previously been assigned end up getting reassigned. This is because the recommendations assignment code is written to always be additive. However, if a classroom unit has previously been archived, I think we can assume the old assignments should not persist and use an empty array.

## HOW
Scope this function to archived classroom units and update the array while we're there.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-recommendations-assigning-extra-students-who-were-not-checked-activities-a3a7b4c2a0084efd920230ccc39abe72
Older example of the same issue: https://www.notion.so/quill/Diagnostic-recommendations-assigned-to-all-students-when-only-a-couple-of-students-are-checked-to-re-f45ea27903fa4a82abe98b11d78a8e3e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
