### PR TITLE
Fix bug with teachers changing from google to clever (#8678)

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/teacher_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_importer.rb
@@ -2,11 +2,12 @@
 
 module CleverIntegration
   class TeacherImporter < ApplicationService
-    attr_reader :data, :clever_id
+    attr_reader :data, :clever_id, :email
 
     def initialize(data)
       @data = data
       @clever_id = data[:clever_id]
+      @email = data[:email]
     end
 
     def run
@@ -14,7 +15,15 @@ module CleverIntegration
     end
 
     private def teacher
-      ::User.find_by(clever_id: clever_id)
+      teacher_by_clever_id || teacher_by_email
+    end
+
+    private def teacher_by_email
+      email && ::User.find_by(email: email)
+    end
+
+    private def teacher_by_clever_id
+      clever_id && ::User.find_by(clever_id: clever_id)
     end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_importer_spec.rb
@@ -3,25 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe CleverIntegration::TeacherImporter do
-  let!(:teacher) { create(:teacher, :signed_up_with_clever) }
+  let(:clever_id) { 'abcdef123' }
+  let(:email) { 'teacher@email.com' }
+
+  let(:data) { { clever_id: clever_id, email: email } }
 
   subject { described_class.run(data) }
 
-  context 'teacher exists' do
-    let(:data) { { clever_id: teacher.clever_id } }
+  context 'teacher does not exist' do
+    it { should_run_teacher_creator }
+  end
 
-    it 'calls the TeacherUpdater' do
-      expect(CleverIntegration::TeacherUpdater).to receive(:run).with(teacher, data)
-      subject
+  context 'teacher exists' do
+    let!(:teacher) { create(:teacher, provider_trait, email: email) }
+
+    context 'teacher is linked with clever' do
+      let(:provider_trait) { :signed_up_with_clever }
+      let(:clever_id) { teacher.clever_id }
+
+      it { should_run_teacher_updater }
+    end
+
+    context 'teacher is linked with google' do
+      let(:provider_trait) { :signed_up_with_google }
+
+      it { should_run_teacher_updater }
+    end
+
+    context 'teacher is neither linked with clever nor google' do
+      let(:provider_trait) { nil }
+
+      it { should_run_teacher_updater }
     end
   end
 
-  context 'teacher does not exist' do
-    let(:data) { { clever_id: 'abcdef123' } }
+  def should_run_teacher_creator
+    expect(CleverIntegration::TeacherCreator).to receive(:run).with(data)
+    subject
+  end
 
-    it 'calls the TeacherCreator' do
-      expect(CleverIntegration::TeacherCreator).to receive(:run).with(data)
-      subject
-    end
+  def should_run_teacher_updater
+    expect(CleverIntegration::TeacherUpdater).to receive(:run).with(teacher, data)
+    subject
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
@@ -3,16 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe CleverIntegration::TeacherUpdater do
-  let!(:teacher) { create(:teacher, :signed_up_with_clever) }
-  let!(:old_name) { teacher.name }
-  let!(:old_email) { teacher.email }
-  let(:new_name) { 'New Name' }
-  let(:new_email) { 'new_name@email.com' }
-
-  let(:data) { { clever_id: teacher.clever_id, email: new_email, name: new_name } }
+  let(:name) { 'The Name' }
+  let(:data_name) { 'New Name' }
+  let(:email) { 'teacher@email.com' }
+  let!(:teacher) { create(:teacher, provider_trait, email: email, name: name) }
 
   subject { described_class.run(teacher, data)}
 
-  it { expect { subject }.to change(teacher, :name).from(old_name).to(new_name) }
-  it { expect { subject }.to change(teacher, :email).from(old_email).to(new_email) }
+  let(:data) { { clever_id: data_clever_id, email: data_email, name: data_name } }
+
+  context 'teacher is already linked with clever' do
+    let(:provider_trait) { :signed_up_with_clever }
+    let(:data_clever_id) { teacher.clever_id }
+    let(:data_email) { 'new' + email }
+
+    it { expect { subject }.to change(teacher, :name).from(name).to(data_name) }
+    it { expect { subject }.to change(teacher, :email).from(email).to(data_email) }
+    it { expect { subject}.not_to change(teacher, :clever_id) }
+  end
+
+  context 'teacher is linked with google' do
+    let(:provider_trait) { :signed_up_with_google }
+    let(:data_clever_id) { "5b2c69d17306d1054bc49f38" }
+    let(:data_email) { email }
+
+    it { expect { subject }.to change(teacher, :clever_id).from(nil).to(data_clever_id) }
+    it { expect { subject }.to change(teacher, :name).from(name).to(data_name) }
+    it { expect { subject}.not_to change(teacher, :email) }
+  end
+
+  context 'teacher neither linked with clever nor google' do
+    let(:provider_trait) { nil }
+    let(:data_clever_id) { "7b2c69d17306d1054bc49f38" }
+    let(:data_email) { email }
+
+    it { expect { subject }.to change(teacher, :clever_id).from(nil).to(data_clever_id) }
+    it { expect { subject }.to change(teacher, :name).from(name).to(data_name) }
+    it { expect { subject}.not_to change(teacher, :email) }
+  end
 end


### PR DESCRIPTION
* Fix bug with teachers changing from google to clever

* Remove nil assignment for google_id

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
