### PR TITLE
Show unsynced Google Classroom students and allow teachers to remove/move those students

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -270,6 +270,9 @@
     font-weight: bold;
     margin-bottom: 24px;
   }
+  .show-overflow {
+    overflow: visible !important;
+  }
   .classroom-card-header, .students-section, .teacher-section {
     padding: 32px;
   }

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -203,9 +203,14 @@ class Teachers::ClassroomsController < ApplicationController
   private def format_students_for_classroom(classroom, activity_counts)
     sorted_students = classroom.students.sort_by(&:last_name)
 
-    sorted_students.map do |s|
-      s.attributes.merge(number_of_completed_activities: activity_counts[s.id] || 0)
+    students = sorted_students.map do |student|
+      student.attributes.merge(number_of_completed_activities: activity_counts[student.id] || 0)
     end
+
+    return students unless classroom.google_classroom?
+
+    provider_classroom = ProviderClassroom.new(classroom)
+    students.map { |student| student.merge(synced: provider_classroom.active_student?(student)) }
   end
 
   private def format_pending_coteachers_for_classroom(classroom)

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -192,6 +192,7 @@ class Teachers::ClassroomsController < ApplicationController
 
     classrooms.compact.map do |classroom|
       classroom_obj = classroom.attributes
+      classroom_obj[:providerClassroom] = classroom.provider_classroom if classroom.provider_classroom?
       classroom_obj[:students] = format_students_for_classroom(classroom, activity_counts_by_student)
       classroom_teachers = format_teachers_for_classroom(classroom)
       pending_coteachers = format_pending_coteachers_for_classroom(classroom)

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -173,6 +173,18 @@ class Classroom < ApplicationRecord
     -1
   end
 
+  def provider_classroom?
+    google_classroom? || clever_classroom?
+  end
+
+  def clever_classroom?
+    clever_id.present?
+  end
+
+  def google_classroom?
+    google_classroom_id.present?
+  end
+
   # Clever integration
   private def clever_classroom
     Clever::Section.retrieve(clever_id, teacher.districts.first.token)

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -185,6 +185,10 @@ class Classroom < ApplicationRecord
     google_classroom_id.present?
   end
 
+  def provider_classroom
+    return 'Google Classroom' if google_classroom?
+  end
+
   # Clever integration
   private def clever_classroom
     Clever::Section.retrieve(clever_id, teacher.districts.first.token)

--- a/services/QuillLMS/app/models/provider_classroom.rb
+++ b/services/QuillLMS/app/models/provider_classroom.rb
@@ -1,0 +1,28 @@
+class ProviderClassroom < SimpleDelegator
+  def active_student?(student_attrs)
+    provider_active_user_ids.include?(provider_user_id(student_attrs))
+  end
+
+  private def provider_active_user_ids
+    @provider_active_user_ids ||=
+      provider_classroom_user_class
+        .active
+        .where(provider_classroom_id: provider_classroom_id)
+        .pluck(:provider_user_id)
+  end
+
+  private def provider_classroom_id
+    return google_classroom_id if google_classroom?
+    return clever_id if clever_classroom?
+  end
+
+  private def provider_classroom_user_class
+    return GoogleClassroomUser if google_classroom?
+    return CleverClassroomUser if clever_classroom?
+  end
+
+  private def provider_user_id(student_attrs)
+    return student_attrs['google_id'] if google_classroom?
+    return student_attrs['clever_id'] if clever_classroom?
+  end
+end

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -258,19 +258,6 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     const dataTableRowSectionClassName = `data-table-row-section ${header.rowSectionClassName}`
     const key = `${header.attribute}-${row.id || sectionText}`
 
