### PR TITLE
Evidence/ add scroll to feedback section of prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import ReactCSSTransitionReplace from 'react-css-transition-replace'
 
+import { BECAUSE, BUT, SO } from '../../../Shared/utils/constants'
+
 const loopSrc = `${process.env.CDN_URL}/images/icons/loop.svg`
 const smallCheckCircleSrc = `${process.env.CDN_URL}/images/icons/check-circle-small.svg`
 const closeIconSrc = `${process.env.CDN_URL}/images/icons/clear-enabled.svg`
@@ -38,6 +40,7 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
   React.useEffect(() => {
     setReportAProblemExpanded(false)
     setReportSubmitted(false)
+    scrollToFeedback();
   }, [lastSubmittedResponse])
 
   React.useEffect(() => {
@@ -46,6 +49,24 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
       el.scrollIntoView(false)
     }
   }, [reportAProblemExpanded])
+
+  function scrollToFeedback() {
+    const scrollContainer = document.getElementsByClassName("steps-outer-container")[0];
+    if (scrollContainer) {
+      const { conjunction } = prompt;
+      const element: any = document.getElementsByClassName("step")[0]
+      const stepHeight = element.offsetHeight;
+      const heightsHash = {
+        // we are already viewing this prompt so we don't need to account for its height
+        [BECAUSE]: 0,
+        // we subtract 8 to show a bit of space above the container
+        [BUT]: (stepHeight * 2) - 8,
+        [SO]: (stepHeight * 3) - 8,
+      };
+      const height = heightsHash[conjunction];
+      scrollContainer.scrollTo(0, height);
+    }
+  }
 
   function toggleReportAProblemExpanded() { setReportAProblemExpanded(!reportAProblemExpanded) }
 

--- a/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
@@ -1,1 +1,4 @@
 export const DEFAULT_HIGHLIGHT_PROMPT = "As you read, highlight two sentences "
+export const BECAUSE = 'because';
+export const BUT = 'but';
+export const SO = 'so';


### PR DESCRIPTION
## WHAT
add scroll to feedback section of prompt

## WHY
the feedback was getting cutoff and students had to scroll to it when viewing in smaller windows

## HOW
add a function in the 'Feedback' element that calculates which position to scroll to based on which prompt is being played

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Feedback-sometimes-gets-cut-off-and-requires-user-to-scroll-ef046893e6b34fb59ee0e98f76b7d828

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
