### PR TITLE
Profanity Prefilter Optimization

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -8,14 +8,14 @@ module Evidence
     OPTIMAL_RULE_UID            = 'a7410335-5dae-4fc7-832a-ce9cf8d5dffb'
     QUESTION_MARK_RULE_UID      = 'f576dadc-7eec-4e27-8c95-7763e6550141'
     MULTIPLE_SENTENCE_RULE_UID  = '66779e2a-74ed-4099-8704-11983121fee5'
-    PROFANITY_RULE_UID          = 'fdee458a-f017-4f9a-a7d4-a72d1143abeb' 
+    PROFANITY_RULE_UID          = 'fdee458a-f017-4f9a-a7d4-a72d1143abeb'
     MINIMUM_WORD_RULE_UID       = '408d4544-5492-46e7-a6b7-3b1ffdd632af'
 
     # When a prefilter lambda identifies a violation, it returns true
     PREFILTERS = {
       QUESTION_MARK_RULE_UID      => ->(entry) { entry.match?(/\?$/) },
       MULTIPLE_SENTENCE_RULE_UID  => ->(entry) { sentence_count(entry) > 1 },
-      PROFANITY_RULE_UID          => ->(entry) { words(entry).find{ |w| Profanity.profane?(w)} },
+      PROFANITY_RULE_UID          => ->(entry) { Profanity.profane?(entry) },
       MINIMUM_WORD_RULE_UID       => ->(entry) { word_count(entry) < MINIMUM_WORD_COUNT}
     }
 
@@ -38,11 +38,11 @@ module Evidence
     end
 
     def feedback_object
-      violated_rule = prefilter_rules.find do |rule| 
+      violated_rule = prefilter_rules.find do |rule|
         next unless PREFILTERS[rule.uid]
-        PREFILTERS[rule.uid].call(entry) 
+        PREFILTERS[rule.uid].call(entry)
       end
-      
+
       return default_response unless violated_rule
 
       feedback = violated_rule.feedbacks.first

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -1,13 +1,28 @@
-module Evidence 
-  class Profanity 
-    def self.profane?(word)
+module Evidence
+  class Profanity
+
+    def self.profane?(entry)
+      flagged_words = BadWords::ALL.select do |word|
+        entry.include?(word.gsub('*',''))
+      end
+
+      return false if flagged_words.empty?
+
+      entry.split(' ').any? { |word| profane_word_check?(word, flagged_words)}
+    end
+
+    # keeping this for now for comparison and benchmarking
+    def self.profane_legacy?(entry)
+      entry.split(' ').any? { |word| profane_word_check?(word)}
+    end
+
+    def self.profane_word_check?(word, bad_words = BadWords::ALL)
       return false unless word.is_a?(String) && word.length > 1
       word = word.downcase.gsub(/[.!?]/, '')
 
-      a_match = BadWords::ALL.find do |badword|
+      a_match = bad_words.any? do |badword|
         match?(badword: badword, word: word)
       end
-      a_match ? true : false
     end
 
     def self.match?(badword:, word:)
@@ -17,12 +32,12 @@ module Evidence
          word.match?(regex)
       elsif badword.start_with?('*')
         regex = ::Regexp.new("#{stripped_badword}$")
-         word.match?(regex) 
+         word.match?(regex)
       elsif badword.end_with?('*')
         regex = ::Regexp.new("^#{stripped_badword}")
-         word.match?(regex) 
-      else 
-         stripped_badword == word 
+         word.match?(regex)
+      else
+         stripped_badword == word
       end
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -2,13 +2,15 @@ module Evidence
   class Profanity
 
     def self.profane?(entry)
-      flagged_words = BadWords::ALL.select do |word|
-        entry.include?(word.gsub('*',''))
+      # find the badword substrings that exist in the entry
+      found_bad_words = BadWords::ALL.select do |word|
+        entry.downcase.include?(word.gsub('*',''))
       end
 
-      return false if flagged_words.empty?
+      return false if found_bad_words.empty?
 
