### PR TITLE
LMS - Add caching to 4 reporting endpoints. (#8671)

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -29,9 +29,18 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     activity_id = results_summary_params[:activity_id]
     classroom_id = results_summary_params[:classroom_id]
     unit_id = results_summary_params[:unit_id]
-    set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, true)
 
-    render json: { students: diagnostic_student_responses }
+    students_json = current_user.classroom_unit_by_ids_cache(
+      classroom_id: classroom_id,
+      unit_id: unit_id,
+      activity_id: activity_id,
+      key: 'diagnostic_reports.diagnostic_student_responses_index'
+    ) do
+      set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, true)
+      diagnostic_student_responses
+    end
+
+    render json: { students: students_json }
   end
 
   def individual_student_diagnostic_responses
@@ -79,7 +88,16 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def lesson_recommendations_for_classroom
-    render json: {lessonsRecommendations: get_recommended_lessons(current_user, params[:unit_id], params[:classroom_id], params[:activity_id])}
+    lesson_recs = current_user.classroom_unit_by_ids_cache(
+      classroom_id: params[:classroom_id],
+      unit_id: params[:unit_id],
+      activity_id: params[:activity_id],
+      key: 'diagnostic_reports.lesson_recommendations_for_classroom'
+    ) do
+      get_recommended_lessons(current_user, params[:unit_id], params[:classroom_id], params[:activity_id])
+    end
+
+    render json: {lessonsRecommendations: lesson_recs}
   end
 
   def diagnostic_activity_ids

--- a/services/QuillLMS/app/models/concerns/user_cacheable.rb
+++ b/services/QuillLMS/app/models/concerns/user_cacheable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# This is a Mixin for the User class to cache objects for a user
+# Also defines common cache_keys in the app and forces a common pattern
+# To add caching to a controller, use one of the public methods here.
+# They have been tested for proper cache expiration
+# (using `touch` and `updated_at` changes)
+
+# Note, this is in the User since for nil objects we'd want to avoid sharing caches between users
+# So, defaulting to the user object as a cache key to avoid that.
+
+# Sample Controller Usage
+# response = user.classroom_unit_cache(classroom_unit, key: 'controller.method') do
+#   # some expensive action to cache that only needs to update
+#   # when a classroom_unit or its children change
+# end
+# render json: response
+module UserCacheable
+  extend ActiveSupport::Concern
+
+  def all_classrooms_cache(key:, groups: {})
+    model_cache(last_updated_classroom, key: key, groups: groups) { yield }
+  end
+
+  def classroom_cache(classroom, key:, groups: {})
+    model_cache(classroom, key: key, groups: groups) { yield }
+  end
+
+  def classroom_unit_cache(classroom_unit, key:, groups: {})
+    model_cache(classroom_unit, key: key, groups: groups) { yield }
+  end
+
+  def classroom_unit_by_ids_cache(classroom_id:, unit_id:, activity_id:, key:, groups: {})
+    classroom_unit = classroom_unit_for_ids(classroom_id: classroom_id, unit_id: unit_id, activity_id: activity_id)
+
+    model_cache(classroom_unit, key: key, groups: groups) { yield }
+  end
+
+  # note: object for caching defaults to the 'user'
+  # This avoids nil cache keys shared by different users
+  private def model_cache_key(object, key:, groups:)
+    group_array = groups.to_a.sort_by(&:first).flatten
+
+    [key, *group_array, object || self]
+  end
+
+  private def model_cache(object, key:, groups:)
+    Rails.cache.fetch(model_cache_key(object, key: key, groups: groups)) do
+      yield
+    end
+  end
+
+  private def last_updated_classroom
+    Classroom
+      .select("classrooms.*, MAX(classrooms.updated_at)")
+      .unscoped
+      .joins(:classrooms_teachers)
+      .where(classrooms_teachers: {user_id: id})
+      .first
+  end
+
+  private def classroom_unit_for_ids(classroom_id:, unit_id:, activity_id:)
+    if unit_id
+      return ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
+    end
+
+    # use ClassroomUnit with the maximium `updated_at`
+    ClassroomUnit
+      .select("classroom_units.*, MAX(classroom_units.updated_at)")
+      .unscoped
+      .where(classroom_id: classroom_id)
+      .joins(:unit_activities)
+      .where(unit: {unit_activities: {activity_id: activity_id}})
+      .group("classroom_units.id")
+      .first
+  end
+end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -58,6 +58,7 @@ class User < ApplicationRecord
   include Student
   include Teacher
   include CheckboxCallback
