### PR TITLE
Lms/figure out csp for coview

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -64,6 +64,8 @@ SecureHeaders::Configuration.default do |config|
     ], 
 
     img_src: [
+      "https://coview.com",
+      "https://*.coview.com",
       "https://heapanalytics.com",
       "https://*.heapanalytics.com",
       "https://intercomassets.com",
@@ -85,6 +87,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.quill.org",
       "https://quill.org",  
       "'unsafe-inline'",
+      "https://coview.com",
+      "https://*.coview.com",
       "https://*.fontawesome.com",
       "https://*.googleapis.com",
       "https://*.gstatic.com"      

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -68,7 +68,7 @@ SecureHeaders::Configuration.default do |config|
     ], 
 
     img_src: [
-      "data:image/png",
+      "data:",
       "https://coview.com",
       "https://*.coview.com",
       "https://heapanalytics.com",

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -53,6 +53,8 @@ SecureHeaders::Configuration.default do |config|
 
     font_src: [
       "'self'",
+      "https://coview.com",
+      "https://*.coview.com",
       "https://intercomcdn.com",
       "https://*.intercomcdn.com",
       "https://quill.org",
@@ -108,6 +110,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.doubleclick.net",
       "https://*.pusherapp.com",
       "https://*.pusher.com",
+      "wss://coview.com",
+      "wss://*.coview.com",
       "wss://*.pusherapp.com",
       "wss://*.inspectlet.com",
       "https://*.intercom.io",

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -9,6 +9,8 @@ SecureHeaders::Configuration.default do |config|
 
     frame_src: [
       "'self'",
+      "https://coview.com",
+      "https://*.coview.com",
       "https://stripe.com",
       "https://*.stripe.com"
     ],
@@ -66,6 +68,7 @@ SecureHeaders::Configuration.default do |config|
     ], 
 
     img_src: [
+      "data:image/png",
       "https://coview.com",
       "https://*.coview.com",
       "https://heapanalytics.com",


### PR DESCRIPTION
## WHAT
Update CSP to allow sourcing for Coview
## WHY
Coview is a tool used by support to get user screen recordings.  It's super useful and we want to make sure that it continues to work.
## HOW
Add `coview.com` as a defined src for fonts, styles, frames, sockets, and images.  Also, part of the Coview implementation involves `data:` as an image src, so add that allowance to the policy as well.

### Notion Card Links
https://www.notion.so/quill/Coview-Failed-to-Access-your-Page-message-for-users-trying-to-send-screen-recordings-8e87d2272e694dfc865d377311eda88f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on CSP
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A