### PR TITLE
fix onboarding checklist icon

### DIFF
--- a/packages/quill-cdn/assets/images/pages/dashboard/icons-check-big.svg
+++ b/packages/quill-cdn/assets/images/pages/dashboard/icons-check-big.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h32v32H0z"/>
+        <path d="M16 0C7.168 0 0 7.168 0 16s7.168 16 16 16 16-7.168 16-16S24.832 0 16 0zm-3.2 24-8-8 2.256-2.256 5.744 5.728L24.944 7.328 27.2 9.6 12.8 24z" fill="#06806B" fill-rule="nonzero"/>
+    </g>
+</svg>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/onboarding_checklist.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/onboarding_checklist.test.jsx.snap
@@ -55,7 +55,7 @@ exports[`OnboardingChecklist component should render 1`] = `
             <img
               alt="Green check icon"
               className="big-check checked"
-              src="undefined/images/icons/icons-check-big.svg"
+              src="undefined/images/pages/dashboard/icons-check-big.svg"
             />
             <span>
               Be inspired by a teacher growing up, and become one yourself
@@ -75,7 +75,7 @@ exports[`OnboardingChecklist component should render 1`] = `
             <img
               alt="Green check icon"
               className="big-check checked"
-              src="undefined/images/icons/icons-check-big.svg"
+              src="undefined/images/pages/dashboard/icons-check-big.svg"
             />
             <span>
               Create a class
@@ -113,7 +113,7 @@ exports[`OnboardingChecklist component should render 1`] = `
             <img
               alt="Green check icon"
               className="big-check checked"
-              src="undefined/images/icons/icons-check-big.svg"
+              src="undefined/images/pages/dashboard/icons-check-big.svg"
             />
             <span>
               Explore our library
@@ -133,7 +133,7 @@ exports[`OnboardingChecklist component should render 1`] = `
             <img
               alt="Green check icon"
               className="big-check checked"
-              src="undefined/images/icons/icons-check-big.svg"
+              src="undefined/images/pages/dashboard/icons-check-big.svg"
             />
             <span>
               Explore our diagnostics

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/onboarding_checklist.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/onboarding_checklist.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 
-import { bigCheckIcon, } from '../../../Shared/index'
-
 const personWithChecklistSrc = `${process.env.CDN_URL}/images/pages/dashboard/person-with-checklist.svg`
+const bigCheckIconSrc = `${process.env.CDN_URL}/images/pages/dashboard/icons-check-big.svg`
+
+const bigCheckIcon = {
+  src: bigCheckIconSrc,
+  alt: 'Green check icon'
+}
 
 interface OnboardingChecklistItemInterface {
   checked: boolean;


### PR DESCRIPTION
## WHAT
Two different icons had the same name, so the one overwrote the other when added to the CDN. This puts the original one back in, namespaced to the specific page. Sidenote, this makes me feel like we should have a more consistent system for icon naming and/or organization.

## WHY
We want this page to use the right icon.

## HOW
Just add the correct icon back and update the linking.

### Screenshots
<img width="987" alt="Screen Shot 2021-09-10 at 11 26 34 AM" src="https://user-images.githubusercontent.com/18669014/132885622-9203c9bc-2e67-4118-8856-b52bdd0f5141.png">


### Notion Card Links
https://www.notion.so/quill/Fix-icon-for-teacher-onboarding-a3f1bd7b30434d0eb5a93b42a30df273

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
