### PR TITLE
deleting active activity sessions

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::ActiveActivitySessionsController < Api::ApiController
-  before_action :activity_session_by_uid, only: [:show, :destroy]
+  before_action :activity_session_by_uid, only: [:show]
 
   def show
     render json: @activity_session.as_json
@@ -29,14 +29,9 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
     render json: @activity_session.as_json
   end
 
-  def destroy
-    @activity_session.destroy
-    render(plain: 'OK')
-  end
-
   private def working_params
     return valid_params unless params.dig(:active_activity_session, :passage)
-    permitted_passage_object = params[:active_activity_session][:passage].map do |paragraph| 
+    permitted_passage_object = params[:active_activity_session][:passage].map do |paragraph|
       paragraph.map do |word_object|
         word_object.permit!
       end

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -23,6 +23,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       status = :ok
       message = "Activity Session Updated"
       handle_concept_results
+      ActiveActivitySession.find_by_uid(@activity_session.uid)&.destroy if @activity_session.completed_at
     else
       status = :unprocessable_entity
       message = "Activity Session Update Failed"

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -156,7 +156,8 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       :activity_session_id,
       :concept_id,
       :concept_uid,
-      :question_type
+      :question_type,
+      :metadata
     ]
   end
 

--- a/services/QuillLMS/client/app/bundles/Connect/actions/sessions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/sessions.js
@@ -33,10 +33,6 @@ export default {
     SessionApi.update(sessionID, normalizedSession);
   },
 
