### PR TITLE
allow coteachers to see data in reports

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -39,13 +39,13 @@ module DiagnosticReports
     end
   end
 
-  private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id=nil, hashify_activity_sessions=false)
+  private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id=nil, hashify_activity_sessions=false)
     if unit_id
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession.where(classroom_unit: classroom_unit, is_final_score: true)
     else
-      classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+      classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true).order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
@@ -56,8 +56,8 @@ module DiagnosticReports
     end
   end
 
-  private def set_pre_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+  private def set_pre_test_activity_sessions_and_assigned_students(activity_id, classroom_id, hashify_activity_sessions=false)
+    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
@@ -68,8 +68,8 @@ module DiagnosticReports
 
   end
 
-  private def set_post_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
+  private def set_post_test_activity_sessions_and_assigned_students(activity_id, classroom_id, hashify_activity_sessions=false)
+    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @post_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -45,8 +45,7 @@ module DiagnosticReports
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession.where(classroom_unit: classroom_unit, is_final_score: true)
     else
-      units = current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
-      classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
+      classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true).order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
@@ -58,8 +57,7 @@ module DiagnosticReports
   end
 
   private def set_pre_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    units = current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
-    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
+    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
@@ -71,8 +69,7 @@ module DiagnosticReports
   end
 
   private def set_post_test_activity_sessions_and_assigned_students(current_user, activity_id, classroom_id, hashify_activity_sessions=false)
-    units = current_user.units.joins(:unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
-    classroom_units = ClassroomUnit.where(unit: units, classroom_id: classroom_id)
+    classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:units, :unit_activities).where(units: {unit_activities: {activity_id: activity_id}})
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @post_test_activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -6,12 +6,11 @@ module GrowthResultsSummary
 
   extend self
 
-  def growth_results_summary(current_user, pre_test_activity_id, post_test_activity_id, classroom_id)
-    @current_user = current_user
+  def growth_results_summary(pre_test_activity_id, post_test_activity_id, classroom_id)
     pre_test = Activity.find(pre_test_activity_id)
     @skill_groups = pre_test.skill_groups
-    set_pre_test_activity_sessions_and_assigned_students(@current_user, pre_test_activity_id, classroom_id, true)
-    set_post_test_activity_sessions_and_assigned_students(@current_user, post_test_activity_id, classroom_id, true)
+    set_pre_test_activity_sessions_and_assigned_students(pre_test_activity_id, classroom_id, true)
+    set_post_test_activity_sessions_and_assigned_students(post_test_activity_id, classroom_id, true)
     @skill_group_summaries = @skill_groups.map do |skill_group|
       {
         name: skill_group.name,

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -10,7 +10,7 @@ module ResultsSummary
     @current_user = current_user
     activity = Activity.find(activity_id)
     @skill_groups = activity.skill_groups
-    set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id, true)
+    set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, true)
     @skill_group_summaries = @skill_groups.map do |skill_group|
       {
         name: skill_group.name,

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -6,8 +6,7 @@ module ResultsSummary
 
   extend self
 
-  def results_summary(current_user, activity_id, classroom_id, unit_id)
-    @current_user = current_user
+  def results_summary(activity_id, classroom_id, unit_id)
     activity = Activity.find(activity_id)
     @skill_groups = activity.skill_groups
     set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, true)

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -266,8 +266,8 @@ class Teachers::ClassroomManagerController < ApplicationController
       pre_test_diagnostic_unit_ids = current_user&.unit_activities&.where(activity_id: act.id)&.map(&:unit_id) || []
       assigned_classroom_ids = ClassroomUnit.where(unit_id: pre_test_diagnostic_unit_ids)&.map(&:classroom_id) || []
       all_classrooms = current_user.classrooms_i_teach.map do |classroom|
