### PR TITLE
Evidence/ small cosmetic changes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
@@ -62,22 +62,22 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
 
   let className = 'feedback'
   let imageSrc = loopSrc
-  let imageAlt = 'Arrows pointing in opposite directions, making a loop'
+  let imageAlt = 'Revise icon'
   if (lastSubmittedResponse.optimal) {
     className += ' optimal'
     imageSrc = smallCheckCircleSrc
-    imageAlt = 'Small green circle with a check in it'
+    imageAlt = 'Check icon'
   }
 
   const key = customFeedbackKey || submittedResponses.length
   const feedback = feedbackToShow(lastSubmittedResponse, submittedResponses, prompt, customFeedback)
 
-  let reportAProblemSection = <button className="report-a-problem-button" onClick={toggleReportAProblemExpanded} type="button">Report a problem</button>
-
+  const reportAProblemButton = <button className="report-a-problem-button interactive-wrapper" onClick={toggleReportAProblemExpanded} type="button">Report a problem</button>
+  let reportAProblemSection = <span />
   if (reportAProblemExpanded) {
     const reportAProblemOptionElements = reportSubmitted ? null : <div className="options">{reportAProblemOptions(lastSubmittedResponse.optimal).map(opt => <ReportAProblemOption handleSelectProblem={handleSelectProblem} key={opt} option={opt} />)}</div>
-    const label = reportSubmitted ? 'Thank you for your feedback!' : 'Report a problem'
-    const text = reportSubmitted ? 'For now, please try your best to revise and improve your sentence.' : 'What did you notice?'
+    const label = reportSubmitted ? 'Thank you for your feedback!' : 'What did you notice?'
+    const text = reportSubmitted ? 'For now, please try your best to revise and improve your sentence.' : ''
 
     reportAProblemSection = (<section className="report-a-problem-section">
       <div className="report-a-problem-section-header">
@@ -101,8 +101,12 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
       >
         <React.Fragment>
           <div className={className} key={key}>
-            <img alt={imageAlt} src={imageSrc} />
+            <div className="feedback-label-section">
+              <img alt={imageAlt} src={imageSrc} />
+              <p>Feedback</p>
+            </div>
             <p className="feedback-text" dangerouslySetInnerHTML={feedbackForInnerHTML(feedback)} role="status" />
+            <div className="report-a-problem-button-container">{reportAProblemButton}</div>
           </div>
           {reportAProblemSection}
         </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -284,7 +284,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     const entry = this.stripHtml(html).trim()
     const awaitingFeedback = numberOfSubmissions !== submittedResponses.length
     const buttonLoadingSpinner = awaitingFeedback ? <ButtonLoadingSpinner /> : null
-    let buttonCopy = submittedResponses.length ? 'Get new feedback' : 'Get feedback'
+    let buttonCopy = 'Get feedback'
     let className = 'quill-button focus-on-light'
     let onClick = () => this.handleGetFeedbackClick(entry, id, text)
 
@@ -293,7 +293,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
       buttonCopy = 'Done'
     } else if (submittedResponses.length === max_attempts || this.lastSubmittedResponse().optimal) {
       onClick = this.completeStep
-      buttonCopy = 'Start next sentence'
+      buttonCopy = 'Next'
     } else if (this.unsubmittableResponses().includes(entry) || awaitingFeedback || responseOverCharacterLimit) {
       className += ' disabled'
       onClick = () => {}

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -25,7 +25,7 @@
   }
 
   .read-passage-container {
-    padding: 48px 40px;
+    padding: 32px 40px;
     width: calc(100% - 680px);
     margin: 0px;
     display: flex;
@@ -289,9 +289,10 @@
   }
 
   @media (max-width: 1099px) {
-    flex-direction: column;
+    flex-direction: column-reverse;
     height: auto;
     &.on-read-passage {
+      flex-direction: column;
       .steps-outer-container, .steps-inner-container {
         padding-bottom: 80px;
       }

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -102,16 +102,9 @@
   .feedback-section {
     margin: 16px 8px 0px 0px;
     .report-a-problem-button {
-      margin-left: 0px;
-      padding: 9px 16px;
-      border-radius: 0px 0px 6px 6px;
-      border: solid 1px #d8d8d8;
-      background-color: #fff;
-      border-top: none;
-      font-size: 14px;
       font-weight: 600;
-      line-height: 1;
-      color: #555;
+      color: #808080;
+      font-size: 14px;
     }
     .report-a-problem-section {
       padding: 9px 16px 16px;
@@ -122,12 +115,12 @@
       .report-a-problem-section-header {
         display: flex;
         justify-content: space-between;
-        align-items: flex-start;
+        align-items: baseline;
         .label {
-          font-size: 14px;
-          font-weight: 600;
+          font-size: 16px;
           line-height: 1;
-          color: #555;
+          font-weight: normal;
+          color: #000000;
           margin-bottom: 8px;
         }
         .interactive-wrapper {
@@ -187,9 +180,11 @@
       }
     }
     .feedback {
-      border-radius: 6px 6px 6px 0px;
+      display: flex;
+      flex-direction: column;
+      border-radius: 6px;
       border: solid 1px #ff9f00;
-      background-color: #fff6e4;
+      background-color: #fff5e5;
       padding: 16px;
       display: flex;
       align-items: flex-start;
@@ -199,14 +194,29 @@
 
       @keyframes revisepulse {
         0%  {
-          background-color: #fff6e4;
+          background-color: #fff5e5;
         }
         50% {
           background-color: #FF9F00;
         }
         100% {
-          background-color: #fff6e4;
+          background-color: #fff5e5;
         }
+      }
+      .feedback-label-section {
+        display: flex;
+        align-items: center;
+        margin-bottom: 12px;
+        p {
+          font-size: 14px;
+          color: #995f00;
+          font-weight: 600;
+        }
+      }
+      .report-a-problem-button-container{
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
       }
       p {
         white-space: pre-wrap;
@@ -219,19 +229,23 @@
         margin-right: 12px;
       }
       &.optimal {
-        border: solid 1px #55a200;
-        background-color: #f4ffe8;
+        border: solid 1px #4ea500;
+        background-color: #e9f4e0;
         animation: optimalpulse 0.8s 1;
-
+        .feedback-label-section {
+          p {
+            color: #2a5900;
+          }
+        }
         @keyframes optimalpulse {
           0%  {
-            background-color: #fff6e4;
+            background-color: #e9f4e0;
           }
           50% {
-            background-color: #55a200;
+            background-color: #4ea500;
           }
           100% {
-            background-color: #fff6e4;
+            background-color: #e9f4e0;
           }
         }
       }

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
             type="button"
           >
             <span>
-              Get new feedback
+              Get feedback
             </span>
           </button>
         </div>
@@ -470,7 +470,7 @@ exports[`PromptStep component active state when an optimal response has been sub
             type="button"
           >
             <span>
-              Start next sentence
+              Next
             </span>
           </button>
         </div>
@@ -726,7 +726,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             type="button"
           >
             <span>
-              Start next sentence
+              Next
             </span>
           </button>
         </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -316,10 +316,17 @@ exports[`PromptStep component active state when a suboptimal response has been s
                       className="feedback"
                       key="1"
                     >
-                      <img
-                        alt="Arrows pointing in opposite directions, making a loop"
-                        src="undefined/images/icons/loop.svg"
-                      />
+                      <div
+                        className="feedback-label-section"
+                      >
+                        <img
+                          alt="Revise icon"
+                          src="undefined/images/icons/loop.svg"
+                        />
+                        <p>
+                          Feedback
+                        </p>
+                      </div>
                       <p
                         className="feedback-text"
                         dangerouslySetInnerHTML={
@@ -329,14 +336,19 @@ exports[`PromptStep component active state when a suboptimal response has been s
                         }
                         role="status"
                       />
+                      <div
+                        className="report-a-problem-button-container"
+                      >
+                        <button
+                          className="report-a-problem-button interactive-wrapper"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          Report a problem
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      className="report-a-problem-button"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Report a problem
-                    </button>
+                    <span />
                   </CSSTransitionGroupChild>
                 </span>
               </div>
@@ -544,10 +556,17 @@ exports[`PromptStep component active state when an optimal response has been sub
                       className="feedback optimal"
                       key="1"
                     >
-                      <img
-                        alt="Small green circle with a check in it"
-                        src="undefined/images/icons/check-circle-small.svg"
-                      />
+                      <div
+                        className="feedback-label-section"
+                      >
+                        <img
+                          alt="Check icon"
+                          src="undefined/images/icons/check-circle-small.svg"
+                        />
+                        <p>
+                          Feedback
+                        </p>
+                      </div>
                       <p
                         className="feedback-text"
                         dangerouslySetInnerHTML={
@@ -557,14 +576,19 @@ exports[`PromptStep component active state when an optimal response has been sub
                         }
                         role="status"
                       />
+                      <div
+                        className="report-a-problem-button-container"
+                      >
+                        <button
+                          className="report-a-problem-button interactive-wrapper"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          Report a problem
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      className="report-a-problem-button"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Report a problem
-                    </button>
+                    <span />
                   </CSSTransitionGroupChild>
                 </span>
               </div>
@@ -828,10 +852,17 @@ exports[`PromptStep component active state when the max attempts have been reach
                       className="feedback"
                       key="5"
                     >
-                      <img
-                        alt="Arrows pointing in opposite directions, making a loop"
-                        src="undefined/images/icons/loop.svg"
-                      />
+                      <div
+                        className="feedback-label-section"
+                      >
+                        <img
+                          alt="Revise icon"
+                          src="undefined/images/icons/loop.svg"
+                        />
+                        <p>
+                          Feedback
+                        </p>
+                      </div>
                       <p
                         className="feedback-text"
                         dangerouslySetInnerHTML={
@@ -843,14 +874,19 @@ exports[`PromptStep component active state when the max attempts have been reach
                         }
                         role="status"
                       />
+                      <div
+                        className="report-a-problem-button-container"
+                      >
+                        <button
+                          className="report-a-problem-button interactive-wrapper"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          Report a problem
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      className="report-a-problem-button"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Report a problem
-                    </button>
+                    <span />
                   </CSSTransitionGroupChild>
                 </span>
               </div>
@@ -1057,10 +1093,17 @@ exports[`PromptStep component active state when the max attempts have been reach
                       className="feedback optimal"
                       key="1"
                     >
-                      <img
-                        alt="Small green circle with a check in it"
-                        src="undefined/images/icons/check-circle-small.svg"
-                      />
+                      <div
+                        className="feedback-label-section"
+                      >
+                        <img
+                          alt="Check icon"
+                          src="undefined/images/icons/check-circle-small.svg"
+                        />
+                        <p>
+                          Feedback
+                        </p>
+                      </div>
                       <p
                         className="feedback-text"
                         dangerouslySetInnerHTML={
@@ -1070,14 +1113,19 @@ exports[`PromptStep component active state when the max attempts have been reach
                         }
                         role="status"
                       />
+                      <div
+                        className="report-a-problem-button-container"
+                      >
+                        <button
+                          className="report-a-problem-button interactive-wrapper"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          Report a problem
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      className="report-a-problem-button"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Report a problem
-                    </button>
+                    <span />
                   </CSSTransitionGroupChild>
                 </span>
               </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
@@ -167,9 +167,9 @@ describe('PromptStep component', () => {
         expect(wrapper.find(EditorContainer)).toHaveLength(1)
       })
 
-      it('has a non-disabled button with the text "Start next sentence"', () => {
+      it('has a non-disabled button with the text "Next"', () => {
         expect(wrapper.find('.quill-button.disabled')).toHaveLength(0)
-        expect(wrapper.find('.quill-button').text()).toEqual("Start next sentence")
+        expect(wrapper.find('.quill-button').text()).toEqual("Next")
       })
 
     })
@@ -193,9 +193,9 @@ describe('PromptStep component', () => {
         expect(wrapper.find(EditorContainer)).toHaveLength(1)
       })
 
-      it('has a disabled button with the text "Get new feedback"', () => {
+      it('has a disabled button with the text "Get feedback"', () => {
         expect(wrapper.find('.quill-button.disabled')).toHaveLength(1)
-        expect(wrapper.find('.quill-button.disabled').text()).toEqual("Get new feedback")
+        expect(wrapper.find('.quill-button.disabled').text()).toEqual("Get feedback")
       })
     })
 
@@ -216,9 +216,9 @@ describe('PromptStep component', () => {
         expect(wrapper.find(EditorContainer)).toHaveLength(1)
       })
 
-      it('has a non-disabled button with the text "Start next sentence"', () => {
+      it('has a non-disabled button with the text "Next"', () => {
         expect(wrapper.find('.quill-button.disabled')).toHaveLength(0)
-        expect(wrapper.find('.quill-button').text()).toEqual("Start next sentence")
+        expect(wrapper.find('.quill-button').text()).toEqual("Next")
       })
     })
 


### PR DESCRIPTION
## WHAT
another set of UI updates for Evidence: decreasing the vertical space between the header and the passage element, updating feedback button copy and displaying the prompt above the passage when viewing on mobile

## WHY
these changes were requested to improve the Evidence UI

## HOW
just update some copy and CSS 

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1419" alt="Screen Shot 2022-01-24 at 7 17 30 PM" src="https://user-images.githubusercontent.com/25959584/150874406-39cf0819-22fa-4ddd-9f92-a845bb880ae2.png">
<img width="208" alt="Screen Shot 2022-01-24 at 7 17 00 PM" src="https://user-images.githubusercontent.com/25959584/150874424-1c9603b8-e674-4752-a394-34c62c7bec91.png">
<img width="648" alt="Screen Shot 2022-01-24 at 7 17 55 PM" src="https://user-images.githubusercontent.com/25959584/150874430-0dda387d-76c7-4e84-a963-9aede543820f.png">
<img width="651" alt="Screen Shot 2022-01-24 at 7 18 14 PM" src="https://user-images.githubusercontent.com/25959584/150874476-12aa59b7-4bda-4a98-87fa-3545054b0337.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Various-small-cosmetic-updates-947d8c641f5e41dabb4a00767efdab8e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
