### PR TITLE
Fix bug with user.shared_with_other_students method

### DIFF
--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -189,7 +189,7 @@ module Student
 
     if teacher_id
       classroom_ids = classroom_ids.select do |classroom_id_hash|
-        Classroom.find(classroom_id_hash['classroom_id']).owner.id == teacher_id
+        Classroom.unscoped.find(classroom_id_hash['classroom_id']).owner.id == teacher_id
       end
     end
 


### PR DESCRIPTION
## WHAT
Fix a bug on a method that gets called when using `merge_student_accounts`.  

## WHY
Certain student accounts can't be merged together since the `classroom_ids` Raw SQL query has no default scope attached whereas `Classroom.find` does.

## HOW
Add unscoped to the `Classroom.find` method so that archived classrooms are available to check

### Screenshots
![Screen Shot 2021-09-30 at 2 14 09 PM](https://user-images.githubusercontent.com/2057805/135509051-2b24e95e-92cd-4c99-93a6-5b26e62baa0b.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