+  include UserCacheable
 
   attr_accessor :validate_username,
                 :require_password_confirmation_when_password_present

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserCacheable, type: :model do
+  let(:user) { build(:user) }
+  let(:groups) { {some_id: 1234, page: 1} }
+
+  describe '#all_classrooms_cache' do
+    context 'teachers without classrooms' do
+      let(:teacher1) { create(:teacher) }
+      let(:teacher2) { create(:teacher) }
+
+      it 'should not share cache for users with no classrooms and update on user touches' do
+        i = 0
+        teacher1_fetch1 = teacher1.all_classrooms_cache(key: 'test.key') { i += 1 }
+        teacher2_fetch1 = teacher2.all_classrooms_cache(key: 'test.key') { i += 1 }
+        teacher1_fetch2 = teacher1.all_classrooms_cache(key: 'test.key') { i += 1 }
+        teacher2_fetch2 = teacher2.all_classrooms_cache(key: 'test.key') { i += 1 }
+
+        # only one teacher is updated
+        teacher1.touch
+
+        teacher1_fetch3 = teacher1.all_classrooms_cache(key: 'test.key') { i += 1 }
+        teacher2_fetch3 = teacher2.all_classrooms_cache(key: 'test.key') { i += 1 }
+
+        expect(teacher1_fetch1).to eq(1)
+        expect(teacher2_fetch1).to eq(2)
+        expect(teacher1_fetch2).to eq(1)
+        expect(teacher2_fetch2).to eq(2)
+
+        expect(teacher1_fetch3).to eq(3)
+        expect(teacher2_fetch3).to eq(2)
+      end
+    end
+
+    context 'teacher with classrooms' do
+      let(:teacher) {create(:teacher_with_one_classroom) }
+
+      it 'should return cached value until the cache_key changes' do
+        i = 0
+        first_fetch = teacher.all_classrooms_cache(key: 'test.key') { i += 1 }
+        second_fetch = teacher.all_classrooms_cache(key: 'test.key') { i += 1 }
+
+        teacher.classrooms_i_teach.first.touch
+
+        post_update_fetch = teacher.all_classrooms_cache(key: 'test.key') { i += 1 }
+
+        expect(first_fetch).to eq(1)
+        expect(second_fetch).to eq(1)
+        expect(post_update_fetch).to eq(2)
+      end
+
+      it 'should keep separate caches for groups, update on cache key change' do
+        i = 0
+        first_page_fetch1 = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 1}) { i += 1 }
+        second_page_fetch1 = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 2}) { i += 1 }
+
+        first_page_fetch2 = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 1}) { i += 1 }
+        second_page_fetch2 = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 2}) { i += 1 }
+
+        teacher.classrooms_i_teach.first.touch
+
+        post_update_first_page_fetch = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 1}) { i += 1 }
+        post_update_second_page_fetch = teacher.all_classrooms_cache(key: 'test.key', groups: {page: 2}) { i += 1 }
+
+        expect(first_page_fetch1).to eq(1)
+        expect(second_page_fetch1).to eq(2)
+        expect(first_page_fetch2).to eq(1)
+        expect(second_page_fetch2).to eq(2)
+
+        expect(post_update_first_page_fetch).to eq(3)
+        expect(post_update_second_page_fetch).to eq(4)
+      end
+    end
+  end
+
+  describe '#classroom_cache' do
+    let(:teacher) {create(:teacher) }
+    let(:classroom) {create(:classroom) }
+
+    it 'should call model_cache' do
+      expect(teacher).to receive(:model_cache).with(classroom, key: 'test.key', groups: {page: 1})
+
+      teacher.classroom_cache(classroom, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should yield to model_cache' do
+      expect {|b| teacher.classroom_cache(classroom, key: 'test.key', groups: {page: 1}, &b) }.to yield_control.exactly(1).times
+    end
+
+    it 'should return cached value until the cache_key changes' do
+      i = 0
+      first_fetch = teacher.classroom_cache(classroom, key: 'test.key') { i += 1 }
+      second_fetch = teacher.classroom_cache(classroom, key: 'test.key') { i += 1 }
+
+      classroom.touch
+
+      post_update_fetch = teacher.classroom_cache(classroom, key: 'test.key') { i += 1 }
+
+      expect(first_fetch).to eq(1)
+      expect(second_fetch).to eq(1)
+      expect(post_update_fetch).to eq(2)
+    end
+  end
+
+  describe '#classroom_unit_cache' do
+    let(:teacher) {create(:teacher) }
+    let(:classroom_unit) {create(:classroom_unit) }
+
+    it 'should call model_cache' do
+      expect(teacher).to receive(:model_cache).with(classroom_unit, key: 'test.key', groups: {page: 1})
+
+      teacher.classroom_unit_cache(classroom_unit, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should yield to model_cache' do
+      expect {|b| teacher.classroom_unit_cache(classroom_unit, key: 'test.key', groups: {page: 1}, &b) }.to yield_control.exactly(1).times
+    end
+
+    it 'should return cached value until the cache_key changes' do
+      i = 0
+      first_fetch = teacher.classroom_unit_cache(classroom_unit, key: 'test.key') { i += 1 }
+      second_fetch = teacher.classroom_unit_cache(classroom_unit, key: 'test.key') { i += 1 }
+
+      classroom_unit.touch
+
+      post_update_fetch = teacher.classroom_unit_cache(classroom_unit, key: 'test.key') { i += 1 }
+
+      expect(first_fetch).to eq(1)
+      expect(second_fetch).to eq(1)
+      expect(post_update_fetch).to eq(2)
+    end
+  end
+
+  describe '#classroom_unit_by_ids_cache' do
+    let(:teacher) {create(:teacher) }
+    let(:classrooms_teacher) {create(:classrooms_teacher, user: teacher) }
+    let(:classroom) { classrooms_teacher.classroom }
+    let(:unit_activity1) { create(:unit_activity)}
+    let(:activity) { unit_activity1.activity }
+    let(:classroom_unit1) {create(:classroom_unit, classroom: classroom, unit: unit_activity1.unit) }
+    let(:unit_activity2) { create(:unit_activity, activity: activity)}
+    let(:classroom_unit2) {create(:classroom_unit, classroom: classroom, unit: unit_activity2.unit) }
+
+    it 'should call model_cache with last updated unit if no unit_id' do
+      expect(teacher).to receive(:model_cache).with(classroom_unit2, key: 'test.key', groups: {page: 1})
+
+      teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should call model_cache with first matching unit if there is a unit_id' do
+      expect(teacher).to receive(:model_cache).with(classroom_unit1, key: 'test.key', groups: {page: 1})
+
+      teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: unit_activity1.unit_id, activity_id: activity.id, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should yield to model_cache' do
+      expect {|b| teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: unit_activity1.unit_id, activity_id: activity.id, key: 'test.key', groups: {page: 1}, &b) }.to yield_control.exactly(1).times
+    end
+
+    it 'should return cached value until the cache_key changes' do
+      i = 0
+      first_fetch = teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key') { i += 1 }
+      second_fetch = teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key') { i += 1 }
+
+      classroom_unit2.touch
+
+      post_update_fetch = teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key') { i += 1 }
+
+      expect(first_fetch).to eq(1)
+      expect(second_fetch).to eq(1)
+      expect(post_update_fetch).to eq(2)
+    end
+  end
+
+  describe '#model_cache_key' do
+    let(:object) { double('fake object') }
+
+    it 'return an array in the expected pattern' do
+      key = user.send(:model_cache_key, object, key: 'test_name', groups: groups)
+
+      expect(key).to eq(['test_name', :page, 1, :some_id, 1234, object])
+    end
+
+    it 'should use the user as the model cache key if object is nil' do
+      key = user.send(:model_cache_key, nil, key: 'test_name', groups: groups)
+
+      expect(key).to eq(['test_name', :page, 1, :some_id, 1234, user])
+    end
+
+    it 'should sort by group keys' do
+      groups = {zebra: 1234, apple: 'a', quill: 7}
+      key = user.send(:model_cache_key, object, key: 'test_name', groups: groups)
+
+      expect(key).to eq(['test_name', :apple, 'a', :quill, 7, :zebra, 1234, object])
+    end
+  end
+
+  describe '#model_cache' do
+    # using an arbitrary AR object with updated_at
+    let(:object) { create(:concept) }
+
+    it 'should raise if not passed a block' do
+      expect { user.send(:model_cache, object, key: 'test.key', groups: {}) }.to raise_error(LocalJumpError)
+    end
+
+    it 'should return cached value until the cache_key changes' do
+      i = 0
+      first_fetch = user.send(:model_cache, object, key: 'test.key', groups: {}) { i += 1 }
+      second_fetch = user.send(:model_cache, object, key: 'test.key', groups: {}) { i += 1 }
+
+      object.touch
+
+      post_update_fetch = user.send(:model_cache, object, key: 'test.key', groups: {}) { i += 1 }
+
+      expect(first_fetch).to eq(1)
+      expect(second_fetch).to eq(1)
+      expect(post_update_fetch).to eq(2)
+    end
+
+    it 'should keep separate caches for groups, update on cache key change' do
+      i = 0
+      first_page_fetch1 = user.send(:model_cache, object, key: 'test.key', groups: {page: 1}) { i += 1 }
+      second_page_fetch1 = user.send(:model_cache, object, key: 'test.key', groups: {page: 2}) { i += 1 }
+
+      first_page_fetch2 = user.send(:model_cache, object, key: 'test.key', groups: {page: 1}) { i += 1 }
+      second_page_fetch2 = user.send(:model_cache, object, key: 'test.key', groups: {page: 2}) { i += 1 }
+
+      object.touch
+
+      post_update_first_page_fetch = user.send(:model_cache, object, key: 'test.key', groups: {page: 1}) { i += 1 }
+      post_update_second_page_fetch = user.send(:model_cache, object, key: 'test.key', groups: {page: 2}) { i += 1 }
+
+      expect(first_page_fetch1).to eq(1)
+      expect(second_page_fetch1).to eq(2)
+      expect(first_page_fetch2).to eq(1)
+      expect(second_page_fetch2).to eq(2)
+
+      expect(post_update_first_page_fetch).to eq(3)
+      expect(post_update_second_page_fetch).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
* Add update touches to be used by caching.

* Cache scorebook.

* Add touches for updating parents.

* Remove redundant method.

* Implement a common cache key setup and add a few examples.

* Fox syntax issues.

* No touch on has_many.

* PR feedback changes.

* Rename CacheKey to CacheGroupKey

* Another rename.

* Move caching to UserCacheable Mixin

* Fix params.

* Remove unused variable.

* Remove old comment.

* Small code refactor.

* Lint fixes

* Add more tests, remove keyword for brevity.

* More testing.

* Fix test setup to prevent duplicates

* Potential test fix (can’t replicate locally)

* Fix test. Remove reload from method that depends on order.

* Update comments

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
