### PR TITLE
Fix bug involving unauthorized google users from running background jobs

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -593,11 +593,11 @@ class User < ApplicationRecord
   end
 
   def clever_authorized?
-    auth_credential&.clever_authorized?
+    clever_id && auth_credential&.clever_authorized?
   end
 
   def google_authorized?
-    auth_credential&.google_authorized?
+    google_id && auth_credential&.google_authorized?
   end
 
   # Note this is an incremented count, so could be off.

--- a/services/QuillLMS/app/workers/google_integration/update_teacher_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/update_teacher_imported_classrooms_worker.rb
@@ -6,14 +6,14 @@ module GoogleIntegration
     sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
     def perform(user_id)
-      return unless google_id?(user_id)
+      return unless google_authorized?(user_id)
 
       TeacherClassroomsRetriever.run(user_id)
       TeacherImportedClassroomsUpdater.run(user_id)
     end
 
-    private def google_id?(user_id)
-      user_id && ::User.find_by(id: user_id)&.google_id&.present?
+    private def google_authorized?(user_id)
+      user_id && ::User.find_by(id: user_id)&.google_authorized?
     end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -35,16 +35,19 @@ FactoryBot.define do
     factory :google_auth_credential do
       provider AuthCredential::GOOGLE_PROVIDER
       expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_google]
     end
 
     factory :clever_district_auth_credential do
       provider AuthCredential::CLEVER_DISTRICT_PROVIDER
       expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_clever]
     end
 
     factory :clever_library_auth_credential do
       provider AuthCredential::CLEVER_LIBRARY_PROVIDER
       expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_clever]
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug involving background jobs being called for users that no longer have authorization.

## WHY
The worker job in question will be called repeatedly with no chance of passing.

## HOW
Add a check in the worker to ensure that the user is authorized.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Sidekiq-GoogleIntegration-UpdateTeacherImportedClassroomsWorker-NilError-7e819b07519c448eadcfb3bd0850273b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
