### PR TITLE
implement additional bypass button for proofreader

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/PageLayout.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/PageLayout.tsx
@@ -35,6 +35,13 @@ export default class PageLayout extends React.Component<any, { showFocusState: b
     element.scrollIntoView()
   }
 
+  handleSkipToPassageButtonsClick = () => {
+    const element = document.getElementById("button-container")
+    if (!element) { return }
+    element.focus()
+    element.scrollIntoView(false)
+  }
+
   render() {
     const { showFocusState, } = this.state
     let className = "ant-layout activity-container "
@@ -44,6 +51,7 @@ export default class PageLayout extends React.Component<any, { showFocusState: b
       <div className={className}>
         <div className="page-content">
           <button className="skip-main" onClick={this.handleSkipToMainContentClick} type="button">Skip to main content</button>
+          <button className="skip-main" onClick={this.handleSkipToPassageButtonsClick} type="button">Skip to passage buttons</button>
           {header}
           <div id="main-content" tabIndex={-1}>{renderRoutes(routes)}</div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -470,7 +470,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
     }
 
     handleNextClick = () => {
-      this.setState({ showWelcomePage: false })
+      this.setState({ showWelcomePage: false }, () => window.scrollTo(0, 0))
     }
 
     handleResetClick = () => {
@@ -633,7 +633,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
           {this.renderPassage()}
         </div>
         <div className="bottom-section">
-          <div className="button-container">
+          <div id="button-container" tabIndex={-1}>
             {this.renderResetButton()}
             {this.renderCheckWorkButton()}
           </div>

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/welcomePage.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/welcomePage.tsx
@@ -29,7 +29,7 @@ const WelcomePage = ({onNextClick}) => {
         <img alt="Follow-up example showing a correct revision" src={practiceExampleSrc} />
       </div>
     </div>
-    <div className="button-section">
+    <div id="button-container" tabIndex={-1}>
       <button className="quill-button large contained primary focus-on-light" onClick={onNextClick} type="button">Next</button>
     </div>
   </div>)

--- a/services/QuillLMS/client/app/bundles/Proofreader/styles/passage.scss
+++ b/services/QuillLMS/client/app/bundles/Proofreader/styles/passage.scss
@@ -155,12 +155,15 @@
     padding: 40px 16px;
     background-color: #ededed;
     min-height: 100vh;
-    .button-container {
+    #button-container {
       max-width: 800px;
       margin: auto;
       display: flex;
       justify-content: space-between;
       align-items: flex-end;
+      &:focus {
+        outline: none;
+      }
     }
     @media (max-width: 800px) {
       padding-top: 24px;

--- a/services/QuillLMS/client/app/bundles/Proofreader/styles/welcomePage.scss
+++ b/services/QuillLMS/client/app/bundles/Proofreader/styles/welcomePage.scss
@@ -5,11 +5,14 @@
       font-size: 28px;
     }
   }
-  .button-section {
+  #button-container {
     padding: 40px 0 96px;
     background-color: #ededed;
+    &:focus {
+      outline: none;
+    }
   }
-  .header-section, .button-section {
+  .header-section, #button-container {
     max-width: 800px;
     margin: auto;
   }
@@ -54,7 +57,7 @@
     }
   }
   @media (max-width: 832px) {
-    .header-section, .button-section {
+    .header-section, #button-container {
       padding-left: 16px;
       padding-right: 16px;
     }

--- a/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/__snapshots__/container.test.tsx.snap
@@ -135,7 +135,8 @@ Over the years, Coney Island has expanded to have a few parks with rides. There 
         </div>
       </div>
       <div
-        className="button-section"
+        id="button-container"
+        tabIndex={-1}
       >
         <button
           className="quill-button large contained primary focus-on-light"

--- a/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/__snapshots__/welcomePage.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/__snapshots__/welcomePage.test.tsx.snap
@@ -73,7 +73,8 @@ exports[`<WelcomePage /> should render 1`] = `
     </div>
   </div>
   <div
-    className="button-section"
+    id="button-container"
+    tabIndex={-1}
   >
     <button
       className="quill-button large contained primary focus-on-light"


### PR DESCRIPTION
## WHAT
Add a "Skip to passage buttons" bypass block for Proofreader.

## WHY
Users who use keyboard navigation had no way to get to the `Undo edits` or `Submit` button on Proofreader without tabbing through every input field in the passage. This gives them quicker access.

## HOW
Just render an additional bypass button that shows up when you tab past the `Skip to main content` bypass button.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Create-a-more-specific-bypass-block-for-Quill-Proofreader-6cc29b1d6210417dabda4826eb9f13f4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
