### PR TITLE
CSP report only enhancements

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -22,6 +22,7 @@ SecureHeaders::Configuration.default do |config|
     default_src: [
       "'self'", 
       "https://*.quill.org",
+      "https://quill.org",
       "'unsafe-inline'"                                           # TODO: remove once nonce strategy is in place
     ],                                                            # fallback for more specific directives
 
@@ -29,7 +30,8 @@ SecureHeaders::Configuration.default do |config|
 
     script_src: [
       "'self'",
-      "https://*.quill.org",  
+      "https://*.quill.org", 
+      "https://quill.org", 
       "'unsafe-inline'",
       "'unsafe-eval'",                                            # allows use of eval()
       "https://*.clever.com",
@@ -62,13 +64,20 @@ SecureHeaders::Configuration.default do |config|
 
     ], 
 
-    img_src: %w(https://*.quill.org https://*.typekit.net),
+    img_src: [
+      "https://*.quill.org",
+      "https://quill.org",
+      "https://*.typekit.net",
+      "https://*.google.com",
+      "https://*.inspectlet.com"
+    ],
 
     base_uri: %w('self'),                                         # used for relative URLs
 
     style_src: [
       "'self'",
-      "https://*.quill.org",  
+      "https://*.quill.org",
+      "https://quill.org",  
       "'unsafe-inline'",
       "https://*.fontawesome.com",
       "https://*.googleapis.com",
@@ -78,6 +87,7 @@ SecureHeaders::Configuration.default do |config|
     connect_src: [                                                # for XHR, etc
       "'self'",  
       "https://*.quill.org",
+      "https://quill.org",
       "https://*.segment.com",
       "https://*.segment.io",
       "https://*.nr-data.net",
@@ -88,6 +98,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.pusherapp.com",
       "https://*.pusher.com",
       "wss://*.pusherapp.com",
+      "wss://*.inspectlet.com",
       "https://*.intercom.io",
       "https://*.coview.com",
       "https://*.sentry.io"


### PR DESCRIPTION
## WHAT
Adds what I think to be the correct CSP config, in "report only" mode.

## WHY
This allows us to test the config in production without breaking the site - the report logs violations to the browser console. Once we have a clean report, we can deploy the config in "real" mode. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Missing-Content-Security-Policy-Header-a285458ffd204229ad0999ba7118da8c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | n/a