### PR TITLE
Enable Layout/EmptyLineAfterGuardClause cop

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -59,6 +59,9 @@ Layout/ElseAlignment:
 Layout/EmptyComment:
   Enabled: true
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 

--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -59,9 +59,6 @@ Layout/ElseAlignment:
 Layout/EmptyComment:
   Enabled: true
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: true
-
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 

--- a/services/.rubocop_todo.yml
+++ b/services/.rubocop_todo.yml
@@ -68,11 +68,6 @@ Layout/CommentIndentation:
     - 'QuillLMS/spec/models/activity_session_spec.rb'
     - 'QuillLMS/spec/services/google_integration/classroom/main_spec.rb'
 
-# Offense count: 146
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 # Offense count: 36
 # Cop supports --auto-correct.
 # Configuration parameters: EmptyLineBetweenMethodDefs, EmptyLineBetweenClassDefs, EmptyLineBetweenModuleDefs, AllowAdjacentOneLineDefs, NumberOfEmptyLines.

--- a/services/QuillCMS/spec/controllers/responses_controller_spec.rb
+++ b/services/QuillCMS/spec/controllers/responses_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ResponsesController, type: :controller do
 
   def get_ids(array)
     return [] if array.nil?
+
     array.map { |r| r['id'] }.sort
   end
 

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -120,6 +120,7 @@ class ActivitySessionsController < ApplicationController
 
   private def authorize_student_belongs_to_classroom_unit!
     return auth_failed if current_user.nil?
+
     @classroom_unit = ClassroomUnit.find params[:classroom_unit_id]
     if current_user.classrooms.exclude?(@classroom_unit.classroom) then auth_failed(hard: false) end
   end

--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -42,6 +42,7 @@ class AdminsController < ApplicationController
 
   private def admin_of_this_teacher!
     return if SchoolsAdmins.where(user_id: current_user.id, school_id: @teacher.school.id).limit(1).exists?
+
     auth_failed
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -23,6 +23,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
       # If, for some reason, running this a second time generates the same error, we don't
       # want to keep retrying because that indicates some other, more worrying, problem.
       raise e if retried
+
       retried = true
       retry
     end
@@ -31,6 +32,7 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
 
   private def working_params
     return valid_params unless params.dig(:active_activity_session, :passage)
+
     permitted_passage_object = params[:active_activity_session][:passage].map do |paragraph|
       paragraph.map do |word_object|
         word_object.permit!

--- a/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/focus_points_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::FocusPointsController < Api::ApiController
 
   def update
     return not_found unless @question.data.dig("focusPoints", params[:id])
+
     if @question.set_focus_point(params[:id], valid_params)
       render_focus_point
     else
@@ -51,6 +52,7 @@ class Api::V1::FocusPointsController < Api::ApiController
   private def render_focus_point
     focus_point = @question.data.dig("focusPoints", params[:id])
     return not_found unless focus_point
+
     render(json: focus_point)
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
 
   def update
     return not_found unless @question.get_incorrect_sequence(params[:id])
+
     if @question.set_incorrect_sequence(params[:id], valid_params)
       render_incorrect_sequence(params[:id])
     else
@@ -55,6 +56,7 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
   private def render_incorrect_sequence(incorrect_sequence_id)
     incorrect_sequence = @question.get_incorrect_sequence(incorrect_sequence_id)
     return not_found unless incorrect_sequence
+
     render(json: incorrect_sequence)
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/rule_feedback_histories_controller.rb
@@ -3,6 +3,7 @@
 class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
   def by_conjunction
     raise ArgumentError unless params.include?('activity_id') && params.include?('conjunction')
+
     options = params.permit(:conjunction, :activity_id, :start_date, :end_date, :turk_session_id).to_h.symbolize_keys
     report = RuleFeedbackHistory.generate_report(**options)
     render json: report
@@ -10,6 +11,7 @@ class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
 
   def rule_detail
     raise ArgumentError unless params.include?('rule_uid') && params.include?('prompt_id')
+
     options = params.permit(:rule_uid, :prompt_id, :start_date, :end_date, :turk_session_id).to_h.symbolize_keys
     report = RuleFeedbackHistory.generate_rulewise_report(**options)
     render json: report
@@ -17,6 +19,7 @@ class Api::V1::RuleFeedbackHistoriesController < Api::ApiController
 
   def prompt_health
     raise ArgumentError unless params.include?('activity_id')
+
     options = params.permit(:activity_id, :start_date, :end_date, :turk_session_id).to_h.symbolize_keys
     report = PromptFeedbackHistory.run(**options)
     render json: report

--- a/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::SharedCacheController < Api::ApiController
     if !cached_data
       return not_found
     end
+
     render(json: cached_data)
   end
 

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -26,26 +26,31 @@ class ApplicationController < ActionController::Base
 
   def admin!
     return if current_user.try(:admin?)
+
     auth_failed
   end
 
   def staff!
     return if current_user.try(:staff?)
+
     auth_failed
   end
 
   def teacher_or_staff!
     return if current_user.try(:teacher?)
+
     staff!
   end
 
   def teacher!
     return if current_user.try(:teacher?)
+
     admin!
   end
 
   def student!
     return if current_user.try(:student?)
+
     auth_failed
   end
 
@@ -129,6 +134,7 @@ class ApplicationController < ActionController::Base
   protected def confirm_valid_session
     # Don't do anything if there's no authorized user or session
     return if !current_user || !session
