### PR TITLE
fix bug with students removed from class still showing in diagnostic reports

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -45,14 +45,14 @@ module DiagnosticReports
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
         .includes(:concept_results, activity: {skills: :concepts})
-        .where(classroom_unit: classroom_unit, is_final_score: true)
+        .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
         .includes(:concept_results, activity: {skills: :concepts})
-        .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true)
+        .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true, user_id: assigned_student_ids)
         .order(completed_at: :desc)
         .uniq { |activity_session| activity_session.user_id }
     end
@@ -68,7 +68,7 @@ module DiagnosticReports
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession
       .includes(:concept_results, activity: {skills: :concepts})
-      .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished')
+      .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }
 
@@ -84,7 +84,7 @@ module DiagnosticReports
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @post_test_activity_sessions = ActivitySession
       .includes(:concept_results, activity: :skills)
-      .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished')
+      .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }
 

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -60,8 +60,7 @@ class Teachers::ClassroomsController < ApplicationController
   def remove_students
     StudentsClassrooms
       .where(student_id: params[:student_ids], classroom_id: params[:classroom_id])
-      .archive_all
-
+      .each { |sc| sc.archive }
     render json: {}
   end
 

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -98,7 +98,7 @@ describe DiagnosticReports do
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit1.remove_assigned_student(student1.id)
         classroom_unit1.reload
-        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
         expect(@assigned_students).to eq([student2, student3])
         expect(@activity_sessions).to eq([activity_session3])
       end

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -61,6 +61,14 @@ describe DiagnosticReports do
         expect(@assigned_students).to eq([student1, student2, student3])
         expect(@activity_sessions).to eq([activity_session1, activity_session2])
       end
+
+      it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
+        classroom_unit.remove_assigned_student(student1.id)
+        classroom_unit.reload
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
+        expect(@assigned_students).to eq([student2, student3])
+        expect(@activity_sessions).to eq([activity_session2])
+      end
     end
 
     describe 'if there is no unit_id' do
@@ -86,6 +94,15 @@ describe DiagnosticReports do
         expect(@assigned_students).to eq([student1, student2, student3])
         expect(@activity_sessions).to eq([activity_session3, activity_session1])
       end
+
+      it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
+        classroom_unit1.remove_assigned_student(student1.id)
+        classroom_unit1.reload
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
+        expect(@assigned_students).to eq([student2, student3])
+        expect(@activity_sessions).to eq([activity_session3])
+      end
+
     end
   end
 


### PR DESCRIPTION
## WHAT
Fix bug where students that had been removed from the class still showed in the diagnostic reports, and also bug where students weren't having their id removed from the `assigned_student_ids` array when their `students_classrooms` relationship got archived.

## WHY
If a teacher removes a student from a classroom, they shouldn't be able to see their data on any reports.

## HOW
Just scope the various queries we're using to only use ids from `assigned_student_ids` arrays, and also update the `remove_students` controller action to use a method that won't ignore validations and callbacks, since we are relying on a callback to remove the student id from `assigned_student_ids` arrays that it shouldn't be part of any longer.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Students-removed-from-class-still-appear-on-new-diagnostic-reports-cd83df57ae7d4a58b027fadc8da50f59

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
