### PR TITLE
Clean invalid emails from clever student importing

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -134,8 +134,6 @@ class User < ApplicationRecord
   # gem validates_email_format_of
   validates_email_format_of :email, if: :email_required_or_present?, message: :invalid
 
-
-
   validates :username,              presence:     { if: ->(m) { m.email.blank? && m.permanent? } },
                                     uniqueness:   { allow_blank: true, message: :taken },
                                     format:       { without: /\s/, message: :no_spaces_allowed, if: :validate_username? }
@@ -174,6 +172,10 @@ class User < ApplicationRecord
           AND username LIKE 'deleted_user_%'
       SQL
     )
+  end
+
+  def self.valid_email?(email)
+    ValidatesEmailFormatOf.validate_email_format(email).nil?
   end
 
   def testing_flag

--- a/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
@@ -23,14 +23,15 @@ module CleverIntegration
     end
 
     private def parsed_students_data
-      students_data.map { |student_data| parsed_student_data(student_data['id'], student_data['name']) }
+      students_data.map { |data| parsed_student_data(data['id'], data['name'], data['email']) }
     end
 
-    private def parsed_student_data(id, name)
+    private def parsed_student_data(id, name, email)
       {
         clever_id: id,
+        email: ::User.valid_email?(email) ? email.downcase : nil,
         name: "#{name['first']} #{name['middle']} #{name['last']}".squish,
-        username: id
+        username: id.downcase
       }
     end
 

--- a/services/QuillLMS/app/services/clever_integration/parsers/student.rb
+++ b/services/QuillLMS/app/services/clever_integration/parsers/student.rb
@@ -3,11 +3,12 @@ module CleverIntegration::Parsers::Student
   def self.run(student)
     name_hash = student.name
     name = generate_name(name_hash.first, name_hash.last)
-    username = student.credentials ? student.credentials.district_username : nil
+    username = student.credentials ? student.credentials.district_username.downcase : nil
     username = username.split('@').first if username =~ ::User::VALID_EMAIL_REGEX
+    email = ::User.valid_email?(student.email) ? student.email.downcase : nil
     {
       clever_id: student.id,
-      email: student.email.try(:downcase),
+      email: email,
       username: username,
       name: name
     }

--- a/services/QuillLMS/app/services/clever_integration/student_creator.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_creator.rb
@@ -8,7 +8,7 @@ module CleverIntegration
     def initialize(data)
       @data = data
       @name = data[:name]
-      @username = data[:username]&.downcase
+      @username = data[:username]
     end
 
     def run

--- a/services/QuillLMS/app/services/clever_integration/student_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_importer.rb
@@ -5,8 +5,8 @@ module CleverIntegration
     def initialize(data)
       @data = data
       @clever_id = data[:clever_id]
-      @email = data[:email]&.downcase
-      @username = data[:username]&.downcase
+      @email = data[:email]
+      @username = data[:username]
     end
 
     def run

--- a/services/QuillLMS/app/services/clever_integration/student_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_updater.rb
@@ -9,7 +9,7 @@ module CleverIntegration
       @student = student
       @data = data
       @clever_id = data[:clever_id]
-      @username = data[:username]&.downcase
+      @username = data[:username]
     end
 
     def run

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1267,6 +1267,13 @@ describe User, type: :model do
     end
   end
 
+  describe '.valid_email?' do
+    it { expect { User.valid_email?('').to be_false } }
+    it { expect { User.valid_email?(nil).to be_false } }
+    it { expect { User.valid_email?('1').to be_false } }
+    it { expect { User.valid_email?('a@b.c').to be_true } }
+  end
+
   describe '#google_authorized?' do
     context 'user without auth_credentials is unauthorized' do
       it { expect(user.google_authorized?).to be false }

--- a/services/QuillLMS/spec/services/clever_integration/classroom_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/classroom_students_importer_spec.rb
@@ -26,10 +26,26 @@ RSpec.describe CleverIntegration::ClassroomStudentsImporter do
   end
 
   context 'students_data has two students' do
+    let(:valid_email) { 'a@b.com' }
+    let(:invalid_email) { 'not-an-email' }
+
     let(:students_data) { [student_data1, student_data2] }
 
-    let(:student_data1) { { 'id' => '123', 'name' => { 'first' => 'Al', 'middle' => 'Ty', 'last' => 'Oz'} } }
-    let(:student_data2) { { 'id' => '456', 'name' => { 'first' => 'Ky', 'middle' => 'Jo', 'last' => 'Su'} } }
+    let(:student_data1) do
+      {
+        'id' => '123',
+        'email' => valid_email,
+        'name' => { 'first' => 'Al', 'middle' => 'Ty', 'last' => 'Oz' }
+      }
+    end
+
+    let(:student_data2) do
+      {
+        'id' => '456',
+        'email' => invalid_email,
+        'name' => { 'first' => 'Ky', 'middle' => 'Jo', 'last' => 'Su' }
+      }
+    end
 
     it { expect { subject.run }.to change(User.student, :count).from(0).to(2) }
     it { expect { subject.run }.to change(StudentsClassrooms, :count).from(0).to(2) }

