### PR TITLE
evidence/set-bing-timeout

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -2,6 +2,7 @@ module Evidence
   class SpellingCheck
     class BingRateLimitException < StandardError; end
 
+    API_TIMEOUT = 5
     ALL_CORRECT_FEEDBACK = 'Correct spelling!'
     FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word(s).'
     FEEDBACK_TYPE = Rule::TYPE_SPELLING
@@ -61,13 +62,16 @@ module Evidence
         query: {
           text: @entry,
           mode: "proof"
-        }
+        },
+        timeout: API_TIMEOUT
       )
       # The rest of this code basically swallows any errors, but we want
       # to avoid swallowing errors around rate limiting, so raise those here
       raise BingRateLimitException if @response.code == 429
 
       JSON.parse(@response.body)
+    rescue Net::OpenTimeout
+      {}
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -46,6 +46,19 @@ module Evidence
         expect(feedback[:concept_uid]).to(be_truthy)
       end
 
+      it 'should return appropriate feedback attributes if there the API request times out on the client side' do
+        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
+        entry = "there is no spelling error here"
+        spelling_check = Evidence::SpellingCheck.new(entry)
+        feedback = spelling_check.feedback_object
+        expect(feedback[:feedback]).to(be_truthy)
+        expect(feedback[:feedback_type]).to(be_truthy)
+        expect(feedback[:optimal]).to(be_truthy)
+        expect(feedback[:entry]).to(be_truthy)
+        expect(feedback[:rule_uid]).to(be_truthy)
+        expect(feedback[:concept_uid]).to(be_truthy)
+      end
+
       it 'should return appropriate error if the endpoint returns an error' do
         stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"


### PR DESCRIPTION
## WHAT
Set a client-side timeout for Bing 
## WHY
So that we don't block on providing feedback for longer than is useful.  We have cases where this call takes 60 or 90 seconds, and we definitely don't want to sit around that long.  So we'll treat calls that take more than 5 seconds optimal.
## HOW
Just add a `timeout` param to the HTTParty call to Bing's spelling API.

### Notion Card Links
https://www.notion.so/quill/Evidence-feedback-sometimes-takes-between-30-sec-1-5-minutes-to-load-6587ba81246444b9b66d5ae6b4540d92

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A