### PR TITLE
Csp3

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -42,6 +42,10 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateHashKey:
   Enabled: true
 
+Lint/PercentStringArray:
+  Exclude:
+    - "QuillLMS/config/initializers/secure_headers.rb"
+
 Lint/InterpolationCheck:
   Enabled: true
 

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -69,7 +69,7 @@ gem 'intercom', '~> 3.5.23'
 gem 'haversine'
 gem 'configs'
 gem 'rack-test', '~> 0.6.3'
-gem 'secure_headers', '5.2.0'
+gem 'secure_headers', '6.3.2'
 
 # Engines
 gem 'evidence', path: 'engines/evidence'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -659,8 +659,7 @@ GEM
       sprockets-rails
       tilt
     scout_apm (2.4.21)
-    secure_headers (5.2.0)
-      useragent (>= 0.15.0)
+    secure_headers (6.3.2)
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.142.7)
@@ -757,7 +756,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode_utils (1.4.0)
     uniform_notifier (1.12.1)
-    useragent (0.16.10)
     validates_email_format_of (1.6.3)
       i18n
     vcr (4.0.0)
@@ -892,7 +890,7 @@ DEPENDENCIES
   sass-rails
   sassc-rails (>= 2.1.0)
   scout_apm
-  secure_headers (= 5.2.0)
+  secure_headers (= 6.3.2)
   select2-rails
   selenium-webdriver
   sentry-raven (>= 0.12.2)

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,5 +1,24 @@
+csp_types = %w(default_src script_src font_src img_src style_src connect_src)
+permissive_config = csp_types.each_with_object({}) do |n, memo|
+  memo[n.to_sym] = [
+    "*" # wildcard directive must not be quoted
+  ]
+  memo
+end
+permissive_config[:script_src] = permissive_config[:script_src].concat(
+  [
+    "'unsafe-inline'",
+    "'unsafe-eval'"    
+  ]
+)
+permissive_config[:style_src] = permissive_config[:style_src].concat(
+  [
+    "'unsafe-inline'"
+  ]
+)
+
 SecureHeaders::Configuration.default do |config|
-  config.csp = {
+  default_config = {
     default_src: [
       "'self'", 
       "https://*.quill.org",
@@ -9,6 +28,7 @@ SecureHeaders::Configuration.default do |config|
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
 
     script_src: [
+      "'self'",
       "https://*.quill.org",  
       "'unsafe-inline'",
       "'unsafe-eval'",                                            # allows use of eval()
@@ -47,6 +67,7 @@ SecureHeaders::Configuration.default do |config|
     base_uri: %w('self'),                                         # used for relative URLs
 
     style_src: [
+      "'self'",
       "https://*.quill.org",  
       "'unsafe-inline'",
       "https://*.fontawesome.com",
@@ -72,6 +93,10 @@ SecureHeaders::Configuration.default do |config|
       "https://*.sentry.io"
     ]
   }
+
+  
+  config.csp_report_only = default_config
+  config.csp             = permissive_config # the order of these two declarations matters.
 
   config.cookies = {
     secure: true, 

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,6 +1,78 @@
 SecureHeaders::Configuration.default do |config|
-  config.csp = SecureHeaders::OPT_OUT
-  config.x_frame_options = SecureHeaders::OPT_OUT
+  config.csp = {
+    default_src: [
+      "'self'", 
+      "https://*.quill.org",
+      "'unsafe-inline'"                                           # TODO: remove once nonce strategy is in place
+    ],                                                            # fallback for more specific directives
+
+    object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
+
+    script_src: [
+      "https://*.quill.org",  
+      "'unsafe-inline'",
+      "'unsafe-eval'",                                            # allows use of eval()
+      "https://*.clever.com",
+      "https://*.fontawesome.com",
+      "http://*.typekit.net",
+      "https://*.segment.com",
+      "https://*.segment.io",
+      "https://*.newrelic.com",
+      "https://*.nr-data.net",
+      "https://*.googleapis.com",
+      "https://*.gstatic.com",
+      "https://*.pusher.com",
+      "https://*.google-analytics.com",
+      "https://*.inspectlet.com",
+      "https://*.satismeter.com",
+      "https://*.stripe.com",
+      "https://*.amplitude.com",
+      "https://*.doubleclick.net",
+      "https://*.intercom.io",
+      "https://*.intercomcdn.com",
+      "https://*.coview.com",
+      "https://*.sentry.io"
+    ],                                                            
+
+    font_src: [
+      "'self'",
+      "https://*.typekit.net",
+      "https://*.fontawesome.com",
+      "https://*.gstatic.com"
+
+    ], 
+
+    img_src: %w(https://*.quill.org https://*.typekit.net),
+
+    base_uri: %w('self'),                                         # used for relative URLs
+
+    style_src: [
+      "https://*.quill.org",  
+      "'unsafe-inline'",
+      "https://*.fontawesome.com",
+      "https://*.googleapis.com",
+      "https://*.gstatic.com"      
+    ],
+
+    connect_src: [                                                # for XHR, etc
+      "'self'",  
+      "https://*.quill.org",
+      "https://*.segment.com",
+      "https://*.segment.io",
+      "https://*.nr-data.net",
+      "https://*.google-analytics.com",
+      "https://*.google.com",
+      "https://*.inspectlet.com",
+      "https://*.doubleclick.net",
+      "https://*.pusherapp.com",
+      "https://*.pusher.com",
+      "wss://*.pusherapp.com",
+      "https://*.intercom.io",
+      "https://*.coview.com",
+      "https://*.sentry.io"
+    ]
+  }
+
   config.cookies = {
     secure: true, 
     httponly: true, 

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -28,4 +28,10 @@ describe DummyController, type: :request do
     expect(response.header['Cache-Control']).to match('no-cache, no-store, max-age=0, must-revalidate')
     expect(response.header['Pragma']).to match('no-cache')
   end
+
+  it 'should have a content security policy, both real and report-only' do 
+    get '/dummy'
+    expect(response.header['Content-Security-Policy']).to_not be nil 
+    expect(response.header['Content-Security-Policy-Report-Only']).to_not be nil
+  end
 end


### PR DESCRIPTION
## WHAT
- adds a very permissive CSP for initial rollout, which is expected to work in production
- I created a [test environment](https://dashboard.heroku.com/apps/agile-savannah-89665) and confirmed that this config works on both staging and the new environment. I plan to buy and manage a new domain name for a more complete test. **I don't want to block this PR until the new domain is set up, but will if there are concerns.**
- adds the full CSP config in report-only mode. This allows use to inspect CSP violations in production via console, but avoids breaking the site for users. This will allow us to incrementally add restrictions. For example, whitelisting fully qualified subdomains, instead of using `*.quill.org` syntax. There is no documented difference between these syntaxes, but there may be a real-life difference.


## WHY
- We don't know why the initial CSP broke production, so we want as many debugging and incremental rollout tools as possible. UPDATE: I have high confidence from a recent test that the issue is that the `*.domain.org` CSP syntax does not encompass `domain.org` assets. In spite of this, I plan to use the same rollout strategy that this PR captures.

## HOW
See secure_headers.rb

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Missing-Content-Security-Policy-Header-a285458ffd204229ad0999ba7118da8c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes