### PR TITLE
Add nightly reset to quill staff demo

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -120,12 +120,12 @@ class Teachers::ProgressReportsController < ApplicationController
   end
 
   private def recreate_demo
-    Demo::ReportDemoDestroyer.destroy_demo(demo_name)
-    Demo::ReportDemoCreator.create_demo(demo_name)
+    Demo::ReportDemoDestroyer.destroy_demo("hello+#{demo_name}@quill.org")
+    Demo::ReportDemoCreator.create_demo("hello+#{demo_name}@quill.org")
   end
 
   private def recreate_staff_demo
-    Demo::ReportDemoDestroyer.destroy_demo(staff_demo_name)
-    Demo::ReportDemoCreator.create_demo(staff_demo_name)
+    Demo::ReportDemoDestroyer.destroy_demo("hello+#{staff_demo_name}@quill.org")
+    Demo::ReportDemoCreator.create_demo("hello+#{staff_demo_name}@quill.org")
   end
 end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -221,7 +221,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.create_teacher(email)
-    email = email || "hello+demoteacher@quill.org"
+    email ||= "hello+demoteacher@quill.org"
 
     existing_teacher = User.find_by_email(email)
     existing_teacher.destroy if existing_teacher

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -207,8 +207,8 @@ module Demo::ReportDemoCreator
     }
   ]
 
-  def self.create_demo(name)
-    teacher = create_teacher(name)
+  def self.create_demo(email)
+    teacher = create_teacher(email)
     classroom = create_classroom(teacher)
     students = create_students(classroom)
     units = create_units(teacher)
@@ -220,8 +220,8 @@ module Demo::ReportDemoCreator
     TeacherActivityFeedRefillWorker.perform_async(teacher.id)
   end
 
-  def self.create_teacher(name)
-    email = name ? "hello+#{name}@quill.org" : "hello+demoteacher@quill.org"
+  def self.create_teacher(email)
+    email = email || "hello+demoteacher@quill.org"
 
     existing_teacher = User.find_by_email(email)
     existing_teacher.destroy if existing_teacher

--- a/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Demo::ReportDemoDestroyer
-  def self.destroy_demo(name)
-    email = name ? "hello+#{name}@quill.org" : "hello+demoteacher@quill.org"
+  def self.destroy_demo(email)
+    email = email || "hello+demoteacher@quill.org"
     teacher  = User.find_by_email(email)
     teacher.destroy if teacher
   end

--- a/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_destroyer.rb
@@ -2,7 +2,7 @@
 
 module Demo::ReportDemoDestroyer
   def self.destroy_demo(email)
-    email = email || "hello+demoteacher@quill.org"
+    email ||= "hello+demoteacher@quill.org"
     teacher  = User.find_by_email(email)
     teacher.destroy if teacher
   end

--- a/services/QuillLMS/app/workers/reset_demo_account_worker.rb
+++ b/services/QuillLMS/app/workers/reset_demo_account_worker.rb
@@ -10,8 +10,8 @@ class ResetDemoAccountWorker
     Demo::ReportDemoDestroyer.destroy_demo(nil)
     Demo::ReportDemoCreator.create_demo(nil)
 
-    Demo::ReportDemoDestroyer.destroy_demo(STAFF_DEMO_NAME)
-    Demo::ReportDemoCreator.create_demo(STAFF_DEMO_NAME)
+    Demo::ReportDemoDestroyer.destroy_demo(STAFF_DEMO_EMAIL)
+    Demo::ReportDemoCreator.create_demo(STAFF_DEMO_EMAIL)
   end
 end
 

--- a/services/QuillLMS/app/workers/reset_demo_account_worker.rb
+++ b/services/QuillLMS/app/workers/reset_demo_account_worker.rb
@@ -3,10 +3,15 @@
 class ResetDemoAccountWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
+  STAFF_DEMO_NAME = "demoteacher+staff"
 
   def perform
+    # sending nil destroys the default /demo account
     Demo::ReportDemoDestroyer.destroy_demo(nil)
     Demo::ReportDemoCreator.create_demo(nil)
+
+    Demo::ReportDemoDestroyer.destroy_demo(STAFF_DEMO_NAME)
+    Demo::ReportDemoCreator.create_demo(STAFF_DEMO_NAME)
   end
 end
 

--- a/services/QuillLMS/app/workers/reset_demo_account_worker.rb
+++ b/services/QuillLMS/app/workers/reset_demo_account_worker.rb
@@ -3,7 +3,7 @@
 class ResetDemoAccountWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
-  STAFF_DEMO_NAME = "demoteacher+staff"
+  STAFF_DEMO_EMAIL = "hello+demoteacher+staff@quill.org"
 
   def perform
     # sending nil destroys the default /demo account

--- a/services/QuillLMS/lib/tasks/report_demo.rake
+++ b/services/QuillLMS/lib/tasks/report_demo.rake
@@ -12,12 +12,12 @@ namespace :report_demo do
     # call this with no arguments if you want quill.org/demo to be created. otherwise
     # to use this call rake report_demo:create["firstname lastname"]
     name = args[:name] ? args[:name].to_s : nil
