### PR TITLE
go/reduce-api-timeout

### DIFF
--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -24,7 +24,7 @@ var default_api_response = APIResponse{
 }
 
 // TODO: This is a temporary replacement `http` that allows us to bypass SSL security checks
-var client = &http.Client {
+var base_client = &http.Client {
 	Transport: &http.Transport {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	},
@@ -109,7 +109,7 @@ func Endpoint(context *gin.Context) {
 	var returnable_result APIResponse
 
 	for index, url := range urls {
-		results[index] = getAPIResponse(url, index, request_body, client)
+		results[index] = getAPIResponse(url, index, request_body, base_client)
 		return_index, finished := processResults(results, len(urls))
 
 		if finished {
@@ -135,7 +135,7 @@ func Endpoint(context *gin.Context) {
 		return
 	}
 
-	recordFeedback(request_object, returnable_result, GetFeedbackHistoryUrl(), client)
+	recordFeedback(request_object, returnable_result, GetFeedbackHistoryUrl(), base_client)
 
 	context.Header("Access-Control-Allow-Origin", "*")
 	context.Header("Content-Type", "application/json")

--- a/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
+++ b/services/comprehension/feedback-api-main/src/endpoint/endpoint.go
@@ -28,6 +28,7 @@ var client = &http.Client {
 	Transport: &http.Transport {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	},
+	Timeout: time.Millisecond * 5000,
 }
 
 func GetFeedbackHistoryUrl() (string) {
@@ -108,7 +109,7 @@ func Endpoint(context *gin.Context) {
 	var returnable_result APIResponse
 
 	for index, url := range urls {
-		results[index] = getAPIResponse(url, index, request_body)
+		results[index] = getAPIResponse(url, index, request_body, client)
 		return_index, finished := processResults(results, len(urls))
 
 		if finished {
@@ -134,7 +135,7 @@ func Endpoint(context *gin.Context) {
 		return
 	}
 
-	recordFeedback(request_object, returnable_result, GetFeedbackHistoryUrl())
+	recordFeedback(request_object, returnable_result, GetFeedbackHistoryUrl(), client)
 
 	context.Header("Access-Control-Allow-Origin", "*")
 	context.Header("Content-Type", "application/json")
@@ -159,7 +160,7 @@ func processResults(results map[int]InternalAPIResponse, length int) (int, bool)
 	return automl_index, all_correct
 }
 
-func getAPIResponse(url string, priority int, json_params [] byte) InternalAPIResponse {
+func getAPIResponse(url string, priority int, json_params [] byte, client *http.Client) InternalAPIResponse {
 
 	// response_json, err := http.Post(url, "application/json", bytes.NewReader(json_params))
 
@@ -222,7 +223,7 @@ func buildFeedbackHistory(request_object APIRequest, feedback APIResponse, used 
 	}
 }
 
-func recordFeedback(incoming_params APIRequest, feedback APIResponse, feedback_history_url string) {
+func recordFeedback(incoming_params APIRequest, feedback APIResponse, feedback_history_url string, client *http.Client) {
 
 
 	history := buildFeedbackHistory(incoming_params, feedback, true, time.Now())


### PR DESCRIPTION
## WHAT
Set a 5 second client-side timeout for API calls and test behavior
## WHY
Now that we do serial feedback we don't want to wait forever to send the user feedback if one of the APIs is taking forever to return.
## HOW
- Configure a client-side timeout in our globally-defined `client`.
- Update calls that use a client to take `client` as an argument (for easier testing)
- Write a test that times the client request out immediately and confirm that we get back the expected response (an `InternalAPIResponse` with `Error == true`.

### Notion Card Links
https://www.notion.so/quill/Evidence-feedback-sometimes-takes-between-30-sec-1-5-minutes-to-load-6587ba81246444b9b66d5ae6b4540d92

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
