### PR TITLE
Bugfix for missing parameters for format_concept_results

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -52,8 +52,8 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
 
     if pre_test && pre_test_activity_session
       concept_results = {
-        pre: { questions: format_concept_results(pre_test_activity_session.concept_results.order("(metadata->>'questionNumber')::int")) },
-        post: { questions: format_concept_results(activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
+        pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.concept_results.order("(metadata->>'questionNumber')::int")) },
+        post: { questions: format_concept_results(activity_session, activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
       }
       formatted_skills = skills.map do |skill|
         {
@@ -63,7 +63,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       end
       skill_results = { skills: formatted_skills.uniq { |formatted_skill| formatted_skill[:pre][:skill] } }
     else
-      concept_results = { questions: format_concept_results(activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
+      concept_results = { questions: format_concept_results(activity_session, activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
       skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
     end
     render json: { concept_results: concept_results, skill_results: skill_results, name: student.name }
@@ -250,7 +250,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       activity_session = @activity_sessions[student.id]
 
       if activity_session
-        formatted_concept_results = format_concept_results(activity_session.concept_results)
+        formatted_concept_results = format_concept_results(activity_session, activity_session.concept_results)
         score = get_average_score(formatted_concept_results)
         if score >= (ProficiencyEvaluator.proficiency_cutoff * 100)
           proficiency = ActivitySession::PROFICIENT

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -172,7 +172,7 @@ module PublicProgressReports
     end
 
     def formatted_score_obj(final_activity_session, classification_key, student, average_score_on_quill)
-      formatted_concept_results = format_concept_results(final_activity_session)
+      formatted_concept_results = format_concept_results(final_activity_session, final_activity_session.concept_results)
       if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification_key)
         score = get_average_score(formatted_concept_results)
       elsif [ActivityClassification::EVIDENCE_KEY].include?(classification_key)
@@ -200,8 +200,8 @@ module PublicProgressReports
       time > 60 ? '> 60' : time
     end
 
-    def format_concept_results(activity_session)
-      activity_session.concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
+    def format_concept_results(activity_session, concept_results)
+      concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
         # if we don't sort them, we can't rely on the first result being the first attemptNum
         # however, it would be more efficient to make them a hash with attempt numbers as keys
         cr.sort!{|x,y| (x[:metadata]['attemptNumber'] || 0) <=> (y[:metadata]['attemptNumber'] || 0)}


### PR DESCRIPTION
## WHAT
Bug fix - I replaced the parameter `concept_results` with `activity_session` in this file, not knowing that it was also used in another file. I don't want to mess with the ordering being passed in in the other file, so instead of replacing the parameter I added in two parameters. 

Two parameters are 1. `activity_session` and 2. `concept_results`.

## WHY
Right now the site is broken for teachers looking at diagnostic reports.

## HOW
Putting in those 2 parameters.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