-    Demo::ReportDemoCreator::create_demo(name)
+    Demo::ReportDemoCreator::create_demo("hello+#{name}@quill.org")
   end
 
   task :destroy, [:name] => :environment do |t, args|
     # to use this call rake demo:create["firstname lastname"]
     name = args[:name] ? args[:name].to_s : nil
-    Demo::ReportDemoDestroyer::destroy_demo(name)
+    Demo::ReportDemoDestroyer::destroy_demo("hello+#{name}@quill.org")
   end
 end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
@@ -34,12 +34,12 @@ describe Teachers::ProgressReportsController do
       context 'when demo account does not exist' do
         before do
           allow(Demo::ReportDemoDestroyer).to receive(:destroy_demo) { true }
-          allow(Demo::ReportDemoCreator).to receive(:create_demo) {|name| create(:user, email: "hello+#{name}@quill.org") }
+          allow(Demo::ReportDemoCreator).to receive(:create_demo) {|email| create(:user, email: email) }
         end
 
         it 'should destroy the current demo and create a new demo' do
-          expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with("demoteacher")
-          expect(Demo::ReportDemoCreator).to receive(:create_demo).with("demoteacher")
+          expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with("hello+demoteacher@quill.org")
+          expect(Demo::ReportDemoCreator).to receive(:create_demo).with("hello+demoteacher@quill.org")
           get :demo
         end
       end
@@ -77,12 +77,12 @@ describe Teachers::ProgressReportsController do
       context 'when demo account does not exist' do
         before do
           allow(Demo::ReportDemoDestroyer).to receive(:destroy_demo) { true }
-          allow(Demo::ReportDemoCreator).to receive(:create_demo) {|name| create(:user, email: "hello+#{name}@quill.org") }
+          allow(Demo::ReportDemoCreator).to receive(:create_demo) {|email| create(:user, email: email) }
         end
 
         it 'should destroy the current demo and create a new demo' do
-          expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with("test")
-          expect(Demo::ReportDemoCreator).to receive(:create_demo).with("test")
+          expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with("hello+test@quill.org")
+          expect(Demo::ReportDemoCreator).to receive(:create_demo).with("hello+test@quill.org")
           get :demo, params: { name: "test" }
         end
       end
@@ -148,11 +148,11 @@ describe Teachers::ProgressReportsController do
 
     context 'when demo account does not exist' do
       before do
-        allow(Demo::ReportDemoCreator).to receive(:create_demo) {|name| create(:user, email: "hello+#{name}@quill.org") }
+        allow(Demo::ReportDemoCreator).to receive(:create_demo) {|email| create(:user, email: email) }
       end
 
       it 'sets the user, redirects to scorebook teachers classrooms path when user doesnt exist' do
-        expect(Demo::ReportDemoCreator).to receive(:create_demo).with("demoteacher+staff")
+        expect(Demo::ReportDemoCreator).to receive(:create_demo).with("hello+demoteacher+staff@quill.org")
 
         get :staff_demo
         expect(response).to redirect_to scorebook_teachers_classrooms_path

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Demo::ReportDemoCreator do
 
 
   it 'creates a teacher with name' do
-    name = 'demoteacher'
-    Demo::ReportDemoCreator.create_teacher(name)
+    email = "hello+demoteacher@quill.org"
+    Demo::ReportDemoCreator.create_teacher(email)
     teacher = User.find_by(name: "Demo Teacher")
     expect(teacher.name).to eq("Demo Teacher")
-    expect(teacher.email).to eq("hello+#{name}@quill.org")
+    expect(teacher.email).to eq(email)
     expect(teacher.role).to eq("teacher")
   end
 

--- a/services/QuillLMS/spec/workers/reset_demo_account_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/reset_demo_account_worker_spec.rb
@@ -10,8 +10,8 @@ describe ResetDemoAccountWorker, type: :worker do
       expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with(nil)
       expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil)
 
-      expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with(ResetDemoAccountWorker::STAFF_DEMO_NAME)
-      expect(Demo::ReportDemoCreator).to receive(:create_demo).with(ResetDemoAccountWorker::STAFF_DEMO_NAME)
+      expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with(ResetDemoAccountWorker::STAFF_DEMO_EMAIL)
+      expect(Demo::ReportDemoCreator).to receive(:create_demo).with(ResetDemoAccountWorker::STAFF_DEMO_EMAIL)
       worker.perform
     end
   end

--- a/services/QuillLMS/spec/workers/reset_demo_account_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/reset_demo_account_worker_spec.rb
@@ -9,6 +9,9 @@ describe ResetDemoAccountWorker, type: :worker do
     it "should destroy and then create a new demo" do
       expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with(nil)
       expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil)
+
+      expect(Demo::ReportDemoDestroyer).to receive(:destroy_demo).with(ResetDemoAccountWorker::STAFF_DEMO_NAME)
+      expect(Demo::ReportDemoCreator).to receive(:create_demo).with(ResetDemoAccountWorker::STAFF_DEMO_NAME)
       worker.perform
     end
   end


### PR DESCRIPTION
## WHAT
For the demo account feature, I made a new demo account for Quill Staff only, but forgot to add a nightly reset for this particular account. I'm adding it now.

## WHY
So the staff demo account behaves as expected (with a nightly reset).

## HOW
Add the commands to reset this account in the nightly reset job.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
