### PR TITLE
Remove all recurring webinar banners

### DIFF
--- a/services/QuillLMS/app/models/recurring_banner.rb
+++ b/services/QuillLMS/app/models/recurring_banner.rb
@@ -6,31 +6,6 @@ class RecurringBanner < WebinarBanner
   # RECURRING have the key format DayOfWeek-Hour
 
   WEBINARS = {
-    '2-16' => {
-      title: "<strong>Quill Webinar 101: Getting Started</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_vA0O4ltWSJKMLqghSm4otw"
-    },
-    '4-11' => {
-      title: "<strong>Quill Webinar 101: Getting Started</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_vA0O4ltWSJKMLqghSm4otw"
-    },
-    '4-17' => {
-      title: "<strong>Quill Webinar 101: Getting Started</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_vA0O4ltWSJKMLqghSm4otw"
-    },
-    '3-16' => {
-      title: "<strong>Quill Webinar 201: Diving into Data</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_aIXMEsiVS_qYmLRTt-T4Tw"
-    },
-    '3-19' => {
-      title: "<strong>Quill Webinar 201: Diving into Data</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_aIXMEsiVS_qYmLRTt-T4Tw"
-    }
   }
 
   private def values

--- a/services/QuillLMS/spec/models/recurring_banner_spec.rb
+++ b/services/QuillLMS/spec/models/recurring_banner_spec.rb
@@ -33,11 +33,11 @@ describe RecurringBanner, type: :model do
     expect(banner.title).to eq(nil)
   end
 
-  it "does return true for show? when the key does have an associated webinar" do
-    time =  DateTime.new(2021,9,2,11,1,0)
-    banner = RecurringBanner.new(time)
-    expect(banner.show?(true)).to eq(true)
-  end
+  # it "does return true for show? when the key does have an associated webinar" do
+  #   time =  DateTime.new(2021,9,2,11,1,0)
+  #   banner = RecurringBanner.new(time)
+  #   expect(banner.show?(true)).to eq(true)
+  # end
 
   it "does not return true for show? when the key falls on a skipped day" do
     time =  DateTime.new(2021,1,18,16,1,0)
@@ -45,11 +45,11 @@ describe RecurringBanner, type: :model do
     expect(banner.show?(true)).to eq(false)
   end
 
-  it "does return correct link and title when the key does have an associated recurring webinar" do
-    time =  DateTime.new(2021,9,2,11,1,0)
-    banner = RecurringBanner.new(time)
-    expect(banner.title).to eq("<strong>Quill Webinar 101: Getting Started</strong> is live now!")
-    expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_vA0O4ltWSJKMLqghSm4otw")
-  end
+  # it "does return correct link and title when the key does have an associated recurring webinar" do
+  #   time =  DateTime.new(2021,9,2,11,1,0)
+  #   banner = RecurringBanner.new(time)
+  #   expect(banner.title).to eq("<strong>Quill Webinar 101: Getting Started</strong> is live now!")
+  #   expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_vA0O4ltWSJKMLqghSm4otw")
+  # end
 
 end

--- a/services/QuillLMS/spec/models/recurring_banner_spec.rb
+++ b/services/QuillLMS/spec/models/recurring_banner_spec.rb
@@ -14,18 +14,6 @@ describe RecurringBanner, type: :model do
     expect(banner.show?("Teacher Trial")).to eq(false)
   end
 
-  # it "does return false for show when the banner is only second and fourth out of the month and its the first week" do
-  #   time =  DateTime.new(2021,3,3,16,0,0)
-  #   banner = RecurringBanner.new(time)
-  #   expect(banner.show?).to eq(false)
-  # end
-
-  # it "does return true for show when the banner is only second and fourth out of the month and its the second week" do
-  #   time =  DateTime.new(2021,3,10,16,0,0)
-  #   banner = RecurringBanner.new(time)
-  #   expect(banner.show?("School Paid")).to eq(true)
-  # end
-
   it "does return no link or title when the key does not have an associated webinar" do
     time =  DateTime.new(2020,1,1,11,0,0)
     banner = RecurringBanner.new(time)
@@ -33,23 +21,10 @@ describe RecurringBanner, type: :model do
     expect(banner.title).to eq(nil)
   end
 
-  # it "does return true for show? when the key does have an associated webinar" do
-  #   time =  DateTime.new(2021,9,2,11,1,0)
-  #   banner = RecurringBanner.new(time)
-  #   expect(banner.show?(true)).to eq(true)
-  # end
-
   it "does not return true for show? when the key falls on a skipped day" do
     time =  DateTime.new(2021,1,18,16,1,0)
     banner = RecurringBanner.new(time)
     expect(banner.show?(true)).to eq(false)
   end
-
-  # it "does return correct link and title when the key does have an associated recurring webinar" do
-  #   time =  DateTime.new(2021,9,2,11,1,0)
-  #   banner = RecurringBanner.new(time)
-  #   expect(banner.title).to eq("<strong>Quill Webinar 101: Getting Started</strong> is live now!")
-  #   expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_vA0O4ltWSJKMLqghSm4otw")
-  # end
 
 end


### PR DESCRIPTION
## WHAT
We don't want to show the recurring webinar banners anymore, now that we're moving to showing one off banners (banners attached to specific dates and times rather than recurring every week).

## WHY
These banners are no longer relevent.

## HOW
Just remove all of the hard coded banner data in recurring banners.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | No, deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
