### PR TITLE
Save clever access_tokens when user authenticates

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/users_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/users_controller.rb
@@ -3,25 +3,7 @@
 class Api::V1::UsersController < Api::ApiController
 
   def index
-    has_refresh_token = false
-    refresh_token_expires_at = nil
-    if current_user
-      user_id = current_user.id
-      auth_credential = AuthCredential.where(user_id: user_id).first
-      if auth_credential.present?
-        if auth_credential.refresh_token
-          has_refresh_token = true
-          refresh_token_expires_at = auth_credential&.expires_at&.in_time_zone&.utc&.to_s&.sub(' ','T')
-        end
-      end
-    end
-
-    render json: {
-      user: current_user,
-      text: "Hi",
-      has_refresh_token: has_refresh_token,
-      refresh_token_expires_at: refresh_token_expires_at
-    }
+    render json: { user: current_user }
   end
 
   def current_user_and_coteachers

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -28,7 +28,11 @@ class AuthCredential < ApplicationRecord
   belongs_to :user
 
   GOOGLE_PROVIDER = 'google'
-  EXPIRATION_DURATION = 6.months
+  GOOGLE_EXPIRATION_DURATION = 6.months
+
+  CLEVER_DISTRICT_PROVIDER = 'clever_district'
+  CLEVER_LIBRARY_PROVIDER = 'clever_library'
+  CLEVER_EXPIRATION_DURATION = 24.hours
 
   def google_authorized?
     provider == GOOGLE_PROVIDER && refresh_token_valid?
@@ -41,6 +45,6 @@ class AuthCredential < ApplicationRecord
   end
 
   def refresh_token_expires_at
-    expires_at + EXPIRATION_DURATION
+    expires_at + GOOGLE_EXPIRATION_DURATION
   end
 end

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -32,19 +32,25 @@ class AuthCredential < ApplicationRecord
 
   CLEVER_DISTRICT_PROVIDER = 'clever_district'
   CLEVER_LIBRARY_PROVIDER = 'clever_library'
-  CLEVER_EXPIRATION_DURATION = 24.hours
+  CLEVER_EXPIRATION_DURATION = 23.hours
 
   def google_authorized?
-    provider == GOOGLE_PROVIDER && refresh_token_valid?
+    google_provider? && refresh_token_valid?
+  end
+
+  def google_provider?
+    provider == GOOGLE_PROVIDER
   end
 
   def refresh_token_valid?
-    return false if expires_at.nil? || refresh_token.nil?
+    return false if !google_provider? || expires_at.nil? || refresh_token.nil?
 
     Time.now < refresh_token_expires_at
   end
 
   def refresh_token_expires_at
+    return nil if !google_provider?
+
     expires_at + GOOGLE_EXPIRATION_DURATION
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
@@ -29,7 +29,7 @@ module CleverIntegration
     end
 
     private def initiate_expiration_worker
-      PurgeExpiredAuthCredentialWorker.perform_in(expires_at - 1.hour, new_auth_credential.id)
+      PurgeExpiredAuthCredentialWorker.perform_in(expires_at, new_auth_credential.id)
     end
 
     private def new_auth_credential

--- a/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module CleverIntegration
+  class AuthCredentialSaver < ApplicationService
+    attr_reader :user, :access_token, :provider
+
+    def initialize(user, access_token, provider)
+      @user = user
+      @access_token = access_token
+      @provider = provider
+    end
+
+    def run
+      delete_previous_credential
+      assign_new_credential
+      initiate_expiration_worker
+    end
+
+    private def assign_new_credential
+      user.auth_credential = new_auth_credential
+    end
+
+    private def delete_previous_credential
+      user.auth_credential&.destroy
+    end
+
+    private def expires_at
+      @expires_at ||= AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+    end
+
+    private def initiate_expiration_worker
+      PurgeExpiredAuthCredentialWorker.perform_in(expires_at - 1.hour, new_auth_credential.id)
+    end
+
+    private def new_auth_credential
+      @new_auth_credential ||= AuthCredential.create!(
+        access_token: access_token,
+        expires_at: expires_at,
+        provider: provider,
+        user: user
+      )
+    end
+  end
+end

--- a/services/QuillLMS/app/services/clever_integration/importers/library.rb
+++ b/services/QuillLMS/app/services/clever_integration/importers/library.rb
@@ -6,6 +6,7 @@ module CleverIntegration::Importers::Library
     user = import_teacher(client)
 
     if auth_hash[:info][:user_type] == 'teacher'
+      AuthCredentialSaver.run(user, auth_hash.credentials.token, AuthCredential::CLEVER_LIBRARY_PROVIDER)
       classrooms = import_classrooms(client, user)
       CleverLibraryStudentImporterWorker.perform_async(classrooms.map(&:id), auth_hash.credentials.token)
     elsif auth_hash[:info][:user_type] == 'school_admin'

