### PR TITLE
lms/nil-check-user-ids-in-jobs

### DIFF
--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -3,7 +3,7 @@ class PremiumAnalyticsWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(id, account_type)
-    @user = User.find(id)
+    @user = User.find_by_id(id)
     return unless @user
     analytics = Analyzer.new
     if Subscription::OFFICIAL_FREE_TYPES.include?(account_type)

--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -4,6 +4,7 @@ class PremiumAnalyticsWorker
 
   def perform(id, account_type)
     @user = User.find(id)
+    return unless @user
     analytics = Analyzer.new
     if Subscription::OFFICIAL_FREE_TYPES.include?(account_type)
       event = SegmentIo::BackgroundEvents::BEGAN_PREMIUM_TRIAL

--- a/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
@@ -3,6 +3,7 @@ class PremiumSchoolSubscriptionEmailWorker
 
   def perform(user_id)
     @user = User.find(user_id)
+    return unless @user
     school = @user.school
     admin = school&.schools_admins&.first&.try(:user)
     @user.send_premium_school_subscription_email(school, admin)

--- a/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
@@ -2,7 +2,7 @@ class PremiumSchoolSubscriptionEmailWorker
   include Sidekiq::Worker
 
   def perform(user_id)
-    @user = User.find(user_id)
+    @user = User.find_by_id(user_id)
     return unless @user
     school = @user.school
     admin = school&.schools_admins&.first&.try(:user)

--- a/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
@@ -31,5 +31,13 @@ describe PremiumAnalyticsWorker do
         subject.perform(user.id, Subscription::OFFICIAL_FREE_TYPES[0])
       end
     end
+
+    context 'when passed an id for a non-existent user' do
+      it 'should return without doing anything' do
+        bad_user_id = user.id * 9
+        expect(analyzer).not_to receive(:track)
+        subject.perform(bad_user_id, Subscription::OFFICIAL_FREE_TYPES[0])
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/premium_school_subscription_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_school_subscription_email_worker_spec.rb
@@ -11,5 +11,11 @@ describe PremiumSchoolSubscriptionEmailWorker do
       expect_any_instance_of(User).to receive(:send_premium_school_subscription_email).with(user.school, user.school.schools_admins.first.try(:user))
       subject.perform(user.id)
     end
+
+    it 'should exit gracefully if passed an invalid id' do
+      bad_user_id = user.id * 9
+      expect_any_instance_of(User).not_to receive(:send_premium_school_subscription_email)
+      subject.perform(bad_user_id)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Make sure that the user_id passed in goes to an actual user record
## WHY
So that we don't crash and retry a job over and over when it's in a state that can't possibly complete
## HOW
Set up an early return if the user object doesn't populate from the database

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A