### PR TITLE
Add banners for fall webinars

### DIFF
--- a/services/QuillLMS/app/models/one_off_banner.rb
+++ b/services/QuillLMS/app/models/one_off_banner.rb
@@ -4,6 +4,106 @@ class OneOffBanner < WebinarBanner
   # RECURRING have the key format DayOfWeek-Hour
 
   WEBINARS = {
+    '11-3-19' => {
+      title: "<strong>Webinar: Supporting ELLs with Quill</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_Yu6rY35bRTGfHOte0ciD0A"
+    },
+    '11-4-16' => {
+      title: "<strong>Webinar: Supporting ELLs with Quill</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_Yu6rY35bRTGfHOte0ciD0A"
+    },
+    '11-10-19' => {
+      title: "<strong>Webinar: Using Quill to Support Students with IEPs</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_fbhlNZrsRz2FDoWMzSBg5Q"
+    },
+    '11-11-16' => {
+      title: "<strong>Webinar: Using Quill to Support Students with IEPs</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_fbhlNZrsRz2FDoWMzSBg5Q"
+    },
+    '11-17-19' => {
+      title: "<strong>Webinar: Reports Deep Dive</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_5A7DtmELR4Kz0trUyzqHXw"
+    },
+    '11-18-16' => {
+      title: "<strong>Webinar: Reports Deep Dive</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_5A7DtmELR4Kz0trUyzqHXw"
+    },
+    '12-1-19' => {
+      title: "<strong>Webinar: Teacher-led Instruction with Quill Lessons</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_5A7DtmELR4Kz0trUyzqHXw"
+    },
+    '12-2-16' => {
+      title: "<strong>Webinar: Teacher-led Instruction with Quill Lessons</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_5A7DtmELR4Kz0trUyzqHXw"
+    },
+    '12-8-19' => {
+      title: "<strong>Webinar: Activities Deep Dive</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_3iBJ4ehuQnGRGYUOmRXtUA"
+    },
+    '12-9-16' => {
+      title: "<strong>Webinar: Activities Deep Dive</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_3iBJ4ehuQnGRGYUOmRXtUA"
+    },
+    '1-3-16' => {
+      title: "<strong>Webinar: Quill 101</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_dI4RRV1qQE-R5s68hXuSDQ"
+    },
+    '1-10-16' => {
+      title: "<strong>Webinar: Quill 101</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_dI4RRV1qQE-R5s68hXuSDQ"
+    },
+    '1-24-16' => {
+      title: "<strong>Webinar: Quill 101</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_dI4RRV1qQE-R5s68hXuSDQ"
+    },
+    '1-31-16' => {
+      title: "<strong>Webinar: Quill 101</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_dI4RRV1qQE-R5s68hXuSDQ"
+    },
+    '1-5-19' => {
+      title: "<strong>Webinar: Using Quill with Google Classroom</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_NJgbT-yJQLim1bdJ_J8g_w"
+    },
+    '1-6-16' => {
+      title: "<strong>Webinar: Using Quill with Google Classroom</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_NJgbT-yJQLim1bdJ_J8g_w"
+    },
+    '1-12-19' => {
+      title: "<strong>Webinar: Quill Diagnostics & Recommendations</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_eLqaiQtpQSyia8QJHz2ZmA"
+    },
+    '1-13-16' => {
+      title: "<strong>Webinar: Quill Diagnostics & Recommendations</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_eLqaiQtpQSyia8QJHz2ZmA"
+    },
+    '1-19-19' => {
+      title: "<strong>Webinar: Exploring the Activity Library</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_-U9oIN30Q_y9JPtzYKrZfg"
+    },
+    '1-20-16' => {
+      title: "<strong>Webinar: Exploring the Activity Library</strong> is live now!",
+      link_display_text: "Click here to register and join.",
+      link: "#{ZOOM_URL}/WN_-U9oIN30Q_y9JPtzYKrZfg"
+    }
   }
 
   private def values

--- a/services/QuillLMS/spec/models/one_off_banner_spec.rb
+++ b/services/QuillLMS/spec/models/one_off_banner_spec.rb
@@ -15,11 +15,11 @@ describe OneOffBanner, type: :model do
     expect(banner.title).to eq(nil)
   end
 
-  # it "does return true for show? when the key does have an associated webinar" do
-  #   time =  DateTime.new(2021,4,7,16,1,0)
-  #   banner = OneOffBanner.new(time)
-  #   expect(banner.show?).to eq(true)
-  # end
+  it "does return true for show? when the key does have an associated webinar" do
+    time =  DateTime.new(2021,11,4,16,1,0)
+    banner = OneOffBanner.new(time)
+    expect(banner.show?).to eq(true)
+  end
 
   it "does not return true for show? when the key falls on a skipped day" do
     time =  DateTime.new(2021,1,18,16,1,0)
@@ -27,11 +27,11 @@ describe OneOffBanner, type: :model do
     expect(banner.show?).to eq(false)
   end
 
-  # it "does return correct link and title when the key does have an associated recurring webinar" do
-  #   time =  DateTime.new(2021,4,7,16,1,0)
-  #   banner = OneOffBanner.new(time)
-  #   expect(banner.title).to eq("Quill's Activity Library Deep Dive is live now!")
-  #   expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_tZvfRYTmSxaGvnUHIb4JOw")
-  # end
+  it "does return correct link and title when the key does have an associated recurring webinar" do
+    time =  DateTime.new(2021,11,4,16,1,0)
+    banner = OneOffBanner.new(time)
+    expect(banner.title).to eq("<strong>Webinar: Supporting ELLs with Quill</strong> is live now!")
+    expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_Yu6rY35bRTGfHOte0ciD0A")
+  end
 
 end


### PR DESCRIPTION
## WHAT
Add a bunch of new one-off banners for fall webinars.

## WHY
To increase attendance at the fall webinars.

## HOW
Add the data for new banners and update tests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Banners-for-deep-dive-webinar-series-eee294629d8e4c788a32422d270bc584

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
