### PR TITLE
scope list item css correctly

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -245,7 +245,7 @@
   }
 }
 
-.list-item {
+.sortable-classroom, .classrooms-page .list-item {
   display: flex;
   align-items: baseline;
   width: 992px;
@@ -425,7 +425,7 @@
 }
 
 @media (min-width: 768px) and (max-width: 992px) {
-  .list-item {
+  .sortable-classroom, .classrooms-page .list-item {
     display: flex;
     align-items: baseline;
     width: 762px;
@@ -434,7 +434,7 @@
 }
 
 @media (max-width: 768px) {
-  .list-item {
+  .sortable-classroom, .classrooms-page .list-item {
     display: flex;
     align-items: baseline;
     width: auto;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.jsx.snap
@@ -1585,6 +1585,7 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
           </React.Fragment>,
         ]
       }
+      helperClass="sortable-classroom"
       sortCallback={[Function]}
       useDragHandle={true}
     />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
@@ -235,7 +235,7 @@ export default class ActiveClassrooms extends React.Component<ActiveClassroomsPr
   renderClassroomRows(ownActiveClassrooms) {
     const classroomCards = this.renderClassroomCards(ownActiveClassrooms)
     const rows = this.getClassroomCardsWithHandle(classroomCards)
-    return <SortableList data={rows} sortCallback={this.sortClassrooms} useDragHandle={true} />
+    return <SortableList data={rows} helperClass="sortable-classroom" sortCallback={this.sortClassrooms} useDragHandle={true} />
   }
 
   renderClassroomCards(ownActiveClassrooms) {


### PR DESCRIPTION
## WHAT
Scope the `list-item` scss that we added for the classrooms page so it doesn't interfere with other `list-items` around the site.

## WHY
I noticed that some CSS was broken on our Activity Library page, and tracked it to this change.

## HOW
Just added a `helperClass` to the `SortableList` component so that we get a class name other than "`.list-item`" when the element is being dragged, and then use that to add a rule so that we can have the right styling for the moving classroom element without messing with the styling for other draggable elements.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Broken-CSS-for-selected-activity-library-elements-45ae1e524e7e423e9a9ec380245ebd77

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
