### PR TITLE
don't include archived data in the teacher dashboard metrics

### DIFF
--- a/services/QuillLMS/app/queries/teacher_dashboard_metrics.rb
+++ b/services/QuillLMS/app/queries/teacher_dashboard_metrics.rb
@@ -17,7 +17,7 @@ class TeacherDashboardMetrics
 
   def count_of_assigned_activities(start_date)
     classroom_units = ClassroomUnit
-      .where(classroom_id: classroom_ids)
+      .where(classroom_id: classroom_ids, visible: true)
       .where("created_at >= ?", start_date)
 
     activity_counts_by_unit = UnitActivity

--- a/services/QuillLMS/spec/queries/teacher_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/teacher_dashboard_metrics_spec.rb
@@ -40,6 +40,15 @@ describe TeacherDashboardMetrics do
       expect(result[:weekly_completed_activities_count]).to eq(3)
       expect(result[:yearly_completed_activities_count]).to eq(9)
     end
+
+    it 'should not include data from archived units' do
+      unit2.update(visible: false)
+      result = TeacherDashboardMetrics.new(teacher).run
+      expect(result[:weekly_assigned_activities_count]).to eq(0)
+      expect(result[:yearly_assigned_activities_count]).to eq(9)
+      expect(result[:weekly_completed_activities_count]).to eq(0)
+      expect(result[:yearly_completed_activities_count]).to eq(6)
+    end
   end
 
 end


### PR DESCRIPTION
## WHAT
Don't include archived data in the teacher dashboard metrics.

## WHY
So that we aren't showing confusing data in the assigned/completed activities count.

## HOW
Just scope the `assigned` count to visible classroom units (classroom units get archived when a unit does, as well as when the classroom itself is unassigned).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Metrics-Summary-on-Home-tab-showing-incorrect-of-activities-4773b1bde39342259205ffda0c37bd1f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A