### PR TITLE
refactor assign a diagnostic page to use constants and a wrapper component

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -1629,6 +1629,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               "when": "Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.",
             }
           }
+          key="ap"
         >
           <AssignmentCard
             bodyArray={
@@ -1739,6 +1740,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               "when": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
             }
           }
+          key="pre-ap-1"
         >
           <AssignmentCard
             bodyArray={
@@ -1849,6 +1851,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               "when": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
             }
           }
+          key="pre-ap-2"
         >
           <AssignmentCard
             bodyArray={
@@ -1959,6 +1962,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               "when": "Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.",
             }
           }
+          key="springboard"
         >
           <AssignmentCard
             bodyArray={

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -1,376 +1,2066 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
-<div
-  className="assignment-flow-container"
+<AssignADiagnostic
+  assignedPreTests={
+    Array [
+      Object {
+        "assigned_classroom_ids": Array [
+          1,
+        ],
+        "id": 1663,
+        "post_test_id": 1664,
+      },
+      Object {
+        "assigned_classroom_ids": Array [],
+        "id": 1668,
+        "post_test_id": 1669,
+      },
+      Object {
+        "assigned_classroom_ids": Array [],
+        "id": 1678,
+        "post_test_id": 1680,
+      },
+    ]
+  }
 >
-  <AssignmentFlowNavigation />
-  <ScrollToTop />
   <div
-    className="diagnostic-page container"
+    className="assignment-flow-container"
   >
-    <h1>
-      Which diagnostic covers the skills you want to assess?
-    </h1>
-    <section
-      className="filter-tabs"
-    >
-      <FilterTab
-        activeFilter="All"
-        filter="All"
-        number={16}
-        setFilter={[Function]}
-      />
-      <FilterTab
-        activeFilter="All"
-        filter="General"
-        number={6}
-        setFilter={[Function]}
-      />
-      <FilterTab
-        activeFilter="All"
-        filter="ELL"
-        number={6}
-        setFilter={[Function]}
-      />
-      <FilterTab
-        activeFilter="All"
-        filter="CollegeBoard"
-        number={4}
-        setFilter={[Function]}
-      />
-    </section>
+    <AssignmentFlowNavigation>
+      <div
+        className="assignment-flow-navigation"
+      >
+        <div
+          className="assignment-flow-navigation-container"
+        >
+          <div
+            className="left"
+          >
+            <img
+              alt="green Quill logo"
+              onClick={[Function]}
+              src="undefined/images/logos/quill-logo-green.svg"
+            />
+            <div
+              className="links"
+            />
+          </div>
+          <div
+            className="right"
+          />
+        </div>
+        <div
+          className="progress-bar"
+        >
+          <div
+            className={null}
+          />
+        </div>
+      </div>
+    </AssignmentFlowNavigation>
+    <ScrollToTop />
     <div
-      className="minis"
+      className="diagnostic-page container"
     >
-      <div
-        className="grouped-minis"
-        key="starter"
+      <h1>
+        Which diagnostic covers the skills you want to assess?
+      </h1>
+      <section
+        className="filter-tabs"
       >
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students are working on basic grammar concepts.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1663"
-          buttonText="Preview"
-          header="Starter Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1664"
-          buttonText="Preview"
-          header="Starter Growth Diagnostic (Post)"
-          lockedText={false}
-          selectCard={[Function]}
-          showNewTag={true}
-        />
-      </div>
+        <FilterTab
+          activeFilter="All"
+          filter="All"
+          number={16}
+          setFilter={[Function]}
+        >
+          <button
+            className="active filter-tab focus-on-light"
+            onClick={[Function]}
+            type="button"
+          >
+            All
+             (
+            16
+            )
+          </button>
+        </FilterTab>
+        <FilterTab
+          activeFilter="All"
+          filter="General"
+          number={6}
+          setFilter={[Function]}
+        >
+          <button
+            className="filter-tab focus-on-light"
+            onClick={[Function]}
+            type="button"
+          >
+            General
+             (
+            6
+            )
+          </button>
+        </FilterTab>
+        <FilterTab
+          activeFilter="All"
+          filter="ELL"
+          number={6}
+          setFilter={[Function]}
+        >
+          <button
+            className="filter-tab focus-on-light"
+            onClick={[Function]}
+            type="button"
+          >
+            ELL
+             (
+            6
+            )
+          </button>
+        </FilterTab>
+        <FilterTab
+          activeFilter="All"
+          filter="CollegeBoard"
+          number={4}
+          setFilter={[Function]}
+        >
+          <button
+            className="filter-tab focus-on-light"
+            onClick={[Function]}
+            type="button"
+          >
+            CollegeBoard
+             (
+            4
+            )
+          </button>
+        </FilterTab>
+      </section>
       <div
-        className="grouped-minis"
-        key="intermediate"
+        className="minis"
       >
-        <AssignmentCard
-          bodyArray={
-            Array [
+        <div
+          className="grouped-minis"
+          key="starter"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
               Object {
-                "key": "What",
-                "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
-              },
+                "activityId": 1663,
+                "name": "Starter Baseline Diagnostic (Pre)",
+                "unitTemplateId": 99,
+                "what": "Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
+                "when": "Your students are working on basic grammar concepts.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students are working on basic grammar concepts.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1663"
+              buttonText="Preview"
+              header="Starter Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Starter Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1663"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students are working on basic grammar concepts.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
               Object {
-                "key": "When",
-                "text": "Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.",
-              },
-            ]
+                "activityId": 1664,
+                "lockedText": "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic.",
+                "name": "Starter Growth Diagnostic (Post)",
+                "unitTemplateId": 217,
+                "what": "The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.",
+                "when": "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            lockedText={false}
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1664"
+              buttonText="Preview"
+              header="Starter Growth Diagnostic (Post)"
+              lockedText={false}
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Starter Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1664"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <div
+          className="grouped-minis"
+          key="intermediate"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1668,
+                "name": "Intermediate Baseline Diagnostic (Pre)",
+                "unitTemplateId": 100,
+                "what": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
+                "when": "Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1668"
+              buttonText="Preview"
+              header="Intermediate Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Intermediate Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1668"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1669,
+                "lockedText": "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic.",
+                "name": "Intermediate Growth Diagnostic (Post)",
+                "unitTemplateId": 237,
+                "what": "The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.",
+                "when": "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1669"
+              buttonText="Preview"
+              header="Intermediate Growth Diagnostic (Post)"
+              lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Intermediate Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1669"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <Tooltip
+                      tooltipText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+                      tooltipTriggerText={
+                        <button
+                          className="quill-button small disabled contained"
+                          type="button"
+                        >
+                          <img
+                            alt="Lock icon"
+                            src="undefined/images/icons/icons-locked.svg"
+                          />
+                           Locked
+                        </button>
+                      }
+                    >
+                      <span
+                        className="quill-tooltip-trigger"
+                      >
+                        <span
+                          className="undefined"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          tabIndex={null}
+                        >
+                          <button
+                            className="quill-button small disabled contained"
+                            type="button"
+                          >
+                            <img
+                              alt="Lock icon"
+                              src="undefined/images/icons/icons-locked.svg"
+                            />
+                             Locked
+                          </button>
+                        </span>
+                        <span
+                          className="quill-tooltip-wrapper"
+                        >
+                          <span
+                            className="quill-tooltip"
+                          />
+                        </span>
+                      </span>
+                    </Tooltip>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <div
+          className="grouped-minis"
+          key="advanced"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1678,
+                "name": "Advanced Baseline Diagnostic (Pre)",
+                "unitTemplateId": 126,
+                "what": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
+                "when": "Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1678"
+              buttonText="Preview"
+              header="Advanced Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Advanced Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1678"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1680,
+                "lockedText": "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic.",
+                "name": "Advanced Growth Diagnostic (Post)",
+                "unitTemplateId": 409,
+                "what": "The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.",
+                "when": "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1680"
+              buttonText="Preview"
+              header="Advanced Growth Diagnostic (Post)"
+              lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        Advanced Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1680"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <Tooltip
+                      tooltipText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+                      tooltipTriggerText={
+                        <button
+                          className="quill-button small disabled contained"
+                          type="button"
+                        >
+                          <img
+                            alt="Lock icon"
+                            src="undefined/images/icons/icons-locked.svg"
+                          />
+                           Locked
+                        </button>
+                      }
+                    >
+                      <span
+                        className="quill-tooltip-trigger"
+                      >
+                        <span
+                          className="undefined"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          tabIndex={null}
+                        >
+                          <button
+                            className="quill-button small disabled contained"
+                            type="button"
+                          >
+                            <img
+                              alt="Lock icon"
+                              src="undefined/images/icons/icons-locked.svg"
+                            />
+                             Locked
+                          </button>
+                        </span>
+                        <span
+                          className="quill-tooltip-wrapper"
+                        >
+                          <span
+                            className="quill-tooltip"
+                          />
+                        </span>
+                      </span>
+                    </Tooltip>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <div
+          className="grouped-minis"
+          key="ell-starter"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1161,
+                "name": "ELL Starter Baseline Diagnostic (Pre)",
+                "unitTemplateId": 154,
+                "what": "Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement",
+                "when": "Your students are beginning English language learners who are working on foundational grammar skills.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students are beginning English language learners who are working on foundational grammar skills.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1161"
+              buttonText="Preview"
+              header="ELL Starter Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Starter Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1161"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students are beginning English language learners who are working on foundational grammar skills.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1774,
+                "lockedText": "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic.",
+                "name": "ELL Starter Growth Diagnostic (Post)",
+                "unitTemplateId": 411,
+                "what": "The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.",
+                "when": "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1774"
+              buttonText="Preview"
+              header="ELL Starter Growth Diagnostic (Post)"
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Starter Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1774"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <div
+          className="grouped-minis"
+          key="ell-intermediate"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1568,
+                "name": "ELL Intermediate Baseline Diagnostic (Pre)",
+                "unitTemplateId": 299,
+                "what": "Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions",
+                "when": "Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1568"
+              buttonText="Preview"
+              header="ELL Intermediate Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Intermediate Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1568"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1814,
+                "lockedText": "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic.",
+                "name": "ELL Intermediate Growth Diagnostic (Post)",
+                "unitTemplateId": 444,
+                "what": "The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.",
+                "when": "Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1814"
+              buttonText="Preview"
+              header="ELL Intermediate Growth Diagnostic (Post)"
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Intermediate Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1814"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <div
+          className="grouped-minis"
+          key="ell-advanced"
+        >
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1590,
+                "name": "ELL Advanced Baseline Diagnostic (Pre)",
+                "unitTemplateId": 300,
+                "what": "Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words",
+                "when": "Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.",
+              }
+            }
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1590"
+              buttonText="Preview"
+              header="ELL Advanced Baseline Diagnostic (Pre)"
+              selectCard={[Function]}
+            >
+              <div
+                className=" assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Advanced Baseline Diagnostic (Pre)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1590"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+          <DiagnosticAssignmentCard
+            diagnostic={
+              Object {
+                "activityId": 1818,
+                "lockedText": "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic.",
+                "name": "ELL Advanced Growth Diagnostic (Post)",
+                "unitTemplateId": 445,
+                "what": "The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.",
+                "when": "Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+              }
+            }
+            showNewTag={true}
+          >
+            <AssignmentCard
+              bodyArray={
+                Array [
+                  Object {
+                    "key": "What",
+                    "text": "The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.",
+                  },
+                  Object {
+                    "key": "When",
+                    "text": "Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+                  },
+                ]
+              }
+              buttonLink="/activity_sessions/anonymous?activity_id=1818"
+              buttonText="Preview"
+              header="ELL Advanced Growth Diagnostic (Post)"
+              selectCard={[Function]}
+              showNewTag={true}
+            >
+              <div
+                className="show-new-tag assignment-card quill-card"
+                onClick={[Function]}
+              >
+                <span
+                  className="new-tag"
+                >
+                  NEW
+                </span>
+                <div
+                  className="top-row"
+                >
+                  <div
+                    className="left"
+                  >
+                    <div
+                      className="header-wrapper"
+                    >
+                      <h2>
+                        ELL Advanced Growth Diagnostic (Post)
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="button-container"
+                  >
+                    <a
+                      className="interactive-wrapper focus-on-light"
+                      href="/activity_sessions/anonymous?activity_id=1818"
+                      onClick={[Function]}
+                      target="_blank"
+                    >
+                      <img
+                        alt="Eye icon"
+                        src="undefined/images/icons/icons-preview.svg"
+                      />
+                      <span>
+                        Preview
+                      </span>
+                    </a>
+                    <button
+                      className="quill-button fun contained primary focus-on-light"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="body"
+                >
+                  <div
+                    className="body-element"
+                    key="What"
+                  >
+                    <p
+                      className="key"
+                    >
+                      What
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.
+                    </p>
+                  </div>
+                  <div
+                    className="body-element"
+                    key="When"
+                  >
+                    <p
+                      className="key"
+                    >
+                      When
+                    </p>
+                    <p
+                      className="text"
+                    >
+                      Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </AssignmentCard>
+          </DiagnosticAssignmentCard>
+        </div>
+        <DiagnosticAssignmentCard
+          diagnostic={
+            Object {
+              "activityId": 992,
+              "name": "AP Writing Skills Survey",
+              "unitTemplateId": 193,
+              "what": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
+              "when": "Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.",
+            }
           }
-          buttonLink="/activity_sessions/anonymous?activity_id=1668"
-          buttonText="Preview"
-          header="Intermediate Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
+        >
+          <AssignmentCard
+            bodyArray={
+              Array [
+                Object {
+                  "key": "What",
+                  "text": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
+                },
+                Object {
+                  "key": "When",
+                  "text": "Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.",
+                },
+              ]
+            }
+            buttonLink="/activity_sessions/anonymous?activity_id=992"
+            buttonText="Preview"
+            header="AP Writing Skills Survey"
+            selectCard={[Function]}
+          >
+            <div
+              className=" assignment-card quill-card"
+              onClick={[Function]}
+            >
+              <div
+                className="top-row"
+              >
+                <div
+                  className="left"
+                >
+                  <div
+                    className="header-wrapper"
+                  >
+                    <h2>
+                      AP Writing Skills Survey
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  className="button-container"
+                >
+                  <a
+                    className="interactive-wrapper focus-on-light"
+                    href="/activity_sessions/anonymous?activity_id=992"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      alt="Eye icon"
+                      src="undefined/images/icons/icons-preview.svg"
+                    />
+                    <span>
+                      Preview
+                    </span>
+                  </a>
+                  <button
+                    className="quill-button fun contained primary focus-on-light"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Select
+                  </button>
+                </div>
+              </div>
+              <div
+                className="body"
+              >
+                <div
+                  className="body-element"
+                  key="What"
+                >
+                  <p
+                    className="key"
+                  >
+                    What
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure
+                  </p>
+                </div>
+                <div
+                  className="body-element"
+                  key="When"
+                >
+                  <p
+                    className="key"
+                  >
+                    When
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </AssignmentCard>
+        </DiagnosticAssignmentCard>
+        <DiagnosticAssignmentCard
+          diagnostic={
+            Object {
+              "activityId": 1229,
+              "name": "Pre-AP Writing Skills Survey 1",
+              "unitTemplateId": 194,
+              "what": "Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions",
+              "when": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
+            }
           }
-          buttonLink="/activity_sessions/anonymous?activity_id=1669"
-          buttonText="Preview"
-          header="Intermediate Growth Diagnostic (Post)"
-          lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
-          selectCard={[Function]}
-          showNewTag={true}
-        />
+        >
+          <AssignmentCard
+            bodyArray={
+              Array [
+                Object {
+                  "key": "What",
+                  "text": "Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions",
+                },
+                Object {
+                  "key": "When",
+                  "text": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
+                },
+              ]
+            }
+            buttonLink="/activity_sessions/anonymous?activity_id=1229"
+            buttonText="Preview"
+            header="Pre-AP Writing Skills Survey 1"
+            selectCard={[Function]}
+          >
+            <div
+              className=" assignment-card quill-card"
+              onClick={[Function]}
+            >
+              <div
+                className="top-row"
+              >
+                <div
+                  className="left"
+                >
+                  <div
+                    className="header-wrapper"
+                  >
+                    <h2>
+                      Pre-AP Writing Skills Survey 1
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  className="button-container"
+                >
+                  <a
+                    className="interactive-wrapper focus-on-light"
+                    href="/activity_sessions/anonymous?activity_id=1229"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      alt="Eye icon"
+                      src="undefined/images/icons/icons-preview.svg"
+                    />
+                    <span>
+                      Preview
+                    </span>
+                  </a>
+                  <button
+                    className="quill-button fun contained primary focus-on-light"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Select
+                  </button>
+                </div>
+              </div>
+              <div
+                className="body"
+              >
+                <div
+                  className="body-element"
+                  key="What"
+                >
+                  <p
+                    className="key"
+                  >
+                    What
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions
+                  </p>
+                </div>
+                <div
+                  className="body-element"
+                  key="When"
+                >
+                  <p
+                    className="key"
+                  >
+                    When
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </AssignmentCard>
+        </DiagnosticAssignmentCard>
+        <DiagnosticAssignmentCard
+          diagnostic={
+            Object {
+              "activityId": 1230,
+              "name": "Pre-AP Writing Skills Survey 2",
+              "unitTemplateId": 195,
+              "what": "Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure",
+              "when": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
+            }
+          }
+        >
+          <AssignmentCard
+            bodyArray={
+              Array [
+                Object {
+                  "key": "What",
+                  "text": "Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure",
+                },
+                Object {
+                  "key": "When",
+                  "text": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
+                },
+              ]
+            }
+            buttonLink="/activity_sessions/anonymous?activity_id=1230"
+            buttonText="Preview"
+            header="Pre-AP Writing Skills Survey 2"
+            selectCard={[Function]}
+          >
+            <div
+              className=" assignment-card quill-card"
+              onClick={[Function]}
+            >
+              <div
+                className="top-row"
+              >
+                <div
+                  className="left"
+                >
+                  <div
+                    className="header-wrapper"
+                  >
+                    <h2>
+                      Pre-AP Writing Skills Survey 2
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  className="button-container"
+                >
+                  <a
+                    className="interactive-wrapper focus-on-light"
+                    href="/activity_sessions/anonymous?activity_id=1230"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      alt="Eye icon"
+                      src="undefined/images/icons/icons-preview.svg"
+                    />
+                    <span>
+                      Preview
+                    </span>
+                  </a>
+                  <button
+                    className="quill-button fun contained primary focus-on-light"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Select
+                  </button>
+                </div>
+              </div>
+              <div
+                className="body"
+              >
+                <div
+                  className="body-element"
+                  key="What"
+                >
+                  <p
+                    className="key"
+                  >
+                    What
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure
+                  </p>
+                </div>
+                <div
+                  className="body-element"
+                  key="When"
+                >
+                  <p
+                    className="key"
+                  >
+                    When
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </AssignmentCard>
+        </DiagnosticAssignmentCard>
+        <DiagnosticAssignmentCard
+          diagnostic={
+            Object {
+              "activityId": 1432,
+              "name": "SpringBoard Writing Skills Survey",
+              "unitTemplateId": 253,
+              "what": "Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words",
+              "when": "Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.",
+            }
+          }
+        >
+          <AssignmentCard
+            bodyArray={
+              Array [
+                Object {
+                  "key": "What",
+                  "text": "Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words",
+                },
+                Object {
+                  "key": "When",
+                  "text": "Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.",
+                },
+              ]
+            }
+            buttonLink="/activity_sessions/anonymous?activity_id=1432"
+            buttonText="Preview"
+            header="SpringBoard Writing Skills Survey"
+            selectCard={[Function]}
+          >
+            <div
+              className=" assignment-card quill-card"
+              onClick={[Function]}
+            >
+              <div
+                className="top-row"
+              >
+                <div
+                  className="left"
+                >
+                  <div
+                    className="header-wrapper"
+                  >
+                    <h2>
+                      SpringBoard Writing Skills Survey
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  className="button-container"
+                >
+                  <a
+                    className="interactive-wrapper focus-on-light"
+                    href="/activity_sessions/anonymous?activity_id=1432"
+                    onClick={[Function]}
+                    target="_blank"
+                  >
+                    <img
+                      alt="Eye icon"
+                      src="undefined/images/icons/icons-preview.svg"
+                    />
+                    <span>
+                      Preview
+                    </span>
+                  </a>
+                  <button
+                    className="quill-button fun contained primary focus-on-light"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Select
+                  </button>
+                </div>
+              </div>
+              <div
+                className="body"
+              >
+                <div
+                  className="body-element"
+                  key="What"
+                >
+                  <p
+                    className="key"
+                  >
+                    What
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words
+                  </p>
+                </div>
+                <div
+                  className="body-element"
+                  key="When"
+                >
+                  <p
+                    className="key"
+                  >
+                    When
+                  </p>
+                  <p
+                    className="text"
+                  >
+                    Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </AssignmentCard>
+        </DiagnosticAssignmentCard>
       </div>
-      <div
-        className="grouped-minis"
-        key="advanced"
-      >
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1678"
-          buttonText="Preview"
-          header="Advanced Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1680"
-          buttonText="Preview"
-          header="Advanced Growth Diagnostic (Post)"
-          lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
-          selectCard={[Function]}
-          showNewTag={true}
-        />
-      </div>
-      <div
-        className="grouped-minis"
-        key="ell-starter"
-      >
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students are beginning English language learners who are working on foundational grammar skills.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1161"
-          buttonText="Preview"
-          header="ELL Starter Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1774"
-          buttonText="Preview"
-          header="ELL Starter Growth Diagnostic (Post)"
-          selectCard={[Function]}
-          showNewTag={true}
-        />
-      </div>
-      <div
-        className="grouped-minis"
-        key="ell-intermediate"
-      >
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1568"
-          buttonText="Preview"
-          header="ELL Intermediate Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1814"
-          buttonText="Preview"
-          header="ELL Intermediate Growth Diagnostic (Post)"
-          selectCard={[Function]}
-          showNewTag={true}
-        />
-      </div>
-      <div
-        className="grouped-minis"
-        key="ell-advanced"
-      >
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1590"
-          buttonText="Preview"
-          header="ELL Advanced Baseline Diagnostic (Pre)"
-          selectCard={[Function]}
-        />
-        <AssignmentCard
-          bodyArray={
-            Array [
-              Object {
-                "key": "What",
-                "text": "The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.",
-              },
-              Object {
-                "key": "When",
-                "text": "Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-              },
-            ]
-          }
-          buttonLink="/activity_sessions/anonymous?activity_id=1818"
-          buttonText="Preview"
-          header="ELL Advanced Growth Diagnostic (Post)"
-          selectCard={[Function]}
-          showNewTag={true}
-        />
-      </div>
-      <AssignmentCard
-        bodyArray={
-          Array [
-            Object {
-              "key": "What",
-              "text": "Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure",
-            },
-            Object {
-              "key": "When",
-              "text": "Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.",
-            },
-          ]
-        }
-        buttonLink="/activity_sessions/anonymous?activity_id=992"
-        buttonText="Preview"
-        header="AP Writing Skills Survey"
-        selectCard={[Function]}
-      />
-      <AssignmentCard
-        bodyArray={
-          Array [
-            Object {
-              "key": "What",
-              "text": "Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions",
-            },
-            Object {
-              "key": "When",
-              "text": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
-            },
-          ]
-        }
-        buttonLink="/activity_sessions/anonymous?activity_id=1229"
-        buttonText="Preview"
-        header="Pre-AP Writing Skills Survey 1"
-        selectCard={[Function]}
-      />
-      <AssignmentCard
-        bodyArray={
-          Array [
-            Object {
-              "key": "What",
-              "text": "Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure",
-            },
-            Object {
-              "key": "When",
-              "text": "Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.",
-            },
-          ]
-        }
-        buttonLink="/activity_sessions/anonymous?activity_id=1230"
-        buttonText="Preview"
-        header="Pre-AP Writing Skills Survey 2"
-        selectCard={[Function]}
-      />
-      <AssignmentCard
-        bodyArray={
-          Array [
-            Object {
-              "key": "What",
-              "text": "Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words",
-            },
-            Object {
-              "key": "When",
-              "text": "Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.",
-            },
-          ]
-        }
-        buttonLink="/activity_sessions/anonymous?activity_id=1432"
-        buttonText="Preview"
-        header="SpringBoard Writing Skills Survey"
-        selectCard={[Function]}
-      />
     </div>
   </div>
-</div>
+</AssignADiagnostic>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/assign_a_diagnostic.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/assign_a_diagnostic.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import AssignADiagnostic from '../create_unit/assign_a_diagnostic';
 import AssignmentCard from '../create_unit/assignment_card';
@@ -7,7 +7,7 @@ import AssignmentCard from '../create_unit/assignment_card';
 const assignedPreTests = [{"id":1663,"post_test_id":1664,"assigned_classroom_ids":[1]},{"id":1668,"post_test_id":1669,"assigned_classroom_ids":[]},{"id":1678,"post_test_id":1680,"assigned_classroom_ids":[]}]
 
 describe('AssignADiagnostic component', () => {
-  const component = shallow(<AssignADiagnostic assignedPreTests={assignedPreTests} />);
+  const component = mount(<AssignADiagnostic assignedPreTests={assignedPreTests} />);
 
   it('should render AssignADiagnostic', () => {
     expect(component).toMatchSnapshot();

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.ts
@@ -28,6 +28,141 @@ export const PRE_AP_WRITINGS_SKILLS_2_UNIT_TEMPLATE_ID = 195
 export const AP_WRITINGS_SKILLS_UNIT_TEMPLATE_ID = 193
 export const SPRING_BOARD_SKILLS_UNIT_TEMPLATE_ID = 253
 
+export const starterPreTest = {
+  activityId: 1663,
+  name: 'Starter Baseline Diagnostic (Pre)',
+  unitTemplateId: STARTER_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words',
+  when: 'Your students are working on basic grammar concepts.'
+}
+
+export const starterPostTest = {
+  activityId: 1664,
+  name: 'Starter Growth Diagnostic (Post)',
+  unitTemplateId: STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.',
+  when: "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic."
+}
+
+export const intermediatePreTest = {
+  activityId: 1668,
+  name: 'Intermediate Baseline Diagnostic (Pre)',
+  unitTemplateId: INTERMEDIATE_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization',
+  when: 'Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.'
+}
+
+export const intermediatePostTest = {
+  activityId: 1669,
+  name: 'Intermediate Growth Diagnostic (Post)',
+  unitTemplateId: INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.',
+  when: "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+}
+
+export const advancedPreTest = {
+  activityId: 1678,
+  name: 'Advanced Baseline Diagnostic (Pre)',
+  unitTemplateId: ADVANCED_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure',
+  when: 'Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.'
+}
+
+export const advancedPostTest = {
+  activityId: 1680,
+  name: 'Advanced Growth Diagnostic (Post)',
+  unitTemplateId: ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.',
+  when: "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+}
+
+export const ellStarterPreTest = {
+  activityId: 1161,
+  name: 'ELL Starter Baseline Diagnostic (Pre)',
+  unitTemplateId: ELL_STARTER_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement',
+  when: 'Your students are beginning English language learners who are working on foundational grammar skills.'
+}
+
+export const ellStarterPostTest = {
+  activityId: 1774,
+  name: 'ELL Starter Growth Diagnostic (Post)',
+  unitTemplateId: ELL_STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.',
+  when: "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic."
+}
+
+export const ellIntermediatePreTest = {
+  activityId: 1568,
+  name: 'ELL Intermediate Baseline Diagnostic (Pre)',
+  unitTemplateId: ELL_INTERMEDIATE_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions',
+  when: 'Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.'
+}
+
+export const ellIntermediatePostTest = {
+  activityId: 1814,
+  name: 'ELL Intermediate Growth Diagnostic (Post)',
+  unitTemplateId: ELL_INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.',
+  when: "Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic."
+}
+
+export const ellAdvancedPreTest = {
+  activityId: 1590,
+  name: 'ELL Advanced Baseline Diagnostic (Pre)',
+  unitTemplateId: ELL_ADVANCED_DIAGNOSTIC_UNIT_TEMPLATE_ID,
+  what: 'Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words',
+  when: 'Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.'
+}
+
+export const ellAdvancedPostTest = {
+  activityId: 1818,
+  name: 'ELL Advanced Growth Diagnostic (Post)',
+  unitTemplateId: ELL_ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
+  what: 'The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.',
+  when: "Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
+  lockedText: "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic."
+}
+
+export const apWritingSkills = {
+  activityId: 992,
+  name: 'AP Writing Skills Survey',
+  unitTemplateId: AP_WRITINGS_SKILLS_UNIT_TEMPLATE_ID,
+  what: 'Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure',
+  when: 'Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.'
+}
+
+export const preAPWritingSkills1 = {
+  activityId: 1229,
+  name: 'Pre-AP Writing Skills Survey 1',
+  unitTemplateId: PRE_AP_WRITINGS_SKILLS_1_UNIT_TEMPLATE_ID,
+  what: 'Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions',
+  when: 'Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.'
+}
+
+export const preAPWritingSkills2 = {
+  activityId: 1230,
+  name: 'Pre-AP Writing Skills Survey 2',
+  unitTemplateId: PRE_AP_WRITINGS_SKILLS_2_UNIT_TEMPLATE_ID,
+  what: 'Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure',
+  when: 'Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.'
+}
+
+export const springboardWritingSkills = {
+  activityId: 1432,
+  name: 'SpringBoard Writing Skills Survey',
+  unitTemplateId: SPRING_BOARD_SKILLS_UNIT_TEMPLATE_ID,
+  what: 'Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words',
+  when: 'Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.'
+}
+
+
 export const postTestClassAssignmentLockedMessages = {
   1664: "You can't assign the Starter Growth Diagnostic to this class until you've assigned them the Starter Baseline Diagnostic.",
   1669: "You can't assign the Intermediate Growth Diagnostic to this class until you've assigned them the Intermediate Baseline Diagnostic.",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -6,52 +6,10 @@ import AssignmentFlowNavigation from '../assignment_flow_navigation'
 import * as constants from '../assignmentFlowConstants'
 import ScrollToTop from '../../shared/scroll_to_top'
 
-const STARTER_DIAGNOSTIC = 'Starter Baseline Diagnostic (Pre)'
-const STARTER_DIAGNOSTIC_POST = 'Starter Growth Diagnostic (Post)'
-const INTERMEDIATE_DIAGNOSTIC = 'Intermediate Baseline Diagnostic (Pre)'
-const INTERMEDIATE_DIAGNOSTIC_POST = 'Intermediate Growth Diagnostic (Post)'
-const ADVANCED_DIAGNOSTIC = 'Advanced Baseline Diagnostic (Pre)'
-const ADVANCED_DIAGNOSTIC_POST = 'Advanced Growth Diagnostic (Post)'
-const ELL_STARTER_DIAGNOSTIC = 'ELL Starter Baseline Diagnostic (Pre)'
-const ELL_STARTER_DIAGNOSTIC_POST = 'ELL Starter Growth Diagnostic (Post)'
-const ELL_INTERMEDIATE_DIAGNOSTIC = 'ELL Intermediate Baseline Diagnostic (Pre)'
-const ELL_INTERMEDIATE_DIAGNOSTIC_POST = 'ELL Intermediate Growth Diagnostic (Post)'
-const ELL_ADVANCED_DIAGNOSTIC = 'ELL Advanced Baseline Diagnostic (Pre)'
-const ELL_ADVANCED_DIAGNOSTIC_POST = 'ELL Advanced Growth Diagnostic (Post)'
-const PRE_AP_WRITINGS_SKILLS_1 = 'Pre-AP Writing Skills Survey 1'
-const PRE_AP_WRITINGS_SKILLS_2 = 'Pre-AP Writing Skills Survey 2'
-const AP_WRITINGS_SKILLS = 'AP Writing Skills Survey'
-const SPRING_BOARD_WRITINGS_SKILLS = 'SpringBoard Writing Skills Survey'
-
-const STARTER_DIAGNOSTIC_ACTIVITY_ID = 1663
-const STARTER_DIAGNOSTIC_POST_ACTIVITY_ID = 1664
-const INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID = 1668
-const INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID = 1669
-const ADVANCED_DIAGNOSTIC_ACTIVITY_ID = 1678
-const ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID = 1680
-const ELL_STARTER_DIAGNOSTIC_ACTIVITY_ID = 1161
-const ELL_STARTER_DIAGNOSTIC_POST_ACTIVITY_ID = 1774
-const ELL_INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID = 1568
-const ELL_INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID = 1814
-const ELL_ADVANCED_DIAGNOSTIC_ACTIVITY_ID = 1590
-const ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID = 1818
-const PRE_AP_WRITINGS_SKILLS_1_ACTIVITY_ID = 1229
-const PRE_AP_WRITINGS_SKILLS_2_ACTIVITY_ID = 1230
-const AP_WRITINGS_SKILLS_ACTIVITY_ID = 992
-const SPRING_BOARD_SKILLS_ACTIVITY_ID = 1432
-
 const ALL = 'All'
 const GENERAL = 'General'
 const ELL = 'ELL'
 const COLLEGEBOARD = 'CollegeBoard'
-
-const STARTER_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic."
-const INTERMEDIATE_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
-const ADVANCED_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
-
-const ELL_STARTER_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic."
-const ELL_INTERMEDIATE_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic."
-const ELL_ADVANCED_POST_TEST_LOCKED_TEXT = "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic."
 
 const selectCard = (history: any, unitTemplateName: string, activityIdsArray: string, unitTemplateId: number) => {
   const unitTemplateIdString = unitTemplateId.toString();
@@ -62,6 +20,34 @@ const selectCard = (history: any, unitTemplateName: string, activityIdsArray: st
   history.push(`/assign/select-classes?diagnostic_unit_template_id=${unitTemplateIdString}`)
 }
 
+interface Diagnostic {
+  activityId: number;
+  name: string;
+  unitTemplateId: number;
+  what: string;
+  when: string;
+  lockedText?: string
+}
+
+const DiagnosticAssignmentCard = ({ diagnostic, lockedText, showNewTag, }: { diagnostic: Diagnostic, lockedText?: string, showNewTag?: boolean, }) => {
+  function onSelectCard() { selectCard(history, diagnostic.name, encodeURIComponent([diagnostic.activityId].toString()), diagnostic.unitTemplateId) }
+
+  return (
+    <AssignmentCard
+      bodyArray={[
+        { key: 'What', text: diagnostic.what, },
+        { key: 'When', text: diagnostic.when, }
+      ]}
+      buttonLink={`/activity_sessions/anonymous?activity_id=${diagnostic.activityId}`}
+      buttonText="Preview"
+      header={diagnostic.name}
+      lockedText={lockedText}
+      selectCard={onSelectCard}
+      showNewTag={showNewTag}
+    />
+  )
+}
+
 const generalDiagnosticMinis = ({ history, assignedPreTests, }) => {
   function isLocked(postTestActivityId) {
     const assignedPreTest = assignedPreTests.find(pretest => pretest.post_test_id === postTestActivityId)
@@ -70,76 +56,16 @@ const generalDiagnosticMinis = ({ history, assignedPreTests, }) => {
 
   return [
     (<div className="grouped-minis" key="starter">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Plural and possessive nouns, verbs, adjectives, adverbs of manner, commas, prepositions, basic capitalization, and commonly confused words', },
-          { key: 'When', text: 'Your students are working on basic grammar concepts.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${STARTER_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={STARTER_DIAGNOSTIC}
-        selectCard={() => selectCard(history, STARTER_DIAGNOSTIC, encodeURIComponent([STARTER_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.STARTER_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.', },
-          { key: 'When', text: "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.", }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${STARTER_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={STARTER_DIAGNOSTIC_POST}
-        lockedText={isLocked(STARTER_DIAGNOSTIC_POST_ACTIVITY_ID) && STARTER_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, STARTER_DIAGNOSTIC_POST, encodeURIComponent([STARTER_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.starterPreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.starterPostTest} lockedText={isLocked(constants.starterPostTest.activityId) && constants.starterPostTest.lockedText} showNewTag={true} />
     </div>),
     (<div className="grouped-minis" key="intermediate">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Compound sentences, complex sentences, conjunctive adverbs, pronouns, and advanced capitalization', },
-          { key: 'When', text: 'Your students have practiced the basics of grammar and are ready to develop their sentence construction skills.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={INTERMEDIATE_DIAGNOSTIC}
-        selectCard={() => selectCard(history, INTERMEDIATE_DIAGNOSTIC, encodeURIComponent([INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.INTERMEDIATE_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.', },
-          { key: 'When', text: 'Your students have completed the Intermediate Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={INTERMEDIATE_DIAGNOSTIC_POST}
-        lockedText={isLocked(INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID) && INTERMEDIATE_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, INTERMEDIATE_DIAGNOSTIC_POST, encodeURIComponent([INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.intermediatePreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.intermediatePostTest} lockedText={isLocked(constants.intermediatePostTest.activityId) && constants.intermediatePostTest.lockedText} showNewTag={true} />
     </div>),
     (<div className="grouped-minis" key="advanced">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure', },
-          { key: 'When', text: 'Your students are experienced with Quill, understand sentence combining, and are ready to develop multi-clause sentences.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ADVANCED_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ADVANCED_DIAGNOSTIC}
-        selectCard={() => selectCard(history, ADVANCED_DIAGNOSTIC, encodeURIComponent([ADVANCED_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.ADVANCED_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.', },
-          { key: 'When', text: 'Your students have completed the Advanced Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ADVANCED_DIAGNOSTIC_POST}
-        lockedText={isLocked(ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID) && ADVANCED_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, ADVANCED_DIAGNOSTIC_POST, encodeURIComponent([ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.advancedPreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.advancedPostTest} lockedText={isLocked(constants.advancedPostTest.activityId) && constants.advancedPostTest.lockedText} showNewTag={true} />
     </div>)
   ]
 }
@@ -152,122 +78,25 @@ const ellDiagnosticMinis = ({ history, assignedPreTests, }) => {
 
   return [
     (<div className="grouped-minis" key="ell-starter">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Simple verb conjugation, articles, subject-verb agreement, simple word order, singular and plural nouns, and adjective placement', },
-          { key: 'When', text: 'Your students are beginning English language learners who are working on foundational grammar skills.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_STARTER_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_STARTER_DIAGNOSTIC}
-        selectCard={() => selectCard(history, ELL_STARTER_DIAGNOSTIC, encodeURIComponent([ELL_STARTER_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.ELL_STARTER_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.', },
-          { key: 'When', text: "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.", }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_STARTER_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_STARTER_DIAGNOSTIC_POST}
-        lockedText={isLocked(ELL_STARTER_DIAGNOSTIC_POST_ACTIVITY_ID) && ELL_STARTER_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, ELL_STARTER_DIAGNOSTIC_POST, encodeURIComponent([ELL_STARTER_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.ELL_STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.ellStarterPreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.ellStarterPostTest} lockedText={isLocked(constants.ellStarterPostTest.activityId) && constants.ellStarterPostTest.lockedText} showNewTag={true} />
     </div>),
     (<div className="grouped-minis" key="ell-intermediate">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Subject-verb agreement, possessives, prepositions, future tense, articles, and intermediate questions', },
-          { key: 'When', text: 'Your students are English language learners who have a foundational understanding of basic English grammar but need more practice with certain concepts.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_INTERMEDIATE_DIAGNOSTIC}
-        selectCard={() => selectCard(history, ELL_INTERMEDIATE_DIAGNOSTIC, encodeURIComponent([ELL_INTERMEDIATE_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.ELL_INTERMEDIATE_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.', },
-          { key: 'When', text: 'Your students have completed the ELL Intermediate Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_INTERMEDIATE_DIAGNOSTIC_POST}
-        lockedText={isLocked(ELL_INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID) && ELL_INTERMEDIATE_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, ELL_INTERMEDIATE_DIAGNOSTIC_POST, encodeURIComponent([ELL_INTERMEDIATE_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.ELL_INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.ellIntermediatePreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.ellIntermediatePostTest} lockedText={isLocked(constants.ellIntermediatePostTest.activityId) && constants.ellIntermediatePostTest.lockedText} showNewTag={true} />
     </div>),
     (<div className="grouped-minis" key="ell-advanced">
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'Regular and irregular past tense, progressive tenses, phrasal verbs, choosing between prepositions, responding to questions, and commonly confused words', },
-          { key: 'When', text: 'Your students are English language learners who need practice with more difficult ELL skills before moving on to the Starter Diagnostic.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_ADVANCED_DIAGNOSTIC_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_ADVANCED_DIAGNOSTIC}
-        selectCard={() => selectCard(history, ELL_ADVANCED_DIAGNOSTIC, encodeURIComponent([ELL_ADVANCED_DIAGNOSTIC_ACTIVITY_ID].toString()), constants.ELL_ADVANCED_DIAGNOSTIC_UNIT_TEMPLATE_ID)}
-      />
-      <AssignmentCard
-        bodyArray={[
-          { key: 'What', text: 'The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.', },
-          { key: 'When', text: 'Your students have completed the ELL Advanced Baseline Diagnostic, you\'ve assigned the recommended practice, and now you\'re ready to measure their growth.', }
-        ]}
-        buttonLink={`/activity_sessions/anonymous?activity_id=${ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID}`}
-        buttonText="Preview"
-        header={ELL_ADVANCED_DIAGNOSTIC_POST}
-        lockedText={isLocked(ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID) && ELL_ADVANCED_POST_TEST_LOCKED_TEXT}
-        selectCard={() => selectCard(history, ELL_ADVANCED_DIAGNOSTIC_POST, encodeURIComponent([ELL_ADVANCED_DIAGNOSTIC_POST_ACTIVITY_ID].toString()), constants.ELL_ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID)}
-        showNewTag={true}
-      />
+      <DiagnosticAssignmentCard diagnostic={constants.ellAdvancedPreTest} />
+      <DiagnosticAssignmentCard diagnostic={constants.ellAdvancedPostTest} lockedText={isLocked(constants.ellAdvancedPostTest.activityId) && constants.ellAdvancedPostTest.lockedText} showNewTag={true} />
     </div>)
   ]
 }
 
-
 const collegeBoardDiagnosticMinis = ({ history }) => [
-  (<AssignmentCard
-    bodyArray={[
-      { key: 'What', text: 'Compound-complex sentences, appositive phrases, relative clauses, participial phrases, and parallel structure', },
-      { key: 'When', text: 'Your students are developing their advanced sentence-level writing skills to prepare for writing in an AP® classroom.', }
-    ]}
-    buttonLink={`/activity_sessions/anonymous?activity_id=${AP_WRITINGS_SKILLS_ACTIVITY_ID}`}
-    buttonText="Preview"
-    header={AP_WRITINGS_SKILLS}
-    selectCard={() => selectCard(history, AP_WRITINGS_SKILLS, encodeURIComponent([AP_WRITINGS_SKILLS_ACTIVITY_ID].toString()), constants.AP_WRITINGS_SKILLS_UNIT_TEMPLATE_ID)}
-  />),
-  (<AssignmentCard
-    bodyArray={[
-      { key: 'What', text: 'Subject-verb agreement, pronouns, and coordinating and subordinating conjunctions', },
-      { key: 'When', text: 'Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.', }
-    ]}
-    buttonLink={`/activity_sessions/anonymous?activity_id=${PRE_AP_WRITINGS_SKILLS_1_ACTIVITY_ID}`}
-    buttonText="Preview"
-    header={PRE_AP_WRITINGS_SKILLS_1}
-    selectCard={() => selectCard(history, PRE_AP_WRITINGS_SKILLS_1, encodeURIComponent([PRE_AP_WRITINGS_SKILLS_1_ACTIVITY_ID].toString()), constants.PRE_AP_WRITINGS_SKILLS_1_UNIT_TEMPLATE_ID)}
-  />),
-  (<AssignmentCard
-    bodyArray={[
-      { key: 'What', text: 'Conjunctive adverbs, relative clauses, appositive phrases, participial phrases, and parallel structure', },
-      { key: 'When', text: 'Your students are working on basic sentence patterns and the skills outlined in the Pre-AP® English High School Course Framework.', }
-    ]}
-    buttonLink={`/activity_sessions/anonymous?activity_id=${PRE_AP_WRITINGS_SKILLS_2_ACTIVITY_ID}`}
-    buttonText="Preview"
-    header={PRE_AP_WRITINGS_SKILLS_2}
-    selectCard={() => selectCard(history, PRE_AP_WRITINGS_SKILLS_2, encodeURIComponent([PRE_AP_WRITINGS_SKILLS_2_ACTIVITY_ID].toString()), constants.PRE_AP_WRITINGS_SKILLS_2_UNIT_TEMPLATE_ID)}
-  />),
-  (<AssignmentCard
-    bodyArray={[
-      { key: 'What', text: 'Subject-verb agreement, pronouns, coordinating and subordinating conjunctions, prepositional phrases, and commonly confused words', },
-      { key: 'When', text: 'Your students are working on basic sentence patterns and the grammar skills covered in the SpringBoard grades 6-8 materials.', }
-    ]}
-    buttonLink={`/activity_sessions/anonymous?activity_id=${SPRING_BOARD_SKILLS_ACTIVITY_ID}`}
-    buttonText="Preview"
-    header={SPRING_BOARD_WRITINGS_SKILLS}
-    selectCard={() => selectCard(history, SPRING_BOARD_WRITINGS_SKILLS, encodeURIComponent([SPRING_BOARD_SKILLS_ACTIVITY_ID].toString()), constants.SPRING_BOARD_SKILLS_UNIT_TEMPLATE_ID)}
-  />)
+  <DiagnosticAssignmentCard diagnostic={constants.apWritingSkills} key="ap" />,
+  <DiagnosticAssignmentCard diagnostic={constants.preAPWritingSkills1} key="pre-ap-1" />,
+  <DiagnosticAssignmentCard diagnostic={constants.preAPWritingSkills2} key="pre-ap-2" />,
+  <DiagnosticAssignmentCard diagnostic={constants.springboardWritingSkills} key="springboard" />
 ];
 
 const FilterTab = ({ activeFilter, filter, setFilter, number, }) => {


### PR DESCRIPTION
## WHAT
Refactor the Assign a Diagnostic page to use constants and a wrapper component.

## WHY
This file was getting unwieldy, and involved a lot of different constants from different places and repeated code. This cleans it up.

## HOW
Pull all of the activity-specific data into hashes for each activity and then just send the whole hash to a new wrapper component.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Refactor-assign_a_diagnostic-file-to-use-constants-for-everything-0b7faa60bc9944939dce362ed8005694

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
