### PR TITLE
Add `touch` calls to test load (for use in Caching).

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -53,7 +53,7 @@ class ActivitySession < ApplicationRecord
   default_scope { where(visible: true)}
   has_many :feedback_sessions, foreign_key: :activity_session_uid, primary_key: :uid
   has_many :feedback_histories, through: :feedback_sessions
-  belongs_to :classroom_unit
+  belongs_to :classroom_unit, touch: true
   belongs_to :activity
   has_one :classification, through: :activity
   has_many :user_activity_classifications, through: :classification

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -134,7 +134,10 @@ class Classroom < ApplicationRecord
   end
 
   def hide_appropriate_classroom_units
-    hide_all_classroom_units unless visible
+    return if visible
+    return unless visible_changed?
+    
+    hide_all_classroom_units
   end
 
   def hide_all_classroom_units

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -29,7 +29,7 @@ class ClassroomUnit < ApplicationRecord
   include AtomicArrays
 
   belongs_to :unit #, touch: true
-  belongs_to :classroom
+  belongs_to :classroom, touch: true
   has_many :activity_sessions
   has_many :unit_activities, through: :unit
   has_many :completed_activity_sessions, -> {completed}, class_name: 'ActivitySession'

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -41,7 +41,7 @@ require 'rails_helper'
 
 describe ActivitySession, type: :model, redis: true do
 
-  it { should belong_to(:classroom_unit) }
+  it { should belong_to(:classroom_unit).touch(true) }
   it { should belong_to(:activity) }
   it { should have_one(:classification).through(:activity) }
   it { should have_many(:user_activity_classifications).through(:classification) }

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -28,7 +28,7 @@ require 'rails_helper'
 
 describe ClassroomUnit, type: :model, redis: true do
 
-  it { should belong_to(:classroom) }
+  it { should belong_to(:classroom).touch(true) }
   it { should belong_to(:unit) }
   it { should have_many(:activity_sessions) }
   it { should have_many(:classroom_unit_activity_states) }


### PR DESCRIPTION
## WHAT
Add the two main `touch` calls to test load in preparation for caching work #8584. These two touches would add the most load, so testing them.
## WHY
Before putting the caching in place and building infrastructure around it, we should ensure that these extra writes don't cause site issues.
## HOW
Add `touch: true` to relations.




PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes, looks amazing
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
