### PR TITLE
Filter previously assigned recommendations query to be accurate

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -312,7 +312,10 @@ module PublicProgressReports
         .activity_recommendations
         .map { |r| r[:activityPackId] }
       associated_teacher_ids = ClassroomsTeacher.where(classroom_id: classroom_id).pluck(:user_id)
-      assigned_lesson_ids = Unit.where(unit_template_id: recommended_lesson_activity_ids, user_id: associated_teacher_ids).pluck(:unit_template_id)
+      assigned_lesson_ids = Unit.where(unit_template_id: recommended_lesson_activity_ids, user_id: associated_teacher_ids)
+        .joins(:classroom_units)
+        .where("classroom_units.classroom_id=?", classroom_id)
+        .pluck(:unit_template_id)
       {
         previouslyAssignedRecommendations: assigned_recommendations,
         previouslyAssignedLessonsRecommendations: assigned_lesson_ids

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -3,6 +3,10 @@ import * as React from 'react'
 const applaudingSrc = `${process.env.CDN_URL}/images/pages/evidence/applauding.svg`
 
 const ThankYouSlide = () => {
+  const backToDashboard = () => {
+    window.location.href = process.env.DEFAULT_URL
+  }
+
   return (<div className="activity-follow-up-container thank-you-slide-container">
     <div className="thank-you-content">
       <section>
@@ -12,7 +16,7 @@ const ThankYouSlide = () => {
       <img alt="Two hands clapping together" src={applaudingSrc} />
     </div>
     <div className="button-section">
-      <a className='quill-button large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL}>Back to my dashboard</a>
+      <a className='quill-button large secondary outlined focus-on-dark' href="https://www.quill.org" onClick={backToDashboard}>Back to my dashboard</a>
     </div>
   </div>)
 }


### PR DESCRIPTION
## WHAT
We have a bug where the Previously Assigned Lessons Recommendations query is considering any of the teacher's assigned Lessons Units to be "previously assigned to X classroom", even if the Unit was not actually assigned to that particular classroom.

## WHY
Fix this bug so it doesn't appear as if a teacher has assigned a Lesson already to a classroom when they have not.

## HOW
Add filters to the query to fetch the assigned units to check it against the classroom IDs.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Recommended-Quill-Lessons-activities-Assign-button-grayed-out-when-not-assigned-to-that-specific-c-3036123bc1a8438d834c37c4e9612e35

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
