### PR TITLE
Update LMS Gemfile

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -22,7 +22,7 @@ gem 'atomic_arrays'
 
 # USER AUTH, ETC
 gem 'bcrypt'
-gem "doorkeeper", ">= 4.2.0"
+gem "doorkeeper", "5.0.3"
 gem 'omniauth'
 gem 'omniauth-google-oauth2', '0.6.0'
 gem 'omniauth-clever'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
-    better_errors (2.5.1)
+    better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -139,7 +139,7 @@ GEM
       colorize
       json
       simplecov
-    coderay (1.1.2)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -164,7 +164,7 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.2)
-    doorkeeper (5.0.2)
+    doorkeeper (5.0.3)
       railties (>= 4.2)
     dotenv (2.6.0)
     dotenv-rails (2.6.0)
@@ -258,7 +258,7 @@ GEM
     google-cloud-env (1.3.0)
       faraday (~> 0.11)
     google-cloud-errors (1.2.0)
-    google-protobuf (3.19.1)
+    google-protobuf (3.19.3)
     googleapis-common-protos (1.3.12)
       google-protobuf (~> 3.14)
       googleapis-common-protos-types (~> 1.2)
@@ -319,7 +319,7 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     interception (0.5)
     intercom (3.5.26)
@@ -372,7 +372,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.10.0)
+    loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -387,18 +387,18 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.0)
-    mini_portile2 (2.5.3)
+    mini_portile2 (2.7.1)
     minisyntax (0.2.5)
-    minitest (5.14.4)
+    minitest (5.15.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
     nested_form (0.3.2)
     newrelic_rpm (6.0.0.351)
-    nio4r (2.5.7)
-    nokogiri (1.11.7)
-      mini_portile2 (~> 2.5.0)
+    nio4r (2.5.8)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -479,7 +479,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (4.0.6)
-    puma (4.3.8)
+    puma (4.3.10)
       nio4r (~> 2.0)
     puma_worker_killer (0.1.1)
       get_process_mem (~> 0.2)
@@ -489,7 +489,7 @@ GEM
       multi_json (~> 1.0)
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-affiliates (0.4.0)
       rack
@@ -529,7 +529,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
     rails_12factor (0.0.3)
       rails_serve_static_assets
@@ -807,7 +807,7 @@ DEPENDENCIES
   coffee-rails
   configs
   cypress-on-rails (~> 1.0)
-  doorkeeper (>= 4.2.0)
+  doorkeeper (= 5.0.3)
   dotenv-rails
   es5-shim-rails
   evidence!


### PR DESCRIPTION
## WHAT
Update some gems in the LMS

## WHY
This will satisfy some security updates.

## HOW
I pinned doorkeeper to 5.0.3 to satisfy the security requirement.  Version 5.5 had some warning that seemed like an API breaking change.

`bundle update nokogiri better_errors google-protobuf puma doorkeeper`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/LMS-High-Security-Package-Updates-90b850a53dd3426c81e7e42526619bcd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Library upgrades
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
