### PR TITLE
Fix bug involving move_activity_sessions

### DIFF
--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -93,10 +93,11 @@ module Student
 
         classroom_units.each do |cu|
           activity_sessions = ActivitySession.where(classroom_unit_id: cu.id, user_id: user_id)
-          activity_sessions.update_all(classroom_unit_id: new_cu.id)
 
-          activity_ids = activity_sessions.pluck(:activity_id) - unit.unit_activities.pluck(:activity_id)
-          activity_ids.each { |activity_id| UnitActivity.create(unit_id: unit.id, activity_id: activity_id) }
+          activity_ids = (activity_sessions.pluck(:activity_id) - unit.unit_activities.pluck(:activity_id)).uniq
+          activity_ids.each { |activity_id| UnitActivity.find_or_create_by(unit_id: unit.id, activity_id: activity_id) }
+
+          activity_sessions.update_all(classroom_unit_id: new_cu.id)
 
           hide_extra_activity_sessions(cu.id)
         end

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -137,6 +137,10 @@ describe 'Student Concern', type: :model do
       expect(new_ca.classroom).to eq(classroom2)
       expect(new_ca.assigned_student_ids).to include(student1.id)
     end
+
+    it 'should create the necessary UnitActivity records for the new classroom' do
+      expect { student1.move_activity_sessions(classroom, classroom2) }.to change(UnitActivity, :count).by(6)
+    end
   end
 
   describe "#merge_student_account" do


### PR DESCRIPTION
## WHAT
Fix a bug where the teacher fix move student from one classroom to another is showing a transferring of activity sessions.

## WHY
We'd like activity sessions to show as transferred when moving a student.

## HOW
There's a [gotcha](https://stackoverflow.com/a/34811890) involving `update_all` call where  `activity_sessions.update_all(classroom_unit_id: new_cu.id)` indirectly updates the value of `activity_sessions` since it's a relation. The subsequent computation of `activity_ids` results in no UnitActivities being created.  To fix this, compute the activity_ids before the `update_all` call.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Move-Students-fix-not-saving-data-for-GC-students-on-interteacher-moves-1423a20f35b740858dd9589952029b84

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
