### PR TITLE
turn off csp for now

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -98,7 +98,7 @@ SecureHeaders::Configuration.default do |config|
     ]
   }
 
-  config.csp = default_config
+  config.csp = SecureHeaders::OPT_OUT
 
   config.x_frame_options = SecureHeaders::OPT_OUT
   

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -29,7 +29,7 @@ describe DummyController, type: :request do
     expect(response.header['Pragma']).to match('no-cache')
   end
 
-  it 'should have a content security policy, both real and report-only' do 
+  xit 'should have a content security policy, both real and report-only' do 
     get '/dummy'
     expect(response.header['Content-Security-Policy']).to_not be nil 
   end


### PR DESCRIPTION
## WHAT
Fixes Quill Lessons Server issue:

lessons-bundle-6a64ac5de0c4d3332af4.js:2 Refused to connect to 'wss://lessons-server.quill.org/socket.io/?EIO=3&transport=websocket&sid=q9qSVmPpu0XzXv3sAAwV' because it violates the following Content Security Policy directive: "connect-src

Turning off CSP temporarily gives us breathing space to debug.

## WHY
Quill Lessons is not loading. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

n/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually on staging
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
