### PR TITLE
Fix bug with assigned activity links

### DIFF
--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -2,7 +2,7 @@ class ActivitiesController < ApplicationController
   before_action :activity, only: [:update]
   before_action :set_activity_by_lesson_id, only: [:preview_lesson]
   before_action :set_activity, only: [:supporting_info, :customize_lesson, :name_and_id, :last_unit_template]
-  before_action :student!, only: :activity_session
+  before_action :signed_in!, only: [:activity_session]
 
   DIAGNOSTIC = 'diagnostic'
 
@@ -68,6 +68,7 @@ class ActivitiesController < ApplicationController
   end
 
   private def authorized_activity_access?
+    current_user.student? &&
     activity &&
     classroom_unit&.assigned_student_ids&.include?(current_user.id) &&
     UnitActivity.exists?(unit: classroom_unit.unit, activity: activity)

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -68,12 +68,23 @@ describe ActivitiesController, type: :controller, redis: true do
     let!(:classroom_unit) { create(:classroom_unit_with_activity_sessions).reload }
     let!(:activity) { classroom_unit.unit.unit_activities.first.activity }
 
-    context 'no student is logged in' do
+    subject { get :activity_session, params: { id: activity.id, classroom_unit_id: classroom_unit.id } }
+
+    context 'no user is logged in' do
       before { session.delete(:user_id) }
 
       it 'redirects to login path' do
-        get :activity_session, params: { id: activity.id, classroom_unit_id: classroom_unit.id }
+        subject
         expect(response).to redirect_to new_session_path
+      end
+    end
+
+    context 'user is not a student' do
+      before { session[:user_id] = create(:teacher).id }
+
+      it 'redirects to profile_path' do
+        subject
+        expect(response).to redirect_to profile_path
       end
     end
 
@@ -81,8 +92,7 @@ describe ActivitiesController, type: :controller, redis: true do
       before { classroom_unit.update(assigned_student_ids: [student.id]) }
 
       it '' do
-        get :activity_session, params: { id: activity.id, classroom_unit_id: classroom_unit.id }
-
+        subject
         expect(response)
           .to redirect_to activity_session_from_classroom_unit_and_activity_path(classroom_unit, activity)
       end
@@ -90,7 +100,7 @@ describe ActivitiesController, type: :controller, redis: true do
 
     context 'student is not assigned to classroom_unit' do
       it '' do
-        get :activity_session, params: { id: activity.id, classroom_unit_id: classroom_unit.id }
+        subject
         expect(response).to redirect_to profile_path
       end
     end


### PR DESCRIPTION
## WHAT
Fix an issue that logs out teacher and staff accounts when attempting to navigate to an assigned activity link.

## WHY
Users should not be logged out when they are 

## HOW
Check if user is logged in.  If not, redirect to session path.
Then check if users is a student.  If not, redirect to the user profile.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A