### PR TITLE
Revert "Add check in clever importing for non-unique & invalid classroom_teachers (#8487)"

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/associators/classrooms_to_teacher.rb
@@ -1,22 +1,11 @@
 module CleverIntegration::Associators::ClassroomsToTeacher
 
   def self.run(classrooms, teacher)
-    classrooms.map do |classroom|
-      role = get_role(classroom, teacher)
-      ClassroomsTeacher.find_or_create_by!(classroom: classroom, user: teacher, role: role)
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      NewRelic::Agent.add_custom_attributes(classroom_id: classroom.id, teacher_id: teacher.id, role: role)
-      NewRelic::Agent.notice_error(e)
-    ensure
+    updated_classrooms = classrooms.map do |classroom|
+      role = classroom&.owner && classroom&.owner != teacher ? 'coteacher' : 'owner'
+      ClassroomsTeacher.find_or_create_by(classroom: classroom, user: teacher, role: role)
       classroom.reload
     end
-  end
-
-  def self.get_role(classroom, teacher)
-    owner_ids = ClassroomsTeacher.where(classroom: classroom, role: 'owner').pluck(:user_id)
-
-    return 'owner' if owner_ids.empty?
-
-    owner_ids.include?(teacher.id) ? 'owner' : 'coteacher'
+    updated_classrooms
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/associators/classrooms_to_teacher_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'CleverIntegration::Associators::ClassroomsToTeacher' do
+
   let!(:classroom1) { create(:classroom, :with_no_teacher) }
   let!(:classroom2) { create(:classroom, :with_no_teacher) }
   let!(:teacher1) { create(:teacher) }
@@ -25,15 +26,6 @@ describe 'CleverIntegration::Associators::ClassroomsToTeacher' do
     it 'creates a classroom owner record' do
       CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher2)
       expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher2.id, role: 'coteacher')).to be
-    end
-  end
-
-  context 'when classroom has two owners' do
-    let!(:classrooms_teacher2) { create(:classrooms_teacher, user: teacher2, classroom: classroom2) }
-
-    it 'gracefully handles the each case of two owners' do
-      CleverIntegration::Associators::ClassroomsToTeacher.run([classroom2], teacher1)
-      expect(ClassroomsTeacher.find_by(classroom_id: classroom2.id, user_id: teacher1.id, role: 'owner')).to be
     end
   end
 end


### PR DESCRIPTION
## WHAT
This reverts commit 83a5235e4bfc3c1fe80607704b9da9c5a1d4c236.

## WHY
Since being deployed this morning, this commit created (or uncovered) many errors:

![Screen Shot 2021-11-11 at 3 14 17 PM](https://user-images.githubusercontent.com/2057805/141362833-ebcf7505-8c66-4871-8d6d-7cc7f67bc269.png)

## HOW
git revert

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | No. revert commit
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