--- a/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/teacher.rb
@@ -21,7 +21,9 @@ module CleverIntegration::SignUp::Teacher
 
   def self.district_integration(auth_hash, district)
     teacher = create_teacher(auth_hash)
+
     if teacher.present?
+      AuthCredentialSaver.run(teacher, district.token, AuthCredential::CLEVER_DISTRICT_PROVIDER)
       associate_teacher_to_district(teacher, district)
       school = import_school(teacher, district.token)
       classrooms = import_classrooms(teacher, district.token)

--- a/services/QuillLMS/app/workers/purge_expired_auth_credential_worker.rb
+++ b/services/QuillLMS/app/workers/purge_expired_auth_credential_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class PurgeExpiredAuthCredentialWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+  def perform(auth_credential_id)
+    AuthCredential.find_by(id: auth_credential_id)&.destroy
+  end
+end

--- a/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
@@ -11,12 +11,7 @@ describe Api::V1::UsersController do
     it 'should return the correct json' do
       get :index, as: :json
 
-      expect(response.body).to eq({
-        user: user,
-        text: "Hi",
-        has_refresh_token: false,
-        refresh_token_expires_at: nil
-      }.to_json)
+      expect(response.body).to eq({ user: user }.to_json)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -564,7 +564,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should kick off the importer' do
-      create(:auth_credential, user: teacher)
+      create(:google_auth_credential, user: teacher)
 
       expect(GoogleStudentImporterWorker).to receive(:perform_async)
       put :import_google_students, params: { selected_classroom_ids: [1,2], as: :json }

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -29,7 +29,22 @@ FactoryBot.define do
     access_token 'fake_token'
     refresh_token 'fake_refresh_token'
     provider 'hooli'
-    expires_at Time.now + 1.day
+    expires_at 1.day.from_now
     user
+
+    factory :google_auth_credential do
+      provider AuthCredential::GOOGLE_PROVIDER
+      expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.from_now
+    end
+
+    factory :clever_district_auth_credential do
+      provider AuthCredential::CLEVER_DISTRICT_PROVIDER
+      expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+    end
+
+    factory :clever_library_auth_credential do
+      provider AuthCredential::CLEVER_LIBRARY_PROVIDER
+      expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+    end
   end
 end

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -51,7 +51,7 @@ describe AuthCredential, type: :model do
     end
 
     context 'expired refresh token' do
-      let(:expires_at) { Time.now - AuthCredential::EXPIRATION_DURATION - 1.month }
+      let(:expires_at) { Time.now - AuthCredential::GOOGLE_EXPIRATION_DURATION - 1.month }
 
       before { auth_credential.update(expires_at: expires_at) }
 

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -29,37 +29,53 @@ require 'rails_helper'
 describe AuthCredential, type: :model do
   it { should belong_to(:user) }
 
-  let(:auth_credential) { create(:auth_credential, provider: 'google') }
+  let(:auth_credential) { create(factory) }
 
-  context '#google_authorized?' do
-    context 'non google provider' do
-      before { auth_credential.update(provider: 'hooli') }
+  context described_class::GOOGLE_PROVIDER do
+    let(:factory) { :google_auth_credential }
 
-      it { should_be_unauthorized_for_google }
+    context '#google_authorized?' do
+      context 'nil expires_at' do
+        before { auth_credential.update(expires_at: nil) }
+
+        it { should_not_be_google_authorized }
+      end
+
+      context 'nil refresh token' do
+        before { auth_credential.update(refresh_token: nil) }
+
+        it { should_not_be_google_authorized }
+      end
+
+      context 'expired refresh token' do
+        let(:expires_at) { Time.now - AuthCredential::GOOGLE_EXPIRATION_DURATION - 1.month }
+
+        before { auth_credential.update(expires_at: expires_at) }
+
+        it { should_not_be_google_authorized }
+      end
     end
+  end
 
-    context 'nil expires_at' do
-      before { auth_credential.update(expires_at: nil) }
+  context described_class::CLEVER_DISTRICT_PROVIDER do
+    let(:factory) { :clever_district_auth_credential }
 
-      it { should_be_unauthorized_for_google }
-    end
+    it { expect(auth_credential.refresh_token_expires_at).to eq nil }
+    it { expect(auth_credential.refresh_token_valid?).to eq false }
 
-    context 'nil refresh token' do
-      before { auth_credential.update(refresh_token: nil) }
+    it { should_not_be_google_authorized }
+  end
 
-      it { should_be_unauthorized_for_google }
-    end
+  context described_class::CLEVER_LIBRARY_PROVIDER do
+    let(:factory) { :clever_library_auth_credential }
 
-    context 'expired refresh token' do
-      let(:expires_at) { Time.now - AuthCredential::GOOGLE_EXPIRATION_DURATION - 1.month }
+    it { expect(auth_credential.refresh_token_expires_at).to eq nil }
+    it { expect(auth_credential.refresh_token_valid?).to eq false }
 
-      before { auth_credential.update(expires_at: expires_at) }
+    it { should_not_be_google_authorized }
+  end
 
-      it { should_be_unauthorized_for_google }
-    end
-
-    def should_be_unauthorized_for_google
-      expect(auth_credential.google_authorized?).to be false
-    end
+  def should_not_be_google_authorized
+    expect(auth_credential.google_authorized?).to be false
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1286,7 +1286,7 @@ describe User, type: :model do
     end
 
     context 'user with auth credentials has valid authorization' do
-      let(:google_user) { create(:auth_credential, provider: 'google').user }
+      let(:google_user) { create(:google_auth_credential).user }
 
       it { expect(google_user.google_authorized?).to be true }
     end

--- a/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
@@ -19,11 +19,7 @@ RSpec.describe CleverIntegration::AuthCredentialSaver do
       let!(:previous_credential) { create(:clever_library_auth_credential, user: teacher) }
 
       it { expects_new_credentials_are_saved }
-
-      it 'removes previous credentials' do
-        subject
-        expect(AuthCredential.find_by(id: previous_credential.id)).to eq nil
-      end
+      it { removes_previous_credentials }
     end
   end
 
@@ -37,17 +33,11 @@ RSpec.describe CleverIntegration::AuthCredentialSaver do
       let!(:previous_credential) { create(:clever_district_auth_credential, user: teacher) }
 
       it { expects_new_credentials_are_saved }
-
-      it 'removes previous credentials' do
-        subject
-        expect(AuthCredential.find_by(id: previous_credential.id)).to eq nil
-      end
+      it { removes_previous_credentials }
     end
   end
 
   def expects_new_credentials_are_saved
-    expect(PurgeExpiredAuthCredentialWorker).to receive(:perform_in)
-
     subject
     expect(teacher.auth_credential.provider).to eq provider
     expect(teacher.auth_credential.access_token).to eq access_token
@@ -62,5 +52,10 @@ RSpec.describe CleverIntegration::AuthCredentialSaver do
 
       Timecop.travel(expires_at) { expect(teacher.auth_credential).to be_nil }
     end
+  end
+
+  def removes_previous_credentials
+    subject
+    expect(AuthCredential.find_by(id: previous_credential.id)).to eq nil
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CleverIntegration::AuthCredentialSaver do
+  let(:teacher) { create(:teacher, :signed_up_with_clever) }
+  let(:access_token) { 'asfUI213bda2j'}
+  let(:expires_at) { AuthCredential::CLEVER_EXPIRATION_DURATION.from_now }
+
+  subject { described_class.run(teacher, access_token, provider) }
+
+  context 'Clever Library' do
+    let(:provider) { AuthCredential::CLEVER_LIBRARY_PROVIDER }
+
+    it { expects_new_credentials_are_saved }
+    it { purges_expired_auth_credentials }
+
+    context 'with previous credentials' do
+      let!(:previous_credential) { create(:clever_library_auth_credential, user: teacher) }
+
+      it { expects_new_credentials_are_saved }
+
+      it 'removes previous credentials' do
+        subject
+        expect(AuthCredential.find_by(id: previous_credential.id)).to eq nil
+      end
+    end
+  end
+
+  context 'Clever District' do
+    let(:provider) { AuthCredential::CLEVER_DISTRICT_PROVIDER }
+
+    it { expects_new_credentials_are_saved }
+    it { purges_expired_auth_credentials }
+
+    context 'with previous credentials' do
+      let!(:previous_credential) { create(:clever_district_auth_credential, user: teacher) }
+
+      it { expects_new_credentials_are_saved }
+
+      it 'removes previous credentials' do
+        subject
+        expect(AuthCredential.find_by(id: previous_credential.id)).to eq nil
+      end
+    end
+  end
+
+  def expects_new_credentials_are_saved
+    expect(PurgeExpiredAuthCredentialWorker).to receive(:perform_in)
+
+    subject
+    expect(teacher.auth_credential.provider).to eq provider
+    expect(teacher.auth_credential.access_token).to eq access_token
+    expect(teacher.auth_credential.expires_at).to be_within(1.minute).of(expires_at)
+  end
+
+  def purges_expired_auth_credentials
+    Sidekiq::Testing.inline! do
+      subject
+      expect(teacher.auth_credential).not_to be_nil
+      teacher.reload
+
+      Timecop.travel(expires_at) { expect(teacher.auth_credential).to be_nil }
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/classroom/refresh_access_token_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom/refresh_access_token_spec.rb
@@ -9,7 +9,7 @@ describe GoogleIntegration::RefreshAccessToken do
 
   it 'returns the new credentials if token is expired' do
     user = create(:user)
