### PR TITLE
active activity session performance

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
     begin
       @activity_session = ActiveActivitySession.find_or_initialize_by(uid: params[:id])
       @activity_session.data ||= {}
-      @activity_session.data = @activity_session.data.merge(working_params)
+      @activity_session.data = params#@activity_session.data.merge(working_params)
       @activity_session.save!
     rescue ActiveRecord::RecordNotUnique => e
       # Due to the way that ActiveRecord handles unique validations such as the one on UID,
@@ -26,7 +26,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
       retried = true
       retry
     end
-    render json: {}, status: 204
+    head :no_content
   end
 
   private def working_params

--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
     begin
       @activity_session = ActiveActivitySession.find_or_initialize_by(uid: params[:id])
       @activity_session.data ||= {}
-      @activity_session.data = params#@activity_session.data.merge(working_params)
+      @activity_session.data = @activity_session.data.merge(working_params)
       @activity_session.save!
     rescue ActiveRecord::RecordNotUnique => e
       # Due to the way that ActiveRecord handles unique validations such as the one on UID,

--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
       retried = true
       retry
     end
-    render json: @activity_session.as_json
+    render json: {}, status: 204
   end
 
   private def working_params

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -401,8 +401,7 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
     it "should create a new session if the requested activity session is not found" do
       data = {"foo" => "bar"}
       put :update, params: { id: 'doesnotexist', active_activity_session: data }, as: :json
-      expect(response.status).to eq(200)
-      expect(response.body).to eq(data.to_json)
+      expect(response.status).to eq(204)
       new_activity_session = ActiveActivitySession.find_by(uid: 'doesnotexist')
       expect(new_activity_session).to be
       expect(new_activity_session.data).to eq(data)

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -20,6 +20,326 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
   end
 
   describe "#update" do
