### PR TITLE
make sure only diagnostic follow-ups get locked

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -93,10 +93,10 @@ const completeHeaders = [
 export default class StudentProfileUnit extends React.Component {
   actionButton = (act, nextActivitySession) => {
     const { isBeingPreviewed, onShowPreviewModal, } = this.props
-    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, } = act
+    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, activity_classification_key, } = act
     let linkText = 'Start'
 
-    if (pre_activity_id && !completed_pre_activity_session) { return <span className="complete-baseline">Complete Baseline first</span>}
+    if (activity_classification_key === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY && pre_activity_id && !completed_pre_activity_session) { return <span className="complete-baseline">Complete Baseline first</span>}
 
     if (!repeatable && finished) { return <span /> }
 


### PR DESCRIPTION
## WHAT
Further restrict the condition where the "Complete Baseline first" message shows so that only diagnostic activities will have it.

## WHY
I didn't realize that there were follow-up activities that could be assigned independently of the original activity, but these do turn out to exist, and we don't want to prevent students from playing them in all cases.

## HOW
Just make sure the activity is a diagnostic.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Students-are-seeing-Complete-baseline-first-message-next-to-activities-1e8156c2419c4a9caced30983f0a5746

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
