### PR TITLE
Add nil check in TeacherActivityFeed

### DIFF
--- a/services/QuillLMS/app/models/teacher_activity_feed.rb
+++ b/services/QuillLMS/app/models/teacher_activity_feed.rb
@@ -21,6 +21,7 @@ class TeacherActivityFeed < RedisFeed
       .includes(:user, :classification, :classroom_unit)
       .where(id: ids)
       .where.not(user_id: nil)
+      .where.not(completed_at: nil)
       .select(:id, :user_id, :classroom_unit_id, :activity_id, :percentage, :completed_at)
 
     # purposely avoiding the SQL sort on the large activity_sessions table

--- a/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
@@ -66,6 +66,18 @@ describe TeacherActivityFeed, type: :model do
         expect(data[1][:id]).to eq(activity_session1.id)
         expect(data[2][:id]).to eq(activity_session2.id)
       end
+
+      it "ignores activity sessions that have no completed_at value" do
+        activity_session
+        activity_session3 = create(:activity_session, classroom_unit_id: classroom_unit1.id, activity_id: activity.id, user_id: student2.id, completed_at: nil)
+        activity_session3.update(state: 'started', completed_at: nil)
+
+        data = TeacherActivityFeed.get(teacher.id)
+        expect(data.length).to eq(3)
+        expect(data[0][:id]).to eq(activity_session.id)
+        expect(data[1][:id]).to eq(activity_session1.id)
+        expect(data[2][:id]).to eq(activity_session2.id)
+      end
     end
 
   end


### PR DESCRIPTION
## WHAT
We have a Sentry error triggering on the odd ActivitySession record with `completed_at: nil` in the `TeacherActivityFeed` class. This PR adds a nil check.

## WHY
Although there shouldn't be any uncompleted activity sessions in the cache in the first place, it appears some edge cases are falling through the filter (likely their `completed_at` values changed to nil after they were added to the cache, by an archive action or some other action). By adding a nil check right before the data is fetched, we can filter out these records so they don't cause a nil error.

## HOW
Add a nil check filter when fetching the sessions.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Teachers-ClassroomManagerController-activity_feed-NilError-01c6cbf2a7f4478db3be642147a3162f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
