### PR TITLE
fix issue when assigning diagnostics to class where student who is no longer in that class has already completed it

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -308,7 +308,7 @@ export default class CreateUnit extends React.Component {
 
   alreadyCompletedDiagnosticStudentNames = () => {
     const { assignedPreTests, } = this.props
-    const { selectedActivities, classrooms, } = this.state
+    const { selectedActivities, } = this.state
 
     const preTestActivityIds = assignedPreTests.map(pretest => pretest.id)
     const postTestActivityIds = assignedPreTests.map(pretest => pretest.post_test_id)
@@ -319,33 +319,28 @@ export default class CreateUnit extends React.Component {
 
     if (preTestBeingAssigned) {
       const relevantPretest = assignedPreTests.find(pretest => pretest.id === preTestBeingAssigned.id)
-      students = relevantPretest.all_classrooms.map(classroom => {
-        const classroomFromState = classrooms.find(classroomFromState => classroomFromState.classroom.id === classroom.id)
-        const studentNamesWhoCouldBeOverwritten = []
-        classroom.completed_pre_test_student_ids.forEach(id => {
-          const studentFromState = classroomFromState.students.find(student => student.id === id)
-          if (studentFromState && studentFromState.isSelected) {
-            studentNamesWhoCouldBeOverwritten.push(studentFromState.name)
-          }
-        })
-        return studentNamesWhoCouldBeOverwritten
-      })
+      students = this.potentiallyOverwrittenStudentNames(relevantPretest, 'completed_pre_test_student_ids')
     } else if (postTestBeingAssigned) {
       const relevantPretest = assignedPreTests.find(pretest => pretest.post_test_id === postTestBeingAssigned.id)
-      students = relevantPretest.all_classrooms.map(classroom => {
-        const classroomFromState = classrooms.find(classroomFromState => classroomFromState.classroom.id === classroom.id)
-        const studentNamesWhoCouldBeOverwritten = []
-        classroom.completed_post_test_student_ids.forEach(id => {
-          const studentFromState = classroomFromState.students.find(student => student.id === id)
-          if (studentFromState && studentFromState.isSelected) {
-            studentNamesWhoCouldBeOverwritten.push(studentFromState.name)
-          }
-        })
-        return studentNamesWhoCouldBeOverwritten
-      })
+      students = this.potentiallyOverwrittenStudentNames(relevantPretest, 'completed_post_test_student_ids')
     }
-
     return [... new Set(students.flat())]
+  }
+
+  potentiallyOverwrittenStudentNames = (relevantPretest, relevantStudentIdKey) => {
+    const { classrooms, } = this.state
+    return relevantPretest.all_classrooms.map(classroom => {
+      const classroomFromState = classrooms.find(classroomFromState => classroomFromState.classroom.id === classroom.id)
+      const studentNamesWhoCouldBeOverwritten = []
+      classroom[relevantStudentIdKey].forEach(id => {
+        const studentFromState = classroomFromState.students.find(student => student.id === id)
+        const isOverwriteCandidate = studentFromState && studentFromState.isSelected // student is both still in classroom and selected to be assigned
+        if (isOverwriteCandidate) {
+          studentNamesWhoCouldBeOverwritten.push(studentFromState.name)
+        }
+      })
+      return studentNamesWhoCouldBeOverwritten
+    })
   }
 
   stage2SpecificComponents = () => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -324,7 +324,7 @@ export default class CreateUnit extends React.Component {
         const studentNamesWhoCouldBeOverwritten = []
         classroom.completed_pre_test_student_ids.forEach(id => {
           const studentFromState = classroomFromState.students.find(student => student.id === id)
-          if (studentFromState.isSelected) {
+          if (studentFromState && studentFromState.isSelected) {
             studentNamesWhoCouldBeOverwritten.push(studentFromState.name)
           }
         })
@@ -337,7 +337,7 @@ export default class CreateUnit extends React.Component {
         const studentNamesWhoCouldBeOverwritten = []
         classroom.completed_post_test_student_ids.forEach(id => {
           const studentFromState = classroomFromState.students.find(student => student.id === id)
-          if (studentFromState.isSelected) {
+          if (studentFromState && studentFromState.isSelected) {
             studentNamesWhoCouldBeOverwritten.push(studentFromState.name)
           }
         })


### PR DESCRIPTION
## WHAT
Fix issue that arises when a teacher is attempting to assign a diagnostic to a class with a student who is no longer in that class having already completed it.  

## WHY
We want teachers to be able to successfully assign the diagnostic.

## HOW
Nil check that the student exists in the class currently before calling `.isSelected` on them.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Loading-issues-when-attempting-to-assign-the-Intermediate-Baseline-Diagnostic-2-teachers-643d1c1794024ffeaee1a4c359d8e6b7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
