### PR TITLE
Fix user_type for district_admin clever login

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/sign_up/sub_main.rb
+++ b/services/QuillLMS/app/services/clever_integration/sign_up/sub_main.rb
@@ -6,7 +6,7 @@ module CleverIntegration::SignUp::SubMain
 
   def self.run(auth_hash)
     case auth_hash[:info][:user_type]
-    when 'district'
+    when 'district_admin'
       result = district(auth_hash)
     when 'student'
       result = student(auth_hash)


### PR DESCRIPTION
## WHAT
Fix a case statement involving user_type with clever_login

## WHY
District admin's user_type should be `district_admin`, not `district`.  The case statement wrongly filters this user to teacher.

## HOW
Update `district_admin` to `district`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Admin-issues-logging-in-via-Clever-30605ee424914196b9327f1f12500028)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A