### PR TITLE
allow for multiple plagiarism text strings

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -2,18 +2,29 @@
 
 exports[`RulePlagiarismAttributes component should render RulePlagiarismAttributes 1`] = `
 <Fragment>
-  <p
-    className="form-subsection-label"
-  >
-    Plagiarism Text
-  </p>
-  <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
-    handleTextChange={[Function]}
-    key="plagiarism-text"
-    shouldCheckSpelling={true}
+  <PlagiarismTextEditor
+    index={0}
+    key="0"
+    setPlagiarismText={[Function]}
   />
+  <div
+    className="button-wrapper"
+  >
+    <button
+      className="add-highlight quill-button small primary outlined"
+      onClick={[Function]}
+      type="button"
+    >
+      Add Text String
+    </button>
+    <button
+      className="remove-highlight quill-button small primary outlined"
+      onClick={[Function]}
+      type="button"
+    >
+      Remove Text String
+    </button>
+  </div>
   <p
     className="form-subsection-label"
   >

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -6,6 +6,13 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     index={0}
     key="0"
     setPlagiarismText={[Function]}
+    text="test plagiarism text"
+  />
+  <PlagiarismTextEditor
+    index={1}
+    key="1"
+    setPlagiarismText={[Function]}
+    text="test another plagiarism text"
   />
   <div
     className="button-wrapper"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
@@ -19,8 +19,8 @@ jest.mock("react-query", () => ({
 }));
 
 const mockRules = [
-  { id: 1, name: 'rule_1', state: 'active', plagiarism_text: { text: 'do not plagiarize!' }, label: { id: 1, name: 'label_1' }, prompt_ids: [7] },
-  { id: 2, name: 'rule_2', state: 'active', plagiarism_text: { text: 'seriously!' }, label: { id: 2, name: 'label_2' }, prompt_ids: [9] },
+  { id: 1, name: 'rule_1', state: 'active', plagiarism_texts: [{ text: 'do not plagiarize!' }], label: { id: 1, name: 'label_1' }, prompt_ids: [7] },
+  { id: 2, name: 'rule_2', state: 'active', plagiarism_texts: [{ text: 'seriously!' }], label: { id: 2, name: 'label_2' }, prompt_ids: [9] },
 ]
 const mockProps = {
   match: {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
@@ -7,7 +7,7 @@ import { TextEditor } from '../../../../Shared/index'
 const mockProps = {
   errors: {},
   plagiarismFeedbacks: [{ text: 'do not plagiarize.' }, { text: 'seriously... do not plagiarize!' }],
-  plagiarismTexts: ['test plagiarism text'],
+  plagiarismTexts: [{ text: 'test plagiarism text', }],
   setPlagiarismFeedbacks: jest.fn(),
   setPlagiarismTexts: jest.fn()
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
@@ -1,26 +1,28 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
-import RulePlagiarismAttributes from '../configureRules/rulePlagiarismAttributes';
+import RulePlagiarismAttributes, { PlagiarismTextEditor, } from '../configureRules/rulePlagiarismAttributes';
 import { TextEditor } from '../../../../Shared/index'
 
 const mockProps = {
   errors: {},
   plagiarismFeedbacks: [{ text: 'do not plagiarize.' }, { text: 'seriously... do not plagiarize!' }],
-  plagiarismTexts: [{ text: 'test plagiarism text', }],
+  plagiarismTexts: [{ text: 'test plagiarism text', }, { text: 'test another plagiarism text', }],
   setPlagiarismFeedbacks: jest.fn(),
   setPlagiarismTexts: jest.fn()
 };
 
 describe('RulePlagiarismAttributes component', () => {
-  let container = mount(<RulePlagiarismAttributes {...mockProps} />);
+  let container = shallow(<RulePlagiarismAttributes {...mockProps} />);
 
   it('should render RulePlagiarismAttributes', () => {
     expect(container).toMatchSnapshot();
   });
 
   it('should render the appropriate form components', () => {
-    // TextEditor: Plagiarism Text, First Plagiarism Feedback, Second Plagiarism Feedback (3)
-    expect(container.find(TextEditor).length).toEqual(3);
+    // TextEditor: First Plagiarism Feedback, Second Plagiarism Feedback (2)
+    // Plagiarism Text Editor: Plagiarism Text - Text String 1, Plagiarism Text - Text String 2 (2)
+    expect(container.find(TextEditor).length).toEqual(2);
+    expect(container.find(PlagiarismTextEditor).length).toEqual(2);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
@@ -7,9 +7,9 @@ import { TextEditor } from '../../../../Shared/index'
 const mockProps = {
   errors: {},
   plagiarismFeedbacks: [{ text: 'do not plagiarize.' }, { text: 'seriously... do not plagiarize!' }],
-  plagiarismText: 'test plagiarism text',
+  plagiarismTexts: ['test plagiarism text'],
   setPlagiarismFeedbacks: jest.fn(),
-  setPlagiarismText: jest.fn()
+  setPlagiarismTexts: jest.fn()
 };
 
 describe('RulePlagiarismAttributes component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulePlagiarismAttributes.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import RulePlagiarismAttributes from '../configureRules/rulePlagiarismAttributes';
 import { TextEditor } from '../../../../Shared/index'
@@ -13,7 +13,7 @@ const mockProps = {
 };
 
 describe('RulePlagiarismAttributes component', () => {
-  let container = shallow(<RulePlagiarismAttributes {...mockProps} />);
+  let container = mount(<RulePlagiarismAttributes {...mockProps} />);
 
   it('should render RulePlagiarismAttributes', () => {
     expect(container).toMatchSnapshot();

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rule.tsx
@@ -39,13 +39,16 @@ const Rule = ({ history, match }) => {
     setShowDeleteRuleModal(!showDeleteRuleModal);
   }
 
-  function handleAttributesFields(feedbacks, plagiarism_text) {
+  function handleAttributesFields(feedbacks, plagiarism_texts) {
     let attributesArray = [];
-    if(plagiarism_text && plagiarism_text.text) {
-      attributesArray = [{
-        label: 'Plagiarism Text',
-        value: stripHtml(plagiarism_text.text)
-      }];
+    if (plagiarism_texts && plagiarism_texts[0]) {
+      attributesArray = plagiarism_texts.map((plagiarism_text, i) => {
+        const { text } = plagiarism_text;
+        return {
+          label: `Plagiarism Text - Text String ${i + 1}`,
+          value: stripHtml(text)
+        }
+      });
     }
     const feedbacksArray = feedbacks.map((feedback, i) => {
       const { text } = feedback;
@@ -62,9 +65,9 @@ const Rule = ({ history, match }) => {
       return [];
     } else {
       // format for DataTable to display labels on left side and values on right
-      const { note, feedbacks, name, prompt_ids, rule_type, plagiarism_text } = rule;
+      const { note, feedbacks, name, prompt_ids, rule_type, plagiarism_texts } = rule;
       const promptsIcons = getPromptsIcons(activityData, prompt_ids);
-      const attributesFields = handleAttributesFields(feedbacks, plagiarism_text);
+      const attributesFields = handleAttributesFields(feedbacks, plagiarism_texts);
       const firstFields = [
         {
           label: 'Type',

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleForm.tsx
@@ -27,15 +27,15 @@ interface RuleFormProps {
 
 const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestErrors,  rule, submitRule, universalRuleType }: RuleFormProps) => {
 
-  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, note, feedbacks, conditional } = rule;
+  const { name, rule_type, id, uid, optimal, plagiarism_texts, concept_uid, note, feedbacks, conditional } = rule;
   const initialRuleType = getInitialRuleType({ isUniversal, rule_type, universalRuleType});
   const initialRuleOptimal = optimal ? ruleOptimalOptions[0] : ruleOptimalOptions[1];
-  const initialPlagiarismText = plagiarism_text || { text: '' }
+  const initialPlagiarismTexts = plagiarism_texts || [{ text: '' }]
   const initialNote = note || '';
   const initialFeedbacks = feedbacks ? formatInitialFeedbacks(feedbacks) : returnInitialFeedback(initialRuleType.value);
 
   const [errors, setErrors] = React.useState<object>({});
-  const [plagiarismText, setPlagiarismText] = React.useState<RuleInterface["plagiarism_text"]>(initialPlagiarismText);
+  const [plagiarismTexts, setPlagiarismTexts] = React.useState<RuleInterface["plagiarism_texts"]>(initialPlagiarismTexts);
   const [regexRules, setRegexRules] = React.useState<object>({});
   const [ruleConceptUID, setRuleConceptUID] = React.useState<string>(concept_uid);
   const [ruleNote, setRuleNote] = React.useState<string>(initialNote);
@@ -93,7 +93,7 @@ const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestEr
 
   function onHandleSubmitRule() {
     handleSubmitRule({
-      plagiarismText,
+      plagiarismTexts,
       regexRules,
       rule,
       ruleName,
@@ -144,9 +144,9 @@ const RuleForm = ({ activityData, activityId, closeModal, isUniversal, requestEr
         {ruleType && ruleType.value === PLAGIARISM && <RulePlagiarismAttributes
           errors={errors}
           plagiarismFeedbacks={ruleFeedbacks}
-          plagiarismText={plagiarismText}
+          plagiarismTexts={plagiarismTexts}
           setPlagiarismFeedbacks={setRuleFeedbacks}
-          setPlagiarismText={setPlagiarismText}
+          setPlagiarismTexts={setPlagiarismTexts}
         />}
         {ruleType && regexRuleTypes.includes(ruleType.value) && <RuleRegexAttributes
           errors={errors}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -12,7 +12,7 @@ import { HIGHLIGHT_ADDITION, HIGHLIGHT_REMOVAL, FEEDBACK, } from '../../../../..
 
 // TODO: add props interface
 
-const PlagiarismTextEditor = ({ text, index, setPlagiarismText, }) => {
+export const PlagiarismTextEditor = ({ text, index, setPlagiarismText, }) => {
   function onHandleSetPlagiarismText(text) {
     setPlagiarismText(text, index)
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { EditorState, ContentState } from 'draft-js'
 
 import {
-  handleSetPlagiarismText,
+  handleSetPlagiarismTexts,
   renderHighlights,
   handleSetFeedback
 } from '../../../helpers/evidence/ruleHelpers';
@@ -12,15 +12,44 @@ import { HIGHLIGHT_ADDITION, HIGHLIGHT_REMOVAL, FEEDBACK, } from '../../../../..
 
 // TODO: add props interface
 
+const PlagiarismTextEditor = ({ text, index, setPlagiarismText, }) => {
+  function onHandleSetPlagiarismText(text) {
+    setPlagiarismText(text, index)
+  }
+
+  return (<React.Fragment key={index}>
+    <p className="form-subsection-label">Plagiarism Text - Text String {index + 1}</p>
+    <TextEditor
+      ContentState={ContentState}
+      EditorState={EditorState}
+      handleTextChange={onHandleSetPlagiarismText}
+      key={`plagiarism-text-${index}`}
+      shouldCheckSpelling={true}
+      text={text}
+    />
+  </React.Fragment>)
+}
+
 const RulePlagiarismAttributes = ({
   errors,
   plagiarismFeedbacks,
-  plagiarismText,
+  plagiarismTexts,
   setPlagiarismFeedbacks,
-  setPlagiarismText
+  setPlagiarismTexts
 }) => {
 
-  function onHandleSetPlagiarismText(text: string) { handleSetPlagiarismText(text, plagiarismText, setPlagiarismText)}
+  function onAddPlagiarismTextString() {
+    const newPlagiarismTexts = [...plagiarismTexts, { text: '', }]
+    setPlagiarismTexts(newPlagiarismTexts)
+  }
+
+  function onRemovePlagiarismTextString() {
+    const newPlagiarismTexts = [...plagiarismTexts]
+    newPlagiarismTexts.pop()
+    setPlagiarismTexts(newPlagiarismTexts)
+  }
+
+  function onHandleSetPlagiarismText(text: string, index: number) { handleSetPlagiarismTexts(text, index, plagiarismTexts, setPlagiarismTexts)}
 
   function onHandleSetPlagiarismFeedback(text: string, i: number, j: number, updateType:  string) {
     handleSetFeedback({
@@ -64,17 +93,22 @@ const RulePlagiarismAttributes = ({
 
   // TODO: break out Plagiarism feedbacks into separate components
 
+    const plagiarismTextEditorElements = plagiarismTexts.map((plagiarismText, i) => {
+      return (<PlagiarismTextEditor
+        index={i}
+        key={i}
+        setPlagiarismText={onHandleSetPlagiarismText}
+        text={plagiarismText.text}
+      />)
+    })
+
     return(
       <React.Fragment>
-        <p className="form-subsection-label">Plagiarism Text</p>
-        {plagiarismText && <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
-          handleTextChange={onHandleSetPlagiarismText}
-          key="plagiarism-text"
-          shouldCheckSpelling={true}
-          text={plagiarismText.text}
-        />}
+        {plagiarismTextEditorElements}
+        <div className="add-and-remove-plagiarism-buttons">
+          <button className="quill-button small primary outlined" onClick={onAddPlagiarismTextString} type="button">Add Text String</button>
+          {!!plagiarismTexts.length && <button className="quill-button small primary outlined" onClick={onRemovePlagiarismTextString} type="button">Remove Text String</button>}
+        </div>
         {errors['Plagiarism Text'] && <p className="error-message">{errors['Plagiarism Text']}</p>}
         <p className="form-subsection-label">First Feedback</p>
         {plagiarismFeedbacks[0] && <TextEditor

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -44,9 +44,11 @@ const RulePlagiarismAttributes = ({
   }
 
   function onRemovePlagiarismTextString() {
-    const newPlagiarismTexts = [...plagiarismTexts]
-    newPlagiarismTexts.pop()
-    setPlagiarismTexts(newPlagiarismTexts)
+    if (window.confirm('Are you sure you want to remove this text string?')) {
+      const newPlagiarismTexts = [...plagiarismTexts]
+      newPlagiarismTexts[plagiarismTexts.length - 1]._destroy = true
+      setPlagiarismTexts(newPlagiarismTexts)
+    }
   }
 
   function onHandleSetPlagiarismText(text: string, index: number) { handleSetPlagiarismTexts(text, index, plagiarismTexts, setPlagiarismTexts)}
@@ -94,6 +96,8 @@ const RulePlagiarismAttributes = ({
   // TODO: break out Plagiarism feedbacks into separate components
 
     const plagiarismTextEditorElements = plagiarismTexts.map((plagiarismText, i) => {
+      if (plagiarismText._destroy) { return <span /> }
+
       return (<PlagiarismTextEditor
         index={i}
         key={i}
@@ -105,9 +109,9 @@ const RulePlagiarismAttributes = ({
     return(
       <React.Fragment>
         {plagiarismTextEditorElements}
-        <div className="add-and-remove-plagiarism-buttons">
-          <button className="quill-button small primary outlined" onClick={onAddPlagiarismTextString} type="button">Add Text String</button>
-          {!!plagiarismTexts.length && <button className="quill-button small primary outlined" onClick={onRemovePlagiarismTextString} type="button">Remove Text String</button>}
+        <div className="button-wrapper">
+          <button className="add-highlight quill-button small primary outlined" onClick={onAddPlagiarismTextString} type="button">Add Text String</button>
+          {!!plagiarismTexts.length && <button className="remove-highlight quill-button small primary outlined" onClick={onRemovePlagiarismTextString} type="button">Remove Text String</button>}
         </div>
         {errors['Plagiarism Text'] && <p className="error-message">{errors['Plagiarism Text']}</p>}
         <p className="form-subsection-label">First Feedback</p>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -53,11 +53,11 @@ const RuleViewForm = ({
   const { params } = match;
   const { promptId } = params;
 
-  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, note, feedbacks, state, label, conditional } = rule;
+  const { name, rule_type, id, uid, optimal, plagiarism_texts, concept_uid, note, feedbacks, state, label, conditional } = rule;
 
   const initialRuleType = getInitialRuleType({ isUniversal, rule_type, universalRuleType: null});
   const initialRuleOptimal = optimal ? ruleOptimalOptions[0] : ruleOptimalOptions[1];
-  const initialPlagiarismText = plagiarism_text || { text: '' }
+  const initialPlagiarismTexts = plagiarism_texts || [{ text: '' }]
   const initalNote = note || '';
   const initialFeedbacks = feedbacks ? formatInitialFeedbacks(feedbacks) : returnInitialFeedback(initialRuleType.value);
   const initialLabel = label && label.name;
@@ -66,7 +66,7 @@ const RuleViewForm = ({
 
   const [errors, setErrors] = React.useState<object>({});
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
-  const [plagiarismText, setPlagiarismText] = React.useState<RuleInterface["plagiarism_text"]>(initialPlagiarismText);
+  const [plagiarismTexts, setPlagiarismTexts] = React.useState<RuleInterface["plagiarism_texts"]>(initialPlagiarismTexts);
   const [regexRules, setRegexRules] = React.useState<object>({});
   const [ruleConditional, setRuleConditional] = React.useState<boolean>(initialConditional)
   const [ruleConceptUID, setRuleConceptUID] = React.useState<string>(concept_uid || '');
@@ -126,7 +126,7 @@ const RuleViewForm = ({
   function onHandleSubmitRule() {
     setIsLoading(true);
     handleSubmitRule({
-      plagiarismText,
+      plagiarismTexts,
       regexRules,
       rule,
       ruleId: id,
@@ -237,9 +237,9 @@ const RuleViewForm = ({
         {ruleType && ruleType.value === PLAGIARISM && <RulePlagiarismAttributes
           errors={errors}
           plagiarismFeedbacks={ruleFeedbacks}
-          plagiarismText={plagiarismText}
+          plagiarismTexts={plagiarismTexts}
           setPlagiarismFeedbacks={setRuleFeedbacks}
-          setPlagiarismText={setPlagiarismText}
+          setPlagiarismTexts={setPlagiarismTexts}
         />}
         {ruleType && regexRuleTypes.includes(ruleType.value) && <RuleRegexAttributes
           errors={errors}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesIndex.tsx
@@ -55,18 +55,14 @@ const PlagiarismRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = 
     if(!filteredRule) {
       return [];
     }
-    const { id, plagiarism_text, feedbacks } = filteredRule;
+
+    const { id, plagiarism_texts, feedbacks } = filteredRule;
     const linkSection = {
       label: '',
       value: (<Link className="data-link" to={`/activities/${activityId}/plagiarism-rules/${id}`}>View</Link>)
     };
     const feedbacksSection = getFeedbacks(feedbacks);
-    let fields: any = [
-      {
-        label: 'Plagiarism Text',
-        value: plagiarism_text ? plagiarism_text.text : ''
-      }
-    ];
+    let fields: any = getPlagiarismTexts(plagiarism_texts)
     fields = fields.concat(feedbacksSection);
     fields.push(linkSection);
     return fields.map((field, i) => {
@@ -84,6 +80,25 @@ const PlagiarismRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = 
       const { text } = feedback;
       return {
         label: `Feedback ${i + 1}`,
+        value: stripHtml(text)
+      }
+    })
+  }
+
+  function getPlagiarismTexts(plagiarismTexts) {
+    if (plagiarismTexts.length === 0) {
+      return [
+        {
+          label: 'Plagiarism Text - Text String 1',
+          value: ''
+        }
+      ]
+    }
+
+    return plagiarismTexts.map((plagiarismText, i) => {
+      const { text } = plagiarismText;
+      return {
+        label: `Plagiarism Text - Text String ${i + 1}`,
         value: stripHtml(text)
       }
     })

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelForm.tsx
@@ -35,11 +35,11 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
   const { params } = match;
   const { promptId } = params;
 
-  const { name, rule_type, id, uid, optimal, plagiarism_text, concept_uid, note, feedbacks, state, label, conditional } = rule;
+  const { name, rule_type, id, uid, optimal, plagiarism_texts, concept_uid, note, feedbacks, state, label, conditional } = rule;
 
   const initialRuleType = getInitialRuleType({ isUniversal, rule_type, universalRuleType: null});
   const initialRuleOptimal = optimal ? ruleOptimalOptions[0] : ruleOptimalOptions[1];
-  const initialPlagiarismText = plagiarism_text || { text: '' }
+  const initialPlagiarismTexts = plagiarism_texts || [{ text: '' }]
   const initialNote = note || '';
   const initialFeedbacks = feedbacks ? formatInitialFeedbacks(feedbacks) : returnInitialFeedback(initialRuleType.value);
   const initialLabel = label && label.name;
@@ -48,7 +48,7 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
 
   const [errors, setErrors] = React.useState<object>({});
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
-  const [plagiarismText, setPlagiarismText] = React.useState<RuleInterface["plagiarism_text"]>(initialPlagiarismText);
+  const [plagiarismTexts, setPlagiarismTexts] = React.useState<RuleInterface["plagiarism_texts"]>(initialPlagiarismTexts);
   const [regexRules, setRegexRules] = React.useState<object>({});
   const [ruleConceptUID, setRuleConceptUID] = React.useState<string>(concept_uid || '');
   const [ruleNote, setRuleNote] = React.useState<string>(initialNote);
@@ -120,7 +120,7 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
   function onHandleSubmitRule() {
     setIsLoading(true);
     handleSubmitRule({
-      plagiarismText,
+      plagiarismTexts,
       regexRules,
       rule,
       ruleId: id,
@@ -219,9 +219,9 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
         {ruleType && ruleType.value === PLAGIARISM && <RulePlagiarismAttributes
           errors={errors}
           plagiarismFeedbacks={ruleFeedbacks}
-          plagiarismText={plagiarismText}
+          plagiarismTexts={plagiarismTexts}
           setPlagiarismFeedbacks={setRuleFeedbacks}
-          setPlagiarismText={setPlagiarismText}
+          setPlagiarismTexts={setPlagiarismTexts}
         />}
         {ruleType && regexRuleTypes.includes(ruleType.value) && <RuleRegexAttributes
           errors={errors}

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -33,10 +33,10 @@ export function handleSetRuleConceptUID(value, setRuleConceptUID) { setRuleConce
 
 export function handleSetRuleNote(text: string, setRuleNote) { setRuleNote(text) }
 
-export function handleSetPlagiarismText(text: string, plagiarismText, setPlagiarismText) {
-  const plagiarismTextObject = {...plagiarismText};
-  plagiarismTextObject.text = text;
-  setPlagiarismText(plagiarismTextObject)
+export function handleSetPlagiarismTexts(text: string, index: number, plagiarismTexts, setPlagiarismTexts) {
+  const newPlagiarismTexts = [...plagiarismTexts]
+  newPlagiarismTexts[index].text = text;
+  setPlagiarismTexts(newPlagiarismTexts)
 }
 
 export function handleRulePromptChange(e: InputEvent, rulePrompts, setRulePrompts) {
@@ -286,7 +286,7 @@ const buildFeedbacks = (feedbacks) => {
 }
 
 export const buildRule = ({
-  plagiarismText,
+  plagiarismTexts,
   regexRules,
   rule,
   rulesCount,
@@ -336,10 +336,11 @@ export const buildRule = ({
     });
     newOrUpdatedRule.regex_rules_attributes = rules;
   } else if(newOrUpdatedRule.rule_type === PLAGIARISM) {
-    newOrUpdatedRule.plagiarism_text_attributes = {
+    const rules = plagiarismTexts.map(plagiarismText => ({
       id: plagiarismText.id,
       text: stripHtml(plagiarismText.text)
-    };
+    }))
+    newOrUpdatedRule.plagiarism_texts_attributes = rules
   } else if(newOrUpdatedRule.rule_type === AUTO_ML) {
     newOrUpdatedRule.label_attributes = {
       name: ruleLabelName
@@ -352,7 +353,7 @@ export const buildRule = ({
 }
 
 export async function handleSubmitRule({
-  plagiarismText,
+  plagiarismTexts,
   regexRules,
   rule,
   ruleName,
@@ -372,7 +373,7 @@ export async function handleSubmitRule({
   universalRulesCount
 }) {
   const newOrUpdatedRule = buildRule({
-    plagiarismText,
+    plagiarismTexts,
     regexRules,
     rule,
     ruleName,
@@ -399,8 +400,12 @@ export async function handleSubmitRule({
       state.push(regexRules[key].regex_text);
     });
   } else if(ruleType.value === PLAGIARISM) {
-    keys = keys.concat(['Plagiarism Text', 'First Plagiarism Feedback', 'Second Plagiarism Feedback']);
-    state = state.concat([plagiarismText.text, ruleFeedbacks[0].text, ruleFeedbacks[1].text]);
+    plagiarismTexts.map((plagiarismText, i) => {
+      keys.push(`Plagiarism Text - Text String ${i + 1}`);
+      state.push(plagiarismText.text);
+    });
+    keys = keys.concat(['First Plagiarism Feedback', 'Second Plagiarism Feedback']);
+    state = state.concat([ruleFeedbacks[0].text, ruleFeedbacks[1].text]);
   } else if(ruleType.value === AUTO_ML) {
     keys.push('Label Name');
     state.push(ruleLabelName);

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -337,7 +337,7 @@ export const buildRule = ({
     newOrUpdatedRule.regex_rules_attributes = rules;
   } else if(newOrUpdatedRule.rule_type === PLAGIARISM) {
     const rules = plagiarismTexts.map(plagiarismText => ({
-      id: plagiarismText.id,
+      ...plagiarismText,
       text: stripHtml(plagiarismText.text)
     }))
     newOrUpdatedRule.plagiarism_texts_attributes = rules

--- a/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
@@ -68,6 +68,12 @@ export interface PassagesInterface {
   highlight_prompt?: string
 }
 
+export interface PlagiarismText {
+  id?: number,
+  rule_id?: number,
+  text: string
+}
+
 export interface RuleInterface {
   id?: number,
   uid?: string,
@@ -85,11 +91,7 @@ export interface RuleInterface {
     id: number,
     name: string
   },
-  plagiarism_text?: {
-    id?: number,
-    rule_id?: number,
-    text: string
-  }
+  plagiarism_texts?: PlagiarismText[],
   regex_rules?: RegexRuleInterface[]
   regex_rules_attributes?: RegexRuleInterface[]
   feedbacks?: {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/rule_form.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/rule_form.scss
@@ -1,4 +1,12 @@
 .rule-form-container {
+  .add-and-remove-plagiarism-buttons {
+    margin-top: 16px;
+    display: flex;
+    .quill-button {
+      margin-right: 16px;
+    }
+  }
+
   .rule-form {
     padding: 0px 30px 0px 30px;
     .title-input, .course-input, .flag-input, .reading-level-input,

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleAPIs.ts
@@ -71,6 +71,7 @@ export const updateRule = async (ruleId: number, rule: RuleInterface) => {
     method: 'PUT',
     body: JSON.stringify({ rule })
   });
+
   const { status } = response;
 
   if(requestFailed(status)) {

--- a/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
+++ b/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # This migration comes from evidence (originally 20220105145314)
 class RemoveUniquenessConstraintFromPlagiarismTextsOnRuleId < ActiveRecord::Migration[5.1]
   def change

--- a/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
+++ b/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+
 # This migration comes from evidence (originally 20220105145314)
 class RemoveUniquenessConstraintFromPlagiarismTextsOnRuleId < ActiveRecord::Migration[5.1]
   def change

--- a/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
+++ b/services/QuillLMS/db/migrate/20220105145446_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.evidence.rb
@@ -1,0 +1,7 @@
+# This migration comes from evidence (originally 20220105145314)
+class RemoveUniquenessConstraintFromPlagiarismTextsOnRuleId < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :comprehension_plagiarism_texts, :rule_id
+    add_index :comprehension_plagiarism_texts, :rule_id
+  end
+end

--- a/services/QuillLMS/engines/evidence/README.rdoc
+++ b/services/QuillLMS/engines/evidence/README.rdoc
@@ -26,7 +26,7 @@ https://guides.rubyonrails.org/v4.2/engines.html
 
 #### Run tests
 
-`bundle exec rake test`
+`bundle exec rspec`
 
 #### Use custom scaffolding
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -20,7 +20,7 @@ module Evidence
       else
         rule.plagiarism_texts.each do |plagiarism_text|
           plagiarism_check = Evidence::PlagiarismCheck.new(@entry, plagiarism_text.text, feedback, rule)
-          break unless plagiarism_check.optimal
+          break unless plagiarism_check.feedback_object['optimal']
         end
         render json: plagiarism_check.feedback_object
       end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -6,19 +6,24 @@ module Evidence
   class FeedbackController < ApiController
     before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling]
 
-    def prefilter 
+    def prefilter
       prefilter_check = Evidence::PrefilterCheck.new(prefilter_params)
       render json: prefilter_check.feedback_object
     end
 
     def plagiarism
       rule = @prompt.rules&.find_by(rule_type: Evidence::Rule::TYPE_PLAGIARISM)
-      passage = rule&.plagiarism_text&.text || ''
       feedback = get_plagiarism_feedback_from_previous_feedback(@previous_feedback, @prompt)
 
-      plagiarism_check = Evidence::PlagiarismCheck.new(@entry, passage, feedback, rule)
-
-      render json: plagiarism_check.feedback_object
+      if rule.plagiarism_texts.none?
+        render json: Evidence::PlagiarismCheck.new(@entry, '', feedback, rule).feedback_object
+      else
+        rule.plagiarism_texts.each do |plagiarism_text|
+          plagiarism_check = Evidence::PlagiarismCheck.new(@entry, plagiarism_text.text, feedback, rule)
+          break unless plagiarism_check.optimal
+        end
+        render json: plagiarism_check.feedback_object
+      end
     end
 
     def regex
@@ -43,7 +48,7 @@ module Evidence
 
     private def prefilter_params
       params.require(:entry)
-    end 
+    end
 
     private def set_params
       @entry = params[:entry]

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -18,9 +18,10 @@ module Evidence
       if rule.plagiarism_texts.none?
         render json: Evidence::PlagiarismCheck.new(@entry, '', feedback, rule).feedback_object
       else
+        plagiarism_check = nil
         rule.plagiarism_texts.each do |plagiarism_text|
           plagiarism_check = Evidence::PlagiarismCheck.new(@entry, plagiarism_text.text, feedback, rule)
-          break unless plagiarism_check.feedback_object['optimal']
+          break unless plagiarism_check.feedback_object[:optimal]
         end
         render json: plagiarism_check.feedback_object
       end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -72,7 +72,7 @@ module Evidence
     private def rule_params
       params.require(:rule).permit(:name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid,
          prompt_ids: [],
-         plagiarism_texts_attributes: [:id, :text],
+         plagiarism_texts_attributes: [:id, :text, :_destroy],
          regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type, :conditional],
          label_attributes: [:id, :name, :state],
          feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index, :_destroy]]

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -72,7 +72,7 @@ module Evidence
     private def rule_params
       params.require(:rule).permit(:name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid,
          prompt_ids: [],
-         plagiarism_text_attributes: [:id, :text],
+         plagiarism_texts_attributes: [:id, :text],
          regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type, :conditional],
          label_attributes: [:id, :name, :state],
          feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index, :_destroy]]

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -23,6 +23,10 @@ module Evidence
     has_many :passages, inverse_of: :activity, dependent: :destroy
     has_many :prompts, inverse_of: :activity, dependent: :destroy
     has_many :turking_rounds, inverse_of: :activity
+    has_many :rules, through: :prompts
+    has_many :feedbacks, through: :rules
+    has_many :highlights, through: :feedbacks
+
     belongs_to :parent_activity, class_name: Evidence.parent_activity_classname
 
     accepts_nested_attributes_for :passages, reject_if: proc { |p| p['text'].blank? }
@@ -88,8 +92,7 @@ module Evidence
     end
 
     def invalid_feedback_highlights
-      related_higlights = prompts.map(&:rules).flatten.map(&:feedbacks).flatten.map(&:highlights).flatten
-      invalid_highlights = related_higlights.select {|h| h.invalid_activity_ids&.include?(id)}
+      invalid_highlights = highlights.select {|h| h.invalid_activity_ids&.include?(id)}
       invalid_highlights.map do |highlight|
         {
           rule_id: highlight.feedback.rule_id,

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -6,7 +6,7 @@ module Evidence
 
     include Evidence::ChangeLog
 
-    belongs_to :rule, inverse_of: :plagiarism_text
+    belongs_to :rule, inverse_of: :plagiarism_texts
 
     validates_presence_of :rule
     validates :text, presence: true

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -4,6 +4,8 @@ module Evidence
   class PlagiarismText < ApplicationRecord
     self.table_name = 'comprehension_plagiarism_texts'
 
+    default_scope { order(created_at: :asc) }
+
     include Evidence::ChangeLog
 
     belongs_to :rule, inverse_of: :plagiarism_texts

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
@@ -5,7 +5,7 @@ module Evidence
     self.table_name = 'comprehension_prompts'
 
     include Evidence::ChangeLog
-    
+
     MIN_TEXT_LENGTH = 10
     MAX_TEXT_LENGTH = 255
     CONJUNCTIONS = %w(because but so)
@@ -32,7 +32,7 @@ module Evidence
     def serializable_hash(options = nil)
       options ||= {}
       super(options.reverse_merge(
-        only: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback, :plagiarism_text, :plagiarism_first_feedback, :plagiarism_second_feedback]
+        only: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback, :plagiarism_texts, :plagiarism_first_feedback, :plagiarism_second_feedback]
       ))
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -37,13 +37,13 @@ module Evidence
     validate :one_plagiarism_per_prompt, on: :create, if: :plagiarism?
 
     has_many :feedbacks, inverse_of: :rule, dependent: :destroy
-    has_one :plagiarism_text, inverse_of: :rule, dependent: :destroy
+    has_many :plagiarism_texts, inverse_of: :rule, dependent: :destroy
     has_one :label, inverse_of: :rule, dependent: :destroy
     has_many :prompts_rules, inverse_of: :rule
     has_many :prompts, through: :prompts_rules, inverse_of: :rules
     has_many :regex_rules, inverse_of: :rule, dependent: :destroy
 
-    accepts_nested_attributes_for :plagiarism_text
+    accepts_nested_attributes_for :plagiarism_texts, allow_destroy: true
     accepts_nested_attributes_for :feedbacks, allow_destroy: true
     accepts_nested_attributes_for :label
     accepts_nested_attributes_for :regex_rules
@@ -61,7 +61,7 @@ module Evidence
 
       super(options.reverse_merge(
         only: [:id, :uid, :name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid, :prompt_ids],
-        include: [:plagiarism_text, :feedbacks, :label, :regex_rules],
+        include: [:plagiarism_texts, :feedbacks, :label, :regex_rules],
         methods: [:prompt_ids, :display_name, :conditional]
       ))
     end

--- a/services/QuillLMS/engines/evidence/db/migrate/20220105145314_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20220105145314_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveUniquenessConstraintFromPlagiarismTextsOnRuleId < ActiveRecord::Migration[5.1]
   def change
     remove_index :comprehension_plagiarism_texts, :rule_id

--- a/services/QuillLMS/engines/evidence/db/migrate/20220105145314_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20220105145314_remove_uniqueness_constraint_from_plagiarism_texts_on_rule_id.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenessConstraintFromPlagiarismTextsOnRuleId < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :comprehension_plagiarism_texts, :rule_id
+    add_index :comprehension_plagiarism_texts, :rule_id
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/change_log.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/change_log.rb
@@ -34,7 +34,7 @@ module Evidence
 
     def log_update
       # certain callbacks cause log_update to be called on creation, so we want to return early when a record has just been created
-      return unless id_before_last_save 
+      return unless id_before_last_save
 
       if !attributes.key?('text')
         saved_changes.except("updated_at".to_sym).each do |key, value|
@@ -69,7 +69,7 @@ module Evidence
                           feedbacks:
                             [:change_logs, highlights: [:change_logs]],
                           regex_rules: [:change_logs],
-                          plagiarism_text: [:change_logs]
+                          plagiarism_texts: [:change_logs]
                         ],
                       automl_models: [:change_logs]
                       ]
@@ -104,12 +104,12 @@ module Evidence
     def rules_change_logs(prompt)
       prompt.rules.reject { |rule| rule.universal_rule_type? }.map { |rule|
         rule_logs = rule.change_logs || []
-        logs = rule_logs + feedbacks_change_logs(rule) + regex_rules_change_logs(rule) + plagiarism_text_change_logs(rule)
+        logs = rule_logs + feedbacks_change_logs(rule) + regex_rules_change_logs(rule) + plagiarism_texts_change_logs(rule)
       }.flatten! || []
     end
 
-    def plagiarism_text_change_logs(rule)
-      rule.plagiarism_text&.change_logs || []
+    def plagiarism_texts_change_logs(rule)
+      rule.plagiarism_texts.map(&:change_logs).flatten! || []
     end
 
     def feedbacks_change_logs(rule)

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -10,28 +10,30 @@ module Evidence
       create(:evidence_regex_rule, :regex_text => "^test", :rule => (rule_regex))
       create(:evidence_prompts_rule, :rule => (rule), :prompt => (prompt))
       create(:evidence_prompts_rule, :rule => (rule_regex), :prompt => (prompt))
-      create(:evidence_plagiarism_text, :text => (plagiarized_text), :rule => (rule))
+      create(:evidence_plagiarism_text, :text => (plagiarized_text1), :rule => (rule))
+      create(:evidence_plagiarism_text, :text => (plagiarized_text2), :rule => (rule))
     end
-    
+
     let!(:prompt) { create(:evidence_prompt) }
     let!(:rule) { create(:evidence_rule, :rule_type => "plagiarism") }
     let!(:rule_regex) { create(:evidence_rule, :rule_type => "rules-based-1") }
-    let(:plagiarized_text) { "do not plagiarize this text please there will be consequences" }
+    let(:plagiarized_text1) { "do not plagiarize this text please there will be consequences" }
+    let(:plagiarized_text2) { "this is completely different text that you also should not plagiarize or else" }
     let!(:first_feedback) { create(:evidence_feedback, :text => "here is our first feedback", :rule => (rule), :order => 0) }
     let!(:second_feedback) { create(:evidence_feedback, :text => "here is our second feedback", :rule => (rule), :order => 1) }
-    
-    describe '#prefilter' do 
-      let!(:profanity_rule) do 
-        create(:evidence_rule, rule_type: 'prefilter', uid: 'fdee458a-f017-4f9a-a7d4-a72d1143abeb')
-      end 
 
-      context 'profanity violation' do 
-        it 'should return correct rule uid' do 
-          post "prefilter", :params => ({ 
-            :entry => "nero was an ahole", 
-            :prompt_id => prompt.id, 
-            :session_id => 1, 
-            :previous_feedback => ([]) 
+    describe '#prefilter' do
+      let!(:profanity_rule) do
+        create(:evidence_rule, rule_type: 'prefilter', uid: 'fdee458a-f017-4f9a-a7d4-a72d1143abeb')
+      end
+
+      context 'profanity violation' do
+        it 'should return correct rule uid' do
+          post "prefilter", :params => ({
+            :entry => "nero was an ahole",
+            :prompt_id => prompt.id,
+            :session_id => 1,
+            :previous_feedback => ([])
           }), :as => :json
           expect(response.status).to eq 200
           parsed_response = JSON.parse(response.body)
@@ -40,13 +42,13 @@ module Evidence
         end
       end
 
-      context 'no violation' do 
-        it 'should return successfully' do 
-          post "prefilter", :params => ({ 
-            :entry => "the quick brown fox", 
-            :prompt_id => prompt.id, 
-            :session_id => 1, 
-            :previous_feedback => ([]) 
+      context 'no violation' do
+        it 'should return successfully' do
+          post "prefilter", :params => ({
+            :entry => "the quick brown fox",
+            :prompt_id => prompt.id,
+            :session_id => 1,
+            :previous_feedback => ([])
           }), :as => :json
           expect(response.status).to eq 200
           parsed_response = JSON.parse(response.body)
@@ -68,15 +70,29 @@ module Evidence
         expect(404).to(eq(response.status))
       end
 
-      it 'should return successfully when there is plagiarism' do
-        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text}"), :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
+      it 'should return successfully when there is plagiarism that matches the first plagiarism text string' do
+        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text1}"), :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
         parsed_response = JSON.parse(response.body)
         expect(false).to(eq(parsed_response["optimal"]))
-        expect(plagiarized_text).to(eq(parsed_response["highlight"][0]["text"]))
-        expect(plagiarized_text).to(eq(parsed_response["highlight"][1]["text"]))
+        expect(plagiarized_text1).to(eq(parsed_response["highlight"][0]["text"]))
+        expect(plagiarized_text1).to(eq(parsed_response["highlight"][1]["text"]))
         expect(first_feedback.text).to(eq(parsed_response["feedback"]))
         request.env.delete("RAW_POST_DATA")
-        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text}"), :prompt_id => prompt.id, :session_id => 5, :previous_feedback => ([parsed_response]) }), :as => :json)
+        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text1}"), :prompt_id => prompt.id, :session_id => 5, :previous_feedback => ([parsed_response]) }), :as => :json)
+        parsed_response = JSON.parse(response.body)
+        expect(false).to(eq(parsed_response["optimal"]))
+        expect(second_feedback.text).to(eq(parsed_response["feedback"]))
+      end
+
+      it 'should return successfully when there is plagiarism that matches the second plagiarism text string' do
+        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text2}"), :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
+        parsed_response = JSON.parse(response.body)
+        expect(false).to(eq(parsed_response["optimal"]))
+        expect(plagiarized_text2).to(eq(parsed_response["highlight"][0]["text"]))
+        expect(plagiarized_text2).to(eq(parsed_response["highlight"][1]["text"]))
+        expect(first_feedback.text).to(eq(parsed_response["feedback"]))
+        request.env.delete("RAW_POST_DATA")
+        post("plagiarism", :params => ({ :entry => ("bla bla bla #{plagiarized_text2}"), :prompt_id => prompt.id, :session_id => 5, :previous_feedback => ([parsed_response]) }), :as => :json)
         parsed_response = JSON.parse(response.body)
         expect(false).to(eq(parsed_response["optimal"]))
         expect(second_feedback.text).to(eq(parsed_response["feedback"]))

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
@@ -508,8 +508,8 @@ module Evidence
 
       it 'should update a valid record with plagiarism_text attributes' do
         plagiarism_text = "New plagiarism text"
-        patch(:update, :params => ({ :id => rule.id, :rule => ({ :plagiarism_text_attributes => ({ :text => plagiarism_text }) }) }))
-        expect(plagiarism_text).to(eq(rule.reload.plagiarism_text.text))
+        patch(:update, :params => ({ :id => rule.id, :rule => ({ :plagiarism_texts_attributes => ([{ :text => plagiarism_text }]) }) }))
+        expect(plagiarism_text).to(eq(rule.reload.plagiarism_texts.first.text))
       end
 
       it 'should update nested feedback attributes if present' do

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
@@ -149,9 +149,11 @@ module Evidence
             rule_type: plagiarism_rule.rule_type,
             universal: plagiarism_rule.universal,
             prompt_ids: [prompt.id],
-            plagiarism_text_attributes: {
-              text: plagiarism_text
-            },
+            plagiarism_texts_attributes: [
+              {
+                text: plagiarism_text
+              }
+            ],
             feedbacks_attributes:
             [
               {
@@ -227,10 +229,10 @@ module Evidence
 
       it 'should create a valid record with plagiarism_text attributes' do
         plagiarism_text = "Here is some text to be checked for plagiarism."
-        post(:create, :params => ({ :rule => ({ :concept_uid => rule.concept_uid, :note => rule.note, :name => rule.name, :optimal => rule.optimal, :state => rule.state, :suborder => rule.suborder, :rule_type => rule.rule_type, :universal => rule.universal, :plagiarism_text_attributes => ({ :text => plagiarism_text }) }) }))
+        post(:create, :params => ({ :rule => ({ :concept_uid => rule.concept_uid, :note => rule.note, :name => rule.name, :optimal => rule.optimal, :state => rule.state, :suborder => rule.suborder, :rule_type => rule.rule_type, :universal => rule.universal, :plagiarism_texts_attributes => ([{ :text => plagiarism_text }]) }) }))
         parsed_response = JSON.parse(response.body)
         expect(parsed_response["name"]).to(eq(rule.name))
-        expect(parsed_response["plagiarism_text"]["text"]).to(eq(plagiarism_text))
+        expect(parsed_response["plagiarism_texts"][0]["text"]).to(eq(plagiarism_text))
       end
 
       it 'should return an error if plagiarism rule already exists for prompt' do
@@ -454,7 +456,7 @@ module Evidence
       it "make a change log record after creating new plagiarism text through update call" do
         plagiarism_text = "New plagiarism text"
         rule.update(rule_type: 'plagiarism')
-        patch :update, params: {id: rule.id, rule: { plagiarism_text_attributes: {text: plagiarism_text}}}
+        patch :update, params: {id: rule.id, rule: { plagiarism_texts_attributes: [{text: plagiarism_text}]}}
 
         rule.reload
         plagiarism_text_obj = Evidence::PlagiarismText.last

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211022145011) do
+ActiveRecord::Schema.define(version: 20220105145314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 20211022145011) do
     t.string "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id", unique: true
+    t.index ["rule_id"], name: "index_comprehension_plagiarism_texts_on_rule_id"
   end
 
   create_table "comprehension_prompts", id: :serial, force: :cascade do |t|
@@ -183,5 +183,4 @@ ActiveRecord::Schema.define(version: 20211022145011) do
   add_foreign_key "comprehension_labels", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "comprehension_plagiarism_texts", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "comprehension_regex_rules", "comprehension_rules", column: "rule_id", on_delete: :cascade
-  add_foreign_key "evidence_sequences", "evidence_sequence_groups", column: "sequence_group_id", on_delete: :cascade
 end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -11,6 +11,12 @@ module Evidence
       it { should have_many(:passages).dependent(:destroy) }
 
       it { should have_many(:prompts).dependent(:destroy) }
+
+      it { should have_many(:turking_rounds).inverse_of(:activity) }
+      it { should have_many(:rules).through(:prompts) }
+      it { should have_many(:feedbacks).through(:rules) }
+      it { should have_many(:highlights).through(:feedbacks) }
+
     end
 
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
@@ -29,7 +29,7 @@ module Evidence
 
       it { should have_one(:label) }
 
-      it { should have_one(:plagiarism_text) }
+      it { should have_many(:plagiarism_texts) }
 
       it { should have_many(:feedbacks) }
 


### PR DESCRIPTION
## WHAT
Update Evidence grading and the Evidence CMS frontend and backend to allow for multiple text strings to be associated with a plagiarism rule.

## WHY
This was a request from the curriculum team, who sometimes wants non-consecutive parts of the text to trigger the plagiarism rule. 

## HOW
Remove the uniqueness restriction on `index_plagiarism_texts_on_rule_id`, change the rule's relationship to plagiarism texts from `has_one` to `has_many`, and go through and change all the places we are expecting one plagiarism text to accept multiple. Also fixed a really non-performant call we were using every time we serialized Evidence activities because it was annoyingly slow in testing.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Allow-curriculum-team-to-input-multiple-sections-of-the-text-into-the-plagiarism-algorithm-1ddbddc1deee4e599a12214da8381438

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
