### PR TITLE
update assignment flow to show warnings in diagnostic assignment edge cases

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -513,6 +513,46 @@
   }
 }
 
+.override-warning-modal,
+.skip-recommendations-warning-modal {
+  overflow: visible;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  position: fixed !important;
+  text-align: left;
+  width: 560px;
+  padding: 32px;
+  border-radius: 6px;
+  background-color: #fff;
+  min-height: min-content;
+  .title {
+    font-size: 24px;
+    font-weight: bold;
+    line-height: 1.33;
+    color: #000;
+  }
+  .modal-body {
+    padding: 0px;
+    margin-top: 24px;
+    margin-bottom: 48px;
+    p {
+      line-height: 1.57;
+      color: #646464;
+      .quill-tooltip-trigger span:first-of-type {
+        border-bottom: 1px dotted #646464;
+      }
+    }
+  }
+  .buttons {
+    display: flex;
+    justify-content: flex-end;
+    .quill-button {
+      margin-left: 16px;
+    }
+  }
+}
+
+
 .rename-class-modal, .rename-activity-pack-modal {
   min-height: 273px;
   height: min-content;

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -37,7 +37,7 @@ module DiagnosticReports
     end
   end
 
-  private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id, hashify_activity_sessions=false)
+  private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id=nil, hashify_activity_sessions=false)
     if unit_id
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
@@ -52,6 +52,31 @@ module DiagnosticReports
 
     if hashify_activity_sessions
       @activity_sessions = @activity_sessions.map { |session| [session.user_id, session] }.to_h
+    end
+  end
+
+  private def set_pre_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
+    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
+    assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
+    @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
+    @pre_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
+
+    if hashify_activity_sessions
+      @pre_test_activity_sessions = @pre_test_activity_sessions.map { |session| [session.user_id, session] }.to_h
+    end
+
+  end
+
+  private def set_post_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
+    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
+    assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
+    @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
+    @post_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
+
+    if hashify_activity_sessions
+      @post_test_activity_sessions = @post_test_activity_sessions.map { |session| [session.user_id, session] }.to_h
     end
   end
 

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -56,7 +56,7 @@ module DiagnosticReports
   end
 
   private def set_pre_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+    units = current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
     classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
@@ -69,7 +69,7 @@ module DiagnosticReports
   end
 
   private def set_post_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+    units = current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
     classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -8,8 +8,8 @@ module GrowthResultsSummary
     @current_user = current_user
     pre_test = Activity.find(pre_test_activity_id)
     @skill_groups = pre_test.skill_groups
-    set_pre_test_activity_sessions_and_assigned_students(pre_test_activity_id, classroom_id)
-    set_post_test_activity_sessions_and_assigned_students(post_test_activity_id, classroom_id)
+    set_pre_test_activity_sessions_and_assigned_students(@current_user, pre_test_activity_id, classroom_id, true)
+    set_post_test_activity_sessions_and_assigned_students(@current_user, post_test_activity_id, classroom_id, true)
     @skill_group_summaries = @skill_groups.map do |skill_group|
       {
         name: skill_group.name,
@@ -23,22 +23,6 @@ module GrowthResultsSummary
       skill_group_summaries: @skill_group_summaries,
       student_results: student_results
     }
-  end
-
-  private def set_pre_test_activity_sessions_and_assigned_students(activity_id, classroom_id)
-    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
-    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
-    assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
-    @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
-    @pre_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }.map { |session| [session.user_id, session] }.to_h
-  end
-
-  private def set_post_test_activity_sessions_and_assigned_students(activity_id, classroom_id)
-    units = @current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
-    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
-    assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
-    @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
-    @post_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }.map { |session| [session.user_id, session] }.to_h
   end
 
   private def student_results

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.ts
@@ -29,3 +29,9 @@ export const postTestClassAssignmentLockedMessages = {
   1669: "You can't assign the Intermediate Growth Diagnostic to this class until you've assigned them the Intermediate Baseline Diagnostic.",
   1680: "You can't assign the Advanced Growth Diagnostic to this class until you've assigned them the Advanced Baseline Diagnostic."
 }
