### PR TITLE
Add app_settings to Demo front end to show only 50% of users

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/handy_actions.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/handy_actions.test.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import HandyActions from '../handy_actions';
+import { handleHasAppSetting } from "../../../../Shared/utils/appSettingAPIs";
+
+
+jest.mock('../../../../Shared/utils/appSettingAPIs')
 
 describe('HandyActions component', () => {
 
   it('should render when the user is not linked to Clever', () => {
+    handleHasAppSetting.mockImplementation((args) => args.appSettingSetter(true));
     const wrapper = mount(<HandyActions linkedToClever={false} />);
     expect(wrapper).toMatchSnapshot()
   });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/handy_actions.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/handy_actions.test.jsx
@@ -16,6 +16,7 @@ describe('HandyActions component', () => {
   });
 
   it('should render when the user is linked to Clever', () => {
+    handleHasAppSetting.mockImplementation((args) => args.appSettingSetter(true));
     const wrapper = mount(<HandyActions linkedToClever={true} />);
     expect(wrapper).toMatchSnapshot()
   });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
@@ -10,6 +10,7 @@ import {
   groupAccountIcon,
   googleClassroomIcon,
 } from '../../../Shared/index'
+import { handleHasAppSetting } from "../../../Shared/utils/appSettingAPIs";
 
 const HandyAction = ({ icon, text, link, }) => (
   <a className="handy-action focus-on-light" href={link}>
@@ -25,18 +26,22 @@ const ExploreDemoAction = ({setShowDemoModal}) => (
   </button>
 )
 
-const HandyActions = ({ linkedToClever, setShowDemoModal}) => (
-  <section className="handy-actions">
+const HandyActions = ({ linkedToClever, setShowDemoModal}) => {
+  const [errors, setErrors] = React.useState<string[]>([])
+  const [hasAppSetting, setHasAppSetting] = React.useState<boolean>(false);
+  if (!hasAppSetting) { handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'demo', }) }
+
+  return(<section className="handy-actions">
     <h2>Handy actions</h2>
     <HandyAction icon={searchMapIcon} link="/assign/activity-library" text="Explore activity library" />
     <HandyAction icon={clipboardCheckIcon} link="/assign/diagnostic" text="Assign a diagnostic" />
     <HandyAction icon={tableCheckIcon} link="/teachers/classrooms/scorebook" text="View activity summary report" />
     <HandyAction icon={accountViewIcon} link="/teachers/classrooms?modal=view-as-student" text="View as a student" />
-    <ExploreDemoAction setShowDemoModal={setShowDemoModal} />
+    {hasAppSetting && <ExploreDemoAction setShowDemoModal={setShowDemoModal} />}
     <HandyAction icon={giftIcon} link="/referrals" text="Refer a teacher" />
     <HandyAction icon={groupAccountIcon} link="/teachers/classrooms/new" text="Add a class" />
     {!linkedToClever && <HandyAction icon={googleClassroomIcon} link="/teachers/classrooms?modal=google-classroom" text="Import classes from Google" />}
-  </section>
-)
+  </section>)
+}
 
 export default HandyActions

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
@@ -31,7 +31,7 @@ const HandyActions = ({ linkedToClever, setShowDemoModal}) => {
   const [hasAppSetting, setHasAppSetting] = React.useState<boolean>(false);
   React.useEffect(() => {
     handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'demo', })
-  });
+  }, []);
 
   return(<section className="handy-actions">
     <h2>Handy actions</h2>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/handy_actions.tsx
@@ -29,7 +29,9 @@ const ExploreDemoAction = ({setShowDemoModal}) => (
 const HandyActions = ({ linkedToClever, setShowDemoModal}) => {
   const [errors, setErrors] = React.useState<string[]>([])
   const [hasAppSetting, setHasAppSetting] = React.useState<boolean>(false);
-  if (!hasAppSetting) { handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'demo', }) }
+  React.useEffect(() => {
+    handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'demo', })
+  });
 
   return(<section className="handy-actions">
     <h2>Handy actions</h2>


### PR DESCRIPTION
## WHAT
We want to try rolling out this feature with `app_settings` to see if we can notice any effects on users, and also to see how the app settings feature integrates with Heap (for the bigger v2 Demo rollout later).

The app setting record I will create in the DB will be called `demo` and I will run this rake task to create it:
`bundle exec rake 'app_settings:create[demo,true,true,50,[]]'`

## WHY
So we can get more comfortable with app_settings and doing more A/B testing rollouts in the future.

## HOW
Add a check before showing the link to see if the app settings permits this user to see the link.
I'll run a rake task in production to add this particular app setting to the DB.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
