### PR TITLE
Evidence/ add spellcheck to internal tool text editors

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -142,6 +142,7 @@ exports[`Activity Form component should render Activities 1`] = `
         EditorState={[Function]}
         handleTextChange={[Function]}
         key="passage-description"
+        shouldCheckSpelling={true}
         text="..."
       />
     </div>
@@ -155,6 +156,7 @@ exports[`Activity Form component should render Activities 1`] = `
       EditorState={[Function]}
       handleTextChange={[Function]}
       key="max-attempt-feedback"
+      shouldCheckSpelling={true}
       text="At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul."
     />
     <Input

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`RuleGenericAttributes component should render RuleGenericAttributes 1`]
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="rule-note"
+    shouldCheckSpelling={true}
     text="test description"
   />
 </Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="plagiarism-text"
+    shouldCheckSpelling={true}
   />
   <p
     className="form-subsection-label"
@@ -23,6 +24,7 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="first-plagiarism-feedback"
+    shouldCheckSpelling={true}
     text="do not plagiarize."
   />
   <div
@@ -47,6 +49,7 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="second-plagiarism-feedback"
+    shouldCheckSpelling={true}
     text="seriously... do not plagiarize!"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleRegexAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleRegexAttributes.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`RuleRegexAttributes component should render RuleRegexAttributes 1`] = `
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="regex-feedback"
+    shouldCheckSpelling={true}
     text="test regex feedback"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="universal-feedback"
+    shouldCheckSpelling={true}
     text="test universal feedback"
   />
   <section
@@ -56,6 +57,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
       EditorState={[Function]}
       handleTextChange={[Function]}
       key="universal-feedback-highlight"
+      shouldCheckSpelling={true}
       text="prompt highlight"
     />
   </section>
@@ -101,6 +103,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
       EditorState={[Function]}
       handleTextChange={[Function]}
       key="universal-feedback-highlight"
+      shouldCheckSpelling={true}
       text="passage highlight"
     />
   </section>
@@ -135,6 +138,7 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     EditorState={[Function]}
     handleTextChange={[Function]}
     key="universal-feedback"
+    shouldCheckSpelling={true}
     text="test universal feedback"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
@@ -117,6 +117,7 @@ const RuleGenericAttributes = ({
         EditorState={EditorState}
         handleTextChange={onHandleSetRuleNote}
         key="rule-note"
+        shouldCheckSpelling={true}
         text={ruleNote}
       />
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -72,6 +72,7 @@ const RulePlagiarismAttributes = ({
           EditorState={EditorState}
           handleTextChange={onHandleSetPlagiarismText}
           key="plagiarism-text"
+          shouldCheckSpelling={true}
           text={plagiarismText.text}
         />}
         {errors['Plagiarism Text'] && <p className="error-message">{errors['Plagiarism Text']}</p>}
@@ -82,6 +83,7 @@ const RulePlagiarismAttributes = ({
           // eslint-disable-next-line
           handleTextChange={(text) => onHandleSetPlagiarismFeedback(text, 0, null, FEEDBACK)}
           key="first-plagiarism-feedback"
+          shouldCheckSpelling={true}
           text={plagiarismFeedbacks[0].text}
         />}
         {plagiarismFeedbacks[0] && plagiarismFeedbacks[0].highlights_attributes && renderHighlights(plagiarismFeedbacks[0].highlights_attributes, 0, onHandleSetPlagiarismFeedback)}
@@ -97,6 +99,7 @@ const RulePlagiarismAttributes = ({
           // eslint-disable-next-line
           handleTextChange={(text) => onHandleSetPlagiarismFeedback(text, 1, null, FEEDBACK)}
           key="second-plagiarism-feedback"
+          shouldCheckSpelling={true}
           text={plagiarismFeedbacks[1].text}
         />}
         {plagiarismFeedbacks[1] && plagiarismFeedbacks[1].highlights_attributes && renderHighlights(plagiarismFeedbacks[1].highlights_attributes, 1, onHandleSetPlagiarismFeedback)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
@@ -107,6 +107,7 @@ const RuleRegexAttributes = ({
         // eslint-disable-next-line
         handleTextChange={(text) => onHandleSetRegexFeedback(text, 0, null, FEEDBACK)}
         key="regex-feedback"
+        shouldCheckSpelling={true}
         text={regexFeedback[0].text}
       />}
       {regexFeedback[0] && regexFeedback[0].highlights_attributes && renderHighlights(regexFeedback[0].highlights_attributes, 0, onHandleSetRegexFeedback)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
@@ -94,6 +94,7 @@ const RuleAttributesSection = ({
             // eslint-disable-next-line
             handleTextChange={(text) => onHandleSetUniversalFeedback(text, i, null, FEEDBACK)}
             key="universal-feedback"
+            shouldCheckSpelling={true}
             text={universalFeedback[i].text}
           />
           {errors['Universal Feedback'] && errors['Universal Feedback'].length && <p className="error-message">{errors['Universal Feedback'][i]}</p>}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -274,6 +274,7 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
             EditorState={EditorState}
             handleTextChange={handleSetPassageText}
             key="passage-description"
+            shouldCheckSpelling={true}
             text={activityPassages[0].text}
           />
         </div>
@@ -284,6 +285,7 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
           EditorState={EditorState}
           handleTextChange={handleSetActivityMaxFeedback}
           key="max-attempt-feedback"
+          shouldCheckSpelling={true}
           text={activityMaxFeedback}
         />
         <Input

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
@@ -5,7 +5,6 @@ import { EditorState, ContentState } from 'draft-js';
 
 import { fetchModel, updateModel } from '../../../utils/evidence/modelAPIs';
 import { DataTable, Spinner, TextEditor } from '../../../../Shared/index';
-import * as request from 'request';
 
 const Model = ({ match }) => {
   const { params } = match;
@@ -28,7 +27,7 @@ const Model = ({ match }) => {
   function onHandleUpdateModel() {
     updateModel(modelId, modelNotes).then((response) => {
       const { error } = response;
-      
+
       if(error) {
         const updatedErrors = {};
         updatedErrors['Model Submission Error'] = error;
@@ -127,6 +126,7 @@ const Model = ({ match }) => {
           EditorState={EditorState}
           handleTextChange={handleSetModelNotes}
           key="model-notes"
+          shouldCheckSpelling={true}
           text={initialNoteValue}
         />
         <DataTable

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -211,6 +211,7 @@ export function renderHighlights(highlights, i, changeHandler) {
           // eslint-disable-next-line
           handleTextChange={(text) => changeHandler(text, i, j, 'highlight text')}
           key="universal-feedback-highlight"
+          shouldCheckSpelling={true}
           text={highlight.text}
         />
         {passageMismatch && <p className="all-errors-message">The text of this highlight does not match with the associated activity text. This means that it will not highlight the text as intended. Please update the text above.</p>}


### PR DESCRIPTION
## WHAT
add spellcheck to all text editors in the Evidence internal tool

## WHY
it was requested by Curriculum

## HOW
just set all `shouldCheckSpelling` prop in all `TextEditor` components to true

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1224" alt="Screen Shot 2021-12-09 at 5 38 47 PM" src="https://user-images.githubusercontent.com/25959584/145492576-9ec6657d-0790-49a5-a717-c25195bbc9b2.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Understand-if-I-ve-made-spelling-errors-in-the-activity-settings-ff8cc5e1d89a40e0a58bac433d8ba6c9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
