### PR TITLE
Fix nil error edge case on some google users

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
     # Assuming that the refresh_token expires at (current_user.auth_credential.created_at  + 6 months),
     # we can reset the session whenever (Time.now > (current_user.auth_credential.created_at + 5 months))
-    return reset_session if current_user.google_id && current_user.auth_credential && (Time.now > (current_user.auth_credential.expires_at) || current_user.auth_credential.expires_at.nil?)
+    return reset_session if current_user.google_id && current_user.auth_credential && (current_user.auth_credential.expires_at.nil? || Time.now > (current_user.auth_credential.expires_at))
   end
 
   protected def user_inactive_for_too_long?

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -71,5 +71,15 @@ describe ApplicationController, type: :controller do
       expect(controller.confirm_valid_session).to be(nil)
       expect(session[:user_id]).to eq(nil)
     end
+
+    it 'when user has a google ID and their auth credential has no expiration date' do
+      user = create(:user, google_id: 123)
+      session[:user_id] = user.id
+      auth_credential = create(:auth_credential, provider: 'google', user: user, refresh_token: 'refresh', expires_at: nil)
+      allow(controller).to receive(:current_user) { user }
+
+      expect(controller.confirm_valid_session).to be(nil)
+      expect(session[:user_id]).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Some google users are seeing a nil error when logging into their accounts because their `expires_at` value is nil.

## WHY
I had accidentally put the two function calls in reverse order - the nil check came after the call on the value, resulting in the nil check not actually working.                      

## HOW
Put the nil check before the value call.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes