### PR TITLE
Remove therubyracer gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -128,9 +128,6 @@ gem 'react_on_rails', '= 11.3.0'
 gem 'webpacker', '~> 3.0.0'
 
 # ASSET/UI
-# TODO: On M1 macs there is still an issue with therubyracer gem. Needs a fix
-# I've temporarily commented this gem out locally until I have time to revisit
-gem 'therubyracer', require: false
 gem 'uglifier',     require: false
 gem 'kaminari', '~> 1.2.1'
 
@@ -202,6 +199,7 @@ group :test do
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
   gem 'codecov'
+  gem 'mini_racer', '= 0.3.1'
   gem 'fakeredis', '~> 0.7.0'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libsqreen (1.0.4.0.0)
-    libv8 (3.16.14.19)
+    libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -388,6 +388,8 @@ GEM
       rake
     mini_mime (1.1.0)
     mini_portile2 (2.7.1)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minisyntax (0.2.5)
     minitest (5.15.0)
     multi_json (1.15.0)
@@ -598,7 +600,6 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    ref (2.0.0)
     regexp_parser (2.1.1)
     remotipart (1.4.4)
     request_store (1.4.1)
@@ -734,9 +735,6 @@ GEM
     terminal-notifier-guard (1.7.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -838,6 +836,7 @@ DEPENDENCIES
   letter_opener
   livingstyleguide
   lograge
+  mini_racer (= 0.3.1)
   newrelic_rpm
   nokogiri (>= 1.10.4)
   omniauth
@@ -909,7 +908,6 @@ DEPENDENCIES
   stripe
   super_diff
   terminal-notifier-guard
-  therubyracer
   time_difference
   timecop
   ttfunk

--- a/services/QuillLMS/bin/dev/bootstrap.sh
+++ b/services/QuillLMS/bin/dev/bootstrap.sh
@@ -7,8 +7,8 @@ fi
 
 [ ! -d '/Applications/Postgres.app' ] && echo 'Please make sure Postgres.app is installed. Use the version "Postgres.app with all currently supported versions" on this page: https://postgresapp.com/downloads.html so that you use Postgres 10. Exiting.' && exit 1
 
-postgres_already_running_msg="It looks like you have a non-Postgres.app version \n 
-of postgres already running. Try running \n 
+postgres_already_running_msg="It looks like you have a non-Postgres.app version \n
+of postgres already running. Try running \n
 pg_ctl -D /usr/local/var/postgresql@10 \n
 to gracefully stop this process."
 
@@ -95,8 +95,6 @@ echo 'Bundle install'
 echo 'If youre on Mac Mojave and hit an error with nokogiri, run:'
 echo 'cd  /Library/Developer/CommandLineTools/Packages/;'
 echo 'open macOS_SDK_headers_for_macOS_10.14.pkg'
-# TODO: There are fixes needed here v8, libv8, and therubyracer to work on M1 Macs.
-echo 'There is an open issue with therubyracer on M1 Macs, see Gemfile'
 bundle install
 
 echo "Install Node"


### PR DESCRIPTION
## WHAT
Remove `therubyracer` gem from the LMS Gemfile.  Add `mini_racer` gem to the test group.

## WHY
Heroku [reports](https://devcenter.heroku.com/articles/rails-asset-pipeline#therubyracer) that therubyracer is no longer needed since "A version of Node is installed by the Ruby buildpack that will be used to compile your assets."  However, circleci cannot run tests due to "ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime."   For this reason, we should use a more modern Gem (i.e. mini_racer) to satisfy the JS runtime requirement, while also potentially fixing an issue with bin/dev/boostrap.sh, `therubyracer` and Apple M1 chips.

NB: I'm pinning `mini_racer` to `0.3.1` since later versions either have an open [bug](https://github.com/rubyjs/mini_racer/issues/220) or require newer versions of Ruby.

## HOW
Update the Gemfile accordingly and run `bundle update`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/LMS-Remove-therubyracer-ideal-or-fix-bootstrap-for-M1-Macs-f362f97698b448b0bfaf70b2e5608e4d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, removal of redundant library.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