-    if (header.noTooltip && sectionText && sectionText.type === Tooltip && sectionText.props.tooltipText && sectionText.props.tooltipTriggerText) {
-      return (
-        <Tooltip
-          key={key}
-          tooltipText={sectionText.props.tooltipText}
-          tooltipTriggerStyle={style}
-          tooltipTriggerText={sectionText.props.tooltipTriggerText}
-          tooltipTriggerTextClass={dataTableRowSectionClassName}
-          tooltipTriggerTextStyle={style}
-        />
-      )
-    }
-
     let linkDisplayText
     if (sectionText && sectionText.type === 'a' && sectionText.props.children && sectionText.props.children[1] && sectionText.props.children[1].props) {
       linkDisplayText = sectionText.props.children[1].props.children

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -257,10 +257,25 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     const headerWidthNumber = Number(header.width.slice(0, -2))
     const dataTableRowSectionClassName = `data-table-row-section ${header.rowSectionClassName}`
     const key = `${header.attribute}-${row.id || sectionText}`
+
+    if (header.noTooltip && sectionText && sectionText.type === Tooltip && sectionText.props.tooltipText && sectionText.props.tooltipTriggerText) {
+      return (
+        <Tooltip
+          key={key}
+          tooltipText={sectionText.props.tooltipText}
+          tooltipTriggerStyle={style}
+          tooltipTriggerText={sectionText.props.tooltipTriggerText}
+          tooltipTriggerTextClass={dataTableRowSectionClassName}
+          tooltipTriggerTextStyle={style}
+        />
+      )
+    }
+
     let linkDisplayText
     if (sectionText && sectionText.type === 'a' && sectionText.props.children && sectionText.props.children[1] && sectionText.props.children[1].props) {
       linkDisplayText = sectionText.props.children[1].props.children
     }
+
     const rowDisplayText = linkDisplayText || sectionText
     if (!header.noTooltip && (String(rowDisplayText).length * averageFontWidth) >= headerWidthNumber) {
       return (<Tooltip

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
@@ -111,12 +111,7 @@ exports[`ClassroomStudentSection component with students should render 1`] = `
         Object {
           "attribute": "username",
           "name": "Username",
-          "width": "362px",
-        },
-        Object {
-          "attribute": "synced",
-          "name": "Synced",
-          "width": "124px",
+          "width": "486px",
         },
         Object {
           "attribute": "actions",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -410,11 +410,10 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
     const { selectedStudentIds, } = this.state
 
     const rows = classroom.students.map(student => {
-      const { name, username, id, google_id, clever_id, } = student
+      const { name, username, id, } = student
       const checked = !!selectedStudentIds.includes(id)
-      let synced = ''
-      if (google_id) { synced = 'Google Classroom'}
-      if (clever_id) { synced = 'Clever' }
+      const synced = student.synced ? 'Yes' : 'No'
+
       return {
         synced,
         name,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -428,7 +428,7 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
   syncedStatus(student: any, providerClassroom: string) {
     const { synced } = student
 
-    if (synced === null) { return null }
+    if (synced === undefined) { return "" }
     if (synced) { return 'Yes' }
 
     return (

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -7,48 +7,31 @@ import MergeStudentAccountsModal from './merge_student_accounts_modal'
 import MoveStudentsModal from './move_students_modal'
 import RemoveStudentsModal from './remove_students_modal'
 
-import { DropdownInput, DataTable } from '../../../Shared/index'
+import { DropdownInput, DataTable, Tooltip, helpIcon } from '../../../Shared/index'
 
 const emptyDeskSrc = `${process.env.CDN_URL}/images/illustrations/empty-desks.svg`
 const bulbSrc = `${process.env.CDN_URL}/images/illustrations/bulb.svg`
 const cleverSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instructions_pdfs/clever_setup_instructions.pdf`
 const googleSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instructions_pdfs/google_setup_instructions.pdf`
 
-const activeHeaders = [
-  {
-    width: '190px',
-    name: 'Name',
-    attribute: 'name'
-  }, {
-    width: '362px',
-    name: 'Username',
-    attribute: 'username'
-  }, {
-    width: '124px',
-    name: 'Synced',
-    attribute: 'synced'
-  }, {
-    name: 'Actions',
-    attribute: 'actions',
-    isActions: true
-  }
-]
+function activeHeaders(providerClassroom: string) {
+  const name = { width: '190px', name: 'Name', attribute: 'name' }
+  const usernameWidth = providerClassroom ? '362px' : '486px'
+  const username = { width: usernameWidth, name: 'Username', attribute: 'username' }
+  const synced = { width: '124px', name: 'Synced', attribute: 'synced', noTooltip: true }
+  const actions =  { name: 'Actions', attribute: 'actions', isActions: true }
 
-const archivedHeaders = [
-  {
-    width: '235px',
-    name: 'Name',
-    attribute: 'name'
-  }, {
-    width: '407px',
-    name: 'Username',
-    attribute: 'username'
-  }, {
-    width: '124px',
-    name: 'Synced',
-    attribute: 'synced'
-  }
-]
+  return providerClassroom ? [name, username, synced, actions] : [name, username, actions]
+}
+
+function archivedHeaders(providerClassroom: string) {
+  const name = { width: '235px', name: 'Name', attribute: 'name' }
+  const usernameWidth = providerClassroom ? '407px' : '531px'
+  const username = { width: usernameWidth, name: 'Username', attribute: 'username' }
+  const synced = { width: '124px', name: 'Synced', attribute: 'synced', noTooltip: true }
+
+  return providerClassroom ? [name, username, synced] : [name, username]
+}
 
 enum modalNames {
   editStudentAccountModal = 'editStudentAccountModal',
@@ -405,15 +388,38 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
     }
   }
 
+  syncedStatus(student: any, providerClassroom: string) {
+    const { synced } = student
+
+    if (synced === null) { return null }
+    if (synced) { return 'Yes' }
+
+    return (
+      <Tooltip
+        tooltipText={`This student is no longer in this class in ${providerClassroom}`}
+
+        tooltipTriggerText={
+          <div className="text-and-icon-wrapper">
+            <span>No&nbsp;</span>
+            <img
+              alt={helpIcon.alt}
+              src={helpIcon.src}
+            />
+          </div>
+        }
+      />
+    )
+  }
+
   renderStudentDataTable() {
     const { classroom, } = this.props
     const { selectedStudentIds, } = this.state
+    const { providerClassroom } = classroom
 
     const rows = classroom.students.map(student => {
       const { name, username, id, } = student
       const checked = !!selectedStudentIds.includes(id)
-      const synced = student.synced ? 'Yes' : 'No'
-
+      const synced = this.syncedStatus(student, providerClassroom)
       return {
         synced,
         name,
@@ -427,7 +433,7 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
     return (<DataTable
       checkAllRows={this.checkAllRows}
       checkRow={this.checkRow}
-      headers={classroom.visible ? activeHeaders : archivedHeaders}
+      headers={classroom.visible ? activeHeaders(providerClassroom) : archivedHeaders(providerClassroom)}
       rows={rows}
       showActions={classroom.visible}
       showCheckboxes={classroom.visible}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -15,20 +15,55 @@ const cleverSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instr
 const googleSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instructions_pdfs/google_setup_instructions.pdf`
 
 function activeHeaders(providerClassroom: string) {
-  const name = { width: '190px', name: 'Name', attribute: 'name' }
-  const usernameWidth = providerClassroom ? '362px' : '486px'
-  const username = { width: usernameWidth, name: 'Username', attribute: 'username' }
-  const synced = { width: '124px', name: 'Synced', attribute: 'synced', noTooltip: true }
-  const actions =  { name: 'Actions', attribute: 'actions', isActions: true }
+  const name = {
+    width: '190px',
+    name: 'Name',
+    attribute: 'name'
+  }
+
+  const username = {
+    width: providerClassroom ? '362px' : '486px',
+    name: 'Username',
+    attribute: 'username'
+  }
+
+  const synced = {
+    width: '124px',
+    name: 'Synced',
+    attribute: 'synced',
+    noTooltip: true,
+    rowSectionClassName: 'show-overflow'
+  }
+
+  const actions =  {
+    name: 'Actions',
+    attribute: 'actions',
+    isActions: true
+  }
 
   return providerClassroom ? [name, username, synced, actions] : [name, username, actions]
 }
 
 function archivedHeaders(providerClassroom: string) {
-  const name = { width: '235px', name: 'Name', attribute: 'name' }
-  const usernameWidth = providerClassroom ? '407px' : '531px'
-  const username = { width: usernameWidth, name: 'Username', attribute: 'username' }
-  const synced = { width: '124px', name: 'Synced', attribute: 'synced', noTooltip: true }
+  const name = {
+    width: '235px',
+    name: 'Name',
+    attribute: 'name'
+  }
+
+  const username = {
+    width: providerClassroom ? '407px' : '531px',
+    name: 'Username',
+    attribute: 'username'
+  }
+
+  const synced = {
+    width: '124px',
+    name: 'Synced',
+    attribute: 'synced',
+    noTooltip: true,
+    rowSectionClassName: 'show-overflow'
+  }
 
   return providerClassroom ? [name, username, synced] : [name, username]
 }
@@ -139,7 +174,7 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
   }
 
   actionsForIndividualStudent = (student) => {
-    const { google_id, clever_id, } = student
+    const { google_id, clever_id, synced } = student
     const { classrooms, isOwnedByCurrentUser, } = this.props
     const {
       editAccount,
@@ -149,8 +184,10 @@ export default class ClassroomStudentSection extends React.Component<ClassroomSt
       moveClass,
       removeFromClass
     } = this.individualStudentActions()
-    if (google_id || clever_id) {
-      return [ viewAsStudent, removeFromClass ]
+    if (google_id) {
+      return synced ? [viewAsStudent] : [viewAsStudent, moveClass, removeFromClass]
+    } else if (clever_id) {
+      return [viewAsStudent, removeFromClass]
     } else if (classrooms.length > 1 && isOwnedByCurrentUser) {
       return [ editAccount, resetPassword, viewAsStudent, mergeAccounts, moveClass, removeFromClass ]
     } else if (isOwnedByCurrentUser) {

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -276,8 +276,8 @@ describe Teachers::ClassroomsController, type: :controller do
         it 'reports which students are no longer in provider classroom' do
           get :index, as: :json
           parsed_response = JSON.parse(response.body)
-          expect(parsed_response["classrooms"][0]["students"][0]["deleted_on_provider"]).to eq false
-          expect(parsed_response["classrooms"][0]["students"][1]["deleted_on_provider"]).to eq true
+          expect(parsed_response["classrooms"][0]["students"][0]["synced"]).to eq true
+          expect(parsed_response["classrooms"][0]["students"][1]["synced"]).to eq false
         end
       end
     end

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -157,94 +157,127 @@ describe Teachers::ClassroomsController, type: :controller do
 
   describe '#index' do
     let!(:teacher) { create(:teacher) }
-    let!(:classroom1) { create(:classroom)}
-    let!(:classroom2) { create(:classroom)}
-    let!(:classroom3) { create(:classroom)}
-    let!(:classrooms_teacher1) { create(:classrooms_teacher, classroom: classroom1, user: teacher )}
-    let!(:classrooms_teacher2) { create(:classrooms_teacher, classroom: classroom2, user: teacher )}
-    let!(:classrooms_teacher3) { create(:classrooms_teacher, classroom: classroom3, user: teacher )}
 
-    before do
-      allow(controller).to receive(:current_user) { teacher }
-    end
+    before { allow(controller).to receive(:current_user) { teacher } }
 
-    context 'when current user has classrooms i teach' do
+    context 'plain classrooms' do
+      let!(:classroom1) { create(:classroom)}
+      let!(:classroom2) { create(:classroom)}
+      let!(:classroom3) { create(:classroom)}
+      let!(:classrooms_teacher1) { create(:classrooms_teacher, classroom: classroom1, user: teacher )}
+      let!(:classrooms_teacher2) { create(:classrooms_teacher, classroom: classroom2, user: teacher )}
+      let!(:classrooms_teacher3) { create(:classrooms_teacher, classroom: classroom3, user: teacher )}
 
-      it 'should return classrooms in order of creation date' do
-        get :index, as: :json
+      before { allow(controller).to receive(:current_user) { teacher } }
 
-        parsed_response = JSON.parse(response.body)
+      context 'when current user has classrooms i teach' do
 
-        expect(parsed_response["classrooms"][0]["id"]).to eq(classroom3.id)
-        expect(parsed_response["classrooms"][1]["id"]).to eq(classroom2.id)
-        expect(parsed_response["classrooms"][2]["id"]).to eq(classroom1.id)
-      end
-
-      it 'should assign the classrooms and classroom and no students' do
-        get :index
-        expect(assigns(:classrooms)[0]['id']).to eq classroom3.id
-        expect(assigns(:classrooms)[1]['id']).to eq classroom2.id
-        expect(assigns(:classrooms)[2]['id']).to eq classroom1.id
-        expect(assigns(:classrooms)[0][:students]).to be_empty
-        expect(assigns(:classrooms)[1][:students]).to be_empty
-        expect(assigns(:classrooms)[2][:students]).to be_empty
-      end
-
-      context "with activity sesions" do
-        let!(:activity) { create(:activity) }
-        let!(:student) { create(:user, classcode: classroom3.code) }
-        let!(:cu) { create(:classroom_unit, classroom: classroom3, assigned_student_ids: [student.id])}
-        let!(:ua) { create(:unit_activity, unit: cu.unit, activity: activity)}
-        let!(:activity_session) { create(:activity_session, user: student, activity: activity, classroom_unit: cu, state: 'finished') }
-
-        it 'should assign students and number_of_completed_activities' do
-          get :index
-          expect(assigns(:classrooms)[0]['id']).to eq classroom3.id
-          expect(assigns(:classrooms)[0][:students][0][:number_of_completed_activities]).to eq 1
-        end
-      end
-
-      context "with order property" do
-        before do
-          # remove classroom_teacher entries from earlier tests
-          ids = [classrooms_teacher1.id, classrooms_teacher2.id, classrooms_teacher3.id]
-          ClassroomsTeacher.all.each do |classroom_teacher|
-            if !ids.include?(classroom_teacher.id)
-              classroom_teacher.destroy!
-            end
-          end
-        end
-
-        it 'should return classrooms in order of creation date if only some classrooms_teacher entries have order property' do
-          ct1 = ClassroomsTeacher.where(classroom_id: classroom1.id).first
-          ct1.order = 1
-          ct1.save!
-
+        it 'should return classrooms in order of creation date' do
           get :index, as: :json
 
           parsed_response = JSON.parse(response.body)
+
           expect(parsed_response["classrooms"][0]["id"]).to eq(classroom3.id)
           expect(parsed_response["classrooms"][1]["id"]).to eq(classroom2.id)
           expect(parsed_response["classrooms"][2]["id"]).to eq(classroom1.id)
         end
 
-        it 'should return classrooms ordered by order properity if all classrooms_teacher entries have order property' do
-          ct1 = ClassroomsTeacher.where(classroom_id: classroom1.id).first
-          ct1.order = 1
-          ct1.save!
-          ct2 = ClassroomsTeacher.where(classroom_id: classroom2.id).first
-          ct2.order = 0
-          ct2.save!
-          ct3 = ClassroomsTeacher.where(classroom_id: classroom3.id).first
-          ct3.order = 2
-          ct3.save!
+        it 'should assign the classrooms and classroom and no students' do
+          get :index
+          expect(assigns(:classrooms)[0]['id']).to eq classroom3.id
+          expect(assigns(:classrooms)[1]['id']).to eq classroom2.id
+          expect(assigns(:classrooms)[2]['id']).to eq classroom1.id
+          expect(assigns(:classrooms)[0][:students]).to be_empty
+          expect(assigns(:classrooms)[1][:students]).to be_empty
+          expect(assigns(:classrooms)[2][:students]).to be_empty
+        end
 
+        context "with activity sesions" do
+          let!(:activity) { create(:activity) }
+          let!(:student) { create(:user, classcode: classroom3.code) }
+          let!(:cu) { create(:classroom_unit, classroom: classroom3, assigned_student_ids: [student.id])}
+          let!(:ua) { create(:unit_activity, unit: cu.unit, activity: activity)}
+          let!(:activity_session) { create(:activity_session, user: student, activity: activity, classroom_unit: cu, state: 'finished') }
+
+          it 'should assign students and number_of_completed_activities' do
+            get :index
+            expect(assigns(:classrooms)[0]['id']).to eq classroom3.id
+            expect(assigns(:classrooms)[0][:students][0][:number_of_completed_activities]).to eq 1
+          end
+        end
+
+        context "with order property" do
+          before do
+            # remove classroom_teacher entries from earlier tests
+            ids = [classrooms_teacher1.id, classrooms_teacher2.id, classrooms_teacher3.id]
+            ClassroomsTeacher.all.each do |classroom_teacher|
+              if !ids.include?(classroom_teacher.id)
+                classroom_teacher.destroy!
+              end
+            end
+          end
+
+          it 'should return classrooms in order of creation date if only some classrooms_teacher entries have order property' do
+            ct1 = ClassroomsTeacher.where(classroom_id: classroom1.id).first
+            ct1.order = 1
+            ct1.save!
+
+            get :index, as: :json
+
+            parsed_response = JSON.parse(response.body)
+            expect(parsed_response["classrooms"][0]["id"]).to eq(classroom3.id)
+            expect(parsed_response["classrooms"][1]["id"]).to eq(classroom2.id)
+            expect(parsed_response["classrooms"][2]["id"]).to eq(classroom1.id)
+          end
+
+          it 'should return classrooms ordered by order properity if all classrooms_teacher entries have order property' do
+            ct1 = ClassroomsTeacher.where(classroom_id: classroom1.id).first
+            ct1.order = 1
+            ct1.save!
+            ct2 = ClassroomsTeacher.where(classroom_id: classroom2.id).first
+            ct2.order = 0
+            ct2.save!
+            ct3 = ClassroomsTeacher.where(classroom_id: classroom3.id).first
+            ct3.order = 2
+            ct3.save!
+
+            get :index, as: :json
+
+            parsed_response = JSON.parse(response.body)
+            expect(parsed_response["classrooms"][0]["id"]).to eq(classroom2.id)
+            expect(parsed_response["classrooms"][1]["id"]).to eq(classroom1.id)
+            expect(parsed_response["classrooms"][2]["id"]).to eq(classroom3.id)
+          end
+        end
+      end
+    end
+
+    context 'provider-based classrooms' do
+      context 'google classroom' do
+        let(:classroom) { create(:classroom_with_a_couple_students, :from_google, students: [student1, student2]) }
+        let(:student1) { create(:student, :signed_up_with_google) }
+        let(:student2) { create(:student, :signed_up_with_google) }
+        let!(:classrooms_teacher) { create(:classrooms_teacher, classroom: classroom, user: teacher )}
+
+        before do
+          create(:google_classroom_user,
+            :active,
+            provider_classroom_id: classroom.google_classroom_id,
+            provider_user_id: student1.google_id
+          )
+
+          create(:google_classroom_user,
+            :deleted,
+            provider_classroom_id: classroom.google_classroom_id,
+            provider_user_id: student2.google_id
+          )
+        end
+
+        it 'reports which students are no longer in provider classroom' do
           get :index, as: :json
-
           parsed_response = JSON.parse(response.body)
-          expect(parsed_response["classrooms"][0]["id"]).to eq(classroom2.id)
-          expect(parsed_response["classrooms"][1]["id"]).to eq(classroom1.id)
-          expect(parsed_response["classrooms"][2]["id"]).to eq(classroom3.id)
+          expect(parsed_response["classrooms"][0]["students"][0]["deleted_on_provider"]).to eq false
+          expect(parsed_response["classrooms"][0]["students"][1]["deleted_on_provider"]).to eq true
         end
       end
     end

--- a/services/QuillLMS/spec/models/provider_classroom_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ProviderClassroom do
+  subject { described_class.new(classroom) }
+
+  describe '#active_student?' do
+    context 'google classroom' do
+      let(:classroom) { create(:classroom_with_a_couple_students, :from_google, students: [student1, student2]) }
+      let(:student1) { create(:student, :signed_up_with_google) }
+      let(:student2) { create(:student, :signed_up_with_google) }
+
+      before do
+        create(:google_classroom_user,
+          :active,
+          provider_classroom_id: classroom.google_classroom_id,
+          provider_user_id: student1.google_id
+        )
+
+        create(:google_classroom_user,
+          :deleted,
+          provider_classroom_id: classroom.google_classroom_id,
+          provider_user_id: student2.google_id
+        )
+      end
+
+      it { expect(subject.active_student?(student1.attributes)).to eq true }
+      it { expect(subject.active_student?(student2.attributes)).to eq false }
+    end
+
+    context 'clever classroom' do
+      let(:classroom) { create(:classroom_with_a_couple_students, :from_clever, students: [student1, student2]) }
+      let(:student1) { create(:student, :signed_up_with_clever) }
+      let(:student2) { create(:student, :signed_up_with_clever) }
+
+      before do
+        create(:clever_classroom_user,
+          :deleted,
+          provider_classroom_id: classroom.clever_id,
+          provider_user_id: student1.clever_id
+        )
+
+        create(:clever_classroom_user,
+          :active,
+          provider_classroom_id: classroom.clever_id,
+          provider_user_id: student2.clever_id
+        )
+      end
+
+      it { expect(subject.active_student?(student1.attributes)).to eq false }
+      it { expect(subject.active_student?(student2.attributes)).to eq true }
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
The new model `ProviderClassroomUser` tracks which students belong to a classroom on a particular provider (i.e. Google Classroom or Clever). Each of these records has a `deleted_at` attribute which when null corresponds to an active student in the provider classroom; a non-null value indicates the student used to be in that classroom but is no longer. This PR addresses requirements for incorporating this data on the teacher classrooms page:

1. Don't show the "Remove from class" option for students that are currently synced with Google Classroom or Clever: 
2. Show "Remove from Class" and "Move class" options for unsynced Google Classroom students
3. Change Synced column details for a 'Google Classroom' classroom to 'Yes' or 'No'.  In the case of 'No' add a hover indicating the 'Student is no longer in this class in Google Classroom'
4. Remove synced column for classrooms without a provider (i.e. Google Classroom or Clever)

## WHY
Actions on Quill should be consistent with the logic and source of truth on Google Classroom provider.

## HOW
To solve these related items, we first add a couple of pieces to the classrooms#index JSON:
a) Add a new `providerClassroom` key to the classrooms JSON.
b) Add a new `synced` key to the  classrooms_students JSON.  The value of `synced` is computed via `ProviderClassroomUser` query to see if a particular record exists and is `active`.  The `ProviderClassroom` uses the decorator pattern to target a specific use case of `Classroom` (i.e. those classrooms with a Provider).  

1 & 2.  Assign actions based on [synced status](https://github.com/empirical-org/Empirical-Core/pull/8269/files#diff-2b27ac339f8a8cd829c6efb0b7a8181c8853cc41c77493e210bc2c635ee1e6b0R188)
3. The crux of the front-end implementation was getting the tooltip to work for with the DataTable Component.  @emilia-friedberg uncovered that an `overflow:  hidden` directive was preventing the tooltip to load.  After adding a small css [rule](https://github.com/empirical-org/Empirical-Core/pull/8269/files#diff-2b27ac339f8a8cd829c6efb0b7a8181c8853cc41c77493e210bc2c635ee1e6b0R35) on the synced column, the tooltip worked.  Once that was in place, utilize the [syncedStatus](https://github.com/empirical-org/Empirical-Core/pull/8269/files#diff-2b27ac339f8a8cd829c6efb0b7a8181c8853cc41c77493e210bc2c635ee1e6b0R428) for display.
4.  Set headers by checking for a [providerClassroom](https://github.com/empirical-org/Empirical-Core/pull/8269/files#diff-2b27ac339f8a8cd829c6efb0b7a8181c8853cc41c77493e210bc2c635ee1e6b0R44)

NB.  The diff is kind of confusing for `services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb` really starts at line 255.  The rest above it is just getting the existing test inside of the new `context 'plain classrooms'`.   

### Screenshots
1. 
![#1](https://user-images.githubusercontent.com/2057805/133676598-dec494ba-baf7-4b2e-98ea-e94df2f8f019.png)
2. 
![#2](https://user-images.githubusercontent.com/2057805/133676646-7b496f64-b773-4c87-bd5e-4df3b8eb1ec6.png)
3. 
![#3](https://user-images.githubusercontent.com/2057805/133676665-a9ed8ee8-6512-4673-b28b-b954d26b04e1.png)
4. 
![#4](https://user-images.githubusercontent.com/2057805/133676681-ba9a82f9-8290-459d-a482-b1fcbd0653d1.png)


### Notion Card Links
https://www.notion.so/quill/Google-Classroom-and-Clever-Make-it-clearer-which-students-are-synced-with-Google-Classroom-or-Clev-edde7e84621d45bb903f1c7ce1a769be

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
