### PR TITLE
Bump the rails asset version

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -3,6 +3,10 @@ import * as React from 'react'
 const applaudingSrc = `${process.env.CDN_URL}/images/pages/evidence/applauding.svg`
 
 const ThankYouSlide = () => {
+  const backToDashboard = () => {
+    window.location.href = process.env.DEFAULT_URL
+  }
+
   return (<div className="activity-follow-up-container thank-you-slide-container">
     <div className="thank-you-content">
       <section>
@@ -12,7 +16,7 @@ const ThankYouSlide = () => {
       <img alt="Two hands clapping together" src={applaudingSrc} />
     </div>
     <div className="button-section">
-      <a className='quill-button large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL}>Back to my dashboard</a>
+      <a className='quill-button large secondary outlined focus-on-dark' href="https://www.quill.org" onClick={backToDashboard}>Back to my dashboard</a>
     </div>
   </div>)
 }

--- a/services/QuillLMS/config/initializers/assets.rb
+++ b/services/QuillLMS/config/initializers/assets.rb
@@ -1,4 +1,4 @@
-Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.version = "1.1"
 Rails.application.config.assets.paths << Rails.root.join('public', 'webpack')
 
 Rails.application.config.assets.precompile += [


### PR DESCRIPTION
NOTE: the other file `ThankYouSlide` is showing up, but that file is already in the code in the develop branch, so I think this is a github glitch.
See the file here: https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx

## WHAT
Bump the version of assets so it recompiles and we can invalidate the cache.

## WHY
Trying a bugfix for the Assets outages.

## HOW
Bump the version number.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
