### PR TITLE
LMS - Use a new questions cache key since Rails.cache uses a different format.

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -33,9 +33,9 @@ class Question < ApplicationRecord
   ]
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
-  CACHE_KEY_ALL = 'ALL_QUESTIONS_'
+  CACHE_KEY_ALL = 'ALL_QUESTIONS_v1_'
   CACHE_EXPIRY = 24.hours
-  CACHE_KEY_QUESTION = 'QUESTION_'
+  CACHE_KEY_QUESTION = 'QUESTION_v1_'
 
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
   REMATCH_TYPE_MAPPING = {

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -34,7 +34,7 @@ class Question < ApplicationRecord
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
   CACHE_KEY_ALL = 'ALL_QUESTIONS_v1_'
-  CACHE_EXPIRY = 24.hours
+  CACHE_EXPIRY = 10.minutes
   CACHE_KEY_QUESTION = 'QUESTION_v1_'
 
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts


### PR DESCRIPTION
## WHAT
Fix for the [last PR](https://github.com/empirical-org/Empirical-Core/pull/8281).

Details
The last deploy returned a lot of these errors that I didn't see in testing:
`incompatible marshal file format (can't be read) format version 4.8 required; 123.34 given`

[Based on this thread](https://github.com/redis-store/redis-store/issues/227#issuecomment-238150527), I believe that's because the deploy is a migration from using `redis` directly for caching vs. going through `Rails.cache.fetch` which uses a different format.

The best workaround here is to just start with new cache keys for the related code.
## WHY
Bug fix
## HOW
New caching format, start with a new cache.



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO',
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