-  delete(sessionID) {
-    SessionApi.remove(sessionID);
-  },
-
   populateQuestions(questionType, questions, forceRefresh) {
     if (questionsInitialized[questionType] && !forceRefresh) return;
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -252,7 +252,6 @@ export class Lesson extends React.Component {
       (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           // to do, use Sentry to capture error
-          SessionActions.delete(sessionID);
           document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${sessionID}`;
           this.setState({ saved: true, });
         } else {

--- a/services/QuillLMS/client/app/bundles/Connect/components/turk/turkActivity.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/turk/turkActivity.jsx
@@ -91,7 +91,6 @@ export class TurkActivity extends React.Component {
       (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           // to do, use Sentry to capture error
-          SessionActions.delete(sessionID);
           this.setState({ saved: true, });
         } else {
           // to do, use Sentry to capture error

--- a/services/QuillLMS/client/app/bundles/Connect/libs/sessions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/sessions_api.ts
@@ -1,4 +1,4 @@
-import { requestDelete, requestGet, requestPost, requestPut } from './request';
+import { requestGet, requestPut } from './request';
 
 const sessionApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/active_activity_sessions`;
 
@@ -9,10 +9,6 @@ class SessionApi {
 
   static update(uid: string, data: object): Promise<object> {
     return requestPut(`${sessionApiBaseUrl}/${uid}.json`, {active_activity_session: data});
-  }
-
-  static remove(uid: string): Promise<string> {
-    return requestDelete(`${sessionApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/sessions_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/sessions_api.test.ts
@@ -1,10 +1,8 @@
 import {
-  mockRequestDelete,
   mockRequestGet,
   mockRequestPut,
 } from '../__mocks__/request_wrapper'
 jest.mock('../../libs/request', () => ({
-  requestDelete: mockRequestDelete,
   requestGet: mockRequestGet,
   requestPut: mockRequestPut,
 }))
@@ -36,12 +34,4 @@ describe('SessionApi calls', () => {
     })
   })
 
-  describe('remove', () => {
-    it('should call requestDelete', () => {
-      const MOCK_ID = 'id'
-      const url = `${sessionApiBaseUrl}/${MOCK_ID}.json`
-      SessionApi.remove(MOCK_ID)
-      expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
-    })
-  })
 })

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/sessions.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/sessions.js
@@ -31,10 +31,6 @@ export default {
     SessionApi.update(sessionID, normalizedSession);
   },
 
-  delete(sessionID) {
-    SessionApi.remove(sessionID)
-  },
-
   populateQuestions(questionType, questions, forceRefresh) {
     if (questionsInitialized[questionType] && !forceRefresh) return;
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/diagnostics/studentDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/diagnostics/studentDiagnostic.jsx
@@ -217,7 +217,6 @@ export class StudentDiagnostic extends React.Component {
       (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           // to do, use Sentry to capture error
-          SessionActions.delete(sessionID);
           document.location.href = process.env.DEFAULT_URL
           this.setState({ saved: true, });
         } else {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
@@ -216,7 +216,6 @@ export class ELLStudentDiagnostic extends React.Component {
       }, (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           // to do, use Sentry to capture error
-          SessionActions.delete(sessionID);
           document.location.href = process.env.DEFAULT_URL
           this.setState({ saved: true, });
         } else {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/turk/turkDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/turk/turkDiagnostic.jsx
@@ -102,7 +102,6 @@ class TurkDiagnostic extends React.Component {
       (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           // to do, use Sentry to capture error
-          SessionActions.delete(sessionID);
           this.setState({ saved: true, });
         } else {
           // to do, use Sentry to capture error

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/sessions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/sessions_api.ts
@@ -10,10 +10,6 @@ class SessionApi {
   static update(uid: string, data: object): Promise<object> {
     return requestPut(`${sessionApiBaseUrl}/${uid}.json`, {active_activity_session: data});
   }
-
-  static remove(uid: string): Promise<string> {
-    return requestDelete(`${sessionApiBaseUrl}/${uid}.json`);
-  }
 }
 
 export {

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -269,10 +269,6 @@ export const checkAnswer = (response: string, question: Question, responses: Res
   }
 }
 
-export const removeSession = (sessionId: string) => {
-  SessionApi.remove(sessionId)
-}
-
 export const goToNextQuestion = () => {
   return dispatch => {
     dispatch({ type: ActionTypes.GO_T0_NEXT_QUESTION })

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -19,7 +19,6 @@ import {
   checkAnswer,
   startListeningToFollowUpQuestionsForProofreaderSession,
   startNewSession,
-  removeSession
 } from "../../actions/session";
 import { startListeningToConceptsFeedback } from '../../actions/conceptsFeedback'
 import { startListeningToConcepts } from '../../actions/concepts'
@@ -270,12 +269,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       }
     }
 
-    removeSession = () => {
-      const sessionID = getParameterByName('student', window.location.href)
-      const proofreaderSessionId = getParameterByName('proofreaderSessionId', window.location.href)
-      removeSession(sessionID || proofreaderSessionId);
-    }
-
     finishActivitySession = (sessionID: string, results: FormattedConceptResult[], score: number, data) => {
       request(
         { url: `${process.env.DEFAULT_URL}/api/v1/activity_sessions/${sessionID}`,
@@ -290,7 +283,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         },
         (err, httpResponse, body) => {
           if (httpResponse && httpResponse.statusCode === 200) {
-            this.removeSession()
             document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
             this.setState({ saved: true, });
           } else {
@@ -320,7 +312,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         },
         (err, httpResponse, body) => {
           if (httpResponse && httpResponse.statusCode === 200) {
-            this.removeSession()
             if (!showTurkCode && !previewMode) {
               document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
             }

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -110,9 +110,11 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
     }
 
     componentDidUpdate(prevProps) {
-      const { timeTracking, introSkipped, } = this.state
+      const { timeTracking, introSkipped, saved, saving, } = this.state
       const { previewMode, questions, questionToPreview, grammarActivities, session, skippedToQuestionFromIntro, dispatch, handleToggleQuestion, } = this.props;
       const { hasreceiveddata } = grammarActivities
+
+      if (saved || saving) { return }
 
       const activityUID = getParameterByName('uid', window.location.href)
 
@@ -283,8 +285,8 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         },
         (err, httpResponse, body) => {
           if (httpResponse && httpResponse.statusCode === 200) {
-            document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
             this.setState({ saved: true, });
+            document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
           } else {
             this.setState({
               saved: false,

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/sessions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/sessions_api.ts
@@ -1,4 +1,4 @@
-import { requestDelete, requestGet, requestPost, requestPut } from './request';
+import { requestGet, requestPut } from './request';
 
 const sessionApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/active_activity_sessions`;
 
@@ -9,10 +9,6 @@ class SessionApi {
 
   static update(uid: string, data: object): Promise<object> {
     return requestPut(`${sessionApiBaseUrl}/${uid}.json`, {active_activity_session: data});
-  }
-
-  static remove(uid: string): Promise<string> {
-    return requestDelete(`${sessionApiBaseUrl}/${uid}.json`);
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/libs/sessions_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/libs/sessions_api.test.ts
@@ -35,13 +35,4 @@ describe('SessionApi calls', () => {
       expect(mockRequestPut).toHaveBeenLastCalledWith(url, {active_activity_session: MOCK_CONTENT})
     })
   })
-
-  describe('remove', () => {
-    it('should call requestDelete', () => {
-      const MOCK_ID = 'id'
-      const url = `${sessionApiBaseUrl}/${MOCK_ID}.json`
-      SessionApi.remove(MOCK_ID)
-      expect(mockRequestDelete).toHaveBeenLastCalledWith(url)
-    })
-  })
 })

--- a/services/QuillLMS/client/app/bundles/Proofreader/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Proofreader/actions/session.ts
@@ -60,7 +60,3 @@ export const updateTimeTracking = (timeTracking: {[key:string]: number}) => {
     dispatch({ type: ActionTypes.SET_TIMETRACKING, timeTracking})
   }
 }
-
-export const removeSession = (sessionId: string) => {
-  SessionApi.remove(sessionId)
-}

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -28,7 +28,6 @@ import {
   updateConceptResultsOnFirebase,
   updateSessionOnFirebase,
   setSessionReducerToSavedSession,
-  removeSession,
   setPassage,
   updateTimeTracking
 } from "../../actions/session";
@@ -315,7 +314,6 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
         },
         (err, httpResponse, body) => {
           if (httpResponse && httpResponse.statusCode === 200) {
-            removeSession(sessionID)
             document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${sessionID}`;
           }
         }
@@ -337,7 +335,6 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
         },
         (err, httpResponse, body) => {
           if (httpResponse && httpResponse.statusCode === 200) {
-            if (sessionID) { removeSession(sessionID) }
             document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
           }
         }

--- a/services/QuillLMS/client/app/bundles/Proofreader/lib/sessions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Proofreader/lib/sessions_api.ts
@@ -10,10 +10,6 @@ class SessionApi {
   static update(uid: string, data: object): Promise<object> {
     return requestPut(`${sessionApiBaseUrl}/${uid}.json`, {active_activity_session: data});
   }
-
-  static remove(uid: string): Promise<string> {
-    return requestDelete(`${sessionApiBaseUrl}/${uid}.json`);
-  }
 }
 
 export {

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -466,7 +466,7 @@ EmpiricalGrammar::Application.routes.draw do
           put 'update_model_concept'
         end
       end
-      resources :active_activity_sessions, only: [:show, :update, :destroy]
+      resources :active_activity_sessions, only: [:show, :update]
       resources :activity_survey_responses, only: [:create]
       resources :student_problem_reports, only: [:create]
 

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -120,16 +120,4 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
     end
   end
 
-  describe "#destroy" do
-    it "should destroy the existing record" do
-      delete :destroy, params: { id: active_activity_session.uid }, as: :json
-      expect(ActiveActivitySession.where(uid: active_activity_session.uid).count).to eq(0)
-    end
-
-    it "should return a 404 if the requested activity session is not found" do
-      delete :destroy, params: { id: 'doesnotexist' }, as: :json
-      expect(response.status).to eq(404)
-      expect(response.body).to include("The resource you were looking for does not exist")
-    end
-  end
 end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -115,6 +115,15 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       end
     end
 
+    context 'the active activity session exists and the activity session is completed' do
+      it 'the active activity session gets deleted' do
+        active_activity_session = create(:active_activity_session, uid: activity_session.uid)
+
+        put :update, params: { id: activity_session.uid, state: 'finished' }, as: :json
+        expect(ActiveActivitySession.find_by_uid(activity_session.uid)).not_to be
+      end
+    end
+
     context 'data time_tracking is included ' do
 
       it 'updates timespent on activity session' do


### PR DESCRIPTION
## WHAT
Update how we delete active activity sessions so that we do it from the controller action that completes the `activity_session`, rather than making another request from the frontend once the `activity_session` has been completed.

## WHY
I discovered, as a result of investigating this Sentry error: https://sentry.io/organizations/quillorg-5s/issues/1631395843/?project=210579&query=is%3Aunresolved&statsPeriod=14d, that the request to delete the active activity session wasn't actually always being sent, because it often didn't finish executing before the redirect occurred. Rather than rewrite how that worked for every activity type, I just removed the code that was supposed to be handling it on the frontend and updated the controller action to implement that functionality itself. I think there is also a case to be made that this should just be done in a callback on `activity_session` when `completed_at` changes, but this seemed like the closest mimic of the existing behavior.

## HOW
Have the `update` controller action for `activity_sessions` delete the `active_activity_session` if there is one and the activity session has successfully been completed, and delete all the code that pertained to the older way of doing things.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-JS-Deleting-ActiveActivitySession-TypeError-a7ef31f5008b484c949dc16c6a747848

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |YES
