### PR TITLE
Rollback caching on scores.

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -134,17 +134,20 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def scores
-    cache_groups = {
-      unit: params[:unit_id],
-      page: params[:current_page],
-      begin: params[:begin_date],
-      end: params[:end_date],
-      offset: current_user.utc_offset
-    }
+    # TODO: Put caching back in
+    # cache_groups = {
+    #   unit: params[:unit_id],
+    #   page: params[:current_page],
+    #   begin: params[:begin_date],
+    #   end: params[:end_date],
+    #   offset: current_user.utc_offset
+    # }
 
-    scores = current_user.all_classrooms_cache(key: 'classroom_manager.scores', groups: cache_groups) do
-       Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
-    end
+    # scores = current_user.all_classrooms_cache(key: 'classroom_manager.scores', groups: cache_groups) do
+    #    Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
+    # end
+
+    scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
 
     last_page = scores.length < 200
 


### PR DESCRIPTION
## WHAT
Rollback this piece of caching for now. Needs to be scope to classroom.
## WHY
It's caching all of the classrooms the same, needs more testing.
## HOW
Rollback.
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Summary-report-only-shows-results-for-one-class-7857e5f90f7d4fb5b39eb9c81fb3a478

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO'
Have you deployed to Staging? |  NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
