### PR TITLE
Add eager loading to activity health query

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
@@ -86,7 +86,7 @@ class Api::V1::ActivitiesController < Api::ApiController
   end
 
   def activities_health
-    render json: {activities_health: ActivityHealth.all.as_json}
+    render json: {activities_health: ActivityHealth.all.includes(:prompt_healths).as_json}
   end
 
   def question_health


### PR DESCRIPTION
## WHAT
We have a [N+1 query problem](https://semaphoreci.com/blog/2017/08/09/faster-rails-eliminating-n-plus-one-queries.html) while loading activity healths. Rails lazy loading makes N queries (N= number of activity health records) to fetch the child object `PromptHealth`, which is very inefficient. It should just make 1 query to fetch all of the `PromptHealth` records.

## WHY
Adding eager loading will speed up the endpoint considerably.

## HOW
Add eager loading to the `ActivityHealth.all` call to fetch all of the children `PromptHealth` records. This way we only make 1 query for all the `PromptHealths`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Performance-Api-V1-ActivitiesController-activities_health-92a42acffe9f4ad19a458725faa6b488

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, no new tests needed.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
