### PR TITLE
Add more fine-grained logic to create Demo Completed Activities

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -192,7 +192,7 @@ module Demo::ReportDemoCreator
     classroom_units = create_classroom_units(classroom, units)
     activity_sessions = create_activity_sessions(students, classroom)
     subscription = create_subscription(teacher)
-    create_replayed_activity_session(students.first)
+    create_replayed_activity_session(students.first, classroom_units.first)
 
     TeacherActivityFeedRefillWorker.perform_async(teacher.id)
   end
@@ -302,11 +302,10 @@ module Demo::ReportDemoCreator
     end
   end
 
-  def self.create_replayed_activity_session(student)
+  def self.create_replayed_activity_session(student, classroom_unit)
     replayed_session = ActivitySession.unscoped.where({activity_id: REPLAYED_ACTIVITY_ID, user_id: REPLAYED_SAMPLE_USER_ID, is_final_score: true}).first
     student_id = student.id
-    cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids)").to_a.first
-    act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: replayed_session&.percentage})
+    act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: classroom_unit.id, user_id: student.id, state: "finished", percentage: replayed_session&.percentage})
     replayed_session&.concept_results&.each do |cr|
       values = {
         activity_session_id: act_session.id,

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -5,19 +5,182 @@ module Demo::ReportDemoCreator
   ACTIVITY_PACKS = [
     {
       name: "Quill Activity Pack",
-      activity_ids: [1663, 437, 434, 215, 41, 386, 289, 295, 418]
+      activity_ids: [1663, 437, 434, 215, 41, 386, 289, 295, 418],
+      activity_sessions: [
+        {
+          1663 => 9706466,
+          437 => 313241,
+          434 => 446637,
+          215 => 369874,
+          41 => 438155,
+          386 => 387966,
+          289 => 442653,
+          295 => 442645,
+          418 => 662204
+        },
+        {
+          1663 => 9706465,
+          437 => 409030,
+          434 => 313319,
+          215 => 370995,
+          41 => 459240,
+          386 => 387956,
+          289 => 442649,
+          295 => 442649,
+          418 => 662204
+        },
+        {
+          1663 => 9706463,
+          437 => 446637,
+          434 => 312664,
+          215 => 369875,
+          41 => 438144,
+          386 => 387967,
+          289 => 442670,
+          295 => 442638,
+          418 => 662204
+        },
+        {
+          1663 => 9962415,
+          437 => 312664,
+          434 => 313241,
+          215 => 369883,
+          41 => 438171,
+          386 => 387954,
+          289 => 442645,
+          295 => 442653,
+          418 => 662204
+        },
+        {
+          1663 => 9962377,
+          437 => 446641,
+          434 => 446641,
+          215 => 369872,
+          41 => 438152,
+          386 => 387948,
+          289 => 442656,
+          295 => 442643,
+          418 => 662204
+        }
+      ]
     },
     {
       name: "Paragraph Transitions",
-      activity_ids: [851, 863, 861, 985, 986, 1446]
+      activity_ids: [851, 863, 861, 985, 986, 1446],
+      activity_sessions: [
+        {
+          851 => 9962415,
+          863 => 9962415,
+          861 => 9962415,
+          985 => 9962415,
+          986 => 9962415,
+          1446 => 9962415
+        },
+        {
+          851 => 9706466,
+          863 => 9706466,
+          861 => 9706466,
+          985 => 9706466,
+          986 => 9706466,
+          1446 => 9706466
+        },
+        {
+          851 => 9706464,
+          863 => 9706464,
+          861 => 9706464,
+          985 => 9706464,
+          986 => 9706464,
+          1446 => 9706464
+        },
+        {
+          851 => 9706465,
+          863 => 9706465,
+          861 => 9706465,
+          985 => 9706465,
+          986 => 9706465,
+          1446 => 9706465
+        },
+        {
+          851 => 9962377,
+          863 => 9962377,
+          861 => 9962377,
+          985 => 9962377,
+          986 => 9962377,
+          1446 => 9962377
+        }
+      ]
     },
     {
       name: "Social Studies: Maya, Aztec, and Inca Sentence Combining Practice",
-      activity_ids: [627, 628, 629, 535, 523]
+      activity_ids: [627, 628, 629, 535, 523],
+      activity_sessions: [
+        {
+          627 => 9962415,
+          628 =>  9962415,
+          629 => 9962415,
+          535 => 9962415,
+          523 => 9962415
+        },
+        {
+          627 => 9706466,
+          628 =>  9706466,
+          629 => 9706466,
+          535 => 9706466,
+          523 => 9706466
+        },
+        {
+          627 => 9706464,
+          628 =>  9706464,
+          629 => 9706464,
+          535 => 9706464,
+          523 => 9706464
+        },
+        {
+          627 => 9706465,
+          628 =>  9706465,
+          629 => 9706465,
+          535 => 9706465,
+          523 => 9706465
+        },
+        {
+          627 => 9962377,
+          628 =>  9962377,
+          629 => 9962377,
+          535 => 9962377,
+          523 => 9962377
+        }
+      ]
     },
     {
       name: "Subject-Verb Agreement Practice",
-      activity_ids: [742, 751, 765]
+      activity_ids: [742, 751, 765],
+      activity_sessions: [
+        {
+          742 => 9962415,
+          751 => 9962415,
+          765 => 9962415
+        },
+        {
+          742 => 9706466,
+          751 => 9706466,
+          765 => 9706466
+        },
+        {
+          742 => 9706464,
+          751 => 9706464,
+          765 => 9706464
+        },
+        {
+          742 => 9706465,
+          751 => 9706465,
+          765 => 9706465
+        },
+        {
+          742 => 9962377,
+          751 => 9962377,
+          765 => 9962377
+        }
+      ]
     }
   ]
 
@@ -27,8 +190,9 @@ module Demo::ReportDemoCreator
     students = create_students(classroom)
     units = create_units(teacher)
     classroom_units = create_classroom_units(classroom, units)
-    activity_sessions = create_activity_sessions(students)
+    activity_sessions = create_activity_sessions(students, classroom)
     subscription = create_subscription(teacher)
+    create_replayed_activity_session(students.first)
 
     TeacherActivityFeedRefillWorker.perform_async(teacher.id)
   end
@@ -154,157 +318,28 @@ module Demo::ReportDemoCreator
     end
   end
 
-  def self.create_activity_sessions(students)
-    templates = [
-      {
-        1663 => 9706466,
-        437 => 313241,
-        434 => 446637,
-        215 => 369874,
-        41 => 438155,
-        386 => 387966,
-        289 => 442653,
-        295 => 442645,
-        418 => 662204,
-        851 => 9962415,
-        863 => 9962415,
-        861 => 9962415,
-        985 => 9962415,
-        986 => 9962415,
-        1446 => 9962415,
-        627 => 9962415,
-        628 =>  9962415,
-        629 => 9962415,
-        535 => 9962415,
-        523 => 9962415,
-        742 => 9962415,
-        751 => 9962415,
-        765 => 9962415
-      },
-
-      {
-        1663 => 9706465,
-        437 => 409030,
-        434 => 313319,
-        215 => 370995,
-        41 => 459240,
-        386 => 387956,
-        289 => 442649,
-        295 => 442649,
-        418 => 662204,
-        851 => 9706466,
-        863 => 9706466,
-        861 => 9706466,
-        985 => 9706466,
-        986 => 9706466,
-        1446 => 9706466,
-        627 => 9706466,
-        628 =>  9706466,
-        629 => 9706466,
-        535 => 9706466,
-        523 => 9706466,
-        742 => 9706466,
-        751 => 9706466,
-        765 => 9706466
-      },
-
-      {
-        1663 => 9706463,
-        437 => 446637,
-        434 => 312664,
-        215 => 369875,
-        41 => 438144,
-        386 => 387967,
-        289 => 442670,
-        295 => 442638,
-        418 => 662204,
-        851 => 9706464,
-        863 => 9706464,
-        861 => 9706464,
-        985 => 9706464,
-        986 => 9706464,
-        1446 => 9706464,
-        627 => 9706464,
-        628 =>  9706464,
-        629 => 9706464,
-        535 => 9706464,
-        523 => 9706464,
-        742 => 9706464,
-        751 => 9706464,
-        765 => 9706464
-      },
-
-      {
-        1663 => 9962415,
-        437 => 312664,
-        434 => 313241,
-        215 => 369883,
-        41 => 438171,
-        386 => 387954,
-        289 => 442645,
-        295 => 442653,
-        418 => 662204,
-        851 => 9706465,
-        863 => 9706465,
-        861 => 9706465,
-        985 => 9706465,
-        986 => 9706465,
-        1446 => 9706465,
-        627 => 9706465,
-        628 =>  9706465,
-        629 => 9706465,
-        535 => 9706465,
-        523 => 9706465,
-        742 => 9706465,
-        751 => 9706465,
-        765 => 9706465
-      },
-
-      {
-        1663 => 9962377,
-        437 => 446641,
-        434 => 446641,
-        215 => 369872,
-        41 => 438152,
-        386 => 387948,
-        289 => 442656,
-        295 => 442643,
-        418 => 662204,
-        851 => 9962377,
-        863 => 9962377,
-        861 => 9962377,
-        985 => 9962377,
-        986 => 9962377,
-        1446 => 9962377,
-        627 => 9962377,
-        628 =>  9962377,
-        629 => 9962377,
-        535 => 9962377,
-        523 => 9962377,
-        742 => 9962377,
-        751 => 9962377,
-        765 => 9962377
-      }
-    ]
+  def self.create_activity_sessions(students, classroom)
 
     students.each_with_index do |student, num|
-      templates[num].each do |act_id, user_id|
-        temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
-        next unless temp
-        cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids)").to_a.first
-        act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
-        temp.concept_results.each do |cr|
-          values = {
-            activity_session_id: act_session.id,
-            concept_id: cr.concept_id,
-            metadata: cr.metadata,
-            question_type: cr.question_type
-          }
-          ConceptResult.create(values)
+      ACTIVITY_PACKS.each do |activity_pack|
+        unit = Unit.find_by(name: activity_pack[:name])
+        act_sessions = activity_pack[:activity_sessions]
+        act_sessions[num].each do |act_id, user_id|
+          temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
+          next unless temp
+          cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
+          act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
+          temp.concept_results.each do |cr|
+            values = {
+              activity_session_id: act_session.id,
+              concept_id: cr.concept_id,
+              metadata: cr.metadata,
+              question_type: cr.question_type
+            }
+            ConceptResult.create(values)
+          end
         end
       end
     end