+
     # if user is staff, logout if last_sign_in was more than 4 hours ago
     if current_user && current_user.role == 'staff' && current_user.last_sign_in
       hours = time_diff(current_user.last_sign_in) / 3600

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -16,6 +16,7 @@ class Cms::RostersController < Cms::CmsController
         next unless t[:email]
         raise "Teacher with email #{t[:email]} already exists." if User.find_by(email: t[:email]).present?
         raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
+
         password = t[:password].present? ? t[:password] : t[:name].split[1]
         teacher = User.create!(name: t[:name], email: t[:email], password: password, password_confirmation: password, role: 'teacher')
         SchoolsUsers.create!(school: school, user: teacher)
@@ -26,6 +27,7 @@ class Cms::RostersController < Cms::CmsController
         raise "Student with email #{s[:email]} already exists." if User.find_by(email: s[:email]).present?
         raise "Teacher with email #{s[:teacher_email]} does not exist." if User.find_by(email: s[:teacher_email]).blank?
         raise "Please provide a last name or password for student #{s[:name]}, otherwise this account will have no password." if s[:password].blank? && s[:name].split[1].blank?
+
         password = s[:password].present? ? s[:password] : s[:name].split[1]
         student = User.create!(name: s[:name], email: s[:email], password: password, password_confirmation: password, role: 'student')
         teacher = User.find_by(email: s[:teacher_email])

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -123,6 +123,7 @@ class Cms::SchoolsController < Cms::CmsController
     begin
       user = User.find_by!(email: params[:email_address])
       raise ArgumentError if user.role != 'teacher'
+
       school = School.find_by!(id: params[:id])
       SchoolsUsers.where(user: user).destroy_all
       SchoolsUsers.create!(user_id: user.id, school_id: school.id)

--- a/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
@@ -37,6 +37,7 @@ class CoteacherClassroomInvitationsController < ApplicationController
     params[:coteacher_invitation_ids].each do |coteacher_invitation_id|
       coteacher_invitation = CoteacherClassroomInvitation.find(coteacher_invitation_id)
       return auth_failed unless coteacher_invitation.invitation.invitee_email == current_user.email
+
       coteacher_invitation.destroy
     end
     respond_to do |format|

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -71,6 +71,7 @@ class GradesController < ApplicationController
 
   private def authorize!
     return unless params[:classroom_unit_id].present?
+
     classroom_unit = ClassroomUnit.includes(:classroom).find(params[:classroom_unit_id])
     classroom_teacher!(classroom_unit.classroom_id)
   end

--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -10,6 +10,7 @@ class InvitationsController < ApplicationController
       validate_email_and_classroom_ids
       @pending_invite = find_or_create_coteacher_invite_from_current_user
       raise StandardError, @pending_invite.errors[:base].join(" ") unless @pending_invite.valid?
+
       assign_classrooms_to_invitee
       invoke_email_worker
       render json: { invite_id: @pending_invite.id }

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -20,6 +20,7 @@ class PagesController < ApplicationController
     if signed_in?
       redirect_to(profile_path) && return
     end
+
     @body_class = 'home-page'
     @activity = Activity.with_classification.find_by_uid(ENVr.fetch('HOMEPAGE_ACTIVITY_UID', ''))
     self.formats = ['html']
@@ -29,6 +30,7 @@ class PagesController < ApplicationController
     if signed_in?
       redirect_to(profile_path) && return
     end
+
     @title = 'Quill.org | Interactive Writing and Grammar'
     @description = 'Quill provides free writing and grammar activities for middle and high school students.'
     # default numbers are current as of 03/12/19

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -62,6 +62,7 @@ class StudentsController < ApplicationController
       errors['current_password'] = 'Wrong password. Try again or click Forgot password to reset it.'
     end
     return render json: {errors: errors}, status: 422 if errors.any?
+
     render json: current_user, serializer: UserSerializer
   end
 

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -176,6 +176,7 @@ class TeacherFixController < ApplicationController
   def merge_two_schools
     begin
       raise 'Please specify a school ID.' if params['from_school_id'].nil? || params['to_school_id'].nil?
+
       TeacherFixes::merge_two_schools(params['from_school_id'], params['to_school_id'])
     rescue => e
       return render json: { error: e.message || e }
@@ -189,6 +190,7 @@ class TeacherFixController < ApplicationController
       classroom2 = Classroom.find_by(code: params['class_code2'])
       raise 'The first class code is invalid' if !classroom1
       raise 'The second class code is invalid' if !classroom2
+
       TeacherFixes::merge_two_classrooms(classroom1.id, classroom2.id)
     rescue => e
       return render json: { error: e.message || e }
@@ -199,6 +201,7 @@ class TeacherFixController < ApplicationController
   def merge_activity_packs
     begin
       raise 'Please specify an activity pack ID.' if params['from_activity_pack_id'].nil? || params['to_activity_pack_id'].nil?
+
       unit1 = Unit.find_by(id: params['from_activity_pack_id'])
       unit2 = Unit.find_by(id: params['to_activity_pack_id'])
       raise 'The first activity pack ID is invalid.' if !unit1
@@ -206,6 +209,7 @@ class TeacherFixController < ApplicationController
       raise 'The two activity packs must belong to the same teacher.' if unit1.user != unit2.user
 
       raise 'The two activity packs must be assigned to the same classroom.' if (unit1.classrooms & unit2.classrooms).empty?
+
       TeacherFixes::merge_two_units(unit1, unit2)
     rescue => e
       return render json: { error: e.message || e }
