### PR TITLE
lms/improve-student-merge-error-message

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -86,7 +86,7 @@ class TeacherFixController < ApplicationController
         if primary_account.merge_student_account(secondary_account)
           render json: {}, status: 200
         else
-          render json: {error: "These students are not in the same classrooms."}
+          render json: {error: "#{params['account_2_identifier']} is in at least one class that #{params['account_1_identifier']} is not in, so we can't merge them."}
         end
       else
         nonstudent_account_identifier = primary_account.role == 'student' ? params['account_2_identifier'] : params['account_1_identifier']

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -202,7 +202,7 @@ describe TeacherFixController do
 
           it 'should return that students are not in the same classroom' do
             post :merge_student_accounts, params: { account_1_identifier: student.email, account_2_identifier: student1.email }
-            expect(response.body).to eq({error: "These students are not in the same classrooms."}.to_json)
+            expect(response.body).to eq({error: "#{student1.email} is in at least one class that #{student.email} is not in, so we can't merge them."}.to_json)
           end
         end
       end


### PR DESCRIPTION
## WHAT
Make the error message on failed merges more useful
## WHY
Support didn't understand why students can't be merged given the current message (since it is often not accurate as student accounts ARE in the same class)
## HOW
Just change the message that's returned by the controller for display to users

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
