### PR TITLE
LMS - Add a weekly job to clean up obsolete ActiveActivitySessions.

### DIFF
--- a/services/QuillLMS/app/models/active_activity_session.rb
+++ b/services/QuillLMS/app/models/active_activity_session.rb
@@ -22,7 +22,7 @@ class ActiveActivitySession < ApplicationRecord
   # Pulls sessions that are finished or their classroom unit are archived
   # These sessions can be deleted
   # Should use with a .limit()
-  scope :obsolete, -> {
+  scope :obsolete, lambda {
     joins(:activity_session)
     .merge(ActivitySession.unscoped.joins(:classroom_unit))
     .where("classroom_units.visible = false OR activity_sessions.completed_at IS NOT NULL")

--- a/services/QuillLMS/app/models/active_activity_session.rb
+++ b/services/QuillLMS/app/models/active_activity_session.rb
@@ -20,7 +20,7 @@ class ActiveActivitySession < ApplicationRecord
   belongs_to :activity_session, -> { unscope(where: :visible) }, foreign_key: :uid, primary_key: :uid
 
   # Pulls sessions that are finished or their classroom unit are archived
-  # These sessiosn can be deleted
+  # These sessions can be deleted
   # Should use with a .limit()
   scope :obsolete, -> {
     joins(:activity_session)

--- a/services/QuillLMS/app/models/active_activity_session.rb
+++ b/services/QuillLMS/app/models/active_activity_session.rb
@@ -17,6 +17,17 @@ class ActiveActivitySession < ApplicationRecord
   validates :uid, presence: true, uniqueness: true
   validate :data_must_be_hash
 
+  belongs_to :activity_session, -> { unscope(where: :visible) }, foreign_key: :uid, primary_key: :uid
+
+  # Pulls sessions that are finished or their classroom unit are archived
+  # These sessiosn can be deleted
+  # Should use with a .limit()
+  scope :obsolete, -> {
+    joins(:activity_session)
+    .merge(ActivitySession.unscoped.joins(:classroom_unit))
+    .where("classroom_units.visible = false OR activity_sessions.completed_at IS NOT NULL")
+  }
+
   def as_json(options=nil)
     data
   end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -60,6 +60,7 @@ class ActivitySession < ApplicationRecord
   has_many :concept_results
   has_many :teachers, through: :classroom
   has_many :concepts, -> { distinct }, through: :concept_results
+  has_one :active_activity_session, foreign_key: :uid, primary_key: :uid
 
   validate :correctly_assigned, :on => :create
 

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -28,6 +28,7 @@ class Cron
     SetImpactMetricsWorker.perform_async
     UploadLeapReportWorker.perform_async(29087)
     PopulateAllActivityHealthsWorker.perform_async
+    DeleteObsoleteActiveActivitySessionsWorker.perform_async
   end
 
   def self.now

--- a/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
+++ b/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
@@ -1,22 +1,14 @@
 class DeleteObsoleteActiveActivitySessionsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
-  BATCH_SIZE = 1_000
 
   def perform
-    loop do
-      obsolete = obsolete_query
-
-      break if obsolete.empty?
-
-      obsolete.destroy_all
-    end
+    obsolete_query.in_batches.delete_all
   end
 
   private def obsolete_query
     ActiveActivitySession
       .select(:id)
       .obsolete
-      .limit(BATCH_SIZE)
   end
 end

--- a/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
+++ b/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
@@ -1,0 +1,22 @@
+class DeleteObsoleteActiveActivitySessionsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+  BATCH_SIZE = 1_000
+
+  def perform
+    loop do
+      obsolete = obsolete_query
+
+      break if obsolete.empty?
+
+      obsolete.destroy_all
+    end
+  end
+
+  private def obsolete_query
+    ActiveActivitySession
+      .select(:id)
+      .obsolete
+      .limit(BATCH_SIZE)
+  end
+end

--- a/services/QuillLMS/spec/factories/active_activity_session.rb
+++ b/services/QuillLMS/spec/factories/active_activity_session.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     foo: 'bar'
   }
   factory :active_activity_session do
-    uid                   SecureRandom.uuid
-    data                  data
+    uid   {SecureRandom.uuid}
+    data  data
   end
 end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -58,5 +58,10 @@ describe "Cron", type: :model do
       expect(PopulateAllActivityHealthsWorker).to receive(:perform_async)
       Cron.run_saturday
     end
+
+    it 'enqueues DeleteObsoleteActiveActivitySessionsWorker' do
+      expect(DeleteObsoleteActiveActivitySessionsWorker).to receive(:perform_async)
+      Cron.run_saturday
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
@@ -16,7 +16,7 @@ describe DeleteObsoleteActiveActivitySessionsWorker, type: :worker do
     )
   end
 
-  it 'should delete obsolete sessiosn' do
+  it 'should delete obsolete sessions' do
     active_id = active_session.id
     obsolete1_id = obsolete_session1.id
     obsolete2_id = obsolete_session2.id

--- a/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe DeleteObsoleteActiveActivitySessionsWorker, type: :worker do
+  let(:worker) { described_class.new }
+
+  let!(:active_session) { create(:active_activity_session) }
+  let!(:obsolete_session1) { create(:active_activity_session) }
+  let!(:obsolete_session2) { create(:active_activity_session) }
+
+  before do
+    create(:activity_session, :finished, uid: obsolete_session1.uid)
+
+    create(:activity_session, :started,
+      uid: obsolete_session2.uid,
+      classroom_unit: create(:classroom_unit, visible: false)
+    )
+  end
+
+  it 'should delete obsolete sessiosn' do
+    active_id = active_session.id
+    obsolete1_id = obsolete_session1.id
+    obsolete2_id = obsolete_session2.id
+
+    worker.perform
+
+    expect(ActiveActivitySession.find_by(id: active_id).id).to be active_id
+    expect(ActiveActivitySession.find_by(id: obsolete1_id)).to be nil
+    expect(ActiveActivitySession.find_by(id: obsolete2_id)).to be nil
+  end
+end


### PR DESCRIPTION
## WHAT
Add a weekly job that deletes `ActiveActivitySessions` that are no longer needed, either because the student finished the activity or
## WHY
This is the second largest table in the DB, so dropping some records should free up some storage. Also, this is table powers the most frequently accessed API endpoint in our system, so keeping the table smaller might have performance benefits (I would guess the gains would be small though)
## HOW
Add a query to search for obsolete records, loop through them in small batches, and `delete_all`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
