### PR TITLE
Fix new year's bug with Vitally Workers

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -57,7 +57,7 @@ class SerializeVitallySalesAccount
   end
 
   private def get_from_cache(key)
-    last_school_year = Date.today.year - 1
+    last_school_year = School.school_year_start(Date.today - 1.year).year
     cached_data = CacheVitallySchoolData.get(@school.id, last_school_year)
     if cached_data.present?
       parsed_data = JSON.parse(cached_data)

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -102,7 +102,7 @@ class SerializeVitallySalesUser
   end
 
   private def get_from_cache(key)
-   last_school_year = Date.today.year - 1
+   last_school_year = School.school_year_start(Date.today - 1.year).year
     cached_data = CacheVitallyTeacherData.get(@user.id, last_school_year)
     if cached_data.present?
       parsed_data = JSON.parse(cached_data)

--- a/services/QuillLMS/app/workers/populate_annual_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/populate_annual_vitally_worker.rb
@@ -9,7 +9,7 @@ class PopulateAnnualVitallyWorker
     # Don't synchronize non-production data
     return unless ENV['SYNC_TO_VITALLY'] == 'true'
 
-    year_to_sync = Date.today.year - 1
+    year_to_sync = School.school_year_start(Date.today - 1.year).year
     schools_to_sync.each_slice(100) do |school_batch|
       school_ids = school_batch.map(&:id)
       SyncVitallyPastYearAccountsWorker.perform_async(school_ids, year_to_sync)

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -26,7 +26,7 @@ describe 'SerializeVitallySalesAccount' do
       activities_finished: 1,
       activities_per_student: 1.0
     }
-    year = Date.today.year - 1
+    year = School.school_year_start(Date.today - 1.year).year
     CacheVitallySchoolData.set(school.id, year, previous_year_data.to_json)
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -35,7 +35,7 @@ describe 'SerializeVitallySalesUser' do
       diagnostics_finished: 2,
       percent_completed_diagnostics: 1.0
     }
-    year = Date.today.year - 1
+    year = School.school_year_start(Date.today - 1.year).year
     CacheVitallyTeacherData.set(teacher.id, year, previous_year_data.to_json)
   end
 

--- a/services/QuillLMS/spec/workers/populate_annual_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_annual_vitally_worker_spec.rb
@@ -7,7 +7,7 @@ describe PopulateAnnualVitallyWorker do
 
   describe "#perform" do
     it "make queries for schools and users and enqueue them for further jobs" do
-      past_year = Date.today.year - 1
+      past_year = School.school_year_start(Date.today - 1.year).year
       ENV['SYNC_TO_VITALLY'] = 'true'
       school = create(:school)
       user = create(:user)


### PR DESCRIPTION
## WHAT
We encountered a bug when the year changed to 2022 with Vitally workers. This fixes it by accurately calculating the last school year using the `school_year_start` method.

## WHY
All the jobs are failing right now because it is trying to calculate previous year data for the year 2021 (which is a still-ongoing school year).

## HOW
Our code is using a quick-and-dirty way to calculate the last school year, subtracting one year from the current date. However this doesn't work in 2022 because the last school year varies based on whether the current date is before or after July (e.g. the last school year right now is 2020, because the last school year began on August 1, 2020, but in October 2022, the last school year will be 2021 because we've entered the 2022-2023 school year).

We already wrote the logic to calculate the date of the beginning of the school year in `School.school_year_start`, so I'm just calling this method with today's date minus one year to get the accurate year of the last school year.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=3736cb90594e4b3fb3f114cab8382aad

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
