### PR TITLE
Update clever import bug to use case insensitive username check

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/student_creator.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_creator.rb
@@ -8,7 +8,7 @@ module CleverIntegration
     def initialize(data)
       @data = data
       @name = data[:name]
-      @username = data[:username]
+      @username = data[:username]&.downcase
     end
 
     def run
@@ -25,7 +25,7 @@ module CleverIntegration
     end
 
     private def fix_username_conflict
-      return unless ::User.exists?(username: username)
+      return unless username.present? && ::User.exists?(username: username)
 
       data[:username] = UsernameGenerator.new(name).run
     end

--- a/services/QuillLMS/app/services/clever_integration/student_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_importer.rb
@@ -5,8 +5,8 @@ module CleverIntegration
     def initialize(data)
       @data = data
       @clever_id = data[:clever_id]
-      @email = data[:email]
-      @username = data[:username]
+      @email = data[:email]&.downcase
+      @username = data[:username]&.downcase
     end
 
     def run
@@ -22,7 +22,7 @@ module CleverIntegration
     end
 
     private def student_with_email
-      ::User.find_by(email: email.downcase) if email.present?
+      ::User.find_by(email: email) if email.present?
     end
 
     private def student_with_clever_id

--- a/services/QuillLMS/app/services/clever_integration/student_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_updater.rb
@@ -1,6 +1,6 @@
 module CleverIntegration
   class StudentUpdater
-    attr_reader :clever_id, :data, :email, :student, :username
+    attr_reader :clever_id, :data, :student, :username
 
     ACCOUNT_TYPE = ::User::CLEVER_ACCOUNT
     ROLE = ::User::STUDENT
@@ -9,8 +9,7 @@ module CleverIntegration
       @student = student
       @data = data
       @clever_id = data[:clever_id]
-      @email = data[:email]
-      @username = data[:username]
+      @username = data[:username]&.downcase
     end
 
     def run
@@ -33,7 +32,7 @@ module CleverIntegration
     end
 
     private def fix_username_conflict
-      data[:username] = nil if username_conflict?
+      data.delete(:username) if username_conflict?
     end
 
     private def student_attrs

--- a/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
@@ -10,8 +10,8 @@ describe CleverIntegration::StudentCreator do
     }
   end
 
-  let(:email) { 'student@gmail.com' }
-  let(:username) { 'username' }
+  let(:email) { 'Student@gmail.com' }
+  let(:username) { 'Username' }
 
   subject { described_class.new(data) }
 
@@ -20,12 +20,13 @@ describe CleverIntegration::StudentCreator do
   end
 
   context 'username already exists' do
-    before { create(:student) { create(:student, username: username)} }
+    before { create(:student, username: username) }
 
     it 'will create a new student with an updated username' do
       subject.run
+      new_student = ::User.find_by(email: email.downcase)
 
-      expect(User.find_by(email: email).username).not_to eq username
+      expect(new_student.username).not_to eq username
     end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe CleverIntegration::StudentImporter do
-  let(:existing_email) { 'existing_student@gmail.com' }
-  let(:existing_username) { 'existing.stduent' }
+  let(:existing_email) { 'Existing_student@gmail.com' }
+  let(:existing_username) { 'Existing.student' }
   let(:existing_clever_id) { '2323abasd32' }
 
   let!(:existing_student1) { create(:student, email: existing_email) }

--- a/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
@@ -11,9 +11,9 @@ describe CleverIntegration::StudentUpdater do
   end
 
   let(:clever_id) { '1' }
-  let(:email) { 'student@gmail.com' }
+  let(:email) { 'Student@gmail.com' }
   let(:name) { 'Student Name' }
-  let(:username) { 'student.username' }
+  let(:username) { 'Student.username' }
 
   subject { described_class.new(student, data) }
 
@@ -86,9 +86,9 @@ describe CleverIntegration::StudentUpdater do
 
     student.reload
     expect(student.clever_id).to eq clever_id
-    expect(student.email).to eq email
+    expect(student.email).to eq email&.downcase
     expect(student.name).to eq name
-    expect(student.username).to eq username
+    expect(student.username).to eq username&.downcase
   end
 
   def updates_student_with_data_except_username
@@ -96,8 +96,8 @@ describe CleverIntegration::StudentUpdater do
 
     student.reload
     expect(student.clever_id).to eq clever_id
-    expect(student.email).to eq email
+    expect(student.email).to eq email&.downcase
     expect(student.name).to eq name
-    expect(student.username).not_to eq username
+    expect(student.username).not_to eq username&.downcase
   end
 end


### PR DESCRIPTION
## WHAT
Fix issue where clever imports are failing on existing users when the update involves a username that already exists in the database (case insensitive).  Existing check only looks at case sensitive.

## WHY
Imports should go through instead of halting at duplicate username

## HOW
Add `username.downcase` to service object initializers.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
