### PR TITLE
Revert google login bugfix

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
     # Assuming that the refresh_token expires at (current_user.auth_credential.created_at  + 6 months),
     # we can reset the session whenever (Time.now > (current_user.auth_credential.created_at + 5 months))
-    return reset_session if current_user.google_id && current_user.auth_credential && (current_user.auth_credential.expires_at.nil? || Time.now > (current_user.auth_credential.expires_at))
+    return reset_session if current_user.google_id && current_user.auth_credential && (Time.now > (current_user.auth_credential.expires_at) || current_user.auth_credential.expires_at.nil?)
   end
 
   protected def user_inactive_for_too_long?

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
     # Assuming that the refresh_token expires at (current_user.auth_credential.created_at  + 6 months),
     # we can reset the session whenever (Time.now > (current_user.auth_credential.created_at + 5 months))
-    return reset_session if current_user.google_id && current_user.auth_credential && (Time.now > (current_user.auth_credential.expires_at) || current_user.auth_credential.expires_at.nil?)
+    return reset_session if current_user.google_id && current_user.auth_credential && Time.now > (current_user.auth_credential.created_at + 5.months)
   end
 
   protected def user_inactive_for_too_long?

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -56,20 +56,4 @@ describe ApplicationController, type: :controller do
     end
 
   end
-
-  describe '#confirm_valid_session' do
-    before(:each) do
-      ApplicationController.send(:public, *ApplicationController.protected_instance_methods)
-    end
-
-    it 'when user has a google ID and their auth credential is expired' do
-      user = create(:user, google_id: 123)
-      session[:user_id] = user.id
-      auth_credential = create(:auth_credential, provider: 'google', user: user, refresh_token: 'refresh', expires_at: Time.now - 1.day)
-      allow(controller).to receive(:current_user) { user }
-
-      expect(controller.confirm_valid_session).to be(nil)
-      expect(session[:user_id]).to eq(nil)
-    end
-  end
 end

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -71,15 +71,5 @@ describe ApplicationController, type: :controller do
       expect(controller.confirm_valid_session).to be(nil)
       expect(session[:user_id]).to eq(nil)
     end
-
-    it 'when user has a google ID and their auth credential has no expiration date' do
-      user = create(:user, google_id: 123)
-      session[:user_id] = user.id
-      auth_credential = create(:auth_credential, provider: 'google', user: user, refresh_token: 'refresh', expires_at: nil)
-      allow(controller).to receive(:current_user) { user }
-
-      expect(controller.confirm_valid_session).to be(nil)
-      expect(session[:user_id]).to eq(nil)
-    end
   end
 end


### PR DESCRIPTION
## WHAT
Revert a bugfix that was addressing auth credentials for users logging in with google accounts

## WHY
Staff users were unable to impersonate users.

## HOW
Git revert the two commits associated with this bugfix

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  revert commit
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
