### PR TITLE
Bug-fix/ fix activity completion date for Activity Summary activity tooltip

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/activity_details.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/activity_details.test.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import ActivityDetails from '../activity_details';
 
 describe('ActivityDetails component', () => {
-  const baseData = { activity_classification_id: '4', caId: '12345', name: 'Sentence Structure Diagnostic', percentage: '1', updated: '2016-09-30 00:05:50.361093', userId: '666', scores: [{percentage: '1', completed_at: '2016-09-30 00:05:50.361093'}]};
+  const baseData = { activity_classification_id: '4', caId: '12345', name: 'Sentence Structure Diagnostic', percentage: '1', updated: '2016-10-17 00:05:50.361093', userId: '666', scores: [{percentage: '0.5', completed_at: '2016-09-30 00:05:50.361093'}, {percentage: '1', completed_at: '2016-10-17 00:05:50.361093'}]};
 
   it('should render div with appropriate class name depending on presence of concept results', () => {
     const wrapperNoConcepts = shallow(<ActivityDetails data={baseData} />);
@@ -38,7 +38,7 @@ describe('ActivityDetails component', () => {
       />
     );
     expect(wrapperWithCompletedAt.text()).toMatch('Completed:');
-    expect(wrapperWithCompletedAt.text()).toMatch('September 30, 2016');
+    expect(wrapperWithCompletedAt.text()).toMatch('October 17, 2016');
   });
 
   it('should render due date text if due', () => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
@@ -1,54 +1,58 @@
 import React from 'react';
 import moment from 'moment';
-import activityTypeFromClassificationId from '../../modules/activity_type_from_classification_id.js';
 
-export default class ActivityDetails extends React.Component {
-  getClassName = () => {
-    if (this.props.data.concept_results && this.props.data.concept_results.length) {
+export const ActivityDetails = ({ data }) => {
+
+  if (!Object.keys(data).length) { return <span /> }
+
+  const { concept_results, started_at, updated, scores, activity_description } = data;
+
+  function getClassName() {
+    if (concept_results && concept_results.length) {
       return 'activity-details';
     }
     return 'activity-details no-concept-results';
   };
 
-  detailOrNot = () => {
-    let dateTitle,
-    dateBody;
-    if (!this.props.data.concept_results || !this.props.data.concept_results.length) {
-      if (this.props.data.started_at) {
+  function detailOrNot() {
+    let dateTitle, dateBody;
+    if (!concept_results || !concept_results.length) {
+      if (started_at) {
         dateTitle = 'Started'
-        dateBody = this.props.data.started_at
+        dateBody = started_at
       }
     } else {
-      const firstScore = this.props.data.scores[0]
-      const firstCr = this.props.data.concept_results[0];
-      if (firstScore && firstScore.completed_at) {
+      const scoresExist = scores && scores.length;
+      const firstCr = concept_results[0];
+      // check if scores exist and use updated for most recent activity completion date
+      if (scoresExist && updated) {
         dateTitle = 'Completed';
-        dateBody = firstScore.completed_at;
+        dateBody = updated;
       } else {
         dateTitle = 'Due';
         dateBody = firstCr.due_date;
       }
     }
-    const obj = this.props.data.activity_description;
-    const objSection = obj ? <p><strong>Objectives:</strong>{` ${obj}`}</p> : <span />
+    const objectiveSection = activity_description ? <p><strong>Objectives:</strong>{` ${activity_description}`}</p> : <span />
     const dateSection = dateTitle ? <p><strong>{`${dateTitle}: `}</strong>{`${moment(dateBody).format('MMMM D, YYYY')}`}</p> : <span />
+
     return (
       <div className="activity-detail">
-        {objSection}
+        {objectiveSection}
         {dateSection}
       </div>
     );
   };
 
-  render() {
-    return (
-      <div className={this.getClassName()}>
-        <div className="activity-detail">
-          <div className="activity-detail-body">
-            {this.detailOrNot()}
-          </div>
+  return (
+    <div className={getClassName()}>
+      <div className="activity-detail">
+        <div className="activity-detail-body">
+          {detailOrNot()}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+export default ActivityDetails


### PR DESCRIPTION
## WHAT
fix activity completion date for Activity Summary activity tooltip

## WHY
we want to display the date for the most recently completed activity session

## HOW
use `updated` value rather than the first score's `completed_at` value in the `scores` array

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Activity-Summary-date-does-not-update-with-latest-attemp-45227e8bf7d943e58e6e827fd96b231e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
