### PR TITLE
Evidence/ pre-fill start date for Rules Analysis 

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -56,6 +56,8 @@ const MoreInfo = (row) => {
 const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ history, match }) => {
   const { params } = match;
   const { activityId, promptConjunction, } = params;
+  const today = new Date();
+  const thirtyDaysAgo = new Date().setDate(today.getDate()-30);
 
   const ruleTypeValues = [DEFAULT_RULE_TYPE].concat(Object.keys(apiOrderLookup))
   const ruleTypeOptions = ruleTypeValues.map(val => ({ label: val, value: val, }))
@@ -63,7 +65,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const initialStartDateString = window.sessionStorage.getItem(`${RULES_ANALYSIS}startDate`) || '';
   const initialEndDateString = window.sessionStorage.getItem(`${RULES_ANALYSIS}endDate`) || '';
   const initialTurkSessionId = window.sessionStorage.getItem(`${RULES_ANALYSIS}turkSessionId`) || '';
-  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : null;
+  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : new Date(thirtyDaysAgo);
   const initialEndDate = initialEndDateString ? new Date(initialEndDateString) : null;
 
   const selectedRuleTypeOption = ruleTypeOptions.find(opt => opt.value === ruleTypeFromUrl)

--- a/services/QuillLMS/client/app/bundles/Staff/styles/date_time_selector.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/date_time_selector.scss
@@ -10,6 +10,15 @@
   }
   &.rules-analysis {
     margin-bottom: 24px;
+
+    .react-datetime-picker {
+      input:nth-of-type(2) {
+        width: 32px !important;
+      }
+      input:nth-of-type(3), input:nth-of-type(4), input:nth-of-type(5), input:nth-of-type(6) {
+        width: 16px !important;
+      }
+    }
   }
   .turk-session-id-input {
     margin-right: 16px;


### PR DESCRIPTION
## WHAT
pre-fill start date for Rules Analysis in the Evidence internal tool

## WHY
it was requested by Curriculum

## HOW
pass a new `Date` object for 30 days from today to the `initialStartDate` prop

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
