### PR TITLE
lms/update-migrations

### DIFF
--- a/services/QuillLMS/db/migrate/20121024193845_create_users.rb
+++ b/services/QuillLMS/db/migrate/20121024193845_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users, force: true do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20130309011601_create_cms.rb
+++ b/services/QuillLMS/db/migrate/20130309011601_create_cms.rb
@@ -1,4 +1,4 @@
-class CreateCms < ActiveRecord::Migration
+class CreateCms < ActiveRecord::Migration[4.2]
   def change
     create_table :file_uploads do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20130319203258_add_practice_lesson_to_grammar_rules.rb
+++ b/services/QuillLMS/db/migrate/20130319203258_add_practice_lesson_to_grammar_rules.rb
@@ -1,4 +1,4 @@
-class AddPracticeLessonToGrammarRules < ActiveRecord::Migration
+class AddPracticeLessonToGrammarRules < ActiveRecord::Migration[4.2]
   def change
     add_column :grammar_rules, :practice_lesson, :text
   end

--- a/services/QuillLMS/db/migrate/20130319203518_add_author_id_to_grammar_rules.rb
+++ b/services/QuillLMS/db/migrate/20130319203518_add_author_id_to_grammar_rules.rb
@@ -1,4 +1,4 @@
-class AddAuthorIdToGrammarRules < ActiveRecord::Migration
+class AddAuthorIdToGrammarRules < ActiveRecord::Migration[4.2]
   def change
     add_column :grammar_rules, :author_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20130423074028_create_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130423074028_create_chapters.rb
@@ -1,4 +1,4 @@
-class CreateChapters < ActiveRecord::Migration
+class CreateChapters < ActiveRecord::Migration[4.2]
   def change
     create_table :chapters do |t|
       t.string :title

--- a/services/QuillLMS/db/migrate/20130423090252_create_assessments.rb
+++ b/services/QuillLMS/db/migrate/20130423090252_create_assessments.rb
@@ -1,4 +1,4 @@
-class CreateAssessments < ActiveRecord::Migration
+class CreateAssessments < ActiveRecord::Migration[4.2]
   def change
     create_table :assessments do |t|
       t.text :title

--- a/services/QuillLMS/db/migrate/20130423090823_create_lessons.rb
+++ b/services/QuillLMS/db/migrate/20130423090823_create_lessons.rb
@@ -1,4 +1,4 @@
-class CreateLessons < ActiveRecord::Migration
+class CreateLessons < ActiveRecord::Migration[4.2]
   def change
     create_table :lessons do |t|
       t.integer :order

--- a/services/QuillLMS/db/migrate/20130423095121_create_workbooks.rb
+++ b/services/QuillLMS/db/migrate/20130423095121_create_workbooks.rb
@@ -1,4 +1,4 @@
-class CreateWorkbooks < ActiveRecord::Migration
+class CreateWorkbooks < ActiveRecord::Migration[4.2]
   def change
     create_table :workbooks do |t|
       t.string :title

--- a/services/QuillLMS/db/migrate/20130423095359_add_workbook_to_chapter.rb
+++ b/services/QuillLMS/db/migrate/20130423095359_add_workbook_to_chapter.rb
@@ -1,4 +1,4 @@
-class AddWorkbookToChapter < ActiveRecord::Migration
+class AddWorkbookToChapter < ActiveRecord::Migration[4.2]
   def change
     add_column :chapters, :workbook_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20130423100133_add_classcode_to_user.rb
+++ b/services/QuillLMS/db/migrate/20130423100133_add_classcode_to_user.rb
@@ -1,4 +1,4 @@
-class AddClasscodeToUser < ActiveRecord::Migration
+class AddClasscodeToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :classcode, :integer
   end

--- a/services/QuillLMS/db/migrate/20130423110858_create_rules.rb
+++ b/services/QuillLMS/db/migrate/20130423110858_create_rules.rb
@@ -1,4 +1,4 @@
-class CreateRules < ActiveRecord::Migration
+class CreateRules < ActiveRecord::Migration[4.2]
   def change
     create_table :rules do |t|
       t.integer :order

--- a/services/QuillLMS/db/migrate/20130423110945_add_ruleid_to_lesson.rb
+++ b/services/QuillLMS/db/migrate/20130423110945_add_ruleid_to_lesson.rb
@@ -1,4 +1,4 @@
-class AddRuleidToLesson < ActiveRecord::Migration
+class AddRuleidToLesson < ActiveRecord::Migration[4.2]
   def change
     add_column :lessons, :rule_id, :integer
     remove_column :lessons, :rule

--- a/services/QuillLMS/db/migrate/20130426032817_create_assignments.rb
+++ b/services/QuillLMS/db/migrate/20130426032817_create_assignments.rb
@@ -1,4 +1,4 @@
-class CreateAssignments < ActiveRecord::Migration
+class CreateAssignments < ActiveRecord::Migration[4.2]
   def change
     create_table :assignments do |t|
       t.integer :user_id

--- a/services/QuillLMS/db/migrate/20130426032952_create_scores.rb
+++ b/services/QuillLMS/db/migrate/20130426032952_create_scores.rb
@@ -1,4 +1,4 @@
-class CreateScores < ActiveRecord::Migration
+class CreateScores < ActiveRecord::Migration[4.2]
   def change
     create_table :scores do |t|
       t.integer :user_id

--- a/services/QuillLMS/db/migrate/20130429171512_add_emailactivation_to_user.rb
+++ b/services/QuillLMS/db/migrate/20130429171512_add_emailactivation_to_user.rb
@@ -1,4 +1,4 @@
-class AddEmailactivationToUser < ActiveRecord::Migration
+class AddEmailactivationToUser < ActiveRecord::Migration[4.2]
   def change
   	add_column :users, :email_activation_token, :string
   	add_column :users, :active, :boolean, default: false

--- a/services/QuillLMS/db/migrate/20130517024024_fix_rules_model.rb
+++ b/services/QuillLMS/db/migrate/20130517024024_fix_rules_model.rb
@@ -1,4 +1,4 @@
-class FixRulesModel < ActiveRecord::Migration
+class FixRulesModel < ActiveRecord::Migration[4.2]
   def change
   	add_column :rules, :category_id, :integer
   	add_column :rules, :workbook_id, :integer, default: 1

--- a/services/QuillLMS/db/migrate/20130517024604_remove_description_from_chapter.rb
+++ b/services/QuillLMS/db/migrate/20130517024604_remove_description_from_chapter.rb
@@ -1,4 +1,4 @@
-class RemoveDescriptionFromChapter < ActiveRecord::Migration
+class RemoveDescriptionFromChapter < ActiveRecord::Migration[4.2]
   def up
   	remove_column :chapters, :description
   end

--- a/services/QuillLMS/db/migrate/20130517024731_remove_title_from_assessment.rb
+++ b/services/QuillLMS/db/migrate/20130517024731_remove_title_from_assessment.rb
@@ -1,4 +1,4 @@
-class RemoveTitleFromAssessment < ActiveRecord::Migration
+class RemoveTitleFromAssessment < ActiveRecord::Migration[4.2]
   def up
   	remove_column :assessments, :title
   end

--- a/services/QuillLMS/db/migrate/20130517024855_remove_order_chapter_id_from_lesson.rb
+++ b/services/QuillLMS/db/migrate/20130517024855_remove_order_chapter_id_from_lesson.rb
@@ -1,4 +1,4 @@
-class RemoveOrderChapterIdFromLesson < ActiveRecord::Migration
+class RemoveOrderChapterIdFromLesson < ActiveRecord::Migration[4.2]
   def up
   	remove_column :lessons, :order
   	remove_column :lessons, :chapter_id

--- a/services/QuillLMS/db/migrate/20130517025139_create_categories.rb
+++ b/services/QuillLMS/db/migrate/20130517025139_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration
+class CreateCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :categories do |t|
       t.text :title

--- a/services/QuillLMS/db/migrate/20130522193452_add_prompt_to_lessons.rb
+++ b/services/QuillLMS/db/migrate/20130522193452_add_prompt_to_lessons.rb
@@ -1,4 +1,4 @@
-class AddPromptToLessons < ActiveRecord::Migration
+class AddPromptToLessons < ActiveRecord::Migration[4.2]
   def up
   	add_column :lessons, :prompt, :text
   end

--- a/services/QuillLMS/db/migrate/20130522193814_add_description_to_rules.rb
+++ b/services/QuillLMS/db/migrate/20130522193814_add_description_to_rules.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToRules < ActiveRecord::Migration
+class AddDescriptionToRules < ActiveRecord::Migration[4.2]
   def up
   	add_column :rules, :description, :text
   end

--- a/services/QuillLMS/db/migrate/20130609214734_add_pseudotitle_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130609214734_add_pseudotitle_to_chapters.rb
@@ -1,4 +1,4 @@
-class AddPseudotitleToChapters < ActiveRecord::Migration
+class AddPseudotitleToChapters < ActiveRecord::Migration[4.2]
   def up
   	add_column :chapters, :description, :text
   end

--- a/services/QuillLMS/db/migrate/20130716160138_add_rule_position_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130716160138_add_rule_position_to_chapters.rb
@@ -1,4 +1,4 @@
-class AddRulePositionToChapters < ActiveRecord::Migration
+class AddRulePositionToChapters < ActiveRecord::Migration[4.2]
   def change
     add_column :chapters, :rule_position, :text
   end

--- a/services/QuillLMS/db/migrate/20130727182529_change_class_code_to_string.rb
+++ b/services/QuillLMS/db/migrate/20130727182529_change_class_code_to_string.rb
@@ -1,4 +1,4 @@
-class ChangeClassCodeToString < ActiveRecord::Migration
+class ChangeClassCodeToString < ActiveRecord::Migration[4.2]
   def up
     change_column :users,       :classcode, :string
     change_column :assignments, :classcode, :string

--- a/services/QuillLMS/db/migrate/20130728210228_add_lesson_input_to_scores.rb
+++ b/services/QuillLMS/db/migrate/20130728210228_add_lesson_input_to_scores.rb
@@ -1,4 +1,4 @@
-class AddLessonInputToScores < ActiveRecord::Migration
+class AddLessonInputToScores < ActiveRecord::Migration[4.2]
   def change
     add_column :scores, :practice_lesson_input, :text
     add_column :scores, :review_lesson_input, :text

--- a/services/QuillLMS/db/migrate/20130729011951_add_missed_rules_to_scores.rb
+++ b/services/QuillLMS/db/migrate/20130729011951_add_missed_rules_to_scores.rb
@@ -1,4 +1,4 @@
-class AddMissedRulesToScores < ActiveRecord::Migration
+class AddMissedRulesToScores < ActiveRecord::Migration[4.2]
   def change
     add_column :scores, :missed_rules, :text
   end

--- a/services/QuillLMS/db/migrate/20130729023130_add_score_values_to_scores.rb
+++ b/services/QuillLMS/db/migrate/20130729023130_add_score_values_to_scores.rb
@@ -1,4 +1,4 @@
-class AddScoreValuesToScores < ActiveRecord::Migration
+class AddScoreValuesToScores < ActiveRecord::Migration[4.2]
   def change
     add_column :scores, :score_values, :text
   end

--- a/services/QuillLMS/db/migrate/20130801130431_add_temporary_to_assignments.rb
+++ b/services/QuillLMS/db/migrate/20130801130431_add_temporary_to_assignments.rb
@@ -1,4 +1,4 @@
-class AddTemporaryToAssignments < ActiveRecord::Migration
+class AddTemporaryToAssignments < ActiveRecord::Migration[4.2]
   def change
     add_column :assignments, :temporary, :boolean, null: false, default: false
   end

--- a/services/QuillLMS/db/migrate/20130809042058_create_homepage_news_slides.rb
+++ b/services/QuillLMS/db/migrate/20130809042058_create_homepage_news_slides.rb
@@ -1,4 +1,4 @@
-class CreateHomepageNewsSlides < ActiveRecord::Migration
+class CreateHomepageNewsSlides < ActiveRecord::Migration[4.2]
   def change
     create_table :homepage_news_slides do |t|
       t.string :link

--- a/services/QuillLMS/db/migrate/20130826165736_create_rule_question_inputs.rb
+++ b/services/QuillLMS/db/migrate/20130826165736_create_rule_question_inputs.rb
@@ -1,4 +1,4 @@
-class CreateRuleQuestionInputs < ActiveRecord::Migration
+class CreateRuleQuestionInputs < ActiveRecord::Migration[4.2]
   def change
     create_table :rule_question_inputs do |t|
       t.string :step

--- a/services/QuillLMS/db/migrate/20130826165806_rename_lessons_to_rule_questions.rb
+++ b/services/QuillLMS/db/migrate/20130826165806_rename_lessons_to_rule_questions.rb
@@ -1,4 +1,4 @@
-class RenameLessonsToRuleQuestions < ActiveRecord::Migration
+class RenameLessonsToRuleQuestions < ActiveRecord::Migration[4.2]
   def change
     rename_table 'lessons', 'rule_questions'
   end

--- a/services/QuillLMS/db/migrate/20130826180321_add_state_to_score.rb
+++ b/services/QuillLMS/db/migrate/20130826180321_add_state_to_score.rb
@@ -1,4 +1,4 @@
-class AddStateToScore < ActiveRecord::Migration
+class AddStateToScore < ActiveRecord::Migration[4.2]
   def change
     add_column :scores, :state, :string, null: false, default: 'unstarted'
   end

--- a/services/QuillLMS/db/migrate/20130827053114_add_hint_to_rule_questions.rb
+++ b/services/QuillLMS/db/migrate/20130827053114_add_hint_to_rule_questions.rb
@@ -1,4 +1,4 @@
-class AddHintToRuleQuestions < ActiveRecord::Migration
+class AddHintToRuleQuestions < ActiveRecord::Migration[4.2]
   def change
     add_column :rule_questions, :instructions, :text
     add_column :rule_questions, :hint, :text

--- a/services/QuillLMS/db/migrate/20130827054952_create_rule_examples.rb
+++ b/services/QuillLMS/db/migrate/20130827054952_create_rule_examples.rb
@@ -1,4 +1,4 @@
-class CreateRuleExamples < ActiveRecord::Migration
+class CreateRuleExamples < ActiveRecord::Migration[4.2]
   def change
     create_table :rule_examples do |t|
       t.text :title

--- a/services/QuillLMS/db/migrate/20130827071255_add_article_header_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130827071255_add_article_header_to_chapters.rb
@@ -1,4 +1,4 @@
-class AddArticleHeaderToChapters < ActiveRecord::Migration
+class AddArticleHeaderToChapters < ActiveRecord::Migration[4.2]
   def change
     rename_column :chapters, :description, :article_header
     add_column :chapters, :description, :text

--- a/services/QuillLMS/db/migrate/20130913182245_add_classification_to_rules.rb
+++ b/services/QuillLMS/db/migrate/20130913182245_add_classification_to_rules.rb
@@ -1,4 +1,4 @@
-class AddClassificationToRules < ActiveRecord::Migration
+class AddClassificationToRules < ActiveRecord::Migration[4.2]
   def change
     add_column :rules, :classification, :string
   end

--- a/services/QuillLMS/db/migrate/20130915033138_add_instructions_to_assessments.rb
+++ b/services/QuillLMS/db/migrate/20130915033138_add_instructions_to_assessments.rb
@@ -1,4 +1,4 @@
-class AddInstructionsToAssessments < ActiveRecord::Migration
+class AddInstructionsToAssessments < ActiveRecord::Migration[4.2]
   def change
     add_column :assessments, :instructions, :text
   end

--- a/services/QuillLMS/db/migrate/20130921210529_create_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20130921210529_create_classrooms.rb
@@ -1,4 +1,4 @@
-class CreateClassrooms < ActiveRecord::Migration
+class CreateClassrooms < ActiveRecord::Migration[4.2]
   def change
     create_table :classrooms do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20130921211036_add_classroom_id_to_assignments.rb
+++ b/services/QuillLMS/db/migrate/20130921211036_add_classroom_id_to_assignments.rb
@@ -1,4 +1,4 @@
-class AddClassroomIdToAssignments < ActiveRecord::Migration
+class AddClassroomIdToAssignments < ActiveRecord::Migration[4.2]
   def change
     add_column :assignments, :classroom_id, :integer
     remove_column :assignments, :user_id, :integer

--- a/services/QuillLMS/db/migrate/20130922005149_add_practice_description_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130922005149_add_practice_description_to_chapters.rb
@@ -1,4 +1,4 @@
-class AddPracticeDescriptionToChapters < ActiveRecord::Migration
+class AddPracticeDescriptionToChapters < ActiveRecord::Migration[4.2]
   def change
     add_column :chapters, :practice_description, :text
   end

--- a/services/QuillLMS/db/migrate/20130923025722_add_username_to_users.rb
+++ b/services/QuillLMS/db/migrate/20130923025722_add_username_to_users.rb
@@ -1,4 +1,4 @@
-class AddUsernameToUsers < ActiveRecord::Migration
+class AddUsernameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :username, :string
   end

--- a/services/QuillLMS/db/migrate/20130926203005_add_story_input_to_stories.rb
+++ b/services/QuillLMS/db/migrate/20130926203005_add_story_input_to_stories.rb
@@ -1,4 +1,4 @@
-class AddStoryInputToStories < ActiveRecord::Migration
+class AddStoryInputToStories < ActiveRecord::Migration[4.2]
   def change
     add_column    :scores, :story_step_input, :text
     rename_column :scores, :practice_lesson_input, :practice_step_input

--- a/services/QuillLMS/db/migrate/20131103061012_remove_columns_from_users.rb
+++ b/services/QuillLMS/db/migrate/20131103061012_remove_columns_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveColumnsFromUsers < ActiveRecord::Migration
+class RemoveColumnsFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :email_activation_token, :string
     remove_column :users, :confirmable_set_at, :datetime

--- a/services/QuillLMS/db/migrate/20131103061122_add_token_to_users.rb
+++ b/services/QuillLMS/db/migrate/20131103061122_add_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddTokenToUsers < ActiveRecord::Migration
+class AddTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :token, :string
   end

--- a/services/QuillLMS/db/migrate/20131110002323_add_grade_to_score.rb
+++ b/services/QuillLMS/db/migrate/20131110002323_add_grade_to_score.rb
@@ -1,4 +1,4 @@
-class AddGradeToScore < ActiveRecord::Migration
+class AddGradeToScore < ActiveRecord::Migration[4.2]
   def change
     add_column :scores, :grade, :float
   end

--- a/services/QuillLMS/db/migrate/20131110025356_create_chapter_levels.rb
+++ b/services/QuillLMS/db/migrate/20131110025356_create_chapter_levels.rb
@@ -1,4 +1,4 @@
-class CreateChapterLevels < ActiveRecord::Migration
+class CreateChapterLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :chapter_levels do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20131110031852_add_chapter_level_id_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20131110031852_add_chapter_level_id_to_chapters.rb
@@ -1,4 +1,4 @@
-class AddChapterLevelIdToChapters < ActiveRecord::Migration
+class AddChapterLevelIdToChapters < ActiveRecord::Migration[4.2]
   def change
     add_reference :chapters, :chapter_level, index: true
   end

--- a/services/QuillLMS/db/migrate/20140114233646_add_hstore.rb
+++ b/services/QuillLMS/db/migrate/20140114233646_add_hstore.rb
@@ -1,4 +1,4 @@
-class AddHstore < ActiveRecord::Migration
+class AddHstore < ActiveRecord::Migration[4.2]
   def up
     execute 'CREATE EXTENSION IF NOT EXISTS hstore'
   end

--- a/services/QuillLMS/db/migrate/20140114233647_migrate_to_new_formats.rb
+++ b/services/QuillLMS/db/migrate/20140114233647_migrate_to_new_formats.rb
@@ -1,4 +1,4 @@
-class MigrateToNewFormats < ActiveRecord::Migration
+class MigrateToNewFormats < ActiveRecord::Migration[4.2]
   def change
     create_table :activity_classifications, force: true do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20140119010550_restore_chapter_levels.rb
+++ b/services/QuillLMS/db/migrate/20140119010550_restore_chapter_levels.rb
@@ -1,4 +1,4 @@
-class RestoreChapterLevels < ActiveRecord::Migration
+class RestoreChapterLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :chapter_levels, force: true do |t|
       t.string   :name

--- a/services/QuillLMS/db/migrate/20140202153308_create_doorkeeper_tables.rb
+++ b/services/QuillLMS/db/migrate/20140202153308_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     execute 'DROP TABLE IF EXISTS oauth_applications'
     execute 'DROP TABLE IF EXISTS oauth_access_grants'

--- a/services/QuillLMS/db/migrate/20140203013343_add_assigned_students_to_classroom_activity.rb
+++ b/services/QuillLMS/db/migrate/20140203013343_add_assigned_students_to_classroom_activity.rb
@@ -1,4 +1,4 @@
-class AddAssignedStudentsToClassroomActivity < ActiveRecord::Migration
+class AddAssignedStudentsToClassroomActivity < ActiveRecord::Migration[4.2]
   def change
     change_table :classroom_activities do |t|
       t.integer :assigned_student_ids, array: true

--- a/services/QuillLMS/db/migrate/20140204201027_rename_sections_sequence.rb
+++ b/services/QuillLMS/db/migrate/20140204201027_rename_sections_sequence.rb
@@ -1,4 +1,4 @@
-class RenameSectionsSequence < ActiveRecord::Migration
+class RenameSectionsSequence < ActiveRecord::Migration[4.2]
   def up
     # execute 'DROP SEQUENCE IF EXISTS sections_id_seq'
     # execute 'ALTER SEQUENCE chapter_levels_id_seq RENAME TO sections_id_seq'

--- a/services/QuillLMS/db/migrate/20140224024344_create_activity_time_entries.rb
+++ b/services/QuillLMS/db/migrate/20140224024344_create_activity_time_entries.rb
@@ -1,4 +1,4 @@
-class CreateActivityTimeEntries < ActiveRecord::Migration
+class CreateActivityTimeEntries < ActiveRecord::Migration[4.2]
   def change
     execute 'DROP TABLE IF EXISTS activity_time_entries'
     create_table :activity_time_entries do |t|

--- a/services/QuillLMS/db/migrate/20140403152608_rename_rules_title_to_name.rb
+++ b/services/QuillLMS/db/migrate/20140403152608_rename_rules_title_to_name.rb
@@ -1,4 +1,4 @@
-class RenameRulesTitleToName < ActiveRecord::Migration
+class RenameRulesTitleToName < ActiveRecord::Migration[4.2]
   def change
     rename_column :rules, :title, :name
   end

--- a/services/QuillLMS/db/migrate/20140403194136_add_uid_to_rules.rb
+++ b/services/QuillLMS/db/migrate/20140403194136_add_uid_to_rules.rb
@@ -1,4 +1,4 @@
-class AddUidToRules < ActiveRecord::Migration
+class AddUidToRules < ActiveRecord::Migration[4.2]
   def change
     add_column :rules, :uid, :string
     add_index :rules, :uid, unique: true

