### PR TITLE
make sure student has completed pre test for that class before they can complete post test

### DIFF
--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -10,6 +10,7 @@ class ActivitySessionsController < ApplicationController
   before_action :activity_session_authorize!, only: [:play, :result]
   before_action :activity_session_authorize_teacher!, only: [:concept_results]
   before_action :authorize_student_belongs_to_classroom_unit!, only: [:activity_session_from_classroom_unit_and_activity]
+  before_action :redirect_if_student_has_not_completed_pre_test, only: [:play]
   after_action  :update_student_last_active, only: [:play, :result]
 
   def play
@@ -98,6 +99,20 @@ class ActivitySessionsController < ApplicationController
     unless AuthorizedTeacherForActivity.new(current_user, @activity_session).call
       render_error(404)
     end
+  end
+
+  private def redirect_if_student_has_not_completed_pre_test
+    pre_test = Activity.find_by(follow_up_activity_id: @activity.id, classification: ActivityClassification.diagnostic)
+    return unless pre_test
+
+    classroom_units_for_classroom = @activity_session.classroom_unit.classroom.classroom_units
+    completed_pre_test_activity_session = ActivitySession.find_by(user: current_user, state: 'finished', classroom_unit: classroom_units_for_classroom)
+
+    return if completed_pre_test_activity_session
+
+    flash[:error] = "You need to complete the Baseline diagnostic before you can complete the Growth diagnostic."
+    flash.keep(:error)
+    redirect_to profile_path
   end
 
   private def update_student_last_active

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -48,9 +48,9 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     student = User.find_by_id(student_id)
     skills = Activity.find(activity_id).skills.distinct
     pre_test = Activity.find_by_follow_up_activity_id(activity_id)
+    pre_test_activity_session = pre_test && find_activity_session_for_student_activity_and_classroom(student_id, pre_test.id, classroom_id, unit_id)
 
-    if pre_test
-      pre_test_activity_session = find_activity_session_for_student_activity_and_classroom(student_id, pre_test.id, classroom_id, unit_id)
+    if pre_test && pre_test_activity_session
       concept_results = {
         pre: { questions: format_concept_results(pre_test_activity_session.concept_results.order("(metadata->>'questionNumber')::int")) },
         post: { questions: format_concept_results(activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -127,7 +127,7 @@ class UnitActivity < ApplicationRecord
           COALESCE(cuas.locked, false) AS locked,
           COALESCE(cuas.pinned, false) AS pinned,
           MAX(acts.percentage) AS max_percentage,
-          SUM(CASE WHEN pre_activity_sessions.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS completed_pre_activity_session,
+          SUM(CASE WHEN pre_activity_sessions_classroom_units.id > 0 AND pre_activity_sessions.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS completed_pre_activity_session,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS finished,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) AS resume_link
         FROM unit_activities AS ua
@@ -147,8 +147,10 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN activity_sessions AS pre_activity_sessions
           ON pre_activity_sessions.activity_id = pre_activity.id
           AND pre_activity_sessions.visible = true
-          AND pre_activity_sessions.classroom_unit_id = cu.id
           AND pre_activity_sessions.user_id = #{user_id.to_i}
+        LEFT JOIN classroom_units AS pre_activity_sessions_classroom_units
+          ON pre_activity_sessions_classroom_units.id = pre_activity_sessions.classroom_unit_id
+          AND pre_activity_sessions_classroom_units.classroom_id = #{classroom_id.to_i}
         JOIN activity_classifications
           ON activity.activity_classification_id = activity_classifications.id
         LEFT JOIN classroom_unit_activity_states AS cuas

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -147,7 +147,8 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN activity_sessions AS pre_activity_sessions
           ON pre_activity_sessions.activity_id = pre_activity.id
           AND pre_activity_sessions.visible = true
-          and pre_activity_sessions.user_id = #{user_id.to_i}
+          AND pre_activity_sessions.classroom_unit_id = cu.id
+          AND pre_activity_sessions.user_id = #{user_id.to_i}
         JOIN activity_classifications
           ON activity.activity_classification_id = activity_classifications.id
         LEFT JOIN classroom_unit_activity_states AS cuas

--- a/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
@@ -9,6 +9,7 @@ describe ActivitySessionsController, type: :controller do
   it { should use_before_action :activity }
   it { should use_before_action :activity_session_authorize! }
   it { should use_before_action :activity_session_authorize_teacher! }
+  it { should use_before_action :redirect_if_student_has_not_completed_pre_test }
   it { should use_after_action :update_student_last_active }
 
   let!(:activity) { create(:activity) }
@@ -95,6 +96,61 @@ describe ActivitySessionsController, type: :controller do
     it 'should redirect to the correct activity session url' do
       get :activity_session_from_classroom_unit_and_activity, params: { classroom_unit_id: cu.id, activity_id: activity.id }
       expect(response).to redirect_to activity_session_url
+    end
+  end
+
+  describe "#redirect_if_student_has_not_completed_pre_test" do
+    let!(:student) { create(:student)}
+    let!(:activity) { create(:diagnostic_activity) }
+
+    before do
+      @activity = create(:diagnostic_activity)
+      @controller = ActivitySessionsController.new
+
+      allow(@controller).to receive(:current_user) { student }
+      @controller.instance_variable_set(:@activity, @activity)
+    end
+
+    it 'should return if there is no activity with the @activity id as a follow_up_activity_id' do
+      @activity_session = create(:activity_session, user: student, state: 'started', activity: @activity)
+
+      get :play, params: { id: @activity_session.id }
+      expect(response).not_to redirect_to(profile_path)
+    end
+
+    it 'should return if there is an activity with the @activity id as a follow_up_activity_id but that activity is not a diagnostic' do
+      create(:lesson_activity, follow_up_activity_id: @activity.id)
+      @activity_session = create(:activity_session, user: student, state: 'started', activity: @activity)
+
+      get :play, params: { id: @activity_session.id }
+      expect(response).not_to redirect_to(profile_path)
+    end
+
+    it 'should return if there is an activity with the @activity id as a follow_up_activity_id and it is a diagnostic but the student has already completed that activity in this classroom' do
+      pre_test_activity = create(:diagnostic_activity, follow_up_activity_id: @activity.id)
+
+      classroom = create(:classroom)
+      pre_test_classroom_unit = create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])
+      post_test_classroom_unit = create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])
+      pre_test_activity_session = create(:activity_session, user: student, state: 'finished', classroom_unit: pre_test_classroom_unit, activity: pre_test_activity)
+      @activity_session = create(:activity_session, user: student, state: 'started', classroom_unit: post_test_classroom_unit, activity: @activity)
+
+      @controller.instance_variable_set(:@activity_session, @activity_session)
+      get :play, params: { id: @activity_session.id }
+      expect(response).not_to redirect_to(profile_path)
+    end
+
+    it 'should redirect to profile path if there is an activity with the @activity id as a follow_up_activity_id and it is a diagnostic and the student has not yet completed that activity in this classroom' do
+      pre_test_activity = create(:diagnostic_activity, follow_up_activity_id: @activity.id)
+
+      classroom = create(:classroom)
+      pre_test_classroom_unit = create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])
+      post_test_classroom_unit = create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])
+      @activity_session = create(:activity_session, user: student, state: 'started', classroom_unit: post_test_classroom_unit, activity: @activity)
+
+      @controller.instance_variable_set(:@activity_session, @activity_session)
+      get :play, params: { id: @activity_session.id }
+      expect(response).to redirect_to(profile_path)
     end
   end
 


### PR DESCRIPTION
## WHAT
Don't allow students to complete a post-test if they haven't completed a pre-test for that class.

## WHY
This messes with our data, and isn't helpful to teachers.

## HOW
Fix a bug in the query we use to pull student data so that there is a value for the pre test activity session only if the pre test session was completed *for that classroom*. Also, as a backup, redirect the student to the profile with a flash error message if they somehow access the link to a post-test anyway without having completed the pre-test. 
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
Not a specific card, but bugs coming in that are caused by students completing post-tests before pre-tests.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
