### PR TITLE
LMS: Fix for Vitally school stats double counting classes with coteachers

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -12,8 +12,8 @@ class SerializeVitallySalesAccount
     school_year_start = School.school_year_start(current_time)
     active_students = active_students_query(@school).count
     active_students_this_year = active_students_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count
-    activities_finished = activities_finished_query(@school).count
-    activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count
+    activities_finished = activities_finished_query(@school).count("DISTINCT activity_sessions.id")
+    activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count("DISTINCT activity_sessions.id")
     {
       accountId: @school.id.to_s,
       # Type is used by Vitally to determine which data type the payload contains in batches

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -153,10 +153,12 @@ describe 'SerializeVitallySalesAccount' do
     active_old_student = create(:user, role: 'student', last_sign_in: Date.today - 2.year)
     inactive_student = create(:user, role: 'student', last_sign_in: Date.today - 2.year)
     teacher = create(:user, role: 'teacher')
+    teacher2 = create(:user, role: 'teacher')
     classroom = create(:classroom)
     classroom_unit = create(:classroom_unit, classroom: classroom)
     old_classroom_unit = create(:classroom_unit, classroom: classroom)
     create(:classrooms_teacher, user: teacher, classroom: classroom)
+    create(:classrooms_teacher, user: teacher2, classroom: classroom, role: 'coteacher')
     create(:students_classrooms, student: active_student, classroom: classroom)
     create(:students_classrooms, student: inactive_student, classroom: classroom)
     create(:students_classrooms, student: active_old_student, classroom: classroom)
@@ -179,6 +181,7 @@ describe 'SerializeVitallySalesAccount' do
     school.users << active_student
     school.users << inactive_student
     school.users << teacher
+    school.users << teacher2
     school.users << create(:user, role: 'student')
 
     school_data = SerializeVitallySalesAccount.new(school).data


### PR DESCRIPTION
## WHAT
Add a `distinct` count to Vitally school stats to fix counting error (see Notion card)
## WHY
Otherwise activities counted are multiplied by the number of coteachers
## HOW
Create a failing test, fix it.

Add `.count("DISTINCT activity_sessions.id")`

### Notion Card Links
https://www.notion.so/quill/Vitally-Data-Issue-Activities-Completed-Count-is-Incorrect-8b5b855365f3454c84ea643ce7b88b7d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
