### PR TITLE
LMS: Fix nil error in caching code.

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -117,6 +117,6 @@ class ClassroomUnit < ApplicationRecord
   end
 
   private def touch_classroom_without_callbacks
-    classroom.update_columns(updated_at: current_time_from_proper_timezone)
+    classroom&.update_columns(updated_at: current_time_from_proper_timezone)
   end
 end

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -168,7 +168,7 @@ describe ClassroomUnit, type: :model, redis: true do
       expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
     end
 
-    context "without a hidden classroom" do
+    context "with a hidden classroom" do
       let(:classroom) { create(:classroom, visible: false) }
       let(:classroom_unit) { create(:classroom_unit, classroom: classroom)}
 

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -167,5 +167,14 @@ describe ClassroomUnit, type: :model, redis: true do
 
       expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
     end
+
+    context "without a hidden classroom" do
+      let(:classroom) { create(:classroom, visible: false) }
+      let(:classroom_unit) { create(:classroom_unit, classroom: classroom)}
+
+      it "should not raise an error" do
+        expect {classroom_unit.save}.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Because of default scopes the `classroom` object on a `classroom_unit` can be nil (even though the DB column cannot be NULL). Adding a test and fixing that error.
## WHY
Nil errors are bad
## HOW
Add a failing test, fix that test.


### Notion Card Links
[New Relic Bug](https://one.newrelic.com/launcher/nr1-core.launcher?platform[timeRange][duration]=1800000&pane=eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiMTZmNjg3ZDUtN2E0My0xMWVjLThjMjAtMDI0MmFjMTEwMDA5XzBfNjE2OCIsImVudGl0eUd1aWQiOiJNall6T1RFeE0zeEJVRTE4UVZCUVRFbERRVlJKVDA1OE5UUTRPRFUyT0RjMSJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1qWXpPVEV4TTN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRRNE9EVTJPRGMxIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9fQ==&state=6a146792-ed27-3004-b5b8-231fe209b291)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