--- a/services/QuillLMS/db/migrate/20140404165107_add_flags_to_activities.rb
+++ b/services/QuillLMS/db/migrate/20140404165107_add_flags_to_activities.rb
@@ -1,4 +1,4 @@
-class AddFlagsToActivities < ActiveRecord::Migration
+class AddFlagsToActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :activities, :flags, :string, array: true, default: [], null: false
     add_column :rules,      :flags, :string, array: true, default: [], null: false

--- a/services/QuillLMS/db/migrate/20140422211405_add_ip_address_to_users.rb
+++ b/services/QuillLMS/db/migrate/20140422211405_add_ip_address_to_users.rb
@@ -1,4 +1,4 @@
-class AddIpAddressToUsers < ActiveRecord::Migration
+class AddIpAddressToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :ip_address, :inet
   end

--- a/services/QuillLMS/db/migrate/20140423225449_add_search_indexes_to_users.rb
+++ b/services/QuillLMS/db/migrate/20140423225449_add_search_indexes_to_users.rb
@@ -1,4 +1,4 @@
-class AddSearchIndexesToUsers < ActiveRecord::Migration
+class AddSearchIndexesToUsers < ActiveRecord::Migration[4.2]
   def up
     execute "
       create index on users using gin(to_tsvector('english', name));

--- a/services/QuillLMS/db/migrate/20140811132110_create_schools.rb
+++ b/services/QuillLMS/db/migrate/20140811132110_create_schools.rb
@@ -1,4 +1,4 @@
-class CreateSchools < ActiveRecord::Migration
+class CreateSchools < ActiveRecord::Migration[4.2]
   def change
     create_table :schools do |t|
       t.string  :nces_id, :lea_id, :leanm, :name, :phone, :mail_street, :mail_city,

--- a/services/QuillLMS/db/migrate/20140812222418_create_districts.rb
+++ b/services/QuillLMS/db/migrate/20140812222418_create_districts.rb
@@ -1,4 +1,4 @@
-class CreateDistricts < ActiveRecord::Migration
+class CreateDistricts < ActiveRecord::Migration[4.2]
   def change
     create_table :districts do |t|
       t.string :clever_id, :name, :token

--- a/services/QuillLMS/db/migrate/20140816031410_add_clever_ids.rb
+++ b/services/QuillLMS/db/migrate/20140816031410_add_clever_ids.rb
@@ -1,4 +1,4 @@
-class AddCleverIds < ActiveRecord::Migration
+class AddCleverIds < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :clever_id, :string
     add_column :classrooms, :clever_id, :string

--- a/services/QuillLMS/db/migrate/20140903200511_add_indexes_where_needed.rb
+++ b/services/QuillLMS/db/migrate/20140903200511_add_indexes_where_needed.rb
@@ -1,4 +1,4 @@
-class AddIndexesWhereNeeded < ActiveRecord::Migration
+class AddIndexesWhereNeeded < ActiveRecord::Migration[4.2]
   def change
     add_index :activity_sessions, :user_id
     add_index :activity_sessions, :activity_id

--- a/services/QuillLMS/db/migrate/20140903225323_more_index_improvements.rb
+++ b/services/QuillLMS/db/migrate/20140903225323_more_index_improvements.rb
@@ -1,4 +1,4 @@
-class MoreIndexImprovements < ActiveRecord::Migration
+class MoreIndexImprovements < ActiveRecord::Migration[4.2]
   def change
     add_index :rule_question_inputs, :rule_question_id
     add_index :rule_question_inputs, :activity_session_id

--- a/services/QuillLMS/db/migrate/20140909163246_add_grade_to_classroom.rb
+++ b/services/QuillLMS/db/migrate/20140909163246_add_grade_to_classroom.rb
@@ -1,4 +1,4 @@
-class AddGradeToClassroom < ActiveRecord::Migration
+class AddGradeToClassroom < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :grade, :string
     add_index :classrooms, :grade

