### PR TITLE
lock diagnostics when pre is not yet complete

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -85,6 +85,10 @@
         }
       }
     }
+    .complete-baseline {
+      white-space: pre-wrap;
+      text-align: right;
+    }
 
     @media (max-width: 991px) {
       .tool-icon-section, .completed-due-date-section {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -93,8 +93,10 @@ const completeHeaders = [
 export default class StudentProfileUnit extends React.Component {
   actionButton = (act, nextActivitySession) => {
     const { isBeingPreviewed, onShowPreviewModal, } = this.props
-    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, } = act
+    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, } = act
     let linkText = 'Start'
+
+    if (pre_activity_id && !completed_pre_activity_session) { return <span className="complete-baseline">Complete Baseline first</span>}
 
     if (!repeatable && finished) { return <span /> }
 

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -16,12 +16,13 @@ describe ProfilesController, type: :controller do
         create(:unit)
       ]
     end
+    let!(:post_test) { create(:activity) }
     let!(:activities) do [
         create(:activity),
+        create(:activity, follow_up_activity_id: post_test.id),
         create(:activity),
         create(:activity),
-        create(:activity),
-        create(:activity)
+        post_test
       ]
     end
     let!(:unit_activities) do [
@@ -210,6 +211,8 @@ describe ProfilesController, type: :controller do
                 classroom_unit: classroom_unit,
                 unit_activity: unit_activity
               )
+              pre_test = Activity.find_by(follow_up_activity_id: activity.id)
+              pre_test_completed_session = ActivitySession.find_by(state: 'finished', activity: pre_test, user: student)
 
               scores_array << {
                 'name' => activity.name,
@@ -219,18 +222,20 @@ describe ProfilesController, type: :controller do
                 'activity_classification_key' => activity.classification.key,
                 'unit_id' => unit.id,
                 'ua_id' => unit_activity.id,
-                'order_number' => unit_activity.order_number,
                 'unit_created_at' => unit.created_at,
                 'unit_name' => unit.name,
                 'classroom_unit_id' => classroom_unit.id,
                 'marked_complete' => false,
                 'activity_id' => activity.id,
                 'act_sesh_updated_at' => activity_session&.updated_at,
+                'order_number' => unit_activity.order_number,
                 'due_date' => unit_activity.due_date,
+                'pre_activity_id' => pre_test&.id,
                 'unit_activity_created_at' => classroom_unit.created_at,
                 'locked' => unit_activity.classroom_unit_activity_states[0].locked,
                 'pinned' => unit_activity.classroom_unit_activity_states[0].pinned,
                 'max_percentage' => activity_session&.percentage,
+                'completed_pre_activity_session' => pre_test_completed_session.present?,
                 'finished' => activity_session&.percentage ? true : false,
                 'resume_link' => activity_session&.state == 'started' ? 1 : 0
               }


### PR DESCRIPTION
## WHAT
Lock post-diagnostics when the pre-diagnostic is not yet complete.

## WHY
The whole setup necessitates that students have pre-diagnostic results before they have post-diagnostic results.

## HOW
Just update the query to see if there is a pre-activity and, if so, if the student has completed an activity session for it.

### Screenshots
<img width="756" alt="Screen Shot 2021-11-11 at 2 00 58 PM" src="https://user-images.githubusercontent.com/18669014/141355121-074f328d-8b29-40a4-be02-13dec25c85f9.png">

### Notion Card Links
https://www.notion.so/quill/Update-the-Student-Dashboard-to-lock-post-diagnostics-til-pre-is-completed-93546a6acf0e4da1a0b751cd7e9a7c68

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - coming all at once (this is the second to last PR before Tom can review!!!)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
