### PR TITLE
Revert google login bugfix (#8483)

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
     # Assuming that the refresh_token expires at (current_user.auth_credential.created_at  + 6 months),
     # we can reset the session whenever (Time.now > (current_user.auth_credential.created_at + 5 months))
-    return reset_session if current_user.google_id && current_user.auth_credential && (current_user.auth_credential.expires_at.nil? || Time.now > (current_user.auth_credential.expires_at))
+    return reset_session if current_user.google_id && current_user.auth_credential && Time.now > (current_user.auth_credential.created_at + 5.months)
   end
 
   protected def user_inactive_for_too_long?

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -56,30 +56,4 @@ describe ApplicationController, type: :controller do
     end
 
   end
-
-  describe '#confirm_valid_session' do
-    before(:each) do
-      ApplicationController.send(:public, *ApplicationController.protected_instance_methods)
-    end
-
-    it 'when user has a google ID and their auth credential is expired' do
-      user = create(:user, google_id: 123)
-      session[:user_id] = user.id
-      auth_credential = create(:auth_credential, provider: 'google', user: user, refresh_token: 'refresh', expires_at: Time.now - 1.day)
-      allow(controller).to receive(:current_user) { user }
-
-      expect(controller.confirm_valid_session).to be(nil)
-      expect(session[:user_id]).to eq(nil)
-    end
-
-    it 'when user has a google ID and their auth credential has no expiration date' do
-      user = create(:user, google_id: 123)
-      session[:user_id] = user.id
-      auth_credential = create(:auth_credential, provider: 'google', user: user, refresh_token: 'refresh', expires_at: nil)
-      allow(controller).to receive(:current_user) { user }
-
-      expect(controller.confirm_valid_session).to be(nil)
-      expect(session[:user_id]).to eq(nil)
-    end
-  end
 end


### PR DESCRIPTION
* Revert "fix aand test (#8479)"

This reverts commit 56dbc5f86d05aede270ed75f0a96a790729d0f06.

* Revert "Log Google users out if their auth credential is expired (#8462)"

This reverts commit e70b444dc805bd40a46f2155a5a4ed98c2d503cd.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