-    expired_auth_credentials = create(:auth_credential,
+    expired_auth_credentials = create(:google_auth_credential,
       user: user,
       access_token: 'mr',
       expires_at: current_time - 1.day,
@@ -27,8 +27,7 @@ describe GoogleIntegration::RefreshAccessToken do
 
     expect(http_client).to receive(:post).and_return(response)
 
-    credentials = GoogleIntegration::RefreshAccessToken.new(user, http_client)
-      .refresh
+    credentials = GoogleIntegration::RefreshAccessToken.new(user, http_client).refresh
 
     expect(credentials).to have_attributes(
       access_token: 'what',
@@ -39,7 +38,7 @@ describe GoogleIntegration::RefreshAccessToken do
 
   it 'updates the user credentials if token is expired' do
     user = create(:user)
-    expired_auth_credentials = create(:auth_credential,
+    expired_auth_credentials = create(:google_auth_credential,
       user: user,
       access_token: 'mr',
       expires_at: current_time - 1.day,
@@ -68,7 +67,7 @@ describe GoogleIntegration::RefreshAccessToken do
 
   it 'does not attempt to refresh if current token is not expired' do
     user = create(:user)
-    auth_credentials = create(:auth_credential,
+    auth_credentials = create(:google_auth_credential,
       user: user,
       access_token: 'mr',
       expires_at: current_time + 1.day,
@@ -83,7 +82,7 @@ describe GoogleIntegration::RefreshAccessToken do
 
   it 'returns the current credentials if not expired' do
     user = create(:user)
-    auth_credentials = create(:auth_credential,
+    auth_credentials = create(:google_auth_credential,
       user: user,
       access_token: 'mr',
       expires_at: current_time + 1.day,

--- a/services/QuillLMS/spec/services/google_integration/client_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/client_spec.rb
@@ -9,9 +9,8 @@ describe GoogleIntegration::Client do
     api_client          = double('api_client')
     api_client_instance = double('api_client_instance')
     token_refresher     = double('token_refresher')
-    auth_credential     = create(:auth_credential,
+    auth_credential     = create(:google_auth_credential,
       user: user,
-      provider: 'google',
       access_token: access_token
     )
 
@@ -38,9 +37,8 @@ describe GoogleIntegration::Client do
     access_token             = 'coolio'
     token_refresher          = double('token_refresher')
     token_refresher_instance = spy('token_refresher_instance')
-    auth_credential          = create(:auth_credential,
+    auth_credential          = create(:google_auth_credential,
       user: user,
-      provider: 'google',
       access_token: access_token
     )
 

--- a/services/QuillLMS/spec/services/google_integration/refresh_access_token.rb
+++ b/services/QuillLMS/spec/services/google_integration/refresh_access_token.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe GoogleIntegration::RefreshAccessToken do
   let(:user) { create(:user) }
-  let!(:auth_credential) { create(:auth_credential, user: user, provider: 'google') }
+  let!(:auth_credential) { create(:google_auth_credential, user: user) }
   let(:subject) { described_class.new(user) }
 
   describe '#refresh' do

--- a/services/QuillLMS/spec/workers/purge_expired_auth_credential_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/purge_expired_auth_credential_worker_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PurgeExpiredAuthCredentialWorker do
+  subject { described_class.new.perform(auth_credential_id) }
+
+  context 'auth_credential exists' do
+    let!(:auth_credential_id) { create(:auth_credential).id }
+
+    it { expect { subject }.to change(AuthCredential, :count).from(1).to(0) }
+  end
+
+  context 'auth_credential does not exist' do
+    let(:auth_credential_id) { nil }
+
+    it { expect { subject }.not_to change(AuthCredential, :count) }
+  end
+end
+
+


### PR DESCRIPTION
## WHAT
When a teacher authenticates via clever, save their access token to the appropriate `auth_credential`. Also, delete the same auth_credential when it has expired.

## WHY
Currently, when a teacher logs in, all of the students and classes are imported immediately.  This is achieved without storing the access token since the controller immediately uses the access token after login.  If we want to use the access token later in a background job or ajax request, we need to store the appropriate token. 

## HOW
Use the AuthCredentialSaver to save the new credential.  Use the `clever_library` or `clever_district` provider depending on the type of integration.  After assigning the new credential, kick off a background job to run in 23 hours that will remove the expired worker.  I'm choosing to expire 1.hour before the actual expiration so as to avoid some edge cases.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
