### PR TITLE
When rake commands are run on production, post the command to quill-developer slack channel

### DIFF
--- a/services/QuillLMS/Rakefile
+++ b/services/QuillLMS/Rakefile
@@ -3,29 +3,18 @@
 
 require File.expand_path('../config/application', __FILE__)
 require 'dotenv/tasks'
+require 'tasks/modules/slack_tasks'
 
 EmpiricalGrammar::Application.load_tasks
 
 task default: [:spec]
 
 task after_hook: :dotenv do
+  include SlackTasks
+
   post_slack_rake_task
 end
 
-Rake.application.tasks.reject do |task|
-  next if [Rake::Task['environment'], Rake::Task['dotenv'], Rake::Task['after_hook']].include?(task)
-
-  task.enhance([:after_hook])
-end
-
-def post_slack_rake_task
-  return unless ENV.fetch('RAILS_ENV', '') == 'production'
-
-  webhook_url = ENV.fetch('SLACK_API_WEBHOOK', '')
-
-  return unless webhook_url.present?
-
-  message = ":rake: rake #{ARGV.join(' ')}"
-
-  sh %(curl -X POST -H 'Content-type: application/json' --data "{'text':'#{message}'}" #{webhook_url})
+Rake.application.tasks.each do |task|
+  task.enhance([:after_hook]) unless %w[after_hook dotenv environment].include?(task.name)
 end

--- a/services/QuillLMS/Rakefile
+++ b/services/QuillLMS/Rakefile
@@ -2,7 +2,30 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'dotenv/tasks'
 
 EmpiricalGrammar::Application.load_tasks
 
 task default: [:spec]
+
+task after_hook: :dotenv do
+  post_slack_rake_task
+end
+
+Rake.application.tasks.reject do |task|
+  next if [Rake::Task['environment'], Rake::Task['dotenv'], Rake::Task['after_hook']].include?(task)
+
+  task.enhance([:after_hook])
+end
+
+def post_slack_rake_task
+  return unless ENV.fetch('RAILS_ENV', '') == 'production'
+
+  webhook_url = ENV.fetch('SLACK_API_WEBHOOK', '')
+
+  return unless webhook_url.present?
+
+  message = ":rake: rake #{ARGV.join(' ')}"
+
+  sh %(curl -X POST -H 'Content-type: application/json' --data "{'text':'#{message}'}" #{webhook_url})
+end

--- a/services/QuillLMS/lib/tasks/modules/slack_tasks.rb
+++ b/services/QuillLMS/lib/tasks/modules/slack_tasks.rb
@@ -1,0 +1,23 @@
+module SlackTasks
+  IGNORED_RAKE_TASKS = %w[
+    assets:clean
+    assets:precompile
+    cron:interval_10_minutes
+    cron:interval_1_hour
+    cron:interval_1_day
+  ]
+
+  def post_slack_rake_task
+    return if IGNORED_RAKE_TASKS.include?(ARGV.first)
+
+    return unless ENV.fetch('RAILS_ENV', '') == 'production'
+
+    webhook_url = ENV.fetch('SLACK_API_WEBHOOK', '')
+
+    return unless webhook_url.present?
+
+    message = ":rake: rake #{ARGV.join(' ')}"
+
+    sh %(curl -X POST -H 'Content-type: application/json' --data "{'text':'#{message}'}" #{webhook_url})
+  end
+end


### PR DESCRIPTION
## WHAT
When a user runs a rake task on our production LMS, post a message to quill-developer channel.

## WHY
It's useful to see commands that alter the production database.

## HOW
Add an after_hook following this [post](https://t2013anurag.medium.com/rails-adding-global-hooks-for-rake-tasks-7faf0844364).  While it would be useful to also post the user who executed the rake task, I wasn't able to find that info easily.

### Screenshots
![Screen Shot 2021-11-12 at 10 20 28 AM](https://user-images.githubusercontent.com/2057805/141492909-d1d42911-4f44-4b49-902a-4571571f5c00.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
