### PR TITLE
Remove Sidekiq Pro gem from CMS

### DIFF
--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -25,7 +25,7 @@ gem 'connection_pool'
 gem 'dalli'
 gem 'redis'
 gem 'redis-namespace'
-gem 'sidekiq-pro', '5.0.0', source: 'https://gems.contribsys.com/'
+gem 'sidekiq-pro', '5.0.0', source: 'http://gems.contribsys.com/'
 gem 'sidekiq', '~> 5.2.9'
 gem 'sinatra', require: false # Used for the web-based queue management interface
 

--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -25,7 +25,7 @@ gem 'connection_pool'
 gem 'dalli'
 gem 'redis'
 gem 'redis-namespace'
-gem 'sidekiq-pro', '5.0.0', source: 'http://gems.contribsys.com/'
+#gem 'sidekiq-pro', '5.0.0', source: 'http://gems.contribsys.com/'
 gem 'sidekiq', '~> 5.2.9'
 gem 'sinatra', require: false # Used for the web-based queue management interface
 

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -1,6 +1,6 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://gems.contribsys.com/
+  remote: http://gems.contribsys.com/
   specs:
     actioncable (6.1.3.2)
       actionpack (= 6.1.3.2)

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: http://gems.contribsys.com/
   specs:
     actioncable (6.1.3.2)
       actionpack (= 6.1.3.2)
@@ -257,9 +256,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
-    sidekiq-pro (5.0.0)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.7)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -322,7 +318,6 @@ DEPENDENCIES
   rubyzip
   scenic (~> 1.5.4)
   sidekiq (~> 5.2.9)
-  sidekiq-pro (= 5.0.0)!
   sinatra
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
## WHAT
Remove Sidekiq PRO gem from CMS
## WHY
We're getting SSL validation errors in production build preventing us from completing builds on new servers
## HOW
Just comment out the declaration in the Gemfile

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, pure Gemfile change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yeah s
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