-
-    create_replayed_activity_session(students.first)
   end
 end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -321,7 +321,7 @@ module Demo::ReportDemoCreator
 
     students.each_with_index do |student, num|
       ACTIVITY_PACKS_TEMPLATES.each do |activity_pack|
-        unit = Unit.find_by(name: activity_pack[:name])
+        unit = Unit.where(name: activity_pack[:name]).last
         act_sessions = activity_pack[:activity_sessions]
         act_sessions[num].each do |act_id, user_id|
           temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,7 +2,7 @@ module Demo::ReportDemoCreator
 
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
-  ACTIVITY_PACKS = [
+  ACTIVITY_PACKS_TEMPLATES = [
     {
       name: "Quill Activity Pack",
       activity_ids: [1663, 437, 434, 215, 41, 386, 289, 295, 418],
@@ -225,7 +225,7 @@ module Demo::ReportDemoCreator
 
   def self.create_units(teacher)
     units = []
-    ACTIVITY_PACKS.each do |ap|
+    ACTIVITY_PACKS_TEMPLATES.each do |ap|
       unit = Unit.create({name: ap[:name], user: teacher})
       ap[:activity_ids].each { |act_id| UnitActivity.create({activity_id: act_id, unit: unit}) }
       units.push(unit)
@@ -320,7 +320,7 @@ module Demo::ReportDemoCreator
   def self.create_activity_sessions(students, classroom)
 
     students.each_with_index do |student, num|
-      ACTIVITY_PACKS.each do |activity_pack|
+      ACTIVITY_PACKS_TEMPLATES.each do |activity_pack|
         unit = Unit.find_by(name: activity_pack[:name])
         act_sessions = activity_pack[:activity_sessions]
         act_sessions[num].each do |act_id, user_id|

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -294,7 +294,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.create_classroom_units(classroom, units)
-    units.each do |unit|
+    units.map do |unit|
       ClassroomUnit.create(
         classroom: classroom,
         unit: unit,

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Demo::ReportDemoCreator do
   let!(:teacher) {create(:teacher)}
 
   before do
-    Demo::ReportDemoCreator::ACTIVITY_PACKS.each do |ap|
+    Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |ap|
       ap[:activity_ids].each {|id| create(:activity, id: id)}
     end
   end
@@ -71,7 +71,7 @@ RSpec.describe Demo::ReportDemoCreator do
       ap[:activity_sessions][0].each do |act_id, user_id|
         user = build(:user, id: user_id)
         user.save
-        create(:activity_session, state:'finished', activity_id: act_id, user_id: user_id, is_final_score: true)
+        create(:activity_session, state: 'finished', activity_id: act_id, user_id: user_id, is_final_score: true)
       end
     end
 

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Demo::ReportDemoCreator do
 
   it 'creates units' do
     Demo::ReportDemoCreator.create_units(teacher)
-    Demo::ReportDemoCreator::ACTIVITY_PACKS.each do |unit_obj|
+    Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |unit_obj|
       unit = Unit.find_by(name: unit_obj[:name])
       expect(unit).to be
       expect(UnitActivity.find_by(unit_id: unit.id, activity_id: unit_obj[:activity_ids][0])).to be

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe Demo::ReportDemoCreator do
     end
   end
 
+  it 'creates replayed activity session' do
+    student = create(:student)
+    classroom = create(:classroom)
+    create(:students_classrooms, student: student, classroom: classroom)
+    classroom_unit = create(:classroom_unit, assign_on_join: true, classroom: classroom)
+    user = build(:user, id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID)
+    user.save
+    sample_session = create(:activity_session, activity_id: Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, user_id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID, is_final_score: true)
+    expect {Demo::ReportDemoCreator.create_replayed_activity_session(student, classroom_unit)}.to change {ActivitySession.count}.by(1)
+  end
+
   it 'creates activity sessions' do
     Demo::ReportDemoCreator::ACTIVITY_PACKS.each do |ap|
       ap[:activity_sessions][0].each do |act_id, user_id|

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Demo::ReportDemoCreator do
   end
 
   it 'creates activity sessions' do
-    Demo::ReportDemoCreator::ACTIVITY_PACKS.each do |ap|
+    Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |ap|
       ap[:activity_sessions][0].each do |act_id, user_id|
         user = build(:user, id: user_id)
         user.save

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -59,10 +59,11 @@ RSpec.describe Demo::ReportDemoCreator do
     student = create(:student)
     classroom = create(:classroom)
     create(:students_classrooms, student: student, classroom: classroom)
-    classroom_unit = create(:classroom_unit, assign_on_join: true, classroom: classroom)
     user = build(:user, id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID)
     user.save
     sample_session = create(:activity_session, activity_id: Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, user_id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID, is_final_score: true)
+    units = Demo::ReportDemoCreator.create_units(teacher)
+    classroom_unit = Demo::ReportDemoCreator.create_classroom_units(classroom, units).first
     expect {Demo::ReportDemoCreator.create_replayed_activity_session(student, classroom_unit)}.to change {ActivitySession.count}.by(1)
   end
 


### PR DESCRIPTION
## WHAT
After adding a bunch of new Demo Activity Sessions, I realized that the logic to create activity sessions was arbitrarily attaching all of the new activity sessions to one classroom unit instead of attaching them to the classroom units they are related to. This PR fixes that issue by attaching new activity sessions to a specific classroom unit (designated from the large `ACTIVITY_PACK_TEMPLATES` object.

## WHY
Right now the code attaches every activity session to the same classroom unit, which is not what the Partnerships team requested.

## HOW
Add all the template data to a big object `ACTIVITY_PACK_TEMPLATES` that finely distinguishes which activity sessions are attached to which units. Then, rewrite the loop that creates activity sessions to select the right classroom unit instead of arbitrarily selecting one.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-Additional-Student-Activity-Data-to-quill-org-demo-857ccdcdaffc4ca4ac2f1d87c7f2c817

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes