### PR TITLE
Fix edge case where imported google classroom students already exist in db as teachers

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -97,7 +97,8 @@ class ChangeLog < ApplicationRecord
     sign_in: 'Impersonated User',
     show: 'Visited User Admin Page',
     edit: 'Visited User Edit Page',
-    update: 'Edited User'
+    update: 'Edited User',
+    skipped_import: 'Skipped User import'
   }
   GENERIC_USER_ACTIONS = [
     'Visited User Directory',

--- a/services/QuillLMS/app/services/google_integration/classroom_student_importer.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_student_importer.rb
@@ -2,49 +2,52 @@ module GoogleIntegration
   class ClassroomStudentImporter
     ROLE = ::User::STUDENT
 
-    attr_reader :data
+    attr_reader :data, :classroom, :email
 
     def initialize(data)
       @data = data
+      @classroom = data[:classroom]
+      @email = data[:email]&.downcase
     end
 
     def run
-      return if invalid_email?
+      return unless email.present?
 
-      update_existing_student_with_google_id_and_different_email
-      import_student
-      assign_classroom
+      update_student_with_google_id_and_different_email
+
+      if student_is_active_teacher?
+        log_skipped_import
+      else
+        import_student
+        assign_classroom
+      end
     end
 
     private def assign_classroom
       Associators::StudentsToClassrooms.run(student, classroom)
     end
 
-    private def classroom
-      data[:classroom]
-    end
-
-    private def email
-      data[:email]&.downcase
-    end
-
     private def import_student
-      importer_class.new(data).run
+      student ? ClassroomStudentUpdater.new(student, data).run : ClassroomStudentCreator.new(data).run
     end
 
-    private def importer_class
-      student.present? ? ClassroomStudentUpdater : ClassroomStudentCreator
-    end
-
-    private def invalid_email?
-      email.nil?
+    private def log_skipped_import
+      ChangeLog.find_or_create_by(
+        changed_record: student,
+        action: ChangeLog::USER_ACTIONS[:skipped_import],
+        explanation: caller_locations[0].to_s
+      )
     end
 
     private def student
-      @student ||= ::User.find_by(email: email, role: ROLE)
+      @student ||= ::User.find_by(email: email)
     end
 
-    private def update_existing_student_with_google_id_and_different_email
+    private def student_is_active_teacher?
+      student&.teacher? && ::ClassroomsTeacher.exists?(user: student)
+    end
+
+    private def update_student_with_google_id_and_different_email
       StudentEmailUpdater.new(data).run
     end
   end

--- a/services/QuillLMS/app/services/google_integration/classroom_student_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_student_updater.rb
@@ -3,24 +3,40 @@ module GoogleIntegration
     ACCOUNT_TYPE = ::User::GOOGLE_CLASSROOM_ACCOUNT
     ROLE = ::User::STUDENT
 
-    attr_reader :email, :google_id
+    attr_reader :google_id, :student
 
-    def initialize(data)
-      @email = data[:email].downcase
+    def initialize(student, data)
+      @student = student
       @google_id = data[:google_id]
     end
 
     def run
+      update_existing_student_role_if_teacher
       update
       student
     end
 
-    private def student
-      ::User.find_by!(email: email, role: ROLE)
+
+    private def update_existing_student_role_if_teacher
+      return unless student.teacher?
+
+      student.update(role: ROLE)
+      log_role_change
     end
 
     private def update
       student.update!(account_type: ACCOUNT_TYPE, google_id: google_id)
+    end
+
+    private def log_role_change
+      ChangeLog.create(
+        changed_record: student,
+        action: ChangeLog::USER_ACTIONS[:update],
+        changed_attribute: :role,
+        previous_value: :teacher,
+        new_value: :student,
+        explanation: caller_locations[0].to_s
+      )
     end
   end
 end

--- a/services/QuillLMS/spec/services/google_integration/classroom_student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_student_updater_spec.rb
@@ -2,21 +2,35 @@ require 'rails_helper'
 
 RSpec.describe GoogleIntegration::ClassroomStudentUpdater do
   let(:email) { 'first_user@gmail.com' }
-  let!(:student) { create(:student, email: email )}
 
   let(:google_id) { '123' }
   let(:data) { { email: email, google_id: google_id } }
-
-  subject { described_class.new(data) }
-
-  let!(:updated_student) { subject.run }
-
   let(:account_type) { described_class::ACCOUNT_TYPE }
+  let(:role) { described_class::ROLE }
 
-  it "updates an existing student's account_type and google_id" do
-    expect(updated_student.email).to eq student.email
-    expect(updated_student.role).to eq student.role
-    expect(updated_student.account_type).to eq account_type
-    expect(updated_student.google_id).to eq google_id
+  subject { described_class.new(student, data) }
+
+  context 'student has role student' do
+    let(:student) { create(:student, email: email )}
+
+    it { updates_student_attributes }
+    it { expect { subject.run }.not_to change(ChangeLog, :count) }
+  end
+
+  context 'student has role teacher' do
+    let(:student) { create(:teacher, email: email )}
+
+    it { updates_student_attributes }
+    it { expect { subject.run }.to change(ChangeLog, :count).by(1) }
+  end
+
+  def updates_student_attributes
+    subject.run
+    student.reload
+
+    expect(student.email).to eq email
+    expect(student.role).to eq role
+    expect(student.account_type).to eq account_type
+    expect(student.google_id).to eq google_id
   end
 end


### PR DESCRIPTION
## WHAT
During the google classroom import process there is an edge case where "students" imported already exist in our database with the role "teacher".  Our current logic expects that any existing users should be students.  This PR addresses this edge case.

## WHY
Currently the import process grinds to a halt when encountering this edge case.

## HOW
There are two cases we'd like to handle.
Case 1) The user has no classrooms => Update the user role from 'teacher' to 'student'
Case 2) The user has classrooms => Skip importing of this user

In both cases, ChangeLogs are created to keep track of how often this happening. 

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A