### PR TITLE
LMS - Use a new questions cache key since Rails.cache uses a differen…

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -33,9 +33,9 @@ class Question < ApplicationRecord
   ]
   LIVE_FLAGS = [FLAG_PRODUCTION, FLAG_ALPHA, FLAG_BETA]
 
-  CACHE_KEY_ALL = 'ALL_QUESTIONS_'
-  CACHE_EXPIRY = 24.hours
-  CACHE_KEY_QUESTION = 'QUESTION_'
+  CACHE_KEY_ALL = 'ALL_QUESTIONS_v1_'
+  CACHE_EXPIRY = 10.minutes
+  CACHE_KEY_QUESTION = 'QUESTION_v1_'
 
   # mapping extracted from Grammar,Connect,Diagnostic rematching.ts
   REMATCH_TYPE_MAPPING = {


### PR DESCRIPTION
…t format. (#8295)

* Use a new cache key since Rails uses a different format.

* Make the cache shorter for now, just in case.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