+    xit 'performance testing' do 
+      100.times do |i|
+        create(:active_activity_session) 
+      end
+
+      data = {
+          "updatedAt": 1593741284430,
+          "questionSet": [
+              {
+                  "attempts": [],
+                  "question": "-LLpg811AFtOLArzxhGD"
+              },
+              {
+                  "attempts": [],
+                  "question": "-LLpge97AyWoQvHD1x-z"
+              },
+              {
+                  "attempts": [],
+                  "question": "-LLpgiatjAx6rqO7WSFM"
+              },
+              "-LLpgoQ5htJoVCvD7UVm",
+              "-LLpgzQe__AE9qPPyGjI",
+              "-LLph6mZ4dNZBKbUp85P",
+              "-LLphFPNUJTDPT_c6051",
+              "-LLphUnDFXlV1j9U-Lhn",
+              "-LLph_7oSgbIcaghSm0O",
+              "-LLpheCBnjyVA-sn0dJl",
+              "-LLphovfRQrIM6fPwQMu"
+          ],
+          "currentQuestion": {
+              "attempts": [
+                  {
+                      "response": {
+                          "text": "I saw the Mayor give a speech at Richmond city hall.",
+                          "count": 1,
+                          "author": "Incorrect Sequence Hint",
+                          "feedback": "<p>Revise your work. Only capitalize a job title if it comes before a name.</p>",
+                          "parent_id": 7641004,
+                          "question_uid": "-LLpgiatjAx6rqO7WSFM",
+                          "concept_results": {
+                              "nrq-IGTxmwLxyr_hieouGg": {
+                                  "key": "nrq-IGTxmwLxyr_hieouGg",
+                                  "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                  "correct": false,
+                                  "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                              }
+                          }
+                      }
+                  },
+                  {
+                      "response": {
+                          "text": "I saw the Mayor give a speech at Richmond City Hall.",
+                          "count": 1,
+                          "author": "Incorrect Sequence Hint",
+                          "feedback": "<p>Revise your work. Only capitalize a job title if it comes before a name.</p>",
+                          "parent_id": 7641004,
+                          "question_uid": "-LLpgiatjAx6rqO7WSFM",
+                          "concept_results": {
+                              "nrq-IGTxmwLxyr_hieouGg": {
+                                  "key": "nrq-IGTxmwLxyr_hieouGg",
+                                  "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                  "correct": false,
+                                  "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                              }
+                          }
+                      }
+                  },
+                  {
+                      "response": {
+                          "text": "I saw the Mayor give a speech at Richmond city Hall.",
+                          "count": 1,
+                          "author": "Incorrect Sequence Hint",
+                          "feedback": "<p>Revise your work. Only capitalize a job title if it comes before a name.</p>",
+                          "parent_id": 7641004,
+                          "question_uid": "-LLpgiatjAx6rqO7WSFM",
+                          "concept_results": {
+                              "nrq-IGTxmwLxyr_hieouGg": {
+                                  "key": "nrq-IGTxmwLxyr_hieouGg",
+                                  "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                  "correct": false,
+                                  "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                              }
+                          }
+                      }
+                  },
+                  {
+                      "response": {
+                          "text": "I saw the Mayor give a speech at Richmond City hall.",
+                          "count": 1,
+                          "author": "Incorrect Sequence Hint",
+                          "feedback": "<p>Revise your work. Only capitalize a job title if it comes before a name.</p>",
+                          "parent_id": 7641004,
+                          "question_uid": "-LLpgiatjAx6rqO7WSFM",
+                          "concept_results": {
+                              "nrq-IGTxmwLxyr_hieouGg": {
+                                  "key": "nrq-IGTxmwLxyr_hieouGg",
+                                  "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                  "correct": false,
+                                  "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                              }
+                          }
+                      }
+                  }
+              ],
+              "question": "-LLpgiatjAx6rqO7WSFM"
+          },
+          "answeredQuestions": [
+              {
+                  "attempts": [
+                      {
+                          "response": {
+                              "text": "The President is originally from North Dakota.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Remember, only capitalize a job title if it comes before a name.</p>",
+                              "parent_id": 7623759,
+                              "question_uid": "-LLpg811AFtOLArzxhGD",
+                              "concept_results": {
+                                  "nrq-IGTxmwLxyr_hieouGg": {
+                                      "key": "nrq-IGTxmwLxyr_hieouGg",
+                                      "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                      "correct": false,
+                                      "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "he President is originally from North Dakota.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Remember, only capitalize a job title if it comes before a name.</p>",
+                              "parent_id": 7623759,
+                              "question_uid": "-LLpg811AFtOLArzxhGD",
+                              "concept_results": {
+                                  "nrq-IGTxmwLxyr_hieouGg": {
+                                      "key": "nrq-IGTxmwLxyr_hieouGg",
+                                      "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                      "correct": false,
+                                      "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "the President is originally from North Dakota.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Remember, only capitalize a job title if it comes before a name.</p>",
+                              "parent_id": 7623759,
+                              "question_uid": "-LLpg811AFtOLArzxhGD",
+                              "concept_results": {
+                                  "nrq-IGTxmwLxyr_hieouGg": {
+                                      "key": "nrq-IGTxmwLxyr_hieouGg",
+                                      "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                      "correct": false,
+                                      "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "the President is originally from north Dakota.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Remember, only capitalize a job title if it comes before a name.</p>",
+                              "parent_id": 7623759,
+                              "question_uid": "-LLpg811AFtOLArzxhGD",
+                              "concept_results": {
+                                  "nrq-IGTxmwLxyr_hieouGg": {
+                                      "key": "nrq-IGTxmwLxyr_hieouGg",
+                                      "name": "Capitalization | Capitalizing Formal Titles | Capitalize Formal Titles",
+                                      "correct": false,
+                                      "conceptUID": "nrq-IGTxmwLxyr_hieouGg"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "The president is originally from north Dakota.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Always capitalize the names of cities, countries, or states.</p>",
+                              "parent_id": 7623759,
+                              "question_uid": "-LLpg811AFtOLArzxhGD",
+                              "concept_results": {
+                                  "YkA1YFe-dUvXqkEXxbNgQw": {
+                                      "name": "Capitalization | Capitalize Geographic Names | Capitalize Geographic Names",
+                                      "correct": false,
+                                      "conceptUID": "YkA1YFe-dUvXqkEXxbNgQw"
+                                  }
+                              }
+                          }
+                      }
+                  ],
+                  "question": "-LLpg811AFtOLArzxhGD"
+              },
+              {
+                  "attempts": [
+                      {
+                          "response": {
+                              "text": "I have maths class with Mr. Jenkins on Tuesday and english class on Thursday.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Capitalize a class name when it&#x27;s a language like <em>English</em> or <em>Spanish</em>.</p>",
+                              "parent_id": 7641019,
+                              "question_uid": "-LLpge97AyWoQvHD1x-z",
+                              "concept_results": {
+                                  "66upe3S5uvqxuHoHOt4PcQ": {
+                                      "key": "66upe3S5uvqxuHoHOt4PcQ",
+                                      "name": "Capitalization | Capitalization | Capitalization",
+                                      "correct": false,
+                                      "conceptUID": "66upe3S5uvqxuHoHOt4PcQ"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "I have Maths class with Mr. Jenkins on Tuesday and English class on Thursday.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Only capitalize the name of a class when it&#x27;s the official name like <em>Introduction to Biology 101 </em>or when it&#x27;s a language like<em> English</em>.</p>",
+                              "parent_id": 7641019,
+                              "question_uid": "-LLpge97AyWoQvHD1x-z",
+                              "concept_results": {
+                                  "66upe3S5uvqxuHoHOt4PcQ": {
+                                      "key": "66upe3S5uvqxuHoHOt4PcQ",
+                                      "name": "Capitalization | Capitalization | Capitalization",
+                                      "correct": false,
+                                      "conceptUID": "66upe3S5uvqxuHoHOt4PcQ"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "I have Maths Class with Mr. Jenkins on Tuesday and English Class on Thursday.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Only capitalize the name of a class when it&#x27;s the official name like <em>Introduction to Biology 101 </em>or when it&#x27;s a language like<em> English</em>.</p>",
+                              "parent_id": 7641019,
+                              "question_uid": "-LLpge97AyWoQvHD1x-z",
+                              "concept_results": {
+                                  "66upe3S5uvqxuHoHOt4PcQ": {
+                                      "key": "66upe3S5uvqxuHoHOt4PcQ",
+                                      "name": "Capitalization | Capitalization | Capitalization",
+                                      "correct": false,
+                                      "conceptUID": "66upe3S5uvqxuHoHOt4PcQ"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "I have Maths Class with Mr. Jenkins on Tuesday and English class on Thursday.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Only capitalize the name of a class when it&#x27;s the official name like <em>Introduction to Biology 101 </em>or when it&#x27;s a language like<em> English</em>.</p>",
+                              "parent_id": 7641019,
+                              "question_uid": "-LLpge97AyWoQvHD1x-z",
+                              "concept_results": {
+                                  "66upe3S5uvqxuHoHOt4PcQ": {
+                                      "key": "66upe3S5uvqxuHoHOt4PcQ",
+                                      "name": "Capitalization | Capitalization | Capitalization",
+                                      "correct": false,
+                                      "conceptUID": "66upe3S5uvqxuHoHOt4PcQ"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "response": {
+                              "text": "I have Maths class with Mr. Jenkins on Tuesday and English class on Thursday.",
+                              "count": 1,
+                              "author": "Incorrect Sequence Hint",
+                              "feedback": "<p>Revise your work. Only capitalize the name of a class when it&#x27;s the official name like <em>Introduction to Biology 101 </em>or when it&#x27;s a language like<em> English</em>.</p>",
+                              "parent_id": 7641019,
+                              "question_uid": "-LLpge97AyWoQvHD1x-z",
+                              "concept_results": {
+                                  "66upe3S5uvqxuHoHOt4PcQ": {
+                                      "key": "66upe3S5uvqxuHoHOt4PcQ",
+                                      "name": "Capitalization | Capitalization | Capitalization",
+                                      "correct": false,
+                                      "conceptUID": "66upe3S5uvqxuHoHOt4PcQ"
+                                  }
+                              }
+                          }
+                      }
+                  ],
+                  "question": "-LLpge97AyWoQvHD1x-z"
+              }
+          ],
+          "unansweredQuestions": [
+              "-LLpgoQ5htJoVCvD7UVm",
+              "-LLpgzQe__AE9qPPyGjI",
+              "-LLph6mZ4dNZBKbUp85P",
+              "-LLphFPNUJTDPT_c6051",
+              "-LLphUnDFXlV1j9U-Lhn",
+              "-LLph_7oSgbIcaghSm0O",
+              "-LLpheCBnjyVA-sn0dJl",
+              "-LLphovfRQrIM6fPwQMu"
+          ],
+          "passage": []
+      }
+
+      Benchmark.bm do |x|
+        x.report do 
+          uids = ActiveActivitySession.all.pluck(:uid)
+          uids.each do |uid|
+            put :update, params: { id: active_activity_session.uid, active_activity_session: data }, as: :json
+          end
+        end
+      end
+    end
+
     it "should update the existing record" do
       data = {"foo" => "bar"}
       put :update, params: { id: active_activity_session.uid, active_activity_session: data }, as: :json


### PR DESCRIPTION
## WHAT
Part one of an initiative to speed up active_activity_session#update
Stops the returning of an unnecessary payload.

I've also included the benchmark I created that motivates this change. Including benchmarks within specs is a new pattern for us. I think it's a good idea, because it's a clear way to document how something was benchmarked, and it can be disabled when not working with it directly.

## WHY
This controller action is not scaling well. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=767be0eaa3204811abc7763eb3b7a0f4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes. Also manually tested Connect & Evidence plays.
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
