### PR TITLE
Fix broken url for premium

### DIFF
--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -15,7 +15,7 @@ module TeacherCenterHelper
     premium_tab = {
       id: PREMIUM,
       name: PREMIUM,
-      url: PREMIUM
+      url: 'premium'
     }
     tabs = [
       {

--- a/services/QuillLMS/spec/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper.rb
@@ -22,12 +22,35 @@ describe TeacherCenterHelper do
       create(:app_setting, name: "comprehension")
       expect(helper.teacher_center_tabs).to eq tabs
     end
+
     it 'should return the tabs with comprehension if app setting is true' do
       comprehension_tab = { id: "Using quill for reading comprehension", name: "Reading comprehension", url: "teacher-center/topic/using-quill-for-reading-comprehension" }
       app_setting.enabled = true
       app_setting.user_ids_allow_list = [current_user.id]
       app_setting.save!
       tabs.insert(1, comprehension_tab)
+      expect(helper.teacher_center_tabs).to eq tabs
+    end
+  end
+
+  describe '#teacher_center_tabs when not signed in' do
+    let(:tabs) {
+      [
+        { id: "All resources", name: "All", url: "teacher-center" },
+        { id: "Getting started", name: "Getting started", url: "teacher-center/topic/getting-started" },
+        { id: "Best practices", name: "Best practices", url: "teacher-center/topic/best-practices" },
+        { id: "Writing instruction research", name: "Research", url: "teacher-center/topic/writing-instruction-research" },
+        { id: "FAQ", name: "FAQ", url: "faq" },
+        { id: "Premium", name: "Premium", url: "premium"}
+      ]
+    }
+
+    before do
+      allow(helper).to receive(:current_user) { nil }
+    end
+
+    it 'should return the tabs with premium tab if current user is nil' do
+      create(:app_setting, name: "comprehension")
       expect(helper.teacher_center_tabs).to eq tabs
     end
   end


### PR DESCRIPTION
## WHAT
Tiny fix -- the premium url was capitalized accidentally, so this just lowercases it.

## WHY
We don't want any links to be broken.

## HOW
Just lowercase this url.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Premium-page-link-broken-from-Teacher-Center-navigation-78a75c27f41245309b0c7b0461a35cdb

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes