### PR TITLE
add flags to UI for evidence cms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -42,6 +42,41 @@ exports[`Activity Form component should render Activities 1`] = `
   <form
     className="comprehension-activity-form"
   >
+    <DropdownInput
+      className="flag-input"
+      handleChange={[Function]}
+      label="Activity Flag"
+      options={
+        Array [
+          Object {
+            "label": "alpha",
+            "value": "alpha",
+          },
+          Object {
+            "label": "beta",
+            "value": "beta",
+          },
+          Object {
+            "label": "gamma",
+            "value": "gamma",
+          },
+          Object {
+            "label": "production",
+            "value": "production",
+          },
+          Object {
+            "label": "archived",
+            "value": "archived",
+          },
+        ]
+      }
+      value={
+        Object {
+          "label": "alpha",
+          "value": "alpha",
+        }
+      }
+    />
     <Input
       autoComplete="on"
       className="title-input"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
@@ -6,8 +6,7 @@ import Navigation from './navigation';
 
 import { ActivityInterface } from '../../interfaces/evidenceInterfaces';
 import { fetchActivities } from '../../utils/evidence/activityAPIs';
-import { DataTable, Error, Spinner } from '../../../Shared/index';
-import { handleHasAppSetting } from "../../../Shared/utils/appSettingAPIs";
+import { DataTable, Error, Spinner, FlagDropdown, } from '../../../Shared/index';
 import { getCheckIcon, renderErrorsContainer } from "../../helpers/evidence";
 
 const Activities = ({ location, match }) => {
@@ -15,10 +14,11 @@ const Activities = ({ location, match }) => {
   // cache activity data for updates
   const { data: activitiesData } = useQuery("activities", fetchActivities);
   const [errors, setErrors] = React.useState<string[]>([])
-  const [hasAppSetting, setHasAppSetting] = React.useState<boolean>(false);
-  handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'foo', })
+  const [flag, setFlag] = React.useState<string>('alpha')
 
-  const formattedRows = activitiesData && activitiesData.activities && activitiesData.activities.map((activity: ActivityInterface) => {
+  const filteredActivities = activitiesData && activitiesData.activities && activitiesData.activities.filter(act => flag === 'All Flags' || act.flag === flag) || []
+
+  const formattedRows = filteredActivities.map((activity: ActivityInterface) => {
     const { id, title, invalid_highlights } = activity;
     const activityLink = (<Link to={`/activities/${id}`}>{title}</Link>);
     const highlightLabel = (<Link to={`/activities/${id}`}>{getCheckIcon(!(invalid_highlights && invalid_highlights.length))}</Link>);
@@ -28,6 +28,8 @@ const Activities = ({ location, match }) => {
       valid_highlights: highlightLabel
     }
   });
+
+  function onFlagChange(e) { setFlag(e.target.value) }
 
   if(!activitiesData) {
     return(
@@ -55,9 +57,9 @@ const Activities = ({ location, match }) => {
 
   return(<React.Fragment>
     <Navigation location={location} match={match} />
-    {hasAppSetting && <div>App setting is enabled.</div>}
     {errors && renderErrorsContainer(false, errors)}
     <div className="activities-container">
+      <FlagDropdown flag={flag} handleFlagChange={onFlagChange} isLessons={true} />
       <DataTable
         className="activities-table"
         defaultSortAttribute="name"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -21,10 +21,11 @@ import {
   IMAGE_ATTRIBUTION,
   IMAGE_CAPTION,
   PARENT_ACTIVITY_ID,
-  HIGHLIGHT_PROMPT
+  HIGHLIGHT_PROMPT,
+  flagOptions
 } from '../../../../../constants/evidence';
 import { ActivityInterface, PromptInterface, PassagesInterface, InputEvent, ClickEvent,  TextAreaEvent } from '../../../interfaces/evidenceInterfaces';
-import { DataTable, Input, TextEditor, } from '../../../../Shared/index'
+import { DataTable, Input, TextEditor, DropdownInput, } from '../../../../Shared/index'
 import { DEFAULT_HIGHLIGHT_PROMPT, } from '../../../../Shared/utils/constants'
 
 interface ActivityFormProps {
@@ -57,7 +58,7 @@ const RULE_TYPE_TO_NAME = {
 }
 
 const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, submitActivity }: ActivityFormProps) => {
-  const { id, parent_activity_id, invalid_highlights, passages, prompts, scored_level, target_level, title, notes, } = activity;
+  const { id, parent_activity_id, invalid_highlights, passages, prompts, scored_level, target_level, title, notes, flag, } = activity;
   const formattedScoredLevel = scored_level || '';
   const formattedTargetLevel = target_level ? target_level.toString() : '';
   const formattedPassage = passages && passages.length ? passages : [{ text: '', highlight_prompt: DEFAULT_HIGHLIGHT_PROMPT }];
@@ -74,6 +75,7 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
 
   const [activityTitle, setActivityTitle] = React.useState<string>(title || '');
   const [activityNotes, setActivityNotes] = React.useState<string>(notes || '');
+  const [activityFlag, setActivityFlag] = React.useState<string>(flag || 'alpha');
   const [activityScoredReadingLevel, setActivityScoredReadingLevel] = React.useState<string>(formattedScoredLevel);
   const [activityTargetReadingLevel, setActivityTargetReadingLevel] = React.useState<string>(formattedTargetLevel);
   const [activityPassages, setActivityPassages] = React.useState<PassagesInterface[]>(formattedPassage);
@@ -85,6 +87,8 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
   const [showHighlights, setShowHighlights] = React.useState(true)
 
   function toggleShowHighlights(e: ClickEvent) { setShowHighlights(!showHighlights)}
+
+  function handleSetActivityFlag(option: { value: string, label: string }) { setActivityFlag(option.value) };
 
   function handleSetActivityTitle(e: InputEvent){ setActivityTitle(e.target.value) };
 
@@ -125,6 +129,7 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
 
   function handleSubmitActivity(){
     const activityObject = buildActivity({
+      activityFlag,
       activityNotes,
       activityTitle,
       activityScoredReadingLevel,
@@ -138,6 +143,7 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
       highlightPrompt: activityPassages[0].highlight_prompt || DEFAULT_HIGHLIGHT_PROMPT
     });
     const state = [
+      activityFlag,
       activityTitle,
       activityNotes,
       activityScoredReadingLevel,
@@ -205,6 +211,13 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
       </div>
       {showErrorsContainer && renderErrorsContainer(formErrorsPresent, requestErrors)}
       <form className="comprehension-activity-form">
+        <DropdownInput
+          className="flag-input"
+          handleChange={handleSetActivityFlag}
+          label="Activity Flag"
+          options={flagOptions}
+          value={flagOptions.find(opt => opt.value === activityFlag)}
+        />
         <Input
           className="title-input"
           error={errors[TITLE]}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activitySettings.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activitySettings.tsx
@@ -39,6 +39,7 @@ const ActivitySettings = ({ activity, history }: {activity: ActivityInterface, h
         setErrors(errors);
       } else {
         queryCache.refetchQueries(`activity-${id}`)
+        queryCache.removeQueries('activities')
         setErrors([]);
         // reset errorOrSuccessMessage in case of subsequent submission
         setErrorOrSuccessMessage('Activity successfully updated!');

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence.tsx
@@ -17,7 +17,8 @@ import {
   IMAGE_ATTRIBUTION,
   HIGHLIGHT_PROMPT,
   PLAGIARISM,
-  ALL
+  ALL,
+  FLAG
 } from '../../../constants/evidence';
 import { PromptInterface, ActivityInterface, DropdownObjectInterface } from '../interfaces/evidenceInterfaces'
 
@@ -122,6 +123,7 @@ export const buildBlankPrompt = (conjunction: string) => {
 }
 
 export const buildActivity = ({
+  activityFlag,
   activityNotes,
   activityTitle,
   activityScoredReadingLevel,
@@ -134,7 +136,6 @@ export const buildActivity = ({
   activitySoPrompt,
   highlightPrompt,
 }) => {
-  // const { label } = activityFlag;
   const prompts = [activityBecausePrompt, activityButPrompt, activitySoPrompt];
   const maxFeedback = activityMaxFeedback || 'Nice effort! You worked hard to make your sentence stronger.';
   prompts.forEach(prompt => prompt.max_attempts_feedback = maxFeedback);
@@ -143,7 +144,7 @@ export const buildActivity = ({
       notes: activityNotes,
       title: activityTitle,
       parent_activity_id: activityParentActivityId ? parseInt(activityParentActivityId) : null,
-      // flag: label,
+      flag: activityFlag,
       scored_level: activityScoredReadingLevel,
       target_level: parseInt(activityTargetReadingLevel),
       highlight_prompt: highlightPrompt,
@@ -352,6 +353,7 @@ export const validateForm = (keys: string[], state: any[], ruleType?: string) =>
       case IMAGE_CAPTION:
       case IMAGE_ATTRIBUTION:
       case HIGHLIGHT_PROMPT:
+      case FLAG:
         break;
       case TARGET_READING_LEVEL:
         const targetError = targetReadingLevelError(value);

--- a/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
@@ -12,9 +12,9 @@ export interface InvalidHighlight {
 export interface ActivityInterface {
   id?: string,
   parent_activity_id?: string,
+  flag?: string,
   title: string,
   notes: string,
-  // flag: string,
   scored_level: string,
   target_level: number,
   passages?: PassagesInterface[],

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activities.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activities.scss
@@ -1,9 +1,6 @@
 .activities-container, .loading-spinner-container, .error-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 70vw;
-  padding-top: 20px;
+  width: calc(100vw - 200px);
+  padding: 20px;
   .activities-table, .tabs-container {
     width: 100%;
     align-self: flex-start;

--- a/services/QuillLMS/client/app/constants/evidence.ts
+++ b/services/QuillLMS/client/app/constants/evidence.ts
@@ -251,6 +251,7 @@ export const SCORED_READING_LEVEL = 'Scored reading level';
 export const TARGET_READING_LEVEL = 'Target reading level';
 export const PARENT_ACTIVITY_ID = 'Parent Activity ID';
 export const HIGHLIGHT_PROMPT = 'Highlight Prompt';
+export const FLAG = 'Flag';
 export const PASSAGE = 'Passage';
 export const MAX_ATTEMPTS_FEEDBACK = 'Max attempts feedback';
 export const BECAUSE_STEM = 'Because stem';
@@ -262,6 +263,7 @@ export const IMAGE_CAPTION = 'Image caption';
 export const IMAGE_ATTRIBUTION = 'Image attribution';
 
 export const activityFormKeys = [
+  FLAG,
   TITLE,
   NOTES,
   SCORED_READING_LEVEL,
@@ -275,7 +277,8 @@ export const activityFormKeys = [
   IMAGE_ALT_TEXT,
   IMAGE_CAPTION,
   IMAGE_ATTRIBUTION,
-  HIGHLIGHT_PROMPT
+  HIGHLIGHT_PROMPT,
+  FLAG
 ];
 
 export const MINIMUM_READING_LEVEL = 4;

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -9,7 +9,7 @@ module Evidence
 
     # GET /activities.json
     def index
-      @activities = Evidence::Activity.order(:title)
+      @activities = Evidence::Activity.order(:title).map { |a| a.serializable_hash(include: []) }
 
       render json: @activities
     end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -9,7 +9,7 @@ module Evidence
 
     # GET /activities.json
     def index
-      @activities = Evidence::Activity.joins("LEFT JOIN activities ON comprehension_activities.parent_activity_id = activities.id").where("parent_activity_id IS NULL OR NOT 'archived' = ANY(activities.flags)").order(:title)
+      @activities = Evidence::Activity.order(:title)
 
       render json: @activities
     end
@@ -72,6 +72,7 @@ module Evidence
         :parent_activity_id,
         :target_level,
         :scored_level,
+        :flag,
         passages_attributes: [:id, :text, :image_link, :image_alt_text, :image_caption, :image_attribution, :highlight_prompt],
         prompts_attributes: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback]
       )

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -58,7 +58,7 @@ module Evidence
       super(options.reverse_merge(
         only: [:id, :parent_activity_id, :title, :notes, :target_level, :scored_level],
         include: [:passages, :prompts],
-        methods: [:invalid_highlights]
+        methods: [:invalid_highlights, :flag]
       ))
     end
 
@@ -74,6 +74,14 @@ module Evidence
       parent_activity&.update(name: title)
     end
 
+    def flag
+      parent_activity&.flag
+    end
+
+    def flag=flag
+      parent_activity.update(flag: flag)
+    end
+
     def invalid_highlights
       invalid_feedback_highlights
     end
@@ -85,7 +93,7 @@ module Evidence
         {
           rule_id: highlight.feedback.rule_id,
           rule_type: highlight.feedback.rule.rule_type,
-          prompt_id: highlight.feedback.rule.prompts.where(activity_id: id).first.id 
+          prompt_id: highlight.feedback.rule.prompts.where(activity_id: id).first.id
         }
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -16,28 +16,6 @@ module Evidence
         expect(parsed_response.empty?).to(eq(true))
       end
 
-      context 'should with activities where one has an archived parent' do
-        let!(:archived_activity) { Evidence.parent_activity_class.create(:name => "Archived Activity", :flags => (["archived"])) }
-        let!(:unarchived_activity) { Evidence.parent_activity_class.create(:name => "Unarchived Activity") }
-
-        before do
-          create(:evidence_activity, :parent_activity_id => archived_activity.id, :title => "First Activity", :target_level => 8)
-          create(:evidence_activity, :parent_activity_id => unarchived_activity.id, :title => "Second Activity", :target_level => 5)
-        end
-
-        it 'should return with only the unarchived activity' do
-          get(:index)
-          parsed_response = JSON.parse(response.body)
-          expect(response.status).to eq(200)
-          expect(parsed_response.class).to(eq(Array))
-          expect(parsed_response.empty?).to(eq(false))
-          expect(1).to(eq(parsed_response.length))
-          expect(parsed_response.first["title"]).to(eq("Second Activity"))
-          expect(parsed_response.first["target_level"]).to(eq(5))
-          expect(parsed_response.first["parent_activity_id"]).to(eq(unarchived_activity.id))
-        end
-      end
-
       context 'should with actitivites' do
         let!(:first_activity) { create(:evidence_activity, :title => "An Activity", :notes => "Notes 1", :target_level => 8) }
         before(:each) do

--- a/services/QuillLMS/engines/evidence/spec/dummy/app/models/activity.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/app/models/activity.rb
@@ -4,4 +4,8 @@ class Activity < ApplicationRecord
     return super(flag) unless flag.nil?
     flags.first&.to_sym
   end
+
+  def flag=(flag=nil)
+    update(flags: [flag])
+  end
 end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -95,7 +95,7 @@ module Evidence
 
     context '#flag' do
       it 'should return the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", :flags => ['alpha'])
+        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         expect(activity.flag).to be(parent_activity.flag)
       end
@@ -103,7 +103,7 @@ module Evidence
 
     context '#flag=' do
       it 'should update the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", :flags => ['alpha'])
+        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         activity.update(flag: 'beta')
         expect(parent_activity.flag).to be('beta')

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -106,7 +106,8 @@ module Evidence
         parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         activity.update(flag: 'beta')
-        expect(parent_activity.flag).to be('beta')
+        parent_activity.reload
+        expect(parent_activity.flag).to be(:beta)
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -95,7 +95,7 @@ module Evidence
 
     context '#flag' do
       it 'should return the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", flag: 'alpha')
+        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         expect(activity.flag).to be(parent_activity.flag)
       end
@@ -103,10 +103,10 @@ module Evidence
 
     context '#flag=' do
       it 'should update the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", flag: 'alpha')
+        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         activity.update(flag: 'beta')
-        expect(parent_activity.flag).to be 'beta'
+        expect(parent_activity.flag).to be('beta')
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -72,26 +72,44 @@ module Evidence
     context 'should create parent activity' do
 
       it 'should set the parent_activity_id to nil if passed in Activity does NOT exist' do
-        activity = create(:evidence_activity, :parent_activity_id => 7) 
+        activity = create(:evidence_activity, :parent_activity_id => 7)
         expect(activity.parent_activity).to(be_nil)
       end
 
       it 'should set the parent_activity_id if passed in Activity does exist' do
         parent_activity = ::Activity.create(:name => "test name")
-        activity = create(:evidence_activity, :parent_activity_id => parent_activity.id) 
+        activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         expect(activity.parent_activity.id).to_not(be_nil)
       end
 
       it 'should create a new LMS activity if the parent_activity_id is not present' do
-        activity = create(:evidence_activity, :parent_activity_id => nil) 
+        activity = create(:evidence_activity, :parent_activity_id => nil)
         expect(activity.parent_activity.id).to(be_truthy)
       end
 
       it 'should set new parent activity flags to [alpha]' do
-        activity = create(:evidence_activity, :parent_activity_id => nil) 
+        activity = create(:evidence_activity, :parent_activity_id => nil)
         expect(activity.parent_activity.flags).to eq([Activity::LMS_ACTIVITY_DEFAULT_FLAG])
       end
     end
+
+    context '#flag' do
+      it 'should return the parent activity flag' do
+        parent_activity = ::Activity.create(:name => "test name", flag: 'alpha')
+        activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
+        expect(activity.flag).to be(parent_activity.flag)
+      end
+    end
+
+    context '#flag=' do
+      it 'should update the parent activity flag' do
+        parent_activity = ::Activity.create(:name => "test name", flag: 'alpha')
+        activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
+        activity.update(flag: 'beta')
+        expect(parent_activity.flag).to be 'beta'
+      end
+    end
+
 
     context '#update_parent_activity_name' do
       let(:activity) { create(:evidence_activity) }
@@ -118,15 +136,15 @@ module Evidence
     context 'should dependent destroy' do
 
       it 'should destroy dependent passages' do
-        activity = create(:evidence_activity) 
-        passage = create(:evidence_passage, :activity => (activity)) 
+        activity = create(:evidence_activity)
+        passage = create(:evidence_passage, :activity => (activity))
         activity.destroy
         expect(Passage.exists?(passage.id)).to(eq(false))
       end
 
       it 'should destroy dependent prompts' do
-        activity = create(:evidence_activity) 
-        prompt = create(:evidence_prompt, :activity => (activity)) 
+        activity = create(:evidence_activity)
+        prompt = create(:evidence_prompt, :activity => (activity))
         activity.destroy
         expect(Prompt.exists?(prompt.id)).to(eq(false))
       end
@@ -135,8 +153,8 @@ module Evidence
     context 'should before_destroy' do
 
       it 'should expire all associated Turking Rounds before destroy' do
-        activity = create(:evidence_activity) 
-        turking_round = create(:evidence_turking_round, :activity => (activity)) 
+        activity = create(:evidence_activity)
+        turking_round = create(:evidence_turking_round, :activity => (activity))
         expect(turking_round.expires_at > Time.zone.now).to be true
         activity.destroy
         turking_round.reload

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -95,7 +95,7 @@ module Evidence
 
     context '#flag' do
       it 'should return the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
+        parent_activity = ::Activity.create(:name => "test name", :flags => ['alpha'])
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         expect(activity.flag).to be(parent_activity.flag)
       end
@@ -103,7 +103,7 @@ module Evidence
 
     context '#flag=' do
       it 'should update the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
+        parent_activity = ::Activity.create(:name => "test name", :flags => ['alpha'])
         activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
         activity.update(flag: 'beta')
         expect(parent_activity.flag).to be('beta')


### PR DESCRIPTION
## WHAT
Add flags to UI for Evidence CMS: a flag dropdown on the activities index for filtering and a flag dropdown on the Activity Settings page for setting an activity's flag.

## WHY
The curriculum team requested it.

## HOW
Update the backend with a getter and setter method for flags that just points to the parent activity, then update the frontend to use both.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-a-user-flag-dropdown-into-the-Evidence-CMS-55ca0fb8948245dbaca58072c691824a
https://www.notion.so/quill/Add-filtering-to-the-Activity-Settings-page-d4d3d9677fc44e7b9a468efe7293abbf

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
