### PR TITLE
remove length validation on FeedbackHistory

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -34,8 +34,6 @@ class FeedbackHistory < ApplicationRecord
   DEFAULT_PROMPT_TYPE = "Evidence::Prompt"
   MIN_ATTEMPT = 1
   MAX_ATTEMPT = 5
-  MIN_ENTRY_LENGTH = 5
-  MAX_ENTRY_LENGTH = 500
   MIN_FEEDBACK_LENGTH = 10
   MAX_FEEDBACK_LENGTH = 500
   FEEDBACK_TYPES = [
@@ -83,7 +81,7 @@ class FeedbackHistory < ApplicationRecord
       less_than_or_equal_to: MAX_ATTEMPT,
       greater_than_or_equal_to: MIN_ATTEMPT
     }
-  validates :entry, presence: true, length: {in: MIN_ENTRY_LENGTH..MAX_ENTRY_LENGTH}
+  validates :entry, presence: true
   validates :feedback_text, length: {in: MIN_FEEDBACK_LENGTH..MAX_FEEDBACK_LENGTH}
   validates :feedback_type, presence: true, inclusion: {in: FEEDBACK_TYPES}
   validates :optimal, inclusion: { in: [true, false] }

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe FeedbackHistory, type: :model do
     it { should validate_length_of(:concept_uid).is_equal_to(22) }
 
     it { should validate_presence_of(:entry) }
-    it { should validate_length_of(:entry).is_at_least(5).is_at_most(500) }
 
     it { should validate_length_of(:feedback_text).is_at_least(10).is_at_most(500) }
 


### PR DESCRIPTION
## WHAT
Remove length validation on FeedbackHistory

## WHY
It allows user-generated input to trigger an HTTP 422, preventing legitimate FeedbackHistories from being persisted. 

## HOW
deletion 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[slack convo](https://quill.slack.com/archives/C03UVPPNH/p1641490737008600)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 