### PR TITLE
add prefilter to universal rules dropdown

### DIFF
--- a/services/QuillLMS/client/app/constants/evidence.ts
+++ b/services/QuillLMS/client/app/constants/evidence.ts
@@ -113,7 +113,8 @@ export const ruleTypeOptions = [
 export const universalRuleTypeOptions = [
   {"value":"grammar","label":"Grammar"},
   {"value":"opinion","label":"Opinion"},
-  {"value":"spelling","label":"Spelling"}
+  {"value":"spelling","label":"Spelling"},
+  {"value":"prefilter","label":"Prefilter"} 
 ];
 
 export const ruleHighlightOptions = [


### PR DESCRIPTION
## WHAT
adds prefilter to dropdown 

## WHY
Sometimes, staff wants to edit or create universal rules of type `prefilter` 

## HOW
adds new label to static list 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Frontend-Admin-add-prefilter-to-u-rules-dropdown-b6ce5325d98a408eb28246765aac97fd)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
