### PR TITLE
"Add a link" button for admin TextEditor 

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/custom.scss
+++ b/services/QuillLMS/app/assets/stylesheets/custom.scss
@@ -473,7 +473,7 @@ label.css-label {
   cursor: grabbing;
 }
 
-#link_url {
+#link-url {
   outline: none;
   background-color: white;
   span {

--- a/services/QuillLMS/app/assets/stylesheets/custom.scss
+++ b/services/QuillLMS/app/assets/stylesheets/custom.scss
@@ -472,3 +472,12 @@ label.css-label {
 .sortable-list .list-item:active {
   cursor: grabbing;
 }
+
+#link_url {
+  outline: none;
+  background-color: white;
+  span {
+    background-color: white;
+    color: rgb(153, 153, 153);
+  }
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
@@ -75,6 +75,12 @@
           line-height: 1.5em;
         }
       }
+      a {
+        color: #027360;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
     }
     .assign-buttons-and-standards {
       max-width: 400px;

--- a/services/QuillLMS/client/app/bundles/Shared/components/draftJSCustomPlugins/addLinkPlugin.js
+++ b/services/QuillLMS/client/app/bundles/Shared/components/draftJSCustomPlugins/addLinkPlugin.js
@@ -13,8 +13,7 @@ export const linkStrategy = (contentBlock, callback, contentState) => {
   );
 };
 
-export const Link = (props) => {
-  const { contentState, entityKey, children } = props;
+export const Link = ({ contentState, entityKey, children }) => {
   const { url } = contentState.getEntity(entityKey).getData();
   return (
     <a

--- a/services/QuillLMS/client/app/bundles/Shared/components/draftJSCustomPlugins/addLinkPlugin.js
+++ b/services/QuillLMS/client/app/bundles/Shared/components/draftJSCustomPlugins/addLinkPlugin.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export const linkStrategy = (contentBlock, callback, contentState) => {
+  contentBlock.findEntityRanges(
+    (character) => {
+      const entityKey = character.getEntity();
+      return (
+        entityKey !== null &&
+        contentState.getEntity(entityKey).getType() === 'LINK'
+      );
+    },
+    callback
+  );
+};
+
+export const Link = (props) => {
+  const { contentState, entityKey, children } = props;
+  const { url } = contentState.getEntity(entityKey).getData();
+  return (
+    <a
+      aria-label={url}
+      className="link"
+      href={url}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {children}
+    </a>
+  );
+};
+
+const addLinkPlugin = {
+
+	decorators: [
+		{
+			strategy: linkStrategy,
+			component: Link
+		}
+	]
+};
+
+export default addLinkPlugin;
+

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -3,8 +3,13 @@ import * as Draft from 'draft-js';
 import Editor from '@draft-js-plugins/editor'
 import { convertFromHTML, convertToHTML } from 'draft-convert'
 import * as Immutable from 'immutable'
+import {
+  RichUtils,
+  EditorState,
+} from 'draft-js'
 
 import { richButtonsPlugin, } from '../../index'
+import addLinkPluginPlugin from "../draftJSCustomPlugins/addLinkPlugin";
 
 const HIGHLIGHT = 'highlight'
 const HIGHLIGHTABLE = 'HIGHLIGHTABLE'
@@ -32,10 +37,12 @@ const customRenderMap = Draft.DefaultDraftBlockRenderMap.merge(
 class TextEditor extends React.Component <any, any> {
   constructor(props: any) {
     super(props)
+    const addLinkPlugin = addLinkPluginPlugin
 
     this.state = {
       text: props.EditorState.createWithContent(this.contentState(props.text || '')),
-      richButtonsPlugin: richButtonsPlugin()
+      richButtonsPlugin: richButtonsPlugin(),
+      addLinkPlugin: addLinkPlugin,
     }
   }
 
@@ -58,6 +65,12 @@ class TextEditor extends React.Component <any, any> {
           return <mark />;
         }
       },
+      entityToHTML: (entity, originalText) => {
+        if (entity.type === 'LINK') {
+          return <a href={entity.data.url}>{originalText}</a>;
+        }
+        return originalText;
+      }
     })(text.getCurrentContent());
   }
 
@@ -68,6 +81,15 @@ class TextEditor extends React.Component <any, any> {
           return currentStyle.add(HIGHLIGHTABLE);
         } else {
           return currentStyle;
+        }
+      },
+      htmlToEntity: (nodeName, node, createEntity) => {
+        if (nodeName === 'a') {
+            return createEntity(
+                'LINK',
+                'MUTABLE',
+                {url: node.href}
+            )
         }
       },
     })(html);
@@ -100,11 +122,29 @@ class TextEditor extends React.Component <any, any> {
       return 'handled';
     }
     return 'not-handled';
