### PR TITLE
Evidence/ disable student highlights after first step

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -471,9 +471,12 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       const innerElements = node.children.map((n, i) => convertNodeToElement(n, i, transformMarkTags))
       const stringifiedInnerElements = node.children.map(n => n.data ? n.data : n.children[0].data).join('')
       let className = ''
-      className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
+      if(activeStep === 1) {
+        className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
+      }
       className += shouldBeHighlightable  ? ' highlightable' : ''
       if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
+      /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
       return <mark className={className} onClick={handleHighlightClick} onKeyDown={handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
     }
   }


### PR DESCRIPTION
## WHAT
hide student highlights after first step in Evidence activity

## WHY
we want to turn them off after the reflection phase until we can  serve feedback on highlighting and be confident that the student highlights are relevant to the writing

## HOW
just add a conditional check for the first step when applying the highlight CSS class

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Disable-green-highlights-in-the-writing-phase-temporarily-d64706fbd9434011b2e60bbdac5195ef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
