### PR TITLE
Overflow on Activity Packs table and Highlight deletion on Evidence CMS

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/table/react-table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/table/react-table.scss
@@ -111,9 +111,20 @@
   &.unit-template-profile-activities .rt-table {
     margin-top: 20px;
     border-radius: 6px;
+    overflow: visible;
+
     .activity-icon {
       width: 40px;
     }
+
+    .rt-thead {
+      overflow: visible;
+    }
+
+    .rt-tbody {
+      overflow: visible;
+    }
+
     .rt-th {
       border-right: none;
       padding-left: 10px;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -46,7 +46,8 @@ const RulePlagiarismAttributes = ({
     });
   }
 
-  function onHandleRemoveFeedbackHighlight(e: ClickEvent) {
+  function onHandleRemoveFeedbackHighlight(e: ClickEvent, plagiarismFeedbackIndex) {
+    const highlightIndex = plagiarismFeedbacks[plagiarismFeedbackIndex].highlights_attributes.filter(h => !h._destroy).length - 1
     const { target } = e;
     const { value } = (target as HTMLButtonElement);
     if (window.confirm('Are you sure you want to delete this highlight?')) {
@@ -56,7 +57,7 @@ const RulePlagiarismAttributes = ({
         setFeedback: setPlagiarismFeedbacks,
         updateType: HIGHLIGHT_REMOVAL,
         feedbackIndex: parseInt(value),
-        highlightIndex: null
+        highlightIndex: highlightIndex
       });
     }
   }
@@ -86,7 +87,7 @@ const RulePlagiarismAttributes = ({
         {plagiarismFeedbacks[0] && plagiarismFeedbacks[0].highlights_attributes && renderHighlights(plagiarismFeedbacks[0].highlights_attributes, 0, onHandleSetPlagiarismFeedback)}
         {plagiarismFeedbacks[0] && (<div className="button-wrapper">
           <button className="add-highlight quill-button small primary outlined" onClick={onHandleAddFeedbackHighlight} type="button" value="0">Add Highlight</button>
-          {plagiarismFeedbacks[0].highlights_attributes && plagiarismFeedbacks[0].highlights_attributes.length ? <button className="remove-highlight quill-button small secondary outlined" onClick={onHandleRemoveFeedbackHighlight} type="button" value="0">Remove Highlight</button> : null}
+          {plagiarismFeedbacks[0].highlights_attributes.filter(h => !h._destroy) && plagiarismFeedbacks[0].highlights_attributes.filter(h => !h._destroy).length ? <button className="remove-highlight quill-button small secondary outlined" onClick={(e) => onHandleRemoveFeedbackHighlight(e, 0)} type="button" value="0">Remove Highlight</button> : null}
         </div>)}
         {errors['First Plagiarism Feedback'] && <p className="error-message">{errors['First Plagiarism Feedback']}</p>}
         <p className="form-subsection-label">Second Feedback</p>
@@ -101,7 +102,7 @@ const RulePlagiarismAttributes = ({
         {plagiarismFeedbacks[1] && plagiarismFeedbacks[1].highlights_attributes && renderHighlights(plagiarismFeedbacks[1].highlights_attributes, 1, onHandleSetPlagiarismFeedback)}
         {plagiarismFeedbacks[1] && (<div className="button-wrapper">
           <button className="add-highlight quill-button small primary outlined" onClick={onHandleAddFeedbackHighlight} type="button" value="1">Add Highlight</button>
-          {plagiarismFeedbacks[1].highlights_attributes && plagiarismFeedbacks[1].highlights_attributes.length ? <button className="remove-highlight quill-button small secondary outlined" onClick={onHandleRemoveFeedbackHighlight} type="button" value="1">Remove Highlight</button> : null}
+          {plagiarismFeedbacks[1].highlights_attributes.filter(h => !h._destroy) && plagiarismFeedbacks[1].highlights_attributes.filter(h => !h._destroy).length ? <button className="remove-highlight quill-button small secondary outlined" onClick={(e) => onHandleRemoveFeedbackHighlight(e, 1)} type="button" value="1">Remove Highlight</button> : null}
         </div>)}
         {errors['Second Plagiarism Feedback'] && <p className="error-message">{errors['Second Plagiarism Feedback']}</p>}
       </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
@@ -75,6 +75,7 @@ const RuleRegexAttributes = ({
   }
 
   function onHandleRemoveFeedbackHighlight(e: ClickEvent) {
+    const highlightIndex = regexFeedback[0].highlights_attributes.filter(h => !h._destroy).length - 1
     const { target } = e;
     const { value } = (target as HTMLButtonElement);
     if (window.confirm('Are you sure you want to delete this highlight?')) {
@@ -84,7 +85,7 @@ const RuleRegexAttributes = ({
         setFeedback: setRegexFeedback,
         updateType: HIGHLIGHT_REMOVAL,
         feedbackIndex: parseInt(value),
-        highlightIndex: null
+        highlightIndex: highlightIndex
       });
     }
   }
@@ -105,7 +106,7 @@ const RuleRegexAttributes = ({
       {regexFeedback[0] && regexFeedback[0].highlights_attributes && renderHighlights(regexFeedback[0].highlights_attributes, 0, onHandleSetRegexFeedback)}
       {regexFeedback[0] && (<div className="button-wrapper">
         <button className="add-highlight quill-button small primary outlined" onClick={onHandleAddFeedbackHighlight} type="button" value="0">Add Highlight</button>
-        {regexFeedback[0].highlights_attributes && regexFeedback[0].highlights_attributes.length ? <button className="remove-highlight quill-button small secondary outlined" onClick={onHandleRemoveFeedbackHighlight} type="button" value="0">Remove Highlight</button> : null}
+        {regexFeedback[0].highlights_attributes.filter(h => !h._destroy) && regexFeedback[0].highlights_attributes.filter(h => !h._destroy).length ? <button className="remove-highlight quill-button small secondary outlined" onClick={onHandleRemoveFeedbackHighlight} type="button" value="0">Remove Highlight</button> : null}
       </div>)}
       {errors['Regex Feedback'] && <p className="error-message">{errors['Regex Feedback']}</p>}
       <p className="form-subsection-label" id="regex-rules-label">Regex Rules</p>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
@@ -42,7 +42,8 @@ const RuleAttributesSection = ({
     });
   }
 
-  function onHandleRemoveHighlight(e: ClickEvent) {
+  function onHandleRemoveHighlight(e: ClickEvent, feedbackIndex) {
+    const highlightIndex = universalFeedback[feedbackIndex].highlights_attributes.filter(h => !h._destroy).length - 1
     const { target } = e;
     const { value } = (target as HTMLButtonElement);
     if (window.confirm('Are you sure you want to delete this highlight?')) {
@@ -52,7 +53,7 @@ const RuleAttributesSection = ({
         setFeedback: setUniversalFeedback,
         updateType: HIGHLIGHT_REMOVAL,
         feedbackIndex: parseInt(value),
-        highlightIndex: null
+        highlightIndex: highlightIndex
       });
     }
   }
@@ -99,7 +100,7 @@ const RuleAttributesSection = ({
           {feedback.highlights_attributes && renderHighlights(feedback.highlights_attributes, i, onHandleSetUniversalFeedback)}
           <div className="button-wrapper">
             <button className={`add-highlight quill-button small primary outlined ${disabledStatus}`} disabled={!!disabledStatus} onClick={onHandleAddHighlight} type="button" value={`${i}`}>Add Highlight</button>
-            {feedback.highlights_attributes && feedback.highlights_attributes.length ? <button className="remove-highlight quill-button small secondary outlined" onClick={onHandleRemoveHighlight} type="button" value={`${i}`}>Remove Highlight</button> : null}
+            {feedback.highlights_attributes.filter(h => !h._destroy) && feedback.highlights_attributes.filter(h => !h._destroy).length ? <button className="remove-highlight quill-button small secondary outlined" onClick={(e) => onHandleRemoveHighlight(e, i)} type="button" value={`${i}`}>Remove Highlight</button> : null}
           </div>
         </React.Fragment>
       );

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -160,7 +160,7 @@ export function handleSetFeedback({
       updatedFeedback[feedbackIndex].highlights_attributes.push({ text: '' });
       break
     case HIGHLIGHT_REMOVAL:
-      updatedFeedback[feedbackIndex].highlights_attributes = updatedFeedback[feedbackIndex].highlights_attributes.slice(0, -1)
+      updatedFeedback[feedbackIndex].highlights_attributes[highlightIndex]._destroy = true
       break
     case HIGHLIGHT_TYPE:
       updatedFeedback[feedbackIndex].highlights_attributes[highlightIndex].highlight_type = text
@@ -181,6 +181,7 @@ export function handleSetFeedback({
 
 export function renderHighlights(highlights, i, changeHandler) {
   return highlights.map((highlight, j) => {
+    if (highlight._destroy) return null;
     let highlightTypeValue = ruleHighlightOptions[0];
     // this is an update for existing rule, convert to object for DropdownInput value
     if(highlight.highlight_type && typeof highlight.highlight_type === 'string') {

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -73,7 +73,7 @@ module Evidence
          plagiarism_text_attributes: [:id, :text],
          regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type],
          label_attributes: [:id, :name, :state],
-         feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index]]
+         feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index, :_destroy]]
       )
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/feedback.rb
@@ -3,13 +3,13 @@ module Evidence
     self.table_name = 'comprehension_feedbacks'
 
     include Evidence::ChangeLog
-    MIN_FEEDBACK_LENGTH = 10 
+    MIN_FEEDBACK_LENGTH = 10
     MAX_FEEDBACK_LENGTH = 500
 
     belongs_to :rule, inverse_of: :feedbacks
     has_many :highlights, inverse_of: :feedback, dependent: :destroy
 
-    accepts_nested_attributes_for :highlights
+    accepts_nested_attributes_for :highlights, allow_destroy: true
 
     validates_presence_of :rule
     validates :text, presence: true, length: {minimum: MIN_FEEDBACK_LENGTH, maximum: MAX_FEEDBACK_LENGTH}

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -41,7 +41,7 @@ module Evidence
     has_many :regex_rules, inverse_of: :rule, dependent: :destroy
 
     accepts_nested_attributes_for :plagiarism_text
-    accepts_nested_attributes_for :feedbacks
+    accepts_nested_attributes_for :feedbacks, allow_destroy: true
     accepts_nested_attributes_for :label
     accepts_nested_attributes_for :regex_rules
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
@@ -339,6 +339,35 @@ module Evidence
         expect([new_prompt.id]).to(eq(rule.reload.prompt_ids))
       end
 
+      it 'should delete a nested highlight record if indicated' do
+        feedback = create(:evidence_feedback, rule_id: rule.id)
+        highlight_one = create(:evidence_highlight, feedback_id: feedback.id)
+        highlight_two = create(:evidence_highlight, feedback_id: feedback.id)
+
+        patch(:update, :params => ({ :id => rule.id, :rule => ({ :concept_uid => rule.concept_uid, :note => rule.note, :name => rule.name, :optimal => rule.optimal, :state => rule.state, :suborder => rule.suborder, :rule_type => rule.rule_type, :universal => rule.universal, :prompt_ids => rule.prompt_ids,
+          :feedbacks_attributes => {
+            :id => feedback.id,
+            :order => feedback.order,
+            :text => feedback.text,
+            :description => feedback.description,
+            :highlights_attributes => [{
+              :id => highlight_one.id,
+              :highlight_type => highlight_one.highlight_type,
+              :text => highlight_one.text,
+              :starting_index => highlight_one.starting_index
+            },
+            {
+              :id => highlight_two.id,
+              :text => highlight_two.text,
+              :_destroy => true
+            }
+          ]
+          } }) }))
+        expect(response.body).to(eq(""))
+        expect(response.code.to_i).to(eq(204))
+        expect(Highlight.find_by(id: highlight_two.id)).to eq(nil)
+      end
+
       it "create a change log record after updating a universal rule" do
         universal_rule = create(:evidence_rule, prompt_ids: [prompt.id], universal: true, rule_type: 'spelling')
         old_name = universal_rule.name


### PR DESCRIPTION
## WHAT
Allow overflow for tooltip visibility on Activity Packs table.
Allow admin to delete highlights on Evidence Rules.

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
