### PR TITLE
lms/allow-stripe-iframes

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -7,6 +7,11 @@ SecureHeaders::Configuration.default do |config|
       "'unsafe-inline'"                                           # TODO: remove once nonce strategy is in place
     ],                                                            # fallback for more specific directives
 
+    frame_src: [
+      "'self'",
+      "https://*.stripe.com"
+    ],
+
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
 
     media_src: [

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -71,6 +71,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.typekit.net",
       "https://*.google.com",
       "https://*.inspectlet.com",
+      "https://*.stripe.com",
       "https://*.amazonaws.com"
     ],
 

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -9,6 +9,7 @@ SecureHeaders::Configuration.default do |config|
 
     frame_src: [
       "'self'",
+      "https://stripe.com",
       "https://*.stripe.com"
     ],
 
@@ -39,6 +40,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.google-analytics.com",
       "https://*.inspectlet.com",
       "https://*.satismeter.com",
+      "https://stripe.com",
       "https://*.stripe.com",
       "https://*.amplitude.com",
       "https://*.doubleclick.net",
@@ -71,6 +73,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.typekit.net",
       "https://*.google.com",
       "https://*.inspectlet.com",
+      "https://stripe.com",
       "https://*.stripe.com",
       "https://*.amazonaws.com"
     ],


### PR DESCRIPTION
## WHAT
Add frame-src rules to CSP and allow Stripe.com to serve frames
## WHY
So that our payment flow actually works
## HOW
Stripe loads an iframe as part of our payment flow, and we need to enable that behavior through our CSP to prevent it from failing.

### Notion Card Links
https://www.notion.so/quill/Credit-Card-payments-cannot-be-completed-0a4a1b7355654712a457a72deced246d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No tests on CSP
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
