### PR TITLE
Temporarily log clever importing

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -101,7 +101,7 @@ class ChangeLog < ApplicationRecord
     skipped_import: 'Skipped User import'
   }
   # TODO remove temporary CLEVER_IMPORT_ACTIONS
-  CLEVER_IMPORT_ACTIONS = %i[
+  CLEVER_IMPORT_ACTIONS = %w[
     library_integration
     district_integration
   ]

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,6 +100,7 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
+  # TODO remove temporary CLEVER_IMPORT_ACTIONS
   CLEVER_IMPORT_ACTIONS = %i[
     library_integration
     district_integration
@@ -108,6 +109,7 @@ class ChangeLog < ApplicationRecord
     'Visited User Directory',
     'Searched Users'
   ]
+  # TODO remove temporary CLEVER_IMPORT_ACTIONS
   ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + CLEVER_IMPORT_ACTIONS
 
   belongs_to :changed_record, polymorphic: true

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,7 +100,7 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
-  # TODO remove temporary CLEVER_IMPORT_ACTIONS
+  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
   CLEVER_IMPORT_ACTIONS = %w[
     library_integration
     district_integration
@@ -109,7 +109,7 @@ class ChangeLog < ApplicationRecord
     'Visited User Directory',
     'Searched Users'
   ]
-  # TODO remove temporary CLEVER_IMPORT_ACTIONS
+  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
   ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + CLEVER_IMPORT_ACTIONS
 
   belongs_to :changed_record, polymorphic: true

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,11 +100,15 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
+  CLEVER_IMPORT_ACTIONS = %i[
+    library_integration
+    district_integration
+  ]
   GENERIC_USER_ACTIONS = [
     'Visited User Directory',
     'Searched Users'
   ]
-  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values
+  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + CLEVER_IMPORT_ACTIONS
 
   belongs_to :changed_record, polymorphic: true
   belongs_to :user

--- a/services/QuillLMS/app/services/clever_integration/importers/library.rb
+++ b/services/QuillLMS/app/services/clever_integration/importers/library.rb
@@ -3,10 +3,6 @@ module CleverIntegration::Importers::Library
     client = CleverLibrary::Api::Client.new(auth_hash.credentials.token)
     user = import_teacher(client)
 
-    unless ChangeLog.exists?(changed_record: user, attr: user_type, action: :clever_library_import)
-      ChangeLog.create(changed_record: user, attr: user_type, action: :clever_library_import, explanation: auth_hash.to_json)
-    end
-
     if auth_hash[:info][:user_type] == 'teacher'
       classrooms = import_classrooms(client, user)
       CleverLibraryStudentImporterWorker.perform_async(classrooms.map(&:id), auth_hash.credentials.token)
@@ -21,7 +17,6 @@ module CleverIntegration::Importers::Library
   def self.import_teacher(client)
     teacher_id = client.user()['id']
     teacher_data = client.get_teacher(teacher_id: teacher_id)
-
     CleverIntegration::Creators::Teacher.run(
       email: teacher_data['email'],
       name: "#{teacher_data['name']['first']} #{teacher_data['name']['middle']} #{teacher_data['name']['last']}".squish,

--- a/services/QuillLMS/app/services/clever_integration/importers/library.rb
+++ b/services/QuillLMS/app/services/clever_integration/importers/library.rb
@@ -3,6 +3,10 @@ module CleverIntegration::Importers::Library
     client = CleverLibrary::Api::Client.new(auth_hash.credentials.token)
     user = import_teacher(client)
 
+    unless ChangeLog.exists?(changed_record: user, attr: user_type, action: :clever_library_import)
+      ChangeLog.create(changed_record: user, attr: user_type, action: :clever_library_import, explanation: auth_hash.to_json)
+    end
+
     if auth_hash[:info][:user_type] == 'teacher'
       classrooms = import_classrooms(client, user)
       CleverLibraryStudentImporterWorker.perform_async(classrooms.map(&:id), auth_hash.credentials.token)
@@ -17,6 +21,7 @@ module CleverIntegration::Importers::Library
   def self.import_teacher(client)
     teacher_id = client.user()['id']
     teacher_data = client.get_teacher(teacher_id: teacher_id)
+
     CleverIntegration::Creators::Teacher.run(
       email: teacher_data['email'],
       name: "#{teacher_data['name']['first']} #{teacher_data['name']['middle']} #{teacher_data['name']['last']}".squish,

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -13,14 +13,14 @@ module CleverIntegration::SignUp::Teacher
     end
   end
 
-  #TODO remove this temporary method
+  #TODO remove this method
   def self.log_import(action, auth_hash)
-    changed_record = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
+    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
     changed_attr = auth_hash.dig(:info, :user_type)
 
-    return if ChangeLog.exists?(changed_record: user, changed_attr: changed_attr, action: action, user: user)
+    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
 
-    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attr: changed_attr, action: action, user: user)
+    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.library_integration(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -13,7 +13,7 @@ module CleverIntegration::SignUp::Teacher
     end
   end
 
-  #TODO remove this method
+  #TODO: remove this method
   def self.log_import(action, auth_hash)
     user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
     changed_attr = auth_hash.dig(:info, :user_type)
@@ -24,12 +24,12 @@ module CleverIntegration::SignUp::Teacher
   end
 
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash) # TODO remove this temporary call
+    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash) # TODO remove this temporary call
+    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     teacher = create_teacher(auth_hash)
     if teacher.present?
       associate_teacher_to_district(teacher, district)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -13,6 +13,7 @@ module CleverIntegration::SignUp::Teacher
     end
   end
 
+  #TODO remove this temporary method
   def self.log_import(action, auth_hash)
     changed_record = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
     changed_attr = auth_hash.dig(:info, :user_type)
@@ -23,12 +24,12 @@ module CleverIntegration::SignUp::Teacher
   end
 
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash)
+    log_import(:district_integration, auth_hash) # TODO remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash)
+    log_import(:library_integration, auth_hash) # TODO remove this temporary call
     teacher = create_teacher(auth_hash)
     if teacher.present?
       associate_teacher_to_district(teacher, district)


### PR DESCRIPTION
## WHAT
Save one clever import auth_hash for each user_type to the database.

## WHY
We currently have no way of testing library integration imports.  These records will give the correct payload to model tests after.

## HOW
Save auth_hash to changelog record.

NB: I'm storing all of the records on my user account: `ENV['CLEVER_IMPORT_LOG_USER_ID']`

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manual testing on staging.
Have you deployed to Staging? | Not yet - deploying now!, NO - non-app change, NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
