### PR TITLE
lms/update-vitally-premium-type

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -82,7 +82,10 @@ class SerializeVitallySalesUser
         percent_completed_diagnostics_last_year: get_from_cache("percent_completed_diagnostics"),
         evidence_activities_assigned_this_year: evidence_assigned_this_year,
         evidence_activities_completed_this_year: evidence_finished_this_year,
-        date_of_last_completed_evidence_activity: date_of_last_completed_evidence_activity
+        date_of_last_completed_evidence_activity: date_of_last_completed_evidence_activity,
+        premium_state: @user.premium_state,
+        premium_type: @user.subscription&.account_type,
+        auditor: @user.auditor?
       }.merge(account_data_params)
     }
   end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -84,8 +84,7 @@ class SerializeVitallySalesUser
         evidence_activities_completed_this_year: evidence_finished_this_year,
         date_of_last_completed_evidence_activity: date_of_last_completed_evidence_activity,
         premium_state: @user.premium_state,
-        premium_type: @user.subscription&.account_type,
-        auditor: @user.auditor?
+        premium_type: @user.subscription&.account_type
       }.merge(account_data_params)
     }
   end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -125,7 +125,10 @@ describe 'SerializeVitallySalesUser' do
 
     expect(teacher_data[:traits]).to include(
       premium_status: 'SUPER DUPER SUB',
-      premium_expiry_date: subscription.expiration
+      premium_expiry_date: subscription.expiration,
+      premium_state: teacher.premium_state,
+      premium_type: teacher.subscription&.account_type,
+      auditor: teacher.auditor?
     )
   end
 


### PR DESCRIPTION
## WHAT
Add 'premium_type', 'premium_state',  and 'autidor' traits to Vitally
## WHY
We were trying to pass these through Segment as part of an `identify` call, but that doesn't seem to be working for some reason.  So we're just adding it to the Vitally sync job.
## HOW
Just add the existing attributes from the old `identify` call code to the Vitally user sync job.

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Determine-why-Premium-type-is-not-flowing-into-Intercom-as-an-attribute-and-resolve-the-problem-36949960406b4330a5c9b4b46ffd977e)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No - small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
