### PR TITLE
add post diagnostic demo data

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -183,6 +183,27 @@ module Demo::ReportDemoCreator
           765 => 9962377
         }
       ]
+    },
+    {
+      name: "Starter Growth Diagnostic (Post)",
+      activity_ids: [1664],
+      activity_sessions: [
+        {
+          1664 => 9962415
+        },
+        {
+          1664 => 9706466
+        },
+        {
+          1664 => 9706464
+        },
+        {
+          1664 => 9706465
+        },
+        {
+          1664 => 9962377
+        }
+      ]
     }
   ]
 

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Demo::ReportDemoCreator do
     units = Demo::ReportDemoCreator.create_units(teacher)
 
     Demo::ReportDemoCreator.create_classroom_units(classroom, units)
-    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(23)
+    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(24)
     act_sesh = ActivitySession.last
     expect(act_sesh.activity_id).to eq(765)
     expect(act_sesh.user_id).to eq(student.id)

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Demo::ReportDemoCreator do
     Demo::ReportDemoCreator.create_classroom_units(classroom, units)
     expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(24)
     act_sesh = ActivitySession.last
-    expect(act_sesh.activity_id).to eq(765)
+    expect(act_sesh.activity_id).to eq(1664)
     expect(act_sesh.user_id).to eq(student.id)
     expect(act_sesh.state).to eq('finished')
     expect(act_sesh.percentage).to eq(temp.percentage)


### PR DESCRIPTION
## WHAT
Add post-diagnostic demo data to demo creator script.

## WHY
So that teachers can see examples of the growth reports in the demo account.

## HOW
Just play through the activity on prod using the student accounts we use for the other demo data, and then point the script to use those activity sessions as models for the generated ones.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-demo-data-for-post-tests-0f33f88bc79a45c1b7de22ac0eedc338

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
