### PR TITLE
don't try to save timespent values that are larger than the maximum

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -105,7 +105,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     timespent = @activity_session&.timespent || ActivitySession.calculate_timespent(time_tracking)
     max_4_bit_integer_size = 2147483647
 
-    if timespent > 3600
+    if timespent && timespent > 3600
       begin
         raise "#{timespent} seconds for user #{@activity_session.user_id} and activity session #{@activity_session.id}"
       rescue => e

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -105,6 +105,14 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     timespent = @activity_session&.timespent || ActivitySession.calculate_timespent(time_tracking)
     max_4_bit_integer_size = 2147483647
 
+    if timespent > 3600
+      begin
+        raise "#{timespent} seconds for user #{@activity_session.user_id} and activity session #{@activity_session.id}"
+      rescue => e
+        Sentry.capture_exception(e)
+      end
+    end
+
     params
       .permit(activity_session_permitted_params)
       .merge(data: data)

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -109,7 +109,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       begin
         raise "#{timespent} seconds for user #{@activity_session.user_id} and activity session #{@activity_session.id}"
       rescue => e
-        Sentry.capture_exception(e)
+        Raven.capture_exception(e)
       end
     end
 

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -103,12 +103,13 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     data = params.delete(:data)&.permit!
     time_tracking = data && data['time_tracking']
     timespent = @activity_session&.timespent || ActivitySession.calculate_timespent(time_tracking)
+    max_4_bit_integer_size = 2147483647
 
     params
       .permit(activity_session_permitted_params)
       .merge(data: data)
       .reject { |_, v| v.nil? }
-      .merge(timespent: timespent)
+      .merge(timespent: max_4_bit_integer_size > (timespent || 0) ? timespent : max_4_bit_integer_size)
   end
 
   private def transform_incoming_request

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   before_action :find_activity_session, only: [:show, :update, :destroy]
   before_action :strip_access_token_from_request
 
-  MAX_4_BIT_INTEGER_SIZE = 2147483647
+  MAX_4_BYTE_INTEGER_SIZE = 2147483647
 
   def show
     render json: @activity_session, meta: {status: 'success', message: nil, errors: nil}, serializer: ActivitySessionSerializer
@@ -118,7 +118,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       .permit(activity_session_permitted_params)
       .merge(data: data)
       .reject { |_, v| v.nil? }
-      .merge(timespent: timespent && [timespent, MAX_4_BIT_INTEGER_SIZE].min)
+      .merge(timespent: timespent && [timespent, MAX_4_BYTE_INTEGER_SIZE].min)
   end
 
   private def transform_incoming_request

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -133,8 +133,8 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         expect(activity_session.data['time_tracking']).to include(data['time_tracking'])
       end
 
-      describe 'the total time tracking value is larger than the maximum 4-bit integer size' do
-        it 'saves timespent with the maximum 4-bit integer size' do
+      describe 'the total time tracking value is larger than the maximum 4-byte integer size' do
+        it 'saves timespent with the maximum 4-byte integer size' do
           data = {
             'time_tracking' => {
               'so' => 2147483648

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -116,23 +116,36 @@ describe Api::V1::ActivitySessionsController, type: :controller do
     end
 
     context 'data time_tracking is included ' do
-      let(:data) do
-        {
+
+      it 'updates timespent on activity session' do
+        data = {
           'time_tracking' => {
             'so' => 1,
             'but' => 2,
             'because' => 3
           }
         }
-      end
 
-      before { put :update, params: { id: activity_session.uid, data: data }, as: :json }
-
-      it 'updates timespent on activity session' do
+        put :update, params: { id: activity_session.uid, data: data }, as: :json
         activity_session.reload
 
         expect(activity_session.timespent).to eq 6
         expect(activity_session.data['time_tracking']).to include(data['time_tracking'])
+      end
+
+      describe 'the total time tracking value is larger than the maximum 4-bit integer size' do
+        it 'saves timespent with the maximum 4-bit integer size' do
+          data = {
+            'time_tracking' => {
+              'so' => 2147483648
+            }
+          }
+
+          put :update, params: { id: activity_session.uid, data: data }, as: :json
+          activity_session.reload
+
+          expect(activity_session.timespent).to eq 2147483647
+        end
       end
     end
   end


### PR DESCRIPTION
## WHAT
If a timespent value is larger than a 4-byte integer size (what's allowed in our database), save the maximum 4-byte integer size instead. Also add tracking so I can see more detail about why we might be getting really large values for timespent in the first place.

## WHY
We have a [sentry error](https://sentry.io/organizations/quillorg-5s/issues/2823293016/?project=11238&query=is%3Aunresolved) that came about as a result of a student with an insanely large timespent value. All instances of this error are from the same student. This value is the equivalent of 68 years. I'm not sure how this value made its way in there, since even if the timetracking never stopped running (which it does, when the user is idle for more than 30 seconds or they switch tabs, according to my testing) this is way way way longer than it should ever possibly be. I'm hoping that adding this Sentry tracking for all sessions longer than an hour will give me some more information about how this might be occurring - possibly browser-specific.

## HOW
Just check that the timespent value is not larger than the maximum size before saving it and, if it is, default to the largest possible size, just so the student can actually save their session.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Sentry-Error-Api-V1-ActivitySessionsController-update-Timetracking-Out-of-Range-f7ed4c129700466b8d7e6319d5d64f6b)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES