### PR TITLE
prefilter backend

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -2,11 +2,10 @@ module Evidence
   require 'json'
 
   class FeedbackController < ApiController
-    before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling, :prefilter]
+    before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling]
 
     def prefilter 
-      prefilter_check = Evidence::PrefilterCheck.new(@entry, @prompt)
-      return render :body => nil, :status => 404 if prefilter_check.feedback_object[:error]
+      prefilter_check = Evidence::PrefilterCheck.new(prefilter_params)
       render json: prefilter_check.feedback_object
     end
 
@@ -39,6 +38,10 @@ module Evidence
       return render :body => {:error => spelling_check.error }.to_json, :status => 500 if spelling_check.error.present?
       render json: spelling_check.feedback_object
     end
+
+    private def prefilter_params
+      params.require(:entry)
+    end 
 
     private def set_params
       @entry = params[:entry]

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -2,7 +2,13 @@ module Evidence
   require 'json'
 
   class FeedbackController < ApiController
-    before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling]
+    before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling, :prefilter]
+
+    def prefilter 
+      prefilter_check = Evidence::PrefilterCheck.new(@entry, @prompt)
+      return render :body => nil, :status => 404 if prefilter_check.feedback_object[:error]
+      render json: prefilter_check.feedback_object
+    end
 
     def plagiarism
       rule = @prompt.rules&.find_by(rule_type: Evidence::Rule::TYPE_PLAGIARISM)

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/prefilter_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/prefilter_controller.rb
@@ -1,9 +1,0 @@
-module Evidence
-  class OpinionController < ApiController
-
-    def fetch
-      oapi_client = Opinion::Client.new(entry: params['entry'], prompt_text: params['prompt_text'])
-      render json: Opinion::FeedbackAssembler.run(oapi_client.post)
-    end
-  end
-end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/prefilter_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/prefilter_controller.rb
@@ -1,0 +1,9 @@
+module Evidence
+  class OpinionController < ApiController
+
+    def fetch
+      oapi_client = Opinion::Client.new(entry: params['entry'], prompt_text: params['prompt_text'])
+      render json: Opinion::FeedbackAssembler.run(oapi_client.post)
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -12,16 +12,27 @@ module Evidence
       STATE_ACTIVE      = 'active',
       STATE_INACTIVE    = 'inactive'
     ]
+
+    TYPE_AUTOML       = 'autoML'
+    TYPE_GRAMMAR      = 'grammar'
+    TYPE_OPINION      = 'opinion'
+    TYPE_PLAGIARISM   = 'plagiarism'
+    TYPE_REGEX_ONE    = 'rules-based-1'
+    TYPE_REGEX_TWO    = 'rules-based-2'
+    TYPE_REGEX_THREE  = 'rules-based-3'
+    TYPE_SPELLING     = 'spelling'
+    TYPE_PREFILTER    = 'prefilter'
+
     TYPES = [
-      TYPE_AUTOML       = 'autoML',
-      TYPE_GRAMMAR      = 'grammar',
-      TYPE_OPINION      = 'opinion',
-      TYPE_PLAGIARISM   = 'plagiarism',
-      TYPE_REGEX_ONE    = 'rules-based-1',
-      TYPE_REGEX_TWO    = 'rules-based-2',
-      TYPE_REGEX_THREE  = 'rules-based-3',
-      TYPE_SPELLING     = 'spelling',
-      TYPE_PREFILTER    = 'prefilter'
+      TYPE_AUTOML,
+      TYPE_GRAMMAR,
+      TYPE_OPINION,
+      TYPE_PLAGIARISM,
+      TYPE_REGEX_ONE,
+      TYPE_REGEX_TWO,
+      TYPE_REGEX_THREE,
+      TYPE_SPELLING,
+      TYPE_PREFILTER
     ]
     DISPLAY_NAMES = {
       'rules-based-1': 'Sentence Structure Regex',

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -9,30 +9,19 @@ module Evidence
     MAX_NAME_LENGTH = 250
     ALLOWED_BOOLEANS = [true, false]
     STATES = [
-      STATE_ACTIVE      = 'active',
-      STATE_INACTIVE    = 'inactive'
+      STATE_ACTIVE = 'active',
+      STATE_INACTIVE = 'inactive'
     ]
-
-    TYPE_AUTOML       = 'autoML'
-    TYPE_GRAMMAR      = 'grammar'
-    TYPE_OPINION      = 'opinion'
-    TYPE_PLAGIARISM   = 'plagiarism'
-    TYPE_REGEX_ONE    = 'rules-based-1'
-    TYPE_REGEX_TWO    = 'rules-based-2'
-    TYPE_REGEX_THREE  = 'rules-based-3'
-    TYPE_SPELLING     = 'spelling'
-    TYPE_PREFILTER    = 'prefilter'
-
     TYPES = [
-      TYPE_AUTOML,
-      TYPE_GRAMMAR,
-      TYPE_OPINION,
-      TYPE_PLAGIARISM,
-      TYPE_REGEX_ONE,
-      TYPE_REGEX_TWO,
-      TYPE_REGEX_THREE,
-      TYPE_SPELLING,
-      TYPE_PREFILTER
+      TYPE_AUTOML       = 'autoML',
+      TYPE_GRAMMAR      = 'grammar',
+      TYPE_OPINION      = 'opinion',
+      TYPE_PLAGIARISM   = 'plagiarism',
+      TYPE_REGEX_ONE    = 'rules-based-1',
+      TYPE_REGEX_TWO    = 'rules-based-2',
+      TYPE_REGEX_THREE  = 'rules-based-3',
+      TYPE_SPELLING     = 'spelling',
+      TYPE_PREFILTER    = 'prefilter'
     ]
     DISPLAY_NAMES = {
       'rules-based-1': 'Sentence Structure Regex',

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -17,11 +17,11 @@ module Evidence
       TYPE_GRAMMAR      = 'grammar',
       TYPE_OPINION      = 'opinion',
       TYPE_PLAGIARISM   = 'plagiarism',
+      TYPE_PREFILTER    = 'prefilter',
       TYPE_REGEX_ONE    = 'rules-based-1',
       TYPE_REGEX_TWO    = 'rules-based-2',
       TYPE_REGEX_THREE  = 'rules-based-3',
-      TYPE_SPELLING     = 'spelling',
-      TYPE_PREFILTER    = 'prefilter'
+      TYPE_SPELLING     = 'spelling'
     ]
     DISPLAY_NAMES = {
       'rules-based-1': 'Sentence Structure Regex',

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -9,18 +9,19 @@ module Evidence
     MAX_NAME_LENGTH = 250
     ALLOWED_BOOLEANS = [true, false]
     STATES = [
-      STATE_ACTIVE = 'active',
-      STATE_INACTIVE = 'inactive'
+      STATE_ACTIVE      = 'active',
+      STATE_INACTIVE    = 'inactive'
     ]
-    TYPES= [
-      TYPE_AUTOML = 'autoML',
-      TYPE_GRAMMAR = 'grammar',
-      TYPE_OPINION = 'opinion',
-      TYPE_PLAGIARISM = 'plagiarism',
-      TYPE_REGEX_ONE = 'rules-based-1',
-      TYPE_REGEX_TWO = 'rules-based-2',
-      TYPE_REGEX_THREE = 'rules-based-3',
-      TYPE_SPELLING = 'spelling'
+    TYPES = [
+      TYPE_AUTOML       = 'autoML',
+      TYPE_GRAMMAR      = 'grammar',
+      TYPE_OPINION      = 'opinion',
+      TYPE_PLAGIARISM   = 'plagiarism',
+      TYPE_REGEX_ONE    = 'rules-based-1',
+      TYPE_REGEX_TWO    = 'rules-based-2',
+      TYPE_REGEX_THREE  = 'rules-based-3',
+      TYPE_SPELLING     = 'spelling',
+      TYPE_PREFILTER    = 'prefilter'
     ]
     DISPLAY_NAMES = {
       'rules-based-1': 'Sentence Structure Regex',

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -12,6 +12,7 @@ Evidence::Engine.routes.draw do
     end
   end
   namespace :feedback do
+    post :prefilter
     post :automl
     post :plagiarism
     post 'regex/:rule_type' => :regex

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -1,0 +1,57 @@
+module Evidence
+  class PrefilterCheck
+    MINIMUM_WORD_COUNT = 3
+    OPTIMAL_RULE_UID = '' # TODO: populate
+
+    PREFILTERS = [
+      'this is a rule uid for TOO_LONG' => lambda do |text|
+        PrefilterCheck.to_word_array.length >= MINIMUM_WORD_COUNT
+      end,
+      'this is another rule uid' => lambda do |text| 
+      end
+    ]
+
+    def initialize(entry, prompt)
+      @entry = entry
+      @prompt = prompt
+      @prefilter_rules = Evidence::Rule.where(rule_type: Evidence::Rule::TYPES[TYPE_PREFILTER]).include(:feedbacks)
+    end
+
+    def default_response
+      {
+        feedback: '',
+        feedback_type: Evidence::Rule::TYPES[TYPE_PREFILTER],
+        optimal: true,
+        response_id: '',
+        entry: @entry,
+        concept_uid: '',
+        rule_uid: OPTIMAL_RULE_UID,
+        highlight: []
+      }
+    end
+
+    def feedback_object
+      violated_rule = @prefilter_rules.find do |rule| 
+        next unless PREFILTERS[rule.uid]
+        !PREFILTERS[rule.uid](text) 
+      end
+
+      return default_response unless violated_rule
+
+      feedback = violated_rule.feedbacks.first
+
+      default_response.merge(
+        {
+          feedback: feedback&.text,
+          optimal: false,
+          rule:uid: violated_rule.uid
+        }
+      )
+    end
+
+    def self.to_word_array(entry)
+      entry.split(' ')
+    end
+
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -18,7 +18,7 @@ module Evidence
     let!(:first_feedback) { create(:evidence_feedback, :text => "here is our first feedback", :rule => (rule), :order => 0) }
     let!(:second_feedback) { create(:evidence_feedback, :text => "here is our second feedback", :rule => (rule), :order => 1) }
     
-    context '#prefilter' do 
+    describe '#prefilter' do 
       it 'should return successfully' do 
         post "prefilter", :params => ({ 
           :entry => "lorem ipsum", 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -18,9 +18,20 @@ module Evidence
     let!(:first_feedback) { create(:evidence_feedback, :text => "here is our first feedback", :rule => (rule), :order => 0) }
     let!(:second_feedback) { create(:evidence_feedback, :text => "here is our second feedback", :rule => (rule), :order => 1) }
     
+    context '#prefilter' do 
+      it 'should return successfully' do 
+        post "prefilter", :params => ({ 
+          :entry => "lorem ipsum", 
+          :prompt_id => prompt.id, 
+          :session_id => 1, 
+          :previous_feedback => ([]) 
+        }), :as => :json
+
+        expect(response.status).to eq 200
+      end
+    end
 
     context 'should plagiarism' do
-
       it 'should return successfully' do
         post("plagiarism", :params => ({ :entry => "No plagiarism here.", :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
         parsed_response = JSON.parse(response.body)

--- a/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(RegexCheck, :type => :model) do
+    let!(:prompt) { create(:evidence_prompt) }
+    let!(:rule) { create(:evidence_rule, :rule_type => "rules-based-1", :prompts => ([prompt]), :suborder => 0) }
+    let!(:regex_rule) { create(:evidence_regex_rule, :rule => (rule), :regex_text => "^Test") }
+    let!(:feedback) { create(:evidence_feedback, :rule => (rule), :text => "This string begins with the word Test!") }
+
+    context 'should #initialize' do
+
+      it 'should should have working accessor methods for all initialized fields' do
+        regex_check = Evidence::RegexCheck.new("entry", prompt, rule.rule_type)
+        expect("entry").to(eq(regex_check.entry))
+        expect(prompt).to(eq(regex_check.prompt))
+      end
+    end
+
+    context 'should #feedback_object' do
+
+      it 'should return optimal blank feedback when there is no regex match' do
+        $redis.redis.flushdb
+        optimal_rule = create(:evidence_rule, :rule_type => "rules-based-1", :optimal => true)
+        entry = "this is not a good regex match"
+        regex_check = Evidence::RegexCheck.new(entry, prompt, optimal_rule.rule_type)
+        feedback = regex_check.feedback_object
+        expect(Evidence::RegexCheck::ALL_CORRECT_FEEDBACK).to(eq(feedback[:feedback]))
+        expect(optimal_rule.rule_type).to(eq(feedback[:feedback_type]))
+        expect(feedback[:optimal]).to(be_truthy)
+        expect(entry).to(eq(feedback[:entry]))
+        expect("").to(eq(feedback[:concept_uid]))
+        expect(optimal_rule.uid).to(eq(feedback[:rule_uid]))
+      end
+
+      it 'should be false when there is a regex match' do
+        entry = "Test this is a good regex match"
+        regex_check = Evidence::RegexCheck.new(entry, prompt, rule.rule_type)
+        local_feedback = regex_check.feedback_object
+        expect(feedback.text).to(eq(local_feedback[:feedback]))
+        expect(rule.rule_type).to(eq(local_feedback[:feedback_type]))
+        expect(local_feedback[:optimal]).to(be_falsey)
+        expect(entry).to(eq(local_feedback[:entry]))
+        expect(rule.concept_uid).to(eq(local_feedback[:concept_uid]))
+        expect(rule.uid).to(eq(local_feedback[:rule_uid]))
+      end
+
+      it 'should return the highest priority feedback when two feedbacks exist' do
+        new_rule = create(:evidence_rule, :rule_type => "rules-based-1", :prompts => ([prompt]), :suborder => 1)
+        new_regex_rule = create(:evidence_regex_rule, :rule => new_rule, :regex_text => "^Testing")
+        entry = "Test this is a good regex match"
+        regex_check = Evidence::RegexCheck.new(entry, prompt, rule.rule_type)
+        feedback = regex_check.feedback_object
+        expect(rule.uid).to(eq(feedback[:rule_uid]))
+      end
+
+      it 'should include any highlights that are attached to the feedback it returns' do
+        highlight = create(:evidence_highlight, feedback: feedback)
+        entry = "Test this is a good regex match"
+        regex_check = Evidence::RegexCheck.new(entry, prompt, rule.rule_type)
+        local_feedback = regex_check.feedback_object
+        expect(feedback.text).to(eq(local_feedback[:feedback]))
+        expect(rule.rule_type).to(eq(local_feedback[:feedback_type]))
+        expect(local_feedback[:optimal]).to(be_falsey)
+        expect(entry).to(eq(local_feedback[:entry]))
+        expect(rule.concept_uid).to(eq(local_feedback[:concept_uid]))
+        expect(rule.uid).to(eq(local_feedback[:rule_uid]))
+        expect(local_feedback[:highlight].length).to eq(1)
+        expect(local_feedback[:highlight].first[:text]).to eq(highlight.text)
+        expect(local_feedback[:highlight].first[:type]).to eq(highlight.highlight_type)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
@@ -22,7 +22,7 @@ module Evidence
       context 'PREFILTERS query hit' do 
         before do 
           Evidence::PrefilterCheck && stub_const('Evidence::PrefilterCheck::PREFILTERS', {
-            '123' => lambda { |x| false }
+            '123' => ->(x) { false }
           })
         end
 


### PR DESCRIPTION
## WHAT
Part 1 of the prefilter project

Includes the LMS prefilter API. 

Separate PRs will add:
- client side adapter
- rake task for populated new rules
- lambdas for the prefilters
- configure golang to use this new endpoint


## WHY
So that golang can hit an API for prefilters, using the same architecture as our existing APIs.

## HOW
new API 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
