### PR TITLE
Go - Make tests match Go version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
   comprehension_go_build:
     working_directory: ~/Empirical-Core
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## WHAT
We had some spurious test failures on the go endpoint. I noticed that the specified [version of Go in circleCi ](https://github.com/empirical-org/Empirical-Core/blob/develop/.circleci/config.yml#L235)didn't match the [Go version in the app](https://github.com/empirical-org/Empirical-Core/blob/develop/services/comprehension/feedback-api-main/src/endpoint/go.mod#L3).

This fixes the tests. I'm not sure if the version mismatch is the underlying test issue, but even if not, these should match.
## WHY
These two versions should match.
## HOW
Bump the test go version number
### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Kinda, but no, this is a test loading issue.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes, really amazing code.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
