### PR TITLE
adding rake task

### DIFF
--- a/services/QuillLMS/lib/tasks/prefilter_data.rake
+++ b/services/QuillLMS/lib/tasks/prefilter_data.rake
@@ -1,0 +1,42 @@
+namespace :data do
+  desc 'Add prefilter rules and feedbacks'
+  task :prefilter => :environment do |t, args|
+    TOO_SHORT_FEEDBACK = "Whoops, it looks like you submitted your response before it was ready! Re-read what you wrote and finish the sentence provided."
+    PROFANITY_FEEDBACK = "Revise your work. When writing your response, make sure to use appropriate language."
+    MULTIPLE_SENTENCES_FEEDBACK = "Revise your work. Your response should be only one sentence long."
+    QUESTION_MARK_FEEDBACK = "Revise your response. Instead of using a question mark, write a statement that ends with a period. Remember, anytime you do an activity like this one on Quill, you'll write statements instead of questions."
+    
+    prefilters = [
+      { name: 'too short', feedback: TOO_SHORT_FEEDBACK }, 
+      { name: 'profanity', feedback: PROFANITY_FEEDBACK }, 
+      { name: 'multiple sentences', feedback: MULTIPLE_SENTENCES_FEEDBACK },
+      { name: 'ends in a question mark', feedback: QUESTION_MARK_FEEDBACK }
+    ]
+
+    ActiveRecord::Base.transaction do 
+      Evidence::Rule.find_or_create_by!(
+        name: 'prefilter - optimal',
+        universal: true,
+        rule_type: 'prefilter',
+        optimal: true,
+        state: 'active' 
+      )
+
+      prefilters.each do |prefilter| 
+        rule = Evidence::Rule.find_or_create_by!(
+          name: 'prefilter - ' << prefilter[:name],
+          universal: true,
+          rule_type: 'prefilter',
+          optimal: false,
+          state: 'active'
+        )
+    
+        Evidence::Feedback.find_or_create_by!(
+          rule_id: rule.id,
+          order: 0,
+          text: prefilter[:feedback]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Creates Rules and Feedbacks that exactly mirror the client side logic found here: https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/client/app/bundles/Evidence/modules/prefilters.ts#L9

(with the exception of the "too long" check) 

## WHY
Part of the prefilters project. 

## HOW
Rake task. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/create-rules-and-feedbacks-for-prefilter-checks-bcef658c5d744cd2b167ecec1b6f12c6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a - data only rake task
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
