### PR TITLE
Add premium banner to premium page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
@@ -4,6 +4,7 @@
   padding-top: 27px;
   background-image: url(/images/star_pattern_5.png);
   min-height: 115px;
+  text-align: left;
   .spinner-container {
     max-height: 97px;
     margin: 0;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -5,8 +5,6 @@ import BasicPricingMini from './premium_minis/basic_pricing_mini.jsx';
 import TeacherPricingMini from './premium_minis/teacher_pricing_mini.jsx';
 import SchoolPricingMini from './premium_minis/school_pricing_mini.jsx';
 
-import PremiumConfirmationModal from '../subscriptions/premium_confirmation_modal';
-
 const handshakeHeartSrc = `${process.env.CDN_URL}/images/icons/handshake-heart.svg`
 
 export default class PremiumPricingMinisRow extends React.Component {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -6,14 +6,11 @@ import TeacherPricingMini from './premium_minis/teacher_pricing_mini.jsx';
 import SchoolPricingMini from './premium_minis/school_pricing_mini.jsx';
 
 import PremiumConfirmationModal from '../subscriptions/premium_confirmation_modal';
-import PurchaseModal from '../../containers/PurchaseModal';
 
 const handshakeHeartSrc = `${process.env.CDN_URL}/images/icons/handshake-heart.svg`
 
 export default class PremiumPricingMinisRow extends React.Component {
   state = {
-    showPremiumConfirmationModal: false,
-    showPurchaseModal: false,
     subscriptionType: null,
     subscriptionStatus: null,
     userIsSignedIn: !!Number(document.getElementById('current-user-id').getAttribute('content')),
@@ -33,65 +30,11 @@ export default class PremiumPricingMinisRow extends React.Component {
     }
   }
 
-  hidePremiumConfirmationModal = () => {
-    this.setState({ showPremiumConfirmationModal: false, });
-  };
-
-  hidePurchaseModal = () => {
-    this.setState({ showPurchaseModal: false, subscriptionType: null, });
-  };
-
-  showPremiumConfirmationModal = () => {
-    this.setState({ showPremiumConfirmationModal: true, });
-  };
-
-  showPurchaseModal = () => {
-    this.setState({ showPurchaseModal: true, });
-  };
-
-  showPurchaseModalForSchoolPurchase = () => {
-    this.setState({ subscriptionType: 'School', }, () => this.setState({ showPurchaseModal: true, }));
-  };
-
-  updateSubscriptionStatus = subscription => {
-    this.setState({ subscriptionStatus: subscription,
-      showPremiumConfirmationModal: true,
-      showPurchaseModal: false, });
-  };
-
-  renderPremiumConfirmationModal() {
-    const { showPremiumConfirmationModal, subscriptionStatus, } = this.state
-    if (!showPremiumConfirmationModal) { return }
-    return (<PremiumConfirmationModal
-      hideModal={this.hidePremiumConfirmationModal}
-      show={showPremiumConfirmationModal}
-      subscription={subscriptionStatus}
-    />)
-  }
-
-  renderPurchaseModal() {
-    const {
-      showPurchaseModal,
-      subscriptionType
-    } = this.state
-    const { lastFour, } = this.props
-    if (!showPurchaseModal) { return }
-    return (<PurchaseModal
-      hideModal={this.hidePurchaseModal}
-      lastFour={lastFour}
-      show={showPurchaseModal}
-      subscriptionType={subscriptionType}
-      updateSubscriptionStatus={this.updateSubscriptionStatus}
-    />)
-  }
-
   render() {
-    const { lastFour, diagnosticActivityCount, lessonsActivityCount, independentPracticeActivityCount, } = this.props
+    const { diagnosticActivityCount, lessonsActivityCount, independentPracticeActivityCount, } = this.props
 
     const {
       userIsSignedIn,
-      subscriptionStatus,
-      subscriptionType,
       isScrolled,
     } = this.state
 
@@ -113,7 +56,6 @@ export default class PremiumPricingMinisRow extends React.Component {
               {...this.props}
               hidePurchaseModal={this.hidePurchaseModal}
               premiumFeatureData={premiumFeatureData}
-              showPurchaseModal={this.showPurchaseModal}
               userIsSignedIn={userIsSignedIn}
             />
             <SchoolPricingMini
@@ -122,8 +64,6 @@ export default class PremiumPricingMinisRow extends React.Component {
             />
           </div>
         </div>
-        {this.renderPremiumConfirmationModal()}
-        {this.renderPurchaseModal()}
       </React.Fragment>
     );
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -30,7 +30,6 @@ export default class PremiumPricingMinisRow extends React.Component {
 
   render() {
     const { diagnosticActivityCount, lessonsActivityCount, independentPracticeActivityCount, } = this.props
-
     const {
       userIsSignedIn,
       isScrolled,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
@@ -11,11 +11,6 @@ export default class FreeTrialBanner extends React.Component {
   }
 
   beginTrial = () => {
-    const { signedIn } = this.props
-    if (!signedIn) {
-      alert("You must be logged in to activate Premium.")
-      return;
-    }
     requestPost('/subscriptions', { subscription: { account_type: 'Teacher Trial', }, }, () => {
       this.setState({ trialStarted: true, })
     })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_banner.jsx
@@ -11,6 +11,11 @@ export default class FreeTrialBanner extends React.Component {
   }
 
   beginTrial = () => {
+    const { signedIn } = this.props
+    if (!signedIn) {
+      alert("You must be logged in to activate Premium.")
+      return;
+    }
     requestPost('/subscriptions', { subscription: { account_type: 'Teacher Trial', }, }, () => {
       this.setState({ trialStarted: true, })
     })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
@@ -14,9 +14,10 @@ export default class extends React.Component {
   };
 
   render() {
-    const premiumButton = this.props.originPage == 'premium' ?
+    const { originPage, upgradeNow } = this.props
+    const premiumButton = originPage == 'premium' ?
     (
-      <button className='btn-orange' onClick={this.props.upgradeNow} type='button'>Upgrade to Premium Now</button>
+      <button className='btn-orange' onClick={upgradeNow} type='button'>Upgrade to Premium Now</button>
     ) :
     (
       <a href='/premium'>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
@@ -14,6 +14,15 @@ export default class extends React.Component {
   };
 
   render() {
+    const premiumButton = this.props.status == 'trial' ?
+    (
+      <button className='btn-orange' type='button' onClick={this.props.upgradeNow}>Upgrade to Premium Now</button>
+    ) :
+    (
+      <a href='/premium'>
+        <button className='btn-orange' type='button'>Upgrade to Premium Now</button>
+      </a>
+    )
     return (
       <div className='row'>
         <div className='col-md-9 col-xs-12 pull-left'>
@@ -22,9 +31,7 @@ export default class extends React.Component {
         </div>
         <div className='col-md-3 col-xs-12 pull-right'>
           <div className='premium-button-box text-center'>
-            <a href='/premium'>
-              <button className='btn-orange' type='button'>Upgrade to Premium Now</button>
-            </a>
+          {premiumButton}
           </div>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
@@ -14,7 +14,7 @@ export default class extends React.Component {
   };
 
   render() {
-    const premiumButton = this.props.status == 'trial' ?
+    const premiumButton = this.props.originPage == 'premium' ?
     (
       <button className='btn-orange' type='button' onClick={this.props.upgradeNow}>Upgrade to Premium Now</button>
     ) :

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
@@ -16,7 +16,7 @@ export default class extends React.Component {
   render() {
     const premiumButton = this.props.originPage == 'premium' ?
     (
-      <button className='btn-orange' type='button' onClick={this.props.upgradeNow}>Upgrade to Premium Now</button>
+      <button className='btn-orange' onClick={this.props.upgradeNow} type='button'>Upgrade to Premium Now</button>
     ) :
     (
       <a href='/premium'>
@@ -31,7 +31,7 @@ export default class extends React.Component {
         </div>
         <div className='col-md-3 col-xs-12 pull-right'>
           <div className='premium-button-box text-center'>
-          {premiumButton}
+            {premiumButton}
           </div>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -20,20 +20,18 @@ export default class PremiumBannerBuilder extends React.Component {
   }
 
   fetchData = () => {
-    const { userIsSignedIn } = this.props
-    if (userIsSignedIn) {
-      var that = this;
-      $.get('/teachers/classrooms/premium')
-      .done(function(data) {
-        that.setState({
-          has_premium: data['hasPremium'],
-          trial_days_remaining: data['trial_days_remaining'],
-          first_day_of_premium_or_trial: data['first_day_of_premium_or_trial']});});
-    }
+    var that = this;
+    $.get('/teachers/classrooms/premium')
+    .done(function(data) {
+      that.setState({
+        has_premium: data['hasPremium'],
+        trial_days_remaining: data['trial_days_remaining'],
+        first_day_of_premium_or_trial: data['first_day_of_premium_or_trial']});});
   };
 
   handleClickUpgradeNow = () => {
-    this.props.showPurchaseModal()
+    const { showPurchaseModal } = this.props
+    showPurchaseModal()
   };
 
   stateSpecificComponents = () => {
@@ -41,11 +39,9 @@ export default class PremiumBannerBuilder extends React.Component {
     // if (this.state.has_premium === null){
     //   return <EC.LoadingIndicator/>;
     // }
-    console.log('here')
-    console.log(has_premium)
     const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
     if (has_premium == 'none'){
-      return(<FreeTrialBanner status={has_premium} signedIn={true}/>);
+      return(<FreeTrialBanner status={has_premium}/>);
     }
     else if (first_day_of_premium_or_trial ){
       return(<NewSignUpBanner status={has_premium} />);
@@ -56,9 +52,6 @@ export default class PremiumBannerBuilder extends React.Component {
         <FreeTrialStatus data={trial_days_remaining} status={has_premium} upgradeNow={this.handleClickUpgradeNow}/>
       </span>
       );
-    }
-    else if (has_premium === undefined || has_premium === null) {
-      return(<FreeTrialBanner status={has_premium} signedIn={false} />);
     }
     else if ((has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {
         return (<span />);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -20,13 +20,20 @@ export default class PremiumBannerBuilder extends React.Component {
   }
 
   fetchData = () => {
-    var that = this;
-    $.get('/teachers/classrooms/premium')
-    .done(function(data) {
-      that.setState({
-        has_premium: data['hasPremium'],
-        trial_days_remaining: data['trial_days_remaining'],
-        first_day_of_premium_or_trial: data['first_day_of_premium_or_trial']});});
+    const { userIsSignedIn } = this.props
+    if (userIsSignedIn) {
+      var that = this;
+      $.get('/teachers/classrooms/premium')
+      .done(function(data) {
+        that.setState({
+          has_premium: data['hasPremium'],
+          trial_days_remaining: data['trial_days_remaining'],
+          first_day_of_premium_or_trial: data['first_day_of_premium_or_trial']});});
+    }
+  };
+
+  handleClickUpgradeNow = () => {
+    this.props.showPurchaseModal()
   };
 
   stateSpecificComponents = () => {
@@ -34,6 +41,8 @@ export default class PremiumBannerBuilder extends React.Component {
     // if (this.state.has_premium === null){
     //   return <EC.LoadingIndicator/>;
     // }
+    console.log('here')
+    console.log(has_premium)
     const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
     if (has_premium == 'none'){
       return(<FreeTrialBanner status={has_premium} signedIn={true}/>);
@@ -42,11 +51,13 @@ export default class PremiumBannerBuilder extends React.Component {
       return(<NewSignUpBanner status={has_premium} />);
     }
     else if ((has_premium == 'trial') || (has_premium == 'locked')){
-      return(<span>
-        <FreeTrialStatus data={trial_days_remaining} status={has_premium} />
-      </span>);
+      return(
+      <span>
+        <FreeTrialStatus data={trial_days_remaining} status={has_premium} upgradeNow={this.handleClickUpgradeNow}/>
+      </span>
+      );
     }
-    else if (has_premium === undefined) {
+    else if (has_premium === undefined || has_premium === null) {
       return(<FreeTrialBanner status={has_premium} signedIn={false} />);
     }
     else if ((has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -41,15 +41,15 @@ export default class PremiumBannerBuilder extends React.Component {
     // }
     const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
     const { originPage } = this.props
-    if (has_premium == 'none'){
+    if (has_premium === 'none'){
       return(<FreeTrialBanner status={has_premium} />);
     }
     else if (first_day_of_premium_or_trial ){
       return(<NewSignUpBanner status={has_premium} />);
     }
-    else if ((has_premium == 'trial') || (has_premium == 'locked')){
+    else if ((has_premium === 'trial') || (has_premium === 'locked')){
       return(
-        <span>s
+        <span>
           <FreeTrialStatus data={trial_days_remaining} originPage={originPage} status={has_premium} upgradeNow={this.handleClickUpgradeNow} />
         </span>
       );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -34,18 +34,22 @@ export default class PremiumBannerBuilder extends React.Component {
     // if (this.state.has_premium === null){
     //   return <EC.LoadingIndicator/>;
     // }
-    if (this.state.has_premium == 'none'){
-      return(<FreeTrialBanner status={this.state.has_premium} />);
+    const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
+    if (has_premium == 'none'){
+      return(<FreeTrialBanner status={has_premium} signedIn={true}/>);
     }
-    else if (this.state.first_day_of_premium_or_trial ){
-      return(<NewSignUpBanner status={this.state.has_premium} />);
+    else if (first_day_of_premium_or_trial ){
+      return(<NewSignUpBanner status={has_premium} />);
     }
-    else if ((this.state.has_premium == 'trial') || (this.state.has_premium == 'locked')){
+    else if ((has_premium == 'trial') || (has_premium == 'locked')){
       return(<span>
-        <FreeTrialStatus data={this.state.trial_days_remaining} status={this.state.has_premium} />
+        <FreeTrialStatus data={trial_days_remaining} status={has_premium} />
       </span>);
     }
-    else if ((this.state.has_premium === 'school') || ((this.state.has_premium === 'paid') && (this.state.first_day_of_premium_or_trial === false))) {
+    else if (has_premium === undefined) {
+      return(<FreeTrialBanner status={has_premium} signedIn={false} />);
+    }
+    else if ((has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {
         return (<span />);
       }
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -40,6 +40,7 @@ export default class PremiumBannerBuilder extends React.Component {
     //   return <EC.LoadingIndicator/>;
     // }
     const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
+    const { originPage } = this.props
     if (has_premium == 'none'){
       return(<FreeTrialBanner status={has_premium}/>);
     }
@@ -49,7 +50,7 @@ export default class PremiumBannerBuilder extends React.Component {
     else if ((has_premium == 'trial') || (has_premium == 'locked')){
       return(
       <span>
-        <FreeTrialStatus data={trial_days_remaining} status={has_premium} upgradeNow={this.handleClickUpgradeNow}/>
+        <FreeTrialStatus data={trial_days_remaining} originPage={originPage} status={has_premium} upgradeNow={this.handleClickUpgradeNow}/>
       </span>
       );
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -42,16 +42,16 @@ export default class PremiumBannerBuilder extends React.Component {
     const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
     const { originPage } = this.props
     if (has_premium == 'none'){
-      return(<FreeTrialBanner status={has_premium}/>);
+      return(<FreeTrialBanner status={has_premium} />);
     }
     else if (first_day_of_premium_or_trial ){
       return(<NewSignUpBanner status={has_premium} />);
     }
     else if ((has_premium == 'trial') || (has_premium == 'locked')){
       return(
-      <span>
-        <FreeTrialStatus data={trial_days_remaining} originPage={originPage} status={has_premium} upgradeNow={this.handleClickUpgradeNow}/>
-      </span>
+        <span>s
+          <FreeTrialStatus data={trial_days_remaining} originPage={originPage} status={has_premium} upgradeNow={this.handleClickUpgradeNow} />
+        </span>
       );
     }
     else if ((has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -60,7 +60,7 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
   };
 
   const updateSubscriptionStatus = subscription => {
-    setSubscriptionType(subscription)
+    setSubscriptionStatus(subscription)
     setShouldShowPremiumConfirmationModal(true)
     setShouldShowPurchaseModal(false)
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -29,7 +29,7 @@ const subscribers = [
    { name: 'Princeton Public Schools logo', source: '/images/subscribers/16_princeton.png', id: 'princeton'}
  ]
 
-export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount }) => {
+export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount, userIsEligibleForNewSubscription }) => {
   // const size = useWindowSize();
   // const onMobile = () => size.width <= MAX_VIEW_WIDTH_FOR_MOBILE
   //
@@ -59,11 +59,6 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
     setShouldShowPurchaseModal(true)
   };
 
-  const showPurchaseModalForSchoolPurchase = () => {
-
-    // this.setState({ subscriptionType: 'School', }, () => this.setState({ showPurchaseModal: true, }));
-  };
-
   const updateSubscriptionStatus = subscription => {
     setSubscriptionType(subscription)
     setShouldShowPremiumConfirmationModal(true)
@@ -74,7 +69,7 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
     if (!shouldShowPremiumConfirmationModal) { return }
     return (<PremiumConfirmationModal
       hideModal={hidePremiumConfirmationModal}
-      show={showPremiumConfirmationModal}
+      show={shouldShowPremiumConfirmationModal}
       subscription={subscriptionStatus}
     />)
   }
@@ -95,7 +90,7 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
       <div className="container premium-page">
         {userIsSignedIn() && <PremiumBannerBuilder originPage="premium" showPurchaseModal={showPurchaseModal} />}
         <div className="overview text-center">
-          <PremiumPricingMinisRow diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lastFour={lastFour} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} />
+          <PremiumPricingMinisRow diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lastFour={lastFour} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}/>
           <PremiumFeaturesTable
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -29,99 +29,94 @@ const subscribers = [
    { name: 'Princeton Public Schools logo', source: '/images/subscribers/16_princeton.png', id: 'princeton'}
  ]
 
-export default class PremiumPricingGuide extends React.Component {
+export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount }) => {
   // const size = useWindowSize();
   // const onMobile = () => size.width <= MAX_VIEW_WIDTH_FOR_MOBILE
   //
-  state = {
-    showPremiumConfirmationModal: false,
-    showPurchaseModal: false,
-    subscriptionType: null,
-    subscriptionStatus: null,
-    userIsSignedIn: !!Number(document.getElementById('current-user-id').getAttribute('content')),
-    isScrolled: false
+  const [shouldShowPremiumConfirmationModal, setShouldShowPremiumConfirmationModal] = React.useState(false)
+  const [shouldShowPurchaseModal, setShouldShowPurchaseModal] = React.useState(false)
+  const [subscriptionType, setSubscriptionType] = React.useState(null)
+  const [subscriptionStatus, setSubscriptionStatus] = React.useState(null)
+  const [isScrolled, setIsScrolled] = React.useState(false)
+
+  const userIsSignedIn = () => {
+    return !!Number(document.getElementById('current-user-id').getAttribute('content'))
+  }
+  const hidePremiumConfirmationModal = () => {
+    setShouldShowPremiumConfirmationModal(false)
   };
 
-  hidePremiumConfirmationModal = () => {
-    this.setState({ showPremiumConfirmationModal: false, });
+  const hidePurchaseModal = () => {
+    setShouldShowPurchaseModal(false)
+    setSubscriptionType(null)
   };
 
-  hidePurchaseModal = () => {
-    this.setState({ showPurchaseModal: false, subscriptionType: null, });
+  const showPremiumConfirmationModal = () => {
+    setShouldShowPremiumConfirmationModal(true)
   };
 
-  showPremiumConfirmationModal = () => {
-    this.setState({ showPremiumConfirmationModal: true, });
+  const showPurchaseModal = () => {
+    setShouldShowPurchaseModal(true)
   };
 
-  showPurchaseModal = () => {
-    this.setState({ showPurchaseModal: true, });
+  const showPurchaseModalForSchoolPurchase = () => {
+
+    // this.setState({ subscriptionType: 'School', }, () => this.setState({ showPurchaseModal: true, }));
   };
 
-  showPurchaseModalForSchoolPurchase = () => {
-    this.setState({ subscriptionType: 'School', }, () => this.setState({ showPurchaseModal: true, }));
+  const updateSubscriptionStatus = subscription => {
+    setSubscriptionType(subscription)
+    setShouldShowPremiumConfirmationModal(true)
+    setShouldShowPurchaseModal(false)
   };
 
-  updateSubscriptionStatus = subscription => {
-    this.setState({ subscriptionStatus: subscription,
-      showPremiumConfirmationModal: true,
-      showPurchaseModal: false, });
-  };
-
-  renderPremiumConfirmationModal = () => {
-    const { showPremiumConfirmationModal, subscriptionStatus, } = this.state
-    if (!showPremiumConfirmationModal) { return }
+  const renderPremiumConfirmationModal = () => {
+    if (!shouldShowPremiumConfirmationModal) { return }
     return (<PremiumConfirmationModal
-      hideModal={this.hidePremiumConfirmationModal}
+      hideModal={hidePremiumConfirmationModal}
       show={showPremiumConfirmationModal}
       subscription={subscriptionStatus}
     />)
   }
 
-  renderPurchaseModal = () => {
-    const {
-      showPurchaseModal,
-      subscriptionType
-    } = this.state
-    const { lastFour, } = this.props
-    if (!showPurchaseModal) { return }
+  const renderPurchaseModal = () => {
+    if (!shouldShowPurchaseModal) { return }
     return (<PurchaseModal
-      hideModal={this.hidePurchaseModal}
+      hideModal={hidePurchaseModal}
       lastFour={lastFour}
       show={showPurchaseModal}
       subscriptionType={subscriptionType}
-      updateSubscriptionStatus={this.updateSubscriptionStatus}
+      updateSubscriptionStatus={updateSubscriptionStatus}
     />)
   }
 
-  render() {
-    const { diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount } = this.props
-    const { userIsSignedIn } = this.state
-    return (
-      <div>
-        <div className="container premium-page">
-          {userIsSignedIn ? <PremiumBannerBuilder originPage="premium" showPurchaseModal={this.showPurchaseModal} /> : ''}
-          <div className="overview text-center">
-            <PremiumPricingMinisRow {...this.props} showPurchaseModal={this.showPurchaseModal} />
-            <PremiumFeaturesTable
-              diagnosticActivityCount={diagnosticActivityCount}
-              independentPracticeActivityCount={independentPracticeActivityCount}
-              lessonsActivityCount={lessonsActivityCount}
-            />
-          </div>
-
-          <div className="features text-center">
-            <SchoolPremium />
-            <SubscriberLogos subscribers={subscribers} />
-          </div>
-          <QuestionsAndAnswers
-            questionsAndAnswersFile="premium"
-            supportLink="https://support.quill.org/quill-premium"
+  return (
+    <div>
+      <div className="container premium-page">
+        {userIsSignedIn() && <PremiumBannerBuilder originPage="premium" showPurchaseModal={showPurchaseModal} />}
+        <div className="overview text-center">
+          <PremiumPricingMinisRow lastFour={lastFour} diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} />
+          <PremiumFeaturesTable
+            diagnosticActivityCount={diagnosticActivityCount}
+            independentPracticeActivityCount={independentPracticeActivityCount}
+            lessonsActivityCount={lessonsActivityCount}
           />
         </div>
-        {this.renderPremiumConfirmationModal()}
-        {this.renderPurchaseModal()}
+
+        <div className="features text-center">
+          <SchoolPremium />
+          <SubscriberLogos subscribers={subscribers} />
+        </div>
+        <QuestionsAndAnswers
+          questionsAndAnswersFile="premium"
+          supportLink="https://support.quill.org/quill-premium"
+        />
       </div>
-    )
-  }
+      {renderPremiumConfirmationModal()}
+      {renderPurchaseModal()}
+    </div>
+  )
+
 }
+
+export default PremiumPricingGuide

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -95,7 +95,7 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
       <div className="container premium-page">
         {userIsSignedIn() && <PremiumBannerBuilder originPage="premium" showPurchaseModal={showPurchaseModal} />}
         <div className="overview text-center">
-          <PremiumPricingMinisRow lastFour={lastFour} diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} />
+          <PremiumPricingMinisRow diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lastFour={lastFour} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} />
           <PremiumFeaturesTable
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -90,7 +90,7 @@ export const PremiumPricingGuide = ({ lastFour, diagnosticActivityCount, indepen
       <div className="container premium-page">
         {userIsSignedIn() && <PremiumBannerBuilder originPage="premium" showPurchaseModal={showPurchaseModal} />}
         <div className="overview text-center">
-          <PremiumPricingMinisRow diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lastFour={lastFour} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}/>
+          <PremiumPricingMinisRow diagnosticActivityCount={diagnosticActivityCount} independentPracticeActivityCount={independentPracticeActivityCount} lastFour={lastFour} lessonsActivityCount={lessonsActivityCount} showPurchaseModal={showPurchaseModal} userIsEligibleForNewSubscription={userIsEligibleForNewSubscription} />
           <PremiumFeaturesTable
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import QuestionsAndAnswers from './QuestionsAndAnswers.tsx'
 
 import PurchaseModal from './PurchaseModal';
+import PremiumConfirmationModal from '../components/subscriptions/premium_confirmation_modal';
 import PremiumBannerBuilder from '../components/scorebook/premium_banners/premium_banner_builder.jsx'
 import PremiumPricingMinisRow from '../components/premium/premium_pricing_minis_row.jsx';
 import SubscriberLogos from '../components/premium/subscriber_logos.jsx';
@@ -97,30 +98,30 @@ export default class PremiumPricingGuide extends React.Component {
     const { diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount } = this.props
     const { userIsSignedIn } = this.state
     return (
-    <div>
-      <div className="container premium-page">
-        <PremiumBannerBuilder showPurchaseModal={this.showPurchaseModal} userIsSignedIn={userIsSignedIn}/>
-        <div className="overview text-center">
-          <PremiumPricingMinisRow {...this.props} showPurchaseModal={this.showPurchaseModal} />
-          <PremiumFeaturesTable
-            diagnosticActivityCount={diagnosticActivityCount}
-            independentPracticeActivityCount={independentPracticeActivityCount}
-            lessonsActivityCount={lessonsActivityCount}
+      <div>
+        <div className="container premium-page">
+          {userIsSignedIn ? <PremiumBannerBuilder showPurchaseModal={this.showPurchaseModal} /> : ''}
+          <div className="overview text-center">
+            <PremiumPricingMinisRow {...this.props} showPurchaseModal={this.showPurchaseModal} />
+            <PremiumFeaturesTable
+              diagnosticActivityCount={diagnosticActivityCount}
+              independentPracticeActivityCount={independentPracticeActivityCount}
+              lessonsActivityCount={lessonsActivityCount}
+            />
+          </div>
+
+          <div className="features text-center">
+            <SchoolPremium />
+            <SubscriberLogos subscribers={subscribers} />
+          </div>
+          <QuestionsAndAnswers
+            questionsAndAnswersFile="premium"
+            supportLink="https://support.quill.org/quill-premium"
           />
         </div>
-
-        <div className="features text-center">
-          <SchoolPremium />
-          <SubscriberLogos subscribers={subscribers} />
-        </div>
-        <QuestionsAndAnswers
-          questionsAndAnswersFile="premium"
-          supportLink="https://support.quill.org/quill-premium"
-        />
+        {this.renderPremiumConfirmationModal()}
+        {this.renderPurchaseModal()}
       </div>
-      {this.renderPremiumConfirmationModal()}
-      {this.renderPurchaseModal()}
-    </div>
     )
   }
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import QuestionsAndAnswers from './QuestionsAndAnswers.tsx'
 
+import PurchaseModal from './PurchaseModal';
 import PremiumBannerBuilder from '../components/scorebook/premium_banners/premium_banner_builder.jsx'
 import PremiumPricingMinisRow from '../components/premium/premium_pricing_minis_row.jsx';
 import SubscriberLogos from '../components/premium/subscriber_logos.jsx';
@@ -27,17 +28,80 @@ const subscribers = [
    { name: 'Princeton Public Schools logo', source: '/images/subscribers/16_princeton.png', id: 'princeton'}
  ]
 
-const PremiumPricingGuide = (props) => {
+export default class PremiumPricingGuide extends React.Component {
   // const size = useWindowSize();
   // const onMobile = () => size.width <= MAX_VIEW_WIDTH_FOR_MOBILE
   //
-  const { diagnosticActivityCount, lessonsActivityCount, independentPracticeActivityCount, } = props
-  return (
+  state = {
+    showPremiumConfirmationModal: false,
+    showPurchaseModal: false,
+    subscriptionType: null,
+    subscriptionStatus: null,
+    userIsSignedIn: !!Number(document.getElementById('current-user-id').getAttribute('content')),
+    isScrolled: false
+  };
+
+  hidePremiumConfirmationModal = () => {
+    this.setState({ showPremiumConfirmationModal: false, });
+  };
+
+  hidePurchaseModal = () => {
+    this.setState({ showPurchaseModal: false, subscriptionType: null, });
+  };
+
+  showPremiumConfirmationModal = () => {
+    this.setState({ showPremiumConfirmationModal: true, });
+  };
+
+  showPurchaseModal = () => {
+    this.setState({ showPurchaseModal: true, });
+  };
+
+  showPurchaseModalForSchoolPurchase = () => {
+    this.setState({ subscriptionType: 'School', }, () => this.setState({ showPurchaseModal: true, }));
+  };
+
+  updateSubscriptionStatus = subscription => {
+    this.setState({ subscriptionStatus: subscription,
+      showPremiumConfirmationModal: true,
+      showPurchaseModal: false, });
+  };
+
+  renderPremiumConfirmationModal = () => {
+    const { showPremiumConfirmationModal, subscriptionStatus, } = this.state
+    if (!showPremiumConfirmationModal) { return }
+    return (<PremiumConfirmationModal
+      hideModal={this.hidePremiumConfirmationModal}
+      show={showPremiumConfirmationModal}
+      subscription={subscriptionStatus}
+    />)
+  }
+
+  renderPurchaseModal = () => {
+    const {
+      showPurchaseModal,
+      subscriptionType
+    } = this.state
+    const { lastFour, } = this.props
+    if (!showPurchaseModal) { return }
+    return (<PurchaseModal
+      hideModal={this.hidePurchaseModal}
+      lastFour={lastFour}
+      show={showPurchaseModal}
+      subscriptionType={subscriptionType}
+      updateSubscriptionStatus={this.updateSubscriptionStatus}
+    />)
+  }
+
+  render() {
+    const { diagnosticActivityCount, independentPracticeActivityCount, lessonsActivityCount } = this.props
+    const { userIsSignedIn } = this.state
+    return (
     <div>
       <div className="container premium-page">
-        <PremiumBannerBuilder />
+        <PremiumBannerBuilder showPurchaseModal={this.showPurchaseModal} userIsSignedIn={userIsSignedIn}/>
         <div className="overview text-center">
-          <PremiumPricingMinisRow {...props} />
+          <PremiumPricingMinisRow {...this.props} showPurchaseModal={this.showPurchaseModal} />
           <PremiumFeaturesTable
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}
@@ -54,8 +118,9 @@ const PremiumPricingGuide = (props) => {
           supportLink="https://support.quill.org/quill-premium"
         />
       </div>
+      {this.renderPremiumConfirmationModal()}
+      {this.renderPurchaseModal()}
     </div>
-  );
+    )
+  }
 }
-
-export default PremiumPricingGuide

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -100,7 +100,7 @@ export default class PremiumPricingGuide extends React.Component {
     return (
       <div>
         <div className="container premium-page">
-          {userIsSignedIn ? <PremiumBannerBuilder showPurchaseModal={this.showPurchaseModal} /> : ''}
+          {userIsSignedIn ? <PremiumBannerBuilder originPage="premium" showPurchaseModal={this.showPurchaseModal} /> : ''}
           <div className="overview text-center">
             <PremiumPricingMinisRow {...this.props} showPurchaseModal={this.showPurchaseModal} />
             <PremiumFeaturesTable

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import QuestionsAndAnswers from './QuestionsAndAnswers.tsx'
 
+import PremiumBannerBuilder from '../components/scorebook/premium_banners/premium_banner_builder.jsx'
 import PremiumPricingMinisRow from '../components/premium/premium_pricing_minis_row.jsx';
 import SubscriberLogos from '../components/premium/subscriber_logos.jsx';
 import SchoolPremium from '../components/premium/school_premium.jsx';
@@ -34,6 +35,7 @@ const PremiumPricingGuide = (props) => {
   return (
     <div>
       <div className="container premium-page">
+        <PremiumBannerBuilder />
         <div className="overview text-center">
           <PremiumPricingMinisRow {...props} />
           <PremiumFeaturesTable

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ProgressReportIndex.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ProgressReportIndex.jsx
@@ -52,7 +52,7 @@ export default class ProgressReportIndex extends React.Component {
     });
 
     return (<div>
-      {shouldHaveBanner ? <PremiumBannerBuilder /> : null}
+      {shouldHaveBanner ? <PremiumBannerBuilder originPage="report" /> : null}
       {component}
     </div>)
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ProgressReportIndex.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ProgressReportIndex.jsx
@@ -52,7 +52,7 @@ export default class ProgressReportIndex extends React.Component {
     });
 
     return (<div>
-      {shouldHaveBanner ? <PremiumBannerBuilder originPage="report" /> : null}
+      {shouldHaveBanner && <PremiumBannerBuilder originPage="report" />}
       {component}
     </div>)
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/PremiumPricingGuide.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/PremiumPricingGuide.test.jsx
@@ -4,6 +4,12 @@ import { shallow } from 'enzyme';
 import PremiumPricingGuide from '../PremiumPricingGuide.jsx';
 
 describe('PremiumPricingGuide container', () => {
+  beforeEach(() => {
+    const div = document.createElement('div');
+    div.setAttribute('id', 'current-user-id');
+    div.setAttribute('content', false);
+    document.body.appendChild(div);
+  });
 
   it('should render', () => {
     expect(shallow(<PremiumPricingGuide diagnosticActivityCount={9} independentPracticeActivityCount={400} lessonsActivityCount={50} />)).toMatchSnapshot();

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
@@ -12,6 +12,7 @@ exports[`PremiumPricingGuide container should render 1`] = `
         diagnosticActivityCount={9}
         independentPracticeActivityCount={400}
         lessonsActivityCount={50}
+        showPurchaseModal={[Function]}
       />
       <PremiumFeaturesTable
         diagnosticActivityCount={9}


### PR DESCRIPTION
## WHAT
Add the Premium banner to the premium page (along with all click behaviors including purchasing premium).

## WHY
We're trying to help teachers purchase premium easily and sign up for trials faster.

## HOW
Add the banner to this page -- I had to lift a bunch of purchasing logic out of the `PremiumPricingMinis` components and put it in the parent component, so that I could pass the logic to the banner as well.

### Screenshots
![Screen Shot 2021-11-12 at 3 53 25 PM](https://user-images.githubusercontent.com/57366100/141533139-461d6ae0-de97-40ce-acfa-c1a62703a1a2.png)

### Notion Card Links
https://www.notion.so/quill/Add-a-trial-banner-to-the-premium-page-747703eebe4241f39ed4bb888ba95065

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes