### PR TITLE
Revert log clever import libary

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,17 +100,11 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
-  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
-  CLEVER_IMPORT_ACTIONS = %w[
-    library_integration
-    district_integration
-  ]
   GENERIC_USER_ACTIONS = [
     'Visited User Directory',
     'Searched Users'
   ]
-  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
-  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + CLEVER_IMPORT_ACTIONS
+  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values
 
   belongs_to :changed_record, polymorphic: true
   belongs_to :user

--- a/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
@@ -12,12 +12,10 @@ module CleverIntegration::SignUp::SchoolAdmin
   end
 
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     user = create_user(auth_hash)
     if user.present?
       associate_user_to_district(user, district)
@@ -26,18 +24,6 @@ module CleverIntegration::SignUp::SchoolAdmin
     else
       {type: 'user_failure', data: "No User Present"}
     end
-  end
-
-  #TODO: remove this method
-  def self.log_import(action, auth_hash)
-    return if Rails.env.test?
-
-    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
-    changed_attr = auth_hash.dig(:info, :user_type)
-
-    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-
-    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.parse_data(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -20,7 +20,7 @@ module CleverIntegration::SignUp::Teacher
 
     return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
 
-    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
+    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.library_integration(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -13,23 +13,11 @@ module CleverIntegration::SignUp::Teacher
     end
   end
 
-  #TODO: remove this method
-  def self.log_import(action, auth_hash)
-    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
-    changed_attr = auth_hash.dig(:info, :user_type)
-
-    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-
-    ChangeLog.create!(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-  end
-
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     teacher = create_teacher(auth_hash)
     if teacher.present?
       associate_teacher_to_district(teacher, district)


### PR DESCRIPTION
## WHAT
Remove temporary logging of clever import auth_hash

## WHY
The culprit in clever importing has been identified

## HOW
Revert the two commits that logged clever auth_hash

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Code revert.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
