### PR TITLE
enable main csp

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -1,22 +1,3 @@
-csp_types = %w(default_src script_src font_src img_src style_src connect_src)
-permissive_config = csp_types.each_with_object({}) do |n, memo|
-  memo[n.to_sym] = [
-    "*" # wildcard directive must not be quoted
-  ]
-  memo
-end
-permissive_config[:script_src] = permissive_config[:script_src].concat(
-  [
-    "'unsafe-inline'",
-    "'unsafe-eval'"    
-  ]
-)
-permissive_config[:style_src] = permissive_config[:style_src].concat(
-  [
-    "'unsafe-inline'"
-  ]
-)
-
 SecureHeaders::Configuration.default do |config|
   default_config = {
     default_src: [
@@ -58,6 +39,8 @@ SecureHeaders::Configuration.default do |config|
 
     font_src: [
       "'self'",
+      "https://quill.org",
+      "https://*.quill.org",
       "https://*.typekit.net",
       "https://*.fontawesome.com",
       "https://*.gstatic.com"
@@ -88,6 +71,7 @@ SecureHeaders::Configuration.default do |config|
       "'self'",  
       "https://*.quill.org",
       "https://quill.org",
+      "https://*.amplitude.com",
       "https://*.segment.com",
       "https://*.segment.io",
       "https://*.nr-data.net",
@@ -105,9 +89,7 @@ SecureHeaders::Configuration.default do |config|
     ]
   }
 
-  
-  config.csp_report_only = default_config
-  config.csp             = permissive_config # the order of these two declarations matters.
+  config.csp = default_config
 
   config.x_frame_options = SecureHeaders::OPT_OUT
   

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -32,6 +32,5 @@ describe DummyController, type: :request do
   it 'should have a content security policy, both real and report-only' do 
     get '/dummy'
     expect(response.header['Content-Security-Policy']).to_not be nil 
-    expect(response.header['Content-Security-Policy-Report-Only']).to_not be nil
   end
 end


### PR DESCRIPTION
## WHAT
Follow-on to #8300
Now that we have confirmed that the report-only config does not report violations in prod, we can use the report-only config in the "live" content security policy.

## WHY
Although we currently have a live content security policy, we want it to be as strict as reasonably possible, which this PR accomplishes. 

## HOW
SecureHeader config changes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Missing-Content-Security-Policy-Header-a285458ffd204229ad0999ba7118da8c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  only manual testing - no app code changes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
