### PR TITLE
fix issue where student results table wasn't showing on larger screens

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthResults.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthResults.tsx
@@ -69,7 +69,7 @@ export const GrowthResults = ({ passedStudentResults, passedSkillGroupSummaries,
   if (loading) { return <LoadingSpinner /> }
 
   return (<main className="results-summary-container growth-results-summary-container">
-    <header>
+    <header className="results-header">
       <h1>Student results</h1>
       <a className="focus-on-light" href="https://support.quill.org/en/articles/5698227-how-do-i-read-the-growth-results-summary-report" rel="noopener noreferrer" target="_blank">{fileDocumentIcon}<span>Guide</span></a>
     </header>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
@@ -84,7 +84,7 @@ export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match
   }
 
   return (<main className="results-summary-container">
-    <header>
+    <header className="results-header">
       <h1>Student results</h1>
       {!!skillGroupSummaries.length && <a className="focus-on-light" href="https://support.quill.org/en/articles/5698112-how-do-i-read-the-results-summary-report" rel="noopener noreferrer" target="_blank">{fileDocumentIcon}<span>Guide</span></a>}
     </header>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -144,7 +144,7 @@ const StudentResultsTable = ({ skillGroupSummaries, studentResults, openPopover,
 
   function paddingLeft() {
     if (MOBILE_WIDTH >= window.innerWidth) { return DEFAULT_LEFT_PADDING_FOR_MOBILE }
-    const skillGroupSummaryCards = document.getElementsByClassName('skill-group-summary-cards')[0]
+    const skillGroupSummaryCards = document.getElementsByClassName('results-header')[0]
     return skillGroupSummaryCards && window.innerWidth >= WIDE_SCREEN_MINIMUM_WIDTH ? skillGroupSummaryCards.getBoundingClientRect().left - LEFT_OFFSET : DEFAULT_LEFT_PADDING
   }
 


### PR DESCRIPTION
## WHAT
Fix issue causing the student results table not to show up on large screen sizes.

## WHY
We want teachers on all monitor sizes to see the results!

## HOW
The issue is that the adjusted size for the table was based off of the skill-group-summary-cards, which are no longer on this page. I switched it to use the className of the header, which is.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/New-Student-Results-page-appearing-blank-for-teachers-8396d2bb71fb40be984c9023de2bd55b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No - manually tested!
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
