### PR TITLE
fix bug where class report shows N/A instead of 0

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -31,7 +31,7 @@ export default class ClassReport extends React.Component {
         field: 'score',
         sortByField: 'score',
         customCell(row) {
-          return row['score'] ? row['score'] + '%' : 'N/A'
+          return row['score'] || row['score'] === 0 ? row['score'] + '%' : 'N/A'
         }
       },
       {


### PR DESCRIPTION
## WHAT
Fix bug where students who get a score of 0 on an activity show "N/A" in the class report view instead of 0.

## WHY
It's confusing for teachers who are looking at scored activity to see "N/A" here.

## HOW
Just make sure we are explicitly still using the numeral if the score is equal to 0. Activities with null scores will still show "N/A".

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Incorrect-score-when-student-misses-everything-on-a-diagnostic-c61ccff523b54628bb30da5483ed05ea)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
