### PR TITLE
Csp2

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -42,6 +42,10 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateHashKey:
   Enabled: true
 
+Lint/PercentStringArray:
+  Exclude:
+    - "QuillLMS/config/initializers/secure_headers.rb"
+
 Lint/InterpolationCheck:
   Enabled: true
 

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -69,7 +69,7 @@ gem 'intercom', '~> 3.5.23'
 gem 'haversine'
 gem 'configs'
 gem 'rack-test', '~> 0.6.3'
-gem 'secure_headers', '5.2.0'
+gem 'secure_headers', '6.3.2'
 
 # Engines
 gem 'comprehension', path: 'engines/comprehension'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -659,8 +659,7 @@ GEM
       sprockets-rails
       tilt
     scout_apm (2.4.21)
-    secure_headers (5.2.0)
-      useragent (>= 0.15.0)
+    secure_headers (6.3.2)
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.142.7)
@@ -757,7 +756,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode_utils (1.4.0)
     uniform_notifier (1.12.1)
-    useragent (0.16.10)
     validates_email_format_of (1.6.3)
       i18n
     vcr (4.0.0)
@@ -892,7 +890,7 @@ DEPENDENCIES
   sass-rails
   sassc-rails (>= 2.1.0)
   scout_apm
-  secure_headers (= 5.2.0)
+  secure_headers (= 6.3.2)
   select2-rails
   selenium-webdriver
   sentry-raven (>= 0.12.2)

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
 
     script_src: [
-      "'self'", 
+      "https://*.quill.org",  
       "'unsafe-inline'",
       "'unsafe-eval'",                                            # allows use of eval()
       "https://*.clever.com",
@@ -47,7 +47,7 @@ SecureHeaders::Configuration.default do |config|
     base_uri: %w('self'),                                         # used for relative URLs
 
     style_src: [
-      "'self'",
+      "https://*.quill.org",  
       "'unsafe-inline'",
       "https://*.fontawesome.com",
       "https://*.googleapis.com",

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,6 +1,78 @@
 SecureHeaders::Configuration.default do |config|
-  config.csp = SecureHeaders::OPT_OUT
-  config.x_frame_options = SecureHeaders::OPT_OUT
+  config.csp = {
+    default_src: [
+      "'self'", 
+      "https://*.quill.org",
+      "'unsafe-inline'"                                           # TODO: remove once nonce strategy is in place
+    ],                                                            # fallback for more specific directives
+
+    object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
+
+    script_src: [
+      "'self'", 
+      "'unsafe-inline'",
+      "'unsafe-eval'",                                            # allows use of eval()
+      "https://*.clever.com",
+      "https://*.fontawesome.com",
+      "http://*.typekit.net",
+      "https://*.segment.com",
+      "https://*.segment.io",
+      "https://*.newrelic.com",
+      "https://*.nr-data.net",
+      "https://*.googleapis.com",
+      "https://*.gstatic.com",
+      "https://*.pusher.com",
+      "https://*.google-analytics.com",
+      "https://*.inspectlet.com",
+      "https://*.satismeter.com",
+      "https://*.stripe.com",
+      "https://*.amplitude.com",
+      "https://*.doubleclick.net",
+      "https://*.intercom.io",
+      "https://*.intercomcdn.com",
+      "https://*.coview.com",
+      "https://*.sentry.io"
+    ],                                                            
+
+    font_src: [
+      "'self'",
+      "https://*.typekit.net",
+      "https://*.fontawesome.com",
+      "https://*.gstatic.com"
+
+    ], 
+
+    img_src: %w('self' https://*.quill.org https://*.typekit.net),
+
+    base_uri: %w('self'),                                         # used for relative URLs
+
+    style_src: [
+      "'self'",
+      "'unsafe-inline'",
+      "https://*.fontawesome.com",
+      "https://*.googleapis.com",
+      "https://*.gstatic.com"      
+    ],
+
+    connect_src: [                                                # for XHR, etc
+      "'self'",  
+      "https://*.quill.org",
+      "https://*.segment.com",
+      "https://*.segment.io",
+      "https://*.nr-data.net",
+      "https://*.google-analytics.com",
+      "https://*.google.com",
+      "https://*.inspectlet.com",
+      "https://*.doubleclick.net",
+      "https://*.pusherapp.com",
+      "https://*.pusher.com",
+      "wss://*.pusherapp.com",
+      "https://*.intercom.io",
+      "https://*.coview.com",
+      "https://*.sentry.io"
+    ]
+  }
+
   config.cookies = {
     secure: true, 
     httponly: true, 

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -42,7 +42,7 @@ SecureHeaders::Configuration.default do |config|
 
     ], 
 
-    img_src: %w('self' https://*.quill.org https://*.typekit.net),
+    img_src: %w(https://*.quill.org https://*.typekit.net),
 
     base_uri: %w('self'),                                         # used for relative URLs
 


### PR DESCRIPTION
WHAT
Adds a Content-Security-Policy header to LMS requests, a way of mitigating XSS vulnerabilities.

This PR reverts the revert, then adds 3 lines of changes in additional commits. 

WHY
This is the suggested remediation to a medium severity security concern raised by CB.

HOW
Configured via the secure_headers initializer.

See original reverted PR for more info: https://github.com/empirical-org/Empirical-Core/pull/8064

## Known requests checklist
- [x] Intercom (support chat window)
- [x] Coview (Intercom plugin to share browser info)
- [x] Sentry (frontend error reporting)
- [x] Clever Login (third-party login)
- [x] Google Login (third-party login - may already be covered in the google urls)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes, manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
