### PR TITLE
make clever id editable from cms schools pages

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -45,7 +45,8 @@ class Cms::SchoolsController < Cms::CmsController
       'District' => @school.leanm,
       'Free and Reduced Price Lunch' => "#{@school.free_lunches}%",
       'NCES ID' => @school.nces_id,
-      'PPIN' => @school.ppin
+      'PPIN' => @school.ppin,
+      'Clever ID' => @school.clever_id
     }
     @teacher_data = teacher_search_query_for_school(params[:id])
     @admins = SchoolsAdmins.includes(:user).where(school_id: params[:id].to_i).map do |admin|
@@ -332,7 +333,8 @@ class Cms::SchoolsController < Cms::CmsController
       'School ZIP' => :zipcode,
       'District Name' => :leanm,
       'FRP Lunch' => :free_lunches,
-      'NCES ID' => :nces_id
+      'NCES ID' => :nces_id,
+      'Clever ID' => :clever_id
     }
   end
 

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -59,7 +59,8 @@ describe Cms::SchoolsController do
        'District' => school.leanm,
        'Free and Reduced Price Lunch' => "#{school.free_lunches}%",
        'NCES ID' => school.nces_id,
-       'PPIN' => school.ppin
+       'PPIN' => school.ppin,
+       'Clever ID' => school.clever_id
       })
       expect(assigns(:teacher_data)).to eq "teacher data"
       expect(assigns(:admins)).to eq(SchoolsAdmins.includes(:user).where(school_id: school.id).map do |admin|
@@ -87,7 +88,8 @@ describe Cms::SchoolsController do
           'School ZIP' => :zipcode,
           'District Name' => :leanm,
           'FRP Lunch' => :free_lunches,
-          'NCES ID' => :nces_id
+          'NCES ID' => :nces_id,
+          'Clever ID' => :clever_id
       })
     end
   end


### PR DESCRIPTION
## WHAT
Make Clever ID editable from CMS school editor.

## WHY
So that partnerships team members don't need to ask a dev to do it when a school is missing from the database or otherwise needs a different Clever ID.

## HOW
Just update the array and hash of editable attributes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Engineering-Request-Clever-ID-Field-on-Edit-School-Info-and-Add-New-School-pages-b85eae5be29f45b197748f91415a8db9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
