### PR TITLE
Stopgap for duplicate google_classroom - clever user collision

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/importers/students.rb
+++ b/services/QuillLMS/app/services/clever_integration/importers/students.rb
@@ -15,7 +15,7 @@ module CleverIntegration::Importers::Students
     parsed_students_response = parse_students_response(students_response)
     students = create_students(parsed_students_response)
     updated_students = associate_students_to_classroom(students, classroom)
-    update_provider_classroom_users(classroom.clever_id, students.map(&:clever_id))
+    update_provider_classroom_users(classroom.clever_id, students.map(&:clever_id).compact)
     updated_students
   end
 

--- a/services/QuillLMS/spec/services/clever_integration/importers/students_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/importers/students_spec.rb
@@ -5,13 +5,14 @@ describe CleverIntegration::Importers::Students do
   let!(:classrooms) { [classroom] }
   let!(:district_token) { '1' }
 
+  let(:clever_student_id) { '53ea7d6b2187a9bc1e188be0' }
   let(:clever_student_email) { 'fake@example.net' }
   let(:clever_student_credentials) { Clever::Credentials.new(district_username: 'username') }
   let(:clever_student_name) { Clever::Name.new(first: 'Fake', last: 'Student') }
 
   let(:clever_student) do
     Clever::Student.new(
-      id: "53ea7d6b2187a9bc1e188be0",
+      id: clever_student_id,
       created: "2014-08-12T20:47:39.084Z",
       email: clever_student_email,
       credentials: clever_student_credentials,
@@ -48,5 +49,12 @@ describe CleverIntegration::Importers::Students do
 
   it 'creates CleverClassroom user records' do
     expect { import_students }.to change(CleverClassroomUser, :count).from(0).to(1)
+  end
+
+  context 'email and clever_id pairing are split among two users in database' do
+    let!(:user) { create(:user, email: clever_student_email, clever_id: nil) }
+    let!(:clever_user) { create(:user, email: nil, clever_id: clever_student_id) }
+
+    it { expect { import_students }.not_to change(CleverClassroomUser, :count) }
   end
 end


### PR DESCRIPTION
## WHAT
Fix an [issue](https://sentry.io/organizations/quillorg-5s/issues/2668793595/?project=11238&query=is%3Aunresolved&statsPeriod=14d) null values when attempting to create `ProviderClassroomUser` objects.

## WHY
This is preventing completion of the rest of the synced status calculation on a Clever Classroom.

## HOW
There are multiple pairs of user objects where 
1) `user_a` has a non-nil `clever_id` 
2) `user_b` has a non-nil `email` 
3) `user_a.clever_id` and `user_b.email` are found on a single user in the clever API database. 

When we attempt to fetch records by email the clever importing process returns the user_b instead of the user_a, resulting in `nil` values when when call `students.map(&:clever_id)`.  Until we decide on how to handle/merge/transfer these two users, I'm proposing  a stopgap, with `compact` to ignore those users with this collision.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-and-Clever-Stopgap-for-duplicate-google_classroom-clever-user-collision-34d63a42ccd7406c93236a42ce9c59b6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet, deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
