### PR TITLE
Bug/ Evidence first highlight issue

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -500,6 +500,9 @@ export class StudentViewContainer extends React.Component<StudentViewContainerPr
       let className = ''
       className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
       className += shouldBeHighlightable  ? ' highlightable' : ''
+      if(stringifiedInnerElements && strippedPassageHighlights && strippedPassageHighlights.includes(stringifiedInnerElements)) {
+        return <p><span className="passage-highlight">{stringifiedInnerElements}</span></p>
+      }
       if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
       return <mark className={className} onClick={this.handleHighlightClick} onKeyDown={this.handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/container.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/container.test.tsx
@@ -49,6 +49,8 @@ const wrapper = mount(<StudentViewContainer
 
 // TODO: update tests to fix activity and prompt IDs for mockTrackAnalyticsEvent calls
 
+// TODO: add tests for transformMarkTags function
+
 describe('StudentViewContainer component', () => {
   describe('when the activity has loaded', () => {
 


### PR DESCRIPTION
## WHAT
fix issue where the first highlight for certain labels weren't showing

## WHY
we want all relevant highlights to show

## HOW
added an additional check for mark tags when comparing content to highlight props. Note, I added a TODO for adding testing for the function that handles this. It was getting pretty complicated trying to mock the library used in this function

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/You-can-t-add-more-than-one-feedback-highlight-3e8136b4645648eba21d479bdf062eae

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested-- see above note
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