--- a/services/QuillLMS/spec/services/clever_integration/parsers/student_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/parsers/student_spec.rb
@@ -1,26 +1,37 @@
 require 'rails_helper'
 
 describe 'CleverIntegration::Parsers::Student' do
-
-  let!(:response) {
-      Clever::Student.new({id: '1',
-       email: 'student@gmail.com',
-       name: Clever::Name.new({first: 'john', last: 'smith'}),
-       credentials: Clever::Credentials.new({district_username: 'username'})})
-  }
-
-  let!(:expected) {
-      {clever_id: '1',
-       email: 'student@gmail.com',
-       name: 'John Smith',
-       username: 'username'}
-  }
-
-  def subject
-    CleverIntegration::Parsers::Student.run(response)
+  let(:data) do
+    Clever::Student.new(
+      id: '1',
+      email: email,
+      name: Clever::Name.new(first: 'john', last: 'smith'),
+      credentials: Clever::Credentials.new(district_username: 'Username')
+    )
   end
 
-  it 'works' do
-    expect(subject).to eq(expected)
+  let!(:parsed_data) do
+    {
+      clever_id: '1',
+      email: parsed_email,
+      name: 'John Smith',
+      username: 'username'
+    }
+  end
+
+  subject { CleverIntegration::Parsers::Student.run(data) }
+
+  context 'valid email' do
+    let(:email) { 'Student@gmail.com' }
+    let(:parsed_email) { email.downcase }
+
+    it { expect(subject).to eq(parsed_data) }
+  end
+
+  context 'invalid email' do
+    let(:email) { 'not-an-email' }
+    let(:parsed_email) { nil }
+
+    it { expect(subject).to eq(parsed_data) }
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_creator_spec.rb
@@ -3,15 +3,16 @@ require 'rails_helper'
 describe CleverIntegration::StudentCreator do
   let(:data) do
     {
-      clever_id: '1',
+      clever_id: clever_id,
       email: email,
       name: 'John Smith',
       username: username
     }
   end
 
-  let(:email) { 'Student@gmail.com' }
-  let(:username) { 'Username' }
+  let(:clever_id) { '1' }
+  let(:email) { 'student@gmail.com' }
+  let(:username) { 'username' }
 
   subject { described_class.new(data) }
 
@@ -24,7 +25,7 @@ describe CleverIntegration::StudentCreator do
 
     it 'will create a new student with an updated username' do
       subject.run
-      new_student = ::User.find_by(email: email.downcase)
+      new_student = ::User.find_by(email: email)
 
       expect(new_student.username).not_to eq username
     end

--- a/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe CleverIntegration::StudentImporter do
-  let(:existing_email) { 'Existing_student@gmail.com' }
-  let(:existing_username) { 'Existing.student' }
+  let(:existing_email) { 'existing_student@gmail.com' }
+  let(:existing_username) { 'existing.student' }
   let(:existing_clever_id) { '2323abasd32' }
 
   let!(:existing_student1) { create(:student, email: existing_email) }

--- a/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
@@ -11,9 +11,9 @@ describe CleverIntegration::StudentUpdater do
   end
 
   let(:clever_id) { '1' }
-  let(:email) { 'Student@gmail.com' }
+  let(:email) { 'student@gmail.com' }
   let(:name) { 'Student Name' }
-  let(:username) { 'Student.username' }
+  let(:username) { 'student.username' }
 
   subject { described_class.new(student, data) }
 
@@ -86,9 +86,9 @@ describe CleverIntegration::StudentUpdater do
 
     student.reload
     expect(student.clever_id).to eq clever_id
-    expect(student.email).to eq email&.downcase
+    expect(student.email).to eq email
     expect(student.name).to eq name
-    expect(student.username).to eq username&.downcase
+    expect(student.username).to eq username
   end
 
   def updates_student_with_data_except_username
@@ -96,8 +96,8 @@ describe CleverIntegration::StudentUpdater do
 
     student.reload
     expect(student.clever_id).to eq clever_id
-    expect(student.email).to eq email&.downcase
+    expect(student.email).to eq email
     expect(student.name).to eq name
-    expect(student.username).not_to eq username&.downcase
+    expect(student.username).not_to eq username
   end
 end


### PR DESCRIPTION
## WHAT
Clever does not run proper validation on student emails .  When attempting to import student data from clever, some of the data has invalid email addresses (e.g.  `1`).  This halts the import process due to email validation on the User model.

## WHY
We'd like for clever importing to continue without a hitch.

## HOW
Add new helper method `valid_email?` which checks clever data before import.  Invalid emails will be set to nil.  I've also moved some of the `downcase` calls upstream to ensure clean data throughout the process.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
