### PR TITLE
LMS - CircleCI, ignore tests on deploy-* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   lms_rails_build:
     working_directory: ~/Empirical-Core
@@ -337,7 +337,6 @@ jobs:
           command: |
             flake8
 workflows:
-  version: 2.1
   build-test:
     filters:
       branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 jobs:
   lms_rails_build:
     working_directory: ~/Empirical-Core
@@ -337,18 +337,37 @@ jobs:
           command: |
             flake8
 workflows:
+  version: 2
   build-test:
-    filters:
-      branches:
-        ignore: /^deploy-.*/
     jobs:
-      - lms_rails_build
-      - lms_integration_build
-      - lms_node_build
-      - marking_logic_node_build
-      - cms_rails_build
-      - comprehension_go_build
-      - evidence_rails_build
+      - lms_rails_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - lms_integration_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - lms_node_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - marking_logic_node_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - cms_rails_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - comprehension_go_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
+      - evidence_rails_build:
+          filters:
+            branches:
+              ignore: /^deploy-.*/
   lint-code:
     jobs:
       - node_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,9 @@ workflows:
           <<: *default_filter
   lint-code:
     jobs:
-      - node_lint
-      - rubocop_lint
-      - flake8_lint
+      - node_lint:
+          <<: *default_filter
+      - rubocop_lint:
+          <<: *default_filter
+      - flake8_lint:
+          <<: *default_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,12 +337,11 @@ jobs:
           command: |
             flake8
 workflows:
-  version: 2
+  version: 2.1
   build-test:
     filters:
       branches:
-        ignore:
-          - /^deploy-.*/
+        ignore: /^deploy-.*/
     jobs:
       - lms_rails_build
       - lms_integration_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,9 @@ jobs:
 workflows:
   version: 2
   build-test:
+    branches:
+      ignore:
+        - /^deploy-.*/
     jobs:
       - lms_rails_build
       - lms_integration_build
@@ -348,6 +351,9 @@ workflows:
       - comprehension_go_build
       - evidence_rails_build
   lint-code:
+    branches:
+      ignore:
+        - /^deploy-.*/
     jobs:
       - node_lint
       - rubocop_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,9 +339,10 @@ jobs:
 workflows:
   version: 2
   build-test:
-    branches:
-      ignore:
-        - /^deploy-.*/
+    filters:
+      branches:
+        ignore:
+          - /^deploy-.*/
     jobs:
       - lms_rails_build
       - lms_integration_build
@@ -351,9 +352,6 @@ workflows:
       - comprehension_go_build
       - evidence_rails_build
   lint-code:
-    branches:
-      ignore:
-        - /^deploy-.*/
     jobs:
       - node_lint
       - rubocop_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,9 +358,6 @@ workflows:
           <<: *default_filter
   lint-code:
     jobs:
-      - node_lint:
-        <<: *default_filter
-      - rubocop_lint:
-        <<: *default_filter
-      - flake8_lint:
-        <<: *default_filter
+      - node_lint
+      - rubocop_lint
+      - flake8_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,36 +340,27 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - lms_rails_build:
+      - lms_rails_build: &default_filter
           filters:
             branches:
               ignore: /^deploy-.*/
       - lms_integration_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
       - lms_node_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
       - marking_logic_node_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
       - cms_rails_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
       - comprehension_go_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
       - evidence_rails_build:
-          filters:
-            branches:
-              ignore: /^deploy-.*/
+          <<: *default_filter
   lint-code:
     jobs:
-      - node_lint
-      - rubocop_lint
-      - flake8_lint
+      - node_lint:
+        <<: *default_filter
+      - rubocop_lint:
+        <<: *default_filter
+      - flake8_lint:
+        <<: *default_filter

--- a/README.md
+++ b/README.md
@@ -51,5 +51,3 @@ Checking out open issues is a great way to get started as an open source contrib
 Note, we have style guides for [Ruby](https://github.com/empirical-org/ruby) and [Javascript](https://github.com/empirical-org/javascript) and a [Code of Conduct](CODE_OF_CONDUCT.md)
 
 Thanks for your interest in Quill.org!
-
-


### PR DESCRIPTION
## WHAT
Filter out `deploy-*` branches from our CircleCI run.
## WHY
Might be causing issues with tests being skipped on PRs. Also, these branches aren't monitored and are only used for deploy (when they are direct copies of branches that already have test runs), so there is no value in running the tests here.
## HOW
Use CircleCI's filtering on each job (you can't do it on the whole workflow).
### Screenshots
![Screen Shot 2021-09-17 at 10 52 05 AM](https://user-images.githubusercontent.com/1304933/133803944-0093fdac-e20e-46b6-8da6-fc85a17818ab.png)


### Notion Card Links
https://www.notion.so/quill/CircleCI-fake-test-passes-edafcd5b52d444839163755dc96a7f81

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, config code
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
