### PR TITLE
add evidence completion button before ActivityFollowup

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
@@ -5,7 +5,6 @@ import ThankYouSlide from '../activitySlides/thankYouSlide'
 import ActivitySurvey from '../activitySlides/activitySurvey'
 
 const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyResponse, }) => {
-  console.log("in ActivityFollowUp")
   const [showActivitySurvey, setShowActivitySurvey] = React.useState(false)
   const [submittedActivitySurvey, setSubmittedActivitySurvey] = React.useState(false)
 
@@ -14,7 +13,6 @@ const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyRespon
   if (submittedActivitySurvey) {
     return <ThankYouSlide />
   }
-  console.log("HERE 1")
   if (showActivitySurvey) {
     return (<ActivitySurvey
       saveActivitySurveyResponse={saveActivitySurveyResponse}
@@ -22,7 +20,6 @@ const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyRespon
       setSubmittedActivitySurvey={setSubmittedActivitySurvey}
     />)
   }
-  console.log("HERE 2")
   return <PostActivitySlide handleClick={onClickNext} responses={responses} user={user} />
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
@@ -5,6 +5,7 @@ import ThankYouSlide from '../activitySlides/thankYouSlide'
 import ActivitySurvey from '../activitySlides/activitySurvey'
 
 const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyResponse, }) => {
+  console.log("in ActivityFollowUp")
   const [showActivitySurvey, setShowActivitySurvey] = React.useState(false)
   const [submittedActivitySurvey, setSubmittedActivitySurvey] = React.useState(false)
 
@@ -13,7 +14,7 @@ const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyRespon
   if (submittedActivitySurvey) {
     return <ThankYouSlide />
   }
-
+  console.log("HERE 1")
   if (showActivitySurvey) {
     return (<ActivitySurvey
       saveActivitySurveyResponse={saveActivitySurveyResponse}
@@ -21,7 +22,7 @@ const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyRespon
       setSubmittedActivitySurvey={setSubmittedActivitySurvey}
     />)
   }
-
+  console.log("HERE 2")
   return <PostActivitySlide handleClick={onClickNext} responses={responses} user={user} />
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
@@ -13,6 +13,7 @@ const ActivityFollowUp = ({ responses, user, sessionID, saveActivitySurveyRespon
   if (submittedActivitySurvey) {
     return <ThankYouSlide />
   }
+
   if (showActivitySurvey) {
     return (<ActivitySurvey
       saveActivitySurveyResponse={saveActivitySurveyResponse}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -77,6 +77,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   const [activeStep, setActiveStep] = React.useState(shouldSkipToPrompts ? READ_PASSAGE_STEP + 1: READ_PASSAGE_STEP)
   const [activityIsComplete, setActivityIsComplete] = React.useState(false)
   const [activityIsReadyForSubmission, setActivityIsReadyForSubmission] = React.useState(false)
+  const [completeButtonClicked, setCompleteButtonClicked] = React.useState(false)
   const [completedSteps, setCompletedSteps] = React.useState(defaultCompletedSteps)
   const [showFocusState, setShowFocusState] = React.useState(false)
   const [startTime, setStartTime] = React.useState(Date.now())
@@ -515,17 +516,15 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       <ExplanationSlide onHandleClick={handleExplanationSlideClick} slideData={explanationData[explanationSlideStep]} />
     );
   }
-  if(activityIsComplete && !window.location.href.includes('turk')) {
-    console.log("\nACTIVITY COMPLETE\n")
-
-
-  }
-
-  const renderActivityFollowup = () => {
-    console.log("renderActivityFollowup.........")
+  if(completeButtonClicked && !window.location.href.includes('turk')) {
     return(
       <ActivityFollowUp responses={submittedResponses} saveActivitySurveyResponse={saveActivitySurveyResponse} sessionID={sessionID} user={user} />
     );
+
+  }
+
+  const completeButtonCallback = () => {
+    setCompleteButtonClicked(true)
   }
 
   return (
@@ -558,6 +557,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         activities={activities}
         activityIsComplete={activityIsComplete}
         closeReadTheDirectionsModal={closeReadTheDirectionsModal}
+        completeButtonCallback={completeButtonCallback}
         completedSteps={completedSteps}
         completeStep={completeStep}
         doneHighlighting={doneHighlighting}
@@ -567,7 +567,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         hasStartedReadPassageStep={hasStartedReadPassageStep}
         onStartPromptSteps={onStartPromptSteps}
         onStartReadPassage={onStartReadPassage}
-        renderActivityFollowup={renderActivityFollowup}
         reportAProblem={submitProblemReport}
         resetTimers={resetTimers}
         scrolledToEndOfPassage={scrolledToEndOfPassage}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -521,7 +521,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   }
 
-  const completeButtonCallback = () => {
+  const completionButtonCallback = () => {
     setCompleteButtonClicked(true)
   }
 
@@ -555,9 +555,9 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         activities={activities}
         activityIsComplete={activityIsComplete}
         closeReadTheDirectionsModal={closeReadTheDirectionsModal}
-        completeButtonCallback={completeButtonCallback}
         completedSteps={completedSteps}
         completeStep={completeStep}
+        completionButtonCallback={completionButtonCallback}
         doneHighlighting={doneHighlighting}
         handleClickDoneHighlighting={handleClickDoneHighlighting}
         handleDoneReadingClick={handleDoneReadingClick}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -36,7 +36,6 @@ interface StudentViewContainerProps {
 interface StudentViewContainerState {
   activeStep?: number;
   activityIsComplete: boolean;
-  activityIsReadyForSubmission: boolean;
   explanationSlidesCompleted: boolean;
   explanationSlideStep:  number;
   completedSteps: Array<number>;
@@ -76,7 +75,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   const [explanationSlidesCompleted, setExplanationSlidesCompleted] = React.useState(shouldSkipToPrompts || (activityCompletionCount > ACTIVITY_COMPLETION_MAXIMUM_FOR_ONBOARDING))
   const [activeStep, setActiveStep] = React.useState(shouldSkipToPrompts ? READ_PASSAGE_STEP + 1: READ_PASSAGE_STEP)
   const [activityIsComplete, setActivityIsComplete] = React.useState(false)
-  const [activityIsReadyForSubmission, setActivityIsReadyForSubmission] = React.useState(false)
   const [completeButtonClicked, setCompleteButtonClicked] = React.useState(false)
   const [completedSteps, setCompletedSteps] = React.useState(defaultCompletedSteps)
   const [showFocusState, setShowFocusState] = React.useState(false)

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -516,6 +516,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     );
   }
   if(activityIsComplete && !window.location.href.includes('turk')) {
+    console.log("\nACTIVITY COMPLETE\n")
     return(
       <ActivityFollowUp responses={submittedResponses} saveActivitySurveyResponse={saveActivitySurveyResponse} sessionID={sessionID} user={user} />
     );

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -517,10 +517,17 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   }
   if(activityIsComplete && !window.location.href.includes('turk')) {
     console.log("\nACTIVITY COMPLETE\n")
+
+
+  }
+
+  const renderActivityFollowup = () => {
+    console.log("renderActivityFollowup.........")
     return(
       <ActivityFollowUp responses={submittedResponses} saveActivitySurveyResponse={saveActivitySurveyResponse} sessionID={sessionID} user={user} />
     );
   }
+
   return (
     <div className={className}>
       {renderStepLinksAndDirections({
@@ -549,6 +556,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         activateStep={activateStep}
         activeStep={activeStep}
         activities={activities}
+        activityIsComplete={activityIsComplete}
         closeReadTheDirectionsModal={closeReadTheDirectionsModal}
         completedSteps={completedSteps}
         completeStep={completeStep}
@@ -559,6 +567,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         hasStartedReadPassageStep={hasStartedReadPassageStep}
         onStartPromptSteps={onStartPromptSteps}
         onStartReadPassage={onStartReadPassage}
+        renderActivityFollowup={renderActivityFollowup}
         reportAProblem={submitProblemReport}
         resetTimers={resetTimers}
         scrolledToEndOfPassage={scrolledToEndOfPassage}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -10,7 +10,9 @@ import { highlightSpellingGrammar } from '../../libs/stringFormatting'
 
 interface PromptStepProps {
   active: Boolean;
+  activityIsComplete: Boolean;
   className: string,
+  completionButtonCallback: () => void; 
   everyOtherStepCompleted: boolean;
   submitResponse: Function;
   completeStep: (event: any) => void;
@@ -279,7 +281,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   }
 
   renderButton = () => {
-    const { prompt, submittedResponses, everyOtherStepCompleted, } = this.props
+    const { prompt, submittedResponses, everyOtherStepCompleted, completionButtonCallback, activityIsComplete} = this.props
     const { id, text, max_attempts } = prompt
     const { html, numberOfSubmissions, } = this.state
     const entry = this.stripHtml(html).trim()
@@ -288,13 +290,17 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     let buttonCopy = submittedResponses.length ? 'Get new feedback' : 'Get feedback'
     let className = 'quill-button focus-on-light'
     let onClick = () => this.handleGetFeedbackClick(entry, id, text)
-    if (submittedResponses.length === max_attempts || this.lastSubmittedResponse().optimal) {
+   
+    if (activityIsComplete) {
+      onClick = completionButtonCallback
+      buttonCopy = 'Done'
+    } else if (submittedResponses.length === max_attempts || this.lastSubmittedResponse().optimal) {
       onClick = this.completeStep
-      buttonCopy = everyOtherStepCompleted ? 'Done' : 'Start next sentence'
+      buttonCopy = 'Start next sentence'
     } else if (this.unsubmittableResponses().includes(entry) || awaitingFeedback) {
       className += ' disabled'
       onClick = () => {}
-    }
+    } 
     return <button className={className} onClick={onClick} type="button">{buttonLoadingSpinner}<span>{buttonCopy}</span></button>
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -11,6 +11,7 @@ const RightPanel = ({
   activities,
   activateStep,
   activeStep,
+  activityIsComplete,
   closeReadTheDirectionsModal,
   completeStep,
   completedSteps,
@@ -21,6 +22,7 @@ const RightPanel = ({
   hasStartedReadPassageStep,
   onStartPromptSteps,
   onStartReadPassage,
+  renderActivityFollowup,
   reportAProblem,
   resetTimers,
   scrolledToEndOfPassage,
@@ -88,11 +90,13 @@ const RightPanel = ({
       activateStep={activateStep}
       activeStep={activeStep}
       activities={activities}
+      activityIsComplete={activityIsComplete}
       closeReadTheDirectionsModal={closeReadTheDirectionsModal}
       completedSteps={completedSteps}
       completeStep={completeStep}
       doneHighlighting={doneHighlighting}
       handleDoneReadingClick={handleDoneReadingClick}
+      renderActivityFollowup={renderActivityFollowup}
       reportAProblem={reportAProblem}
       resetTimers={resetTimers}
       session={session}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -14,6 +14,7 @@ const RightPanel = ({
   activityIsComplete,
   closeReadTheDirectionsModal,
   completeStep,
+  completeButtonCallback,
   completedSteps,
   doneHighlighting,
   handleClickDoneHighlighting,
@@ -22,7 +23,6 @@ const RightPanel = ({
   hasStartedReadPassageStep,
   onStartPromptSteps,
   onStartReadPassage,
-  renderActivityFollowup,
   reportAProblem,
   resetTimers,
   scrolledToEndOfPassage,
@@ -92,11 +92,11 @@ const RightPanel = ({
       activities={activities}
       activityIsComplete={activityIsComplete}
       closeReadTheDirectionsModal={closeReadTheDirectionsModal}
+      completeButtonCallback={completeButtonCallback}
       completedSteps={completedSteps}
       completeStep={completeStep}
       doneHighlighting={doneHighlighting}
       handleDoneReadingClick={handleDoneReadingClick}
-      renderActivityFollowup={renderActivityFollowup}
       reportAProblem={reportAProblem}
       resetTimers={resetTimers}
       session={session}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -14,8 +14,8 @@ const RightPanel = ({
   activityIsComplete,
   closeReadTheDirectionsModal,
   completeStep,
-  completeButtonCallback,
   completedSteps,
+  completionButtonCallback,
   doneHighlighting,
   handleClickDoneHighlighting,
   handleDoneReadingClick,
@@ -92,9 +92,9 @@ const RightPanel = ({
       activities={activities}
       activityIsComplete={activityIsComplete}
       closeReadTheDirectionsModal={closeReadTheDirectionsModal}
-      completeButtonCallback={completeButtonCallback}
       completedSteps={completedSteps}
       completeStep={completeStep}
+      completionButtonCallback={completionButtonCallback}
       doneHighlighting={doneHighlighting}
       handleDoneReadingClick={handleDoneReadingClick}
       reportAProblem={reportAProblem}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
@@ -8,7 +8,7 @@ const Steps = ({
   activities,
   activityIsComplete,
   handleDoneReadingClick,
-  completeButtonCallback,
+  completionButtonCallback,
   completeStep,
   submitResponse,
   closeReadTheDirectionsModal,
@@ -27,7 +27,7 @@ const Steps = ({
         {renderPromptSteps({
           activateStep,
           activityIsComplete,
-          completeButtonCallback,
+          completionButtonCallback,
           completeStep,
           submitResponse,
           closeReadTheDirectionsModal,

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
@@ -8,7 +8,7 @@ const Steps = ({
   activities,
   activityIsComplete,
   handleDoneReadingClick,
-  completeButtonCallback={completeButtonCallback},
+  completeButtonCallback,
   completeStep,
   submitResponse,
   closeReadTheDirectionsModal,
@@ -20,19 +20,14 @@ const Steps = ({
   stepsHash,
   reportAProblem,
 }) => {
-  function renderCompletionButton() {
-    let className = 'quill-button focus-on-light'
-    return(
-      <button className={className} onClick={completeButtonCallback} type="button"><span>{'Complete'}</span></button>
-    )
-  }
-
   return(
     <div className="steps-outer-container" onScroll={resetTimers}>
       <div className="steps-inner-container" onScroll={resetTimers}>
         {renderReadPassageStep(activeStep, activities, handleDoneReadingClick)}
         {renderPromptSteps({
           activateStep,
+          activityIsComplete,
+          completeButtonCallback,
           completeStep,
           submitResponse,
           closeReadTheDirectionsModal,
@@ -45,7 +40,6 @@ const Steps = ({
           stepsHash,
           reportAProblem,
         })}
-        {activityIsComplete && renderCompletionButton()}
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
@@ -8,13 +8,13 @@ const Steps = ({
   activities,
   activityIsComplete,
   handleDoneReadingClick,
+  completeButtonCallback={completeButtonCallback},
   completeStep,
   submitResponse,
   closeReadTheDirectionsModal,
   session,
   completedSteps,
   doneHighlighting,
-  renderActivityFollowup,
   resetTimers,
   showReadTheDirectionsModal,
   stepsHash,
@@ -23,7 +23,7 @@ const Steps = ({
   function renderCompletionButton() {
     let className = 'quill-button focus-on-light'
     return(
-      <button className={className} onClick={renderActivityFollowup} type="button"><span>{'Complete'}</span></button>
+      <button className={className} onClick={completeButtonCallback} type="button"><span>{'Complete'}</span></button>
     )
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/steps.tsx
@@ -6,6 +6,7 @@ const Steps = ({
   activeStep,
   activateStep,
   activities,
+  activityIsComplete,
   handleDoneReadingClick,
   completeStep,
   submitResponse,
@@ -13,11 +14,19 @@ const Steps = ({
   session,
   completedSteps,
   doneHighlighting,
+  renderActivityFollowup,
   resetTimers,
   showReadTheDirectionsModal,
   stepsHash,
   reportAProblem,
 }) => {
+  function renderCompletionButton() {
+    let className = 'quill-button focus-on-light'
+    return(
+      <button className={className} onClick={renderActivityFollowup} type="button"><span>{'Complete'}</span></button>
+    )
+  }
+
   return(
     <div className="steps-outer-container" onScroll={resetTimers}>
       <div className="steps-inner-container" onScroll={resetTimers}>
@@ -36,6 +45,7 @@ const Steps = ({
           stepsHash,
           reportAProblem,
         })}
+        {activityIsComplete && renderCompletionButton()}
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
@@ -111,7 +111,7 @@ export const renderPromptSteps = ({
     let containerClassName = 'step clickable active'
     return(
       <div className={containerClassName}>
-        <button className={className} onClick={completeButtonCallback} type="button"><span>'Complete Activity'</span></button>
+        <button className={className} onClick={completeButtonCallback} type="button"><span>Complete Activity</span></button>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
@@ -89,7 +89,7 @@ export const renderStepLinksAndDirections = ({
 export const renderPromptSteps = ({
   activateStep,
   activityIsComplete,
-  completeButtonCallback,
+  completionButtonCallback,
   completeStep,
   submitResponse,
   closeReadTheDirectionsModal,
@@ -106,16 +106,6 @@ export const renderPromptSteps = ({
   const { submittedResponses, hasReceivedData, } = session
   if (!currentActivity || !hasReceivedData) return
 
-  function renderCompletionButton() {
-    let className = 'quill-button focus-on-light'
-    let containerClassName = 'step clickable active'
-    return(
-      <div className={containerClassName}>
-        <button className={className} onClick={completeButtonCallback} type="button"><span>Complete Activity</span></button>
-      </div>
-    )
-  }
-
   // sort by conjunctions in alphabetical order: because, but, so
   const steps =  orderedSteps(activities).map((prompt, i) => {
     // using i + 2 because the READ_PASSAGE_STEP is 1, so the first item in the set of prompts will always be 2
@@ -125,9 +115,11 @@ export const renderPromptSteps = ({
     return (<PromptStep
       activateStep={activateStep}
       active={stepNumber === activeStep}
+      activityIsComplete={activityIsComplete}
       canBeClicked={canBeClicked}
       className={`step ${canBeClicked ? 'clickable' : ''} ${activeStep === stepNumber ? 'active' : ''}`}
       completeStep={completeStep}
+      completionButtonCallback={completionButtonCallback}
       everyOtherStepCompleted={everyOtherStepCompleted(stepNumber, completedSteps)}
       key={stepNumber}
       passedRef={stepsHash[`step${stepNumber}`]} // eslint-disable-line react/jsx-no-bind
@@ -143,7 +135,6 @@ export const renderPromptSteps = ({
   return (<div className="prompt-steps">
     {renderDirectionsSectionAndModal({ className: 'hide-on-mobile', closeReadTheDirectionsModal, activeStep, doneHighlighting, showReadTheDirectionsModal, activities })}
     {steps}
-    {activityIsComplete && renderCompletionButton()}
   </div>)
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/helpers/containerRenderHelpers.tsx
@@ -88,6 +88,8 @@ export const renderStepLinksAndDirections = ({
 
 export const renderPromptSteps = ({
   activateStep,
+  activityIsComplete,
+  completeButtonCallback,
   completeStep,
   submitResponse,
   closeReadTheDirectionsModal,
@@ -103,6 +105,16 @@ export const renderPromptSteps = ({
   const { currentActivity, } = activities
   const { submittedResponses, hasReceivedData, } = session
   if (!currentActivity || !hasReceivedData) return
+
+  function renderCompletionButton() {
+    let className = 'quill-button focus-on-light'
+    let containerClassName = 'step clickable active'
+    return(
+      <div className={containerClassName}>
+        <button className={className} onClick={completeButtonCallback} type="button"><span>'Complete Activity'</span></button>
+      </div>
+    )
+  }
 
   // sort by conjunctions in alphabetical order: because, but, so
   const steps =  orderedSteps(activities).map((prompt, i) => {
@@ -131,6 +143,7 @@ export const renderPromptSteps = ({
   return (<div className="prompt-steps">
     {renderDirectionsSectionAndModal({ className: 'hide-on-mobile', closeReadTheDirectionsModal, activeStep, doneHighlighting, showReadTheDirectionsModal, activities })}
     {steps}
+    {activityIsComplete && renderCompletionButton()}
   </div>)
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`PromptStep component active state before any responses have been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -119,6 +120,7 @@ exports[`PromptStep component active state before any responses have been submit
 exports[`PromptStep component active state when a profane response has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -325,6 +327,7 @@ exports[`PromptStep component active state when a profane response has been subm
 exports[`PromptStep component active state when a response with multiple sentences has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -531,6 +534,7 @@ exports[`PromptStep component active state when a response with multiple sentenc
 exports[`PromptStep component active state when a suboptimal response has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -766,6 +770,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
 exports[`PromptStep component active state when a too-long response has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -972,6 +977,7 @@ exports[`PromptStep component active state when a too-long response has been sub
 exports[`PromptStep component active state when a too-short response has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -1178,6 +1184,7 @@ exports[`PromptStep component active state when a too-short response has been su
 exports[`PromptStep component active state when an optimal response has been submitted matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -1401,6 +1408,7 @@ exports[`PromptStep component active state when an optimal response has been sub
 exports[`PromptStep component active state when the max attempts have been reached matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={false}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={false}
@@ -1682,6 +1690,7 @@ exports[`PromptStep component active state when the max attempts have been reach
 exports[`PromptStep component active state when the max attempts have been reached or the last answer is optimal and every other question has been completed matches snapshot 1`] = `
 <PromptStep
   active={true}
+  activityIsComplete={true}
   className="step active"
   completeStep={[Function]}
   everyOtherStepCompleted={true}
@@ -1780,7 +1789,6 @@ exports[`PromptStep component active state when the max attempts have been reach
           </EditorContainer>
           <button
             className="quill-button focus-on-light"
-            onClick={[Function]}
             type="button"
           >
             <span>
@@ -1905,6 +1913,7 @@ exports[`PromptStep component active state when the max attempts have been reach
 exports[`PromptStep component inactive state renders 1`] = `
 <PromptStep
   active={false}
+  activityIsComplete={false}
   className="step"
   completeStep={[Function]}
   everyOtherStepCompleted={false}

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
@@ -14,6 +14,7 @@ const prompt = activityOne.prompts[2]
 
 const defaultProps = {
   active: false,
+  activityIsComplete: false,
   className: 'step',
   everyOtherStepCompleted: false,
   submitResponse: () => {},
@@ -339,6 +340,7 @@ describe('PromptStep component', () => {
       const wrapper = mount(<PromptStep
         {...defaultProps}
         active
+        activityIsComplete
         className="step active"
         everyOtherStepCompleted
         submittedResponses={submittedResponses}


### PR DESCRIPTION
## WHAT
Adds 'Complete Activity' button after an activity is completed, but before the user is routed to the ActivityFollowup component. 

## WHY
This is the intended UX.

## HOW
Re-arrange callbacks, make a new button component.

### Screenshots

<img width="1423" alt="Screen Shot 2021-11-10 at 12 25 44 PM" src="https://user-images.githubusercontent.com/90669/141182417-9a21010a-113d-461d-a85b-f0b8f9890eca.png">

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=02c5cb240f91444c8ec71a41b389b6b2)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested. manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Tom is evaluating the styling.
