### PR TITLE
cms/compress-response-bodies

### DIFF
--- a/services/QuillCMS/config/application.rb
+++ b/services/QuillCMS/config/application.rb
@@ -45,5 +45,7 @@ module QuillCMS
     # Skip views, helpers and assets when generating a new resource.
 
     config.api_only = true
+
+    config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
## WHAT
Compress response bodies coming from the CMS
## WHY
Because we send all `optimal` responses back in a lot of our payloads, those payloads can get pretty big.  By using gzip to compress those payloads before sending them back to clients, we reduce response times and hopefully provide a marginal improvement to user experience multiplied by every action users take in activities.
## HOW
Just register `Rack::Deflater` as a middleware provider for the CMS application in its config.

### Screenshots
![image](https://user-images.githubusercontent.com/331565/136592891-e82151ca-e5d5-4325-a82a-f9f1b7b502b8.png)

### Notion Card Links
https://www.notion.so/quill/Compress-CMS-responses-and-multiple-choice-endpoints-efe9037ad82f466dae0846ebb3dc85ef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No tests on config
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
