### PR TITLE
nil check for pre test activity session

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -31,7 +31,7 @@ module GrowthResultsSummary
     @post_test_assigned_students.map do |assigned_student|
       post_test_activity_session = @post_test_activity_sessions[assigned_student.id]
       pre_test_activity_session = @pre_test_activity_sessions[assigned_student.id]
-      if post_test_activity_session
+      if post_test_activity_session && pre_test_activity_session
         skill_groups = skill_groups_for_session(@skill_groups, post_test_activity_session.id, pre_test_activity_session.id, assigned_student.name)
         total_acquired_skills_count = skill_groups.map { |sg| sg[:acquired_skill_ids] }.flatten.uniq.count
         {

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -401,9 +401,9 @@ class Teachers::UnitsController < ApplicationController
     record['skills_count'] = 0
     if pre_test_activity_id
       record['skills_count'] = activity_sessions.reduce(0) do |sum, as|
-        post_correct_skill_ids = as.correct_skill_ids
-        pre_correct_skill_ids = ActivitySession.where(user_id: as.user_id, activity_id: pre_test_activity_id).order(completed_at: :desc).first.correct_skill_ids
-        total_acquired_skills_count = (post_correct_skill_ids - pre_correct_skill_ids).length
+        post_correct_skill_ids = as&.correct_skill_ids
+        pre_correct_skill_ids = ActivitySession.where(user_id: as.user_id, activity_id: pre_test_activity_id).order(completed_at: :desc).first&.correct_skill_ids
+        total_acquired_skills_count = post_correct_skill_ids && pre_correct_skill_ids ? (post_correct_skill_ids - pre_correct_skill_ids).length : 0
         sum += total_acquired_skills_count > 0 ? total_acquired_skills_count : 0
       end
     end


### PR DESCRIPTION
## WHAT
Handle case where students have completed a post-test activity but not the pre-test for the `diagnostic_units` method.

## WHY
We shouldn't be in this state - it isn't possible for students to start a post-test from their dashboard without having completed the pre-test first, but I think I overlooked an edge case where the new Google Classroom activity links will still work if a teacher assigns both at the same time. Going to fix that in another PR, but in the interim this should allow the teacher's page to load. There may be other related errors which we will need to fix, but I will have better insight into what those are once this page is working.

## HOW
Nil check the activity session before calling `correct_skill_ids` on it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/New-diagnostic-reports-not-loading-for-1-user-even-after-clearing-cache-742072097680429984e90d5eaaeba3ae)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES