### PR TITLE
Grammar/ only fetch activity once

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/__snapshots__/container.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Container component should render 1`] = `
+<Connect(PlayGrammarContainer)
+  conceptsFeedback={Object {}}
+  dispatch={[MockFunction]}
+  grammarActivities={Object {}}
+  handleTogglePreviewMenu={[MockFunction]}
+  handleToggleQuestion={[MockFunction]}
+  isOnMobile={false}
+  previewMode={true}
+  questionToPreview={Object {}}
+  questions={Array []}
+  session={Object {}}
+  skippedToQuestionFromIntro={false}
+/>
+`;

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/container.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/container.test.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import {shallow} from "enzyme";
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+
+import PlayGrammarContainer from "../container";
+
+describe("Container component", () => {
+  const mockProps = {
+    grammarActivities: {},
+    conceptsFeedback: {},
+    session: {},
+    dispatch: jest.fn(),
+    previewMode: true,
+    questionToPreview: {},
+    questions: [],
+    handleToggleQuestion: jest.fn(),
+    skippedToQuestionFromIntro: false,
+    isOnMobile: false,
+    handleTogglePreviewMenu: jest.fn()
+  }
+  const wrapper = shallow(<Provider store={createMockStore()}><PlayGrammarContainer {...mockProps} /></Provider>);
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../../Shared/index'
 
 interface PlayGrammarContainerState {
+  activityFetched: boolean;
   showTurkCode: boolean;
   saved: boolean;
   error: boolean;
@@ -71,6 +72,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       super(props);
 
       this.state = {
+        activityFetched: false,
         showTurkCode: false,
         saving: false,
         saved: false,
@@ -149,7 +151,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
     }
 
     componentDidUpdate(prevProps) {
-      const { timeTracking, } = this.state
+      const { timeTracking, activityFetched } = this.state
       const { grammarActivities, dispatch, session, } = this.props
       const { hasreceiveddata } = grammarActivities
 
@@ -159,8 +161,10 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         document.title = `Quill.org | ${grammarActivities.currentActivity.title}`
       }
 
-      if (!hasreceiveddata && activityUID) {
-        dispatch(getActivity(activityUID))
+      if (!hasreceiveddata && activityUID && !activityFetched) {
+        this.setState({ activityFetched: true }, () => {
+          dispatch(getActivity(activityUID))
+        });
       }
 
       if (!_.isEqual(prevProps.session.timeTracking, session.timeTracking)) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/teacherPreviewMenu.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/teacherPreviewMenu.tsx
@@ -3,8 +3,6 @@ import * as Redux from "redux";
 import { connect } from "react-redux";
 import stripHtml from "string-strip-html";
 
-import { getActivity } from "../../../Grammar/actions/grammarActivities";
-import getParameterByName from "../../../Grammar/helpers/getParameterByName";
 import { Question } from '../../../Grammar/interfaces/questions';
 import * as diagnosticActions from '../../../Diagnostic/actions/diagnostics.js';
 import * as connectActions from '../../../Connect/actions';
@@ -225,14 +223,6 @@ const TeacherPreviewMenuComponent = ({
   showPreview,
   titleCards
 }: TeacherPreviewMenuProps) => {
-
-  React.useEffect(() => {
-    // we need to fetch grammar activities here
-    const activityUID = getParameterByName('uid', window.location.href);
-    if (activityUID) {
-      dispatch(getActivity(activityUID))
-    }
-  }, [session]);
 
   const handleToggleMenu = () => {
     onTogglePreview();


### PR DESCRIPTION
## WHAT
make sure a Grammar activity is only being fetched once

## WHY
we don't want multiple unnecessary calls to the same endpoint

## HOW
remove `useEffect` call in `TeacherPreviewMenu` and update `activityFetched` state in main Grammar container to ensure activity is only fetched once

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Grammar-hits-the-same-endpoints-multiple-times-eb3124255a54481aab10f916b4e87a27

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes