### PR TITLE
LMS - Add better caching for Concepts / Questions / ConceptFeedback

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -92,6 +92,7 @@ gem 'redis', '3.3.5'
 gem 'redis-namespace'
 gem 'redis-rails'
 gem 'redis-rack-cache'
+gem 'actionpack-action_caching'
 
 # JS/APP/UI
 gem 'turbolinks'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.2)
+      actionpack (>= 4.0.0)
     actionview (5.1.7)
       activesupport (= 5.1.7)
       builder (~> 3.1)
@@ -779,6 +781,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   active_link_to
   active_model_serializers (~> 0.9.0)
   addressable

--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
   before_action :activity_type
   before_action :concept_feedback_by_uid, except: [:index, :create, :update]
 
+  # TODO: Cache this once routes are fixed
   def index
     all_concept_feedbacks = ConceptFeedback.where(activity_type: @activity_type).all.reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
     render(json: all_concept_feedbacks)

--- a/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
@@ -10,6 +10,8 @@ class Api::V1::ConceptsController < Api::ApiController
     end
   end
 
+  caches_action :index, format: 'json', expires_in: 1.hour
+
   def index
     # Returns all the concepts, sorted by level
     # Example Response:

--- a/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
@@ -2,29 +2,12 @@ class Api::V1::QuestionsController < Api::ApiController
   before_action :get_question_type, only: [:index, :create]
   before_action :get_question_by_uid, except: [:index, :create, :show]
 
-  ALL_QUESTIONS_CACHE_KEY = 'ALL_QUESTIONS'
-  ALL_QUESTIONS_CACHE_EXPIRY = 600
-  QUESTION_CACHE_KEY_PREFIX = 'QUESTION'
-  QUESTION_CACHE_KEY_EXPIRY = 600
-
   def index
-    cache_key = ALL_QUESTIONS_CACHE_KEY + "_#{@question_type}"
-    all_questions = $redis.get(cache_key)
-
-    if !all_questions
-      all_questions = Question.where(question_type: @question_type.to_s).reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
-      $redis.set(cache_key, all_questions.to_json, {ex: ALL_QUESTIONS_CACHE_EXPIRY})
-    end
-    render(json: all_questions)
+    render json: Question.all_questions_json_cached(@question_type)
   end
 
   def show
-    @question = $redis.get(get_question_cache_key(params[:id]))
-    if !@question
-      @question = Question.find_by!(uid: params[:id]).to_json
-      $redis.set(get_question_cache_key(params[:id]), @question, {ex: QUESTION_CACHE_KEY_EXPIRY})
-    end
-    render(json: @question)
+    render json: Question.question_json_cached(params[:id])
   end
 
   def create

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -22,6 +22,8 @@ class Cron
     SyncVitallyWorker.perform_async
     MaterializedViewRefreshWorker.perform_async
     RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