--- a/services/QuillLMS/db/migrate/20140916143956_make_username_downcase.rb
+++ b/services/QuillLMS/db/migrate/20140916143956_make_username_downcase.rb
@@ -1,4 +1,4 @@
-class MakeUsernameDowncase < ActiveRecord::Migration
+class MakeUsernameDowncase < ActiveRecord::Migration[4.2]
   def change
 
     User.all.each { |u| 

--- a/services/QuillLMS/db/migrate/20140916183213_add_index_to_users.rb
+++ b/services/QuillLMS/db/migrate/20140916183213_add_index_to_users.rb
@@ -1,4 +1,4 @@
-class AddIndexToUsers < ActiveRecord::Migration
+class AddIndexToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :classcode
   end

--- a/services/QuillLMS/db/migrate/20141007210647_fix_bad_activity_id_on_session.rb
+++ b/services/QuillLMS/db/migrate/20141007210647_fix_bad_activity_id_on_session.rb
@@ -1,4 +1,4 @@
-class FixBadActivityIdOnSession < ActiveRecord::Migration
+class FixBadActivityIdOnSession < ActiveRecord::Migration[4.2]
   def change
 
     # noop, because this now lives in a worker.

--- a/services/QuillLMS/db/migrate/20141008152913_changes_to_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20141008152913_changes_to_activity_session.rb
@@ -1,4 +1,4 @@
-class ChangesToActivitySession < ActiveRecord::Migration
+class ChangesToActivitySession < ActiveRecord::Migration[4.2]
   def change
 
     change_column :activity_sessions, :temporary, :boolean, default: 'f'

--- a/services/QuillLMS/db/migrate/20141014162137_add_app_name_to_classification.rb
+++ b/services/QuillLMS/db/migrate/20141014162137_add_app_name_to_classification.rb
@@ -1,4 +1,4 @@
-class AddAppNameToClassification < ActiveRecord::Migration
+class AddAppNameToClassification < ActiveRecord::Migration[4.2]
   def change
 
     add_column :activity_classifications, :app_name, :string

--- a/services/QuillLMS/db/migrate/20150105170428_create_concept_tags.rb
+++ b/services/QuillLMS/db/migrate/20150105170428_create_concept_tags.rb
@@ -1,4 +1,4 @@
-class CreateConceptTags < ActiveRecord::Migration
+class CreateConceptTags < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_tags do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150105170550_create_concept_tag_results.rb
+++ b/services/QuillLMS/db/migrate/20150105170550_create_concept_tag_results.rb
@@ -1,4 +1,4 @@
-class CreateConceptTagResults < ActiveRecord::Migration
+class CreateConceptTagResults < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_tag_results do |t|
       t.belongs_to :activity_session

--- a/services/QuillLMS/db/migrate/20150113144201_create_concept_tag_categories.rb
+++ b/services/QuillLMS/db/migrate/20150113144201_create_concept_tag_categories.rb
@@ -1,4 +1,4 @@
-class CreateConceptTagCategories < ActiveRecord::Migration
+class CreateConceptTagCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_tag_categories do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150113154458_add_null_false_to_concept_tag_results.rb
+++ b/services/QuillLMS/db/migrate/20150113154458_add_null_false_to_concept_tag_results.rb
@@ -1,4 +1,4 @@
-class AddNullFalseToConceptTagResults < ActiveRecord::Migration
+class AddNullFalseToConceptTagResults < ActiveRecord::Migration[4.2]
   def change
     change_column_null :concept_tag_results, :concept_tag_id, false
   end

--- a/services/QuillLMS/db/migrate/20150113170755_add_additional_concepts_to_concept_tags.rb
+++ b/services/QuillLMS/db/migrate/20150113170755_add_additional_concepts_to_concept_tags.rb
@@ -1,4 +1,4 @@
-class AddAdditionalConceptsToConceptTags < ActiveRecord::Migration
+class AddAdditionalConceptsToConceptTags < ActiveRecord::Migration[4.2]
   def change
     add_column :concept_tags, :additional_concepts, :string
   end

--- a/services/QuillLMS/db/migrate/20150120173017_rename_concept_tag_categories.rb
+++ b/services/QuillLMS/db/migrate/20150120173017_rename_concept_tag_categories.rb
@@ -1,4 +1,4 @@
-class RenameConceptTagCategories < ActiveRecord::Migration
+class RenameConceptTagCategories < ActiveRecord::Migration[4.2]
   def change
     rename_table :concept_tag_categories, :concept_classes
     rename_column :concept_tags, :concept_tag_category_id, :concept_class_id

--- a/services/QuillLMS/db/migrate/20150204201702_create_topic_categories.rb
+++ b/services/QuillLMS/db/migrate/20150204201702_create_topic_categories.rb
@@ -1,4 +1,4 @@
-class CreateTopicCategories < ActiveRecord::Migration
+class CreateTopicCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :topic_categories do |t|
     	t.string :name

--- a/services/QuillLMS/db/migrate/20150204201738_add_topic_category_to_topics.rb
+++ b/services/QuillLMS/db/migrate/20150204201738_add_topic_category_to_topics.rb
@@ -1,4 +1,4 @@
-class AddTopicCategoryToTopics < ActiveRecord::Migration
+class AddTopicCategoryToTopics < ActiveRecord::Migration[4.2]
   def change
     add_reference :topics, :topic_category, index: true
   end

--- a/services/QuillLMS/db/migrate/20150206184619_add_is_retry_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20150206184619_add_is_retry_to_activity_sessions.rb
@@ -1,4 +1,4 @@
-class AddIsRetryToActivitySessions < ActiveRecord::Migration
+class AddIsRetryToActivitySessions < ActiveRecord::Migration[4.2]
   def change
   	add_column :activity_sessions, :is_retry, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20150224180253_add_timestamp_to_units.rb
+++ b/services/QuillLMS/db/migrate/20150224180253_add_timestamp_to_units.rb
@@ -1,4 +1,4 @@
-class AddTimestampToUnits < ActiveRecord::Migration
+class AddTimestampToUnits < ActiveRecord::Migration[4.2]
   def change
     add_column :units, :created_at, :datetime
     add_column :units, :updated_at, :datetime

--- a/services/QuillLMS/db/migrate/20150302183545_create_concept_categories.rb
+++ b/services/QuillLMS/db/migrate/20150302183545_create_concept_categories.rb
@@ -1,4 +1,4 @@
-class CreateConceptCategories < ActiveRecord::Migration
+class CreateConceptCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_categories do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150302190844_add_concept_category_id_to_concept_tag_results.rb
+++ b/services/QuillLMS/db/migrate/20150302190844_add_concept_category_id_to_concept_tag_results.rb
@@ -1,4 +1,4 @@
-class AddConceptCategoryIdToConceptTagResults < ActiveRecord::Migration
+class AddConceptCategoryIdToConceptTagResults < ActiveRecord::Migration[4.2]
   def change
     add_column :concept_tag_results, :concept_category_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20150303220841_add_case_insensitive_unique_indices_on_concept_tables.rb
+++ b/services/QuillLMS/db/migrate/20150303220841_add_case_insensitive_unique_indices_on_concept_tables.rb
@@ -1,4 +1,4 @@
-class AddCaseInsensitiveUniqueIndicesOnConceptTables < ActiveRecord::Migration
+class AddCaseInsensitiveUniqueIndicesOnConceptTables < ActiveRecord::Migration[4.2]
   def up
     remove_index :concept_tags, :name
     execute "CREATE UNIQUE INDEX index_concept_tags_on_lowercase_name

--- a/services/QuillLMS/db/migrate/20150316231711_create_csv_exports.rb
+++ b/services/QuillLMS/db/migrate/20150316231711_create_csv_exports.rb
@@ -1,4 +1,4 @@
-class CreateCsvExports < ActiveRecord::Migration
+class CreateCsvExports < ActiveRecord::Migration[4.2]
   def change
     create_table :csv_exports do |t|
       t.string :type

--- a/services/QuillLMS/db/migrate/20150317200555_add_is_final_score_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20150317200555_add_is_final_score_to_activity_sessions.rb
@@ -1,4 +1,4 @@
-class AddIsFinalScoreToActivitySessions < ActiveRecord::Migration
+class AddIsFinalScoreToActivitySessions < ActiveRecord::Migration[4.2]
   def change
   	add_column :activity_sessions, :is_final_score, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20150317215753_add_csv_file_to_csv_exports.rb
+++ b/services/QuillLMS/db/migrate/20150317215753_add_csv_file_to_csv_exports.rb
@@ -1,4 +1,4 @@
-class AddCsvFileToCsvExports < ActiveRecord::Migration
+class AddCsvFileToCsvExports < ActiveRecord::Migration[4.2]
   def change
     add_column :csv_exports, :csv_file, :string
   end

--- a/services/QuillLMS/db/migrate/20150318220008_change_csv_exports_type_column.rb
+++ b/services/QuillLMS/db/migrate/20150318220008_change_csv_exports_type_column.rb
@@ -1,4 +1,4 @@
-class ChangeCsvExportsTypeColumn < ActiveRecord::Migration
+class ChangeCsvExportsTypeColumn < ActiveRecord::Migration[4.2]
   def change
     rename_column :csv_exports, :type, :export_type
   end

--- a/services/QuillLMS/db/migrate/20150605213737_add_subscription_to_users.rb
+++ b/services/QuillLMS/db/migrate/20150605213737_add_subscription_to_users.rb
@@ -1,4 +1,4 @@
-class AddSubscriptionToUsers < ActiveRecord::Migration
+class AddSubscriptionToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :subscription, :string, default: 'free'
   end

--- a/services/QuillLMS/db/migrate/20150605220554_remove_subscription_from_users.rb
+++ b/services/QuillLMS/db/migrate/20150605220554_remove_subscription_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveSubscriptionFromUsers < ActiveRecord::Migration
+class RemoveSubscriptionFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :subscription
   end

--- a/services/QuillLMS/db/migrate/20150605220923_create_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20150605220923_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriptions do |t|
       t.belongs_to :user

--- a/services/QuillLMS/db/migrate/20150605221918_add_timestamp_to_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20150605221918_add_timestamp_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddTimestampToSubscriptions < ActiveRecord::Migration
+class AddTimestampToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :created_at, :datetime
     add_column :subscriptions, :updated_at, :datetime

--- a/services/QuillLMS/db/migrate/20150616191252_create_concepts.rb
+++ b/services/QuillLMS/db/migrate/20150616191252_create_concepts.rb
@@ -1,4 +1,4 @@
-class CreateConcepts < ActiveRecord::Migration
+class CreateConcepts < ActiveRecord::Migration[4.2]
   def change
     create_table :concepts do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150622172421_drop_unused_tables.rb
+++ b/services/QuillLMS/db/migrate/20150622172421_drop_unused_tables.rb
@@ -1,4 +1,4 @@
-class DropUnusedTables < ActiveRecord::Migration
+class DropUnusedTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :chapters
     drop_table :chapter_levels

--- a/services/QuillLMS/db/migrate/20150622181401_drop_homepage_news_slides.rb
+++ b/services/QuillLMS/db/migrate/20150622181401_drop_homepage_news_slides.rb
@@ -1,4 +1,4 @@
-class DropHomepageNewsSlides < ActiveRecord::Migration
+class DropHomepageNewsSlides < ActiveRecord::Migration[4.2]
   def change
     drop_table :homepage_news_slides
   end

--- a/services/QuillLMS/db/migrate/20150622182815_drop_more_unused_tables.rb
+++ b/services/QuillLMS/db/migrate/20150622182815_drop_more_unused_tables.rb
@@ -1,4 +1,4 @@
-class DropMoreUnusedTables < ActiveRecord::Migration
+class DropMoreUnusedTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :activity_time_entries
     drop_table :assessments

--- a/services/QuillLMS/db/migrate/20150625224316_create_firebase_apps.rb
+++ b/services/QuillLMS/db/migrate/20150625224316_create_firebase_apps.rb
@@ -1,4 +1,4 @@
-class CreateFirebaseApps < ActiveRecord::Migration
+class CreateFirebaseApps < ActiveRecord::Migration[4.2]
   def change
     create_table :firebase_apps do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150805212906_add_fields_to_concepts.rb
+++ b/services/QuillLMS/db/migrate/20150805212906_add_fields_to_concepts.rb
@@ -1,4 +1,4 @@
-class AddFieldsToConcepts < ActiveRecord::Migration
+class AddFieldsToConcepts < ActiveRecord::Migration[4.2]
   def change
     add_column :concepts, :parent_id, :integer
     add_column :concepts, :uid, :string, null: false

--- a/services/QuillLMS/db/migrate/20150805224448_create_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20150805224448_create_concept_results.rb
@@ -1,4 +1,4 @@
-class CreateConceptResults < ActiveRecord::Migration
+class CreateConceptResults < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_results do |t|
       t.integer "activity_session_id"

--- a/services/QuillLMS/db/migrate/20150817164457_add_uid_to_topics.rb
+++ b/services/QuillLMS/db/migrate/20150817164457_add_uid_to_topics.rb
@@ -1,4 +1,4 @@
-class AddUidToTopics < ActiveRecord::Migration
+class AddUidToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :uid, :string
   end

--- a/services/QuillLMS/db/migrate/20150817164501_add_uid_to_topic_categories.rb
+++ b/services/QuillLMS/db/migrate/20150817164501_add_uid_to_topic_categories.rb
@@ -1,4 +1,4 @@
-class AddUidToTopicCategories < ActiveRecord::Migration
+class AddUidToTopicCategories < ActiveRecord::Migration[4.2]
   def change
     add_column :topic_categories, :uid, :string
   end

--- a/services/QuillLMS/db/migrate/20150817164507_add_uid_to_sections.rb
+++ b/services/QuillLMS/db/migrate/20150817164507_add_uid_to_sections.rb
@@ -1,4 +1,4 @@
-class AddUidToSections < ActiveRecord::Migration
+class AddUidToSections < ActiveRecord::Migration[4.2]
   def change
     add_column :sections, :uid, :string
   end

--- a/services/QuillLMS/db/migrate/20150826175849_drop_concept_tag_tables.rb
+++ b/services/QuillLMS/db/migrate/20150826175849_drop_concept_tag_tables.rb
@@ -1,4 +1,4 @@
-class DropConceptTagTables < ActiveRecord::Migration
+class DropConceptTagTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :concept_tags
     drop_table :concept_classes

--- a/services/QuillLMS/db/migrate/20150908190948_add_signed_up_with_google_to_users.rb
+++ b/services/QuillLMS/db/migrate/20150908190948_add_signed_up_with_google_to_users.rb
@@ -1,4 +1,4 @@
-class AddSignedUpWithGoogleToUsers < ActiveRecord::Migration
+class AddSignedUpWithGoogleToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :signed_up_with_google, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20150922164057_create_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20150922164057_create_unit_templates.rb
@@ -1,4 +1,4 @@
-class CreateUnitTemplates < ActiveRecord::Migration
+class CreateUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     create_table :unit_templates do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20150922180615_create_join_table.rb
+++ b/services/QuillLMS/db/migrate/20150922180615_create_join_table.rb
@@ -1,4 +1,4 @@
-class CreateJoinTable < ActiveRecord::Migration
+class CreateJoinTable < ActiveRecord::Migration[4.2]
   def change
     create_join_table :unit_templates, :activities do |t|
       t.index [:unit_template_id, :activity_id], name: 'uta'

--- a/services/QuillLMS/db/migrate/20151001184736_create_unit_template_categories.rb
+++ b/services/QuillLMS/db/migrate/20151001184736_create_unit_template_categories.rb
@@ -1,4 +1,4 @@
-class CreateUnitTemplateCategories < ActiveRecord::Migration
+class CreateUnitTemplateCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :unit_template_categories do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20151001185332_add_unit_template_category_reference_to_unit_template.rb
+++ b/services/QuillLMS/db/migrate/20151001185332_add_unit_template_category_reference_to_unit_template.rb
@@ -1,4 +1,4 @@
-class AddUnitTemplateCategoryReferenceToUnitTemplate < ActiveRecord::Migration
+class AddUnitTemplateCategoryReferenceToUnitTemplate < ActiveRecord::Migration[4.2]
   def change
     add_reference :unit_templates, :unit_template_category, index: true
   end

--- a/services/QuillLMS/db/migrate/20151001212257_add_fields_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20151001212257_add_fields_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddFieldsToUnitTemplates < ActiveRecord::Migration
+class AddFieldsToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :time, :integer
     add_column :unit_templates, :description, :text

--- a/services/QuillLMS/db/migrate/20151001221349_add_grades_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20151001221349_add_grades_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddGradesToUnitTemplates < ActiveRecord::Migration
+class AddGradesToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :grades, :text
   end

--- a/services/QuillLMS/db/migrate/20151006193029_create_authors.rb
+++ b/services/QuillLMS/db/migrate/20151006193029_create_authors.rb
@@ -1,4 +1,4 @@
-class CreateAuthors < ActiveRecord::Migration
+class CreateAuthors < ActiveRecord::Migration[4.2]
   def change
     create_table :authors do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20151006193157_add_avatar_column_to_authors.rb
+++ b/services/QuillLMS/db/migrate/20151006193157_add_avatar_column_to_authors.rb
@@ -1,4 +1,4 @@
-class AddAvatarColumnToAuthors < ActiveRecord::Migration
+class AddAvatarColumnToAuthors < ActiveRecord::Migration[4.2]
   def up
     add_attachment :authors, :avatar
   end

--- a/services/QuillLMS/db/migrate/20151006193526_add_author_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20151006193526_add_author_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddAuthorToUnitTemplates < ActiveRecord::Migration
+class AddAuthorToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_reference :unit_templates, :author, index: true
   end

--- a/services/QuillLMS/db/migrate/20151013204326_add_primary_and_secondary_colors_to_unit_template_category.rb
+++ b/services/QuillLMS/db/migrate/20151013204326_add_primary_and_secondary_colors_to_unit_template_category.rb
@@ -1,4 +1,4 @@
-class AddPrimaryAndSecondaryColorsToUnitTemplateCategory < ActiveRecord::Migration
+class AddPrimaryAndSecondaryColorsToUnitTemplateCategory < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_template_categories, :primary_color, :string
     add_column :unit_template_categories, :secondary_color, :string

--- a/services/QuillLMS/db/migrate/20151014171836_add_description_to_author.rb
+++ b/services/QuillLMS/db/migrate/20151014171836_add_description_to_author.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToAuthor < ActiveRecord::Migration
+class AddDescriptionToAuthor < ActiveRecord::Migration[4.2]
   def change
     add_column :authors, :description, :text
   end

--- a/services/QuillLMS/db/migrate/20151014171914_add_fields_to_unit_template.rb
+++ b/services/QuillLMS/db/migrate/20151014171914_add_fields_to_unit_template.rb
@@ -1,4 +1,4 @@
-class AddFieldsToUnitTemplate < ActiveRecord::Migration
+class AddFieldsToUnitTemplate < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :problem, :text
     add_column :unit_templates, :summary, :text

--- a/services/QuillLMS/db/migrate/20151014172251_remove_description_from_unit_template.rb
+++ b/services/QuillLMS/db/migrate/20151014172251_remove_description_from_unit_template.rb
@@ -1,4 +1,4 @@
-class RemoveDescriptionFromUnitTemplate < ActiveRecord::Migration
+class RemoveDescriptionFromUnitTemplate < ActiveRecord::Migration[4.2]
   def change
     remove_column :unit_templates, :description
   end

--- a/services/QuillLMS/db/migrate/20151027174224_add_send_newsletter_to_user.rb
+++ b/services/QuillLMS/db/migrate/20151027174224_add_send_newsletter_to_user.rb
@@ -1,4 +1,4 @@
-class AddSendNewsletterToUser < ActiveRecord::Migration
+class AddSendNewsletterToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :send_newsletter, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20151102200755_add_archived_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20151102200755_add_archived_to_classrooms.rb
@@ -1,4 +1,4 @@
-class AddArchivedToClassrooms < ActiveRecord::Migration
+class AddArchivedToClassrooms < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :archived, :boolean, default: true
   end

--- a/services/QuillLMS/db/migrate/20151102201346_change_archived_default_for_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20151102201346_change_archived_default_for_classrooms.rb
@@ -1,4 +1,4 @@
-class ChangeArchivedDefaultForClassrooms < ActiveRecord::Migration
+class ChangeArchivedDefaultForClassrooms < ActiveRecord::Migration[4.2]
   def self.up
     change_table :classrooms do |t|
       t.change :archived, :boolean, default: false

--- a/services/QuillLMS/db/migrate/20151102202446_add_not_null_to_archived_row_in_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20151102202446_add_not_null_to_archived_row_in_classrooms.rb
@@ -1,4 +1,4 @@
-class AddNotNullToArchivedRowInClassrooms < ActiveRecord::Migration
+class AddNotNullToArchivedRowInClassrooms < ActiveRecord::Migration[4.2]
   def self.up
     change_table :classrooms do |t|
       t.change :archived, :boolean, null: false, default: false

--- a/services/QuillLMS/db/migrate/20151103143507_fix_archive_name.rb
+++ b/services/QuillLMS/db/migrate/20151103143507_fix_archive_name.rb
@@ -1,4 +1,4 @@
-class FixArchiveName < ActiveRecord::Migration
+class FixArchiveName < ActiveRecord::Migration[4.2]
   def change
     rename_column :classrooms, :archived, :hidden
   end

--- a/services/QuillLMS/db/migrate/20151109222903_remove_hidden_from_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20151109222903_remove_hidden_from_classrooms.rb
@@ -1,4 +1,4 @@
-class RemoveHiddenFromClassrooms < ActiveRecord::Migration
+class RemoveHiddenFromClassrooms < ActiveRecord::Migration[4.2]
   def change
     remove_column :classrooms, :hidden
   end

--- a/services/QuillLMS/db/migrate/20151109223356_add_hidden_column_to_classroom.rb
+++ b/services/QuillLMS/db/migrate/20151109223356_add_hidden_column_to_classroom.rb
@@ -1,4 +1,4 @@
-class AddHiddenColumnToClassroom < ActiveRecord::Migration
+class AddHiddenColumnToClassroom < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :hidden, :boolean, null: false, default: false
   end

--- a/services/QuillLMS/db/migrate/20151109231711_remove_hidden_from_classrooms_again.rb
+++ b/services/QuillLMS/db/migrate/20151109231711_remove_hidden_from_classrooms_again.rb
@@ -1,4 +1,4 @@
-class RemoveHiddenFromClassroomsAgain < ActiveRecord::Migration
+class RemoveHiddenFromClassroomsAgain < ActiveRecord::Migration[4.2]
   def change
     remove_column :classrooms, :hidden
   end

--- a/services/QuillLMS/db/migrate/20151109231813_add_visible_column_to_classroom.rb
+++ b/services/QuillLMS/db/migrate/20151109231813_add_visible_column_to_classroom.rb
@@ -1,4 +1,4 @@
-class AddVisibleColumnToClassroom < ActiveRecord::Migration
+class AddVisibleColumnToClassroom < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :visible, :boolean, null: false, default: true
   end

--- a/services/QuillLMS/db/migrate/20151123192127_add_visible_column_to_units.rb
+++ b/services/QuillLMS/db/migrate/20151123192127_add_visible_column_to_units.rb
@@ -1,4 +1,4 @@
-class AddVisibleColumnToUnits < ActiveRecord::Migration
+class AddVisibleColumnToUnits < ActiveRecord::Migration[4.2]
   def change
     add_column :units, :visible, :boolean, null: false, default: true
   end

--- a/services/QuillLMS/db/migrate/20151123211533_add_visible_column_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20151123211533_add_visible_column_to_activity_sessions.rb
@@ -1,4 +1,4 @@
-class AddVisibleColumnToActivitySessions < ActiveRecord::Migration
+class AddVisibleColumnToActivitySessions < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_sessions, :visible, :boolean, null: false, default: true
   end

--- a/services/QuillLMS/db/migrate/20151214185801_drop_work_books_table.rb
+++ b/services/QuillLMS/db/migrate/20151214185801_drop_work_books_table.rb
@@ -1,4 +1,4 @@
-class DropWorkBooksTable < ActiveRecord::Migration
+class DropWorkBooksTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :workbooks
   end

--- a/services/QuillLMS/db/migrate/20151214204602_remove_work_book_id_column_from_sections_table.rb
+++ b/services/QuillLMS/db/migrate/20151214204602_remove_work_book_id_column_from_sections_table.rb
@@ -1,4 +1,4 @@
-class RemoveWorkBookIdColumnFromSectionsTable < ActiveRecord::Migration
+class RemoveWorkBookIdColumnFromSectionsTable < ActiveRecord::Migration[4.2]
   def change
     remove_column :sections, :workbook_id
   end

--- a/services/QuillLMS/db/migrate/20151221190346_create_admin_relationships.rb
+++ b/services/QuillLMS/db/migrate/20151221190346_create_admin_relationships.rb
@@ -1,4 +1,4 @@
-class CreateAdminRelationships < ActiveRecord::Migration
+class CreateAdminRelationships < ActiveRecord::Migration[4.2]
   def change
     create_table :admin_relationships do |t|
       t.integer :admin_id

--- a/services/QuillLMS/db/migrate/20151221194609_drop_admin_relationships_table.rb
+++ b/services/QuillLMS/db/migrate/20151221194609_drop_admin_relationships_table.rb
@@ -1,4 +1,4 @@
-class DropAdminRelationshipsTable < ActiveRecord::Migration
+class DropAdminRelationshipsTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :admin_relationships
   end

--- a/services/QuillLMS/db/migrate/20151221195034_create_admin_accounts.rb
+++ b/services/QuillLMS/db/migrate/20151221195034_create_admin_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAdminAccounts < ActiveRecord::Migration
+class CreateAdminAccounts < ActiveRecord::Migration[4.2]
   def change
     create_table :admin_accounts do |t|
 

--- a/services/QuillLMS/db/migrate/20151221195138_create_admin_accounts_admins.rb
+++ b/services/QuillLMS/db/migrate/20151221195138_create_admin_accounts_admins.rb
@@ -1,4 +1,4 @@
-class CreateAdminAccountsAdmins < ActiveRecord::Migration
+class CreateAdminAccountsAdmins < ActiveRecord::Migration[4.2]
   def change
     create_table :admin_accounts_admins do |t|
       t.integer :admin_account_id

--- a/services/QuillLMS/db/migrate/20151221195203_create_admin_accounts_teachers.rb
+++ b/services/QuillLMS/db/migrate/20151221195203_create_admin_accounts_teachers.rb
@@ -1,4 +1,4 @@
-class CreateAdminAccountsTeachers < ActiveRecord::Migration
+class CreateAdminAccountsTeachers < ActiveRecord::Migration[4.2]
   def change
     create_table :admin_accounts_teachers do |t|
       t.integer :admin_account_id

--- a/services/QuillLMS/db/migrate/20151221195736_add_indexes_for_admin_stuff.rb
+++ b/services/QuillLMS/db/migrate/20151221195736_add_indexes_for_admin_stuff.rb
@@ -1,4 +1,4 @@
-class AddIndexesForAdminStuff < ActiveRecord::Migration
+class AddIndexesForAdminStuff < ActiveRecord::Migration[4.2]
   def change
     add_index :admin_accounts_admins, :admin_account_id
     add_index :admin_accounts_admins, :admin_id

--- a/services/QuillLMS/db/migrate/20151222172610_add_name_to_admin_account.rb
+++ b/services/QuillLMS/db/migrate/20151222172610_add_name_to_admin_account.rb
@@ -1,4 +1,4 @@
-class AddNameToAdminAccount < ActiveRecord::Migration
+class AddNameToAdminAccount < ActiveRecord::Migration[4.2]
   def change
     add_column :admin_accounts, :name, :string
   end

--- a/services/QuillLMS/db/migrate/20160107221454_add_index_to_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20160107221454_add_index_to_concept_results.rb
@@ -1,4 +1,4 @@
-class AddIndexToConceptResults < ActiveRecord::Migration
+class AddIndexToConceptResults < ActiveRecord::Migration[4.2]
   def change
     add_index :concept_results, :activity_session_id
   end

--- a/services/QuillLMS/db/migrate/20160111193235_remove_time_spent_from_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20160111193235_remove_time_spent_from_activity_sessions.rb
@@ -1,4 +1,4 @@
-class RemoveTimeSpentFromActivitySessions < ActiveRecord::Migration
+class RemoveTimeSpentFromActivitySessions < ActiveRecord::Migration[4.2]
   def change
     remove_column :activity_sessions, :time_spent
   end

--- a/services/QuillLMS/db/migrate/20160126222414_create_ip_locations.rb
+++ b/services/QuillLMS/db/migrate/20160126222414_create_ip_locations.rb
@@ -1,4 +1,4 @@
-class CreateIpLocations < ActiveRecord::Migration
+class CreateIpLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :ip_locations do |t|
       t.string :country

--- a/services/QuillLMS/db/migrate/20160127210202_create_ip_locations_users.rb
+++ b/services/QuillLMS/db/migrate/20160127210202_create_ip_locations_users.rb
@@ -1,4 +1,4 @@
-class CreateIpLocationsUsers < ActiveRecord::Migration
+class CreateIpLocationsUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :ip_locations_users, id: false do |t|
       t.references :ip_location, null: false

--- a/services/QuillLMS/db/migrate/20160128163047_drop_ip_locations_users_table.rb
+++ b/services/QuillLMS/db/migrate/20160128163047_drop_ip_locations_users_table.rb
@@ -1,4 +1,4 @@
-class DropIpLocationsUsersTable < ActiveRecord::Migration
+class DropIpLocationsUsersTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :ip_locations_users
   end

--- a/services/QuillLMS/db/migrate/20160201185836_add_indices_to_ip_locations_table.rb
+++ b/services/QuillLMS/db/migrate/20160201185836_add_indices_to_ip_locations_table.rb
@@ -1,4 +1,4 @@
-class AddIndicesToIpLocationsTable < ActiveRecord::Migration
+class AddIndicesToIpLocationsTable < ActiveRecord::Migration[4.2]
   def change
     add_index :ip_locations, :user_id
     add_index :ip_locations, :zip

--- a/services/QuillLMS/db/migrate/20160208185912_add_google_classroom_id_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20160208185912_add_google_classroom_id_to_classrooms.rb
@@ -1,4 +1,4 @@
-class AddGoogleClassroomIdToClassrooms < ActiveRecord::Migration
+class AddGoogleClassroomIdToClassrooms < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :google_classroom_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20160208191348_add_type_to_subscriptions_table.rb
+++ b/services/QuillLMS/db/migrate/20160208191348_add_type_to_subscriptions_table.rb
@@ -1,4 +1,4 @@
-class AddTypeToSubscriptionsTable < ActiveRecord::Migration
+class AddTypeToSubscriptionsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :type, :string
   end

--- a/services/QuillLMS/db/migrate/20160208230538_change_type_column_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20160208230538_change_type_column_subscriptions.rb
@@ -1,4 +1,4 @@
-class ChangeTypeColumnSubscriptions < ActiveRecord::Migration
+class ChangeTypeColumnSubscriptions < ActiveRecord::Migration[4.2]
   def change
     rename_column :subscriptions, :type, :account_type
   end

--- a/services/QuillLMS/db/migrate/20160229220357_create_students_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20160229220357_create_students_classrooms.rb
@@ -1,4 +1,4 @@
-class CreateStudentsClassrooms < ActiveRecord::Migration
+class CreateStudentsClassrooms < ActiveRecord::Migration[4.2]
   def change
     create_table :students_classrooms do |t|
       t.integer :student_id, index: true

--- a/services/QuillLMS/db/migrate/20160308005554_add_visible_column_to_classroom_activities.rb
+++ b/services/QuillLMS/db/migrate/20160308005554_add_visible_column_to_classroom_activities.rb
@@ -1,4 +1,4 @@
-class AddVisibleColumnToClassroomActivities < ActiveRecord::Migration
+class AddVisibleColumnToClassroomActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :classroom_activities, :visible, :boolean, null: false, default: true
   end

--- a/services/QuillLMS/db/migrate/20160516211635_create_objectives.rb
+++ b/services/QuillLMS/db/migrate/20160516211635_create_objectives.rb
@@ -1,4 +1,4 @@
-class CreateObjectives < ActiveRecord::Migration
+class CreateObjectives < ActiveRecord::Migration[4.2]
   def change
     create_table :objectives do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20160516214056_create_checkboxes.rb
+++ b/services/QuillLMS/db/migrate/20160516214056_create_checkboxes.rb
@@ -1,4 +1,4 @@
-class CreateCheckboxes < ActiveRecord::Migration
+class CreateCheckboxes < ActiveRecord::Migration[4.2]
   def change
     create_table :checkboxes do |t|
       t.integer :user_id

--- a/services/QuillLMS/db/migrate/20160520200929_add_columns_to_objective.rb
+++ b/services/QuillLMS/db/migrate/20160520200929_add_columns_to_objective.rb
@@ -1,4 +1,4 @@
-class AddColumnsToObjective < ActiveRecord::Migration
+class AddColumnsToObjective < ActiveRecord::Migration[4.2]
   def change
     add_column :objectives, :help_info, :string
     add_column :objectives, :section, :string

--- a/services/QuillLMS/db/migrate/20160624180702_add_activity_classification_id_to_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20160624180702_add_activity_classification_id_to_concept_results.rb
@@ -1,4 +1,4 @@
-class AddActivityClassificationIdToConceptResults < ActiveRecord::Migration
+class AddActivityClassificationIdToConceptResults < ActiveRecord::Migration[4.2]
   def change
     add_reference :concept_results, :activity_classification, index: true, foreign_key: true
   end

--- a/services/QuillLMS/db/migrate/20160722174111_add_grade_level_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20160722174111_add_grade_level_to_classrooms.rb
@@ -1,4 +1,4 @@
-class AddGradeLevelToClassrooms < ActiveRecord::Migration
+class AddGradeLevelToClassrooms < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms, :grade_level, :integer
     add_index :classrooms, :grade_level

--- a/services/QuillLMS/db/migrate/20160822145724_add_repeatable_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20160822145724_add_repeatable_to_activity.rb
@@ -1,4 +1,4 @@
-class AddRepeatableToActivity < ActiveRecord::Migration
+class AddRepeatableToActivity < ActiveRecord::Migration[4.2]
   def change
     add_column :activities, :repeatable, :boolean, default: true
   end

--- a/services/QuillLMS/db/migrate/20160908153832_add_big_int_to_google_classroom_id.rb
+++ b/services/QuillLMS/db/migrate/20160908153832_add_big_int_to_google_classroom_id.rb
@@ -1,4 +1,4 @@
-class AddBigIntToGoogleClassroomId < ActiveRecord::Migration
+class AddBigIntToGoogleClassroomId < ActiveRecord::Migration[4.2]
   def change
     change_column :classrooms, :google_classroom_id, :integer, limit: 8
   end

--- a/services/QuillLMS/db/migrate/20160913173130_add_flag_to_user.rb
+++ b/services/QuillLMS/db/migrate/20160913173130_add_flag_to_user.rb
@@ -1,4 +1,4 @@
-class AddFlagToUser < ActiveRecord::Migration
+class AddFlagToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :flag, :string
     add_index :users, :flag

--- a/services/QuillLMS/db/migrate/20160919150448_add_flag_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20160919150448_add_flag_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddFlagToUnitTemplates < ActiveRecord::Migration
+class AddFlagToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :flag, :string
   end

--- a/services/QuillLMS/db/migrate/20161019184132_add_question_type_to_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20161019184132_add_question_type_to_concept_results.rb
@@ -1,4 +1,4 @@
-class AddQuestionTypeToConceptResults < ActiveRecord::Migration
+class AddQuestionTypeToConceptResults < ActiveRecord::Migration[4.2]
   def change
     add_column :concept_results, :question_type, :string, :null => true
     add_index :concept_results, :question_type

--- a/services/QuillLMS/db/migrate/20170103191349_add_user_id_to_units.rb
+++ b/services/QuillLMS/db/migrate/20170103191349_add_user_id_to_units.rb
@@ -1,4 +1,4 @@
-class AddUserIdToUnits < ActiveRecord::Migration
+class AddUserIdToUnits < ActiveRecord::Migration[4.2]
   def change
     add_column :units, :user_id, :integer
     add_index :units, :user_id

--- a/services/QuillLMS/db/migrate/20170105213544_remove_classroom_id_from_units.rb
+++ b/services/QuillLMS/db/migrate/20170105213544_remove_classroom_id_from_units.rb
@@ -1,4 +1,4 @@
-class RemoveClassroomIdFromUnits < ActiveRecord::Migration
+class RemoveClassroomIdFromUnits < ActiveRecord::Migration[4.2]
   def change
     remove_column :units, :classroom_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20170126211938_add_pg_trgm_extension_to_db.rb
+++ b/services/QuillLMS/db/migrate/20170126211938_add_pg_trgm_extension_to_db.rb
@@ -1,4 +1,4 @@
-class AddPgTrgmExtensionToDb < ActiveRecord::Migration
+class AddPgTrgmExtensionToDb < ActiveRecord::Migration[4.2]
   def change
     execute "create extension pg_trgm;"
   end

--- a/services/QuillLMS/db/migrate/20170127014847_add_gin_index_to_users.rb
+++ b/services/QuillLMS/db/migrate/20170127014847_add_gin_index_to_users.rb
@@ -1,4 +1,4 @@
-class AddGinIndexToUsers < ActiveRecord::Migration
+class AddGinIndexToUsers < ActiveRecord::Migration[4.2]
   # An index can be created concurrently only outside of a transaction.
   disable_ddl_transaction!
 

--- a/services/QuillLMS/db/migrate/20170127020417_add_gin_index_to_users_on_name.rb
+++ b/services/QuillLMS/db/migrate/20170127020417_add_gin_index_to_users_on_name.rb
@@ -1,4 +1,4 @@
-class AddGinIndexToUsersOnName < ActiveRecord::Migration
+class AddGinIndexToUsersOnName < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def up

--- a/services/QuillLMS/db/migrate/20170217201048_add_order_number_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20170217201048_add_order_number_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddOrderNumberToUnitTemplates < ActiveRecord::Migration
+class AddOrderNumberToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :order_number, :integer, default: 999999999
   end

--- a/services/QuillLMS/db/migrate/20170222165119_add_order_number_to_activity_classification.rb
+++ b/services/QuillLMS/db/migrate/20170222165119_add_order_number_to_activity_classification.rb
@@ -1,4 +1,4 @@
-class AddOrderNumberToActivityClassification < ActiveRecord::Migration
+class AddOrderNumberToActivityClassification < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_classifications, :order_number, :integer, default: 999999999
   end

--- a/services/QuillLMS/db/migrate/20170313154512_add_google_id_to_users.rb
+++ b/services/QuillLMS/db/migrate/20170313154512_add_google_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddGoogleIdToUsers < ActiveRecord::Migration
+class AddGoogleIdToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :google_id, :string
     add_index :users, :google_id

--- a/services/QuillLMS/db/migrate/20170314181527_add_activity_info_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20170314181527_add_activity_info_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddActivityInfoToUnitTemplates < ActiveRecord::Migration
+class AddActivityInfoToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :activity_info, :text
     add_index :unit_templates, :activity_info

--- a/services/QuillLMS/db/migrate/20170315183853_add_time_stamps_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20170315183853_add_time_stamps_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddTimeStampsToUnitTemplates < ActiveRecord::Migration
+class AddTimeStampsToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :created_at, :datetime
     add_column :unit_templates, :updated_at, :datetime

--- a/services/QuillLMS/db/migrate/20170412154159_add_index_to_students_classrooms_table.rb
+++ b/services/QuillLMS/db/migrate/20170412154159_add_index_to_students_classrooms_table.rb
@@ -1,4 +1,4 @@
-class AddIndexToStudentsClassroomsTable < ActiveRecord::Migration
+class AddIndexToStudentsClassroomsTable < ActiveRecord::Migration[4.2]
   def change
     add_index :students_classrooms, [:student_id, :classroom_id], unique: true
   end

--- a/services/QuillLMS/db/migrate/20170502185232_add_gin_index_to_users_email.rb
+++ b/services/QuillLMS/db/migrate/20170502185232_add_gin_index_to_users_email.rb
@@ -1,4 +1,4 @@
-class AddGinIndexToUsersEmail < ActiveRecord::Migration
+class AddGinIndexToUsersEmail < ActiveRecord::Migration[4.2]
   # An index can be created concurrently only outside of a transaction.
   disable_ddl_transaction!
 

--- a/services/QuillLMS/db/migrate/20170505182334_user_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20170505182334_user_subscriptions.rb
@@ -1,4 +1,4 @@
-class UserSubscriptions < ActiveRecord::Migration
+class UserSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :user_subscriptions do |t|
       t.integer :user_id

--- a/services/QuillLMS/db/migrate/20170505195744_school_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20170505195744_school_subscriptions.rb
@@ -1,4 +1,4 @@
-class SchoolSubscriptions < ActiveRecord::Migration
+class SchoolSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :school_subscriptions do |t|
       t.integer :school_id

--- a/services/QuillLMS/db/migrate/20170517152031_add_visible_column_to_users_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20170517152031_add_visible_column_to_users_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddVisibleColumnToUsersSubscriptions < ActiveRecord::Migration
+class AddVisibleColumnToUsersSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :user_subscriptions, :visible, :boolean, null: false, default: true
   end

--- a/services/QuillLMS/db/migrate/20170526220204_add_last_sign_in_to_user.rb
+++ b/services/QuillLMS/db/migrate/20170526220204_add_last_sign_in_to_user.rb
@@ -1,4 +1,4 @@
-class AddLastSignInToUser < ActiveRecord::Migration
+class AddLastSignInToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :last_sign_in, :datetime
   end

--- a/services/QuillLMS/db/migrate/20170718160133_add_instructor_mode_to_activity_classification.rb
+++ b/services/QuillLMS/db/migrate/20170718160133_add_instructor_mode_to_activity_classification.rb
@@ -1,4 +1,4 @@
-class AddInstructorModeToActivityClassification < ActiveRecord::Migration
+class AddInstructorModeToActivityClassification < ActiveRecord::Migration[4.2]
   def change
       add_column :activity_classifications, :instructor_mode, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20170719192243_add_locked_by_default_to_activity_classification_and_locked_to_classroom_activity.rb
+++ b/services/QuillLMS/db/migrate/20170719192243_add_locked_by_default_to_activity_classification_and_locked_to_classroom_activity.rb
@@ -1,4 +1,4 @@
-class AddLockedByDefaultToActivityClassificationAndLockedToClassroomActivity < ActiveRecord::Migration
+class AddLockedByDefaultToActivityClassificationAndLockedToClassroomActivity < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_classifications, :locked_by_default, :boolean, default: false
     add_column :classroom_activities, :locked, :boolean, default: false

--- a/services/QuillLMS/db/migrate/20170720140557_add_pinned_to_classroom_activity.rb
+++ b/services/QuillLMS/db/migrate/20170720140557_add_pinned_to_classroom_activity.rb
@@ -1,4 +1,4 @@
-class AddPinnedToClassroomActivity < ActiveRecord::Migration
+class AddPinnedToClassroomActivity < ActiveRecord::Migration[4.2]
   def change
     add_column :classroom_activities, :pinned, :boolean, :default => false
     add_index :classroom_activities, [:classroom_id, :pinned], where: "pinned = true", unique: true

--- a/services/QuillLMS/db/migrate/20170720195450_add_follow_up_activity_to_activities.rb
+++ b/services/QuillLMS/db/migrate/20170720195450_add_follow_up_activity_to_activities.rb
@@ -1,4 +1,4 @@
-class AddFollowUpActivityToActivities < ActiveRecord::Migration
+class AddFollowUpActivityToActivities < ActiveRecord::Migration[4.2]
   def change
     add_reference :activities, :follow_up_activity, foreign_key: false
   end

--- a/services/QuillLMS/db/migrate/20170804154221_create_milestones.rb
+++ b/services/QuillLMS/db/migrate/20170804154221_create_milestones.rb
@@ -1,4 +1,4 @@
-class CreateMilestones < ActiveRecord::Migration
+class CreateMilestones < ActiveRecord::Migration[4.2]
   def change
     create_table :milestones do |t|
       t.string :name, index: true, unique: true, null: false

--- a/services/QuillLMS/db/migrate/20170804154740_create_user_milestones.rb
+++ b/services/QuillLMS/db/migrate/20170804154740_create_user_milestones.rb
@@ -1,4 +1,4 @@
-class CreateUserMilestones < ActiveRecord::Migration
+class CreateUserMilestones < ActiveRecord::Migration[4.2]
   def change
     create_table :user_milestones do |t|
       t.integer :user_id, index: true, null: false

--- a/services/QuillLMS/db/migrate/20170809151404_add_primary_key_to_schools_users.rb
+++ b/services/QuillLMS/db/migrate/20170809151404_add_primary_key_to_schools_users.rb
@@ -1,4 +1,4 @@
-class AddPrimaryKeyToSchoolsUsers < ActiveRecord::Migration
+class AddPrimaryKeyToSchoolsUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :schools_users, :id, :primary_key
   end

--- a/services/QuillLMS/db/migrate/20170809202510_add_unique_index_to_schools_users.rb
+++ b/services/QuillLMS/db/migrate/20170809202510_add_unique_index_to_schools_users.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToSchoolsUsers < ActiveRecord::Migration
+class AddUniqueIndexToSchoolsUsers < ActiveRecord::Migration[4.2]
   def change
     remove_index :schools_users, :user_id
     add_index :schools_users, :user_id, unique: true

--- a/services/QuillLMS/db/migrate/20170811192029_drop_visibility_from_user_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20170811192029_drop_visibility_from_user_subscriptions.rb
@@ -1,4 +1,4 @@
-class DropVisibilityFromUserSubscriptions < ActiveRecord::Migration
+class DropVisibilityFromUserSubscriptions < ActiveRecord::Migration[4.2]
   def change
     remove_column :user_subscriptions, :visible
   end

--- a/services/QuillLMS/db/migrate/20170817144049_create_schools_admins.rb
+++ b/services/QuillLMS/db/migrate/20170817144049_create_schools_admins.rb
@@ -1,4 +1,4 @@
-class CreateSchoolsAdmins < ActiveRecord::Migration
+class CreateSchoolsAdmins < ActiveRecord::Migration[4.2]
   def change
     create_table :schools_admins do |t|
       t.integer :user_id, index: true

--- a/services/QuillLMS/db/migrate/20170824150025_add_unique_google_id_and_email_indices_to_users.rb
+++ b/services/QuillLMS/db/migrate/20170824150025_add_unique_google_id_and_email_indices_to_users.rb
@@ -1,4 +1,4 @@
-class AddUniqueGoogleIdAndEmailIndicesToUsers < ActiveRecord::Migration
+class AddUniqueGoogleIdAndEmailIndicesToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :email, unique: true, name: 'unique_index_users_on_email', where: "id > 1641954 AND email IS NOT null AND email <>  '' "
     add_index :users, :google_id, unique: true, name: 'unique_index_users_on_google_id', where: "id > 1641954 and google_id IS NOT null AND google_id <> '' "

--- a/services/QuillLMS/db/migrate/20170824171451_add_unique_user_name_index_to_users.rb
+++ b/services/QuillLMS/db/migrate/20170824171451_add_unique_user_name_index_to_users.rb
@@ -1,4 +1,4 @@
-class AddUniqueUserNameIndexToUsers < ActiveRecord::Migration
+class AddUniqueUserNameIndexToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :username, unique: true, name: 'unique_index_users_on_username', where: "id > 1641954 and username IS NOT null AND username <>  '' "
   end

--- a/services/QuillLMS/db/migrate/20170911140007_uniquness_validation_for_nces.rb
+++ b/services/QuillLMS/db/migrate/20170911140007_uniquness_validation_for_nces.rb
@@ -1,4 +1,4 @@
-class UniqunessValidationForNces < ActiveRecord::Migration
+class UniqunessValidationForNces < ActiveRecord::Migration[4.2]
   def change
     add_index :schools, :nces_id, unique: true, name: 'unique_index_schools_on_nces_id', where: "nces_id != ''"
   end

--- a/services/QuillLMS/db/migrate/20170911191447_create_activity_category_and_activity_category_activities_tables.rb
+++ b/services/QuillLMS/db/migrate/20170911191447_create_activity_category_and_activity_category_activities_tables.rb
@@ -1,4 +1,4 @@
-class CreateActivityCategoryAndActivityCategoryActivitiesTables < ActiveRecord::Migration
+class CreateActivityCategoryAndActivityCategoryActivitiesTables < ActiveRecord::Migration[4.2]
   def change
     create_table :activity_categories do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20170914145423_add_index_to_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20170914145423_add_index_to_classrooms.rb
@@ -1,4 +1,4 @@
-class AddIndexToClassrooms < ActiveRecord::Migration
+class AddIndexToClassrooms < ActiveRecord::Migration[4.2]
   def change
     add_index :classrooms, :teacher_id
     add_index :classroom_activities, :updated_at

--- a/services/QuillLMS/db/migrate/20170920133317_add_supporting_info_to_activities.rb
+++ b/services/QuillLMS/db/migrate/20170920133317_add_supporting_info_to_activities.rb
@@ -1,4 +1,4 @@
-class AddSupportingInfoToActivities < ActiveRecord::Migration
+class AddSupportingInfoToActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :activities, :supporting_info, :string
   end

--- a/services/QuillLMS/db/migrate/20170920211610_add_index_to_activity_category_activities.rb
+++ b/services/QuillLMS/db/migrate/20170920211610_add_index_to_activity_category_activities.rb
@@ -1,4 +1,4 @@
-class AddIndexToActivityCategoryActivities < ActiveRecord::Migration
+class AddIndexToActivityCategoryActivities < ActiveRecord::Migration[4.2]
   def change
     add_index :activity_category_activities, [:activity_id, :activity_category_id], name: 'index_act_category_acts_on_act_id_and_act_cat_id'
   end

--- a/services/QuillLMS/db/migrate/20170927213514_add_assign_on_join_to_classroom_activities.rb
+++ b/services/QuillLMS/db/migrate/20170927213514_add_assign_on_join_to_classroom_activities.rb
@@ -1,4 +1,4 @@
-class AddAssignOnJoinToClassroomActivities < ActiveRecord::Migration
+class AddAssignOnJoinToClassroomActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :classroom_activities, :assign_on_join, :boolean
   end

--- a/services/QuillLMS/db/migrate/20170928203242_add_ppin_and_unique_validation_on_schools.rb
+++ b/services/QuillLMS/db/migrate/20170928203242_add_ppin_and_unique_validation_on_schools.rb
@@ -1,4 +1,4 @@
-class AddPpinAndUniqueValidationOnSchools < ActiveRecord::Migration
+class AddPpinAndUniqueValidationOnSchools < ActiveRecord::Migration[4.2]
   def change
     add_column :schools, :ppin, :string
     add_index :schools, :ppin, unique: true, name: 'unique_index_schools_on_ppin', where: "ppin != ''"

--- a/services/QuillLMS/db/migrate/20171005210006_set_default_values_for_classroom_activities_again.rb
+++ b/services/QuillLMS/db/migrate/20171005210006_set_default_values_for_classroom_activities_again.rb
@@ -1,4 +1,4 @@
-class SetDefaultValuesForClassroomActivitiesAgain < ActiveRecord::Migration
+class SetDefaultValuesForClassroomActivitiesAgain < ActiveRecord::Migration[4.2]
   def change
     change_column_default :classroom_activities, :assigned_student_ids, nil
     change_column_default :classroom_activities, :assign_on_join, false

--- a/services/QuillLMS/db/migrate/20171006150857_change_default_classroom_activity_columns_again.rb
+++ b/services/QuillLMS/db/migrate/20171006150857_change_default_classroom_activity_columns_again.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultClassroomActivityColumnsAgain < ActiveRecord::Migration
+class ChangeDefaultClassroomActivityColumnsAgain < ActiveRecord::Migration[4.2]
   def change
     change_column_default :classroom_activities, :assign_on_join, nil
   end

--- a/services/QuillLMS/db/migrate/20171006151454_change_default_assigned_student_ids.rb
+++ b/services/QuillLMS/db/migrate/20171006151454_change_default_assigned_student_ids.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultAssignedStudentIds < ActiveRecord::Migration
+class ChangeDefaultAssignedStudentIds < ActiveRecord::Migration[4.2]
   def change
     change_column_default :classroom_activities, :assigned_student_ids, nil
   end

--- a/services/QuillLMS/db/migrate/20171006194812_remove_problem_summary_and_teacher_review_from_unit_template.rb
+++ b/services/QuillLMS/db/migrate/20171006194812_remove_problem_summary_and_teacher_review_from_unit_template.rb
@@ -1,4 +1,4 @@
-class RemoveProblemSummaryAndTeacherReviewFromUnitTemplate < ActiveRecord::Migration
+class RemoveProblemSummaryAndTeacherReviewFromUnitTemplate < ActiveRecord::Migration[4.2]
   def change
     remove_column :unit_templates, :problem, :string
     remove_column :unit_templates, :summary, :string

--- a/services/QuillLMS/db/migrate/20171009155139_remove_avatar_from_authors.rb
+++ b/services/QuillLMS/db/migrate/20171009155139_remove_avatar_from_authors.rb
@@ -1,4 +1,4 @@
-class RemoveAvatarFromAuthors < ActiveRecord::Migration
+class RemoveAvatarFromAuthors < ActiveRecord::Migration[4.2]
   def change
     remove_attachment :authors, :avatar
   end

--- a/services/QuillLMS/db/migrate/20171009160011_add_avatar_to_authors.rb
+++ b/services/QuillLMS/db/migrate/20171009160011_add_avatar_to_authors.rb
@@ -1,4 +1,4 @@
-class AddAvatarToAuthors < ActiveRecord::Migration
+class AddAvatarToAuthors < ActiveRecord::Migration[4.2]
   def change
     add_column :authors, :avatar, :text
   end

--- a/services/QuillLMS/db/migrate/20171009162550_remove_description_from_authors.rb
+++ b/services/QuillLMS/db/migrate/20171009162550_remove_description_from_authors.rb
@@ -1,4 +1,4 @@
-class RemoveDescriptionFromAuthors < ActiveRecord::Migration
+class RemoveDescriptionFromAuthors < ActiveRecord::Migration[4.2]
   def change
     remove_column :authors, :description
   end

--- a/services/QuillLMS/db/migrate/20171011202936_add_completed_to_classroom_activity.rb
+++ b/services/QuillLMS/db/migrate/20171011202936_add_completed_to_classroom_activity.rb
@@ -1,4 +1,4 @@
-class AddCompletedToClassroomActivity < ActiveRecord::Migration
+class AddCompletedToClassroomActivity < ActiveRecord::Migration[4.2]
   def change
     add_column :classroom_activities, :completed, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20171019150737_add_unit_template_to_units.rb
+++ b/services/QuillLMS/db/migrate/20171019150737_add_unit_template_to_units.rb
@@ -1,4 +1,4 @@
-class AddUnitTemplateToUnits < ActiveRecord::Migration
+class AddUnitTemplateToUnits < ActiveRecord::Migration[4.2]
   def change
     add_reference :units, :unit_template, index: true, foreign_key: true
   end

--- a/services/QuillLMS/db/migrate/20171106201721_create_classrooms_teachers.rb
+++ b/services/QuillLMS/db/migrate/20171106201721_create_classrooms_teachers.rb
@@ -1,4 +1,4 @@
-class CreateClassroomsTeachers < ActiveRecord::Migration
+class CreateClassroomsTeachers < ActiveRecord::Migration[4.2]
   def change
     create_table :classrooms_teachers do |t|
       t.integer :user_id, index: true, null: false

--- a/services/QuillLMS/db/migrate/20171106203046_add_constraint_to_classrooms_teachers.rb
+++ b/services/QuillLMS/db/migrate/20171106203046_add_constraint_to_classrooms_teachers.rb
@@ -1,4 +1,4 @@
-class AddConstraintToClassroomsTeachers < ActiveRecord::Migration
+class AddConstraintToClassroomsTeachers < ActiveRecord::Migration[4.2]
   def self.up
     execute "ALTER TABLE classrooms_teachers ADD CONSTRAINT check_role_is_valid CHECK (role IN ('owner', 'coteacher') AND role IS NOT null)"
     add_index :classrooms_teachers, [:user_id, :classroom_id], unique: true, name: 'unique_classroom_and_user_ids_on_classrooms_teachers'

--- a/services/QuillLMS/db/migrate/20171128154249_create_coteacher_invitation.rb
+++ b/services/QuillLMS/db/migrate/20171128154249_create_coteacher_invitation.rb
@@ -1,4 +1,4 @@
-class CreateCoteacherInvitation < ActiveRecord::Migration
+class CreateCoteacherInvitation < ActiveRecord::Migration[4.2]
   def change
     create_table :coteacher_invitations do |t|
       t.string :invitee_email, null: false, index: true

--- a/services/QuillLMS/db/migrate/20171128192444_change_coteacher_invitation.rb
+++ b/services/QuillLMS/db/migrate/20171128192444_change_coteacher_invitation.rb
@@ -1,4 +1,4 @@
-class ChangeCoteacherInvitation < ActiveRecord::Migration
+class ChangeCoteacherInvitation < ActiveRecord::Migration[4.2]
   def change
     add_column :coteacher_invitations, :invitation_type, :string
     rename_table :coteacher_invitations, :pending_invitations

--- a/services/QuillLMS/db/migrate/20171128211301_coteacher_classroom_invitations.rb
+++ b/services/QuillLMS/db/migrate/20171128211301_coteacher_classroom_invitations.rb
@@ -1,4 +1,4 @@
-class CoteacherClassroomInvitations < ActiveRecord::Migration
+class CoteacherClassroomInvitations < ActiveRecord::Migration[4.2]
   def change
     create_table :coteacher_classroom_invitations do |t|
       t.integer :pending_invitation_id, null: false, index: true, foreign_key: true

--- a/services/QuillLMS/db/migrate/20171204202718_rename_pending_invitations.rb
+++ b/services/QuillLMS/db/migrate/20171204202718_rename_pending_invitations.rb
@@ -1,4 +1,4 @@
-class RenamePendingInvitations < ActiveRecord::Migration
+class RenamePendingInvitations < ActiveRecord::Migration[4.2]
   def change
     rename_table :pending_invitations, :invitations
   end

--- a/services/QuillLMS/db/migrate/20171204203843_add_status_column_to_invitations.rb
+++ b/services/QuillLMS/db/migrate/20171204203843_add_status_column_to_invitations.rb
@@ -1,4 +1,4 @@
-class AddStatusColumnToInvitations < ActiveRecord::Migration
+class AddStatusColumnToInvitations < ActiveRecord::Migration[4.2]
   def self.up
     add_column :invitations, :status, :string, default: 'pending'
     execute "ALTER TABLE invitations ADD CONSTRAINT check_status_is_valid CHECK (status IN ('pending', 'accepted', 'rejected') AND status IS NOT null)"

--- a/services/QuillLMS/db/migrate/20171204205938_rename_pending_invitation_id_to_invitation_id_on_coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/db/migrate/20171204205938_rename_pending_invitation_id_to_invitation_id_on_coteacher_classroom_invitation.rb
@@ -1,4 +1,4 @@
-class RenamePendingInvitationIdToInvitationIdOnCoteacherClassroomInvitation < ActiveRecord::Migration
+class RenamePendingInvitationIdToInvitationIdOnCoteacherClassroomInvitation < ActiveRecord::Migration[4.2]
   def change
     rename_column :coteacher_classroom_invitations, :pending_invitation_id, :invitation_id
   end

--- a/services/QuillLMS/db/migrate/20171204220339_add_archived_column_and_remove_status_column_from_invitations.rb
+++ b/services/QuillLMS/db/migrate/20171204220339_add_archived_column_and_remove_status_column_from_invitations.rb
@@ -1,4 +1,4 @@
-class AddArchivedColumnAndRemoveStatusColumnFromInvitations < ActiveRecord::Migration
+class AddArchivedColumnAndRemoveStatusColumnFromInvitations < ActiveRecord::Migration[4.2]
   def change
     add_column :invitations, :archived, :boolean, default: false
     remove_column :invitations, :status

--- a/services/QuillLMS/db/migrate/20171205181155_remove_index_from_invitations.rb
+++ b/services/QuillLMS/db/migrate/20171205181155_remove_index_from_invitations.rb
@@ -1,4 +1,4 @@
-class RemoveIndexFromInvitations < ActiveRecord::Migration
+class RemoveIndexFromInvitations < ActiveRecord::Migration[4.2]
   def change
     remove_index :invitations, name: :index_invitations_on_invitee_email_and_inviter_id
   end

--- a/services/QuillLMS/db/migrate/20171214152937_add_timestamps_to_classrooms_teachers.rb
+++ b/services/QuillLMS/db/migrate/20171214152937_add_timestamps_to_classrooms_teachers.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToClassroomsTeachers < ActiveRecord::Migration
+class AddTimestampsToClassroomsTeachers < ActiveRecord::Migration[4.2]
   def change
     add_column :classrooms_teachers, :created_at, :datetime
     add_column :classrooms_teachers, :updated_at, :datetime

--- a/services/QuillLMS/db/migrate/20171218222306_add_last_active_to_user.rb
+++ b/services/QuillLMS/db/migrate/20171218222306_add_last_active_to_user.rb
@@ -1,4 +1,4 @@
-class AddLastActiveToUser < ActiveRecord::Migration
+class AddLastActiveToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :last_active, :datetime
   end

--- a/services/QuillLMS/db/migrate/20180102151559_add_scored_to_activity_classification.rb
+++ b/services/QuillLMS/db/migrate/20180102151559_add_scored_to_activity_classification.rb
@@ -1,4 +1,4 @@
-class AddScoredToActivityClassification < ActiveRecord::Migration
+class AddScoredToActivityClassification < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_classifications, :scored, :boolean, default: true
   end

--- a/services/QuillLMS/db/migrate/20180110221301_add_pkey_to_firebase_app.rb
+++ b/services/QuillLMS/db/migrate/20180110221301_add_pkey_to_firebase_app.rb
@@ -1,4 +1,4 @@
-class AddPkeyToFirebaseApp < ActiveRecord::Migration
+class AddPkeyToFirebaseApp < ActiveRecord::Migration[4.2]
   def change
     add_column :firebase_apps, :pkey, :text
   end

--- a/services/QuillLMS/db/migrate/20180119152409_add_referrer_user_table.rb
+++ b/services/QuillLMS/db/migrate/20180119152409_add_referrer_user_table.rb
@@ -1,4 +1,4 @@
-class AddReferrerUserTable < ActiveRecord::Migration
+class AddReferrerUserTable < ActiveRecord::Migration[4.2]
   def change
     create_table :referrer_users do |t|
       t.integer :user_id, null: false

--- a/services/QuillLMS/db/migrate/20180119162847_create_referrals_users.rb
+++ b/services/QuillLMS/db/migrate/20180119162847_create_referrals_users.rb
@@ -1,4 +1,4 @@
-class CreateReferralsUsers < ActiveRecord::Migration
+class CreateReferralsUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :referrals_users do |t|
       t.integer :user_id, null: false

--- a/services/QuillLMS/db/migrate/20180122184126_create_blog_post.rb
+++ b/services/QuillLMS/db/migrate/20180122184126_create_blog_post.rb
@@ -1,4 +1,4 @@
-class CreateBlogPost < ActiveRecord::Migration
+class CreateBlogPost < ActiveRecord::Migration[4.2]
   def change
     create_table :blog_posts do |t|
       t.string :title, null: false, index: true, unique: true

--- a/services/QuillLMS/db/migrate/20180126191518_remove_unique_constrains_from_user_and_school_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20180126191518_remove_unique_constrains_from_user_and_school_subscriptions.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueConstrainsFromUserAndSchoolSubscriptions < ActiveRecord::Migration
+class RemoveUniqueConstrainsFromUserAndSchoolSubscriptions < ActiveRecord::Migration[4.2]
   def change
     remove_index :user_subscriptions, :user_id
     add_index :user_subscriptions, :user_id, unique: false

--- a/services/QuillLMS/db/migrate/20180126203911_remove_user_id_from_subscription.rb
+++ b/services/QuillLMS/db/migrate/20180126203911_remove_user_id_from_subscription.rb
@@ -1,4 +1,4 @@
-class RemoveUserIdFromSubscription < ActiveRecord::Migration
+class RemoveUserIdFromSubscription < ActiveRecord::Migration[4.2]
   def change
     remove_column :subscriptions, :user_id
   end

--- a/services/QuillLMS/db/migrate/20180129225903_add_contact_email_and_start_date_to_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20180129225903_add_contact_email_and_start_date_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddContactEmailAndStartDateToSubscriptions < ActiveRecord::Migration
+class AddContactEmailAndStartDateToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :contact_email, :string
     add_column :subscriptions, :start_date, :datetime

--- a/services/QuillLMS/db/migrate/20180129231657_create_subscription_types.rb
+++ b/services/QuillLMS/db/migrate/20180129231657_create_subscription_types.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptionTypes < ActiveRecord::Migration
+class CreateSubscriptionTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :subscription_types do |t|
       t.string :name, null: false, index: true

--- a/services/QuillLMS/db/migrate/20180129233216_add_subscription_type_reference_to_subscriptions_table.rb
+++ b/services/QuillLMS/db/migrate/20180129233216_add_subscription_type_reference_to_subscriptions_table.rb
@@ -1,4 +1,4 @@
-class AddSubscriptionTypeReferenceToSubscriptionsTable < ActiveRecord::Migration
+class AddSubscriptionTypeReferenceToSubscriptionsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :subscription_type_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20180130164532_add_default_start_date_to_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20180130164532_add_default_start_date_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddDefaultStartDateToSubscriptions < ActiveRecord::Migration
+class AddDefaultStartDateToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     change_column_default :subscriptions, :start_date, Time.now
   end

--- a/services/QuillLMS/db/migrate/20180130165729_change_defaut_start_date.rb
+++ b/services/QuillLMS/db/migrate/20180130165729_change_defaut_start_date.rb
@@ -1,4 +1,4 @@
-class ChangeDefautStartDate < ActiveRecord::Migration
+class ChangeDefautStartDate < ActiveRecord::Migration[4.2]
   def change
     change_column_default :subscriptions, :start_date, Date.today
   end

--- a/services/QuillLMS/db/migrate/20180131153416_add_preview_card_content_to_blog_posts_table.rb
+++ b/services/QuillLMS/db/migrate/20180131153416_add_preview_card_content_to_blog_posts_table.rb
@@ -1,4 +1,4 @@
-class AddPreviewCardContentToBlogPostsTable < ActiveRecord::Migration
+class AddPreviewCardContentToBlogPostsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :preview_card_content, :text, null: false
   end

--- a/services/QuillLMS/db/migrate/20180131165556_add_price_and_teacher_alias_to_subscription_type.rb
+++ b/services/QuillLMS/db/migrate/20180131165556_add_price_and_teacher_alias_to_subscription_type.rb
@@ -1,4 +1,4 @@
-class AddPriceAndTeacherAliasToSubscriptionType < ActiveRecord::Migration
+class AddPriceAndTeacherAliasToSubscriptionType < ActiveRecord::Migration[4.2]
   def change
     add_column :subscription_types, :price, :integer
     add_column :subscription_types, :teacher_alias, :string

--- a/services/QuillLMS/db/migrate/20180131212358_add_contact_user_id_to_subscription.rb
+++ b/services/QuillLMS/db/migrate/20180131212358_add_contact_user_id_to_subscription.rb
@@ -1,4 +1,4 @@
-class AddContactUserIdToSubscription < ActiveRecord::Migration
+class AddContactUserIdToSubscription < ActiveRecord::Migration[4.2]
   def change
       add_column :subscriptions, :contact_user_id, :integer
       add_index :subscriptions, :contact_user_id

--- a/services/QuillLMS/db/migrate/20180201191052_add_stripe_customer_id_to_user.rb
+++ b/services/QuillLMS/db/migrate/20180201191052_add_stripe_customer_id_to_user.rb
@@ -1,4 +1,4 @@
-class AddStripeCustomerIdToUser < ActiveRecord::Migration
+class AddStripeCustomerIdToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :stripe_customer_id, :string
     add_index :users, :stripe_customer_id

--- a/services/QuillLMS/db/migrate/20180201221940_add_recurring_to_subscription.rb
+++ b/services/QuillLMS/db/migrate/20180201221940_add_recurring_to_subscription.rb
@@ -1,4 +1,4 @@
-class AddRecurringToSubscription < ActiveRecord::Migration
+class AddRecurringToSubscription < ActiveRecord::Migration[4.2]
   def change
       add_column :subscriptions, :recurring, :boolean, default: false
       add_index :subscriptions, :recurring

--- a/services/QuillLMS/db/migrate/20180205170220_add_de_activated_date_to_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20180205170220_add_de_activated_date_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddDeActivatedDateToSubscriptions < ActiveRecord::Migration
+class AddDeActivatedDateToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :de_activated_date, :datetime, default: nil
     add_index :subscriptions, :de_activated_date

--- a/services/QuillLMS/db/migrate/20180206154253_create_credit_transactions.rb
+++ b/services/QuillLMS/db/migrate/20180206154253_create_credit_transactions.rb
@@ -1,4 +1,4 @@
-class CreateCreditTransactions < ActiveRecord::Migration
+class CreateCreditTransactions < ActiveRecord::Migration[4.2]
   def change
     create_table :credit_transactions do |t|
       t.integer :amount, null: false

--- a/services/QuillLMS/db/migrate/20180206171118_convert_start_date_and_de_activated_dates_from_date_time.rb
+++ b/services/QuillLMS/db/migrate/20180206171118_convert_start_date_and_de_activated_dates_from_date_time.rb
@@ -1,4 +1,4 @@
-class ConvertStartDateAndDeActivatedDatesFromDateTime < ActiveRecord::Migration
+class ConvertStartDateAndDeActivatedDatesFromDateTime < ActiveRecord::Migration[4.2]
   def change
     change_column :subscriptions, :start_date, :date
     change_column :subscriptions, :de_activated_date, :date

--- a/services/QuillLMS/db/migrate/20180206210355_create_announcements.rb
+++ b/services/QuillLMS/db/migrate/20180206210355_create_announcements.rb
@@ -1,4 +1,4 @@
-class CreateAnnouncements < ActiveRecord::Migration
+class CreateAnnouncements < ActiveRecord::Migration[4.2]
   def change
     create_table :announcements do |t|
       t.string :type

--- a/services/QuillLMS/db/migrate/20180206215115_change_announcements_type_column_to_announcements_type.rb
+++ b/services/QuillLMS/db/migrate/20180206215115_change_announcements_type_column_to_announcements_type.rb
@@ -1,4 +1,4 @@
-class ChangeAnnouncementsTypeColumnToAnnouncementsType < ActiveRecord::Migration
+class ChangeAnnouncementsTypeColumnToAnnouncementsType < ActiveRecord::Migration[4.2]
   def change
     rename_column :announcements, :type, :announcement_type
   end

--- a/services/QuillLMS/db/migrate/20180206232452_change_announcement_to_be_more_restrictive.rb
+++ b/services/QuillLMS/db/migrate/20180206232452_change_announcement_to_be_more_restrictive.rb
@@ -1,4 +1,4 @@
-class ChangeAnnouncementToBeMoreRestrictive < ActiveRecord::Migration
+class ChangeAnnouncementToBeMoreRestrictive < ActiveRecord::Migration[4.2]
   def change
     remove_column :announcements, :html
     add_column :announcements, :link, :text

--- a/services/QuillLMS/db/migrate/20180206235328_add_time_zone_to_announcement_time_stamp.rb
+++ b/services/QuillLMS/db/migrate/20180206235328_add_time_zone_to_announcement_time_stamp.rb
@@ -1,4 +1,4 @@
-class AddTimeZoneToAnnouncementTimeStamp < ActiveRecord::Migration
+class AddTimeZoneToAnnouncementTimeStamp < ActiveRecord::Migration[4.2]
   def change
     change_column :announcements, :start, 'timestamp with time zone'
     change_column :announcements, :end, 'timestamp with time zone'

--- a/services/QuillLMS/db/migrate/20180207154242_remove_zone_from_announcements_times.rb
+++ b/services/QuillLMS/db/migrate/20180207154242_remove_zone_from_announcements_times.rb
@@ -1,4 +1,4 @@
-class RemoveZoneFromAnnouncementsTimes < ActiveRecord::Migration
+class RemoveZoneFromAnnouncementsTimes < ActiveRecord::Migration[4.2]
   def change
     change_column :announcements, :start, 'timestamp without time zone'
     change_column :announcements, :end, 'timestamp without time zone'

--- a/services/QuillLMS/db/migrate/20180207165525_add_slug_column_to_blog_posts_table.rb
+++ b/services/QuillLMS/db/migrate/20180207165525_add_slug_column_to_blog_posts_table.rb
@@ -1,4 +1,4 @@
-class AddSlugColumnToBlogPostsTable < ActiveRecord::Migration
+class AddSlugColumnToBlogPostsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :slug, :string
     add_index :blog_posts, :slug, unique: true

--- a/services/QuillLMS/db/migrate/20180209153502_add_payment_method_and_payment_amount_to_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20180209153502_add_payment_method_and_payment_amount_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddPaymentMethodAndPaymentAmountToSubscriptions < ActiveRecord::Migration
+class AddPaymentMethodAndPaymentAmountToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :payment_method, :string, index: true
     add_column :subscriptions, :payment_amount, :integer, index: true

--- a/services/QuillLMS/db/migrate/20180220204422_add_premium_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20180220204422_add_premium_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddPremiumToBlogPosts < ActiveRecord::Migration
+class AddPremiumToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :premium, :boolean, default: false
   end

--- a/services/QuillLMS/db/migrate/20180221162940_add_ts_vector_column_to_blog_posts_table.rb
+++ b/services/QuillLMS/db/migrate/20180221162940_add_ts_vector_column_to_blog_posts_table.rb
@@ -1,4 +1,4 @@
-class AddTsVectorColumnToBlogPostsTable < ActiveRecord::Migration
+class AddTsVectorColumnToBlogPostsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :tsv, :tsvector
     execute("CREATE INDEX tsv_idx ON blog_posts USING gin(tsv);")

--- a/services/QuillLMS/db/migrate/20180221163408_add_trigger_to_update_blog_posts_tsv.rb
+++ b/services/QuillLMS/db/migrate/20180221163408_add_trigger_to_update_blog_posts_tsv.rb
@@ -1,4 +1,4 @@
-class AddTriggerToUpdateBlogPostsTsv < ActiveRecord::Migration
+class AddTriggerToUpdateBlogPostsTsv < ActiveRecord::Migration[4.2]
   def change
     execute("
       CREATE FUNCTION blog_posts_search_trigger() RETURNS trigger AS $$

--- a/services/QuillLMS/db/migrate/20180221170200_add_index_to_announcements.rb
+++ b/services/QuillLMS/db/migrate/20180221170200_add_index_to_announcements.rb
@@ -1,4 +1,4 @@
-class AddIndexToAnnouncements < ActiveRecord::Migration
+class AddIndexToAnnouncements < ActiveRecord::Migration[4.2]
   def change
     add_index :announcements, [:start, :end], order: {start: :asc, end: :desc}
   end

--- a/services/QuillLMS/db/migrate/20180222160256_change_contact_user_id_name_add_authorizer_id.rb
+++ b/services/QuillLMS/db/migrate/20180222160256_change_contact_user_id_name_add_authorizer_id.rb
@@ -1,4 +1,4 @@
-class ChangeContactUserIdNameAddAuthorizerId < ActiveRecord::Migration
+class ChangeContactUserIdNameAddAuthorizerId < ActiveRecord::Migration[4.2]
   def change
     rename_column :subscriptions, :contact_user_id, :purchaser_id
     rename_column :subscriptions, :contact_email, :purchaser_email

--- a/services/QuillLMS/db/migrate/20180222160302_create_blog_post_user_ratings.rb
+++ b/services/QuillLMS/db/migrate/20180222160302_create_blog_post_user_ratings.rb
@@ -1,4 +1,4 @@
-class CreateBlogPostUserRatings < ActiveRecord::Migration
+class CreateBlogPostUserRatings < ActiveRecord::Migration[4.2]
   def change
     create_table :blog_post_user_ratings do |t|
       t.integer :blog_post_id

--- a/services/QuillLMS/db/migrate/20180222190628_add_coordinator_and_authorizer_to_school.rb
+++ b/services/QuillLMS/db/migrate/20180222190628_add_coordinator_and_authorizer_to_school.rb
@@ -1,4 +1,4 @@
-class AddCoordinatorAndAuthorizerToSchool < ActiveRecord::Migration
+class AddCoordinatorAndAuthorizerToSchool < ActiveRecord::Migration[4.2]
   def change
     add_column :schools, :authorizer_id, :integer, index: true
     add_column :schools, :coordinator_id, :integer, index: true

--- a/services/QuillLMS/db/migrate/20180227193833_add_published_at_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20180227193833_add_published_at_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToBlogPosts < ActiveRecord::Migration
+class AddPublishedAtToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :published_at, :datetime
   end

--- a/services/QuillLMS/db/migrate/20180227215931_add_external_link_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20180227215931_add_external_link_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddExternalLinkToBlogPosts < ActiveRecord::Migration
+class AddExternalLinkToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :external_link, :string
   end

--- a/services/QuillLMS/db/migrate/20180228171538_add_center_images_to_blog_post.rb
+++ b/services/QuillLMS/db/migrate/20180228171538_add_center_images_to_blog_post.rb
@@ -1,4 +1,4 @@
-class AddCenterImagesToBlogPost < ActiveRecord::Migration
+class AddCenterImagesToBlogPost < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :center_images, :boolean
   end

--- a/services/QuillLMS/db/migrate/20180301064334_add_order_number_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20180301064334_add_order_number_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddOrderNumberToBlogPosts < ActiveRecord::Migration
+class AddOrderNumberToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :order_number, :integer
   end

--- a/services/QuillLMS/db/migrate/20180301211956_create_images.rb
+++ b/services/QuillLMS/db/migrate/20180301211956_create_images.rb
@@ -1,4 +1,4 @@
-class CreateImages < ActiveRecord::Migration
+class CreateImages < ActiveRecord::Migration[4.2]
   def change
     create_table :images do |t|
       t.string :file

--- a/services/QuillLMS/db/migrate/20180307212219_change_default_start_date.rb
+++ b/services/QuillLMS/db/migrate/20180307212219_change_default_start_date.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultStartDate < ActiveRecord::Migration
+class ChangeDefaultStartDate < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:subscriptions, :start_date, nil)
   end

--- a/services/QuillLMS/db/migrate/20180308203054_remove_purchaser_email_index_from_subscriptions_and_add_without_uniqueness.rb
+++ b/services/QuillLMS/db/migrate/20180308203054_remove_purchaser_email_index_from_subscriptions_and_add_without_uniqueness.rb
@@ -1,4 +1,4 @@
-class RemovePurchaserEmailIndexFromSubscriptionsAndAddWithoutUniqueness < ActiveRecord::Migration
+class RemovePurchaserEmailIndexFromSubscriptionsAndAddWithoutUniqueness < ActiveRecord::Migration[4.2]
   def change
     # this was unique before, which we do not wantF
     remove_index :subscriptions, :purchaser_email

--- a/services/QuillLMS/db/migrate/20180312180605_create_sales_accounts.rb
+++ b/services/QuillLMS/db/migrate/20180312180605_create_sales_accounts.rb
@@ -1,4 +1,4 @@
-class CreateSalesAccounts < ActiveRecord::Migration
+class CreateSalesAccounts < ActiveRecord::Migration[4.2]
   def change
     create_table :sales_accounts do |t|
       t.references :school, index: true, foreign_key: true

--- a/services/QuillLMS/db/migrate/20180312204645_remove_account_limit_from_subscription.rb
+++ b/services/QuillLMS/db/migrate/20180312204645_remove_account_limit_from_subscription.rb
@@ -1,4 +1,4 @@
-class RemoveAccountLimitFromSubscription < ActiveRecord::Migration
+class RemoveAccountLimitFromSubscription < ActiveRecord::Migration[4.2]
   def change
     remove_column :subscriptions, :account_limit, :integer
   end

--- a/services/QuillLMS/db/migrate/20180319133511_drop_sales_accounts_table.rb
+++ b/services/QuillLMS/db/migrate/20180319133511_drop_sales_accounts_table.rb
@@ -1,4 +1,4 @@
-class DropSalesAccountsTable < ActiveRecord::Migration
+class DropSalesAccountsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :sales_accounts
   end

--- a/services/QuillLMS/db/migrate/20180319145514_create_sales_stage_types_table.rb
+++ b/services/QuillLMS/db/migrate/20180319145514_create_sales_stage_types_table.rb
@@ -1,4 +1,4 @@
-class CreateSalesStageTypesTable < ActiveRecord::Migration
+class CreateSalesStageTypesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :sales_stage_types do |t|
       t.text :description

--- a/services/QuillLMS/db/migrate/20180319145837_create_sales_contacts.rb
+++ b/services/QuillLMS/db/migrate/20180319145837_create_sales_contacts.rb
@@ -1,4 +1,4 @@
-class CreateSalesContacts < ActiveRecord::Migration
+class CreateSalesContacts < ActiveRecord::Migration[4.2]
   def change
     create_table :sales_contacts do |t|
       t.references :user, index: true, foreign_key: true

--- a/services/QuillLMS/db/migrate/20180319145946_create_sales_stages_table.rb
+++ b/services/QuillLMS/db/migrate/20180319145946_create_sales_stages_table.rb
@@ -1,4 +1,4 @@
-class CreateSalesStagesTable < ActiveRecord::Migration
+class CreateSalesStagesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :sales_stages do |t|
       t.references :user, index: true, foreign_key: true

--- a/services/QuillLMS/db/migrate/20180319165718_rename_completed_column_on_sales_stages.rb
+++ b/services/QuillLMS/db/migrate/20180319165718_rename_completed_column_on_sales_stages.rb
@@ -1,4 +1,4 @@
-class RenameCompletedColumnOnSalesStages < ActiveRecord::Migration
+class RenameCompletedColumnOnSalesStages < ActiveRecord::Migration[4.2]
   def change
     rename_column :sales_stages, :completed, :completed_at
   end

--- a/services/QuillLMS/db/migrate/20180319192659_add_trigger_to_sales_stage_types.rb
+++ b/services/QuillLMS/db/migrate/20180319192659_add_trigger_to_sales_stage_types.rb
@@ -1,4 +1,4 @@
-class AddTriggerToSalesStageTypes < ActiveRecord::Migration
+class AddTriggerToSalesStageTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :sales_stage_types, :trigger, :integer
   end

--- a/services/QuillLMS/db/migrate/20180319195339_add_unique_index_to_name_and_order_on_sales_stage_types.rb
+++ b/services/QuillLMS/db/migrate/20180319195339_add_unique_index_to_name_and_order_on_sales_stage_types.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToNameAndOrderOnSalesStageTypes < ActiveRecord::Migration
+class AddUniqueIndexToNameAndOrderOnSalesStageTypes < ActiveRecord::Migration[4.2]
   def change
     add_index :sales_stage_types, [:name, :order], unique: true
   end

--- a/services/QuillLMS/db/migrate/20180319200940_add_null_constraints_to_sales_stage_types.rb
+++ b/services/QuillLMS/db/migrate/20180319200940_add_null_constraints_to_sales_stage_types.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintsToSalesStageTypes < ActiveRecord::Migration
+class AddNullConstraintsToSalesStageTypes < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:sales_stage_types, :name, false)
     change_column_null(:sales_stage_types, :order, false)

