### PR TITLE
make sure segment event still fires for completed activity sessions

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -547,11 +547,9 @@ class ActivitySession < ApplicationRecord
   end
 
   private def trigger_events
-    should_async = saved_change_to_state?
-
     yield # http://stackoverflow.com/questions/4998553/rails-around-callbacks
 
-    return unless should_async
+    return unless saved_change_to_state?
 
     if state == 'finished'
       FinishActivityWorker.perform_async(uid)


### PR DESCRIPTION
## WHAT
Remove check for whether or not activity state has saved from before it's supposed to save. 

## WHY
This is causing the logic below to never run, when we want it to. Prior to yesterday, this was just checking to see if `state` had changed, which is why it used to work but no longer does.

## HOW
Just put all the checks after the `yield` function.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Segment-Event-may-not-be-Loading-Student-Completed-an-Activity-6df4d247b0fe410fb2fcac7519d1693f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
