### PR TITLE
LMS: Remove one touch for now.

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -29,7 +29,8 @@ class ClassroomUnit < ApplicationRecord
   include AtomicArrays
 
   belongs_to :unit # Note, there is a touch in the unit -> classroom_unit direction, so don't add one here.
-  belongs_to :classroom, touch: true
+  # TODO: put this touch back in for caching
+  belongs_to :classroom #, touch: true
   has_many :activity_sessions
   has_many :unit_activities, through: :unit
   has_many :completed_activity_sessions, -> {completed}, class_name: 'ActivitySession'

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -28,7 +28,7 @@ require 'rails_helper'
 
 describe ClassroomUnit, type: :model, redis: true do
 
-  it { should belong_to(:classroom).touch(true) }
+  it { should belong_to(:classroom) }
   it { should belong_to(:unit) }
   it { should have_many(:activity_sessions) }
   it { should have_many(:classroom_unit_activity_states) }


### PR DESCRIPTION
## WHAT
Rolling back a small portion of my last release
## WHY
This touch is causing a deadlock error for a small portion of `AssignRecommendationWorker`s
I didn't have time on Friday to fix the issue, so rolling back the specific `touch` that is causing the issue.
## HOW
Remove a `touch`


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
