### PR TITLE
make sure satismeter is part of the connect_src in the csp

### DIFF
--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -109,19 +109,20 @@ SecureHeaders::Configuration.default do |config|
       "wss://*.intercom.io",
       "https://*.coview.com",
       "https://*.sentry.io",
-      "wss://*.quill.org"
+      "wss://*.quill.org",
+      "https://*.satismeter.com"
     ]
   }
 
-  config.csp = default_config 
+  config.csp = default_config
 
   config.x_frame_options = SecureHeaders::OPT_OUT
-  
+
   config.cookies = {
-    secure: true, 
-    httponly: true, 
+    secure: true,
+    httponly: true,
     samesite: {
-      lax: true 
+      lax: true
     }
   }
 end


### PR DESCRIPTION
## WHAT
Make sure we include the Satismeter link in the `connect_src` part of the CSP.

## WHY
Our CSP policy was blocking the load of our Satismeter widget. This fixes that.

## HOW
Just add it to the `connect_src` as well as the `script_src`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Satismeter-collected-it-s-last-survey-on-October-8-c41b54c49b7740078c6edb779ff6f188)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A