### PR TITLE
remove code that was sometimes redirecting students after they completed their last evidence prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -277,7 +277,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     let className = 'quill-button focus-on-light'
     let onClick = () => this.handleGetFeedbackClick(entry, id, text)
     if (submittedResponses.length === max_attempts || this.lastSubmittedResponse().optimal) {
-      onClick = everyOtherStepCompleted ? () => window.location.href = "/" : this.completeStep
+      onClick = this.completeStep
       buttonCopy = everyOtherStepCompleted ? 'Done' : 'Start next sentence'
     } else if (this.unsubmittableResponses().includes(entry) || awaitingFeedback) {
       className += ' disabled'


### PR DESCRIPTION
…ted their last evidence prompt (#8361)

* upgrade webpack and associated libraries; run tests

* remove cli options that no longer work

* stop redirecitng students after completion

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