+
+    Question::TYPES.each {|type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 
   def self.run_saturday

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -77,7 +77,7 @@ class Question < ApplicationRecord
 
   def self.question_json_cached(uid, refresh: false)
     Rails.cache.fetch(CACHE_KEY_QUESTION + uid.to_s, expires_in: CACHE_EXPIRY, force: refresh) do
-      Question.find_by!(uid: uid).to_json
+      find_by!(uid: uid).to_json
     end
   end
 

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -33,6 +33,10 @@ class Question < ApplicationRecord
   ]
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
+  CACHE_KEY_ALL = 'ALL_QUESTIONS_'
+  CACHE_EXPIRY = 8.hours
+  CACHE_KEY_QUESTION = 'QUESTION_'
+
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
   REMATCH_TYPE_MAPPING = {
     TYPE_CONNECT_SENTENCE_COMBINING => 'questions',
@@ -50,13 +54,31 @@ class Question < ApplicationRecord
   validate :data_must_be_hash
   validate :validate_sequences
 
-  after_save :expire_all_questions_cache
+  after_save :refresh_caches
 
   scope :live, -> {where("data->>'flag' IN (?)", LIVE_FLAGS)}
   scope :production, -> {where("data->>'flag' = ?", FLAG_PRODUCTION)}
 
   def as_json(options=nil)
     data
+  end
+
+  def self.all_questions_json(question_type)
+    where(question_type: question_type)
+      .reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+      .to_json
+  end
+
+  def self.all_questions_json_cached(question_type, refresh: false)
+    Rails.cache.fetch(CACHE_KEY_ALL + question_type, expires_in: CACHE_EXPIRY, force: refresh) do
+      all_questions_json(question_type)
+    end
+  end
+
+  def self.question_json_cached(uid, refresh: false)
+    Rails.cache.fetch(CACHE_KEY_QUESTION + uid.to_s, expires_in: CACHE_EXPIRY, force: refresh) do
+      Question.find_by!(uid: uid).to_json
+    end
   end
 
   def add_focus_point(new_data)
@@ -131,11 +153,9 @@ class Question < ApplicationRecord
     REMATCH_TYPE_MAPPING.fetch(question_type)
   end
 
-  private def expire_all_questions_cache
-    cache_key = Api::V1::QuestionsController::ALL_QUESTIONS_CACHE_KEY + "_#{question_type}"
-    $redis.del(cache_key)
-    cache_key = "#{Api::V1::QuestionsController::QUESTION_CACHE_KEY_PREFIX}_#{uid}"
-    $redis.del(cache_key)
+  private def refresh_caches
+    Question.all_questions_json_cached(question_type, refresh: true)
+    Question.question_json_cached(uid, refresh: true)
   end
 
   private def new_uuid

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -34,7 +34,7 @@ class Question < ApplicationRecord
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
   CACHE_KEY_ALL = 'ALL_QUESTIONS_'
-  CACHE_EXPIRY = 8.hours
+  CACHE_EXPIRY = 24.hours
   CACHE_KEY_QUESTION = 'QUESTION_'
 
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
@@ -154,8 +154,7 @@ class Question < ApplicationRecord
   end
 
   private def refresh_caches
-    Question.all_questions_json_cached(question_type, refresh: true)
-    Question.question_json_cached(uid, refresh: true)
+    RefreshQuestionCacheWorker.perform_async(question_type, uid)
   end
 
   private def new_uuid

--- a/services/QuillLMS/app/workers/refresh_question_cache_worker.rb
+++ b/services/QuillLMS/app/workers/refresh_question_cache_worker.rb
@@ -1,0 +1,12 @@
+class RefreshQuestionCacheWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  def perform(question_type, uid = nil)
+    Question.all_questions_json_cached(question_type, refresh: true)
+
+    return unless uid
+
+    Question.question_json_cached(uid, refresh: true)
+  end
+end

--- a/services/QuillLMS/client/app/bundles/Connect/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const CONNECT_TYPE = 'connect'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${CONNECT_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const CONNECT_TYPE = 'connect'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${CONNECT_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/test/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/test/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const GRAMMAR_TYPE = 'grammar'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${GRAMMAR_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -390,8 +390,8 @@ EmpiricalGrammar::Application.routes.draw do
       end
 
       resources :users, only: [:index]
-      resources :app_settings, only: [:index, :show], param: :name do 
-          member do 
+      resources :app_settings, only: [:index, :show], param: :name do
+          member do
             get :admin_show
           end
       end
@@ -433,7 +433,10 @@ EmpiricalGrammar::Application.routes.draw do
         end
       end
       resources :shared_cache, only: [:show, :update, :destroy]
-      resources :concept_feedback
+      scope 'activity_type/:activity_type' do
+        resources :concept_feedback, shallow: true
+      end
+
       resources :questions, except: [:destroy] do
         resources :focus_points do
           put :update_all, on: :collection

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -6,23 +6,8 @@ describe Api::V1::QuestionsController, type: :controller do
 
   describe "#index" do
     it "should return a list of Questions" do
-      expect($redis).to receive(:get).and_return(nil)
       get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)
-    end
-
-    it "should set cache if it is empty" do
-      expect($redis).to receive(:get).and_return(nil)
-      expect($redis).to receive(:set)
-      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
-    end
-
-    it "should not set cache if there is a cache hit" do
-      mock_cached_data = {"foo" => "bar"}
-      expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
-      expect($redis).not_to receive(:set)
-      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
-      expect(JSON.parse(response.body)).to eq(mock_cached_data)
     end
 
     it "should include the response from the db" do
@@ -37,24 +22,20 @@ describe Api::V1::QuestionsController, type: :controller do
       expect(JSON.parse(response.body)).to eq(question.data)
     end
 
-    it "should set cache if it is empty" do
-      expect($redis).to receive(:get).and_return(nil)
-      expect($redis).to receive(:set)
-      get :show, params: { id: question.uid }, as: :json
-    end
-
-    it "should not set cache if there is a cache hit" do
-      mock_cached_data = {"foo" => "bar"}
-      expect($redis).to receive(:get).and_return(JSON.dump(mock_cached_data))
-      expect($redis).not_to receive(:set)
-      get :show, params: { id: question.uid }, as: :json
-      expect(JSON.parse(response.body)).to eq(mock_cached_data)
-    end
-
     it "should return a 404 if the requested Question is not found" do
       get :show, params: { id: 'doesnotexist' }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
+    end
+
+    it "should return a 404 when not found, but 200 once created" do
+      some_id = 'some_id'
+      get :show, params: { id: some_id }, as: :json
+      expect(response.status).to eq(404)
+
+      create(:question, uid: some_id)
+      get :show, params: { id: some_id }, as: :json
+      expect(response.status).to eq(200)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -5,18 +5,21 @@ describe Api::V1::QuestionsController, type: :controller do
   let!(:question) { create(:question) }
 
   describe "#index" do
+    before(:each) do
+      Rails.cache.clear
+    end
     it "should return a list of Questions" do
       get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
-      expect(JSON.parse(response.body).keys.length).to eq(1)
-    end
 
-    it "should include the response from the db" do
-      get :index, params: { question_type: 'connect_sentence_combining' }, as: :json
+      expect(JSON.parse(response.body).keys.length).to eq(1)
       expect(JSON.parse(response.body).keys.first).to eq(question.uid)
     end
   end
 
   describe "#show" do
+    before(:each) do
+      Rails.cache.clear
+    end
     it "should return the specified question" do
       get :show, params: { id: question.uid }, as: :json
       expect(JSON.parse(response.body)).to eq(question.data)

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -41,6 +41,11 @@ describe "Cron", type: :model do
       expect(RematchUpdatedQuestionsWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
+
+    it "enqueues RefreshQuestionCacheWorker" do
+      expect(RefreshQuestionCacheWorker).to receive(:perform_async).exactly(7).times
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_saturday" do

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -289,21 +289,27 @@ RSpec.describe Question, type: :model do
     end
   end
 
-  describe '#after_save' do
-    it 'should execute invalidate_all_questions_cache to invalidate the ALL_QUESTIONS cache' do
-      key = Api::V1::QuestionsController::ALL_QUESTIONS_CACHE_KEY + "_#{question.question_type}"
-      $redis.set(key, 'Dummy data')
-      question.data = {foo: "bar"}
-      question.save
-      expect($redis.get(key)).to be_nil
+  describe '#refresh_cache' do
+    let!(:question) {create(:question, uid: '1234', data: {'foo' => 'initial_value'})}
+
+    it 'should refresh cache for all questions on update' do
+      json = JSON.parse(Question.all_questions_json_cached(question.question_type))
+      expect(json['1234']['foo']).to eq('initial_value')
+
+      question.update(data: {'foo' => 'new_value'})
+
+      new_json = JSON.parse(Question.all_questions_json_cached(question.question_type))
+      expect(new_json['1234']['foo']).to eq('new_value')
     end
 
-    it 'should execute invalidate_all_questions_cache to invalidate the specific QUESTION_* cache' do
-      key = Api::V1::QuestionsController::QUESTION_CACHE_KEY_PREFIX + "_#{question.uid}"
-      $redis.set(key, 'Dummy data')
-      question.data = {foo: "bar"}
-      question.save
-      expect($redis.get(key)).to be_nil
+    it 'should refresh cache for individual questions on update' do
+      json = JSON.parse(Question.question_json_cached(question.uid))
+      expect(json['foo']).to eq('initial_value')
+
+      question.update(data: {'foo' => 'new_value'})
+
+      new_json = JSON.parse(Question.question_json_cached(question.uid))
+      expect(new_json['foo']).to eq('new_value')
     end
   end
 

--- a/services/QuillLMS/spec/workers/refresh_question_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/refresh_question_cache_worker_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe RefreshQuestionCacheWorker, type: :worker do
+  let(:worker) { described_class.new }
+
+  describe "#perform" do
+    it "should call force refresh methods" do
+      expect(Question).to receive(:all_questions_json_cached).with('type', refresh: true)
+      expect(Question).to receive(:question_json_cached).with('123', refresh: true)
+
+      worker.perform('type', '123')
+    end
+
+    it "should call force refresh methods for type only" do
+      expect(Question).to receive(:all_questions_json_cached).with('type', refresh: true)
+      expect(Question).to_not receive(:question_json_cached)
+
+      worker.perform('type')
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
This adds/adjusts caching in 2 places and preps a third to be cached:
1. Use action caching to cache concepts
2. Make the `questions#index` and `#show` caching longer, and refactor to refresh cache on update.
3. Prep `ConceptFeedback#index` for future/easier caching by moving a param to the route (leave a TODO, will use `action_caching`)
## WHY
These are all high volume endpoints, so there are caching gains to be had here.
## HOW
I'm putting standard Rails caching in place rather than custom caching code. I'm using:
1. `action_caching` for data that rarely changes (less complex)
2. `Rails.cache.fetch` for data that does change, and expiring/refreshing it as is needed (more complex)
### Screenshots
![Screen Shot 2021-09-20 at 11 17 32 AM](https://user-images.githubusercontent.com/1304933/134057186-527895b4-2487-440a-aee1-d2b9403e4f92.png)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/a
