### PR TITLE
Profanity highlight

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -9,16 +9,11 @@ module Evidence
     MIN_TEXT_LENGTH = 1
     MAX_TEXT_LENGTH = 5000
 
-    TYPE_PASSAGE  = 'passage'
-    TYPE_RESPONSE = 'response'
-    TYPE_PROMPT   = 'prompt'
-
     TYPES = [
-      TYPE_PASSAGE,
-      TYPE_RESPONSE,
-      TYPE_PROMPT
+      TYPE_PASSAGE = 'passage',
+      TYPE_RESPONSE = 'response',
+      TYPE_PROMPT = 'prompt'
     ]
-
     belongs_to :feedback, inverse_of: :highlights
 
     validates :text, presence: true, length: {minimum: MIN_TEXT_LENGTH, maximum: MAX_TEXT_LENGTH}

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -8,10 +8,10 @@ module Evidence
     
     MIN_TEXT_LENGTH = 1
     MAX_TEXT_LENGTH = 5000
-    TYPES= [
-      'passage',
-      'response',
-      'prompt'
+    TYPES = [
+      PASSAGE = 'passage',
+      RESPONSE = 'response',
+      PROMPT = 'prompt'
     ]
 
     belongs_to :feedback, inverse_of: :highlights

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -8,10 +8,15 @@ module Evidence
     
     MIN_TEXT_LENGTH = 1
     MAX_TEXT_LENGTH = 5000
+
+    TYPE_PASSAGE  = 'passage'
+    TYPE_RESPONSE = 'response'
+    TYPE_PROMPT   = 'prompt'
+
     TYPES = [
-      PASSAGE = 'passage',
-      RESPONSE = 'response',
-      PROMPT = 'prompt'
+      TYPE_PASSAGE,
+      TYPE_RESPONSE,
+      TYPE_PROMPT
     ]
 
     belongs_to :feedback, inverse_of: :highlights

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -83,7 +83,6 @@ module Evidence
     end
 
     def highlights
-      return [] if optimal?
       return [] if @violated_rule != PROFANITY_RULE_UID
       [{
         type: Evidence::Highlight::TYPES[RESPONSE],

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -26,18 +26,11 @@ module Evidence
       @entry = entry
       @prefilter_rules = Evidence::Rule.where(rule_type: Evidence::Rule::TYPE_PREFILTER).includes(:feedbacks)
       @violated_rule = nil
-      @profanity_instance = nil
+      @profanity_instance = Profanity.profane(entry)
     end
 
     def profanity?
-      profanity = Profanity.profane(entry)
-      
-      if profanity.nil?
-        false 
-      else 
-        @profanity_instance = profanity
-        true
-      end
+      @profanity_instance.present?
     end
 
     def default_response

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -17,10 +17,10 @@ module Evidence
     def initialize(entry)
       # When a prefilter lambda identifies a violation, it returns true
       @prefilters = {
-        QUESTION_MARK_RULE_UID      => ->(entry) { entry.match?(/\?$/) },
-        MULTIPLE_SENTENCE_RULE_UID  => ->(entry) { PrefilterCheck.sentence_count(entry) > 1 },
-        PROFANITY_RULE_UID          => ->(entry) { profanity?(entry)},
-        MINIMUM_WORD_RULE_UID       => ->(entry) { PrefilterCheck.word_count(entry) < MINIMUM_WORD_COUNT}
+        QUESTION_MARK_RULE_UID      => ->(the_entry) { the_entry.match?(/\?$/) },
+        MULTIPLE_SENTENCE_RULE_UID  => ->(the_entry) { PrefilterCheck.sentence_count(the_entry) > 1 },
+        PROFANITY_RULE_UID          => ->(the_entry) { profanity?(the_entry)},
+        MINIMUM_WORD_RULE_UID       => ->(the_entry) { PrefilterCheck.word_count(the_entry) < MINIMUM_WORD_COUNT}
       }
 
       @entry = entry

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -19,7 +19,7 @@ module Evidence
       @prefilters = {
         QUESTION_MARK_RULE_UID      => ->(the_entry) { the_entry.match?(/\?$/) },
         MULTIPLE_SENTENCE_RULE_UID  => ->(the_entry) { PrefilterCheck.sentence_count(the_entry) > 1 },
-        PROFANITY_RULE_UID          => ->(the_entry) { profanity?(the_entry)},
+        PROFANITY_RULE_UID          => ->(the_entry) { profanity? },
         MINIMUM_WORD_RULE_UID       => ->(the_entry) { PrefilterCheck.word_count(the_entry) < MINIMUM_WORD_COUNT}
       }
 
@@ -29,7 +29,7 @@ module Evidence
       @profanity_instance = nil
     end
 
-    def profanity?(entry)
+    def profanity?
       profanity = Profanity.profane(entry)
       
       if profanity.nil?

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -3,28 +3,37 @@
 module Evidence
   class Profanity
 
-    def self.profane?(entry)
+    # Returns: string | nil
+    def self.profane(entry)
       # find the badword substrings that exist in the entry
       found_bad_words = BadWords::ALL.select do |word|
         entry.downcase.include?(word.gsub('*',''))
       end
 
-      return false if found_bad_words.empty?
+      return nil if found_bad_words.empty?
 
       # do a more rigorous word-by-word check for found bad words
-      entry.split(' ').any? { |word| profane_word_check?(word, found_bad_words)}
+      entry.split(' ').find { |word| profane_word_check(word, found_bad_words)}
     end
 
-    # keeping this for now for comparison and benchmarking
-    def self.profane_legacy?(entry)
-      entry.split(' ').any? { |word| profane_word_check?(word)}
-    end
+    # When you want the actual word, not a boolean
+    # def self.get_profanity_instance(entry)
+    #   find_profane_word = lambda do |word|
+    #     return nil unless word.is_a?(String) && word.length > 1
+    #     word = word.downcase.gsub(/[.!?]/, '')
+    #     BadWords::ALL.find do |badword|
+    #       match?(badword: badword, word: word)
+    #     end
+    #   end
 
-    def self.profane_word_check?(word, bad_words = BadWords::ALL)
-      return false unless word.is_a?(String) && word.length > 1
+    #   entry.split(' ').find { |word| find_profane_word.call(word)}
+    # end
+
+    def self.profane_word_check(word, bad_words = BadWords::ALL)
+      return nil unless word.is_a?(String) && word.length > 1
       word = word.downcase.gsub(/[.!?]/, '')
 
-      a_match = bad_words.any? do |badword|
+      a_match = bad_words.find do |badword|
         match?(badword: badword, word: word)
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -10,38 +10,33 @@ module Evidence
       end
 
       return false if found_bad_words.empty?
-
-      # do a more rigorous word-by-word check for found bad words
-      entry.split.any? { |word| profane_word_check?(word, found_bad_words)}
+      
+      # do a more rigorous word-by-word check if bad word stems detected
+      profane_word_check?(entry)
     end
 
-    # keeping this for now for comparison and benchmarking
-    def self.profane_legacy?(entry)
-      entry.split.any? { |word| profane_word_check?(word)}
-    end
-
-    def self.profane_word_check?(word, bad_words = BadWords::ALL)
-      return false unless word.is_a?(String) && word.length > 1
-      word = word.downcase.gsub(/[.!?]/, '')
+    def self.profane_word_check?(entry, bad_words = BadWords::ALL)
+      return false unless entry.is_a?(String) && entry.length > 1
+      entry = entry.downcase.gsub(/[.!?]/, '')
 
       a_match = bad_words.any? do |badword|
-        match?(badword: badword, word: word)
+        match?(badword: badword, entry: entry)
       end
     end
 
-    def self.match?(badword:, word:)
+    def self.match?(badword:, entry:)
       stripped_badword = badword.gsub('*', '')
       if badword.start_with?('*') && badword.end_with?('*')
         regex = ::Regexp.new(stripped_badword)
-         word.match?(regex)
+        entry.match?(regex)
       elsif badword.start_with?('*')
         regex = ::Regexp.new("#{stripped_badword}$")
-         word.match?(regex)
+        entry.match?(regex)
       elsif badword.end_with?('*')
         regex = ::Regexp.new("^#{stripped_badword}")
-         word.match?(regex)
+        entry.match?(regex)
       else
-         stripped_badword == word
+         entry.match(stripped_badword)
       end
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -10,33 +10,38 @@ module Evidence
       end
 
       return false if found_bad_words.empty?
-      
-      # do a more rigorous word-by-word check if bad word stems detected
-      profane_word_check?(entry)
+
+      # do a more rigorous word-by-word check for found bad words
+      entry.split(' ').any? { |word| profane_word_check?(word, found_bad_words)}
     end
 
-    def self.profane_word_check?(entry, bad_words = BadWords::ALL)
-      return false unless entry.is_a?(String) && entry.length > 1
-      entry = entry.downcase.gsub(/[.!?]/, '')
+    # keeping this for now for comparison and benchmarking
+    def self.profane_legacy?(entry)
+      entry.split(' ').any? { |word| profane_word_check?(word)}
+    end
+
+    def self.profane_word_check?(word, bad_words = BadWords::ALL)
+      return false unless word.is_a?(String) && word.length > 1
+      word = word.downcase.gsub(/[.!?]/, '')
 
       a_match = bad_words.any? do |badword|
-        match?(badword: badword, entry: entry)
+        match?(badword: badword, word: word)
       end
     end
 
-    def self.match?(badword:, entry:)
+    def self.match?(badword:, word:)
       stripped_badword = badword.gsub('*', '')
       if badword.start_with?('*') && badword.end_with?('*')
         regex = ::Regexp.new(stripped_badword)
-        entry.match?(regex)
+         word.match?(regex)
       elsif badword.start_with?('*')
         regex = ::Regexp.new("#{stripped_badword}$")
-        entry.match?(regex)
+         word.match?(regex)
       elsif badword.end_with?('*')
         regex = ::Regexp.new("^#{stripped_badword}")
-        entry.match?(regex)
+         word.match?(regex)
       else
-         entry.match(stripped_badword)
+         stripped_badword == word
       end
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -16,19 +16,6 @@ module Evidence
       entry.split(' ').find { |word| profane_word_check(word, found_bad_words)}
     end
 
-    # When you want the actual word, not a boolean
-    # def self.get_profanity_instance(entry)
-    #   find_profane_word = lambda do |word|
-    #     return nil unless word.is_a?(String) && word.length > 1
-    #     word = word.downcase.gsub(/[.!?]/, '')
-    #     BadWords::ALL.find do |badword|
-    #       match?(badword: badword, word: word)
-    #     end
-    #   end
-
-    #   entry.split(' ').find { |word| find_profane_word.call(word)}
-    # end
-
     def self.profane_word_check(word, bad_words = BadWords::ALL)
       return nil unless word.is_a?(String) && word.length > 1
       word = word.downcase.gsub(/[.!?]/, '')

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -13,7 +13,7 @@ module Evidence
       return nil if found_bad_words.empty?
 
       # do a more rigorous word-by-word check for found bad words
-      entry.split(' ').find { |word| profane_word_check(word, found_bad_words)}
+      entry.split.find { |word| profane_word_check(word, found_bad_words)}
     end
 
     def self.profane_word_check(word, bad_words = BadWords::ALL)

--- a/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
@@ -37,7 +37,7 @@ module Evidence
       context 'profanity detected' do 
         it 'should return a profane highlight' do
           prefilter_check = Evidence::PrefilterCheck.new("nero was an ahole")
-          expect(prefilter_check.feedback_object[:highlight]).to eq (
+          expect(prefilter_check.feedback_object[:highlight]).to eq(
             [
               {
                 category: "", 

--- a/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
@@ -23,6 +23,33 @@ module Evidence
       end
     end
 
+    describe '#highlights' do 
+      let!(:profanity_rule) do 
+        create(:evidence_rule, **rule_factory_overrides, uid: PrefilterCheck::PROFANITY_RULE_UID)
+      end
+      context 'no profanity' do 
+        it 'should return []' do 
+          prefilter_check = Evidence::PrefilterCheck.new("entry")
+          expect(prefilter_check.feedback_object[:highlight]).to eq []
+        end
+      end
+
+      context 'profanity detected' do 
+        it 'should return a profane highlight' do
+          prefilter_check = Evidence::PrefilterCheck.new("nero was an ahole")
+          expect(prefilter_check.feedback_object[:highlight]).to eq (
+            [
+              {
+                category: "", 
+                text: "ahole", 
+                type: Evidence::Highlight::TYPE_RESPONSE
+              }
+            ]
+          )
+        end
+      end
+    end
+
     describe '#feedback_object' do
       violations = [
         { 
@@ -68,7 +95,7 @@ module Evidence
 
       context 'no violation' do 
         it 'should return default_response' do 
-          prefilter_check = Evidence::PrefilterCheck.new('they descided on cheeseburgers.')
+          prefilter_check = Evidence::PrefilterCheck.new('they decided on cheeseburgers.')
           result = prefilter_check.feedback_object
           expect(result).to eq(prefilter_check.default_response)
         end

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: truthy
+# frozen_string_literal: true
 
 require 'rails_helper'
 

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -15,6 +15,11 @@ module Evidence
         expect(Profanity.profane?('There is something in a pumpkin')).to be true
       end
 
+      it 'should match space delimited profanities' do 
+        stub_const("BadWords::ALL", ['pie hole'])
+        expect(Profanity.profane?('You are a pie hole.')).to be true
+      end
+
       it 'should return true given a profane word simple match case insensitive' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
         expect(Profanity.profane?('THERE IS SOMETHING IN A PUMPKIN')).to be true

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -1,89 +1,89 @@
-# frozen_string_literal: true
+# frozen_string_literal: truthy
 
 require 'rails_helper'
 
 module Evidence
   RSpec.describe(Profanity) do
-    describe '#profane?' do
-      it 'should return false given no profanity' do
+    describe '#profane' do
+      it 'should return nil given no profanity' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
-        expect(Profanity.profane?('This sentence has no orange gourds.')).to be false
+        expect(Profanity.profane('This sentence has no orange gourds.')).to be nil
       end
 
-      it 'should return true given a profane word simple match' do
+      it 'should return truthy given a profane word simple match' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
-        expect(Profanity.profane?('There is something in a pumpkin')).to be true
+        expect(Profanity.profane('There is something in a pumpkin')).to be_truthy
       end
 
-      it 'should return true given a profane word simple match case insensitive' do
+      it 'should return truthy given a profane word simple match case insensitive' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
-        expect(Profanity.profane?('THERE IS SOMETHING IN A PUMPKIN')).to be true
+        expect(Profanity.profane('THERE IS SOMETHING IN A PUMPKIN')).to be_truthy
       end
 
-      it 'should return false given a partial exact match' do
+      it 'should return nil given a partial exact match' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
-        expect(Profanity.profane?('Mother, here is something in a pumpkins')).to be false
+        expect(Profanity.profane('Mother, here is something in a pumpkins')).to be nil
       end
 
-      it 'should return true given a profane word regex match right glob' do
+      it 'should return truthy given a profane word regex match right glob' do
         stub_const("BadWords::ALL", ['other', 'pumpkin*'])
-        expect(Profanity.profane?('There is something in a pumpkining')).to be true
+        expect(Profanity.profane('There is something in a pumpkining')).to be_truthy
       end
 
-      it 'should return true given a profane word regex match left glob' do
+      it 'should return truthy given a profane word regex match left glob' do
         stub_const("BadWords::ALL", ['other', '*pumpkin'])
-        expect(Profanity.profane?('There is something in a orangepumpkin')).to be true
+        expect(Profanity.profane('There is something in a orangepumpkin')).to be_truthy
       end
 
-      it 'should return false given a substring of a bad word' do
+      it 'should return nil given a substring of a bad word' do
         stub_const("BadWords::ALL", ['other', '*pumpkin*'])
-        expect(Profanity.profane?('this is not pump')).to be false
+        expect(Profanity.profane('this is not pump')).to be nil
       end
 
-      it 'should return true given a profane word regex match left right glob' do
+      it 'should return truthy given a profane word regex match left right glob' do
         stub_const("BadWords::ALL", ['other', '*pumpkin*'])
-        expect(Profanity.profane?('There is orangepumpkins, everywhere')).to be true
+        expect(Profanity.profane('There is orangepumpkins, everywhere')).to be_truthy
       end
 
-      it 'should return true given a profane word with ending punctuation' do
+      it 'should return truthy given a profane word with ending punctuation' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
-        expect(Profanity.profane?('This is a pumpkin.')).to be true
+        expect(Profanity.profane('This is a pumpkin.')).to be_truthy
       end
     end
 
-    describe '#profane_word_check?' do
-      it 'should return true given a profane word simple match' do
+    describe '#profane_word_check' do
+      it 'should return truthy given a profane word simple match' do
         stub_const("BadWords::ALL", ['pumpkin'])
-        expect(Profanity.profane_word_check?('pumpkin')).to be true
+        expect(Profanity.profane_word_check('pumpkin')).to be_truthy
       end
 
-      it 'should return true given a profane word regex match right glob' do
+      it 'should return truthy given a profane word regex match right glob' do
         stub_const("BadWords::ALL", ['pumpkin*'])
-        expect(Profanity.profane_word_check?('pumpkins')).to be true
+        expect(Profanity.profane_word_check('pumpkins')).to be_truthy
       end
 
-      it 'should return true given a profane word regex match left glob' do
+      it 'should return truthy given a profane word regex match left glob' do
         stub_const("BadWords::ALL", ['*pumpkin'])
-        expect(Profanity.profane_word_check?('orangepumpkin')).to be true
+        expect(Profanity.profane_word_check('orangepumpkin')).to be_truthy
       end
 
-      it 'should return false given a substring of a bad word' do
+      it 'should return nil given a substring of a bad word' do
         stub_const("BadWords::ALL", ['*pumpkin*'])
-        expect(Profanity.profane_word_check?('pump')).to be false
+        expect(Profanity.profane_word_check('pump')).to be nil
       end
 
-      it 'should return true given a profane word regex match left right glob' do
+      it 'should return truthy given a profane word regex match left right glob' do
         stub_const("BadWords::ALL", ['*pumpkin*'])
-        expect(Profanity.profane_word_check?('orangepumpkins')).to be true
+        expect(Profanity.profane_word_check('orangepumpkins')).to be_truthy
       end
 
-      it 'should return true given a profane word with ending punctuation' do
+      it 'should return truthy given a profane word with ending punctuation' do
         stub_const("BadWords::ALL", ['pumpkin'])
-        expect(Profanity.profane_word_check?('pumpkin.')).to be true
+        expect(Profanity.profane_word_check('pumpkin.')).to be_truthy
       end
 
-      it 'should return false given a normal word' do
-        expect(Profanity.profane_word_check?('bird')).to be false
+      it 'should return nil given a normal word' do
+        expect(Profanity.profane_word_check('bird')).to be nil
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/profanity_spec.rb
@@ -15,11 +15,6 @@ module Evidence
         expect(Profanity.profane?('There is something in a pumpkin')).to be true
       end
 
-      it 'should match space delimited profanities' do 
-        stub_const("BadWords::ALL", ['pie hole'])
-        expect(Profanity.profane?('You are a pie hole.')).to be true
-      end
-
       it 'should return true given a profane word simple match case insensitive' do
         stub_const("BadWords::ALL", ['other', 'pumpkin'])
         expect(Profanity.profane?('THERE IS SOMETHING IN A PUMPKIN')).to be true


### PR DESCRIPTION
## WHAT
Adds profanity highlighting in student responses. 

## WHY
Product request.

## HOW
This required a bit of refactoring.
- the `profanity` library now returns the actual profane word or nil, rather than a boolean. This allows us to check for profanity only once rather than twice (it's an expensive operation)
- the profanity check is the only check that depends on instance variables (the instance variable memoizes the expensive operation). Thus, it cannot be initialized as a lambda-constant. I moved all checks from lamba-constants to lambda-instance variables for consistency.
- 
<img width="620" alt="Screen Shot 2022-01-21 at 10 21 31 AM" src="https://user-images.githubusercontent.com/90669/150571660-0f3a6605-15b9-48fe-8673-7884eaf33474.png">

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=44d09dfa7511488c98e11186eb774648

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
