### PR TITLE
lms/add-script-to-set-activitities-private

### DIFF
--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -15,6 +15,27 @@ namespace :activities do
       end
       activity.save!
     end
+  end
 
+  desc 'Take pipe of CSV with activity names to be set to "private"'
+  task set_to_private_by_name: :environment do
+    pipe_data = STDIN.read unless STDIN.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake activities:set_to_private_by_name < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake activities:set_to_private_by_name -a empirical-grammar --no-tty < path/to/local/file.csv'
+      exit 1
+    end
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      activity = Activity.find_by(name: row['name'])
+      activity.flag = 'private'
+      activity.save
+    rescue
+      puts "Failed to update for activity named '#{row['name']}'"
+    end
   end
 end

--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -33,7 +33,7 @@ namespace :activities do
     CSV.parse(pipe_data, headers: true) do |row|
       activity = Activity.find_by(name: row['name'])
       activity.flag = 'private'
-      activity.save
+      activity.save!
     rescue
       puts "Failed to update for activity named '#{row['name']}'"
     end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -22,7 +22,7 @@ namespace :users do
       puts '  rake users:refresh_school_subscriptions < path/to/local/file.csv'
       puts ''
       puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
-      puts '  heroku run rake schools:update_clever_ids -a empirical-grammar --no-tty < path/to/local/file.csv'
+      puts '  heroku run rake users:refresh_school_subscriptions -a empirical-grammar --no-tty < path/to/local/file.csv'
       exit 1
     end
 


### PR DESCRIPTION
## WHAT
Add a rake task that can set activities as "private" based on names in a CSV
## WHY
Curriculum has a list of 120 activities that they want to mass set to "private"
## HOW
Just take a pipe of a CSV file and parse each row to find an Activity by name and set the flag to `private`

### Notion Card Links
https://www.notion.so/quill/Change-these-activities-from-production-to-private-1966233fd36d47b8bf113191a8c8a96f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No tests on rake tasks
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
