### PR TITLE
Fix links for analysis page, attempt #2

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`SessionsIndex component should render SessionsIndex 1`] = `
     <p
       className="link-info-blurb"
     >
-      If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence/activities/
+      If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence#/activities/
       <strong>
         activityID
       </strong>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -173,7 +173,7 @@ const SessionsIndex = ({ match }) => {
       {renderHeader(activityData, 'View Sessions')}
       <section>
         <p className="link-info-blurb">Use <a href={metabaseLink}><strong>this Metabase</strong></a> query to display feedback sessions on a single page.</p>
-        <p className="link-info-blurb">If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence/activities/<strong>activityID</strong>/<strong>sessionID</strong></p>
+        <p className="link-info-blurb">If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence#/activities/<strong>activityID</strong>/<strong>sessionID</strong></p>
         <section className="top-section">
           <section className="total-container">
             <p className="total-label">Total</p>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -161,7 +161,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
           note,
           firstLayerFeedback: first_feedback,
           secondLayerFeedback: second_feedback,
-          handleClick: () => window.open(`/cms/evidence/activities/${activityId}/rules-analysis/${selectedPrompt.conjunction}/rule/${rule_uid}/prompt/${selectedPrompt.id}`, '_blank')
+          handleClick: () => window.open(`/cms/evidence#/activities/${activityId}/rules-analysis/${selectedPrompt.conjunction}/rule/${rule_uid}/prompt/${selectedPrompt.id}`, '_blank')
         }
       }).sort(firstBy('apiOrder').thenBy('ruleOrder'));
       setFormattedRows(formattedRows);


### PR DESCRIPTION
## WHAT
Fix links on the Quill Evidence Rules Analysis page links have references to `comprehension`

## WHY
We want links to be functioning properly.

## HOW
Update references of `comprehension` to `evidence`.  But make sure to include `#`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/The-links-for-the-rules-analysis-page-need-to-be-updated-307a08dcaf0c4fbf989661037fd468b3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
