### PR TITLE
LMS: Add touches for use by caching

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -28,7 +28,7 @@ class ClassroomUnit < ApplicationRecord
   include ::NewRelic::Agent
   include AtomicArrays
 
-  belongs_to :unit #, touch: true
+  belongs_to :unit
   belongs_to :classroom, touch: true
   has_many :activity_sessions
   has_many :unit_activities, through: :unit

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -28,7 +28,7 @@ class ClassroomUnit < ApplicationRecord
   include ::NewRelic::Agent
   include AtomicArrays
 
-  belongs_to :unit
+  belongs_to :unit # Note, there is a touch in the unit -> classroom_unit direction, so don't add one here.
   belongs_to :classroom, touch: true
   has_many :activity_sessions
   has_many :unit_activities, through: :unit

--- a/services/QuillLMS/app/models/classroom_unit_activity_state.rb
+++ b/services/QuillLMS/app/models/classroom_unit_activity_state.rb
@@ -29,7 +29,7 @@ class ClassroomUnitActivityState < ApplicationRecord
   include ::NewRelic::Agent
   include LessonsCache
 
-  belongs_to :classroom_unit
+  belongs_to :classroom_unit, touch: true
   belongs_to :unit_activity
 
   after_save :update_lessons_cache_with_data

--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -21,7 +21,7 @@
 #
 class ClassroomsTeacher < ApplicationRecord
   belongs_to :user
-  belongs_to :classroom
+  belongs_to :classroom, touch: true
 
   after_create :delete_classroom_minis_cache_for_each_teacher_of_this_classroom, :reset_lessons_cache_for_teacher
   before_destroy :delete_classroom_minis_cache_for_each_teacher_of_this_classroom, :reset_lessons_cache_for_teacher

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -32,6 +32,8 @@ module Teacher
     classrooms_i_teach.any? && !classrooms_i_teach.all?(&:new_record?)
   end
 
+  # TODO: classrooms_i_teach is also a defined association on User
+  # we should eliminate one of these
   def classrooms_i_teach
     Classroom.find_by_sql(base_sql_for_teacher_classrooms)
   end

--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -21,7 +21,7 @@ class StudentsClassrooms < ApplicationRecord
   include Archivable
   include CheckboxCallback
   belongs_to :student, class_name: "User"
-  belongs_to :classroom, class_name: "Classroom"
+  belongs_to :classroom, class_name: "Classroom", touch: true
   # validates uniqueness of student/classroom on db
   after_save :checkbox, :run_associator
 

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -43,8 +43,10 @@ class Unit < ApplicationRecord
   has_many :standards, through: :activities
   default_scope { where(visible: true)}
   belongs_to :unit_template
-  after_save :hide_classroom_units_and_unit_activities_if_visible_false, :create_any_new_classroom_unit_activity_states
+  after_save :hide_classroom_units_and_unit_activities_if_visible_false
+  after_save :create_any_new_classroom_unit_activity_states
   after_touch :save
+  after_save :touch_classroom_units
 
   def hide_if_no_visible_unit_activities
     if !unit_activities.where(visible: true).exists?
@@ -94,4 +96,7 @@ class Unit < ApplicationRecord
     end
   end
 
+  private def touch_classroom_units
+    classroom_units.each(&:touch)
+  end
 end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -28,7 +28,7 @@ class UnitActivity < ApplicationRecord
   include ::NewRelic::Agent
   include CheckboxCallback
 
-  belongs_to :unit #, touch: true
+  belongs_to :unit, touch: true
   belongs_to :activity
   has_many :classroom_unit_activity_states
 

--- a/services/QuillLMS/app/serializers/lesson_planner/unit_serializer.rb
+++ b/services/QuillLMS/app/serializers/lesson_planner/unit_serializer.rb
@@ -73,7 +73,7 @@ class LessonPlanner::UnitSerializer < ActiveModel::Serializer
   end
 
   private def dueDates
-    object.reload.unit_activities.uniq(&:activity).each_with_object({}) do |unit_activity, acc|
+    object.unit_activities.uniq(&:activity).each_with_object({}) do |unit_activity, acc|
       acc[unit_activity.activity.id] = unit_activity.formatted_due_date
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -142,18 +142,13 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   describe '#unpin_and_lock_activity' do
     let(:unit_activity) { UnitActivity.find_by(unit: classroom_unit.unit, activity: activity) }
 
-    let!(:classroom_unit_activity_state) do
-      create(:classroom_unit_activity_state,
-        classroom_unit: classroom_unit,
-        unit_activity: unit_activity,
-        pinned: true,
-        locked: false
-      )
-    end
-
     before { session[:user_id] = teacher.id }
 
+
     it 'should unpin and lock the state of classroom unit activity' do
+      classroom_unit_activity_state = ClassroomUnitActivityState.find_by(unit_activity_id: unit_activity.id, classroom_unit_id: classroom_unit.id)
+      classroom_unit_activity_state.update_columns(pinned: true, locked: false)
+
       put :unpin_and_lock_activity,
         params: {
           activity_id: activity.uid,

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -510,7 +510,7 @@ describe User, type: :model do
       it 'should return classrooms and students if the teacher is a coteacher' do
         coteacher = create(:classrooms_teacher, classroom: classroom, role: 'coteacher').user
         response = coteacher.classrooms_i_am_the_coteacher_for_with_a_specific_teacher_with_students(teacher.id)
-        expect(response).to include(classroom.attributes.merge(students: classroom.students))
+        expect(response).to include(classroom.reload.attributes.merge(students: classroom.students))
       end
 
       it 'should return an empty array if user does not coteach with the teacher' do

--- a/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
@@ -69,8 +69,8 @@ describe LessonPlanner::UnitSerializer, type: :serializer do
       ]
     end
 
-    def subject
-      LessonPlanner::UnitSerializer.new(unit, root: false).as_json
+    subject do
+      LessonPlanner::UnitSerializer.new(unit.reload, root: false).as_json
     end
 
     context 'assigned_student_ids = []' do


### PR DESCRIPTION
## WHAT
Pre-requisite deploy for #8671 to add model `touch`es to keep `updated_at` dates up to date and usable by caching.
## WHY
I want to put these changes out separately, before the caching to monitor and make sure they don't cause issue.
## HOW
Adding lots of touches to associations.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes, small changes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
