### PR TITLE
csp rule relaxations

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -40,6 +40,8 @@ SecureHeaders::Configuration.default do |config|
 
     font_src: [
       "'self'",
+      "https://intercomcdn.com",
+      "https://*.intercomcdn.com",
       "https://quill.org",
       "https://*.quill.org",
       "https://*.typekit.net",
@@ -49,11 +51,16 @@ SecureHeaders::Configuration.default do |config|
     ], 
 
     img_src: [
+      "https://heapanalytics.com",
+      "https://*.heapanalytics.com",
+      "https://intercomassets.com",
+      "https://*.intercomassets.com",
       "https://*.quill.org",
       "https://quill.org",
       "https://*.typekit.net",
       "https://*.google.com",
-      "https://*.inspectlet.com"
+      "https://*.inspectlet.com",
+      "https://*.amazonaws.com"
     ],
 
     base_uri: %w('self'),                                         # used for relative URLs


### PR DESCRIPTION
## WHAT
Adds font and image relaxations to the Content Security Policy. Also relaxes the img CSP for heap analytics beaconing.

## WHY
Certain Teach Center images are not loading from s3. The impact of the missing fonts is negligible, but why not clean them up as well. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-Center-cover-photos-are-not-displaying-44e9c03dbdc546faaab09cd2e5e2bd6a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested on staging
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
