### PR TITLE
lms/disable-prepared-statements

### DIFF
--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -1,5 +1,6 @@
 default: &default
   pool: <%= ENV.fetch("MAX_THREADS") { 5 } %>
+  prepared_statements: false
   timeout: 5000
 
 development_env: &development_env


### PR DESCRIPTION
## WHAT
Disable prepared statements for all database environments
## WHY
The ActiveRecord implementation for prepared statements does not play nicely with connection pooling (multiple connections may try to create a prepared statement with the same name, and when those connections are pooled into a single actual database connection that generates errors).
## HOW
Just update the `database.yml` file with a flag to turn off prepared statements for all connections

### Notion Card Links
https://www.notion.so/quill/Implement-LMS-Heroku-DB-connection-Pooling-964161abd8684b678ea4831ac3263c31

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on config
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
