### PR TITLE
Bug fix/ Evidence bolding nonbreaking space characters

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -11,7 +11,7 @@ interface PromptStepProps {
   active: Boolean;
   activityIsComplete: Boolean;
   className: string,
-  completionButtonCallback: () => void; 
+  completionButtonCallback: () => void;
   everyOtherStepCompleted: boolean;
   submitResponse: Function;
   completeStep: (event: any) => void;
@@ -281,7 +281,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     let buttonCopy = submittedResponses.length ? 'Get new feedback' : 'Get feedback'
     let className = 'quill-button focus-on-light'
     let onClick = () => this.handleGetFeedbackClick(entry, id, text)
-   
+
     if (activityIsComplete) {
       onClick = completionButtonCallback
       buttonCopy = 'Done'
@@ -291,7 +291,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     } else if (this.unsubmittableResponses().includes(entry) || awaitingFeedback) {
       className += ' disabled'
       onClick = () => {}
-    } 
+    }
     return <button className={className} onClick={onClick} type="button">{buttonLoadingSpinner}<span>{buttonCopy}</span></button>
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -22,5 +22,13 @@ describe('stringFormatting', () => {
       const result = highlightSpellingGrammar("lorem shouldn't ipsum", 'should')
       expect(result).toEqual(`lorem <b>shouldn't</b> ipsum`)
     });
+    it('should highlight all of a word when a word substring is matched', () => {
+      const result = highlightSpellingGrammar("lorem shouldn't ipsum", 'should')
+      expect(result).toEqual(`lorem <b>shouldn't</b> ipsum`)
+    });
+    it('should not highlight nonbreaking space character', () => {
+      const result = highlightSpellingGrammar("&nbsp lorem ipsum shouldn't", "&nbsp")
+      expect(result).toEqual(`&nbsp lorem ipsum shouldn't`)
+    });
   });
-}); 
+});

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -3,7 +3,7 @@ export const highlightSpellingGrammar = (str: string, wordsToFormat: string | st
   let newString = str
   wordArray.forEach((word) => {
     const matched = newString.match(`${word}[\\w\']*`)
-    if (matched) {
+    if (matched && matched[0] &&  matched[0] !== '&nbsp') {
       const augmentedRegex = new RegExp(`${matched[0]}`, 'g')
       newString = newString.replace(augmentedRegex, `<b>${matched[0]}</b>`)
     }

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -3,7 +3,7 @@
 SecureHeaders::Configuration.default do |config|
   default_config = {
     default_src: [
-      "'self'", 
+      "'self'",
       "https://*.quill.org",
       "https://quill.org",
       "'unsafe-inline'"                                           # TODO: remove once nonce strategy is in place
@@ -27,8 +27,8 @@ SecureHeaders::Configuration.default do |config|
 
     script_src: [
       "'self'",
-      "https://*.quill.org", 
-      "https://quill.org", 
+      "https://*.quill.org",
+      "https://quill.org",
       "'unsafe-inline'",
       "'unsafe-eval'",                                            # allows use of eval()
       "https://*.clever.com",
@@ -53,7 +53,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.coview.com",
       "https://*.sentry.io",
       "https://*.heapanalytics.com"
-    ],                                                            
+    ],
 
     font_src: [
       "'self'",
@@ -67,7 +67,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.fontawesome.com",
       "https://*.gstatic.com"
 
-    ], 
+    ],
 
     img_src: [
       "*",
@@ -80,17 +80,17 @@ SecureHeaders::Configuration.default do |config|
     style_src: [
       "'self'",
       "https://*.quill.org",
-      "https://quill.org",  
+      "https://quill.org",
       "'unsafe-inline'",
       "https://coview.com",
       "https://*.coview.com",
       "https://*.fontawesome.com",
       "https://*.googleapis.com",
-      "https://*.gstatic.com"      
+      "https://*.gstatic.com"
     ],
 
     connect_src: [                                                # for XHR, etc
-      "'self'",  
+      "'self'",
       "https://*.quill.org",
       "https://quill.org",
       "https://*.amplitude.com",
@@ -112,7 +112,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.coview.com",
       "https://*.sentry.io",
       "wss://*.quill.org",
-      "https://*.satismeter.com"
+      "https://*.satismeter.com",
+      "http://localhost:8080/"
     ]
   }
 


### PR DESCRIPTION
## WHAT
fix issue where semicolons were being inserted into responses after a user tries to insert a space at the beginning of a response after spacing feedback. Note: this also adds `http://localhost:8080/` to our `secure_headers` config so that we can make API calls from client to local instances of Go

## WHY
we don't want these characters inserted into student responses

## HOW
updated the `highlightSpellingGrammar` function to run a check for `&nbsp` characters

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Adding-a-space-to-the-beginning-of-an-Evidence-response-inserts-a-series-of-semicolons-79cec70d26f64d5a8503fca7fd5c598d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | (yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
