### PR TITLE
put scorebook back the way it was

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -137,17 +137,7 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def scores
-    cache_groups = {
-      unit: params[:unit_id],
-      page: params[:current_page],
-      begin: params[:begin_date],
-      end: params[:end_date],
-      offset: current_user.utc_offset
-    }
-
-    scores = current_user.all_classrooms_cache(key: 'classroom_manager.scores', groups: cache_groups) do
-       Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
-    end
+    scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
 
     last_page = scores.length < 200
 


### PR DESCRIPTION
## WHAT
Remove caching from scorebook.

## WHY
Teachers aren't able to switch between classes.

## HOW
Just put the code back the way it was prior to the change.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Summary-and-Activity-Analysis-reports-do-not-allow-to-switch-between-classes-7857e5f90f7d4fb5b39eb9c81fb3a478

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
