### PR TITLE
lms/ignore-empty-rows-in-roster-uploads

### DIFF
--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -22,6 +22,7 @@ class Cms::RostersController < Cms::CmsController
           end
 
           params[:students]&.each do |s|
+            next unless s[:email]
             raise "Student with email #{s[:email]} already exists." if User.find_by(email: s[:email]).present?
             raise "Teacher with email #{s[:teacher_email]} does not exist." if User.find_by(email: s[:teacher_email]).blank?
             raise "Please provide a last name or password for student #{s[:name]}, otherwise this account will have no password." if s[:password].blank? && s[:name].split[1].blank?

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -13,6 +13,7 @@ class Cms::RostersController < Cms::CmsController
       else
         ActiveRecord::Base.transaction do
           params[:teachers]&.each do |t|
+            next unless t[:email]
             raise "Teacher with email #{t[:email]} already exists." if User.find_by(email: t[:email]).present?
             raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
             password = t[:password].present? ? t[:password] : t[:name].split[1]

--- a/services/QuillLMS/spec/controllers/cms/rosters_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/rosters_controller_spec.rb
@@ -10,7 +10,7 @@ describe Cms::RostersController do
   describe '#upload_teachers_and_students' do
     let!(:school) { create(:school)}
 
-    it 'should create teachers and students based on the data provided' do
+    it 'should create teachers and students based on the data provided, and it should ignore empty items in payload arrays' do
       teacher_email = "email@test.org"
       student_email = "studentemail@test.org"
       another_student_email = "anotheremail@test.org"
@@ -22,7 +22,8 @@ describe Cms::RostersController do
             name: "Test Teacher",
             email: teacher_email,
             password: nil
-          }
+          },
+          {} # Intentionally empty hash to test error handling
         ],
         students: [
           {
@@ -40,7 +41,8 @@ describe Cms::RostersController do
             teacher_email: teacher_email,
             classroom: classroom_name,
             password: nil
-          }
+          },
+          {} # Intentionally empty hash to test error handling
         ]
       }
 


### PR DESCRIPTION
## WHAT
Skip empty rows when parsing roster uploads
## WHY
Sometimes XLSX files save empty rows as having data in them (but all columns are empty), and when these are parsed they can not actually be used to create records causing the whole transaction to fail
## HOW
Add an early `next` call to the loops parsing data

### Notion Card Links
https://www.notion.so/quill/Bulk-teacher-account-creation-for-district-tried-the-new-feature-but-getting-email-error-52689131c7434bd2980667fc5966da07

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
