### PR TITLE
Eager Load ConceptResults and Skills For Diagnostic Reports

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -31,7 +31,7 @@ module GrowthResultsSummary
       post_test_activity_session = @post_test_activity_sessions[assigned_student.id]
       pre_test_activity_session = @pre_test_activity_sessions[assigned_student.id]
       if post_test_activity_session && pre_test_activity_session
-        skill_groups = skill_groups_for_session(@skill_groups, post_test_activity_session.id, pre_test_activity_session.id, assigned_student.name)
+        skill_groups = skill_groups_for_session(@skill_groups, post_test_activity_session, pre_test_activity_session, assigned_student.name)
         total_acquired_skills_count = skill_groups.map { |sg| sg[:acquired_skill_ids] }.flatten.uniq.count
         {
           name: assigned_student.name,
@@ -45,12 +45,12 @@ module GrowthResultsSummary
     end
   end
 
-  private def skill_groups_for_session(skill_groups, post_test_activity_session_id, pre_test_activity_session_id, student_name)
+  private def skill_groups_for_session(skill_groups, post_test_activity_session, pre_test_activity_session, student_name)
     skill_groups.map do |skill_group|
       skills = skill_group.skills.map do |skill|
         {
-          pre: data_for_skill_by_activity_session(pre_test_activity_session_id, skill),
-          post: data_for_skill_by_activity_session(post_test_activity_session_id, skill)
+          pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
+          post: data_for_skill_by_activity_session(post_test_activity_session.concept_results, skill)
         }
       end
       pre_correct_skills = skills.select { |skill| skill[:pre][:summary] == FULLY_CORRECT }

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -31,7 +31,7 @@ module ResultsSummary
         {
           name: assigned_student.name,
           id: assigned_student.id,
-          skill_groups: skill_groups_for_session(@skill_groups, activity_session.id, assigned_student.name)
+          skill_groups: skill_groups_for_session(@skill_groups, activity_session, assigned_student.name)
         }
       else
         { name: assigned_student.name }
@@ -39,9 +39,9 @@ module ResultsSummary
     end
   end
 
-  private def skill_groups_for_session(skill_groups, activity_session_id, student_name)
+  private def skill_groups_for_session(skill_groups, activity_session, student_name)
     skill_groups.map do |skill_group|
-      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session_id, skill) }
+      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }
       present_skill_number = skills.reduce(0) { |sum, skill| sum += skill[:summary] == NOT_PRESENT ? 0 : 1 }
       correct_skill_number = skills.reduce(0) { |sum, skill| sum += skill[:summary] == FULLY_CORRECT ? 1 : 0 }
       proficiency_text = summarize_student_proficiency_for_skill_per_activity(present_skill_number, correct_skill_number)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -57,14 +57,14 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       }
       formatted_skills = skills.map do |skill|
         {
-          pre: data_for_skill_by_activity_session(pre_test_activity_session.id, skill),
-          post: data_for_skill_by_activity_session(activity_session.id, skill)
+          pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
+          post: data_for_skill_by_activity_session(activity_session.concept_results, skill)
         }
       end
       skill_results = { skills: formatted_skills.uniq { |formatted_skill| formatted_skill[:pre][:skill] } }
     else
       concept_results = { questions: format_concept_results(activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
-      skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.id, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
+      skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
     end
     render json: { concept_results: concept_results, skill_results: skill_results, name: student.name }
   end

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -393,7 +393,11 @@ class Teachers::UnitsController < ApplicationController
     records = diagnostic_records.select { |record| record['activity_id'] == activity_id && record['classroom_id'] == classroom_id }
     return if records.empty?
     classroom_unit_ids = records.map { |record| record['classroom_unit_id'] }
-    activity_sessions = ActivitySession.where(activity_id: activity_id, classroom_unit_id: classroom_unit_ids, state: 'finished').order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }
+    activity_sessions = ActivitySession
+      .includes(:concept_results, activity: :skills)
+      .where(activity_id: activity_id, classroom_unit_id: classroom_unit_ids, state: 'finished')
+      .order(completed_at: :desc)
+      .uniq { |activity_session| activity_session.user_id }
     record = records[0]
     return if !record
     record['completed_count'] = activity_sessions.size
@@ -402,7 +406,12 @@ class Teachers::UnitsController < ApplicationController
     if pre_test_activity_id
       record['skills_count'] = activity_sessions.reduce(0) do |sum, as|
         post_correct_skill_ids = as&.correct_skill_ids
-        pre_correct_skill_ids = ActivitySession.where(user_id: as.user_id, activity_id: pre_test_activity_id).order(completed_at: :desc).first&.correct_skill_ids
+        pre_correct_skill_ids = ActivitySession
+          .includes(:concept_results, activity: :skills)
+          .where(user_id: as.user_id, activity_id: pre_test_activity_id)
+          .order(completed_at: :desc)
+          .first
+          &.correct_skill_ids
         total_acquired_skills_count = post_correct_skill_ids && pre_correct_skill_ids ? (post_correct_skill_ids - pre_correct_skill_ids).length : 0
         sum += total_acquired_skills_count > 0 ? total_acquired_skills_count : 0
       end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -501,22 +501,22 @@ class ActivitySession < ApplicationRecord
     ((completed_at - started_at)/60).round
   end
 
-  def correct_skill_count
-    skills = activity.skills.distinct
-    skills.reduce(0) do |sum, skill|
-      concept_results = ConceptResult.where(activity_session_id: id, concept_id: [skill.concept_ids])
-      sum += concept_results.length && concept_results.all?(&:correct?) ? 1 : 0
-    end
+  def skills
+    @skills ||= activity.skills.distinct
   end
 
   def correct_skill_ids
-    skills = activity.skills.distinct
-    correct_skill_ids = []
-    skills.each do |skill|
-      concept_results = ConceptResult.where(activity_session_id: id, concept_id: [skill.concept_ids])
-      correct_skill_ids.push(skill.id) if concept_results.length && concept_results.all?(&:correct?)
+    correct_skills.map(&:id)
+  end
+
+  def correct_skills
+    @correct_skills ||= begin
+      skills.select do |skill|
+        results = concept_results.where(concept_id: skill.concept_ids)
+
+        results.length && results.all?(&:correct?)
+      end
     end
-    correct_skill_ids
   end
 
   private def correctly_assigned

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -502,7 +502,7 @@ class ActivitySession < ApplicationRecord
   end
 
   def skills
-    @skills ||= activity.skills.distinct
+    @skills ||= activity.skills.uniq
   end
 
   def correct_skill_ids

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -13,31 +13,31 @@ describe DiagnosticReports do
     let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
     it 'should return data with the name of the skill, number of correct concept results, number of incorrect concept results, and a summary' do
-      expect(data_for_skill_by_activity_session(activity_session.id, skill_concept.skill)).to eq({
+      expect(data_for_skill_by_activity_session(activity_session.concept_results, skill_concept.skill)).to eq({
         id: skill_concept.skill.id,
         skill: skill_concept.skill.name,
         number_correct: 1,
         number_incorrect: 1,
-        summary: PARTIALLY_CORRECT
+        summary: DiagnosticReports::PARTIALLY_CORRECT
       })
     end
   end
 
   describe '#summarize_correct_skills' do
     it 'should return NOT_PRESENT if both number_correct and number_incorrect are 0' do
-      expect(summarize_correct_skills(0, 0)).to eq(NOT_PRESENT)
+      expect(summarize_correct_skills(0, 0)).to eq(DiagnosticReports::NOT_PRESENT)
     end
 
     it 'should return NOT_CORRECT if number_correct is 0 and number_incorrect is not 0' do
-      expect(summarize_correct_skills(0, 1)).to eq(NOT_CORRECT)
+      expect(summarize_correct_skills(0, 1)).to eq(DiagnosticReports::NOT_CORRECT)
     end
 
     it 'should return FULLY_CORRECT if number_correct is 0 and number_incorrect is not 0' do
-      expect(summarize_correct_skills(1, 0)).to eq(FULLY_CORRECT)
+      expect(summarize_correct_skills(1, 0)).to eq(DiagnosticReports::FULLY_CORRECT)
     end
 
     it 'should return PARTIALLY_CORRECT if neither number_correct nor number_incorrect is 0' do
-      expect(summarize_correct_skills(1, 1)).to eq(PARTIALLY_CORRECT)
+      expect(summarize_correct_skills(1, 1)).to eq(DiagnosticReports::PARTIALLY_CORRECT)
     end
   end
 
@@ -91,15 +91,15 @@ describe DiagnosticReports do
 
   describe '#summarize_student_proficiency_for_skill_per_activity' do
     it 'should return NO_PROFICIENCY if the correct skill number is 0' do
-      expect(summarize_student_proficiency_for_skill_per_activity(1, 0)).to eq(NO_PROFICIENCY)
+      expect(summarize_student_proficiency_for_skill_per_activity(1, 0)).to eq(DiagnosticReports::NO_PROFICIENCY)
     end
 
     it 'should return PROFICIENCY if the correct skill number equals the present skill number' do
-      expect(summarize_student_proficiency_for_skill_per_activity(1, 1)).to eq(PROFICIENCY)
+      expect(summarize_student_proficiency_for_skill_per_activity(1, 1)).to eq(DiagnosticReports::PROFICIENCY)
     end
 
     it 'should return PARTIAL_PROFICIENCY if the correct skill number is between 0 and the present skill number' do
-      expect(summarize_student_proficiency_for_skill_per_activity(2, 1)).to eq(PARTIAL_PROFICIENCY)
+      expect(summarize_student_proficiency_for_skill_per_activity(2, 1)).to eq(DiagnosticReports::PARTIAL_PROFICIENCY)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -235,7 +235,7 @@ describe GrowthResultsSummary do
           not_yet_proficient_in_post_test_student_names: [],
         }
       ]
-      expect(skill_groups_for_session([pre_test_skill_group_activity.skill_group], post_test_activity_session.id, pre_test_activity_session.id, student1.name)).to eq [
+      expect(skill_groups_for_session([pre_test_skill_group_activity.skill_group], post_test_activity_session, pre_test_activity_session, student1.name)).to eq [
         {
           skill_group: pre_test_skill_group_activity.skill_group.name,
           description: pre_test_skill_group_activity.skill_group.description,
@@ -276,7 +276,7 @@ describe GrowthResultsSummary do
           not_yet_proficient_in_post_test_student_names: [],
         }
       ]
-      skill_groups_for_session([pre_test_skill_group_activity.skill_group], post_test_activity_session.id, pre_test_activity_session.id, student1.name)
+      skill_groups_for_session([pre_test_skill_group_activity.skill_group], post_test_activity_session, pre_test_activity_session, student1.name)
       expect(@skill_group_summaries[0][:not_yet_proficient_in_pre_test_student_names]).to eq [student1.name]
       expect(@skill_group_summaries[0][:not_yet_proficient_in_post_test_student_names]).to eq []
     end

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -115,7 +115,7 @@ describe ResultsSummary do
           not_yet_proficient_student_names: []
         }
       ]