+
+export const postTestWarningModalPreNameCorrespondence = {
+  1664: "Starter Baseline Diagnostic (Pre)",
+  1669: "Intermediate Baseline Diagnostic (Pre)",
+  1680: "Advanced Baseline Diagnostic (Pre)"
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/overrideWarningModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/overrideWarningModal.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+import { Tooltip, } from '../../../../../Shared/index'
+
+const OverrideWarningModal = ({ handleClickAssign, handleCloseModal, studentNames, activityName, }) => {
+  const tooltip = (<Tooltip
+    tooltipText={studentNames.join('<br />')}
+    tooltipTriggerText={`${studentNames.length} student${studentNames.length === 1 ? '' : 's'}`}
+  />)
+  const haveOrHas = studentNames.length === 1 ? 'has' : 'have'
+  return (<div className="modal-container override-warning-modal-container">
+    <div className="modal-background" />
+    <div className="override-warning-modal quill-modal">
+
+      <div className="override-warning-modal-header">
+        <h3 className="title">Are you sure you want to assign this diagnostic?</h3>
+      </div>
+
+      <div className="override-warning-modal-body modal-body">
+        <p>{tooltip} {haveOrHas} already completed the {activityName}. If you assign the diagnostic to them, they can take it again, but it will override their scores.</p>
+      </div>
+
+      <div className="override-warning-modal-footer">
+        <div className="buttons">
+          <button className="quill-button outlined secondary medium focus-on-light" onClick={handleCloseModal} type="button">Cancel</button>
+          <button className="quill-button contained primary medium focus-on-light" onClick={handleClickAssign} type="button">Yes, assign</button>
+        </div>
+      </div>
+
+    </div>
+  </div>)
+
+}
+
+export default OverrideWarningModal

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/skipRecommendationsWarningModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/skipRecommendationsWarningModal.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+import { postTestWarningModalPreNameCorrespondence } from '../../assignmentFlowConstants'
+import { Tooltip, } from '../../../../../Shared/index'
+
+const SkipRecommendationsWarningModal = ({ handleClickAssign, handleCloseModal, studentNames, restrictedActivityId, }) => {
+  const tooltip = (<Tooltip
+    tooltipText={studentNames.join('<br />')}
+    tooltipTriggerText={`${studentNames.length} student${studentNames.length === 1 ? '' : 's'}`}
+  />)
+  const haveOrHas = studentNames.length === 1 ? 'has' : 'have'
+  return (<div className="modal-container skip-recommendations-warning-modal-container">
+    <div className="modal-background" />
+    <div className="skip-recommendations-warning-modal quill-modal">
+
+      <div className="skip-recommendations-warning-modal-header">
+        <h3 className="title">Are you sure you want to assign this diagnostic?</h3>
+      </div>
+
+      <div className="skip-recommendations-warning-modal-body modal-body">
+        <p>{tooltip} {haveOrHas} not yet completed the {postTestWarningModalPreNameCorrespondence[restrictedActivityId]}. Usually, students complete a Pre diagnostic and its practice activities first. Then, they move on to the Post diagnostic. If you assign the Post diagnostic now, students who haven&#39;t finished their practice activities yet will be able to take it, so we recommend waiting.</p>
+      </div>
+
+      <div className="skip-recommendations-warning-modal-footer">
+        <div className="buttons">
+          <button className="quill-button outlined secondary medium focus-on-light" onClick={handleCloseModal} type="button">Cancel</button>
+          <button className="quill-button contained primary medium focus-on-light" onClick={handleClickAssign} type="button">Assign now</button>
+        </div>
+      </div>
+
+    </div>
+  </div>)
+
+}
+
+export default SkipRecommendationsWarningModal

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -123,7 +123,10 @@ describe Teachers::ClassroomManagerController, type: :controller do
         let!(:advanced_pre_test) { create(:diagnostic_activity, id: Activity::ADVANCED_DIAGNOSTIC_ACTIVITY_ID, follow_up_activity_id: advanced_post_test.id) }
         let!(:unit) { create(:unit, user: user) }
         let!(:unit_activity) { create(:unit_activity, unit: unit, activity: starter_pre_test) }
-        let!(:classroom_unit) { create(:classroom_unit, unit: unit, classroom: user.classrooms_i_teach.last) }
+        let!(:students_classrooms) { create(:students_classrooms, classroom: user.classrooms_i_teach.last) }
+        let!(:classroom_unit) { create(:classroom_unit, unit: unit, classroom: user.classrooms_i_teach.last, assigned_student_ids: [students_classrooms.student.id]) }
+        let!(:activity_session) { create(:activity_session, user: students_classrooms.student, activity: starter_pre_test, classroom_unit: classroom_unit) }
+
 
         it 'should be a an array with objects containing the activity id, post test id, and assigned classroom ids' do
           get :assign
@@ -131,17 +134,38 @@ describe Teachers::ClassroomManagerController, type: :controller do
             {
               id: starter_pre_test.id,
               post_test_id: starter_post_test.id,
-              assigned_classroom_ids: [user.classrooms_i_teach.last.id]
+              assigned_classroom_ids: [user.classrooms_i_teach.last.id],
+              all_classrooms: [
+                {
+                  id: user.classrooms_i_teach.last.id,
+                  completed_pre_test_student_ids: [students_classrooms.student.id],
+                  completed_post_test_student_ids: []
+                }
+              ]
             },
             {
               id: intermediate_pre_test.id,
               post_test_id: intermediate_post_test.id,
-              assigned_classroom_ids: []
+              assigned_classroom_ids: [],
+              all_classrooms: [
+                {
+                  id: user.classrooms_i_teach.last.id,
+                  completed_pre_test_student_ids: [],
+                  completed_post_test_student_ids: []
+                }
+              ]
             },
             {
               id: advanced_pre_test.id,
               post_test_id: advanced_post_test.id,
-              assigned_classroom_ids: []
+              assigned_classroom_ids: [],
+              all_classrooms: [
+                {
+                  id: user.classrooms_i_teach.last.id,
+                  completed_pre_test_student_ids: [],
+                  completed_post_test_student_ids: []
+                }
+              ]
             }
           ])
         end


### PR DESCRIPTION
## WHAT
Update the assignment flow so that we show warnings when a) a teacher is attempting to assign a post diagnostic to students who have not yet completed the pre diagnostic and b) when a teacher is assigning a pre or post diagnostic to students who have already completed that diagnostic.

## WHY
Assigning activities like that could result in teachers seeing data that is not useful to them, so we want to allow them to do it but also flag it as a potential problem.

## HOW
Update the `assigned_pre_tests` variable with the data we need and use it to determine whether or not to render these modals at the end.

### Screenshots
<img width="499" alt="Screen Shot 2021-11-11 at 11 21 56 AM" src="https://user-images.githubusercontent.com/18669014/141354817-803196cc-511f-46da-a89f-32c2a0db3c75.png">
<img width="490" alt="Screen Shot 2021-11-11 at 11 27 58 AM" src="https://user-images.githubusercontent.com/18669014/141354820-e9f79120-b66d-4e9c-a92f-4b3edaecadde.png">


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Add-assign-review-page-warnings-for-pre-and-post-diagnostics-5d9341795511467d9f023588d920f238)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - waiting til everything else is complete (so close now!)
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
