### PR TITLE
evidence/fuzzy-plagiarism-performance-enhancements

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -126,14 +126,14 @@ module Evidence
     private def identify_matched_slices(entry_slices, passage_slices)
       entry_slices.select do |_, slice|
         # Check to see if there's enough similarity for it to be worth doing a Levenshtein comparison
-        next false unless confirm_minimum_overlap(slice, passage_slices)
+        next false unless confirm_minimum_overlap?(slice, passage_slices)
         slice_string = slice.join(' ')
         passage_slice_strings = passage_slices.map { |s| s.join(' ') }
         passage_slice_strings.any? { |passage_string| DidYouMean::Levenshtein.distance(slice_string, passage_string) <= FUZZY_CHARACTER_THRESHOLD }
       end.keys
     end
 
-    private def confirm_minimum_overlap(target_array, source_arrays)
+    private def confirm_minimum_overlap?(target_array, source_arrays)
       # Since we allow character deviation that's smaller than the total number of words compared
       # we know that there's a minimum number of words that have to be identical.  This function
       # confirms that minimum amount of overlap to justify doing a set of Levenshtein calculations.

--- a/services/QuillLMS/engines/evidence/lib/tasks/benchmark.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/benchmark.rake
@@ -17,7 +17,7 @@ namespace :benchmark do
       "The 2014 pulse flow was considered successful, so 11.4 billion gallons of water was released to the river to keep it from drying out.",
       "The 2014 pulse flow was considered successful, so another 11.4 billion gallons of water was released into the river.",
       "The 2014 pulse flow was considered successful, so they decided to add more water.",
-      "The 2014 pulse flow was considered successful, so one more 11.4 billion gallons of water were delivered into the river.",
+      "The 2014 pulse flow was considered successful, so one more 11.4 billion gallons of water were delivered into the river."
     ]
     
     passage = "Due to the success of the 2014 pulse flow, another 11.4 billion gallons of water was released into the river in May 2021. Scientists think that this pulse flow will support the other conservation efforts Pronatura Noroeste and other local groups are already leading."
@@ -26,6 +26,6 @@ namespace :benchmark do
         Evidence::PlagiarismCheck.new(entry, passage, '', nil).feedback_object
       end
     end
-    puts 'Average run time for the Plagiarism algorithm was %.9f seconds' % (runtime / entries.length)
+    puts format('Average run time for the Plagiarism algorithm was %<runtime>.9f seconds', {runtime: (runtime / entries.length)})
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/tasks/benchmark.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/benchmark.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+
+namespace :benchmark do
+
+  desc "Runs a benchmark on the Plagiarism algorithm"
+
+  task :plagiarism => :environment do |t, args|
+    entries = [
+      "The 2014 pulse flow was considered successful, so they added 11.4 million gallons into the river.",
+      "The 2014 pulse flow was considered successful, so scientists believe that it will be able to support other conservation efforts.",
+      "The 2014 pulse flow was considered successful, so scientists think that it will support the other conservation efforts Pronatura Noroeste and other local groups are already leading.",
+      "The 2014 pulse flow was considered successful, so countries have been willing to continue releasing water into the river.",
+      "The 2014 pulse flow was considered successful, so scientists released water into the river to keep it from drying out again.",
+      "The 2014 pulse flow was considered successful, so 11.4 billion gallons of water was emptied into the river to keep it from drying out.",
+      "The 2014 pulse flow was considered successful, so 11.4 billion gallons of water was released to the river to keep it from drying out.",
+      "The 2014 pulse flow was considered successful, so another 11.4 billion gallons of water was released into the river.",
+      "The 2014 pulse flow was considered successful, so they decided to add more water.",
+      "The 2014 pulse flow was considered successful, so one more 11.4 billion gallons of water were delivered into the river.",
+    ]
+    
+    passage = "Due to the success of the 2014 pulse flow, another 11.4 billion gallons of water was released into the river in May 2021. Scientists think that this pulse flow will support the other conservation efforts Pronatura Noroeste and other local groups are already leading."
+    runtime = Benchmark.realtime do
+      entries.each do |entry|
+        Evidence::PlagiarismCheck.new(entry, passage, '', nil).feedback_object
+      end
+    end
+    puts 'Average run time for the Plagiarism algorithm was %.9f seconds' % (runtime / entries.length)
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
@@ -127,6 +127,7 @@ module Evidence
           expect(passage).to include(feedback[:highlight][1][:text])
         end
       end
+
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
@@ -127,7 +127,6 @@ module Evidence
           expect(passage).to include(feedback[:highlight][1][:text])
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
## WHAT
This is a first pass to tweak fuzzy plagiarism match to be more performant.  On my local machine benchmark time fell from approximately 270ms to 170ms per run with the test dataset.

Also add a benchmarking rake task to calculate performance improvements
## WHY
By not running Levenshtein comparisons if there aren't enough exact matching words to allow the maximum fuzziness to exist.
## HOW
We know that we only care about Levenshtein distance if it is low enough.  Given the size of the word arrays we compare, that means that for the Levenshtein distance to be as low as we want requires that a minimum number of words in the comparison be identical.  This new code basically confirms that there are enough matching words that it's possible for the Levenshtein distance to be as low as we want before computing said distance, allowing us to reduce the required CPU time by short-circuiting the most expensive part of the algorithm when we know it won't find a match anyway.

NOTE: The benchmarked performance improvement (a 40%-ish reduction in run time) may not actually achieve our target of 500ms for all production runs, but I want to get this into production to see how the benchmark correlates with production times to figure out how much more aggressive we might need to be with algorithm revisions.

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Improve-Performance-of-Fuzzy-Matching-5a75072d26784ac28e773074cbcb73e4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  We don't actually want to change behavior/outcomes here
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
