### PR TITLE
change default parent activity flagset

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -12,6 +12,10 @@ module Evidence
     MAX_TITLE_LENGTH = 100
     MAX_SCORED_LEVEL_LENGTH = 100
 
+    # See activity.rb in the enclosing app for the ur-constant,
+    # which is not accessible from here
+    LMS_ACTIVITY_DEFAULT_FLAG = 'alpha'
+
     before_destroy :expire_turking_rounds
     before_validation :set_parent_activity, on: :create
     after_save :update_parent_activity_name, if: :saved_change_to_title?
@@ -42,7 +46,9 @@ module Evidence
         self.parent_activity = Evidence.parent_activity_class.find_or_create_by(
           name: title,
           activity_classification_id: Evidence.parent_activity_classification_class.evidence&.id
-        )
+        ) do |activity|
+          activity.flags = [LMS_ACTIVITY_DEFAULT_FLAG]
+        end
       end
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -46,8 +46,8 @@ module Evidence
         self.parent_activity = Evidence.parent_activity_class.find_or_create_by(
           name: title,
           activity_classification_id: Evidence.parent_activity_classification_class.evidence&.id
-        ) do |activity|
-          activity.flags = [LMS_ACTIVITY_DEFAULT_FLAG]
+        ) do |parent_activity|
+          parent_activity.flags = [LMS_ACTIVITY_DEFAULT_FLAG]
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -86,6 +86,11 @@ module Evidence
         activity = create(:evidence_activity, :parent_activity_id => nil) 
         expect(activity.parent_activity.id).to(be_truthy)
       end
+
+      it 'should set new parent activity flags to [alpha]' do
+        activity = create(:evidence_activity, :parent_activity_id => nil) 
+        expect(activity.parent_activity.flags).to eq([Activity::LMS_ACTIVITY_DEFAULT_FLAG])
+      end
     end
 
     context '#update_parent_activity_name' do


### PR DESCRIPTION
## WHAT
When an Evidence activity is created, set the parent activity's flagset to `alpha` instead of beta 

## WHY
So that beta users are not immediately exposed to in-development content 

## HOW
See diff. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Flag-new-Quill-Evidence-activities-with-the-alpha-flag-instead-of-beta-4b27813ce676482c8b494a9ebabf390b)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
