### PR TITLE
Fix bug where repurposed old clever classrooms are not showing up on …

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/teacher_imported_classrooms_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_imported_classrooms_updater.rb
@@ -4,11 +4,15 @@ module CleverIntegration
   class TeacherImportedClassroomsUpdater < ApplicationService
     attr_reader :teacher_id
 
+    COTEACHER = ClassroomsTeacher::ROLE_TYPES[:coteacher]
+    OWNER = ClassroomsTeacher::ROLE_TYPES[:owner]
+
     def initialize(teacher_id)
       @teacher_id = teacher_id
     end
 
     def run
+      update_classrooms_teachers
       update_classrooms
       update_classrooms_students
     end
@@ -25,6 +29,10 @@ module CleverIntegration
       @classrooms_data ||= TeacherClassroomsData.new(teacher, serialized_classrooms_data)
     end
 
+    private def existing_classrooms_where_teacher_was_added_in_clever
+      ::Classroom.where(clever_id: classroom_clever_ids - imported_classrooms.pluck(:clever_id))
+    end
+
     private def imported_classrooms
       teacher.clever_classrooms.where(clever_id: classroom_clever_ids)
     end
@@ -38,11 +46,20 @@ module CleverIntegration
     end
 
     private def update_classrooms
-     imported_classrooms.each { |classroom| ClassroomUpdater.run(classroom, classroom_data(classroom)) }
+     imported_classrooms.each { |classroom| ClassroomUpdater.run(classroom, classroom_data(classroom) )}
     end
 
     private def update_classrooms_students
       ImportClassroomStudentsWorker.perform_async(teacher_id, imported_classrooms.map(&:id))
+    end
+
+    private def update_classrooms_teachers
+      existing_classrooms_where_teacher_was_added_in_clever.each do |classroom|
+        teacher.classrooms_teachers.find_or_create_by!(
+          classroom: classroom,
+          role: classroom.classrooms_teachers.exists?(role: OWNER) ? COTEACHER : OWNER
+        )
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_imported_classrooms_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_imported_classrooms_updater_spec.rb
@@ -3,29 +3,82 @@
 require 'rails_helper'
 
 RSpec.describe CleverIntegration::TeacherImportedClassroomsUpdater do
-  let!(:imported_classroom) { create(:classroom, :from_clever).reload }
-
-  let(:teacher_id) { imported_classroom.owner.id }
-  let(:new_classroom_clever_id) { 'abcdefg' }
-  let(:updated_name) { "new_#{imported_classroom.name}"}
-
-  let(:data) do
-    {
-      classrooms: [
-        { clever_id: new_classroom_clever_id },
-        { clever_id: imported_classroom.clever_id, name: updated_name }
-      ]
-    }.to_json
-  end
+  let(:teacher) { create(:teacher, :signed_up_with_clever) }
+  let(:teacher_id) { teacher.id }
+  let(:data) { { classrooms: classrooms }.to_json }
+  let(:owner) { described_class::OWNER }
+  let(:coteacher) { described_class::COTEACHER }
 
   subject { described_class.run(teacher_id) }
 
-  it 'updates only previously imported classrooms that have clever_id' do
+  before do
     expect(CleverIntegration::TeacherClassroomsCache).to receive(:read).with(teacher_id).and_return(data)
-    expect(CleverIntegration::ImportClassroomStudentsWorker).to receive(:perform_async).with(teacher_id, [imported_classroom.id])
-    subject
+    expect(CleverIntegration::ImportClassroomStudentsWorker).to receive(:perform_async).with(teacher_id, classroom_ids)
+  end
 
-    expect(Classroom.count).to eq 1
-    expect(imported_classroom.reload.synced_name).to eq updated_name
+  context 'data has one new classroom' do
+    let(:classrooms) { [{ clever_id: 'abcdefgh' }] }
+    let(:classroom_ids) { []}
+
+    it { expect { subject }.not_to change(Classroom, :count) }
+  end
+
+  context 'data has one already imported classroom with the teacher coteaches' do
+    let(:classroom) { create(:classroom, :from_clever, :with_no_teacher).reload }
+    let(:updated_name) { "new_#{classroom.name}" }
+    let(:classrooms) { [{ clever_id: classroom.clever_id, name: updated_name}] }
+    let(:classroom_ids) { [classroom.id] }
+
+    before { create(:classrooms_teacher, user: teacher, classroom: classroom, role: coteacher) }
+
+    it { expect { subject }.not_to change(teacher.classrooms_teachers, :count) }
+    it { should_update_the_classroom_synced_name }
+  end
+
+  context 'data has one already imported classroom with the teacher owns' do
+    let(:classroom) { create(:classroom, :from_clever, :with_no_teacher).reload }
+    let(:updated_name) { "new_#{classroom.name}" }
+    let(:classrooms) { [{ clever_id: classroom.clever_id, name: updated_name}] }
+    let(:classroom_ids) { [classroom.id] }
+
+    before { create(:classrooms_teacher, user: teacher, classroom: classroom, role: owner) }
+
+    it { expect { subject }.not_to change(teacher.classrooms_teachers, :count) }
+    it { should_update_the_classroom_synced_name }
+  end
+
+  context 'data has one already imported classroom that the teacher has no corresponding ClassroomsTeacher object ' do
+    let(:classroom) { create(:classroom, :from_clever).reload }
+    let(:updated_name) { "new_#{classroom.name}" }
+    let(:classrooms) { [{ clever_id: classroom.clever_id, name: updated_name}] }
+    let(:classroom_ids) { [classroom.id] }
+
+    it { expect { subject }.to change(teacher.classrooms_teachers, :count).by(1) }
+    it { should_update_the_classroom_synced_name }
+
+    context 'the classroom has a corresponding ClassroomsTeacher object with coteacher role ' do
+      before { classroom.classrooms_teachers.first.update(role: coteacher) }
+
+      it 'assigns owner role to the teacher' do
+        subject
+        expect(teacher.classrooms_teachers.find_by(classroom: classroom).role).to eq owner
+      end
+    end
+
+    context 'the classroom has a corresponding ClassroomsTeacher object with owner role' do
+      before { classroom.classrooms_teachers.first.update(role: owner) }
+
+      it 'assigns coteacher role to the teacher' do
+        subject
+        expect(teacher.classrooms_teachers.find_by(classroom: classroom).role).to eq coteacher
+      end
+    end
+  end
+
+  def should_update_the_classroom_synced_name
+    expect {
+      subject
+      classroom.reload
+    }.to change(classroom, :synced_name).to(updated_name)
   end
 end


### PR DESCRIPTION
…new teacher pages. (#8743)

* Fix bug where repurposed old clever classrooms are not showing up on new teacher page

* Address race condition with exists? and create!

* Fix rubocop failure

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
