### PR TITLE
Update Go endpoint to look at evidence routes

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -62,12 +62,12 @@ func AssembleUrls() ([api_count]string) {
 	opinion_domain := GetOpinionDomain()
 
 	var (
-		automl_api = fmt.Sprintf("%s/api/v1/comprehension/feedback/automl.json", lms_domain)
-		plagiarism_api = fmt.Sprintf("%s/api/v1/comprehension/feedback/plagiarism.json", lms_domain)
-		sentence_structure_regex_api = fmt.Sprintf("%s/api/v1/comprehension/feedback/regex/rules-based-1.json", lms_domain)
-		post_topic_regex_api         = fmt.Sprintf("%s/api/v1/comprehension/feedback/regex/rules-based-2.json", lms_domain)
-		typo_regex_api               = fmt.Sprintf("%s/api/v1/comprehension/feedback/regex/rules-based-3.json", lms_domain)
-		spell_check_bing             = fmt.Sprintf("%s/api/v1/comprehension/feedback/spelling.json", lms_domain)
+		automl_api = fmt.Sprintf("%s/api/v1/evidence/feedback/automl.json", lms_domain)
+		plagiarism_api = fmt.Sprintf("%s/api/v1/evidence/feedback/plagiarism.json", lms_domain)
+		sentence_structure_regex_api = fmt.Sprintf("%s/api/v1/evidence/feedback/regex/rules-based-1.json", lms_domain)
+		post_topic_regex_api         = fmt.Sprintf("%s/api/v1/evidence/feedback/regex/rules-based-2.json", lms_domain)
+		typo_regex_api               = fmt.Sprintf("%s/api/v1/evidence/feedback/regex/rules-based-3.json", lms_domain)
+		spell_check_bing             = fmt.Sprintf("%s/api/v1/evidence/feedback/spelling.json", lms_domain)
 
 		grammar_check_api = "https://quill.spell.services/Quill/grammar/predict"
 		opinion_check_api = fmt.Sprintf("%s/", opinion_domain)

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint_test.go
@@ -162,7 +162,7 @@ func TestFirstResponseErrorLaterNonOptimal(t *testing.T) {
 }
 
 func TestAutoMLIndex(t *testing.T) {
-	if "https://www.quill.org/api/v1/comprehension/feedback/automl.json" != AssembleUrls()[automl_index] {
+	if "https://www.quill.org/api/v1/evidence/feedback/automl.json" != AssembleUrls()[automl_index] {
 		t.Errorf("automl_index does not match automl_api")
 	}
 }


### PR DESCRIPTION
## WHAT
Update routes hard-coded into the Go endpoint to look at `evidence` instead of `comprehension` now that those routes are updated
## WHY
So that we can get useful feedback from routes in the Evidence engine
## HOW
Just update the hard-coded values for the URLs.

### Notion Card Links
https://www.notion.so/quill/Quill-Evidence-topic-feedback-is-not-working-b697b1292e1f48f5b9dc1146e6de7573

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on hard-coded values
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A