### PR TITLE
fix activity preview links for both advanced growth diagnostics

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               },
             ]
           }
-          buttonLink="/activity_sessions/anonymous?activity_id=1678"
+          buttonLink="/activity_sessions/anonymous?activity_id=1680"
           buttonText="Preview"
           header="Advanced Growth Diagnostic (Post)"
           lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
@@ -291,7 +291,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               },
             ]
           }
-          buttonLink="/activity_sessions/anonymous?activity_id=1590"
+          buttonLink="/activity_sessions/anonymous?activity_id=1818"
           buttonText="Preview"
           header="ELL Advanced Growth Diagnostic (Post)"
           selectCard={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -133,7 +133,7 @@ const generalDiagnosticMinis = ({ history, assignedPreTests, }) => {
           { key: 'What', text: 'The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.', },
           { key: 'When', text: 'Your students have completed the Advanced Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
         ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ADVANCED_DIAGNOSTIC_ACTIVITY_ID}`}
+        buttonLink={`/activity_sessions/anonymous?activity_id=${ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID}`}
         buttonText="Preview"
         header={ADVANCED_DIAGNOSTIC_POST}
         lockedText={isLocked(ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID) && ADVANCED_POST_TEST_LOCKED_TEXT}
@@ -215,7 +215,7 @@ const ellDiagnosticMinis = ({ history, assignedPreTests, }) => {
           { key: 'What', text: 'The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.', },
           { key: 'When', text: 'Your students have completed the ELL Advanced Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
         ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_ADVANCED_DIAGNOSTIC_ACTIVITY_ID}`}
+        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID}`}
         buttonText="Preview"
         header={ELL_ADVANCED_DIAGNOSTIC_POST}
         lockedText={isLocked(ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID) && ELL_ADVANCED_POST_TEST_LOCKED_TEXT}


### PR DESCRIPTION
## WHAT
Fix activity preview links for both the Advanced Growth Diagnostic and the ELL Advanced Growth Diagnostic.

## WHY
We were linking to the pre-tests instead of the post-tests in both cases.

## HOW
Just update the constant it uses (I have a refactor for this file on the product board and that should make these mistakes easier to avoid).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Advanced-and-ELL-Advanced-Growth-Diagnostics-incorrect-preview-link-fd8f3d18986b466bbe969b26bab343fb)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
