### PR TITLE
Evidence/ fix tooltip for header image

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -262,7 +262,8 @@
     }
 
     .read-passage-container {
-      overflow: scroll;
+      overflow-y: scroll;
+      overflow-x: hidden;
       margin-right: 4px;
     }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -56,6 +56,7 @@
           margin-left: 24px;
           font-size: 14px;
           color: #808080;
+          text-align: right;
           .image-attribution-tooltip {
             border-bottom: dashed 1px #808080;
           }
@@ -64,6 +65,7 @@
             outline-offset: 4px;
           }
           .quill-tooltip-wrapper {
+            position: relative;
             .quill-tooltip {
               a {
                 color: white;


### PR DESCRIPTION
## WHAT
fix tooltip for header image so it doesn't cause a horizontal scroll to show

## WHY
it makes the UI look a bit janky when the window size is smaller

## HOW
just added some CSS rules

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1247" alt="Screen Shot 2021-10-27 at 1 26 38 PM" src="https://user-images.githubusercontent.com/25959584/139125194-9fe154b0-515b-4c5b-9e4f-2a8074f2848f.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Second-Scroll-Bar-Image-Credits-e3cc4fbd06234e64baf78ca57bdb0cbb

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested, small CSS change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
