### PR TITLE
make sure edition questions have loaded for marking lesson completed

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -96,6 +96,7 @@ function select(props) {
   return {
     classroomSessions: props.classroomSessions,
     classroomLesson: props.classroomLesson,
+    customize: props.customize
   };
 }
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -44,19 +44,23 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
     const { classroomUnitId, classroomSessionId } = this.state
     const activityId: string = match.params.lessonID;
     if (classroomUnitId && classroomSessionId) {
-      dispatch(getClassLesson(activityId));
       dispatch(startListeningToSessionForTeacher(activityId, classroomUnitId, classroomSessionId));
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { classroomSessions, classroomLesson, customize, dispatch, } = this.props
+    const { classroomSessions, customize, dispatch, } = this.props
+
+    console.log('classroomSessions', classroomSessions)
+    console.log('customize', customize)
 
     if (classroomSessions.hasreceiveddata && classroomSessions.data.edition_id) {
+      console.log('does this get called')
       dispatch(getEditionQuestions(classroomSessions.data.edition_id))
     }
 
-    if (classroomSessions.hasreceiveddata && classroomLesson.hasreceiveddata && customize && customize.editionQuestions) {
+    if (classroomSessions.hasreceiveddata && customize && customize.editionQuestions) {
+      console.log('what about this')
       this.finishLesson(this.props)
     }
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -51,16 +51,11 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
   componentDidUpdate(prevProps) {
     const { classroomSessions, customize, dispatch, } = this.props
 
-    console.log('classroomSessions', classroomSessions)
-    console.log('customize', customize)
-
     if (classroomSessions.hasreceiveddata && classroomSessions.data.edition_id) {
-      console.log('does this get called')
       dispatch(getEditionQuestions(classroomSessions.data.edition_id))
     }
 
     if (classroomSessions.hasreceiveddata && Object.keys(customize.editionQuestions).length) {
-      console.log('what about this')
       this.finishLesson(this.props)
     }
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -8,9 +8,11 @@ import {
 import {
   getClassLesson
 } from '../../../actions/classroomLesson';
+import {
+  getEditionQuestions,
+} from '../../../actions/customize'
 import { getParameterByName } from '../../../libs/getParameterByName';
 import {
-  ClassroomLessonSessions,
   ClassroomLessonSession,
   ClassroomUnitId,
   ClassroomSessionId
@@ -47,12 +49,17 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.classroomSessions.hasreceiveddata && nextProps.classroomLesson.hasreceiveddata) {
-      const data: ClassroomLessonSession = nextProps.classroomSessions.data;
-      const lessonData: ClassroomLesson = nextProps.classroomLesson.data;
-      this.finishLesson(nextProps)
+  componentDidUpdate(prevProps) {
+    const { classroomSessions, classroomLesson, customize, dispatch, } = this.props
+
+    if (classroomSessions.hasreceiveddata && classroomSessions.data.edition_id && customize.editionQuestions) {
+      dispatch(getEditionQuestions(classroomSessions.data.edition_id))
     }
+
+    if (classroomSessions.hasreceiveddata && classroomLesson.hasreceiveddata) {
+      this.finishLesson(this.props)
+    }
+
   }
 
   finishLesson(nextProps) {

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -52,11 +52,11 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
   componentDidUpdate(prevProps) {
     const { classroomSessions, classroomLesson, customize, dispatch, } = this.props
 
-    if (classroomSessions.hasreceiveddata && classroomSessions.data.edition_id && customize.editionQuestions) {
+    if (classroomSessions.hasreceiveddata && classroomSessions.data.edition_id) {
       dispatch(getEditionQuestions(classroomSessions.data.edition_id))
     }
 
-    if (classroomSessions.hasreceiveddata && classroomLesson.hasreceiveddata) {
+    if (classroomSessions.hasreceiveddata && classroomLesson.hasreceiveddata && customize && customize.editionQuestions) {
       this.finishLesson(this.props)
     }
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/markingLessonAsCompleted.tsx
@@ -59,7 +59,7 @@ class MarkingLessonAsCompleted extends React.Component<any, MarkingLessonsAsComp
       dispatch(getEditionQuestions(classroomSessions.data.edition_id))
     }
 
-    if (classroomSessions.hasreceiveddata && customize && customize.editionQuestions) {
+    if (classroomSessions.hasreceiveddata && Object.keys(customize.editionQuestions).length) {
       console.log('what about this')
       this.finishLesson(this.props)
     }


### PR DESCRIPTION
## WHAT
This morning I put out a PR to fix some logic around marking lessons as completed, but I neglected to notice that the edition questions aren't necessarily already in the reducer state when this component is loaded. This handles that.

## WHY
So that teachers can mark lessons as completed.

## HOW
Just make sure `getEditionQuestions` is always called before `finishLesson`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A