### PR TITLE
Correct school year start to July 1

### DIFF
--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -129,7 +129,7 @@ class School < ApplicationRecord
   end
 
   def self.school_year_start(time)
-    time.month >= 8 ? time.beginning_of_year + 7.months : time.beginning_of_year - 5.months
+    time.month >= 7 ? time.beginning_of_year + 6.months : time.beginning_of_year - 6.months
   end
 
   private def generate_leap_csv_row(student, teacher, classroom, activity_session)

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -85,6 +85,9 @@ class School < ApplicationRecord
     NOT_LISTED_SCHOOL_NAME => US_K12_SCHOOL_DISPLAY_NAME
   }
 
+  SCHOOL_YEAR_START_MONTH = 7
+  HALF_A_YEAR = 6.months
+
   def subscription
    subscriptions.where("expiration > ? AND start_date <= ?", Date.today, Date.today).order(expiration: :desc).limit(1).first
   end
@@ -129,7 +132,7 @@ class School < ApplicationRecord
   end
 
   def self.school_year_start(time)
-    time.month >= 7 ? time.beginning_of_year + 6.months : time.beginning_of_year - 6.months
+    time.month >= SCHOOL_YEAR_START_MONTH ? time.beginning_of_year + HALF_A_YEAR : time.beginning_of_year - HALF_A_YEAR
   end
 
   private def generate_leap_csv_row(student, teacher, classroom, activity_session)

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -150,14 +150,14 @@ describe School, type: :model do
   end
 
   describe('school_year_start method') do
-    it 'fetches 08-01 of this year if the date is after 08-01' do
-      time = Date.parse('2020-08-01')
+    it 'fetches 07-01 of this year if the date is after 07-01' do
+      time = Date.parse('2020-07-01')
       expect(School.school_year_start(time)).to eq(time.beginning_of_day)
     end
 
-    it 'fetches 08-01 of last year if the date is before 08-01' do
-      time = Date.parse('2020-07-01')
-      expect(School.school_year_start(time)).to eq(Date.parse('2019-08-01').beginning_of_day)
+    it 'fetches 07-01 of last year if the date is before 07-01' do
+      time = Date.parse('2020-06-01')
+      expect(School.school_year_start(time)).to eq(Date.parse('2019-07-01').beginning_of_day)
     end
   end
 end


### PR DESCRIPTION
## WHAT
When I was correcting a new year's bug last week, I noticed that we have the wrong month for the first month of the school year. I'm correcting it to July.

## WHY
July 1 was the month we agreed to make the "beginning" of the school year for data recording purposes. This is a holdover from when we used to have it as August, it will slightly skew the data we're rporting.

## HOW
Just correct the month.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
