### PR TITLE
use the react-router location, not the window.location for the querystring in diagnostic reports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/individualStudentResponses.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/individualStudentResponses.tsx
@@ -93,7 +93,7 @@ const Tab = ({ activeTab, label, setPreOrPost, value, }) => {
   return (<button className={`${activeTab === value ? 'active' : ''} focus-on-light tab`} onClick={handleClick} type="button">{label}</button>)
 }
 
-export const IndividualStudentResponses = ({ match, passedConceptResults, passedSkillResults, mobileNavigation, }) => {
+export const IndividualStudentResponses = ({ match, passedConceptResults, passedSkillResults, mobileNavigation, location, }) => {
   const [loading, setLoading] = React.useState<boolean>(!(passedConceptResults && passedSkillResults));
   const [name, setName] = React.useState<string>('')
   const [conceptResults, setConceptResults] = React.useState<ConceptResults>(passedConceptResults || []);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/questions.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/questions.tsx
@@ -107,7 +107,7 @@ const DirectionsAndPrompt = ({ directions, prompt, onMobile, }) => {
   </div>)
 }
 
-export const Questions = ({ passedQuestions, match, mobileNavigation, }) => {
+export const Questions = ({ passedQuestions, match, mobileNavigation, location, }) => {
   const [loading, setLoading] = React.useState<boolean>(!passedQuestions);
   const [questions, setQuestions] = React.useState<Question[]>(passedQuestions || []);
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
@@ -176,7 +176,7 @@ const LessonsRecommendationsButtons = ({ lessonsSelections, assignLessonsActivit
   return <RecommendationsButtons assignActivityPacks={assignLessonsActivityPacks} assigned={assigned} assigning={assigning} deselectAll={handleDeselectAllClick} numberSelected={lessonsSelections.length} selectAll={handleSelectAllClick} selectAllRecommended={handleSelectAllRecommendedClick} />
 }
 
-export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passedPreviouslyAssignedLessonRecommendations, passedIndependentRecommendations, passedLessonRecommendations, match, mobileNavigation, activityName, }) => {
+export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passedPreviouslyAssignedLessonRecommendations, passedIndependentRecommendations, passedLessonRecommendations, match, mobileNavigation, activityName, location, }) => {
   const [loading, setLoading] = React.useState<boolean>(!passedPreviouslyAssignedRecommendations && !passedIndependentRecommendations && !passedLessonRecommendations);
   const [previouslyAssignedIndependentRecommendations, setPreviouslyAssignedIndependentRecommendations] = React.useState<Recommendation[]>(passedPreviouslyAssignedRecommendations);
   const [previouslyAssignedLessonsRecommendations, setPreviouslyAssignedLessonsRecommendations] = React.useState<LessonRecommendation[]>(passedPreviouslyAssignedLessonRecommendations);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
@@ -197,7 +197,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
   const { params, } = match
   const { activityId, classroomId, } = params
   const unitId = qs.parse(location.search.replace('?', '')).unit
-  const unitQueryString = unitId ? `&unit_id=${unitId}` : ''
+  const unitQueryString = unitId ? `?unit_id=${unitId}` : ''
 
   React.useEffect(() => {
     getRecommendations()

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
@@ -89,8 +89,6 @@ export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match
   }, [openPopover])
 
   function getResults() {
-    debugger;
-
     requestGet(`/teachers/progress_reports/diagnostic_results_summary?activity_id=${activityId}&classroom_id=${classroomId}${unitQueryString}`,
       (data) => {
         setStudentResults(data.student_results);
@@ -100,7 +98,7 @@ export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match
     )
   }
 
-  const responsesLink = (studentId) => `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}${unitQueryString}`
+  const responsesLink = (studentId: number) => unitId ? `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}?unit=${unitId}` : `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}`
 
   function closePopoverOnOutsideClick(e) {
     if (!openPopover.studentId) { return }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
@@ -62,7 +62,7 @@ const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }) => 
   </section>)
 }
 
-export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match, mobileNavigation, }) => {
+export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match, mobileNavigation, location, }) => {
   const [loading, setLoading] = React.useState<boolean>(!passedStudentResults);
   const [studentResults, setStudentResults] = React.useState<StudentResult[]>(passedStudentResults || []);
   const [skillGroupSummaries, setSkillGroupSummaries] = React.useState<SkillGroupSummary[]>(passedSkillGroupSummaries || []);
@@ -89,6 +89,7 @@ export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match
   }, [openPopover])
 
   function getResults() {
+    debugger;
 
     requestGet(`/teachers/progress_reports/diagnostic_results_summary?activity_id=${activityId}&classroom_id=${classroomId}${unitQueryString}`,
       (data) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -116,7 +116,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     )
   }
 
-  const responsesLink = (studentId: number) => `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}${unitQueryString}`
+  const responsesLink = (studentId: number) => unitId ? `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}?unit=${unitId}` : `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}`
 
   if (loading) { return <LoadingSpinner /> }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -89,7 +89,7 @@ const ProficiencyKey = ({ className, studentCount, range, title, }) => {
 }
 
 
-export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation, }) => {
+export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation, location, }) => {
   const [loading, setLoading] = React.useState<boolean>(!passedStudents);
   const [students, setStudents] = React.useState<Student[]>(passedStudents || []);
 


### PR DESCRIPTION
## WHAT
Make sure we're pulling `location` from props rather than from the window in the diagnostic reports.

## WHY
We are calling `location.search` to get the unit id in these reports, but it was using `window.location` instead of the `react-router` location and coming up undefined.

## HOW
Just make sure we're actually using the prop.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Skills-Survey-results-overriden-when-reassigned-f61b4f38d5d34923b7e1ba78a217080c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
