### PR TITLE
Temporarily log clever importing for school admin

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
@@ -12,10 +12,12 @@ module CleverIntegration::SignUp::SchoolAdmin
   end
 
   def self.library_integration(auth_hash)
+    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
+    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     user = create_user(auth_hash)
     if user.present?
       associate_user_to_district(user, district)
@@ -24,6 +26,18 @@ module CleverIntegration::SignUp::SchoolAdmin
     else
       {type: 'user_failure', data: "No User Present"}
     end
+  end
+
+  #TODO: remove this method
+  def self.log_import(action, auth_hash)
+    return if Rails.env.test?
+
+    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
+    changed_attr = auth_hash.dig(:info, :user_type)
+
+    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
+
+    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.parse_data(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
@@ -37,7 +37,7 @@ module CleverIntegration::SignUp::SchoolAdmin
 
     return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
 
-    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
+    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.parse_data(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -20,7 +20,7 @@ module CleverIntegration::SignUp::Teacher
 
     return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
 
-    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
+    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.library_integration(auth_hash)


### PR DESCRIPTION
## WHAT
Save one clever import auth_hash for each user_type to the database.

## WHY
We currently have no way of testing library integration imports. These records will give the correct payload to model tests after.

## HOW
Save auth_hash to changelog record.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual testing on staging.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
