### PR TITLE
have apis just use quill authentication

### DIFF
--- a/services/QuillLMS/app/controllers/api/api_controller.rb
+++ b/services/QuillLMS/app/controllers/api/api_controller.rb
@@ -35,10 +35,4 @@ class Api::ApiController < ActionController::Base
     response.headers['X-Platform-Spec'] = 'https://github.com/interagent/http-api-design'
     response.headers['X-API-Reference'] = 'http://docs.empirical.org/api-reference/'
   end
-
-  private def doorkeeper_token
-    return @token if instance_variable_defined?(:@token)
-    methods = Doorkeeper.configuration.access_token_methods
-    @token = Doorkeeper::OAuth::Token.authenticate(request, *methods)
-  end
 end

--- a/services/QuillLMS/app/controllers/api/api_controller.rb
+++ b/services/QuillLMS/app/controllers/api/api_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::ApiController < ActionController::Base
+  include QuillAuthentication
 
   class AccessForbidden < StandardError; end
 
@@ -33,23 +34,6 @@ class Api::ApiController < ActionController::Base
   private def add_platform_doc_header
     response.headers['X-Platform-Spec'] = 'https://github.com/interagent/http-api-design'
     response.headers['X-API-Reference'] = 'http://docs.empirical.org/api-reference/'
-  end
-
-  private def current_user
-    begin
-      if session[:user_id]
-        @current_user ||= User.find(session[:user_id])
-      elsif doorkeeper_token
-        User.find_by_id(doorkeeper_token.resource_owner_id)
-      else
-        authenticate_with_http_basic do |username, password|
-          return @current_user ||= User.find_by_token!(username) if username.present?
-        end
-      end
-    rescue ActiveRecord::RecordNotFound
-      sign_out
-      nil
-    end
   end
 
   private def doorkeeper_token

--- a/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::ActivitiesController < Api::ApiController
-  include QuillAuthentication
-
   CLASSIFICATION_TO_TOOL = {:connect => "connect", :sentence => "grammar"}
 
   before_action :doorkeeper_authorize!, only: [:create, :update, :destroy], unless: :staff?

--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::ClassroomUnitsController < Api::ApiController
-  include QuillAuthentication
   before_action :authorize!
 
   def student_names

--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::ProgressReportsController < Api::ApiController
-  include QuillAuthentication
   before_action :authorize!, only: :student_overview_data
 
   def activities_scores_by_classroom_data


### PR DESCRIPTION
## WHAT
Include `QuillAuthentication` module in the `api_controller` so we don't need a separate `current_user` method.

## WHY
The API version of the `current_user` method had once been the same as the `QuillAuthentication` version, but diverged as we made changes, which caused at least one bug where the demo account couldn't really present Quill Lessons (because nothing was coming through as the current user). Rather than try to keep two separate methods in sync, there didn't really seem to be a downside to just including QuillAuthentication here, and we were already using it in some specific API controllers.

## HOW
Just include the module and remove inclusions in sub-controllers.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-go-to-Next-Slide-on-Quill-Lessons-ba94a468e7244278808d675738eaf87d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