-      entry.split(' ').any? { |word| profane_word_check?(word, flagged_words)}
+      # do a more rigorous word-by-word check for found bad words
+      entry.split(' ').any? { |word| profane_word_check?(word, found_bad_words)}
     end
 
     # keeping this for now for comparison and benchmarking

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -1,40 +1,77 @@
 require 'rails_helper'
 
 module Evidence
-  RSpec.describe(Profanity) do 
-    describe '#profane?' do 
-      it 'should return true given a profane word simple match' do  
+  RSpec.describe(Profanity) do
+    describe '#profane?' do
+      it 'should return false given no profanity' do
         stub_const("BadWords::ALL", ['pumpkin'])
-        expect(Profanity.profane?('pumpkin')).to be true
+        expect(Profanity.profane?('This sentence has no orange gourds.')).to be false
       end
 
-      it 'should return true given a profane word regex match right glob' do 
-        stub_const("BadWords::ALL", ['pumpkin*']) 
-        expect(Profanity.profane?('pumpkins')).to be true
+      it 'should return true given a profane word simple match' do
+        stub_const("BadWords::ALL", ['pumpkin'])
+        expect(Profanity.profane?('There is something in a pumpkin')).to be true
       end
 
-      it 'should return true given a profane word regex match left glob' do 
-        stub_const("BadWords::ALL", ['*pumpkin']) 
-        expect(Profanity.profane?('orangepumpkin')).to be true
+      it 'should return true given a profane word regex match right glob' do
+        stub_const("BadWords::ALL", ['pumpkin*'])
+        expect(Profanity.profane?('There is something in a pumpkining')).to be true
       end
 
-      it 'should return false given a substring of a bad word' do 
-        stub_const("BadWords::ALL", ['*pumpkin*']) 
-        expect(Profanity.profane?('pump')).to be false
+      it 'should return true given a profane word regex match left glob' do
+        stub_const("BadWords::ALL", ['*pumpkin'])
+        expect(Profanity.profane?('There is something in a orangepumpkin')).to be true
       end
 
-      it 'should return true given a profane word regex match left right glob' do 
-        stub_const("BadWords::ALL", ['*pumpkin*']) 
-        expect(Profanity.profane?('orangepumpkins')).to be true
+      it 'should return false given a substring of a bad word' do
+        stub_const("BadWords::ALL", ['*pumpkin*'])
+        expect(Profanity.profane?('this is not pump')).to be false
       end
 
-      it 'should return true given a profane word with ending punctuation' do 
-        stub_const("BadWords::ALL", ['pumpkin']) 
-        expect(Profanity.profane?('pumpkin.')).to be true
+      it 'should return true given a profane word regex match left right glob' do
+        stub_const("BadWords::ALL", ['*pumpkin*'])
+        expect(Profanity.profane?('There is orangepumpkins, everywhere')).to be true
       end
 
-      it 'should return false given a normal word' do 
-        expect(Profanity.profane?('bird')).to be false
+      it 'should return true given a profane word with ending punctuation' do
+        stub_const("BadWords::ALL", ['pumpkin'])
+        expect(Profanity.profane?('This is a pumpkin.')).to be true
+      end
+    end
+
+    describe '#profane_word_check?' do
+      it 'should return true given a profane word simple match' do
+        stub_const("BadWords::ALL", ['pumpkin'])
+        expect(Profanity.profane_word_check?('pumpkin')).to be true
+      end
+
+      it 'should return true given a profane word regex match right glob' do
+        stub_const("BadWords::ALL", ['pumpkin*'])
+        expect(Profanity.profane_word_check?('pumpkins')).to be true
+      end
+
+      it 'should return true given a profane word regex match left glob' do
+        stub_const("BadWords::ALL", ['*pumpkin'])
+        expect(Profanity.profane_word_check?('orangepumpkin')).to be true
+      end
+
+      it 'should return false given a substring of a bad word' do
+        stub_const("BadWords::ALL", ['*pumpkin*'])
+        expect(Profanity.profane_word_check?('pump')).to be false
+      end
+
+      it 'should return true given a profane word regex match left right glob' do
+        stub_const("BadWords::ALL", ['*pumpkin*'])
+        expect(Profanity.profane_word_check?('orangepumpkins')).to be true
+      end
+
+      it 'should return true given a profane word with ending punctuation' do
+        stub_const("BadWords::ALL", ['pumpkin'])
+        expect(Profanity.profane_word_check?('pumpkin.')).to be true
+      end
+
+      it 'should return false given a normal word' do
+        expect(Profanity.profane_word_check?('bird')).to be false
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -4,37 +4,47 @@ module Evidence
   RSpec.describe(Profanity) do
     describe '#profane?' do
       it 'should return false given no profanity' do
