### PR TITLE
LMS - Add better caching for Concepts / Questions / ConceptFeedback (…

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -92,6 +92,7 @@ gem 'redis', '3.3.5'
 gem 'redis-namespace'
 gem 'redis-rails'
 gem 'redis-rack-cache'
+gem 'actionpack-action_caching'
 
 # JS/APP/UI
 gem 'turbolinks'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.2)
+      actionpack (>= 4.0.0)
     actionview (5.1.7)
       activesupport (= 5.1.7)
       builder (~> 3.1)
@@ -779,6 +781,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   active_link_to
   active_model_serializers (~> 0.9.0)
   addressable

--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
   before_action :activity_type
   before_action :concept_feedback_by_uid, except: [:index, :create, :update]
 
+  # TODO: Cache this once routes are fixed
   def index
     all_concept_feedbacks = ConceptFeedback.where(activity_type: @activity_type).all.reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
     render(json: all_concept_feedbacks)

--- a/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
@@ -10,6 +10,8 @@ class Api::V1::ConceptsController < Api::ApiController
     end
   end
 
+  caches_action :index, format: 'json', expires_in: 1.hour
+
   def index
     # Returns all the concepts, sorted by level
     # Example Response:

--- a/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
@@ -2,29 +2,12 @@ class Api::V1::QuestionsController < Api::ApiController
   before_action :get_question_type, only: [:index, :create]
   before_action :get_question_by_uid, except: [:index, :create, :show]
 
-  ALL_QUESTIONS_CACHE_KEY = 'ALL_QUESTIONS'
-  ALL_QUESTIONS_CACHE_EXPIRY = 600
-  QUESTION_CACHE_KEY_PREFIX = 'QUESTION'
-  QUESTION_CACHE_KEY_EXPIRY = 600
-
   def index
-    cache_key = ALL_QUESTIONS_CACHE_KEY + "_#{@question_type}"
-    all_questions = $redis.get(cache_key)
-
-    if !all_questions
-      all_questions = Question.where(question_type: @question_type.to_s).reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
-      $redis.set(cache_key, all_questions.to_json, {ex: ALL_QUESTIONS_CACHE_EXPIRY})
-    end
-    render(json: all_questions)
+    render json: Question.all_questions_json_cached(@question_type)
   end
 
   def show
-    @question = $redis.get(get_question_cache_key(params[:id]))
-    if !@question
-      @question = Question.find_by!(uid: params[:id]).to_json
-      $redis.set(get_question_cache_key(params[:id]), @question, {ex: QUESTION_CACHE_KEY_EXPIRY})
-    end
-    render(json: @question)
+    render json: Question.question_json_cached(params[:id])
   end
 
   def create

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -22,6 +22,8 @@ class Cron
     SyncVitallyWorker.perform_async
     MaterializedViewRefreshWorker.perform_async
     RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
