### PR TITLE
Nr for evidence

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/api_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/api_controller.rb
@@ -4,6 +4,10 @@ require_dependency 'evidence/application_controller'
 
 module Evidence
   class ApiController < ApplicationController
+    if Object.const_defined?('NewRelicAttributable') 
+      include NewRelicAttributable 
+    end
+    
     skip_before_action :verify_authenticity_token
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -20,5 +20,11 @@ module Evidence
 
       g.fallbacks[:shoulda] = :test_unit
     end
+
+    config.after_initialize do 
+      if self.const_defined? (:NewRelicAttributable) 
+        ApplicationController.module_eval { include NewRelicAttributable }
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -20,11 +20,5 @@ module Evidence
 
       g.fallbacks[:shoulda] = :test_unit
     end
-
-    config.after_initialize do 
-      if self.const_defined? (:NewRelicAttributable) 
-        ApplicationController.module_eval { include NewRelicAttributable }
-      end
-    end
   end
 end

--- a/services/QuillLMS/spec/controllers/concerns/new_relic_attributable_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/new_relic_attributable_spec.rb
@@ -34,4 +34,19 @@ describe NewRelicAttributable, type: :controller do
       get :index
     end
   end
+
+  context 'Evidence engine' do 
+    controller(Evidence::ApiController) do
+  
+      def index
+        head :ok
+      end
+    end
+
+    it 'should pass user_id to NewRelic' do
+      allow(controller).to receive(:current_user) { user }
+      expect(::NewRelic::Agent).to receive(:add_custom_attributes).with({user_id: user.id})
+      get :index
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
We want to surface user_id in Evidence controllers in New Relic for diagnostic purposes. This behavior is already in place for the root app. 

## WHY

## HOW
Check that NewRelicAttributable module is loaded before including it in ApiController. This way, the concern is completely managed by the root app, and the engine doesn't need to manage a separate NewRelic config, or even load NewRelicAttributable.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Add-user_id-to-NewRelic-for-Quill-Evidence-279bf0eaf8434b3ab89ccaa092fd9d4f)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