--- a/services/QuillLMS/db/migrate/20180319201128_add_null_constraint_to_sales_contacts.rb
+++ b/services/QuillLMS/db/migrate/20180319201128_add_null_constraint_to_sales_contacts.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintToSalesContacts < ActiveRecord::Migration
+class AddNullConstraintToSalesContacts < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:sales_contacts, :user_id, false)
   end

--- a/services/QuillLMS/db/migrate/20180319201311_add_null_constraints_to_sales_stages.rb
+++ b/services/QuillLMS/db/migrate/20180319201311_add_null_constraints_to_sales_stages.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintsToSalesStages < ActiveRecord::Migration
+class AddNullConstraintsToSalesStages < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:sales_stages, :sales_stage_type_id, false)
     change_column_null(:sales_stages, :sales_contact_id, false)

--- a/services/QuillLMS/db/migrate/20180417202537_add_flags_to_users.rb
+++ b/services/QuillLMS/db/migrate/20180417202537_add_flags_to_users.rb
@@ -1,4 +1,4 @@
-class AddFlagsToUsers < ActiveRecord::Migration
+class AddFlagsToUsers < ActiveRecord::Migration[4.2]
   add_column :users, :flags, :string, array: true, default: [], null: false
   add_index :users, :flags
 end

--- a/services/QuillLMS/db/migrate/20180418185045_remove_flag_from_user.rb
+++ b/services/QuillLMS/db/migrate/20180418185045_remove_flag_from_user.rb
@@ -1,4 +1,4 @@
-class RemoveFlagFromUser < ActiveRecord::Migration
+class RemoveFlagFromUser < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :flag, :string
   end

--- a/services/QuillLMS/db/migrate/20180502152419_add_time_zone_to_users.rb
+++ b/services/QuillLMS/db/migrate/20180502152419_add_time_zone_to_users.rb
@@ -1,4 +1,4 @@
-class AddTimeZoneToUsers < ActiveRecord::Migration
+class AddTimeZoneToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :time_zone, :string
     add_index :users, :time_zone

--- a/services/QuillLMS/db/migrate/20180517045137_add_title_to_users.rb
+++ b/services/QuillLMS/db/migrate/20180517045137_add_title_to_users.rb
@@ -1,4 +1,4 @@
-class AddTitleToUsers < ActiveRecord::Migration
+class AddTitleToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :title, :string
   end

--- a/services/QuillLMS/db/migrate/20180530145153_create_auth_credentials.rb
+++ b/services/QuillLMS/db/migrate/20180530145153_create_auth_credentials.rb
@@ -1,4 +1,4 @@
-class CreateAuthCredentials < ActiveRecord::Migration
+class CreateAuthCredentials < ActiveRecord::Migration[4.2]
   def change
     create_table :auth_credentials do |t|
       t.references :user, index: true, foreign_key: true, null: false

--- a/services/QuillLMS/db/migrate/20180625211305_create_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180625211305_create_recommendations.rb
@@ -1,4 +1,4 @@
-class CreateRecommendations < ActiveRecord::Migration
+class CreateRecommendations < ActiveRecord::Migration[4.2]
   def change
     create_table :recommendations do |t|
       t.string :name, length: 150, null: false

--- a/services/QuillLMS/db/migrate/20180627183421_add_type_to_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180627183421_add_type_to_recommendations.rb
@@ -1,4 +1,4 @@
-class AddTypeToRecommendations < ActiveRecord::Migration
+class AddTypeToRecommendations < ActiveRecord::Migration[4.2]
   def change
     add_column :recommendations, :type, :integer, null: false
   end

