### PR TITLE
Fix bug involving google classrooms importing wrong classes

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -307,6 +307,7 @@ module Teacher
 
   def google_classrooms
     Classroom
+      .unscoped
       .joins(:classrooms_teachers)
       .where(classrooms_teachers: { user_id: id })
       .where.not(google_classroom_id: nil)
@@ -314,6 +315,7 @@ module Teacher
 
   def clever_classrooms
     Classroom
+      .unscoped
       .joins(:classrooms_teachers)
       .where(classrooms_teachers: { user_id: id })
       .where.not(clever_id: nil)

--- a/services/QuillLMS/app/services/google_integration/teacher_imported_classrooms_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_imported_classrooms_updater.rb
@@ -13,7 +13,7 @@ module GoogleIntegration
     end
 
     private def classroom_data(classroom)
-      classrooms_data.detect { |data| data[:google_classroom_id] = classroom.google_classroom_id }
+      classrooms_data.detect { |data| data[:google_classroom_id] == classroom.google_classroom_id }
     end
 
     private def classrooms_data
@@ -25,7 +25,7 @@ module GoogleIntegration
     end
 
     private def imported_classrooms
-      teacher.google_classrooms.unscoped.where(google_classroom_id: google_classroom_ids, visible: true)
+      teacher.google_classrooms.where(google_classroom_id: google_classroom_ids, visible: true)
     end
 
     private def serialized_classrooms_data

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -424,15 +424,34 @@ describe User, type: :model do
     end
 
     describe '#google_classrooms' do
-      let(:google_classroom) { create(:classroom, :from_google) }
+      let!(:google_classroom) { create(:classroom, :from_google) }
+      let!(:archived_google_classroom) { create(:classroom, :from_google, :with_no_teacher, :archived) }
       let(:google_classroom_teacher) { google_classroom.owner }
 
+      before { create(:classrooms_teacher, user: google_classroom_teacher, classroom: archived_google_classroom) }
+
       it "should return all the teacher's google classrooms" do
-        expect(google_classroom_teacher.google_classrooms).to eq([google_classroom])
+        expect(google_classroom_teacher.google_classrooms).to match_array [google_classroom, archived_google_classroom]
       end
 
       it 'should return empty if there are no google classrooms' do
         expect(teacher.google_classrooms).to eq([])
+      end
+    end
+
+    describe '#clever_classrooms' do
+      let!(:clever_classroom) { create(:classroom, :from_clever) }
+      let!(:archived_clever_classroom) { create(:classroom, :from_clever, :with_no_teacher, :archived) }
+      let(:clever_classroom_teacher) { clever_classroom.owner }
+
+      before { create(:classrooms_teacher, user: clever_classroom_teacher, classroom: archived_clever_classroom) }
+
+      it "should return all the teacher's clever classrooms" do
+        expect(clever_classroom_teacher.clever_classrooms).to match_array [clever_classroom, archived_clever_classroom]
+      end
+
+      it 'should return empty if there are no clever classrooms' do
+        expect(teacher.clever_classrooms).to eq([])
       end
     end
 
@@ -552,7 +571,7 @@ describe User, type: :model do
       it 'should return only the correct students assigned' do
         student_ids = assigned_units.pluck(:assigned_student_ids).flatten
 
-        other_teacher = create(:teacher, :with_classrooms_students_and_activities) 
+        other_teacher = create(:teacher, :with_classrooms_students_and_activities)
         other_assigned_activities_ids = other_teacher.assigned_students_per_activity_assigned.pluck(:id)
         other_student_ids = other_teacher.assigned_students_per_activity_assigned
           .pluck(:assigned_student_ids)


### PR DESCRIPTION
## WHAT
Fix a bug where teachers are reporting that their classes have suddenly been renamed. 

## WHY
Teachers are seeing the wrong classes

## HOW
Make sure scopes for `google_classrooms` are correct and then fix errant `=` to `==`equality check.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Teachers-reporting-classes-have-been-renamed-3e5d4ca8627a40fb842e36bc423cd36c)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | No.  Hot-fix
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