-}
+  }
+
+  // this code was pasted from the tutorial here:
+  // https://medium.com/@siobhanpmahoney/building-a-rich-text-editor-with-react-and-draft-js-part-2-2-embedding-links-d71b57d187a7
+  handleAddLink = () => {
+    const { text } = this.state
+    const editorState = text;
+    const selection = editorState.getSelection();
+    const link = window.prompt('Paste the link -')
+    if (!link) {
+      this.handleTextChange(RichUtils.toggleLink(editorState, selection, null));
+      return 'handled';
+    }
+    const content = editorState.getCurrentContent();
+    const contentWithEntity = content.createEntity('LINK', 'MUTABLE', { url: link });
+    const newEditorState = EditorState.push(editorState, contentWithEntity, 'create-entity');
+    const entityKey = contentWithEntity.getLastCreatedEntityKey();
+    this.handleTextChange(RichUtils.toggleLink(newEditorState, selection, entityKey))
+  }
 
   render() {
     const { shouldCheckSpelling } = this.props;
-    const { richButtonsPlugin, text, } = this.state
+    const { richButtonsPlugin, text, addLinkPlugin } = this.state
     const {
       // inline buttons
       ItalicButton, BoldButton, UnderlineButton, createStyleButton,
@@ -131,6 +171,9 @@ class TextEditor extends React.Component <any, any> {
             <BlockquoteButton />
             <ULButton />
             <HighlightButton />
+            <button className="add-link" id="link_url" onClick={this.handleAddLink} type="button">
+              <span>Link</span>
+            </button>
           </div>
         </header>
         <div className="card-content">
@@ -142,7 +185,7 @@ class TextEditor extends React.Component <any, any> {
               handleKeyCommand={this.onKeyCommand}
               keyBindingFn={this.keyBindingFn}
               onChange={this.handleTextChange}
-              plugins={[richButtonsPlugin]}
+              plugins={[richButtonsPlugin, addLinkPlugin]}
               spellCheck={!!shouldCheckSpelling}
             />
           </div>

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -13,6 +13,8 @@ import addLinkPluginPlugin from "../draftJSCustomPlugins/addLinkPlugin";
 
 const HIGHLIGHT = 'highlight'
 const HIGHLIGHTABLE = 'HIGHLIGHTABLE'
+const LINK = 'LINK'
+const MUTABLE = 'MUTABLE'
 
 // interface TextEditorProps {
 //   text: string;
@@ -66,7 +68,7 @@ class TextEditor extends React.Component <any, any> {
         }
       },
       entityToHTML: (entity, originalText) => {
-        if (entity.type === 'LINK') {
+        if (entity.type === LINK) {
           return <a href={entity.data.url}>{originalText}</a>;
         }
         return originalText;
@@ -86,8 +88,8 @@ class TextEditor extends React.Component <any, any> {
       htmlToEntity: (nodeName, node, createEntity) => {
         if (nodeName === 'a') {
             return createEntity(
-                'LINK',
-                'MUTABLE',
+                LINK,
+                MUTABLE,
                 {url: node.href}
             )
         }
@@ -136,7 +138,7 @@ class TextEditor extends React.Component <any, any> {
       return 'handled';
     }
     const content = editorState.getCurrentContent();
-    const contentWithEntity = content.createEntity('LINK', 'MUTABLE', { url: link });
+    const contentWithEntity = content.createEntity(LINK, MUTABLE, { url: link });
     const newEditorState = EditorState.push(editorState, contentWithEntity, 'create-entity');
     const entityKey = contentWithEntity.getLastCreatedEntityKey();
     this.handleTextChange(RichUtils.toggleLink(newEditorState, selection, entityKey))
@@ -171,7 +173,7 @@ class TextEditor extends React.Component <any, any> {
             <BlockquoteButton />
             <ULButton />
             <HighlightButton />
-            <button className="add-link" id="link_url" onClick={this.handleAddLink} type="button">
+            <button className="add-link" id="link-url" onClick={this.handleAddLink} type="button">
               <span>Link</span>
             </button>
           </div>


### PR DESCRIPTION
## WHAT
Admin requested an extra button, "Link" that enables them to add a hyperlink to any text in the HTML Text Editor they currently use for Evidence/Activity Packs.

## WHY
They sometimes need to link a PDF document when writing activity pack descriptions.

## HOW
Using[ this tutorial, ](https://medium.com/@siobhanpmahoney/building-a-rich-text-editor-with-react-and-draft-js-part-2-2-embedding-links-d71b57d187a7), I created a new plugin `addLinkPlugin` that returns the components and functions necessary to add a new link using the DraftJSPlugin guidelines.

### Screenshots
![Screen Shot 2022-01-20 at 3 52 21 PM](https://user-images.githubusercontent.com/57366100/150569269-1def73b7-3410-40ef-9c05-ba31716bb4e1.png)
![Screen Shot 2022-01-20 at 3 52 37 PM](https://user-images.githubusercontent.com/57366100/150569283-d24ed2cf-44cb-4bdf-857a-7020ca83d66e.png)


### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now! 
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes