### PR TITLE
lms/cache-teacher-scores-reporting

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -135,14 +135,27 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def scores
-    scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
-
-    last_page = scores.length < 200
-
-    render json: {
-      scores: scores,
-      is_last_page: last_page
+    classroom = Classroom.find(params[:classroom_id])
+    cache_groups = {
+      unit: params[:unit_id],
+      page: params[:current_page],
+      begin: params[:begin_date],
+      end: params[:end_date],
+      offset: current_user.utc_offset
     }
+
+    json = current_user.classroom_cache(classroom, key: 'classroom_manager.teacher_dashboard_metrics', groups: cache_groups) do
+      scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
+
+      last_page = scores.length < 200
+
+      {
+        scores: scores,
+        is_last_page: last_page
+      }
+    end
+
+    render json: json
   end
 
   def my_account

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -144,7 +144,7 @@ class Teachers::ClassroomManagerController < ApplicationController
       offset: current_user.utc_offset
     }
 
-    json = current_user.classroom_cache(classroom, key: 'classroom_manager.teacher_dashboard_metrics', groups: cache_groups) do
+    json = current_user.classroom_cache(classroom, key: 'classroom_manager.scores', groups: cache_groups) do
       scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
 
       last_page = scores.length < 200

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -566,10 +566,12 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
   describe '#scores' do
     let(:teacher) { create(:teacher) }
+    let(:classroom) { create(:classroom) }
 
     before do
       allow(controller).to receive(:current_user) { teacher }
       allow(Scorebook::Query).to receive(:run) { [1, 2, 3] }
+      allow(Classroom).to receive(:find) { classroom }
     end
 
     it 'should render the correct json' do


### PR DESCRIPTION
## WHAT
Update basic Teacher `/scores` caching
## WHY
To reduce database load on commonly-viewed reports.  This particular report is especially prevalent as it's one of the "default" report pages that a lot teachers land on even if they're going somewhere else.
## HOW
Wrap the payload construction code with the new user `classroom`-level caching code

### Notion Card Links
https://www.notion.so/quill/Implement-Caching-on-3-endpoints-07b97e6538134ea090ba0f7fd5df3d8b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
