### PR TITLE
Tweak demo sample data to show more growth

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -189,7 +189,7 @@ module Demo::ReportDemoCreator
       activity_ids: [1664],
       activity_sessions: [
         {
-          1664 => 9962415
+          1664 => 11662573
         },
         {
           1664 => 9706466


### PR DESCRIPTION
## WHAT
On our demo account, the Post-Diagnostic growth report only shows growth in one concept, so we wanted to tweak the sample data slightly to give more impressive growth results.

## WHY
This way teachers will have more useful information to play around with, since they'll be able to see more examples of growth in concepts.

## HOW
Just replace the sample user ID we were using with a different user ID (this user got better results on their post diagnostic, so the growth report will show more growth).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-new-demo-account-to-show-additional-growth-3488559f240a4f618f37a58f84706cd3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
