### PR TITLE
Fix circleci failure with quill-marking-logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
   marking_logic_node_build:
     working_directory: ~/Empirical-Core
     docker:
-      - image: circleci/node:latest-browsers
+      - image: cimg/node:14.18-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## WHAT
Pin the node version for the `quill-marking-logic` to a specific version

## WHY
There's a failure 
![Screen Shot 2021-11-05 at 10 01 43 AM](https://user-images.githubusercontent.com/2057805/140522605-fca383e7-f200-4011-b95d-907d5181e03c.png) that occurred.  Since our node image is pinned to `latest-browser`, we automatically upgrade to newer versions which can pose problems with other libraries, in this case webpack, which are pinned to specific versions.

## HOW
I noticed the fix via this [post](https://github.com/webpack/webpack/issues/14532#issuecomment-960533495).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Testing configuration change.
Have you deployed to Staging? | No.  Testing change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