@@ -220,6 +224,7 @@ class TeacherFixController < ApplicationController
       activity = Activity.find_by(name: params['activity_name'])
       raise 'No such student' if !user
       raise 'No such activity' if !activity
+
       TeacherFixes::delete_last_activity_session(user.id, activity.id)
     rescue => e
       return render json: { error: e.message || e }

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -87,6 +87,7 @@ class Teachers::ClassroomsController < ApplicationController
   def bulk_archive
     Classroom.where(id: params[:ids]).each do |classroom|
       next if classroom.owner != current_user
+
       classroom.visible = false
       # we want to skip validations here because otherwise they can prevent archiving the classroom, when the classroom was created before the validation was added
       classroom.save(validate: false)
@@ -254,13 +255,16 @@ class Teachers::ClassroomsController < ApplicationController
   private def authorize_owner!
     classroom_id = block_given? ? yield : params[:id]
     return auth_failed unless classroom_id.present?
+
     classroom = Classroom.find_by(id: classroom_id)
     return auth_failed unless classroom
+
     classroom_owner!(classroom.id)
   end
 
   private def authorize_teacher!
     return unless params[:id].present?
+
     classroom_teacher!(params[:id])
   end
 end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -158,6 +158,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     return "1 min" if seconds >= 60 && seconds < 120
     return "#{((seconds % 3600) / 60).floor} min" if seconds >= 120 && seconds < 3600
     return "1 hr" if seconds >= 3600 && seconds < 3660
+
     hours = (seconds / 60 / 60).floor
     minutes = ((seconds % 3600) / 60).floor
     hours_text = hours > 1 ? "hrs" : "hr"

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/concepts_controller.rb
@@ -37,6 +37,7 @@ class Teachers::ProgressReports::Concepts::ConceptsController < Teachers::Progre
   private def student
     student_object = current_user.students.find{|student| student.id == params[:student_id].to_i}
     raise ActiveRecord::RecordNotFound unless student_object
+
     student_object
   end
 end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -231,6 +231,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     if params[:whole_class]
       $redis.set("user_id:#{current_user.id}_lesson_diagnostic_recommendations_start_time", Time.now)
       return render json: {}, status: 401 unless current_user.classrooms_i_teach.map(&:id).include?(params[:classroom_id].to_i)
+
       params[:unit_template_ids].each_with_index do |unit_template_id, index|
         last = (params[:unit_template_ids].length - 1 == index)
         UnitTemplate.assign_to_whole_class(params[:classroom_id], unit_template_id, last)

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -86,6 +86,7 @@ class Teachers::UnitsController < ApplicationController
     activity_id = params[:activity_id].to_i
     classroom_units = get_classroom_units_for_activity(activity_id)
     return render json: {errors: 'No activities found'}, status: 422 if classroom_units.empty?
