### PR TITLE
Fix clever info_hash district key

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/teacher_integration.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_integration.rb
@@ -11,7 +11,7 @@ module CleverIntegration
     def initialize(auth_hash)
       @auth_hash = auth_hash
       @info_hash = auth_hash.info
-      @district_id = info_hash.district_id
+      @district_id = info_hash.district
     end
 
     def run

--- a/services/QuillLMS/spec/support/shared_contexts/clever_teacher_auth_hash.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/clever_teacher_auth_hash.rb
@@ -42,7 +42,7 @@ RSpec.shared_context "Clever Teacher auth_hash" do
           "expires" => false
         },
         "info" => {
-          "district_id" => district_clever_id,
+          "district" => district_clever_id,
           "email" => email,
           "id" => teacher_clever_id,
           "name" => {


### PR DESCRIPTION
## WHAT
Fix a bug involving the InfoHash object used during clever authentication.

## WHY
Currently the key is set to `district_id` instead of `district`.  This means that all users are short-circuited to library integration.

## HOW
Update key from `district` to `district_id`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
