### PR TITLE
Fix lesson server

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -10,7 +10,9 @@ SecureHeaders::Configuration.default do |config|
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
 
     media_src: [
-      "*"
+      "*",
+      "data:",
+      "blob:"
     ],
 
     script_src: [

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -94,7 +94,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.intercom.io",
       "wss://*.intercom.io",
       "https://*.coview.com",
-      "https://*.sentry.io"
+      "https://*.sentry.io",
+      "wss://*.quill.org"
     ]
   }
 

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -9,6 +9,10 @@ SecureHeaders::Configuration.default do |config|
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
 
+    media_src: [
+      "*"
+    ],
+
     script_src: [
       "'self'",
       "https://*.quill.org", 

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -103,7 +103,7 @@ SecureHeaders::Configuration.default do |config|
     ]
   }
 
-  config.csp = SecureHeaders::OPT_OUT
+  config.csp = default_config 
 
   config.x_frame_options = SecureHeaders::OPT_OUT
   


### PR DESCRIPTION
## WHAT
Fixes Quill Lessons Server issue:

lessons-bundle-6a64ac5de0c4d3332af4.js:2 Refused to connect to 'wss://lessons-server.quill.org/socket.io/?EIO=3&transport=websocket&sid=q9qSVmPpu0XzXv3sAAwV' because it violates the following Content Security Policy directive: "connect-src

## WHY
Quill Lessons will not load properly otherwise. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

n/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually on staging
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
