### PR TITLE
LMS bugfix/ fix scorebook query

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -21,10 +21,10 @@ class Scorebook::Query
           MAX(acts.updated_at) AS updated_at,
           MIN(acts.started_at) AS started_at,
           MAX(acts.percentage) AS percentage,
+          SUM(acts.timespent) AS timespent,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) AS completed_attempts,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) AS started,
-          SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS id,
-          acts.timespent AS timespent
+          SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS id
         FROM classroom_units AS cu
         LEFT JOIN students_classrooms AS sc
           ON cu.classroom_id = sc.classroom_id
@@ -57,7 +57,6 @@ class Scorebook::Query
           activity.name,
           activity.description,
           cuas.completed,
-          acts.timespent,
           activity.id
         ORDER BY split_part( students.name, ' ' , 2),
           CASE WHEN SUM(CASE WHEN acts.percentage IS NOT NULL THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,


### PR DESCRIPTION
## WHAT
fix issue with Scorebook query causing multiple icons to show for activities

## WHY
we want these to be aggregated to one icon display when played multiple times

## HOW
wrap using `SUM`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
