### PR TITLE
Add error logging for Clever importing of teacher classrooms 

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
@@ -1,11 +1,22 @@
 module CleverIntegration::Associators::ClassroomsToTeacher
 
   def self.run(classrooms, teacher)
-    updated_classrooms = classrooms.map do |classroom|
-      role = classroom&.owner && classroom&.owner != teacher ? 'coteacher' : 'owner'
-      ClassroomsTeacher.find_or_create_by(classroom: classroom, user: teacher, role: role)
+    classrooms.map do |classroom|
+      role = get_role(classroom, teacher)
+      ClassroomsTeacher.find_or_create_by!(classroom: classroom, user: teacher, role: role)
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      NewRelic::Agent.add_custom_attributes(classroom_id: classroom.id, teacher_id: teacher.id, role: role)
+      NewRelic::Agent.notice_error(e)
+    ensure
       classroom.reload
     end
-    updated_classrooms
+  end
+
+  def self.get_role(classroom, teacher)
+    owner_ids = ClassroomsTeacher.where(classroom: classroom, role: 'owner').pluck(:user_id)
+
+    return 'owner' if owner_ids.empty?
+
+    owner_ids.include?(teacher.id) ? 'owner' : 'coteacher'
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe 'CleverIntegration::Associators::ClassroomsToTeacher' do
-
   let!(:classroom1) { create(:classroom, :with_no_teacher) }
   let!(:classroom2) { create(:classroom, :with_no_teacher) }
   let!(:teacher1) { create(:teacher) }
@@ -26,6 +25,15 @@ describe 'CleverIntegration::Associators::ClassroomsToTeacher' do
     it 'creates a classroom owner record' do
       CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher2)
       expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher2.id, role: 'coteacher')).to be
+    end
+  end
+
+  context 'when classroom has two owners' do
+    let!(:classrooms_teacher2) { create(:classrooms_teacher, user: teacher2, classroom: classroom2) }
+
+    it 'gracefully handles the each case of two owners' do
+      CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher1)
+      expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher1.id, role: 'owner')).to be
     end
   end
 end


### PR DESCRIPTION
## WHAT
During Clever Importing of teachers and classrooms:
1.  Fix an edge case involving classrooms with two owners
2. Log errors to New Relic caused by `ClassroomsTeacher.find_or_create_by!`

## WHY
1.  In the case of a classroom having two owners, `classroom.owner` is non-deterministic since it uses (`find_by_role`).  When assigning a role for clever import we should have predictable assignment.
2. There's still a larger bug that I'm working on, but it would be useful to add in some logging in the interim to get more information during failure.

## HOW
1.  Check to see if the current teacher is in the set of owners rather than equal to `classroom.owner`
2.  Add in `find_or_create_by!` method and rescue errors and log them to New Relic

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Clever-Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
