### PR TITLE
lms/add-connection-pooling

### DIFF
--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -18,11 +18,7 @@ test_env: &test_env
 # here are intended to simplify later decision to use followers
 # as well as disambiguate similarly-named ENV variables.
 leader_db_env: &leader_db_env
-  database: <%= ENV['LEADER_DB_NAME'] %>
-  username: <%= ENV['LEADER_DB_USERNAME'] %>
-  password: <%= ENV['LEADER_DB_PASSWORD'] %>
-  host: <%= ENV['LEADER_DB_HOSTNAME'] %>
-  port: <%= ENV['LEADER_DB_PORT'] %>
+  url: <%= ENV['DATABASE_CONNECTION_POOL_URL'] || ENV['DATABASE_URL'] %>
 
 
 development: &development


### PR DESCRIPTION
## WHAT
Tweak database config to connect to PGBouncer pools when configured instead of connecting directly to the database
## WHY
This should give us virtually unlimited database connections so that we can avoid errors when making more than 500 database connections to the database.
## HOW
Using these instructions (https://devcenter.heroku.com/articles/postgres-connection-pooling) we've configured a PGBouncer connection pool.  Connect to that endpoint instead of the database directly (note that the only difference between the PGBouncer instance connection and the raw database connection is the port being connected to) when it's defined in the config, or connect directly to the db if there is no pool defined.

### Notion Card Links
https://www.notion.so/quill/Implement-LMS-Heroku-DB-connection-Pooling-964161abd8684b678ea4831ac3263c31

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on configs
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
