### PR TITLE
Add an onClick handler to broken button in Activity Survey

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -16,7 +16,7 @@ const ThankYouSlide = () => {
       <img alt="Two hands clapping together" src={applaudingSrc} />
     </div>
     <div className="button-section">
-      <a className='quill-button large secondary outlined focus-on-dark' href="https://www.quill.org" onClick={backToDashboard}>Back to my dashboard</a>
+      <a className='quill-button large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL} onClick={backToDashboard}>Back to my dashboard</a>
     </div>
   </div>)
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -3,6 +3,10 @@ import * as React from 'react'
 const applaudingSrc = `${process.env.CDN_URL}/images/pages/evidence/applauding.svg`
 
 const ThankYouSlide = () => {
+  const backToDashboard = () => {
+    window.location.href = process.env.DEFAULT_URL
+  }
+
   return (<div className="activity-follow-up-container thank-you-slide-container">
     <div className="thank-you-content">
       <section>
@@ -12,7 +16,7 @@ const ThankYouSlide = () => {
       <img alt="Two hands clapping together" src={applaudingSrc} />
     </div>
     <div className="button-section">
-      <a className='quill-button large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL}>Back to my dashboard</a>
+      <a className='quill-button large secondary outlined focus-on-dark' href="https://www.quill.org" onClick={backToDashboard}>Back to my dashboard</a>
     </div>
   </div>)
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/thankYouSlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/thankYouSlide.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`ThankYouSlide Component should match snapshot 1`] = `
     >
       <a
         className="quill-button large secondary outlined focus-on-dark"
+        onClick={[Function]}
       >
         Back to my dashboard
       </a>


### PR DESCRIPTION
## WHAT
The "Back to Dashboard" button isn't working -- it's not redirecting the user. I'm not sure why this is happening, but this quick fix will enable students to go back to their dashboards for now.

## WHY
Students need to be able to return to their dashboards.

## HOW
Add a quick and dirty fix -- an onClick handler. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Back-to-my-dashboard-button-isn-t-working-af2846fa352f4d878cedaa71a6f6fa14

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  Yes