-        set_pre_test_activity_sessions_and_assigned_students(current_user, act.id, classroom.id)
-        set_post_test_activity_sessions_and_assigned_students(current_user, act.follow_up_activity_id, classroom.id)
+        set_pre_test_activity_sessions_and_assigned_students(act.id, classroom.id)
+        set_post_test_activity_sessions_and_assigned_students(act.follow_up_activity_id, classroom.id)
         {
           id: classroom.id,
           completed_pre_test_student_ids: @pre_test_activity_sessions.map(&:user_id),

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -184,12 +184,12 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def diagnostic_results_summary
-    render json: ResultsSummary.results_summary(current_user, results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
+    render json: ResultsSummary.results_summary(results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
   end
 
   def diagnostic_growth_results_summary
     pre_test = Activity.find_by(follow_up_activity_id: results_summary_params[:activity_id])
-    render json: GrowthResultsSummary.growth_results_summary(current_user, pre_test.id, results_summary_params[:activity_id], results_summary_params[:classroom_id])
+    render json: GrowthResultsSummary.growth_results_summary(pre_test.id, results_summary_params[:activity_id], results_summary_params[:classroom_id])
   end
 
   private def create_or_update_selected_packs

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -6,7 +6,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   include DiagnosticReports
   require 'pusher'
 
-  before_action :authorize_teacher!, only: [:question_view, :students_by_classroom, :recommendations_for_classroom, :lesson_recommendations_for_classroom, :previously_assigned_recommendations]
+  before_action :authorize_teacher!, only: [:question_view, :students_by_classroom, :recommendations_for_classroom, :lesson_recommendations_for_classroom, :previously_assigned_recommendations, :growth_results_summary, :results_summary]
 
   def show
     @classroom_id = current_user.classrooms_i_teach&.last&.id || nil

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -14,7 +14,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def question_view
-      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, params[:activity_id], params[:classroom_id], params[:unit_id])
+      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(params[:activity_id], params[:classroom_id], params[:unit_id])
       activity = Activity.includes(:classification)
                          .find(params[:activity_id])
       render json: { data: results_by_question(params[:activity_id]),
@@ -29,7 +29,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     activity_id = results_summary_params[:activity_id]
     classroom_id = results_summary_params[:classroom_id]
     unit_id = results_summary_params[:unit_id]
-    set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id, true)
+    set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, true)
 
     render json: { students: diagnostic_student_responses }
   end

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -31,6 +31,7 @@ class ClassroomUnit < ApplicationRecord
   belongs_to :unit #, touch: true
   belongs_to :classroom
   has_many :activity_sessions
+  has_many :unit_activities, through: :unit
   has_many :completed_activity_sessions, -> {completed}, class_name: 'ActivitySession'
   has_many :classroom_unit_activity_states
 

--- a/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
@@ -7,7 +7,7 @@ module LessonsRecommendations
     extend ActiveSupport::Concern
 
     def get_recommended_lessons(current_user, unit_id, classroom_id, activity_id)
-      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id)
+      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id)
       @activity_id = activity_id
       @classroom_id = classroom_id
       @activity_sessions_with_counted_concepts = act_sesh_with_counted_concepts

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -255,7 +255,7 @@ module PublicProgressReports
     end
 
     def generate_recommendations_for_classroom(current_user, unit_id, classroom_id, activity_id)
-      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(current_user, activity_id, classroom_id, unit_id)
+      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id)
       diagnostic = Activity.find(activity_id)
       activity_sessions_counted = activity_sessions_with_counted_concepts(@activity_sessions)
       students = @assigned_students.map do |s|

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -57,7 +57,7 @@ describe DiagnosticReports do
       let!(:activity_session2) { create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit, activity: unit_activity.activity) }
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit' do
-        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit.user, unit_activity.activity_id, classroom.id, unit.id)
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
         expect(@assigned_students).to eq([student1, student2, student3])
         expect(@activity_sessions).to eq([activity_session1, activity_session2])
       end
@@ -82,7 +82,7 @@ describe DiagnosticReports do
       let!(:activity_session3) { create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit2, activity: unit_activity1.activity) }
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit, with only one per student' do
-        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit1.user, unit_activity1.activity_id, classroom.id, nil)
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
         expect(@assigned_students).to eq([student1, student2, student3])
         expect(@activity_sessions).to eq([activity_session3, activity_session1])
       end

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -30,7 +30,7 @@ describe GrowthResultsSummary do
 
   describe '#growth_results_summary' do
     it 'should return data with the student results and skill group summaries' do
-      expect(growth_results_summary(pre_test_unit.user, pre_test_unit_activity.activity_id, post_test_unit_activity.activity_id, classroom.id)).to eq({
+      expect(growth_results_summary(pre_test_unit_activity.activity_id, post_test_unit_activity.activity_id, classroom.id)).to eq({
         skill_group_summaries: [
           {
             name: pre_test_skill_group_activity.skill_group.name,

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -23,7 +23,7 @@ describe ResultsSummary do
 
   describe '#results_summary' do
     it 'should return data with the student results and skill group summaries' do
-      expect(results_summary(unit.user, unit_activity.activity_id, classroom.id, nil)).to eq({
+      expect(results_summary(unit_activity.activity_id, classroom.id, nil)).to eq({
         skill_group_summaries: [
           {
             name: skill_group_activity.skill_group.name,


### PR DESCRIPTION
## WHAT
Update how we generate data for the results and growth results summary so that coteachers can see this data too.

## WHY
So that coteachers have access to the same data the owner of the classroom does.

## HOW
Build joins off of the `classroom_units` table instead of from `current_user.units` so that teachers who did not create those units, but are nonetheless teachers for the classroom, can see the data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-report-says-no-data-even-though-students-have-completed-it-c3ea78360fd34b0baed9135e6ef05aa8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
