### PR TITLE
skipping onboarding should not mess up timetracking

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -73,7 +73,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   const inactivityTimer = React.useRef(null)
 
   const [explanationSlideStep, setExplanationSlideStep] = React.useState(0)
-  const [explanationSlidesCompleted, setExplanationSlidesCompleted] = React.useState(shouldSkipToPrompts)
+  const [explanationSlidesCompleted, setExplanationSlidesCompleted] = React.useState(shouldSkipToPrompts || (activityCompletionCount > ACTIVITY_COMPLETION_MAXIMUM_FOR_ONBOARDING))
   const [activeStep, setActiveStep] = React.useState(shouldSkipToPrompts ? READ_PASSAGE_STEP + 1: READ_PASSAGE_STEP)
   const [activityIsComplete, setActivityIsComplete] = React.useState(false)
   const [activityIsReadyForSubmission, setActivityIsReadyForSubmission] = React.useState(false)
@@ -507,7 +507,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   const className = `activity-container ${showFocusState ? '' : 'hide-focus-outline'} ${activeStep === READ_PASSAGE_STEP ? 'on-read-passage' : ''}`
 
-  if((!explanationSlidesCompleted && activityCompletionCount <= ACTIVITY_COMPLETION_MAXIMUM_FOR_ONBOARDING)) {
+  if(!explanationSlidesCompleted) {
     if (explanationSlideStep === 0) {
       return <WelcomeSlide onHandleClick={handleExplanationSlideClick} user={user} />
     }


### PR DESCRIPTION
## WHAT
Fix issue where students who skipped onboarding weren't having their timetracking calculated correctly.

## WHY
We want students to have their time tracked regardless of whether or not they see the onboarding slides.  

## HOW
If students had completed enough Evidence activities to be able to skip the onboarding, they were never actually having the `explanationSlidesCompleted` boolean set to true, which is how we determine whether to add time to the onboarding step or one of the later ones. I cleaned up the code by determining the default value for `explanationSlidesCompleted` when we initially set it, which also lets us take it out of the conditional for rendering it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Some-time-tracking-data-is-missing-61b632cf6112402a82b2f375ff038c5e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
