### PR TITLE
Bug/ prevent Show Menu button from showing for students

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -436,6 +436,7 @@ export class Lesson extends React.Component {
     const { data, hasreceiveddata, } = lessons
     const { params } = match
     const { lessonID, } = params;
+    const studentSession = getParameterByName('student', window.location.href);
     let component;
 
     if (!this.dataHasLoaded()) {
@@ -531,7 +532,7 @@ export class Lesson extends React.Component {
     return (
       <div>
         <section className="section is-fullheight minus-nav student">
-          {isOnMobile && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
+          {isOnMobile && !studentSession && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
           {this.renderProgressBar()}
           <div className="student-container student-container-diagnostic">
             {component}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/diagnostics/studentDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/diagnostics/studentDiagnostic.jsx
@@ -412,6 +412,8 @@ export class StudentDiagnostic extends React.Component {
     const progressPercent = getProgressPercent(playDiagnostic);
     const totalQuestionCount = questionCount(playDiagnostic);
 
+    const studentSession = getParameterByName('student', window.location.href);
+
     return (<ProgressBar
       answeredQuestionCount={displayedAnsweredQuestionCount > totalQuestionCount ? totalQuestionCount : displayedAnsweredQuestionCount}
       label='questions'
@@ -505,7 +507,7 @@ export class StudentDiagnostic extends React.Component {
     return (
       <div>
         <section className="section is-fullheight minus-nav student">
-          {isOnMobile && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
+          {isOnMobile && !studentSession && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
           {this.renderProgressBar()}
           <div className="student-container student-container-diagnostic">
             <CarouselAnimation>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
@@ -457,6 +457,8 @@ export class ELLStudentDiagnostic extends React.Component {
     const progressPercent = getProgressPercent(playDiagnostic);
     const totalQuestionCount = questionCount(playDiagnostic);
 
+
+
     return (<ProgressBar
       answeredQuestionCount={displayedAnsweredQuestionCount > totalQuestionCount ? totalQuestionCount : displayedAnsweredQuestionCount}
       label='questions'
@@ -470,6 +472,8 @@ export class ELLStudentDiagnostic extends React.Component {
     const { dispatch, match, playDiagnostic, t, previewMode, isOnMobile, handleTogglePreview } = this.props;
     const { params } = match;
     const { diagnosticID } = params;
+
+    const studentSession = getParameterByName('student', window.location.href);
 
     let component;
     const minusHowMuch = this.language() ? 'minus-nav-and-footer' : 'minus-nav'
@@ -507,7 +511,7 @@ export class ELLStudentDiagnostic extends React.Component {
     return (
       <div className="ell-diagnostic-container">
         <section className={`section is-fullheight student ${minusHowMuch}`}>
-          {isOnMobile && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
+          {isOnMobile && !studentSession && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreview} />}
           {this.renderProgressBar()}
           <div className="student-container student-container-diagnostic">
             <CarouselAnimation>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
@@ -8,6 +8,7 @@ import { Question } from '../../interfaces/questions'
 import { GrammarActivity } from '../../interfaces/grammarActivities'
 import * as responseActions from '../../actions/responses'
 import { setCurrentQuestion } from '../../actions/session'
+import { getParameterByName } from '../../../Connect/libs/getParameterByName';
 import {
   hashToCollection,
   ProgressBar,
@@ -327,8 +328,9 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     const { activity, isOnMobile, handleTogglePreviewMenu } = this.props;
     const counts = this.getQuestionCounts();
     const meterWidth = counts['answeredQuestionCount'] / counts['totalQuestionCount'] * 100
+    const studentSession = getParameterByName('student', window.location.href);
     return (<div className="top-section">
-      {isOnMobile && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreviewMenu} />}
+      {isOnMobile && !studentSession && <TeacherPreviewMenuButton containerClass="is-on-mobile" handleTogglePreview={handleTogglePreviewMenu} />}
       <ProgressBar
         answeredQuestionCount={counts['answeredQuestionCount']}
         label="questions"


### PR DESCRIPTION
## WHAT
prevent show menu button from showing for students on mobile

## WHY
this button should only render for teachers (it doesn't functionally do anything for students, but we don't want to render it)

## HOW
just add a check for student sessions where rendering the `TeacherPreviewMenuButton`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- quick bug fix, manually tested
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
