### PR TITLE
Revert log clever import libary (#8536)

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,17 +100,11 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
-  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
-  CLEVER_IMPORT_ACTIONS = %w[
-    library_integration
-    district_integration
-  ]
   GENERIC_USER_ACTIONS = [
     'Visited User Directory',
     'Searched Users'
   ]
-  # TODO: remove temporary CLEVER_IMPORT_ACTIONS
-  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + CLEVER_IMPORT_ACTIONS
+  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values
 
   belongs_to :changed_record, polymorphic: true
   belongs_to :user

--- a/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/school_admin.rb
@@ -12,12 +12,10 @@ module CleverIntegration::SignUp::SchoolAdmin
   end
 
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     user = create_user(auth_hash)
     if user.present?
       associate_user_to_district(user, district)
@@ -26,18 +24,6 @@ module CleverIntegration::SignUp::SchoolAdmin
     else
       {type: 'user_failure', data: "No User Present"}
     end
-  end
-
-  #TODO: remove this method
-  def self.log_import(action, auth_hash)
-    return if Rails.env.test?
-
-    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
-    changed_attr = auth_hash.dig(:info, :user_type)
-
-    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-
-    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
   end
 
   def self.parse_data(auth_hash)

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -13,23 +13,11 @@ module CleverIntegration::SignUp::Teacher
     end
   end
 
-  #TODO: remove this method
-  def self.log_import(action, auth_hash)
-    user = User.find(ENV['CLEVER_IMPORT_LOG_USER_ID'])
-    changed_attr = auth_hash.dig(:info, :user_type)
-
-    return if ChangeLog.exists?(changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-
-    ChangeLog.create(explanation: auth_hash.to_json, changed_record: user, changed_attribute: changed_attr, action: action, user: user)
-  end
-
   def self.library_integration(auth_hash)
-    log_import(:district_integration, auth_hash) # TODO: remove this temporary call
     CleverIntegration::Importers::Library.run(auth_hash)
   end
 
   def self.district_integration(auth_hash, district)
-    log_import(:library_integration, auth_hash) # TODO: remove this temporary call
     teacher = create_teacher(auth_hash)
     if teacher.present?
       associate_teacher_to_district(teacher, district)


### PR DESCRIPTION
* Revert "Temporarily log clever importing for school admin (#8531)"

This reverts commit 66b496d31a9e590e36063ca66de2199c1225c44e.

* Revert "Temporarily log clever importing (#8522)"

This reverts commit 2bf4487c3543a5937e80b1a95ed30d50859b3be8.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
