### PR TITLE
fixing x_frame_options regression

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -98,6 +98,8 @@ SecureHeaders::Configuration.default do |config|
   config.csp_report_only = default_config
   config.csp             = permissive_config # the order of these two declarations matters.
 
+  config.x_frame_options = SecureHeaders::OPT_OUT
+  
   config.cookies = {
     secure: true, 
     httponly: true, 


### PR DESCRIPTION
## WHAT
Fixes a regression caused by #8283 which removed this line:

`config.x_frame_options = SecureHeaders::OPT_OUT`

## WHY
Prevents Nearpod from working correctly. 

## HOW TO TEST
Go to a sample website, like peterkong.com, and replicate the Ghost Inspector test by running this in the console:
```
    var iframeUrl = "https://pkong.quill.org";
    var theBody = document.getElementsByTagName('body')[0]
    var iframe = document.createElement('iframe')
    iframe.setAttribute("src", iframeUrl)
    theBody.appendChild(iframe)
```
Confirm the iframe loads.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  see How To Test
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