+
     render json: {
       classroom_units: classroom_units,
       activity_name: Activity.select('name').where("id = #{activity_id}")
@@ -394,6 +395,7 @@ class Teachers::UnitsController < ApplicationController
   private def record_with_aggregated_activity_sessions(diagnostic_records, activity_id, classroom_id, pre_test_activity_id)
     records = diagnostic_records.select { |record| record['activity_id'] == activity_id && record['classroom_id'] == classroom_id }
     return if records.empty?
+
     classroom_unit_ids = records.map { |record| record['classroom_unit_id'] }
     assigned_student_ids = records.map { |r| r['assigned_student_ids'] }.flatten.uniq
     activity_sessions = ActivitySession
@@ -402,6 +404,7 @@ class Teachers::UnitsController < ApplicationController
       .uniq { |activity_session| activity_session.user_id }
     record = records[0]
     return if !record
+
     record['completed_count'] = activity_sessions.size
     record['assigned_count'] = assigned_student_ids.size
     record.except('unit_id', 'unit_name', 'classroom_unit_id', 'assigned_student_ids')

--- a/services/QuillLMS/app/graphql/types/query_type.rb
+++ b/services/QuillLMS/app/graphql/types/query_type.rb
@@ -22,6 +22,7 @@ class Types::QueryType < Types::BaseObject
     return Concept.level_zero_only if level_zero_only
     return Concept.where(parent_id: nil) if level_two_only
     return Concept.level_one_only if level_one_only
+
     Concept.all
   end
 
@@ -43,6 +44,7 @@ class Types::QueryType < Types::BaseObject
 
   def change_logs(concept_change_logs: false)
     return ChangeLog.where(changed_record_type: 'Concept') if concept_change_logs
+
     ChangeLog.all
   end
 end

--- a/services/QuillLMS/app/helpers/concept_helper.rb
+++ b/services/QuillLMS/app/helpers/concept_helper.rb
@@ -3,6 +3,7 @@
 module ConceptHelper
   def all_concept_stats(activity_session)
     return '' unless activity_session.present?
+
     # Generate a header for each applicable concept class (activity session has concept tag results for that class)
     concept_results = activity_session.concept_results
     concepts = activity_session.concepts
@@ -17,6 +18,7 @@ module ConceptHelper
     incorrect_count = 0
     concept_results.each do |result|
       next unless result.concept == concept
+
       if result.correct?
         correct_count += 1
       else

--- a/services/QuillLMS/app/helpers/scorebook_helper.rb
+++ b/services/QuillLMS/app/helpers/scorebook_helper.rb
@@ -6,6 +6,7 @@ module ScorebookHelper
     proficiency_cutoff = ProficiencyEvaluator.proficiency_cutoff
     nearly_proficient_cutoff = ProficiencyEvaluator.nearly_proficient_cutoff
     return 'gray' unless score
+
     score = score.to_f / 100.0 if score > 1
     score = score.round(2)
     case score

--- a/services/QuillLMS/app/lib/csv_loader/loader.rb
+++ b/services/QuillLMS/app/lib/csv_loader/loader.rb
@@ -17,6 +17,7 @@ class GoogleDriveLoader
   # Initialize the client.
   def client
     return @client if defined? @client
+
     @client = Google::APIClient.new(
       application_name: 'Example Ruby application',
       application_version: '1.0.0'
@@ -88,6 +89,7 @@ class GoogleDriveFile
 
   def initialize loader, child
     raise if loader.nil?
+
     @loader = loader
     @child = child
   end

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -39,11 +39,13 @@ module QuillAuthentication
 
   def classroom_owner!(classroom_id)
     return if ClassroomsTeacher.exists?(classroom_id: classroom_id, user: current_user, role: 'owner')
+
     auth_failed
   end
 
   def classroom_coteacher!(classroom_id)
     return if ClassroomsTeacher.exists?(classroom_id: classroom_id, user: current_user, role: 'coteacher')
+
     auth_failed
   end
 
@@ -52,6 +54,7 @@ module QuillAuthentication
       classroom_id: classroom_id,
       user: current_user
     )
+
     auth_failed
   end
 
@@ -120,6 +123,7 @@ module QuillAuthentication
 
   def signed_in!
     return if signed_in?
+
     auth_failed
   end
 
@@ -165,6 +169,7 @@ module QuillAuthentication
 
   def doorkeeper_token
     return @token if instance_variable_defined?(:@token)
+
     methods = Doorkeeper.configuration.access_token_methods
     @token = Doorkeeper::OAuth::Token.authenticate(request, *methods)
   end

--- a/services/QuillLMS/app/lib/staff_constraint.rb
+++ b/services/QuillLMS/app/lib/staff_constraint.rb
@@ -3,6 +3,7 @@
 class StaffConstraint
   def matches?(request)
     return false unless request.session[:user_id]
+
     user = User.find request.session[:user_id]
     user && user.staff?
   end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -169,6 +169,7 @@ class Activity < ApplicationRecord
   # TODO: cleanup
   def flag(flag = nil)
     return super(flag) unless flag.nil?
+
     flags.first
   end
 
@@ -213,6 +214,7 @@ class Activity < ApplicationRecord
 
   def add_question(question)
     return if !validate_question(question)
+
     if !ACTIVITY_TYPES_WITH_QUESTIONS.include?(activity_classification_id)
       errors.add(:activity, "You can't add questions to this type of activity.")
       return
@@ -242,6 +244,7 @@ class Activity < ApplicationRecord
 
   def child_activity
     return unless is_evidence?
+
     Evidence::Activity.find_by(parent_activity_id: id)
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -242,11 +242,13 @@ class ActivitySession < ApplicationRecord
 
   def formatted_due_date
     return nil if unit_activity&.due_date.nil?
+
     unit_activity.due_date.strftime('%A, %B %d, %Y')
   end
 
   def formatted_completed_at
     return nil if completed_at.nil?
+
     completed_at.strftime('%A, %B %d, %Y')
   end
 
@@ -286,6 +288,7 @@ class ActivitySession < ApplicationRecord
 
   def start
     return if state != 'unstarted'
+
     self.started_at ||= Time.current
     self.state = 'started'
   end
@@ -479,6 +482,7 @@ class ActivitySession < ApplicationRecord
 
   def minutes_to_complete
     return nil unless completed_at && started_at
+
     ((completed_at - started_at)/60).round
   end
 

--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -36,6 +36,7 @@ class AppSetting < ApplicationRecord
   def self.enabled?(name:, user:)
     app_setting = AppSetting.find_by_name(name)
     return false unless app_setting
+
     app_setting.enabled_for_user?(user)
   end
 

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -125,6 +125,7 @@ class BlogPost < ApplicationRecord
   def can_be_accessed_by(user)
     return true unless premium
     return true if premium && user&.is_premium?
+
     false
   end
 

--- a/services/QuillLMS/app/models/classroom_unit_activity_state.rb
+++ b/services/QuillLMS/app/models/classroom_unit_activity_state.rb
@@ -86,6 +86,7 @@ class ClassroomUnitActivityState < ApplicationRecord
       classroom_unit_ids = classroom.classroom_units.ids.flatten
       pinned_cua = ClassroomUnitActivityState.unscoped.find_by(pinned: true, classroom_unit_id: classroom_unit_ids)
       return if pinned_cua && pinned_cua == self
+
       pinned_cua.update_column("pinned", false) if pinned_cua
     end
   end

--- a/services/QuillLMS/app/models/concerns/concepts.rb
+++ b/services/QuillLMS/app/models/concerns/concepts.rb
@@ -6,6 +6,7 @@ module Concepts
   # This groups all concept results by question type, then groups them by concept for the reports page
   def all_concept_stats(activity_session)
     return '' unless activity_session.present?
+
     @concepts = activity_session.concepts
     @concept_results_by_question_type = activity_session.concept_results.group_by{|c| c.question_type}.values
     organize_by_type
@@ -35,6 +36,7 @@ module Concepts
     incorrect_count = 0
     concept_results.each do |result|
       next unless result.concept == concept
+
       if result.correct?
         correct_count += 1
       else

--- a/services/QuillLMS/app/models/concerns/owner.rb
+++ b/services/QuillLMS/app/models/concerns/owner.rb
@@ -36,6 +36,7 @@ module Owner
   def owned_by? user
     return false if owner.blank?
     return false if user.blank?
+
     owner == user
   end
 end

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -357,6 +357,7 @@ module PublicProgressReports
       question_array = []
       questions.compact.each do |q|
         next if !q.data['prompt']
+
         question_array.push({
           question_id: question_array.length + 1,
           score: nil,

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -335,6 +335,7 @@ module Teacher
 
   def update_teacher params
     return if !teacher?
+
     params[:role] = 'teacher' if params[:role] != 'student'
     params.permit(
       :id,

--- a/services/QuillLMS/app/models/csv_export.rb
+++ b/services/QuillLMS/app/models/csv_export.rb
@@ -35,6 +35,7 @@ class CsvExport < ApplicationRecord
 
   def export!
     return if sent?
+
     begin
       file = generate_csv
       csv_file.store!(file)

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -96,6 +96,7 @@ class FeedbackHistory < ApplicationRecord
 
   def concept_results_hash
     return {} if concept.blank?
+
     {
       concept_uid: concept_uid,
       activity_session_id: activity_session&.id,
@@ -263,6 +264,7 @@ class FeedbackHistory < ApplicationRecord
   def self.serialize_detail_by_activity_session(feedback_session_uid)
     history = FeedbackHistory.list_by_activity_session.where(feedback_session_uid: feedback_session_uid).first
     return nil unless history
+
     histories = FeedbackHistory.where(feedback_session_uid: feedback_session_uid).all
 
     output = history.serialize_by_activity_session

--- a/services/QuillLMS/app/models/provider_classroom.rb
+++ b/services/QuillLMS/app/models/provider_classroom.rb
@@ -4,6 +4,7 @@ class ProviderClassroom < SimpleDelegator
   def synced_status(student_attrs)
     return true if provider_active_user_ids.include?(provider_user_id(student_attrs))
     return false if provider_deleted_user_ids.include?(provider_user_id(student_attrs))
+
     return nil
   end
 

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -116,6 +116,7 @@ class Question < ApplicationRecord
 
   def get_incorrect_sequence(incorrect_sequence_id)
     return nil if !data['incorrectSequences']
+
     incorrect_sequence_id = incorrect_sequence_id.to_i if stored_as_array?('incorrectSequences')
     return data['incorrectSequences'][incorrect_sequence_id]
   end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -162,6 +162,7 @@ class School < ApplicationRecord
 
   private def lower_grade_greater_than_upper_grade
     return true unless lower_grade && upper_grade
+
     errors.add(:lower_grade, 'must be less than or equal to upper grade') if lower_grade.to_i > upper_grade.to_i
   end
 end

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -82,6 +82,7 @@ class Unit < ApplicationRecord
   def self.create_with_incremented_name(user_id:, name: )
     unit = Unit.create(user_id: user_id, name: name)
     return unit if unit.persisted?
+
     (2..20).each do |counter|
       unit = Unit.create(user_id: user_id, name: "#{name} #{counter}")
       return unit if unit.persisted?

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -102,6 +102,7 @@ class UnitActivity < ApplicationRecord
 
   def self.get_classroom_user_profile(classroom_id, user_id)
     return [] unless classroom_id && user_id
+
     # Generate a rich profile of Classroom Activities for a given user in a given classroom
     RawSqlRunner.execute(
       <<-SQL

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -544,6 +544,7 @@ class User < ApplicationRecord
   def generate_student_username_if_absent
     return if !student?
     return if username.present?
+
     classroom_id = classrooms.any? ? classrooms.first.id : nil
     generate_username(classroom_id)
   end
@@ -638,6 +639,7 @@ class User < ApplicationRecord
     return false if clever_id
     return false if role.temporary?
     return true if teacher?
+
     false
   end
 
@@ -652,6 +654,7 @@ class User < ApplicationRecord
   private def requires_password?
     return false if clever_id
     return false if signed_up_with_google
+
     permanent? && new_record?
   end
 
@@ -662,6 +665,7 @@ class User < ApplicationRecord
 
   private def get_class_code(classroom_id)
     return 'student' if classroom_id.nil?
+
     Classroom.find(classroom_id).code
   end
 

--- a/services/QuillLMS/app/models/zipcode_info.rb
+++ b/services/QuillLMS/app/models/zipcode_info.rb
@@ -38,6 +38,7 @@ class ZipcodeInfo < ApplicationRecord
     unless distance.is_a? Integer or distance.is_a? Float
       return []
     end
+
     distance = distance.to_i # if distance is a float
 
     dist_btwn_lat_deg = 69.172

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -85,6 +85,7 @@ class Scorebook::Query
     sanitized_begin_date = sanitize_date(begin_date)
     sanitized_end_date = sanitize_date(new_end_date)
     return unless sanitized_begin_date || sanitized_end_date
+
     "AND (
       CASE
       WHEN acts.completed_at IS NOT NULL THEN

--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -32,6 +32,7 @@ class Admin::TeacherSerializer < ActiveModel::Serializer
   def time_spent
     x = object.try(:time_spent)
     return "No time yet" if x.nil?
+
     mm, ss = x.divmod(60)
     ss2 = ss.floor
     hh, mm2 = mm.divmod(60)

--- a/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
@@ -23,6 +23,7 @@ class ProgressReports::Standards::StandardSerializer < ActiveModel::Serializer
 
   def standard_students_href
     return '' unless classroom_id.present?
+
     teachers_progress_reports_standards_classroom_standard_students_path(
       standard_id: object.id,
       classroom_id: classroom_id)

--- a/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
@@ -23,6 +23,7 @@ class ProgressReports::Standards::StudentSerializer < ActiveModel::Serializer
 
   def student_standards_href
     return '' unless classroom_id.present?
+
     teachers_progress_reports_standards_classroom_student_standards_path(
       student_id: object.id,
       classroom_id: classroom_id)

--- a/services/QuillLMS/app/services/clever_integration/associators/teacher_to_district.rb
+++ b/services/QuillLMS/app/services/clever_integration/associators/teacher_to_district.rb
@@ -4,6 +4,7 @@ module CleverIntegration::Associators::TeacherToDistrict
 
   def self.run(teacher, district)
     return if teacher.districts.include?(district)
+
     teacher.districts << district
     teacher
   end

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -206,6 +206,7 @@ module Demo::ReportDemoAPCreator
       templates[num].each do |act_id, user_id|
         temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
         next unless temp
+
         cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids) AND classroom_id=#{classroom.id}").first
         act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
         temp.concept_results.each do |cr|

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -353,6 +353,7 @@ module Demo::ReportDemoCreator
         act_sessions[num].each do |act_id, user_id|
           temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
           next unless temp
+
           cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
           act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
           temp.concept_results.each do |cr|

--- a/services/QuillLMS/app/services/generate_username.rb
+++ b/services/QuillLMS/app/services/generate_username.rb
@@ -38,6 +38,7 @@ class GenerateUsername < ApplicationService
 
   private def at_classcode(classcode)
     return "" if classcode.nil?
+
     "@#{classcode}"
   end
 end

--- a/services/QuillLMS/app/services/google_integration/classroom/parsers/students.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/parsers/students.rb
@@ -22,6 +22,7 @@ module GoogleIntegration::Classroom::Parsers::Students
 
   def self.run(students)
     return [] if !students || !students.length
+
     student_data = students.map do |hash|
       parse_hash(hash)
     end

--- a/services/QuillLMS/app/services/google_integration/classroom/requesters/students.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/requesters/students.rb
@@ -27,6 +27,7 @@ module GoogleIntegration::Classroom::Requesters::Students
     if response.next_page_token
       return make_google_classroom_api_call(course_id, api_method, client, students, response.next_page_token)
     end
+
     students
   end
 end

--- a/services/QuillLMS/app/services/google_integration/classroom/student.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/student.rb
@@ -4,6 +4,7 @@ module GoogleIntegration::Classroom::Student
 
   def self.run(user, google_classroom_ids)
     return if google_classroom_ids.empty?
+
     classrooms = Classroom.where(google_classroom_id: google_classroom_ids)
     classrooms.each { |c| join_classroom(user, c)}
   end

--- a/services/QuillLMS/app/services/google_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_creator.rb
@@ -55,6 +55,7 @@ module GoogleIntegration
 
       loop do
         return temp_name unless other_owned_classroom_names.include?(temp_name)
+
         temp_name += '_1'
       end
     end

--- a/services/QuillLMS/app/services/google_integration/client.rb
+++ b/services/QuillLMS/app/services/google_integration/client.rb
@@ -16,6 +16,7 @@ module GoogleIntegration
 
     def create
       raise AccessTokenError, "No access token found" if !access_token
+
       client.authorization.access_token = access_token
       client
     end

--- a/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
+++ b/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
@@ -34,6 +34,7 @@ module GoogleIntegration
         # 6 months can not be refreshed:
         # https://developers.google.com/identity/protocols/OAuth2#expiration
         raise TokenTooOldToRefreshError if token_too_old_to_refresh?
+
         handle_response(make_request)
       else
         current_credentials

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -67,11 +67,13 @@ class SerializeActivityHealth
 
   private def average(list, attribute)
     return nil if list.empty?
+
     (list.map {|p| p[attribute] || 0}.sum(0.0) / list.size).round(2)
   end
 
   private def standard_deviation(list, attribute)
     return nil if list.empty?
+
     list = list.map {|p| p[attribute] }
     mean = list.sum(0.0) / list.size
     squares = list.map {|m| (m - mean) ** 2}

--- a/services/QuillLMS/app/workers/csv_export_worker.rb
+++ b/services/QuillLMS/app/workers/csv_export_worker.rb
@@ -7,6 +7,7 @@ class CsvExportWorker
   def perform(csv_export_id, current_user_id)
     csv_export = CsvExport.find(csv_export_id)
     return if csv_export.sent?
+
     csv_export.export!
     csv_export.csv_file.url
     PusherCSVExportCompleted.run(current_user_id, csv_export.csv_file.url)

--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -7,6 +7,7 @@ class PremiumAnalyticsWorker
   def perform(id, account_type)
     @user = User.find_by_id(id)
     return unless @user
+
     analytics = Analyzer.new
     if Subscription::OFFICIAL_FREE_TYPES.include?(account_type)
       event = SegmentIo::BackgroundEvents::BEGAN_PREMIUM_TRIAL

--- a/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_school_subscription_email_worker.rb
@@ -6,6 +6,7 @@ class PremiumSchoolSubscriptionEmailWorker
   def perform(user_id)
     @user = User.find_by_id(user_id)
     return unless @user
+
     school = @user.school
     admin = school&.schools_admins&.first&.try(:user)
     @user.send_premium_school_subscription_email(school, admin)

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -13,6 +13,7 @@ class SyncVitallyWorker
     end
     # Don't synchronize non-production data
     return unless ENV['SYNC_TO_VITALLY'] == 'true'
+
     schools_to_sync.each_slice(100) do |school_batch|
       school_ids = school_batch.map { |school| school.id }
       SyncVitallyAccountsWorker.perform_async(school_ids)

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -40,6 +40,7 @@ module Evidence
     def regex
       rule_type = params[:rule_type]
       return render :body => nil, :status => 404 if !Evidence::Rule::TYPES.include? rule_type
+
       regex_check = Evidence::RegexCheck.new(@entry, @prompt, rule_type)
       render json: regex_check.feedback_object
     end
@@ -48,12 +49,14 @@ module Evidence
       automl_check = Evidence::AutomlCheck.new(@entry, @prompt, @previous_feedback)
       feedback_object = automl_check.feedback_object
       return render :body => nil, :status => 404 unless feedback_object
+
       render json: feedback_object
     end
 
     def spelling
       spelling_check = Evidence::SpellingCheck.new(@entry)
       return render :body => {:error => spelling_check.error }.to_json, :status => 500 if spelling_check.error.present?
+
       render json: spelling_check.feedback_object
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -59,6 +59,7 @@ module Evidence
       self
     rescue StandardError => e
       raise e unless e.is_a?(ActiveRecord::RecordInvalid)
+
       return false
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -61,9 +61,11 @@ module Evidence
 
     def invalid_activity_ids
       return unless highlight_type == 'passage'
+
       related_passages = feedback.rule.prompts.map(&:activity).uniq.map(&:passages).flatten
       invalid_ids = related_passages.reject {|p| p.text.include?(text)}.map {|p| p.activity.id}
       return if invalid_ids.empty?
+
       invalid_ids
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
@@ -64,6 +64,7 @@ module Evidence
 
     private def set_default_case_sensitivity
       return if case_sensitive.in? CASE_SENSITIVE_ALLOWED_VALUES
+
       self.case_sensitive = DEFAULT_CASE_SENSITIVITY
     end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -76,11 +76,13 @@ module Evidence
 
     def regex_is_passing?(entry)
       return true if regex_rules.empty?
+
       grade_sequences(entry)
     end
 
     def grade_sequences(entry)
       return true if all_incorrect_sequences_passing?(entry) && one_non_conditional_required_sequences_passing?(entry)
+
       at_least_one_conditional_required_sequence_passing?(entry)
     end
 
@@ -142,16 +144,19 @@ module Evidence
 
     def conjunctions
       return nil if universal_rule_type?
+
       prompts.map(&:conjunction)
     end
 
     def conditional
       return nil if !regex? || regex_rules.empty?
+
       return regex_rules.all? { |r| r.conditional? }
     end
 
     private def all_incorrect_sequences_passing?(entry)
       return true if incorrect_sequences.empty?
+
       incorrect_sequences.none? do |regex_rule|
         regex_rule.entry_failing?(entry)
       end
@@ -159,6 +164,7 @@ module Evidence
 
     private def at_least_one_conditional_required_sequence_passing?(entry)
       return false if required_sequences.where(conditional: true).empty?
+
       required_sequences.where(conditional: true).any? do |regex_rule|
         !regex_rule.entry_failing?(entry)
       end
@@ -166,6 +172,7 @@ module Evidence
 
     private def one_non_conditional_required_sequences_passing?(entry)
       return true if required_sequences.where(conditional: false).empty?
+
       required_sequences.where(conditional: false).any? do |regex_rule|
         !regex_rule.entry_failing?(entry)
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
@@ -30,6 +30,7 @@ module Evidence
 
     private def expires_at_in_future
       return if expires_at.blank?
+
       errors.add(:expires_at, 'must be in the future') unless expires_at > Time.zone.now
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/automl_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/automl_check.rb
@@ -14,6 +14,7 @@ module Evidence
 
     def feedback_object
       return unless matched_rule
+
       feedback = matched_rule.determine_feedback_from_history(@previous_feedback)
       highlight = feedback.highlights.map do |h|
         {
@@ -40,6 +41,7 @@ module Evidence
 
     private def fetch_matched_rule
       return unless @automl_model
+
       google_automl_label = @automl_model.fetch_automl_label(@entry)
       @prompt.rules.joins(:label).find_by(comprehension_labels: {name: google_automl_label})
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -26,6 +26,7 @@ module Evidence
           if !response.success? 
             raise GrammarApiError, "Encountered upstream error: #{response}"
           end
+
           response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
         end
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
@@ -26,6 +26,7 @@ module Evidence
           if !response.success? 
             raise OpinionAPIError, "Encountered upstream error: #{response}"
           end
+
           response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
         end
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -125,6 +125,7 @@ module Evidence
       slices_to_match_strings = nil
       slices_to_assemble.each do |slice|
         next false unless confirm_minimum_overlap?(slice, slices_to_match)
+
         slice_string = slice.join(' ')
         slices_to_match_strings ||= slices_to_match.map { |s| s.join(' ') }
         match = slices_to_match_strings.any? { |match_string| DidYouMean::Levenshtein.distance(slice_string, match_string) <= FUZZY_CHARACTER_THRESHOLD }

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -51,6 +51,7 @@ module Evidence
 
     private def highlights
       return [] if optimal?
+
       [entry_highlight, passage_highlight]
     end
 
@@ -80,11 +81,13 @@ module Evidence
 
     private def matched_slice
       return "" if !minimum_overlap?
+
       @matched_slice ||= match_entry_on_passage
     end
 
     private def matched_slice_passage
       return "" if !minimum_overlap?
+
       @matched_slice_passage ||= match_passage_on_entry
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -49,6 +49,7 @@ module Evidence
     def feedback_object
       @violated_rule = prefilter_rules.find do |rule|
         next unless @prefilters[rule.uid]
+
         @prefilters[rule.uid].call(entry)
       end
       return default_response unless @violated_rule
@@ -79,6 +80,7 @@ module Evidence
 
     def highlights
       return [] if @violated_rule.uid != PROFANITY_RULE_UID
+
       [{
         type: Evidence::Highlight::TYPE_RESPONSE,
         text: @profanity_instance,

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/profanity.rb
@@ -18,6 +18,7 @@ module Evidence
 
     def self.profane_word_check(word, bad_words = BadWords::ALL)
       return nil unless word.is_a?(String) && word.length > 1
+
       word = word.downcase.gsub(/[.!?]/, '')
 
       a_match = bad_words.find do |badword|

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
@@ -42,6 +42,7 @@ module Evidence
 
     private def feedback_text
       return ALL_CORRECT_FEEDBACK unless matched_rule
+
       feedback&.text
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_migration_runner.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_migration_runner.rb
@@ -6,6 +6,7 @@ module Evidence
       ActiveRecord::Base.transaction do
         RuleSet.all.each do |rule_set|
           next unless Evidence::Rule.where(name: rule_set.name, rule_type: Evidence::Rule::TYPE_REGEX, suborder: rule_set.priority).joins(:prompts).merge( Evidence::Prompt.where(id: rule_set.prompt_ids)).empty?
+
           rule = Rule.create!(
             name: rule_set.name,
             suborder: rule_set.priority,

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -19,6 +19,7 @@ module Evidence
 
     def feedback_object
       return {} if error.present?
+
       {
         feedback: optimal? ? ALL_CORRECT_FEEDBACK : non_optimal_feedback_string,
         feedback_type: FEEDBACK_TYPE,
@@ -41,6 +42,7 @@ module Evidence
 
     private def spelling_rule
       return @spelling_rule if @spelling_rule
+
       @spelling_rule ||= Rule.where(rule_type: FEEDBACK_TYPE).first
     end
 

--- a/services/QuillLMS/engines/evidence/lib/tasks/migrate_plagiarism.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/migrate_plagiarism.rake
@@ -10,6 +10,7 @@ namespace :plagiarism do
     ActiveRecord::Base.transaction do
       Evidence::Prompt.all.each do |prompt|
         next unless prompt.plagiarism_text.present? && Evidence::Rule.where(name: 'Plagiarism').joins(:prompts).merge( Evidence::Prompt.where(id: prompt.id)).empty?
+
         rule = Evidence::Rule.create!(name: 'Plagiarism', rule_type: Evidence::Rule::TYPE_PLAGIARISM, universal: false, optimal: false, suborder: 0, concept_uid: concept.uid)
         Evidence::PromptsRule.create!(rule_id: rule.id, prompt_id: prompt.id)
         Evidence::Feedback.create!(text: prompt.plagiarism_first_feedback, order: 0, rule_id: rule.id) if prompt.plagiarism_first_feedback.present?

--- a/services/QuillLMS/lib/tasks/convert_to_markdown.rake
+++ b/services/QuillLMS/lib/tasks/convert_to_markdown.rake
@@ -5,6 +5,7 @@ namespace :unit_templates do
   task :convert_to_markdown => :environment do
     UnitTemplate.all.each do |ut|
       next unless ut.activity_info.blank?
+
       markdown = ''
       unless ut.problem.blank?
         markdown.concat "### Problem\n\n#{ut.problem}\n\n"

--- a/services/QuillLMS/lib/tasks/flags.rake
+++ b/services/QuillLMS/lib/tasks/flags.rake
@@ -20,6 +20,7 @@ namespace :flags do
           end
 
           next if user.flags.include?(row['flag'])
+
           user.flags.append(row['flag'])
           user.save!
       end

--- a/services/QuillLMS/script/lessons/add_lesson_type_to_lessons.rb
+++ b/services/QuillLMS/script/lessons/add_lesson_type_to_lessons.rb
@@ -7,6 +7,7 @@ Lesson.all.each do |lesson|
   if data["questions"].blank?
     next
   end
+
   first_question = data["questions"][0]
   question_type = first_question["questionType"]
   if question_type && question_type.empty?

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -423,6 +423,7 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
       allow_any_instance_of(ActiveActivitySession).to receive(:save!) do
         call_count += 1
         raise(ActiveRecord::RecordNotUnique, 'Error') if call_count == 1
+
         true
       end
       put :update, params: { id: active_activity_session.uid, active_activity_session: active_activity_session.data }

--- a/services/QuillLMS/spec/support/async_helper.rb
+++ b/services/QuillLMS/spec/support/async_helper.rb
@@ -15,6 +15,7 @@ module AsyncHelper
       end
       return if e.nil?
       raise e if Time.now >= time_limit
+
       sleep interval
     end
   end


### PR DESCRIPTION
## WHAT
Enable the Rubocop configuration that enforces empty lines after guard clauses.

## WHY
Leaving an empty line after guard clauses helps with readability at it signals a change in control flow.  Otherwise, return clauses can get lost in a mix of instructions.

## HOW
Autocorrect applies on this rule so a simple: `rubocop -A --only Layout/EmptyLineAfterGuardClause`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Cosmetic change.
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A