### PR TITLE
allow prefilter in feedback history

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -46,7 +46,8 @@ class FeedbackHistory < ApplicationRecord
     RULES_BASED_THREE = "rules-based-3",
     AUTO_ML = "autoML",
     SPELLING = "spelling",
-    OPINION = "opinion"
+    OPINION = "opinion",
+    PREFILTER = "prefilter"
   ]
   FILTER_TYPES = [
     FILTER_ALL = "all",


### PR DESCRIPTION
## WHAT
Adds prefilter to FeedbackHistory allowlist 

## WHY
So that FeedbackHistory will process prefilter payloads 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Pre-filter-responses-aren-t-showing-up-in-Metabase-2c3781cdc5b44fbeaf120b754b7bea68)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - trivial
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
