### PR TITLE
Evidence/ disable onboarding slides after multiple completions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -491,9 +491,8 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   if(activityCompletionCount) {
     activityCompletionCount = parseInt(activityCompletionCount)
   }
-  console.log("🚀 ~ file: container.tsx ~ line 493 ~ StudentViewContainer ~ activityCompletionCount", activityCompletionCount)
 
-  if(!explanationSlidesCompleted || (activityCompletionCount && activityCompletionCount > 3)) {
+  if(!explanationSlidesCompleted || (activityCompletionCount && activityCompletionCount < 4)) {
     if (explanationSlideStep === 0) {
       return <WelcomeSlide onHandleClick={handleExplanationSlideClick} user={user} />
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -487,7 +487,12 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   const className = `activity-container ${showFocusState ? '' : 'hide-focus-outline'} ${activeStep === READ_PASSAGE_STEP ? 'on-read-passage' : ''}`
 
-  if(!explanationSlidesCompleted) {
+  let activityCompletionCount: string | number = getParameterByName('activities', window.location.href);
+  if(activityCompletionCount) {
+    activityCompletionCount = parseInt(activityCompletionCount)
+  }
+
+  if(!explanationSlidesCompleted || (activityCompletionCount && activityCompletionCount > 3)) {
     if (explanationSlideStep === 0) {
       return <WelcomeSlide onHandleClick={handleExplanationSlideClick} user={user} />
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -491,6 +491,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   if(activityCompletionCount) {
     activityCompletionCount = parseInt(activityCompletionCount)
   }
+  console.log("🚀 ~ file: container.tsx ~ line 493 ~ StudentViewContainer ~ activityCompletionCount", activityCompletionCount)
 
   if(!explanationSlidesCompleted || (activityCompletionCount && activityCompletionCount > 3)) {
     if (explanationSlideStep === 0) {


### PR DESCRIPTION
## WHAT
disable onboarding slides after student has completed more than 3 Evidence activities 

## WHY
at this point, we feel it would be cumbersome and not useful for them to play through these slides

## HOW
just add a check for `activities` param in URL

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Quill-Evidence-Hide-onboarding-slides-on-repeated-activity-1f7280988173479c82145dace7f275c4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes