### PR TITLE
Show the feedback for student's 5th attempt in Question Reports

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -172,7 +172,7 @@ module PublicProgressReports
     end
 
     def formatted_score_obj(final_activity_session, classification_key, student, average_score_on_quill)
-      formatted_concept_results = format_concept_results(final_activity_session.concept_results)
+      formatted_concept_results = format_concept_results(final_activity_session.concept_results, final_activity_session)
       if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification_key)
         score = get_average_score(formatted_concept_results)
       elsif [ActivityClassification::EVIDENCE_KEY].include?(classification_key)
@@ -200,25 +200,28 @@ module PublicProgressReports
       time > 60 ? '> 60' : time
     end
 
-    def format_concept_results(concept_results)
+    def format_concept_results(concept_results, activity_session)
       concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
         # if we don't sort them, we can't rely on the first result being the first attemptNum
         # however, it would be more efficient to make them a hash with attempt numbers as keys
         cr.sort!{|x,y| (x[:metadata]['attemptNumber'] || 0) <=> (y[:metadata]['attemptNumber'] || 0)}
         directfirst = cr.first[:metadata]["directions"] || cr.first[:metadata]["instructions"] || ""
+        prompt_text = cr.first[:metadata]["prompt"]
         hash = {
           directions: directfirst.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", ""),
-          prompt: cr.first[:metadata]["prompt"],
+          prompt: prompt_text,
           answer: cr.first[:metadata]["answer"],
           score: get_score_for_question(cr),
           concepts: cr.map { |crs|
+            attempt_number = crs[:metadata]["attemptNumber"]
             direct = crs[:metadata]["directions"] || crs[:metadata]["instructions"] || ""
             {
               id: crs.concept_id,
               name: crs.concept.name,
               correct: crs[:metadata]["correct"] == 1,
+              feedback: get_feedback_from_feedback_history(activity_session, prompt_text, attempt_number),
               lastFeedback: crs[:metadata]["lastFeedback"],
-              attempt: crs[:metadata]["attemptNumber"] || 1,
+              attempt: attempt_number || 1,
               answer: crs[:metadata]["answer"],
               directions: direct.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", "")
             }
@@ -246,6 +249,16 @@ module PublicProgressReports
       else
         (formatted_results.inject(0) {|sum, crs| sum + crs[:score]} / formatted_results.length).round()
       end
+    end
+
+    def get_feedback_from_feedback_history(activity_session, prompt_text, attempt_number)
+      feedback_histories = activity_session.feedback_histories
+      return "" if feedback_histories.empty? || prompt_text.blank? || attempt_number.blank?
+
+      prompt_ids = activity_sessions.activity.child_activity.prompt_ids
+      prompt = Evidence::Prompt.where(id: prompt_ids, text: prompt_text)
+      feedback_history = feedback_histories.select {|fh| fh.attempt == attempt_number.to_i && fh.prompt_id == prompt.id }
+      feedback_history.feedback_text
     end
 
     def generate_recommendations_for_classroom(current_user, unit_id, classroom_id, activity_id)

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -48,6 +48,8 @@ export default createReactClass({
 				if (typeof feedback === 'string') {
 					feedback = this.feedbackOrDirections(feedback, 'Feedback')
 				}
+			} else if (currAttempt[0].feedback) {
+				feedback = currAttempt[0].feedback
 			}
 			let score = 0;
 			let concepts = currAttempt.map((concept)=>{

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -28,6 +28,7 @@ export default createReactClass({
 	},
 
     conceptsByAttempt: function() {
+		const maxAttemptsIncorrectFeedback = 'Nice effort! You worked hard to make your sentence stronger.'
 		const conceptsByAttempt = this.groupByAttempt();
 		let attemptNum = 1;
 		let results = [];
@@ -45,7 +46,9 @@ export default createReactClass({
 					index += 1;
 				}
 			} else if (currAttempt[0].feedback) {
-				feedback = currAttempt[0].feedback
+				// this is the last attempt, so if it was incorrect then we return the default max attempts feedback
+				// that the student saw
+				feedback = currAttempt[0].correct ? currAttempt[0].feedback : maxAttemptsIncorrectFeedback
 			}
 			// sometimes feedback is coming through as a react variable, I've been unable to find the source of it
 			if (feedback && typeof feedback === 'string') {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/connect_student_report_box.jsx
@@ -44,12 +44,12 @@ export default createReactClass({
 					feedback = nextAttempt[index].lastFeedback || nextAttempt[index].directions
 					index += 1;
 				}
-				// sometimes feedback is coming through as a react variable, I've been unable to find the source of it
-				if (typeof feedback === 'string') {
-					feedback = this.feedbackOrDirections(feedback, 'Feedback')
-				}
 			} else if (currAttempt[0].feedback) {
 				feedback = currAttempt[0].feedback
+			}
+			// sometimes feedback is coming through as a react variable, I've been unable to find the source of it
+			if (feedback && typeof feedback === 'string') {
+				feedback = this.feedbackOrDirections(feedback, 'Feedback')
 			}
 			let score = 0;
 			let concepts = currAttempt.map((concept)=>{


### PR DESCRIPTION
## WHAT
We want to start showing the feedback the student received for their 5th attempt in Question Reports. Right now we don't show anything in that row, because we don't record that feedback in `ConceptResults`.

## WHY
This will improve the teacher experience of the Question Reports UI.

## HOW
On the back end:

We don't actually keep the feedback the student received in `ConceptResults`, so we have to do an awkward thing here where we cross-reference the student's attempt with the corresponding `FeedbackHistory` object. That object stores the feedback the student received in `feedback_text`, which we can then return in the payload for the concept report.

On the front end:

We currently just skip setting the `feedback` variable if we're showing the student's last attempt. Instead, if we're showing the last attempt we want to check if the `feedback` field exists on the JSON payload, and if it does we will show the `feedback` if it was correct, and if it was incorrect we show the default incorrect response for evidence.

### Screenshots
![Screen Shot 2021-12-09 at 4 01 43 PM](https://user-images.githubusercontent.com/57366100/145476382-2f122fbc-717f-4240-8548-7fc836fd5e52.png)

### Notion Card Links
https://www.notion.so/quill/Display-the-fifth-attempt-feedback-on-Evidence-Activity-Analysis-e58f0720da714cdebe3c91df4328bdb1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