+
+    Question::TYPES.each {|type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 
   def self.run_saturday

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -33,6 +33,10 @@ class Question < ApplicationRecord
   ]
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
+  CACHE_KEY_ALL = 'ALL_QUESTIONS_'
+  CACHE_EXPIRY = 24.hours
+  CACHE_KEY_QUESTION = 'QUESTION_'
+
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
   REMATCH_TYPE_MAPPING = {
     TYPE_CONNECT_SENTENCE_COMBINING => 'questions',
@@ -50,13 +54,31 @@ class Question < ApplicationRecord
   validate :data_must_be_hash
   validate :validate_sequences
 
-  after_save :expire_all_questions_cache
+  after_save :refresh_caches
 
   scope :live, -> {where("data->>'flag' IN (?)", LIVE_FLAGS)}
   scope :production, -> {where("data->>'flag' = ?", FLAG_PRODUCTION)}
 
   def as_json(options=nil)
     data
+  end
+
+  def self.all_questions_json(question_type)
+    where(question_type: question_type)
+      .reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+      .to_json
+  end
+
+  def self.all_questions_json_cached(question_type, refresh: false)
+    Rails.cache.fetch(CACHE_KEY_ALL + question_type, expires_in: CACHE_EXPIRY, force: refresh) do
+      all_questions_json(question_type)
+    end
+  end
+
+  def self.question_json_cached(uid, refresh: false)
+    Rails.cache.fetch(CACHE_KEY_QUESTION + uid.to_s, expires_in: CACHE_EXPIRY, force: refresh) do
+      find_by!(uid: uid).to_json
+    end
   end
 
   def add_focus_point(new_data)
@@ -131,11 +153,8 @@ class Question < ApplicationRecord
     REMATCH_TYPE_MAPPING.fetch(question_type)
   end
 
-  private def expire_all_questions_cache
-    cache_key = Api::V1::QuestionsController::ALL_QUESTIONS_CACHE_KEY + "_#{question_type}"
-    $redis.del(cache_key)
-    cache_key = "#{Api::V1::QuestionsController::QUESTION_CACHE_KEY_PREFIX}_#{uid}"
-    $redis.del(cache_key)
+  private def refresh_caches
+    RefreshQuestionCacheWorker.perform_async(question_type, uid)
   end
 
   private def new_uuid

--- a/services/QuillLMS/app/workers/refresh_question_cache_worker.rb
+++ b/services/QuillLMS/app/workers/refresh_question_cache_worker.rb
@@ -1,0 +1,12 @@
+class RefreshQuestionCacheWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  def perform(question_type, uid = nil)
+    Question.all_questions_json_cached(question_type, refresh: true)
+
+    return unless uid
+
+    Question.question_json_cached(uid, refresh: true)
+  end
+end

--- a/services/QuillLMS/client/app/bundles/Connect/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const CONNECT_TYPE = 'connect'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${CONNECT_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const CONNECT_TYPE = 'connect'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${CONNECT_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${CONNECT_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/test/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/test/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${CONNECT_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/concept_feedback_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/concept_feedback_api.ts
@@ -3,27 +3,27 @@ import { ConceptFeedback, ConceptFeedbackCollection } from '../interfaces/concep
 
 const GRAMMAR_TYPE = 'grammar'
 
-const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/concept_feedback`;
+const conceptFeedbackApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activity_type/${GRAMMAR_TYPE}/concept_feedback`;
 
 class ConceptFeedbackApi {
   static getAll(): Promise<ConceptFeedbackCollection> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}.json`);
   }
 
   static get(uid: string): Promise<ConceptFeedback> {
-    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestGet(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 
   static create(data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPost(`${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`, {concept_feedback: data});
+    return requestPost(`${conceptFeedbackApiBaseUrl}.json`, {concept_feedback: data});
   }
 
   static update(uid: string, data: ConceptFeedback): Promise<ConceptFeedback> {
-    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`, {concept_feedback: data});
+    return requestPut(`${conceptFeedbackApiBaseUrl}/${uid}.json`, {concept_feedback: data});
   }
 
   static remove(uid: string): Promise<string> {
-    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json?activity_type=${GRAMMAR_TYPE}`);
+    return requestDelete(`${conceptFeedbackApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/libs/concept_feedback_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/libs/concept_feedback_api.test.ts
@@ -24,7 +24,7 @@ import {
 describe('ConceptFeedbackApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.getAll()
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -33,7 +33,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('get', () => {
     it('should call requestGet', () => {
       const MOCK_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.get(MOCK_ID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url)
     })
@@ -44,7 +44,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}.json`
       ConceptFeedbackApi.create(MOCK_CONTENT)
       expect(mockRequestPost).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -56,7 +56,7 @@ describe('ConceptFeedbackApi calls', () => {
       const MOCK_CONTENT : ConceptFeedback = {
         name: 'test',
       }
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_ID}.json`
       ConceptFeedbackApi.update(MOCK_ID, MOCK_CONTENT)
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {concept_feedback: MOCK_CONTENT})
     })
@@ -65,7 +65,7 @@ describe('ConceptFeedbackApi calls', () => {
   describe('remove', () => {
     it('should call requestDelete', () => {
       const MOCK_QUESTION_ID = 'id'
-      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json?activity_type=${GRAMMAR_TYPE}`
+      const url = `${conceptFeedbackApiBaseUrl}/${MOCK_QUESTION_ID}.json`
       ConceptFeedbackApi.remove(MOCK_QUESTION_ID)
       expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
     })

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -390,8 +390,8 @@ EmpiricalGrammar::Application.routes.draw do
       end
 
       resources :users, only: [:index]
-      resources :app_settings, only: [:index, :show], param: :name do 
-          member do 
+      resources :app_settings, only: [:index, :show], param: :name do
+          member do
             get :admin_show
           end
       end
@@ -433,7 +433,10 @@ EmpiricalGrammar::Application.routes.draw do
         end
       end
       resources :shared_cache, only: [:show, :update, :destroy]
-      resources :concept_feedback
+      scope 'activity_type/:activity_type' do
+        resources :concept_feedback, shallow: true
+      end
+
       resources :questions, except: [:destroy] do
         resources :focus_points do
           put :update_all, on: :collection

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -41,6 +41,11 @@ describe "Cron", type: :model do
       expect(RematchUpdatedQuestionsWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
+
+    it "enqueues RefreshQuestionCacheWorker" do
+      expect(RefreshQuestionCacheWorker).to receive(:perform_async).exactly(7).times
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_saturday" do

--- a/services/QuillLMS/spec/workers/refresh_question_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/refresh_question_cache_worker_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe RefreshQuestionCacheWorker, type: :worker do
+  let(:worker) { described_class.new }
+
+  describe "#perform" do
+    it "should call force refresh methods" do
+      expect(Question).to receive(:all_questions_json_cached).with('type', refresh: true)
+      expect(Question).to receive(:question_json_cached).with('123', refresh: true)
+
+      worker.perform('type', '123')
+    end
+
+    it "should call force refresh methods for type only" do
+      expect(Question).to receive(:all_questions_json_cached).with('type', refresh: true)
+      expect(Question).to_not receive(:question_json_cached)
+
+      worker.perform('type')
+    end
+  end
+end


### PR DESCRIPTION
…#8281)

* Add action caching and cache concepts.

* Move params to url for future concept feedback caching.

* Questions - Use Rails caching instead of manual setup.

* Remove redundant Question in class method.

* Move question cache refresh to background.

* Clear cache in tests.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
