### PR TITLE
Eager Loading - Use Ruby finders to ensure using eager loaded items

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -44,14 +44,14 @@ module DiagnosticReports
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:concept_results, activity: :skills)
+        .includes(:concept_results, activity: {skills: :concepts})
         .where(classroom_unit: classroom_unit, is_final_score: true)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:concept_results, activity: :skills)
+        .includes(:concept_results, activity: {skills: :concepts})
         .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true)
         .order(completed_at: :desc)
         .uniq { |activity_session| activity_session.user_id }
@@ -67,7 +67,7 @@ module DiagnosticReports
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession
-      .includes(:concept_results, activity: :skills)
+      .includes(:concept_results, activity: {skills: :concepts})
       .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished')
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -15,7 +15,7 @@ module DiagnosticReports
   MAINTAINED_PROFICIENCY = 'Maintained proficiency'
 
   def data_for_skill_by_activity_session(all_concept_results, skill)
-    concept_results = all_concept_results.where(concept_id: skill.concept_ids)
+    concept_results = all_concept_results.select {|cr| cr.concept_id.in?(skill.concept_ids)}
     number_correct = concept_results.select(&:correct?).length
     number_incorrect = concept_results.reject(&:correct?).length
     {

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -394,7 +394,7 @@ class Teachers::UnitsController < ApplicationController
     return if records.empty?
     classroom_unit_ids = records.map { |record| record['classroom_unit_id'] }
     activity_sessions = ActivitySession
-      .includes(:concept_results, activity: :skills)
+      .includes(:concept_results, activity: {skills: :concepts})
       .where(activity_id: activity_id, classroom_unit_id: classroom_unit_ids, state: 'finished')
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }
@@ -407,7 +407,7 @@ class Teachers::UnitsController < ApplicationController
       record['skills_count'] = activity_sessions.reduce(0) do |sum, as|
         post_correct_skill_ids = as&.correct_skill_ids
         pre_correct_skill_ids = ActivitySession
-          .includes(:concept_results, activity: :skills)
+          .includes(:concept_results, activity: {skills: :concepts})
           .where(user_id: as.user_id, activity_id: pre_test_activity_id)
           .order(completed_at: :desc)
           .first

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -510,7 +510,7 @@ class ActivitySession < ApplicationRecord
   end
 
   # when using this method, you should eager load ass
-  # e.g. includes(:concept_results, activity: :skills)
+  # e.g. .includes(:concept_results, activity: {skills: :concepts})
   def correct_skills
     @correct_skills ||= begin
       skills.select do |skill|

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -509,10 +509,12 @@ class ActivitySession < ApplicationRecord
     correct_skills.map(&:id)
   end
 
+  # when using this method, you should eager load ass
+  # e.g. includes(:concept_results, activity: :skills)
   def correct_skills
     @correct_skills ||= begin
       skills.select do |skill|
-        results = concept_results.where(concept_id: skill.concept_ids)
+        results = concept_results.select {|cr| cr.concept_id.in?(skill.concept_ids)}
 
         results.length && results.all?(&:correct?)
       end


### PR DESCRIPTION
## WHAT
Fix to my last PR: https://github.com/empirical-org/Empirical-Core/pull/8570. It was still querying the DB despite these items being eager loaded.
## WHY
To make this more performant and to work as intended.
## HOW
Use ruby finders on the loaded resource to ensure it doesn't hit the DB.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', small bug fix
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