--- a/services/QuillLMS/db/migrate/20180627184008_remove_concept_reference_from_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180627184008_remove_concept_reference_from_recommendations.rb
@@ -1,4 +1,4 @@
-class RemoveConceptReferenceFromRecommendations < ActiveRecord::Migration
+class RemoveConceptReferenceFromRecommendations < ActiveRecord::Migration[4.2]
   def change
     remove_reference :recommendations, :concept, index: true
   end

--- a/services/QuillLMS/db/migrate/20180627200532_change_type_to_category_on_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180627200532_change_type_to_category_on_recommendations.rb
@@ -1,4 +1,4 @@
-class ChangeTypeToCategoryOnRecommendations < ActiveRecord::Migration
+class ChangeTypeToCategoryOnRecommendations < ActiveRecord::Migration[4.2]
   def change
     rename_column :recommendations, :type, :category
   end

--- a/services/QuillLMS/db/migrate/20180628161337_create_criteria.rb
+++ b/services/QuillLMS/db/migrate/20180628161337_create_criteria.rb
@@ -1,4 +1,4 @@
-class CreateCriteria < ActiveRecord::Migration
+class CreateCriteria < ActiveRecord::Migration[4.2]
   def change
     create_table :criteria do |t|
       t.references :concept, index: true, foreign_key: true, null: false

--- a/services/QuillLMS/db/migrate/20180628182314_add_recommendation_to_criteria.rb
+++ b/services/QuillLMS/db/migrate/20180628182314_add_recommendation_to_criteria.rb
@@ -1,4 +1,4 @@
-class AddRecommendationToCriteria < ActiveRecord::Migration
+class AddRecommendationToCriteria < ActiveRecord::Migration[4.2]
   def change
     add_reference :criteria, :recommendation, index: true, foreign_key: true, null: false
   end

--- a/services/QuillLMS/db/migrate/20180628191240_add_uniqueness_contraint_on_criteria.rb
+++ b/services/QuillLMS/db/migrate/20180628191240_add_uniqueness_contraint_on_criteria.rb
@@ -1,4 +1,4 @@
-class AddUniquenessContraintOnCriteria < ActiveRecord::Migration
+class AddUniquenessContraintOnCriteria < ActiveRecord::Migration[4.2]
   def change
     add_index :criteria, [:recommendation_id, :concept_id, :category], unique: true
   end

--- a/services/QuillLMS/db/migrate/20180629151757_remove_name_uniqueness_constriant_on_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180629151757_remove_name_uniqueness_constriant_on_recommendations.rb
@@ -1,4 +1,4 @@
-class RemoveNameUniquenessConstriantOnRecommendations < ActiveRecord::Migration
+class RemoveNameUniquenessConstriantOnRecommendations < ActiveRecord::Migration[4.2]
   def change
     remove_index :recommendations, :name
   end

--- a/services/QuillLMS/db/migrate/20180702201017_add_order_to_recommendations.rb
+++ b/services/QuillLMS/db/migrate/20180702201017_add_order_to_recommendations.rb
@@ -1,4 +1,4 @@
-class AddOrderToRecommendations < ActiveRecord::Migration
+class AddOrderToRecommendations < ActiveRecord::Migration[4.2]
   def change
     add_column :recommendations, :order, :integer, null: false, default: 0
   end

--- a/services/QuillLMS/db/migrate/20180703154253_add_no_incorrect_to_criteria.rb
+++ b/services/QuillLMS/db/migrate/20180703154253_add_no_incorrect_to_criteria.rb
@@ -1,4 +1,4 @@
-class AddNoIncorrectToCriteria < ActiveRecord::Migration
+class AddNoIncorrectToCriteria < ActiveRecord::Migration[4.2]
   def change
     add_column :criteria, :no_incorrect, :boolean, null: false, default: false
   end

--- a/services/QuillLMS/db/migrate/20180703154718_remove_category_from_criteria.rb
+++ b/services/QuillLMS/db/migrate/20180703154718_remove_category_from_criteria.rb
@@ -1,4 +1,4 @@
-class RemoveCategoryFromCriteria < ActiveRecord::Migration
+class RemoveCategoryFromCriteria < ActiveRecord::Migration[4.2]
   def up
     remove_column :criteria, :category
   end

--- a/services/QuillLMS/db/migrate/20180709190219_add_unit_activities_table.rb
+++ b/services/QuillLMS/db/migrate/20180709190219_add_unit_activities_table.rb
@@ -1,4 +1,4 @@
-class AddUnitActivitiesTable < ActiveRecord::Migration
+class AddUnitActivitiesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :unit_activities do |t|
       t.references :unit, index: true, foreign_key: true, null: false

--- a/services/QuillLMS/db/migrate/20180709190257_add_classroom_units_table.rb
+++ b/services/QuillLMS/db/migrate/20180709190257_add_classroom_units_table.rb
@@ -1,4 +1,4 @@
-class AddClassroomUnitsTable < ActiveRecord::Migration
+class AddClassroomUnitsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :classroom_units do |t|
       t.references :classroom, index: true, foreign_key: true, null: false

--- a/services/QuillLMS/db/migrate/20180709190427_add_classroom_unit_activity_state_table.rb
+++ b/services/QuillLMS/db/migrate/20180709190427_add_classroom_unit_activity_state_table.rb
@@ -1,4 +1,4 @@
-class AddClassroomUnitActivityStateTable < ActiveRecord::Migration
+class AddClassroomUnitActivityStateTable < ActiveRecord::Migration[4.2]
   def change
     create_table :classroom_unit_activity_states do |t|
       t.references :classroom_unit, index: true, foreign_key: true, null: false

--- a/services/QuillLMS/db/migrate/20180709192646_add_classroom_unit_id_to_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180709192646_add_classroom_unit_id_to_activity_session.rb
@@ -1,4 +1,4 @@
-class AddClassroomUnitIdToActivitySession < ActiveRecord::Migration
+class AddClassroomUnitIdToActivitySession < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_sessions, :classroom_unit_id, :integer
   end

--- a/services/QuillLMS/db/migrate/20180718195853_add_classroom_unit_id_index_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20180718195853_add_classroom_unit_id_index_to_activity_sessions.rb
@@ -1,4 +1,4 @@
-class AddClassroomUnitIdIndexToActivitySessions < ActiveRecord::Migration
+class AddClassroomUnitIdIndexToActivitySessions < ActiveRecord::Migration[4.2]
   def change
     add_index :activity_sessions, [:classroom_unit_id]
   end

--- a/services/QuillLMS/db/migrate/20180810181001_add_visible_and_replacement_id_to_concepts.rb
+++ b/services/QuillLMS/db/migrate/20180810181001_add_visible_and_replacement_id_to_concepts.rb
@@ -1,4 +1,4 @@
-class AddVisibleAndReplacementIdToConcepts < ActiveRecord::Migration
+class AddVisibleAndReplacementIdToConcepts < ActiveRecord::Migration[4.2]
   def change
     add_column :concepts, :replacement_id, :integer, foreign_key: true
     add_column :concepts, :visible, :boolean, default: true

--- a/services/QuillLMS/db/migrate/20180815174156_create_notifications.rb
+++ b/services/QuillLMS/db/migrate/20180815174156_create_notifications.rb
@@ -1,4 +1,4 @@
-class CreateNotifications < ActiveRecord::Migration
+class CreateNotifications < ActiveRecord::Migration[4.2]
   def change
     create_table :notifications do |t|
     end

--- a/services/QuillLMS/db/migrate/20180815180204_add_text_to_notifications.rb
+++ b/services/QuillLMS/db/migrate/20180815180204_add_text_to_notifications.rb
@@ -1,4 +1,4 @@
-class AddTextToNotifications < ActiveRecord::Migration
+class AddTextToNotifications < ActiveRecord::Migration[4.2]
   def change
     add_column :notifications, :text, :text, null: false, limit: 500
   end

--- a/services/QuillLMS/db/migrate/20180816210411_add_user_ref_to_notifications.rb
+++ b/services/QuillLMS/db/migrate/20180816210411_add_user_ref_to_notifications.rb
@@ -1,4 +1,4 @@
-class AddUserRefToNotifications < ActiveRecord::Migration
+class AddUserRefToNotifications < ActiveRecord::Migration[4.2]
   def change
     add_reference :notifications, :user, foreign_key: true, index: true, null: false
   end

--- a/services/QuillLMS/db/migrate/20180817171936_create_activity_session_interaction_logs.rb
+++ b/services/QuillLMS/db/migrate/20180817171936_create_activity_session_interaction_logs.rb
@@ -1,4 +1,4 @@
-class CreateActivitySessionInteractionLogs < ActiveRecord::Migration
+class CreateActivitySessionInteractionLogs < ActiveRecord::Migration[4.2]
   def change
     create_table :activity_session_interaction_logs do |t|
       t.datetime :date

--- a/services/QuillLMS/db/migrate/20180820154444_add_meta_column_to_notifications.rb
+++ b/services/QuillLMS/db/migrate/20180820154444_add_meta_column_to_notifications.rb
@@ -1,4 +1,4 @@
-class AddMetaColumnToNotifications < ActiveRecord::Migration
+class AddMetaColumnToNotifications < ActiveRecord::Migration[4.2]
   def change
     add_column :notifications, :meta, :jsonb, null: false, default: '{}'
   end

--- a/services/QuillLMS/db/migrate/20180821200652_add_function_timespent_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180821200652_add_function_timespent_activity_session.rb
@@ -1,4 +1,4 @@
-class AddFunctionTimespentActivitySession < ActiveRecord::Migration
+class AddFunctionTimespentActivitySession < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_activity_session(act_sess int) RETURNS integer AS $$

--- a/services/QuillLMS/db/migrate/20180821201236_add_function_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821201236_add_function_timespent_teacher.rb
@@ -1,4 +1,4 @@
-class AddFunctionTimespentTeacher < ActiveRecord::Migration
+class AddFunctionTimespentTeacher < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_teacher(teacher int) RETURNS bigint AS $$

--- a/services/QuillLMS/db/migrate/20180821201559_add_function_timespent_student.rb
+++ b/services/QuillLMS/db/migrate/20180821201559_add_function_timespent_student.rb
@@ -1,4 +1,4 @@
-class AddFunctionTimespentStudent < ActiveRecord::Migration
+class AddFunctionTimespentStudent < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_student(student int) RETURNS bigint AS $$

--- a/services/QuillLMS/db/migrate/20180821202836_add_function_timespent_student_for_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821202836_add_function_timespent_student_for_teacher.rb
@@ -1,4 +1,4 @@
-class AddFunctionTimespentStudentForTeacher < ActiveRecord::Migration
+class AddFunctionTimespentStudentForTeacher < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_student_for_teacher(student int, teacher int) RETURNS bigint AS $$

--- a/services/QuillLMS/db/migrate/20180821213520_add_function_old_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821213520_add_function_old_timespent_teacher.rb
@@ -1,4 +1,4 @@
-class AddFunctionOldTimespentTeacher < ActiveRecord::Migration
+class AddFunctionOldTimespentTeacher < ActiveRecord::Migration[4.2]
   # backward compatibility function. hardcoded timestamp should be the datetime
   # of the migration.
   def up

--- a/services/QuillLMS/db/migrate/20180822144355_replace_function_old_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822144355_replace_function_old_timespent_teacher.rb
@@ -1,4 +1,4 @@
-class ReplaceFunctionOldTimespentTeacher < ActiveRecord::Migration
+class ReplaceFunctionOldTimespentTeacher < ActiveRecord::Migration[4.2]
   # backward compatibility function. hardcoded timestamp should be the datetime
   # of the migration.
   def up

--- a/services/QuillLMS/db/migrate/20180822155024_replace_function_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822155024_replace_function_timespent_teacher.rb
@@ -1,4 +1,4 @@
-class ReplaceFunctionTimespentTeacher < ActiveRecord::Migration
+class ReplaceFunctionTimespentTeacher < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_teacher(teacher int) RETURNS bigint AS $$

--- a/services/QuillLMS/db/migrate/20180822155243_replace_function_timespent_student_for_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822155243_replace_function_timespent_student_for_teacher.rb
@@ -1,4 +1,4 @@
-class ReplaceFunctionTimespentStudentForTeacher < ActiveRecord::Migration
+class ReplaceFunctionTimespentStudentForTeacher < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_student_for_teacher(student int, teacher int) RETURNS bigint AS $$

--- a/services/QuillLMS/db/migrate/20180824185130_replace_function_timepent_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180824185130_replace_function_timepent_activity_session.rb
@@ -1,4 +1,4 @@
-class ReplaceFunctionTimepentActivitySession < ActiveRecord::Migration
+class ReplaceFunctionTimepentActivitySession < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_activity_session(act_sess int) RETURNS integer AS $$

--- a/services/QuillLMS/db/migrate/20180824185824_add_timespent_to_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180824185824_add_timespent_to_activity_session.rb
@@ -1,4 +1,4 @@
-class AddTimespentToActivitySession < ActiveRecord::Migration
+class AddTimespentToActivitySession < ActiveRecord::Migration[4.2]
   def change
     add_column :activity_sessions, :timespent, :integer
   end

--- a/services/QuillLMS/db/migrate/20180824195642_replace_function_timepent_activity_session_again.rb
+++ b/services/QuillLMS/db/migrate/20180824195642_replace_function_timepent_activity_session_again.rb
@@ -1,4 +1,4 @@
-class ReplaceFunctionTimepentActivitySessionAgain < ActiveRecord::Migration
+class ReplaceFunctionTimepentActivitySessionAgain < ActiveRecord::Migration[4.2]
   def up
     connection.execute(%q{
       CREATE OR REPLACE FUNCTION timespent_activity_session(act_sess int) RETURNS integer AS $$

--- a/services/QuillLMS/db/migrate/20180827212450_add_timestamps_to_notifications.rb
+++ b/services/QuillLMS/db/migrate/20180827212450_add_timestamps_to_notifications.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToNotifications < ActiveRecord::Migration
+class AddTimestampsToNotifications < ActiveRecord::Migration[4.2]
   def change
     change_table :notifications do |t|
       t.timestamps

--- a/services/QuillLMS/db/migrate/20180831194810_add_function_timespent_question.rb
+++ b/services/QuillLMS/db/migrate/20180831194810_add_function_timespent_question.rb
@@ -1,4 +1,4 @@
-class AddFunctionTimespentQuestion < ActiveRecord::Migration
+class AddFunctionTimespentQuestion < ActiveRecord::Migration[4.2]
   # backward compatibility function. hardcoded timestamp should be the datetime
   # of the migration.
   def up

--- a/services/QuillLMS/db/migrate/20180910152342_add_activated_column_to_referrals_user.rb
+++ b/services/QuillLMS/db/migrate/20180910152342_add_activated_column_to_referrals_user.rb
@@ -1,4 +1,4 @@
-class AddActivatedColumnToReferralsUser < ActiveRecord::Migration
+class AddActivatedColumnToReferralsUser < ActiveRecord::Migration[4.2]
   def change
     add_column :referrals_users, :activated, :boolean, default: false
     add_index :referrals_users, :activated

--- a/services/QuillLMS/db/migrate/20180911171536_add_description_to_concepts.rb
+++ b/services/QuillLMS/db/migrate/20180911171536_add_description_to_concepts.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToConcepts < ActiveRecord::Migration
+class AddDescriptionToConcepts < ActiveRecord::Migration[4.2]
   def change
     add_column :concepts, :description, :text
   end

--- a/services/QuillLMS/db/migrate/20181012155250_add_account_type_to_users.rb
+++ b/services/QuillLMS/db/migrate/20181012155250_add_account_type_to_users.rb
@@ -1,4 +1,4 @@
-class AddAccountTypeToUsers < ActiveRecord::Migration
+class AddAccountTypeToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :account_type, :string, default: 'unknown'
   end

--- a/services/QuillLMS/db/migrate/20181018195753_add_image_link_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20181018195753_add_image_link_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddImageLinkToBlogPosts < ActiveRecord::Migration
+class AddImageLinkToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :image_link, :string
   end

--- a/services/QuillLMS/db/migrate/20181026201202_create_zipcode_infos.rb
+++ b/services/QuillLMS/db/migrate/20181026201202_create_zipcode_infos.rb
@@ -1,4 +1,4 @@
-class CreateZipcodeInfos < ActiveRecord::Migration
+class CreateZipcodeInfos < ActiveRecord::Migration[4.2]
   def change
     create_table :zipcode_infos do |t|
       t.text :zipcode, index: { unique: true }

--- a/services/QuillLMS/db/migrate/20181030155356_add_index_to_schools.rb
+++ b/services/QuillLMS/db/migrate/20181030155356_add_index_to_schools.rb
@@ -1,4 +1,4 @@
-class AddIndexToSchools < ActiveRecord::Migration
+class AddIndexToSchools < ActiveRecord::Migration[4.2]
   def change
     add_index :schools, :mail_zipcode
   end

--- a/services/QuillLMS/db/migrate/20181105212102_add_pkey_to_activities_units_templates.rb
+++ b/services/QuillLMS/db/migrate/20181105212102_add_pkey_to_activities_units_templates.rb
@@ -1,4 +1,4 @@
-class AddPkeyToActivitiesUnitsTemplates < ActiveRecord::Migration
+class AddPkeyToActivitiesUnitsTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :activities_unit_templates, :id, :primary_key, auto_increment: true
   end

--- a/services/QuillLMS/db/migrate/20181203161708_remove_index_on_key_from_activity_classifications.rb
+++ b/services/QuillLMS/db/migrate/20181203161708_remove_index_on_key_from_activity_classifications.rb
@@ -1,4 +1,4 @@
-class RemoveIndexOnKeyFromActivityClassifications < ActiveRecord::Migration
+class RemoveIndexOnKeyFromActivityClassifications < ActiveRecord::Migration[4.2]
   def change
     remove_index :activity_classifications, column: :key
   end

--- a/services/QuillLMS/db/migrate/20181214192858_index_users_on_clever_id.rb
+++ b/services/QuillLMS/db/migrate/20181214192858_index_users_on_clever_id.rb
@@ -1,4 +1,4 @@
-class IndexUsersOnCleverId < ActiveRecord::Migration
+class IndexUsersOnCleverId < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :clever_id
   end

--- a/services/QuillLMS/db/migrate/20190128203336_add_order_number_to_unit_activities.rb
+++ b/services/QuillLMS/db/migrate/20190128203336_add_order_number_to_unit_activities.rb
@@ -1,4 +1,4 @@
-class AddOrderNumberToUnitActivities < ActiveRecord::Migration
+class AddOrderNumberToUnitActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_activities, :order_number, :integer, limit: 2, after: :due_date
   end

--- a/services/QuillLMS/db/migrate/20190214172006_add_concept_index_to_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20190214172006_add_concept_index_to_concept_results.rb
@@ -1,4 +1,4 @@
-class AddConceptIndexToConceptResults < ActiveRecord::Migration
+class AddConceptIndexToConceptResults < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def up
     add_index :concept_results, :concept_id, algorithm: :concurrently unless index_exists?(:concept_results, :concept_id)

--- a/services/QuillLMS/db/migrate/20190312193928_add_image_link_to_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20190312193928_add_image_link_to_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddImageLinkToUnitTemplates < ActiveRecord::Migration
+class AddImageLinkToUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :unit_templates, :image_link, :string
   end

--- a/services/QuillLMS/db/migrate/20190412152236_add_post_google_classroom_assignments_to_users.rb
+++ b/services/QuillLMS/db/migrate/20190412152236_add_post_google_classroom_assignments_to_users.rb
@@ -1,4 +1,4 @@
-class AddPostGoogleClassroomAssignmentsToUsers < ActiveRecord::Migration
+class AddPostGoogleClassroomAssignmentsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :post_google_classroom_assignments, :boolean
   end

--- a/services/QuillLMS/db/migrate/20190604133438_create_change_log.rb
+++ b/services/QuillLMS/db/migrate/20190604133438_create_change_log.rb
@@ -1,4 +1,4 @@
-class CreateChangeLog < ActiveRecord::Migration
+class CreateChangeLog < ActiveRecord::Migration[4.2]
   def change
     create_table :change_logs do |t|
       t.text :explanation, null: false

--- a/services/QuillLMS/db/migrate/20190611155916_add_previous_value_to_change_logs.rb
+++ b/services/QuillLMS/db/migrate/20190611155916_add_previous_value_to_change_logs.rb
@@ -1,4 +1,4 @@
-class AddPreviousValueToChangeLogs < ActiveRecord::Migration
+class AddPreviousValueToChangeLogs < ActiveRecord::Migration[4.2]
   def change
     add_column :change_logs, :changed_attribute, :string, after: :action
     add_column :change_logs, :previous_value, :text, after: :action

--- a/services/QuillLMS/db/migrate/20191001184042_create_title_cards.rb
+++ b/services/QuillLMS/db/migrate/20191001184042_create_title_cards.rb
@@ -1,4 +1,4 @@
-class CreateTitleCards < ActiveRecord::Migration
+class CreateTitleCards < ActiveRecord::Migration[4.2]
   def change
     create_table :title_cards do |t|
       t.string :uid

--- a/services/QuillLMS/db/migrate/20191001190234_add_uid_index_to_title_card.rb
+++ b/services/QuillLMS/db/migrate/20191001190234_add_uid_index_to_title_card.rb
@@ -1,4 +1,4 @@
-class AddUidIndexToTitleCard < ActiveRecord::Migration
+class AddUidIndexToTitleCard < ActiveRecord::Migration[4.2]
   def change
     add_index :title_cards, :uid, unique: true
   end

--- a/services/QuillLMS/db/migrate/20191003192319_make_title_cards_uid_not_null.rb
+++ b/services/QuillLMS/db/migrate/20191003192319_make_title_cards_uid_not_null.rb
@@ -1,4 +1,4 @@
-class MakeTitleCardsUidNotNull < ActiveRecord::Migration
+class MakeTitleCardsUidNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:title_cards, :uid, false)
   end

--- a/services/QuillLMS/db/migrate/20191008191026_create_third_party_user_ids.rb
+++ b/services/QuillLMS/db/migrate/20191008191026_create_third_party_user_ids.rb
@@ -1,4 +1,4 @@
-class CreateThirdPartyUserIds < ActiveRecord::Migration
+class CreateThirdPartyUserIds < ActiveRecord::Migration[4.2]
   def change
     create_table :third_party_user_ids do |t|
       t.references :user, index: true, foreign_key: true

--- a/services/QuillLMS/db/migrate/20191016155645_add_order_to_activities_unit_templates.rb
+++ b/services/QuillLMS/db/migrate/20191016155645_add_order_to_activities_unit_templates.rb
@@ -1,4 +1,4 @@
-class AddOrderToActivitiesUnitTemplates < ActiveRecord::Migration
+class AddOrderToActivitiesUnitTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :activities_unit_templates, :order_number, :integer
   end

--- a/services/QuillLMS/db/migrate/20191016202708_add_partner_content.rb
+++ b/services/QuillLMS/db/migrate/20191016202708_add_partner_content.rb
@@ -1,4 +1,4 @@
-class AddPartnerContent < ActiveRecord::Migration
+class AddPartnerContent < ActiveRecord::Migration[4.2]
   def change
     create_table :partner_contents do |t|
       t.string :partner, limit: 50

--- a/services/QuillLMS/db/migrate/20191022142949_add_press_name_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20191022142949_add_press_name_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddPressNameToBlogPosts < ActiveRecord::Migration
+class AddPressNameToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :press_name, :string
   end

--- a/services/QuillLMS/db/migrate/20191024150907_create_questions.rb
+++ b/services/QuillLMS/db/migrate/20191024150907_create_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.string :uid

--- a/services/QuillLMS/db/migrate/20191030183959_make_question_columns_not_null.rb
+++ b/services/QuillLMS/db/migrate/20191030183959_make_question_columns_not_null.rb
@@ -1,4 +1,4 @@
-class MakeQuestionColumnsNotNull < ActiveRecord::Migration
+class MakeQuestionColumnsNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column_null :questions, :uid, false
     change_column_null :questions, :data, false, {}

--- a/services/QuillLMS/db/migrate/20191122181105_add_question_type_to_questions.rb
+++ b/services/QuillLMS/db/migrate/20191122181105_add_question_type_to_questions.rb
@@ -1,4 +1,4 @@
-class AddQuestionTypeToQuestions < ActiveRecord::Migration
+class AddQuestionTypeToQuestions < ActiveRecord::Migration[4.2]
   def up
     add_column :questions, :question_type, :string
     add_index :questions, :question_type

--- a/services/QuillLMS/db/migrate/20191218174724_add_unique_clever_id_index_to_users.rb
+++ b/services/QuillLMS/db/migrate/20191218174724_add_unique_clever_id_index_to_users.rb
@@ -1,4 +1,4 @@
-class AddUniqueCleverIdIndexToUsers < ActiveRecord::Migration
+class AddUniqueCleverIdIndexToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :clever_id, unique: true, name: 'unique_index_users_on_clever_id', where: "clever_id IS NOT null AND clever_id != '' AND (id > 5593155 OR role = 'student') "
   end

--- a/services/QuillLMS/db/migrate/20200123170454_allow_null_on_change_logs_column.rb
+++ b/services/QuillLMS/db/migrate/20200123170454_allow_null_on_change_logs_column.rb
@@ -1,4 +1,4 @@
-class AllowNullOnChangeLogsColumn < ActiveRecord::Migration
+class AllowNullOnChangeLogsColumn < ActiveRecord::Migration[4.2]
   def change
     change_column_null :change_logs, :changed_record_id, true
     change_column_null :change_logs, :explanation, true

--- a/services/QuillLMS/db/migrate/20200324192053_add_lessons_table.rb
+++ b/services/QuillLMS/db/migrate/20200324192053_add_lessons_table.rb
@@ -1,4 +1,4 @@
-class AddLessonsTable < ActiveRecord::Migration
+class AddLessonsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :lessons do |t|
       t.string :uid

--- a/services/QuillLMS/db/migrate/20200326152208_add_type_to_title_card.rb
+++ b/services/QuillLMS/db/migrate/20200326152208_add_type_to_title_card.rb
@@ -1,4 +1,4 @@
-class AddTypeToTitleCard < ActiveRecord::Migration
+class AddTypeToTitleCard < ActiveRecord::Migration[4.2]
   def up
     add_column :title_cards, :title_card_type, :string
     add_index :title_cards, :title_card_type

--- a/services/QuillLMS/db/migrate/20200326220320_add_lesson_type_to_lessons.rb
+++ b/services/QuillLMS/db/migrate/20200326220320_add_lesson_type_to_lessons.rb
@@ -2,11 +2,9 @@ class AddLessonTypeToLessons < ActiveRecord::Migration[4.2]
   def up
     add_column :lessons, :lesson_type, :string
     add_index :lessons, :lesson_type
-# Commenting this out since there's no longer a `Lesson` model in the
-# code-base, and that means that this migration can't run anymore.
-# Dropping this line won't matter since a follow-on migration deletes
-# this table anyway
-#    Lesson.update_all(lesson_type: 'connect_lesson')
+    # The Lesson model no longer exists, so we need to modify
+    # the migration to avoid this call for modern versions of the code
+    Lesson.update_all(lesson_type: 'connect_lesson') if defined?(Lesson)
     change_column_null :lessons, :lesson_type, false
   end
   def down

--- a/services/QuillLMS/db/migrate/20200326220320_add_lesson_type_to_lessons.rb
+++ b/services/QuillLMS/db/migrate/20200326220320_add_lesson_type_to_lessons.rb
@@ -1,8 +1,12 @@
-class AddLessonTypeToLessons < ActiveRecord::Migration
+class AddLessonTypeToLessons < ActiveRecord::Migration[4.2]
   def up
     add_column :lessons, :lesson_type, :string
     add_index :lessons, :lesson_type
-    Lesson.update_all(lesson_type: 'connect_lesson')
+# Commenting this out since there's no longer a `Lesson` model in the
+# code-base, and that means that this migration can't run anymore.
+# Dropping this line won't matter since a follow-on migration deletes
+# this table anyway
+#    Lesson.update_all(lesson_type: 'connect_lesson')
     change_column_null :lessons, :lesson_type, false
   end
   def down

--- a/services/QuillLMS/db/migrate/20200409151835_add_concept_feedback_table.rb
+++ b/services/QuillLMS/db/migrate/20200409151835_add_concept_feedback_table.rb
@@ -1,4 +1,4 @@
-class AddConceptFeedbackTable < ActiveRecord::Migration
+class AddConceptFeedbackTable < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_feedbacks do |t|
       t.string :uid

--- a/services/QuillLMS/db/migrate/20200415170227_add_explanation_to_concepts.rb
+++ b/services/QuillLMS/db/migrate/20200415170227_add_explanation_to_concepts.rb
@@ -1,4 +1,4 @@
-class AddExplanationToConcepts < ActiveRecord::Migration
+class AddExplanationToConcepts < ActiveRecord::Migration[4.2]
   def change
     add_column :concepts, :explanation, :text
   end

--- a/services/QuillLMS/db/migrate/20200505171239_add_activity_type_to_concept_feedback.rb
+++ b/services/QuillLMS/db/migrate/20200505171239_add_activity_type_to_concept_feedback.rb
@@ -1,4 +1,4 @@
-class AddActivityTypeToConceptFeedback < ActiveRecord::Migration
+class AddActivityTypeToConceptFeedback < ActiveRecord::Migration[4.2]
   def up
     add_column :concept_feedbacks, :activity_type, :string
     ConceptFeedback.update_all(activity_type: 'connect')

--- a/services/QuillLMS/db/migrate/20200511203004_drop_activity_session_logs.rb
+++ b/services/QuillLMS/db/migrate/20200511203004_drop_activity_session_logs.rb
@@ -1,4 +1,4 @@
-class DropActivitySessionLogs < ActiveRecord::Migration
+class DropActivitySessionLogs < ActiveRecord::Migration[4.2]
   def up
     connection.execute(
       <<~SQL.squish

--- a/services/QuillLMS/db/migrate/20200601153535_add_active_activity_session_table.rb
+++ b/services/QuillLMS/db/migrate/20200601153535_add_active_activity_session_table.rb
@@ -1,4 +1,4 @@
-class AddActiveActivitySessionTable < ActiveRecord::Migration
+class AddActiveActivitySessionTable < ActiveRecord::Migration[4.2]
   def change
     create_table :active_activity_sessions do |t|
       t.string :uid

--- a/services/QuillLMS/db/migrate/20200603171807_make_data_json_blob.rb
+++ b/services/QuillLMS/db/migrate/20200603171807_make_data_json_blob.rb
@@ -1,4 +1,4 @@
-class MakeDataJsonBlob < ActiveRecord::Migration
+class MakeDataJsonBlob < ActiveRecord::Migration[4.2]
   def change
     change_column :activities, :data, 'jsonb USING CAST(data AS jsonb)'
   end

--- a/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
@@ -1,72 +1,68 @@
 class MigrateLessonsToActivity < ActiveRecord::Migration[4.2]
   def change
-    if defined?(Lesson)
-      # Before running this part, make sure that the inconsistent names in this
-      # spreadsheet are resolved:
-      # https://docs.google.com/spreadsheets/d/1mSXhH0K_cI3aKY7pbO15qnDciBqomwMAueJmBIni8Zo/edit#gid=1194313690
-      lessons_to_archive = [
-                            '-KSIwNNwPar51hq9bNIw',
-                            '-LJ_F7B64Mn4YtIRE-Sk',
-                            '-LKldebIl3TApTzAWgBM',
-                            '-KKxoMfLSawnlMtZUXC6',
-                            '-LKldaleWFYhQN2eVJ7T',
-                            '-KW_2fEvZBJB3GKYpzK2'
-                          ]
-      lessons_to_alpha = [
-                          '-LKldZKSHx3hP9_2Vv5v',
-                          '-LKldYuOrBMBpfujBbjg',
-                          '-LKld_Wf0lzgNnEvY5aA'
+    # Before running this part, make sure that the inconsistent names in this
+    # spreadsheet are resolved:
+    # https://docs.google.com/spreadsheets/d/1mSXhH0K_cI3aKY7pbO15qnDciBqomwMAueJmBIni8Zo/edit#gid=1194313690
+    lessons_to_archive = [
+                          '-KSIwNNwPar51hq9bNIw',
+                          '-LJ_F7B64Mn4YtIRE-Sk',
+                          '-LKldebIl3TApTzAWgBM',
+                          '-KKxoMfLSawnlMtZUXC6',
+                          '-LKldaleWFYhQN2eVJ7T',
+                          '-KW_2fEvZBJB3GKYpzK2'
                         ]
+    lessons_to_alpha = [
+                         '-LKldZKSHx3hP9_2Vv5v',
+                         '-LKldYuOrBMBpfujBbjg',
+                         '-LKld_Wf0lzgNnEvY5aA'
+                       ]
 
-      # The Lesson model is no longer in the code base, so this
-      # migration can't run as-written.  Failing to do these updates
-      # should be fine, however, since a subsequent migration drops
-      # the `lessons` table entirely
-      #Lesson.where(uid: lessons_to_archive).each do |lesson|
-      #  lesson[:data]["flag"] = "archived"
-      #  lesson.save!
-      #end
-
-      #Lesson.where(uid: lessons_to_alpha).each do |lesson|
-      #  lesson[:data]["flag"] = "alpha"
-      #  lesson.save!
-      #end
-
-      #Lesson.all.each do |lesson|
-      #  activity = Activity.find_by(uid: lesson.uid)
-      #  if activity.blank?
-      #    activity = Activity.new(:name=> lesson[:data]["name"], :uid=>lesson.uid, :flags=>[lesson[:data]["flag"]])
-
-      #    if lesson.lesson_type == Lesson::TYPE_CONNECT_LESSON
-      #      activity.activity_classification_id = 5
-      #    elsif lesson.lesson_type == Lesson::TYPE_DIAGNOSTIC_LESSON
-      #      activity.activity_classification_id = 4
-      #    elsif lesson.lesson_type == Lesson::TYPE_GRAMMAR_ACTIVITY
-      #      activity.name = lesson[:data]["title"]
-      #      activity.activity_classification_id = 2
-      #    else
-      #      activity.activity_classification_id = 1
-      #    end
-
-      #    if lesson[:data]["flag"] == "archived"
-      #      activity.flags = ["archived"]
-      #    elsif lesson[:data]["flag"] == "alpha"
-      #      activity.flags = ["alpha"]
-      #    end
-      #  end
-
-      #  activity.data = lesson.data
-      #  activity.save! if !lesson[:data]["flag"].blank?
-
-      #end
-
-      Activity.where(:data=> nil).each do |a|
-        data = {}
-        data["flag"] = a.flags[0]
-        a.data = data
-        a.save!
+    if defined?(Lesson)
+      Lesson.where(uid: lessons_to_archive).each do |lesson|
+        lesson[:data]["flag"] = "archived"
+        lesson.save!
       end
 
+      Lesson.where(uid: lessons_to_alpha).each do |lesson|
+        lesson[:data]["flag"] = "alpha"
+        lesson.save!
+      end
+
+      Lesson.all.each do |lesson|
+        activity = Activity.find_by(uid: lesson.uid)
+        if activity.blank?
+          activity = Activity.new(:name=> lesson[:data]["name"], :uid=>lesson.uid, :flags=>[lesson[:data]["flag"]])
+
+          if lesson.lesson_type == Lesson::TYPE_CONNECT_LESSON
+            activity.activity_classification_id = 5
+          elsif lesson.lesson_type == Lesson::TYPE_DIAGNOSTIC_LESSON
+            activity.activity_classification_id = 4
+          elsif lesson.lesson_type == Lesson::TYPE_GRAMMAR_ACTIVITY
+            activity.name = lesson[:data]["title"]
+            activity.activity_classification_id = 2
+          else
+            activity.activity_classification_id = 1
+          end
+
+          if lesson[:data]["flag"] == "archived"
+            activity.flags = ["archived"]
+          elsif lesson[:data]["flag"] == "alpha"
+            activity.flags = ["alpha"]
+          end
+        end
+
+        activity.data = lesson.data
+        activity.save! if !lesson[:data]["flag"].blank?
+
+      end
     end
+
+    Activity.where(:data=> nil).each do |a|
+      data = {}
+      data["flag"] = a.flags[0]
+      a.data = data
+      a.save!
+    end
+
   end
 end

--- a/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
@@ -1,4 +1,4 @@
-class MigrateLessonsToActivity < ActiveRecord::Migration
+class MigrateLessonsToActivity < ActiveRecord::Migration[4.2]
   def change
     if defined?(Lesson)
       # Before running this part, make sure that the inconsistent names in this
@@ -18,43 +18,47 @@ class MigrateLessonsToActivity < ActiveRecord::Migration
                           '-LKld_Wf0lzgNnEvY5aA'
                         ]
 
-      Lesson.where(uid: lessons_to_archive).each do |lesson|
-        lesson[:data]["flag"] = "archived"
-        lesson.save!
-      end
+      # The Lesson model is no longer in the code base, so this
+      # migration can't run as-written.  Failing to do these updates
+      # should be fine, however, since a subsequent migration drops
+      # the `lessons` table entirely
+      #Lesson.where(uid: lessons_to_archive).each do |lesson|
+      #  lesson[:data]["flag"] = "archived"
+      #  lesson.save!
+      #end
 
-      Lesson.where(uid: lessons_to_alpha).each do |lesson|
-        lesson[:data]["flag"] = "alpha"
-        lesson.save!
-      end
+      #Lesson.where(uid: lessons_to_alpha).each do |lesson|
+      #  lesson[:data]["flag"] = "alpha"
+      #  lesson.save!
+      #end
 
-      Lesson.all.each do |lesson|
-        activity = Activity.find_by(uid: lesson.uid)
-        if activity.blank?
-          activity = Activity.new(:name=> lesson[:data]["name"], :uid=>lesson.uid, :flags=>[lesson[:data]["flag"]])
+      #Lesson.all.each do |lesson|
+      #  activity = Activity.find_by(uid: lesson.uid)
+      #  if activity.blank?
+      #    activity = Activity.new(:name=> lesson[:data]["name"], :uid=>lesson.uid, :flags=>[lesson[:data]["flag"]])
 
-          if lesson.lesson_type == Lesson::TYPE_CONNECT_LESSON
-            activity.activity_classification_id = 5
-          elsif lesson.lesson_type == Lesson::TYPE_DIAGNOSTIC_LESSON
-            activity.activity_classification_id = 4
-          elsif lesson.lesson_type == Lesson::TYPE_GRAMMAR_ACTIVITY
-            activity.name = lesson[:data]["title"]
-            activity.activity_classification_id = 2
-          else
-            activity.activity_classification_id = 1
-          end
+      #    if lesson.lesson_type == Lesson::TYPE_CONNECT_LESSON
+      #      activity.activity_classification_id = 5
+      #    elsif lesson.lesson_type == Lesson::TYPE_DIAGNOSTIC_LESSON
+      #      activity.activity_classification_id = 4
+      #    elsif lesson.lesson_type == Lesson::TYPE_GRAMMAR_ACTIVITY
+      #      activity.name = lesson[:data]["title"]
+      #      activity.activity_classification_id = 2
+      #    else
+      #      activity.activity_classification_id = 1
+      #    end
 
-          if lesson[:data]["flag"] == "archived"
-            activity.flags = ["archived"]
-          elsif lesson[:data]["flag"] == "alpha"
-            activity.flags = ["alpha"]
-          end
-        end
+      #    if lesson[:data]["flag"] == "archived"
+      #      activity.flags = ["archived"]
+      #    elsif lesson[:data]["flag"] == "alpha"
+      #      activity.flags = ["alpha"]
+      #    end
+      #  end
 
-        activity.data = lesson.data
-        activity.save! if !lesson[:data]["flag"].blank?
+      #  activity.data = lesson.data
+      #  activity.save! if !lesson[:data]["flag"].blank?
 
-      end
+      #end
 
       Activity.where(:data=> nil).each do |a|
         data = {}

--- a/services/QuillLMS/db/migrate/20200610144620_drop_lessons_table.rb
+++ b/services/QuillLMS/db/migrate/20200610144620_drop_lessons_table.rb
@@ -1,4 +1,4 @@
-class DropLessonsTable < ActiveRecord::Migration
+class DropLessonsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :lessons
   end

--- a/services/QuillLMS/db/migrate/20200612165828_create_comprehension_activities.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200612165828_create_comprehension_activities.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200605133641)
-class CreateComprehensionActivities < ActiveRecord::Migration
+class CreateComprehensionActivities < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_activities do |t|
       t.string :title, limit: 100

--- a/services/QuillLMS/db/migrate/20200612165829_create_comprehension_passages.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200612165829_create_comprehension_passages.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200608233222)
-class CreateComprehensionPassages < ActiveRecord::Migration
+class CreateComprehensionPassages < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_passages do |t|
       t.integer :activity_id

--- a/services/QuillLMS/db/migrate/20200612165830_create_comprehension_prompts.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200612165830_create_comprehension_prompts.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200609005839)
-class CreateComprehensionPrompts < ActiveRecord::Migration
+class CreateComprehensionPrompts < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts do |t|
       t.integer :activity_id

--- a/services/QuillLMS/db/migrate/20200629191908_create_comprehension_rule_sets.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200629191908_create_comprehension_rule_sets.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200625222938)
-class CreateComprehensionRuleSets < ActiveRecord::Migration
+class CreateComprehensionRuleSets < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rule_sets do |t|
       t.integer :activity_id

--- a/services/QuillLMS/db/migrate/20200629191909_create_comprehension_rules.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200629191909_create_comprehension_rules.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200626160522)
-class CreateComprehensionRules < ActiveRecord::Migration
+class CreateComprehensionRules < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rules do |t|
       t.integer :rule_set_id

--- a/services/QuillLMS/db/migrate/20200702140252_create_comprehension_turking_rounds.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200702140252_create_comprehension_turking_rounds.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200630161345)
-class CreateComprehensionTurkingRounds < ActiveRecord::Migration
+class CreateComprehensionTurkingRounds < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_turking_rounds do |t|
       t.integer :activity_id

--- a/services/QuillLMS/db/migrate/20200706135059_create_comprehension_prompts_rule_sets_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20200706135059_create_comprehension_prompts_rule_sets_table.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20200626181312)
-class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration
+class CreateComprehensionPromptsRuleSetsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts_rule_sets do |t|
       t.integer :prompt_id

--- a/services/QuillLMS/db/migrate/20200707144528_add_featured_order_number_to_blog_posts.rb
+++ b/services/QuillLMS/db/migrate/20200707144528_add_featured_order_number_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddFeaturedOrderNumberToBlogPosts < ActiveRecord::Migration
+class AddFeaturedOrderNumberToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :blog_posts, :featured_order_number, :integer
   end

--- a/services/QuillLMS/db/migrate/20200928193105_create_standard_level.rb
+++ b/services/QuillLMS/db/migrate/20200928193105_create_standard_level.rb
@@ -1,4 +1,4 @@
-class CreateStandardLevel < ActiveRecord::Migration
+class CreateStandardLevel < ActiveRecord::Migration[4.2]
   def change
     create_table :standard_levels do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20200928193310_create_standard_category.rb
+++ b/services/QuillLMS/db/migrate/20200928193310_create_standard_category.rb
@@ -1,4 +1,4 @@
-class CreateStandardCategory < ActiveRecord::Migration
+class CreateStandardCategory < ActiveRecord::Migration[4.2]
   def change
     create_table :standard_categories do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20200928193551_create_standard.rb
+++ b/services/QuillLMS/db/migrate/20200928193551_create_standard.rb
@@ -1,4 +1,4 @@
-class CreateStandard < ActiveRecord::Migration
+class CreateStandard < ActiveRecord::Migration[4.2]
   def change
     create_table :standards do |t|
       t.string :name

--- a/services/QuillLMS/db/migrate/20200928193744_add_standard_id_to_activities.rb
+++ b/services/QuillLMS/db/migrate/20200928193744_add_standard_id_to_activities.rb
@@ -1,4 +1,4 @@
-class AddStandardIdToActivities < ActiveRecord::Migration
+class AddStandardIdToActivities < ActiveRecord::Migration[4.2]
   def change
     add_reference :activities, :standard, foreign_key: true
   end

--- a/services/QuillLMS/db/migrate/20201013203506_create_content_partners.rb
+++ b/services/QuillLMS/db/migrate/20201013203506_create_content_partners.rb
@@ -1,4 +1,4 @@
-class CreateContentPartners < ActiveRecord::Migration
+class CreateContentPartners < ActiveRecord::Migration[4.2]
   def change
     create_table :content_partners do |t|
       t.string :name, :null => false

--- a/services/QuillLMS/db/migrate/20201013204354_create_content_partner_activities.rb
+++ b/services/QuillLMS/db/migrate/20201013204354_create_content_partner_activities.rb
@@ -1,4 +1,4 @@
-class CreateContentPartnerActivities < ActiveRecord::Migration
+class CreateContentPartnerActivities < ActiveRecord::Migration[4.2]
   def change
     create_table :content_partner_activities do |t|
       t.references :content_partner, foreign_key: true

--- a/services/QuillLMS/db/migrate/20201016142046_populate_content_partners.rb
+++ b/services/QuillLMS/db/migrate/20201016142046_populate_content_partners.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-class PopulateContentPartners < ActiveRecord::Migration
+class PopulateContentPartners < ActiveRecord::Migration[4.2]
   CONTENT_PARTNERS = ["Core Knowledge", "College Board", "Word Generation"]
 
   def change

