### PR TITLE
Fix duplicate clever username bug

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/student_creator.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_creator.rb
@@ -3,13 +3,16 @@ module CleverIntegration
     ACCOUNT_TYPE = ::User::CLEVER_ACCOUNT
     ROLE = ::User::STUDENT
 
-    attr_reader :data
+    attr_reader :data, :name, :username
 
     def initialize(data)
       @data = data
+      @name = data[:name]
+      @username = data[:username]
     end
 
     def run
+      fix_username_conflict
       student
     end
 
@@ -19,6 +22,12 @@ module CleverIntegration
 
     private def student_attrs
       data.merge(role: ROLE, account_type: ACCOUNT_TYPE)
+    end
+
+    private def fix_username_conflict
+      return unless ::User.exists?(username: username)
+
+      data[:username] = UsernameGenerator.new(name).run
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/username_generator.rb
+++ b/services/QuillLMS/app/services/clever_integration/username_generator.rb
@@ -1,0 +1,14 @@
+module CleverIntegration
+  class UsernameGenerator
+    attr_reader :first_name, :last_name
+
+    def initialize(name)
+      @first_name = name.to_s.split("\s")[0]
+      @last_name = name.to_s.split("\s")[-1]
+    end
+
+    def run
+      GenerateUsername.new(first_name, last_name).call
+    end
+  end
+end

--- a/services/QuillLMS/app/services/generate_username.rb
+++ b/services/QuillLMS/app/services/generate_username.rb
@@ -1,7 +1,7 @@
 class GenerateUsername
   MAX_LOOPS = 1_000
 
-  def initialize(first_name, last_name, classcode)
+  def initialize(first_name, last_name, classcode = nil)
     @first_name = first_name
     @last_name = last_name
     @classcode = classcode

--- a/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
@@ -1,18 +1,31 @@
 require 'rails_helper'
 
 describe CleverIntegration::StudentCreator do
-  let(:data) {
+  let(:data) do
     {
       clever_id: '1',
-      email: 'student@gmail.com',
+      email: email,
       name: 'John Smith',
-      username: 'username'
+      username: username
     }
-  }
+  end
+
+  let(:email) { 'student@gmail.com' }
+  let(:username) { 'username' }
 
   subject { described_class.new(data) }
 
   it 'will create a new student if none currently exists' do
     expect { subject.run }.to change(User, :count).from(0).to(1)
+  end
+
+  context 'username already exists' do
+    before { create(:student) { create(:student, username: username)} }
+
+    it 'will create a new student with an updated username' do
+      subject.run
+
+      expect(User.find_by(email: email).username).not_to eq username
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug where clever student accounts that have a username that already exists in or database halt an import process.

## WHY
Clever imports are currently halted when hitting this bug.

## HOW
Generate a new username during student account creation. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Clever-Sidekiq-CleverStudentImporterWorker-Validation-failed-Username-That-usernam-c5284e15205c4ef08244b989c46797e1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A