-        stub_const("BadWords::ALL", ['pumpkin'])
+        stub_const("BadWords::ALL", ['other', 'pumpkin'])
         expect(Profanity.profane?('This sentence has no orange gourds.')).to be false
       end
 
       it 'should return true given a profane word simple match' do
-        stub_const("BadWords::ALL", ['pumpkin'])
+        stub_const("BadWords::ALL", ['other', 'pumpkin'])
         expect(Profanity.profane?('There is something in a pumpkin')).to be true
       end
 
+      it 'should return true given a profane word simple match case insensitive' do
+        stub_const("BadWords::ALL", ['other', 'pumpkin'])
+        expect(Profanity.profane?('THERE IS SOMETHING IN A PUMPKIN')).to be true
+      end
+
+      it 'should return false given a partial exact match' do
+        stub_const("BadWords::ALL", ['other', 'pumpkin'])
+        expect(Profanity.profane?('Mother, here is something in a pumpkins')).to be false
+      end
+
       it 'should return true given a profane word regex match right glob' do
-        stub_const("BadWords::ALL", ['pumpkin*'])
+        stub_const("BadWords::ALL", ['other', 'pumpkin*'])
         expect(Profanity.profane?('There is something in a pumpkining')).to be true
       end
 
       it 'should return true given a profane word regex match left glob' do
-        stub_const("BadWords::ALL", ['*pumpkin'])
+        stub_const("BadWords::ALL", ['other', '*pumpkin'])
         expect(Profanity.profane?('There is something in a orangepumpkin')).to be true
       end
 
       it 'should return false given a substring of a bad word' do
-        stub_const("BadWords::ALL", ['*pumpkin*'])
+        stub_const("BadWords::ALL", ['other', '*pumpkin*'])
         expect(Profanity.profane?('this is not pump')).to be false
       end
 
       it 'should return true given a profane word regex match left right glob' do
-        stub_const("BadWords::ALL", ['*pumpkin*'])
+        stub_const("BadWords::ALL", ['other', '*pumpkin*'])
         expect(Profanity.profane?('There is orangepumpkins, everywhere')).to be true
       end
 
       it 'should return true given a profane word with ending punctuation' do
-        stub_const("BadWords::ALL", ['pumpkin'])
+        stub_const("BadWords::ALL", ['other', 'pumpkin'])
         expect(Profanity.profane?('This is a pumpkin.')).to be true
       end
     end


### PR DESCRIPTION
## WHAT
Small optimization PR building on #8475
## WHY
A few extra lines made this 25-50x faster for long strings. Most students aren't going to write profanity, so we want to keep this fast in that scenario. This optimizes for that case.
## HOW
Search the whole entry for any bad word substrings, then do word-by-word check ONLY on those substrings.
### Screenshots
For a random 1,000 entries > 100 characters pulled from the DB.
<img width="702" alt="Screen Shot 2021-11-15 at 4 59 36 PM" src="https://user-images.githubusercontent.com/1304933/141860269-13c6da8b-1e5f-47fe-a9a0-d525b9eca6a8.png">

A single long entry in milliseconds.
<img width="966" alt="Screen Shot 2021-11-15 at 5 02 16 PM" src="https://user-images.githubusercontent.com/1304933/141860283-adf69413-5c63-463c-bc19-6faa9e47015b.png">

<img width="998" alt="Screen Shot 2021-11-15 at 5 06 58 PM" src="https://user-images.githubusercontent.com/1304933/141860631-ede5e44a-353d-49c2-b4a9-dfd03f9b6735.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
