### PR TITLE
evidence/fix-start-explanation-slide-dismissal

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -58,7 +58,8 @@ const ALL_STEPS = [READ_PASSAGE_STEP, 2, 3, 4]
 const MINIMUM_STUDENT_HIGHLIGHT_COUNT = 2
 
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user, }: StudentViewContainerProps) => {
-  const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts')
+  const activityCompletionCount: number = parseInt(getParameterByName('activities', window.location.href, '0'));
+  const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || activityCompletionCount > 3
   const defaultCompletedSteps = shouldSkipToPrompts ? [READ_PASSAGE_STEP] : []
 
   const refs = {
@@ -496,12 +497,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   const className = `activity-container ${showFocusState ? '' : 'hide-focus-outline'} ${activeStep === READ_PASSAGE_STEP ? 'on-read-passage' : ''}`
 
-  let activityCompletionCount: string | number = getParameterByName('activities', window.location.href);
-  if(activityCompletionCount) {
-    activityCompletionCount = parseInt(activityCompletionCount)
-  }
-
-  if(!explanationSlidesCompleted || (activityCompletionCount && activityCompletionCount < 4)) {
+  if(!explanationSlidesCompleted) {
     if (explanationSlideStep === 0) {
       return <WelcomeSlide onHandleClick={handleExplanationSlideClick} user={user} />
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/helpers/getParameterByName.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/helpers/getParameterByName.ts
@@ -1,9 +1,9 @@
-export default function getParameterByName(name: string, url: string) {
+export default function getParameterByName(name: string, url: string, ifMissing: any = '') {
   if (!url) { url = window.location.href; }
   name = name.replace(/[\[\]]/g, '\\$&');
   const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`),
     results = regex.exec(url);
-  if (!results) { return null; }
-  if (!results[2]) { return ''; }
+  if (!results) { return ifMissing; }
+  if (!results[2]) { return ifMissing; }
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }


### PR DESCRIPTION
## WHAT
Tweak logic to skip Evidence intro based on activities completed
## WHY
The existing logic would sometimes put students in a loop where they could never get out of the introductory slides, even when clicking "start" as hard as they could
## HOW
Check to see how many previous Evidence activities a student has done at the top of the component, and use that value to to set `shouldSkipToPrompts` when the user has completed enough previous activities.  This lets us piggy-back on the existing logic for skipping intro slides.

### Notion Card Links
https://www.notion.so/quill/Some-students-can-t-press-Start-when-trying-to-begin-an-Evidence-activity-7fea0c8e98ac4b9ca125f3781bc229a4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests covering skip logic
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A