-      expect(skill_groups_for_session([skill_group_activity.skill_group], activity_session.id, student1.name)).to eq [
+      expect(skill_groups_for_session([skill_group_activity.skill_group], activity_session, student1.name)).to eq [
         {
           skill_group: skill_group_activity.skill_group.name,
           description: skill_group_activity.skill_group.description,
@@ -143,7 +143,7 @@ describe ResultsSummary do
           not_yet_proficient_student_names: []
         }
       ]
-      skill_groups_for_session([skill_group_activity.skill_group], activity_session.id, student1.name)
+      skill_groups_for_session([skill_group_activity.skill_group], activity_session, student1.name)
       expect(@skill_group_summaries[0][:not_yet_proficient_student_names]).to eq [student1.name]
     end
 


### PR DESCRIPTION
## WHAT
With the new Post tests and its use of concepts/skills, there are 3 endpoints that can benefit from eager loading those relations (See screenshots below, each call does hundreds and sometimes thousands of queries to `concept_results`)
- Teachers::UnitsController#diagnostic_units
- Teachers::ProgressReports::DiagnosticReportsController#diagnostic_growth_results_summary
- Teachers::ProgressReports::DiagnosticReportsController#diagnostic_results_summary

This PR attempts to load the concept_results and skills upfront, so there's less queries.
## WHY
This should, at least partially improve the speed of the pages. 
Two notes:
- There are other items that might be able to be sped up, 
- Given concept_results is a huge table, there's a small chance that a few larger queries on concept_results could be slower than thousands of small requests. I don' think that will be the case, but I will monitor.
## HOW
Use eager loading (`.includes(:concept_results, activity: :skills)`), refactor to make sure sub-methods are using pre-loaded objects.
### Screenshots
![Screen Shot 2021-12-03 at 11 23 39 AM](https://user-images.githubusercontent.com/1304933/144638396-85f67237-ba8f-46b3-9e61-3fe9af15ab8c.png)
![Screen Shot 2021-12-03 at 11 23 36 AM](https://user-images.githubusercontent.com/1304933/144638398-b4092fea-791d-4db4-9cc7-aa7d88fcd6f2.png)
![Screen Shot 2021-12-03 at 11 22 42 AM](https://user-images.githubusercontent.com/1304933/144638399-86ae8e41-e12b-4882-9e5c-5a7fbdee5fe3.png)
![Screen Shot 2021-12-03 at 11 34 08 AM](https://user-images.githubusercontent.com/1304933/144638624-fd438569-2b0e-44dc-9e8a-f71e3adcd658.png)



### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | YES - this is deployed to the `dan` environment
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
