### PR TITLE
fix issue where we were pulling questions from the wrong place when marking lessons as completed

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+
 import {
   startListeningToSessionForTeacher,
   finishActivity,
@@ -37,11 +38,12 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
   }
 
   componentDidMount() {
+    const { dispatch, match, } = this.props
     const { classroomUnitId, classroomSessionId } = this.state
-    const activityId: string = this.props.match.params.lessonID;
+    const activityId: string = match.params.lessonID;
     if (classroomUnitId && classroomSessionId) {
-      this.props.dispatch(getClassLesson(activityId));
-      this.props.dispatch(startListeningToSessionForTeacher(activityId, classroomUnitId, classroomSessionId));
+      dispatch(getClassLesson(activityId));
+      dispatch(startListeningToSessionForTeacher(activityId, classroomUnitId, classroomSessionId));
     }
   }
 
@@ -54,10 +56,11 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
   }
 
   finishLesson(nextProps) {
-    const questions = nextProps.classroomLesson.data.questions;
-    const submissions = nextProps.classroomSessions.data.submissions;
-    const activityId = this.props.match.params.lessonID;
-    const classroomUnitId:ClassroomUnitId|null = this.state.classroomUnitId;
+    const { match, } = this.props
+    const { classroomUnitId, } = this.state
+    const { questions, } = nextProps.customize.editionQuestions;
+    const { submissions, } = nextProps.classroomSessions.data;
+    const activityId = match.params.lessonID;
     const conceptResults = generate(questions, submissions);
 
     if (classroomUnitId) {


### PR DESCRIPTION
## WHAT
Fix issue where some newer Lessons can't be "marked as completed" because we were pulling questions from the wrong place.

## WHY
We want teachers to be able to "complete" Lessons once they've exited them.

## HOW
Just update it to pull questions from `editionQuestions`, rather than the `classroomLessons` object (an older version). Also fix some linter errors while I was in there.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Teacher-s-Lessons-Not-Marking-as-Complete-b167cb4cc3b644119ec81138222af846)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
