### PR TITLE
lms/relax-img-src-csp

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -68,21 +68,9 @@ SecureHeaders::Configuration.default do |config|
     ], 
 
     img_src: [
+      "*",
       "data:",
-      "https://coview.com",
-      "https://*.coview.com",
-      "https://heapanalytics.com",
-      "https://*.heapanalytics.com",
-      "https://intercomassets.com",
-      "https://*.intercomassets.com",
-      "https://*.quill.org",
-      "https://quill.org",
-      "https://*.typekit.net",
-      "https://*.google.com",
-      "https://*.inspectlet.com",
-      "https://stripe.com",
-      "https://*.stripe.com",
-      "https://*.amazonaws.com"
+      "blob:"
     ],
 
     base_uri: %w('self'),                                         # used for relative URLs


### PR DESCRIPTION
## WHAT 
Simplify and relax img_src CSP
## WHY
So that we don't have to worry about all of the places someone might try to load an image.  This sets our img_src policy to match our media_src policy, so should probably be okay.
## HOW
Just copy the policy from `media_src` and use it for `img_src`.

### Notion Card Links
https://www.notion.so/quill/CSP-rejects-a-GA-img-beacon-during-Evidence-activities-2632011648684931872c6a1f38efc9b6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on CSP
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Tes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
