### PR TITLE
lms/add-subscription-refresh-task

### DIFF
--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -13,4 +13,22 @@ namespace :users do
       progress_bar.increment
     end
   end
+
+  task refresh_school_subscriptions: :environment do
+    pipe_data = STDIN.read unless STDIN.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake users:refresh_school_subscriptions < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake schools:update_clever_ids -a empirical-grammar --no-tty < path/to/local/file.csv'
+      exit 1
+    end
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      user = User.find(row['user_id'])
+      user.updated_school(user.school.id)
+    end
+  end
 end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -29,6 +29,8 @@ namespace :users do
     CSV.parse(pipe_data, headers: true) do |row|
       user = User.find(row['user_id'])
       user.updated_school(user.school.id)
+    rescue
+      puts "Failed to update for user #{row['user_id']}"
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add a rake task that takes a list of user ids to refresh subscriptions by checking their schools to see if there are newer subscriptions to use
## WHY
Somehow a group of around 250 users don't have their subscriptions updated from the current subscription from the schools that they're assigned to.  We want to trigger the code that updates their subscriptions individually.
## HOW
Take a pipe of a CSV file and parse it to figure out which users need to be refreshed, then refresh each one.

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Some-users-not-getting-premium-access-from-the-school-subscription-702a8b272c0146c2b3d8872bcb48b52c)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on tasks
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
