### PR TITLE
Evidence/narrow fuzzy match threshold

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -8,7 +8,7 @@ module Evidence
     ENTRY_TYPE = 'response'
     MATCH_MINIMUM = 10
     OPTIMAL_RULE_KEY = 'optimal_plagiarism_rule_serialized'
-    FUZZY_CHARACTER_THRESHOLD = 5
+    FUZZY_CHARACTER_THRESHOLD = 3
     attr_reader :entry, :passage, :nonoptimal_feedback
 
     def initialize(entry, passage, feedback, rule)

--- a/services/QuillLMS/engines/evidence/lib/tasks/plagiarized_responses.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/plagiarized_responses.rake
@@ -48,7 +48,7 @@ namespace :plagiarized_responses do
     # Derived from lib/evidence/evidence/plagiarism_check.rb 'match_entry_on_passage'
     def minimum_edit_distance_per_slice(entry, plagiarism_text)
       match_minimum = 10
-      shortest_distance_we_care_about = 5
+      shortest_distance_we_care_about = 3
 
       entry_arr = entry.gsub(/[[:punct:]]/, '').downcase.split
       plagiarism_arr = plagiarism_text.gsub(/[[:punct:]]/, '').downcase.split
@@ -67,21 +67,19 @@ namespace :plagiarized_responses do
 
     input = CSV.read(args[:input_csv_path], headers: true)
     output_file_path = args[:input_csv_path].sub('.csv', '.result.csv')
-    output_headers = input.headers + ['Plagiarism Feedback', '5 Character Difference', '10 Character Difference', '15 Character Difference', '20 Character Difference']
+    output_headers = input.headers + ['Plagiarism Feedback', '3 Character Difference', '5 Character Difference', '3 and 5 Match?']
     start = Time.now
     CSV.open(output_file_path, 'w', write_headers: true, headers: output_headers) do |output|
       input.each do |row|
         row['Plagiarism Feedback'] = (row['feedback_type'] == 'plagiarism')
+        row['3 Character Difference'] = false
         row['5 Character Difference'] = false
-        row['10 Character Difference'] = false
-        row['15 Character Difference'] = false
-        row['20 Character Difference'] = false
+        row['3 and 5 Match?'] = true
         closest_plagiarism = minimum_edit_distance_per_slice(row['entry'], row['plagiarism_text'])
         unless closest_plagiarism.nil?
+          row['3 Character Difference'] = (closest_plagiarism <= 3)
           row['5 Character Difference'] = (closest_plagiarism <= 5)
-          row['10 Character Difference'] = (closest_plagiarism <= 10)
-          row['15 Character Difference'] = (closest_plagiarism <= 15)
-          row['20 Character Difference'] = (closest_plagiarism <= 20)
+          row['3 and 5 Match?'] = (closest_plagiarism <= 3) == (closest_plagiarism <= 5)
         end
         output << row
       end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -245,10 +245,10 @@ module Evidence
       end
 
       it 'should return successfully when there is fuzzy match plagiarism' do
-        post("plagiarism", :params => ({ :entry => ("bla bla bla FUZZY#{plagiarized_text1}"), :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
+        post("plagiarism", :params => ({ :entry => ("bla bla bla FZY#{plagiarized_text1}"), :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
         parsed_response = JSON.parse(response.body)
         expect(false).to(eq(parsed_response["optimal"]))
-        expect("FUZZY#{plagiarized_text1}").to(eq(parsed_response["highlight"][0]["text"]))
+        expect("FZY#{plagiarized_text1}").to(eq(parsed_response["highlight"][0]["text"]))
         expect(plagiarized_text1).to(eq(parsed_response["highlight"][1]["text"]))
         expect(first_feedback.text).to(eq(parsed_response["feedback"]))
         request.env.delete("RAW_POST_DATA")


### PR DESCRIPTION
## WHAT
Narrow our fuzzy-matching plagiarism algorithm so that only student entries that are within 3 characters (instead of the old 5) will be flagged as plagiarism
## WHY
We have some code within the algorithm that short-circuits the relatively CPU-intensive Levenshtein distance calculation if there isn't already enough similarity between the student entry and the `plagiarism_text` of the prompt being responded to.  This short-circuit is allowed to be more aggressive the fewer characters of difference we allow, which lets us more often skip the need to do any Levenshtein calculations at all for most entries (which have no plagiarism).

Basically, while we derive no pedagogical benefits from this change, we do derive performance benefits, which will hopefully bring the max run-time of this algorithm down below our target of 500ms.

One nice thing worth noting here, is that an analysis of 10k student entries from the `FeedbackHistory` table reveals that 3-character matching and 5-character matching have 99.97% the same results.  This means that we shouldn't be reducing our pedagogical rigor with this change.
## HOW
Fortunately, the specificity of fuzzy-matching is a constant, so I simply reduced the value from 5 to 3.

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Improve-Performance-of-Fuzzy-Matching-5a75072d26784ac28e773074cbcb73e4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
