### PR TITLE
lms/add-premium-type-to-intercom-identify

### DIFF
--- a/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
+++ b/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
@@ -8,6 +8,7 @@ class SegmentAnalyticsUserSerializer < UserSerializer
       userType: object.role,
       createdAt: object.created_at,
       daysSinceJoining: ((Time.zone.now - object.created_at) / 60 / 60 / 24).to_i,
+      premium_type: object.subscription&.account_type
     }
   end
 end

--- a/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
+++ b/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
@@ -8,7 +8,7 @@ class SegmentAnalyticsUserSerializer < UserSerializer
       userType: object.role,
       createdAt: object.created_at,
       daysSinceJoining: ((Time.zone.now - object.created_at) / 60 / 60 / 24).to_i,
-      premium_type: object.subscription&.account_type
+      premiumType: object.subscription&.account_type
     }
   end
 end

--- a/services/QuillLMS/spec/helpers/segment_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/segment_helper_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe SegmentioHelper do
-  let!(:user) {create(:teacher)}
+  let!(:user) {create(:teacher, :premium)}
 
   describe '#generate_segment_identify_arguments' do
     it 'should construct a series of three javascript-parsable "function arguments"' do
@@ -22,6 +22,7 @@ describe SegmentioHelper do
         userType: user.role,
         createdAt: user.created_at,
         daysSinceJoining: ((Time.zone.now - user.created_at) / 60 / 60 / 24).to_i,
+        premiumType: user.subscription.account_type
       }
       expect(serialization).to eq(expected_serialization)
     end


### PR DESCRIPTION
## WHAT
Add premium_type to the front-end based Segment identify code
## WHY
Partnerships wants this data available in Intercom, and the attempt we made last year by adding it to the back-end `identify` code 

It looks like back-end based identify calls don't sync to Intercom (there's some special code that's used to validate data for Intercom using our Intercom secret, which isn't used on the back-end identify call), so we need to do this to make sure the data gets to Intercom.  Maybe?  Because it looks like Intercom is still getting some data from other places somehow?  Not totally clear.
## HOW
Add the same property that we were trying to sync before to the code that generates payloads for front-end identification

### Notion Card Links
https://www.notion.so/quill/Determine-why-Premium-type-is-not-flowing-into-Intercom-as-an-attribute-and-resolve-the-problem-36949960406b4330a5c9b4b46ffd977e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