--- a/services/QuillLMS/db/migrate/20201019142543_create_raw_scores.rb
+++ b/services/QuillLMS/db/migrate/20201019142543_create_raw_scores.rb
@@ -1,4 +1,4 @@
-class CreateRawScores < ActiveRecord::Migration
+class CreateRawScores < ActiveRecord::Migration[4.2]
   def change
     create_table :raw_scores do |t|
       t.string :name, null: false

--- a/services/QuillLMS/db/migrate/20201019142759_add_raw_score_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20201019142759_add_raw_score_to_activity.rb
@@ -1,4 +1,4 @@
-class AddRawScoreToActivity < ActiveRecord::Migration
+class AddRawScoreToActivity < ActiveRecord::Migration[4.2]
   def change
     add_reference :activities, :raw_score, foreign_key: true
   end

--- a/services/QuillLMS/db/migrate/20201019183425_populate_raw_scores_by_activity.rb
+++ b/services/QuillLMS/db/migrate/20201019183425_populate_raw_scores_by_activity.rb
@@ -1,4 +1,4 @@
-class PopulateRawScoresByActivity < ActiveRecord::Migration
+class PopulateRawScoresByActivity < ActiveRecord::Migration[4.2]
   RAW_SCORES = ["BR100-0", "0-100", "100-200", "200-300", "300-400", "400-500", "500-600", "600-700",
                 "700-800", "800-900", "900-1000", "1000-1100", "1100-1200", "1200-1300", "1300-1400",
                 "1400-1500"]

--- a/services/QuillLMS/db/migrate/20201020200935_create_teacher_saved_activities.rb
+++ b/services/QuillLMS/db/migrate/20201020200935_create_teacher_saved_activities.rb
@@ -1,4 +1,4 @@
-class CreateTeacherSavedActivities < ActiveRecord::Migration
+class CreateTeacherSavedActivities < ActiveRecord::Migration[4.2]
   def change
     create_table :teacher_saved_activities do |t|
       t.integer :teacher_id, null: false

--- a/services/QuillLMS/db/migrate/20201020204615_archive_standard_levels.rb
+++ b/services/QuillLMS/db/migrate/20201020204615_archive_standard_levels.rb
@@ -1,4 +1,4 @@
-class ArchiveStandardLevels < ActiveRecord::Migration
+class ArchiveStandardLevels < ActiveRecord::Migration[4.2]
 
   TO_ARCHIVE = ["Diagnostic", "Quill Tutorial Lesson"]
 

--- a/services/QuillLMS/db/migrate/20201023192128_drop_topics.rb
+++ b/services/QuillLMS/db/migrate/20201023192128_drop_topics.rb
@@ -1,4 +1,4 @@
-class DropTopics < ActiveRecord::Migration
+class DropTopics < ActiveRecord::Migration[4.2]
   def change
     drop_table :topics
     drop_table :topic_categories

--- a/services/QuillLMS/db/migrate/20201023192229_create_topics_and_activity_topics.rb
+++ b/services/QuillLMS/db/migrate/20201023192229_create_topics_and_activity_topics.rb
@@ -1,4 +1,4 @@
-class CreateTopicsAndActivityTopics < ActiveRecord::Migration
+class CreateTopicsAndActivityTopics < ActiveRecord::Migration[4.2]
   def change
     create_table :topics do |t|
       t.string :name, null: false

--- a/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
+++ b/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
@@ -1,4 +1,4 @@
-class PopulateTopics < ActiveRecord::Migration
+class PopulateTopics < ActiveRecord::Migration[4.2]
   def change
     table = CSV.parse(File.read("lib/data/topics_by_activity.csv"), headers: true)
     table.each do |row|

--- a/services/QuillLMS/db/migrate/20201026184657_add_indices_to_foreign_keys.rb
+++ b/services/QuillLMS/db/migrate/20201026184657_add_indices_to_foreign_keys.rb
@@ -1,4 +1,4 @@
-class AddIndicesToForeignKeys < ActiveRecord::Migration
+class AddIndicesToForeignKeys < ActiveRecord::Migration[4.2]
   def change
     add_index :teacher_saved_activities, :activity_id
     add_index :teacher_saved_activities, :teacher_id

--- a/services/QuillLMS/db/migrate/20201026185613_create_feedback_history.rb
+++ b/services/QuillLMS/db/migrate/20201026185613_create_feedback_history.rb
@@ -1,4 +1,4 @@
-class CreateFeedbackHistory < ActiveRecord::Migration
+class CreateFeedbackHistory < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_histories do |t|
       t.text :activity_session_uid

--- a/services/QuillLMS/db/migrate/20201116132148_add_timestamps_to_topics.rb
+++ b/services/QuillLMS/db/migrate/20201116132148_add_timestamps_to_topics.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToTopics < ActiveRecord::Migration
+class AddTimestampsToTopics < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :topics
   end

--- a/services/QuillLMS/db/migrate/20201125190536_create_comprehension_turking_round_activity_sessions.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20201125190536_create_comprehension_turking_round_activity_sessions.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20201125161727)
-class CreateComprehensionTurkingRoundActivitySessions < ActiveRecord::Migration
+class CreateComprehensionTurkingRoundActivitySessions < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_turking_round_activity_sessions do |t|
       t.integer :turking_round_id

--- a/services/QuillLMS/db/migrate/20201202224853_add_plagiarism_columns_to_prompt.rb
+++ b/services/QuillLMS/db/migrate/20201202224853_add_plagiarism_columns_to_prompt.rb
@@ -1,4 +1,4 @@
-class AddPlagiarismColumnsToPrompt < ActiveRecord::Migration
+class AddPlagiarismColumnsToPrompt < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_prompts, :plagiarism_text, :text
     add_column :comprehension_prompts, :plagiarism_first_feedback, :text

--- a/services/QuillLMS/db/migrate/20201203173440_add_visible_to_content_partners.rb
+++ b/services/QuillLMS/db/migrate/20201203173440_add_visible_to_content_partners.rb
@@ -1,4 +1,4 @@
-class AddVisibleToContentPartners < ActiveRecord::Migration
+class AddVisibleToContentPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :content_partners, :visible, :boolean, default: true
   end

--- a/services/QuillLMS/db/migrate/20210113130854_add_uniqueness_restriction_to_teacher_id_and_activity_id_on_teacher_saved_activities.rb
+++ b/services/QuillLMS/db/migrate/20210113130854_add_uniqueness_restriction_to_teacher_id_and_activity_id_on_teacher_saved_activities.rb
@@ -1,4 +1,4 @@
-class AddUniquenessRestrictionToTeacherIdAndActivityIdOnTeacherSavedActivities < ActiveRecord::Migration
+class AddUniquenessRestrictionToTeacherIdAndActivityIdOnTeacherSavedActivities < ActiveRecord::Migration[4.2]
   def change
     add_index :teacher_saved_activities, [:teacher_id, :activity_id], unique: true
   end

--- a/services/QuillLMS/db/migrate/20210114160155_create_regex_rules_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210114160155_create_regex_rules_table.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210114154926)
-class CreateRegexRulesTable < ActiveRecord::Migration
+class CreateRegexRulesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_regex_rules do |t|
       t.integer :rule_set_id, null: false

--- a/services/QuillLMS/db/migrate/20210114164445_remove_rule_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210114164445_remove_rule_table.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210114164149)
-class RemoveRuleTable < ActiveRecord::Migration
+class RemoveRuleTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :comprehension_rules
   end

--- a/services/QuillLMS/db/migrate/20210114202136_create_comprehension_rules_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210114202136_create_comprehension_rules_table.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210114182832)
-class CreateComprehensionRulesTable < ActiveRecord::Migration
+class CreateComprehensionRulesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_rules do |t|
       t.string :uid, null: false

--- a/services/QuillLMS/db/migrate/20210121213613_create_comprehension_feedbacks.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210121213613_create_comprehension_feedbacks.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210121200031)
-class CreateComprehensionFeedbacks < ActiveRecord::Migration
+class CreateComprehensionFeedbacks < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_feedbacks do |t|
       t.references :rule, null: false

--- a/services/QuillLMS/db/migrate/20210122150843_create_comprehension_prompts_rules.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210122150843_create_comprehension_prompts_rules.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210122144228)
-class CreateComprehensionPromptsRules < ActiveRecord::Migration
+class CreateComprehensionPromptsRules < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_prompts_rules do |t|
       t.references :prompt, null: false

--- a/services/QuillLMS/db/migrate/20210122172552_create_plagiarism_text_table.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210122172552_create_plagiarism_text_table.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210122165204)
-class CreatePlagiarismTextTable < ActiveRecord::Migration
+class CreatePlagiarismTextTable < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_plagiarism_texts do |t|
       t.references :rule, null: false

--- a/services/QuillLMS/db/migrate/20210122195721_create_comprehension_highlights.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210122195721_create_comprehension_highlights.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210122165328)
-class CreateComprehensionHighlights < ActiveRecord::Migration
+class CreateComprehensionHighlights < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_highlights do |t|
       t.references :feedback, null: false

--- a/services/QuillLMS/db/migrate/20210128152452_drop_plagiarism_columns_from_prompt.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210128152452_drop_plagiarism_columns_from_prompt.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210128152309)
-class DropPlagiarismColumnsFromPrompt < ActiveRecord::Migration
+class DropPlagiarismColumnsFromPrompt < ActiveRecord::Migration[4.2]
   def change
     remove_column :comprehension_prompts, :plagiarism_text
     remove_column :comprehension_prompts, :plagiarism_first_feedback

--- a/services/QuillLMS/db/migrate/20210128174648_associate_regex_rule_with_rule.rb
+++ b/services/QuillLMS/db/migrate/20210128174648_associate_regex_rule_with_rule.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210128155938)
-class AssociateRegexRuleWithRule < ActiveRecord::Migration
+class AssociateRegexRuleWithRule < ActiveRecord::Migration[4.2]
   def change
     add_reference :comprehension_regex_rules, :rule, index: true
     add_foreign_key :comprehension_regex_rules, :comprehension_rules, column: :rule_id, on_delete: :cascade

--- a/services/QuillLMS/db/migrate/20210202210617_add_rule_uid_to_feedback_history.rb
+++ b/services/QuillLMS/db/migrate/20210202210617_add_rule_uid_to_feedback_history.rb
@@ -1,4 +1,4 @@
-class AddRuleUidToFeedbackHistory < ActiveRecord::Migration
+class AddRuleUidToFeedbackHistory < ActiveRecord::Migration[4.2]
   def change
     add_column :feedback_histories, :rule_uid, :string
     add_index :feedback_histories, :rule_uid

--- a/services/QuillLMS/db/migrate/20210203214036_delete_rule_sets.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210203214036_delete_rule_sets.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210129184505)
-class DeleteRuleSets < ActiveRecord::Migration
+class DeleteRuleSets < ActiveRecord::Migration[4.2]
   def change
     drop_table :comprehension_rule_sets
     drop_table :comprehension_prompts_rule_sets

--- a/services/QuillLMS/db/migrate/20210216195544_create_student_feedback_responses.rb
+++ b/services/QuillLMS/db/migrate/20210216195544_create_student_feedback_responses.rb
@@ -1,4 +1,4 @@
-class CreateStudentFeedbackResponses < ActiveRecord::Migration
+class CreateStudentFeedbackResponses < ActiveRecord::Migration[4.2]
   def change
     create_table :student_feedback_responses do |t|
       t.text :question, default: ''

--- a/services/QuillLMS/db/migrate/20210219164011_add_image_link_and_image_alt_text_to_passages.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210219164011_add_image_link_and_image_alt_text_to_passages.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210219163806)
-class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration
+class AddImageLinkAndImageAltTextToPassages < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_passages, :image_link, :string
     add_column :comprehension_passages, :image_alt_text, :string, default: ''

--- a/services/QuillLMS/db/migrate/20210219185502_add_sequence_type_to_regex_rules.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210219185502_add_sequence_type_to_regex_rules.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210218213618)
-class AddSequenceTypeToRegexRules < ActiveRecord::Migration
+class AddSequenceTypeToRegexRules < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_regex_rules, :sequence_type, :text, null: false, default: "incorrect"
     change_column :comprehension_rules, :suborder, :text, null: true

--- a/services/QuillLMS/db/migrate/20210222201347_add_timestamps_to_student_feedback.rb
+++ b/services/QuillLMS/db/migrate/20210222201347_add_timestamps_to_student_feedback.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToStudentFeedback < ActiveRecord::Migration
+class AddTimestampsToStudentFeedback < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :student_feedback_responses
   end

--- a/services/QuillLMS/db/migrate/20210224165328_create_comprehension_automl_models.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210224165328_create_comprehension_automl_models.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210209200555)
-class CreateComprehensionAutomlModels < ActiveRecord::Migration
+class CreateComprehensionAutomlModels < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_automl_models do |t|
       t.string :automl_model_id, null: false, unique: true

--- a/services/QuillLMS/db/migrate/20210224165329_create_comprehension_labels.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210224165329_create_comprehension_labels.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210212194127)
-class CreateComprehensionLabels < ActiveRecord::Migration
+class CreateComprehensionLabels < ActiveRecord::Migration[4.2]
   def change
     create_table :comprehension_labels do |t|
       t.string :name, null: false

--- a/services/QuillLMS/db/migrate/20210224165330_add_state_column_to_rule.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210224165330_add_state_column_to_rule.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210218195536)
-class AddStateColumnToRule < ActiveRecord::Migration
+class AddStateColumnToRule < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_rules, :state, :string
     Comprehension::Rule.update_all(state: 'active')

--- a/services/QuillLMS/db/migrate/20210311173333_drop_old_activity_sessions_table.rb
+++ b/services/QuillLMS/db/migrate/20210311173333_drop_old_activity_sessions_table.rb
@@ -1,4 +1,4 @@
-class DropOldActivitySessionsTable < ActiveRecord::Migration
+class DropOldActivitySessionsTable < ActiveRecord::Migration[4.2]
   def up
     return unless ActiveRecord::Base.connection.tables.include?('old_activity_sessions')
 

--- a/services/QuillLMS/db/migrate/20210316161120_add_name_to_comprehension_activities.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210316161120_add_name_to_comprehension_activities.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210316160648)
-class AddNameToComprehensionActivities < ActiveRecord::Migration
+class AddNameToComprehensionActivities < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_activities, :name, :string
   end

--- a/services/QuillLMS/db/migrate/20210319160956_create_feedback_history_ratings.rb
+++ b/services/QuillLMS/db/migrate/20210319160956_create_feedback_history_ratings.rb
@@ -1,4 +1,4 @@
-class CreateFeedbackHistoryRatings < ActiveRecord::Migration
+class CreateFeedbackHistoryRatings < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_history_ratings do |t|
       t.boolean :rating,  null: false

--- a/services/QuillLMS/db/migrate/20210330160626_create_activity_session_feedback_history.rb
+++ b/services/QuillLMS/db/migrate/20210330160626_create_activity_session_feedback_history.rb
@@ -1,4 +1,4 @@
-class CreateActivitySessionFeedbackHistory < ActiveRecord::Migration
+class CreateActivitySessionFeedbackHistory < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_sessions do |t|
       t.string :activity_session_uid

--- a/services/QuillLMS/db/migrate/20210409161449_feedback_history_rename_session_uid_column.rb
+++ b/services/QuillLMS/db/migrate/20210409161449_feedback_history_rename_session_uid_column.rb
@@ -1,4 +1,4 @@
-class FeedbackHistoryRenameSessionUidColumn < ActiveRecord::Migration
+class FeedbackHistoryRenameSessionUidColumn < ActiveRecord::Migration[4.2]
   def change
     rename_column :feedback_histories, :activity_session_uid, :feedback_session_uid
   end

--- a/services/QuillLMS/db/migrate/20210421181107_create_feedback_history_flags.rb
+++ b/services/QuillLMS/db/migrate/20210421181107_create_feedback_history_flags.rb
@@ -1,4 +1,4 @@
-class CreateFeedbackHistoryFlags < ActiveRecord::Migration
+class CreateFeedbackHistoryFlags < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_history_flags do |t|
       t.references :feedback_history, null: false

--- a/services/QuillLMS/db/migrate/20210421190032_create_activity_healths.rb
+++ b/services/QuillLMS/db/migrate/20210421190032_create_activity_healths.rb
@@ -1,4 +1,4 @@
-class CreateActivityHealths < ActiveRecord::Migration
+class CreateActivityHealths < ActiveRecord::Migration[4.2]
   def change
     create_table :activity_healths do |t|
       t.string               :name

--- a/services/QuillLMS/db/migrate/20210421191605_create_prompt_healths.rb
+++ b/services/QuillLMS/db/migrate/20210421191605_create_prompt_healths.rb
@@ -1,4 +1,4 @@
-class CreatePromptHealths < ActiveRecord::Migration
+class CreatePromptHealths < ActiveRecord::Migration[4.2]
   def change
     create_table :prompt_healths do |t|
       t.string      :text

--- a/services/QuillLMS/db/migrate/20210423165423_change_avg_completion_time_column.rb
+++ b/services/QuillLMS/db/migrate/20210423165423_change_avg_completion_time_column.rb
@@ -1,4 +1,4 @@
-class ChangeAvgCompletionTimeColumn < ActiveRecord::Migration
+class ChangeAvgCompletionTimeColumn < ActiveRecord::Migration[4.2]
   def change
     remove_column :activity_healths, :avg_completion_time, :time
     remove_column :activity_healths, :activity_packs, :string

--- a/services/QuillLMS/db/migrate/20210429151331_rename_rule_description_to_rule_note.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210429151331_rename_rule_description_to_rule_note.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210429144611)
-class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration
+class RenameRuleDescriptionToRuleNote < ActiveRecord::Migration[4.2]
   def change
     rename_column :comprehension_rules, :description, :note
   end

--- a/services/QuillLMS/db/migrate/20210430212613_add_mview_to_feedback_history.rb
+++ b/services/QuillLMS/db/migrate/20210430212613_add_mview_to_feedback_history.rb
@@ -1,4 +1,4 @@
-class AddMviewToFeedbackHistory < ActiveRecord::Migration
+class AddMviewToFeedbackHistory < ActiveRecord::Migration[4.2]
   def up
     sql = <<~SQL 
       CREATE MATERIALIZED VIEW feedback_histories_grouped_by_rule_uid AS

--- a/services/QuillLMS/db/migrate/20210505150457_remove_null_restriction_from_feedback_history_ratings.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210505150457_remove_null_restriction_from_feedback_history_ratings.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210505150340)
-class RemoveNullRestrictionFromFeedbackHistoryRatings < ActiveRecord::Migration
+class RemoveNullRestrictionFromFeedbackHistoryRatings < ActiveRecord::Migration[4.2]
   def change
     change_column_null :feedback_history_ratings, :rating, true
   end

--- a/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210511161300_update_comprehension_rule_suborder_type_to_integer.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210511160025)
-class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration
+class UpdateComprehensionRuleSuborderTypeToInteger < ActiveRecord::Migration[4.2]
   def change
     change_column :comprehension_rules, :suborder, 'integer USING CAST(suborder AS integer)', null: true
   end

--- a/services/QuillLMS/db/migrate/20210518151248_change_classroom_unit_activity_states_data_default.rb
+++ b/services/QuillLMS/db/migrate/20210518151248_change_classroom_unit_activity_states_data_default.rb
@@ -1,4 +1,4 @@
-class ChangeClassroomUnitActivityStatesDataDefault < ActiveRecord::Migration
+class ChangeClassroomUnitActivityStatesDataDefault < ActiveRecord::Migration[4.2]
   def up
     change_column_default :classroom_unit_activity_states, :data, {}
   end

--- a/services/QuillLMS/db/migrate/20210518162719_change_notifications_meta_default.rb
+++ b/services/QuillLMS/db/migrate/20210518162719_change_notifications_meta_default.rb
@@ -1,4 +1,4 @@
-class ChangeNotificationsMetaDefault < ActiveRecord::Migration
+class ChangeNotificationsMetaDefault < ActiveRecord::Migration[4.2]
   def up
     change_column_default :notifications, :meta, {}
   end

--- a/services/QuillLMS/db/migrate/20210521152206_drop_unused_large_indexes.rb
+++ b/services/QuillLMS/db/migrate/20210521152206_drop_unused_large_indexes.rb
@@ -1,4 +1,4 @@
-class DropUnusedLargeIndexes < ActiveRecord::Migration
+class DropUnusedLargeIndexes < ActiveRecord::Migration[4.2]
   def change
     remove_index_if_exists :concept_results, :index_concept_results_on_question_type
     remove_index_if_exists :concept_results, :index_concept_results_on_activity_classification_id

--- a/services/QuillLMS/db/migrate/20210525200201_add_notes_to_auto_ml_model.comprehension.rb
+++ b/services/QuillLMS/db/migrate/20210525200201_add_notes_to_auto_ml_model.comprehension.rb
@@ -1,5 +1,5 @@
 # This migration comes from comprehension (originally 20210525194626)
-class AddNotesToAutoMlModel < ActiveRecord::Migration
+class AddNotesToAutoMlModel < ActiveRecord::Migration[4.2]
   def change
     add_column :comprehension_automl_models, :notes, :text, default: ''
   end

--- a/services/QuillLMS/db/migrate/20210528142650_convert_activity_session_data_column_from_hstore_to_jsonb.rb
+++ b/services/QuillLMS/db/migrate/20210528142650_convert_activity_session_data_column_from_hstore_to_jsonb.rb
@@ -1,4 +1,4 @@
-class ConvertActivitySessionDataColumnFromHstoreToJsonb < ActiveRecord::Migration
+class ConvertActivitySessionDataColumnFromHstoreToJsonb < ActiveRecord::Migration[4.2]
   def up
     change_column :activity_sessions, :data, :jsonb, using: 'data::jsonb'
   end

--- a/services/QuillLMS/db/migrate/20210614190031_update_activity_name_to_notes.rb
+++ b/services/QuillLMS/db/migrate/20210614190031_update_activity_name_to_notes.rb
@@ -1,4 +1,4 @@
-class UpdateActivityNameToNotes < ActiveRecord::Migration
+class UpdateActivityNameToNotes < ActiveRecord::Migration[4.2]
   def change
     rename_column :comprehension_activities, :name, :notes
   end

--- a/services/QuillLMS/db/migrate/20210614205654_create_app_settings.rb
+++ b/services/QuillLMS/db/migrate/20210614205654_create_app_settings.rb
@@ -1,4 +1,4 @@
-class CreateAppSettings < ActiveRecord::Migration
+class CreateAppSettings < ActiveRecord::Migration[4.2]
   def change
     create_table :app_settings do |t|
       t.string :name, null: false


### PR DESCRIPTION
## WHAT
Update old migration files so that they're runnable
## WHY
So that new developers, or anyone who needs to wipe and rebuild their database, can run through all the migrations
## HOW
For the most part, just add a Rails version (`[4.2]`) to old migrations.  In a couple of places, comment out some code that refers to no-longer-existent models.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test behavior changed, but tests do pass.
Have you deployed to Staging? | No - not really relevant to staging
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
