### PR TITLE
make sure we can create a new evidence activity

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -7,22 +7,6 @@ exports[`Activity Form component should render Activities 1`] = `
   <div
     className="button-container"
   >
-    <a
-      className="quill-button fun secondary outlined"
-      href="/evidence/#/play?uid=undefined&skipToPrompts=true"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Play Test Activity
-    </a>
-    <a
-      className="quill-button fun secondary outlined"
-      href="/evidence/#/play?uid=undefined"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Play Student Activity
-    </a>
     <button
       className="quill-button fun secondary outlined"
       onClick={[MockFunction]}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -204,8 +204,8 @@ const ActivityForm = ({ activity, handleClickArchiveActivity, requestErrors, sub
   return(
     <div className="activity-form-container">
       <div className="button-container">
-        <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Test Activity</a>
-        <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Play Student Activity</a>
+        {activity.id && <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Test Activity</a>}
+        {activity.id && <a className="quill-button fun secondary outlined" href={`/evidence/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Play Student Activity</a>}
         {activity.parent_activity_id && <button className="quill-button fun secondary outlined" onClick={handleClickArchiveActivity} type="button">Archive Activity</button>}
         <button className="quill-button fun primary contained" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">Save</button>
       </div>

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -79,6 +79,7 @@ module Evidence
     end
 
     def flag=flag
+      set_parent_activity
       parent_activity.update(flag: flag)
     end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -102,12 +102,23 @@ module Evidence
     end
 
     context '#flag=' do
-      it 'should update the parent activity flag' do
-        parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
-        activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
-        activity.update(flag: 'beta')
-        parent_activity.reload
-        expect(parent_activity.flag).to be(:beta)
+      describe 'if there is already a parent activity' do
+        it 'should update the parent activity flag' do
+          parent_activity = ::Activity.create(:name => "test name", :flag => 'alpha')
+          activity = create(:evidence_activity, :parent_activity_id => parent_activity.id)
+          activity.update(flag: 'beta')
+          parent_activity.reload
+          expect(parent_activity.flag).to be(:beta)
+        end
+      end
+
+      describe 'if there is not a parent activity' do
+        it 'should create one with the correct activity flag' do
+          activity = create(:evidence_activity)
+          activity.update(flag: 'beta')
+          activity.reload
+          expect(::Activity.find(activity.parent_activity_id).flag).to be(:beta)
+        end
       end
     end
 


### PR DESCRIPTION
## WHAT
Fix issue where new Evidence activities weren't saving because they didn't yet have a parent activity.

## WHY
We want new Evidence activities to be creatable.

## HOW
Just call `set_parent_activity` at the top of the flags file, and also hide the `Play Activity` buttons until there is actually an activity saved to play because they won't work otherwise (unrelated to the bug but something called out in the card).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Save-button-not-working-in-Evidence-CMS-ff888c7cbb9b433aac0aa8acf80300e0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
