### PR TITLE
LMS Bugfix - Fix call to our Geo API service

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -55,7 +55,6 @@ gem 'global'
 gem 'google-api-client', '0.8.6'
 gem 'faraday_middleware'
 gem 'newrelic_rpm'
-gem 'pointpin', '~> 1.0.0' #IP-GEOLOCATION
 gem 'stripe'
 gem 'prawn'
 gem 'prawn-table'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -444,10 +444,6 @@ GEM
       ruby-rc4
       ttfunk
     pg (0.18.4)
-    pointpin (1.0.1)
-      faraday
-      hashie
-      multi_json
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
@@ -849,7 +845,6 @@ DEPENDENCIES
   pdf-core
   pdf-inspector
   pg (= 0.18.4)
-  pointpin (~> 1.0.0)
   prawn
   prawn-table
   premailer-rails

--- a/services/QuillLMS/app/workers/ip_location_worker.rb
+++ b/services/QuillLMS/app/workers/ip_location_worker.rb
@@ -10,7 +10,7 @@ class IpLocationWorker
     response = HTTParty.get(pinpoint_url(ip_address))
 
     if !response.success?
-      raise PinpointAPIError.new("#{response.code}: #{response}")
+      raise PinpointAPIError, "#{response.code}: #{response}"
     end
 
     postcode = response["postcode"]

--- a/services/QuillLMS/config/initializers/pointpin.rb
+++ b/services/QuillLMS/config/initializers/pointpin.rb
@@ -1,1 +1,0 @@
-Pointpin.api_key = ENV["POINTPIN_KEY"]

--- a/services/QuillLMS/spec/workers/ip_location_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/ip_location_worker_spec.rb
@@ -5,30 +5,60 @@ describe IpLocationWorker do
 
   describe '#perform' do
     let!(:user) { create(:user) }
+    let(:api_key) { '12345' }
+    let(:api_base) { 'https://testurl.com' }
+    let(:ip_address) {'12.34.56.78'}
+    let(:api_url) { "#{api_base}/#{api_key}/json/#{ip_address}"}
+    # This is needed for proper HTTParty stubbing
+    let(:response_headers) { {content_type: 'application/json'} }
 
     before do
-      allow(Pointpin).to receive(:locate) {
+      stub_const('IpLocationWorker::API_KEY', api_key)
+      stub_const('IpLocationWorker::BASE_URL', api_base)
+    end
+
+    context 'successful API response' do
+      let(:response_body) {
         {
           "country_name" => "country",
           "region_name" => "region",
           "city_name" => "city",
           "postcode" => "110011",
-        }
+        }.to_json
       }
+
+      before do
+        stub_request(:get, api_url)
+          .to_return(status: 200, body: response_body, headers: response_headers)
+      end
+
+      it 'should create the ip location unless the location is in the given blacklist' do
+        subject.perform(user.id, ip_address, [])
+
+        expect(IpLocation.last.country).to eq "country"
+        expect(IpLocation.last.state).to eq "region"
+        expect(IpLocation.last.city).to eq "city"
+        expect(IpLocation.last.zip).to eq 110011
+        expect(IpLocation.last.user).to eq user
+      end
+
+      it 'should not create the ip location if it is in the given blacklist' do
+        subject.perform(user.id, ip_address, ["110011"])
+        expect(IpLocation.count).to eq 0
+      end
     end
 
-    it 'should create the ip location unless the location is in the given blacklist' do
-      subject.perform(user.id, "some_ip", [])
-      expect(IpLocation.last.country).to eq "country"
-      expect(IpLocation.last.state).to eq "region"
-      expect(IpLocation.last.city).to eq "city"
-      expect(IpLocation.last.zip).to eq 110011
-      expect(IpLocation.last.user).to eq user
-    end
+    context 'errored API response' do
+      let(:response_body) { {"error"=>"Invalid API key"}.to_json}
 
-    it 'should not create the ip location if it is in the given blacklist' do
-      subject.perform(user.id, "some_ip", ["110011"])
-      expect(IpLocation.count).to eq 0
+      before do
+        stub_request(:get, api_url)
+          .to_return(status: 429, body: response_body, headers: response_headers)
+      end
+
+      it 'should raise a PinpointAPIError' do
+        expect { subject.perform(user.id, ip_address) }.to(raise_error(IpLocationWorker::PinpointAPIError))
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
We are getting errors for calls to Pointpin using their gem (this is our top error today). The gem uses [`http`](https://github.com/pointpin/pointpin-ruby/blob/master/lib/pointpin/configuration.rb#L4), which they seem to not support anymore (`https` calls work).

Removing the gem and making the `https` request ourselves.
## WHY
We want to fix this error. There is an added bonus of removing a gem dependency.
## HOW
Don't use their API wrapper gem, just make the `https` calls directly. Note, we could just specify the api_endpoint in the gem, but I'd rather just remove this external dependency.

### Notion Card Links
https://sentry.io/organizations/quillorg-5s/issues/2728230665/?project=11238&query=is%3Aunresolved

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
