### PR TITLE
Evidence/ CSS fix for image caption

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -57,6 +57,7 @@
           font-size: 14px;
           color: #808080;
           text-align: right;
+          max-width: 88px;
           .image-attribution-tooltip {
             border-bottom: dashed 1px #808080;
           }


### PR DESCRIPTION
## WHAT
small CSS fix for image caption

## WHY
we want the image caption to display correctly on smaller screen sizes

## HOW
just add a `max-width` property to caption

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1237" alt="Screen Shot 2021-11-08 at 4 42 44 PM" src="https://user-images.githubusercontent.com/25959584/140829834-ca640742-bf3f-455a-953a-185580a5ee48.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/The-Evidence-image-caption-is-not-formatting-properly-on-mobile-and-smaller-screens-eec89ae3849f4a88843a1bbd7a4ed0c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small CSS change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes