### PR TITLE
Connect/ add spellcheck for feedback text editors

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -198,6 +198,7 @@ export class FocusPointsContainer extends Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(fp.conceptResults, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -203,6 +203,7 @@ class IncorrectSequencesContainer extends Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, sequence.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={sequence.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -103,6 +103,7 @@ class TextEditor extends React.Component <any, any> {
 }
 
   render() {
+    const { shouldCheckSpelling } = this.props;
     const { richButtonsPlugin, text, } = this.state
     const {
       // inline buttons
@@ -142,6 +143,7 @@ class TextEditor extends React.Component <any, any> {
               keyBindingFn={this.keyBindingFn}
               onChange={this.handleTextChange}
               plugins={[richButtonsPlugin]}
+              spellCheck={!!shouldCheckSpelling}
             />
           </div>
         </div>


### PR DESCRIPTION
## WHAT
add spellcheck feature for Connect feedback text editors in the CMS

## WHY
Curriculum requested this feature as it's easy to make spelling mistakes while writing feedback

## HOW
just add a `spellCheck` prop to the draft-js editor for the editor used for Incorrect Sequences and Focus Points

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1428" alt="Screen Shot 2021-11-11 at 10 16 48 AM" src="https://user-images.githubusercontent.com/25959584/141331759-2df932ef-53b6-40c0-ac2a-d14a3f710c9f.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change, manually tested various text editors
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
