### PR TITLE
Enable Metrics/CyclomaticComplexity cop

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -274,6 +274,9 @@ Metrics/AbcSize:
 Metrics/BlockNesting:
   Max: 4
 
+Metrics/CyclomaticComplexity:
+  Max: 7
+
 # TODO temporaily disable since it's outputting too much noise
 Metrics/MethodLength:
   Enabled: false

--- a/services/.rubocop_todo.yml
+++ b/services/.rubocop_todo.yml
@@ -356,11 +356,6 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 508
 
-# Offense count: 101
-# Configuration parameters: IgnoredMethods.
-Metrics/CyclomaticComplexity:
-  Max: 27
-
 # Offense count: 86
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:

--- a/services/QuillCMS/app/controllers/responses_controller.rb
+++ b/services/QuillCMS/app/controllers/responses_controller.rb
@@ -93,6 +93,7 @@ class ResponsesController < ApplicationController
     render json: IncorrectSequenceCalculator.incorrect_sequences_for_question(params[:question_uid])
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def count_affected_by_incorrect_sequences
     used_sequences = (
       params_for_count_affected_by_incorrect_sequences[:used_sequences] || []
@@ -114,10 +115,11 @@ class ResponsesController < ApplicationController
       if matching_selected_sequence
         matched_responses_count += 1
       end
-
     end
+
     render json: {matchedCount: matched_responses_count}
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def count_affected_by_focus_points
     selected_sequences = params_for_count_affected_by_focus_points[:selected_sequences]

--- a/services/QuillCMS/lib/modules/incorrect_sequence_calculator.rb
+++ b/services/QuillCMS/lib/modules/incorrect_sequence_calculator.rb
@@ -13,6 +13,8 @@ class ActiveRecord::Relation
   #
   # Returns
   #   nothing is returned from the function
+
+  # rubocop:disable Metrics/CyclomaticComplexity
   def pluck_in_batches(*columns, batch_size: 1000)
     if columns.empty?
       raise "There must be at least one column to pluck"
@@ -60,6 +62,7 @@ class ActiveRecord::Relation
       batch_start = last_id + 1
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end
 
 module IncorrectSequenceCalculator
@@ -156,6 +159,7 @@ module IncorrectSequenceCalculator
     counter
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.amplify(incorrect_substrings, correct_substrings)
     begin
       incorrect_substrings.each do |substring,v|
@@ -178,5 +182,6 @@ module IncorrectSequenceCalculator
       raise
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillCMS/lib/tasks/import_from_firebase.rake
+++ b/services/QuillCMS/lib/tasks/import_from_firebase.rake
@@ -172,6 +172,7 @@ namespace :responses do
     puts dupes_hash
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def convert_to_csv
     graded_file_name = "tmp/data/gradedResponses.json"
     graded_file = File.read(graded_file_name)
@@ -235,6 +236,7 @@ namespace :responses do
     end;0
 
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def import_from_zip
     Zip::File.open('respforpostgres.csv.zip') do |zip_file|

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -101,6 +101,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     @activity_session = ActivitySession.unscoped.find_by_uid!(params[:id])
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def activity_session_params
     params.delete(:activity_session)
     data = params.delete(:data)&.permit!
@@ -121,6 +122,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
       .reject { |_, v| v.nil? }
       .merge(timespent: timespent && [timespent, MAX_4_BYTE_INTEGER_SIZE].min)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def transform_incoming_request
     if params[:concept_results].present?

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -126,6 +126,7 @@ class ApplicationController < ActionController::Base
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   protected def confirm_valid_session
     # Don't do anything if there's no authorized user or session
     return if !current_user || !session
@@ -152,6 +153,7 @@ class ApplicationController < ActionController::Base
     # we can reset the session whenever (Time.now > (current_user.auth_credential.created_at + 5 months))
     return reset_session if current_user.google_id && current_user.auth_credential && Time.now > (current_user.auth_credential.created_at + 5.months)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   protected def user_inactive_for_too_long?
     return false if session[KEEP_ME_SIGNED_IN] || current_user.google_id || current_user.clever_id

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -29,6 +29,7 @@ class BlogPostsController < ApplicationController
     render :index
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def show
     draft_statuses = current_user&.staff? ? [true, false] : false
 
@@ -55,6 +56,7 @@ class BlogPostsController < ApplicationController
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def search
     @query = params[:query]

--- a/services/QuillLMS/app/controllers/cms/activity_categories_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activity_categories_controller.rb
@@ -5,6 +5,7 @@ class Cms::ActivityCategoriesController < Cms::CmsController
     render json: { activity_categories: format_activity_categories }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def mass_update
     ActivityCategory.all.each do |extant_ac|
       ac = params[:activity_categories].find { |activity_category| activity_category[:id].to_i == extant_ac.id }
@@ -24,6 +25,7 @@ class Cms::ActivityCategoriesController < Cms::CmsController
     end
     render json: { activity_categories: format_activity_categories }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def create
     activity_category = ActivityCategory.create(activity_category_params)

--- a/services/QuillLMS/app/controllers/cms/cms_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/cms_controller.rb
@@ -3,6 +3,7 @@
 class Cms::CmsController < ApplicationController
   before_action :staff!
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def subscription_data
     if !@school && !@user && @subscription.schools.any?
       # then we are here directly through edit subscriptions and we want to select
@@ -22,4 +23,5 @@ class Cms::CmsController < ApplicationController
 
     @schools_users = @school.users.map{|u| {id: u.id, name: u.name, email: u.email}}
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -7,6 +7,7 @@ class Cms::RostersController < Cms::CmsController
 
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def upload_teachers_and_students
     school = School.find_by(id: params[:school_id])
     raise "School not found. Check that the ID is correct and try again." if school.blank?
@@ -43,5 +44,6 @@ class Cms::RostersController < Cms::CmsController
   rescue StandardError => e
     render json: {errors: e.message}, status: 422
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -33,6 +33,7 @@ class Cms::SchoolsController < Cms::CmsController
 
   # This allows staff members to drill down on a specific school, including
   # viewing an index of teachers at this school.
+  # rubocop:disable Metrics/CyclomaticComplexity
   def show
     @subscription = @school&.subscription
     @school_subscription_info = {
@@ -60,6 +61,7 @@ class Cms::SchoolsController < Cms::CmsController
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   # This allows staff members to edit certain details about a school.
   def edit
@@ -239,6 +241,7 @@ class Cms::SchoolsController < Cms::CmsController
     'HAVING COUNT(schools_users.*) != 0'
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def where_query_string_builder
     conditions = []
     # This converts all of the search inputs into strings so we can iterate
@@ -253,6 +256,7 @@ class Cms::SchoolsController < Cms::CmsController
     conditions = conditions.reject(&:nil?)
     "WHERE #{conditions.join(' AND ')}" unless conditions.empty?
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def where_query_string_clause_for(param, param_value)
     # Potential params by which to search:

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -216,6 +216,7 @@ class Cms::UsersController < Cms::CmsController
     "WHERE #{conditions.reject(&:nil?).join(' AND ')}"
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   protected def where_query_string_clause_for(param, param_value)
     # Potential params by which to search:
     # User name: users.name
@@ -252,6 +253,7 @@ class Cms::UsersController < Cms::CmsController
       nil
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   protected def class_code_string_builder
     class_code = user_query_params["class_code"]

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -39,6 +39,7 @@ module DiagnosticReports
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id=nil, hashify_activity_sessions: false)
     if unit_id
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
@@ -61,6 +62,7 @@ module DiagnosticReports
 
     @activity_sessions = @activity_sessions.map { |session| [session.user_id, session] }.to_h
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def set_pre_test_activity_sessions_and_assigned_students(activity_id, classroom_id, hashify_activity_sessions: false)
     classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -50,6 +50,7 @@ module GrowthResultsSummary
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def skill_groups_for_session(skill_groups, post_test_activity_session, pre_test_activity_session, student_name)
     skill_groups.map do |skill_group|
       skills = skill_group.skills.map do |skill|
@@ -88,6 +89,7 @@ module GrowthResultsSummary
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def summarize_student_proficiency_for_skill_overall(present_skill_number, correct_skill_number, pre_correct_skill_number)
     case correct_skill_number

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -45,6 +45,7 @@ module ResultsSummary
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def skill_groups_for_session(skill_groups, activity_session, student_name)
     skill_groups.map do |skill_group|
       skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }
@@ -70,5 +71,6 @@ module ResultsSummary
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -44,7 +44,7 @@ module TeacherFixes
     cu1.update!(visible: false)
   end
 
-  # rubocop:disable Lint/DuplicateBranch
+  # rubocop:disable Lint/DuplicateBranch, Metrics/CyclomaticComplexity
   def self.merge_activity_sessions_between_two_classroom_units(cu1, cu2)
     # use the most recently completed activity session
     cu1.activity_sessions.each do |act_sesh1|
@@ -64,7 +64,7 @@ module TeacherFixes
       end
     end
   end
-  # rubocop:enable Lint/DuplicateBranch
+  # rubocop:enable Lint/DuplicateBranch, Metrics/CyclomaticComplexity
 
   def self.move_activity_sessions(user, classroom1, classroom2)
     classroom1_id = classroom1.id

--- a/services/QuillLMS/app/controllers/concerns/units_with_completed_activities.rb
+++ b/services/QuillLMS/app/controllers/concerns/units_with_completed_activities.rb
@@ -3,6 +3,7 @@
 module UnitsWithCompletedActivities
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def units_with_completed_activities(cus)
     all_assigned_units = cus.group_by{|cu| cu.unit_id}
     relevant_unit_ids = []
@@ -13,5 +14,6 @@ module UnitsWithCompletedActivities
     end
     Unit.where(id: relevant_unit_ids)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -25,6 +25,7 @@ class PagesController < ApplicationController
     self.formats = ['html']
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def home_new
     if signed_in?
       redirect_to(profile_path) && return
@@ -44,6 +45,7 @@ class PagesController < ApplicationController
     end
     self.formats = ['html']
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def develop
   end
@@ -409,6 +411,7 @@ class PagesController < ApplicationController
   end
 
   # for link to premium within 'about' (discover) pages
+  # rubocop:disable Metrics/CyclomaticComplexity
   def premium
     @user_is_eligible_for_new_subscription= current_user&.eligible_for_new_subscription?
     @user_is_eligible_for_trial = current_user&.subscriptions&.where&.not(account_type: Subscription::COVID_TYPES)&.none?
@@ -441,6 +444,7 @@ class PagesController < ApplicationController
 
     @title = 'Premium'
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def tutorials
   end
@@ -514,6 +518,7 @@ class PagesController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def determine_js_file
     case action_name
     when 'partners', 'mission', 'faq', 'impact', 'team', 'tos', 'media_kit', 'media', 'privacy', 'map', 'teacher-center', 'news', 'stats', 'activities'
@@ -536,6 +541,7 @@ class PagesController < ApplicationController
       @js_file = ApplicationController::DIAGNOSTIC
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def determine_flag
     case action_name

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -6,6 +6,7 @@ class SchoolsController < ApplicationController
   include CheckboxCallback
   MIN_PREFIX_LENGHT_WHEN_LAT_LON_NOT_PRESENT = 4
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def index
     @radius = params[:radius].presence || 5
     @lat = params[:lat]
@@ -82,6 +83,7 @@ class SchoolsController < ApplicationController
     end
 
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def new
   end

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -10,6 +10,7 @@ class SessionsController < ApplicationController
 
   before_action :signed_in!, only: [:destroy]
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def create
     email_or_username = params[:user][:email].downcase.strip unless params[:user][:email].nil?
     @user =  User.find_by_username_or_email(email_or_username)
@@ -37,7 +38,9 @@ class SessionsController < ApplicationController
       login_failure_message
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def login_through_ajax
     email_or_username = params[:user][:email].downcase.strip unless params[:user][:email].nil?
     @user =  User.find_by_username_or_email(email_or_username)
@@ -71,6 +74,7 @@ class SessionsController < ApplicationController
       render json: {message: 'Wrong password. Try again or click Forgot password to reset it.', type: 'password'}, status: 401
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def destroy
     admin_id = session.delete(:admin_id)

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -98,6 +98,7 @@ class StudentsController < ApplicationController
     auth_failed unless current_user
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def redirect_to_profile
     @current_user = current_user
     classroom_id = params["classroom"]
@@ -113,6 +114,7 @@ class StudentsController < ApplicationController
       redirect_to classes_path
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def flash_missing_unit_error
     classroom_id = params["classroom"]

--- a/services/QuillLMS/app/controllers/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/subscriptions_controller.rb
@@ -68,6 +68,7 @@ class SubscriptionsController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def subscription_status
     current_subscription = current_user.subscription
     if current_subscription
@@ -85,6 +86,7 @@ class SubscriptionsController < ApplicationController
     subscription_attributes = @subscription_status_obj&.attributes || {}
     @subscription_status = subscription_attributes.merge(attributes_for_front_end)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def subscription_params
     params.require(:subscription).permit(:id, :purchaser_id, :expiration, :account_type, :authenticity_token, :recurring)

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -80,6 +80,7 @@ class TeacherFixController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def merge_student_accounts
     primary_account = User.find_by_username_or_email(params['account1_identifier'])
     secondary_account = User.find_by_username_or_email(params['account2_identifier'])
@@ -99,7 +100,9 @@ class TeacherFixController < ApplicationController
       render json: {error: "We do not have an account for #{missing_account_identifier}"}
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def merge_teacher_accounts
     account1 = User.find_by_username_or_email(params['account1_identifier'])
     account2 = User.find_by_username_or_email(params['account2_identifier'])
@@ -125,6 +128,7 @@ class TeacherFixController < ApplicationController
       render json: {error: "We do not have an account for #{missing_account_identifier}"}
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def move_student_from_one_class_to_another
     account_identifier = params['student_identifier']
@@ -196,6 +200,7 @@ class TeacherFixController < ApplicationController
     render json: {}, status: 200
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def merge_activity_packs
     begin
       raise 'Please specify an activity pack ID.' if params['from_activity_pack_id'].nil? || params['to_activity_pack_id'].nil?
@@ -212,6 +217,7 @@ class TeacherFixController < ApplicationController
     end
     render json: {}, status: 200
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def delete_last_activity_session
     begin

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -70,6 +70,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     @classroom = @classroom.as_json
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def dashboard
     if current_user.classrooms_i_teach.empty? && current_user.archived_classrooms.none? && !current_user.has_outstanding_coteacher_invitation? && current_user.schools_admins.any?
         redirect_to teachers_admin_dashboard_path
@@ -87,6 +88,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     growth_diagnostic_promotion_card_milestone = Milestone.find_by_name(Milestone::TYPES[:acknowledge_growth_diagnostic_promotion_card])
     @show_diagnostic_promotion_card = !UserMilestone.find_by(milestone_id: growth_diagnostic_promotion_card_milestone&.id, user_id: current_user&.id) && (current_user.created_at < "2021-11-29".to_date || current_user&.unit_activities&.where(activity_id: Activity.diagnostic_activity_ids)&.any?)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def students_list
     @classroom = current_user.classrooms_i_teach.find {|classroom| classroom.id == params[:id]&.to_i}
@@ -255,6 +257,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     render json: { data: TeacherActivityFeed.get(current_user.id) }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def generate_onboarding_checklist
     Objective::ONBOARDING_CHECKLIST_NAMES.map do |name|
       objective = Objective.find_by_name(name)
@@ -272,6 +275,7 @@ class Teachers::ClassroomManagerController < ApplicationController
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def set_classroom_variables
     @tab = params[:tab]
@@ -286,6 +290,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     @last_classroom_id = last_classroom.id
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def set_banner_variables
     acknowledge_diagnostic_banner_milestone = Milestone.find_by_name(Milestone::TYPES[:acknowledge_diagnostic_banner])
     acknowledge_lessons_banner_milestone = Milestone.find_by_name(Milestone::TYPES[:acknowledge_lessons_banner])
@@ -293,7 +298,9 @@ class Teachers::ClassroomManagerController < ApplicationController
     @show_diagnostic_banner = !UserMilestone.find_by(milestone_id: acknowledge_diagnostic_banner_milestone&.id, user_id: current_user&.id) && current_user&.unit_activities&.where(activity_id: diagnostic_ids)&.none?
     @show_lessons_banner = !UserMilestone.find_by(milestone_id: acknowledge_lessons_banner_milestone&.id, user_id: current_user&.id) && current_user&.classroom_unit_activity_states&.where(completed: true)&.none?
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def set_diagnostic_variables
     @assigned_pre_tests = Activity.where(id: Activity::PRE_TEST_DIAGNOSTIC_IDS).map do |act|
       pre_test_diagnostic_unit_ids = current_user&.unit_activities&.where(activity_id: act.id)&.map(&:unit_id) || []
@@ -315,6 +322,7 @@ class Teachers::ClassroomManagerController < ApplicationController
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def classroom_with_students_json(classrooms)
     { classrooms_and_their_students: classrooms.map { |classroom| classroom_json(classroom) } }

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -157,6 +157,7 @@ class Teachers::ClassroomsController < ApplicationController
     render json: {}
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def format_coteacher_invitations_for_index
     coteacher_invitations = CoteacherClassroomInvitation.includes(invitation: :inviter).joins(:invitation, :classroom).where(invitations: {invitee_email: current_user.email}, classrooms: { visible: true})
 
@@ -168,6 +169,7 @@ class Teachers::ClassroomsController < ApplicationController
       coteacher_invitation_obj
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def format_classrooms_for_index
     has_classroom_order = ClassroomsTeacher.where(user_id: current_user.id).all? { |classroom| classroom.order }

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -21,6 +21,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def return_data(should_return_json)
     classroom_units_filter = params[:classroom_id].blank? ? '' : "AND classroom_units.classroom_id = #{params[:classroom_id].to_i}"
     student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
@@ -143,6 +144,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
       render plain: csv_string(activity_sessions)
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def score(percentage)
     case percentage
@@ -152,6 +154,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def timespent_string(seconds)
     return "N/A" unless seconds
     return "<1 min" if seconds < 60
@@ -167,6 +170,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     end
     "#{hours} #{hours_text}"
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def csv_string(activity_sessions)
     CSV.generate do |csv|

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -44,6 +44,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     render json: { students: students_json }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def individual_student_diagnostic_responses
     activity_id = individual_student_diagnostic_responses_params[:activity_id]
     classroom_id = individual_student_diagnostic_responses_params[:classroom_id]
@@ -78,6 +79,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     end
     render json: { concept_results: concept_results, skill_results: skill_results, name: student.name }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def classrooms_with_students
     classrooms = classrooms_with_students_for_report(params[:unit_id], params[:activity_id])
@@ -117,6 +119,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     render json: { skills_growth: skills_growth_by_classroom_for_post_tests(params[:classroom_id], params[:post_test_activity_id], params[:pre_test_activity_id]) }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit
     params.permit(:unit_id, :activity_id)
     unit_id = params[:unit_id]
@@ -138,6 +141,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     end
     # rubocop:enable Style/GuardClause
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def assign_selected_packs
       if params[:selections]
@@ -227,6 +231,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     render json: GrowthResultsSummary.growth_results_summary(pre_test.id, results_summary_params[:activity_id], results_summary_params[:classroom_id])
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def create_or_update_selected_packs
     if params[:whole_class]
       $redis.set("user_id:#{current_user.id}_lesson_diagnostic_recommendations_start_time", Time.now)
@@ -259,6 +264,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def authorize_teacher!
     classroom_teacher!(params[:classroom_id])

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -196,6 +196,7 @@ class Teachers::UnitsController < ApplicationController
     units_i_teach_own_or_coteach('teach', report, false)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def units_i_teach_own_or_coteach(teach_own_or_coteach, report, lessons)
     # returns an empty array if teach_own_or_coteach_classrooms_array is empty
     teach_own_or_coteach_classrooms_array = current_user.send("classrooms_i_#{teach_own_or_coteach}").map(&:id)
@@ -314,6 +315,7 @@ class Teachers::UnitsController < ApplicationController
       unit
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def diagnostic_unit_records
     diagnostic_activity_ids = ActivityClassification.find_by_key('diagnostic').activity_ids
@@ -352,6 +354,7 @@ class Teachers::UnitsController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def diagnostics_organized_by_classroom
     classrooms = []
     diagnostic_records = diagnostic_unit_records
@@ -390,7 +393,9 @@ class Teachers::UnitsController < ApplicationController
     end
     classrooms
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def record_with_aggregated_activity_sessions(diagnostic_records, activity_id, classroom_id, pre_test_activity_id)
     records = diagnostic_records.select { |record| record['activity_id'] == activity_id && record['classroom_id'] == classroom_id }
     return if records.empty?
@@ -406,6 +411,7 @@ class Teachers::UnitsController < ApplicationController
     record['assigned_count'] = assigned_student_ids.size
     record.except('unit_id', 'unit_name', 'classroom_unit_id', 'assigned_student_ids')
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def grouped_name(record)
     activity_ids_to_names = {

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -2,7 +2,8 @@
 
 module PagesHelper
 
-	def pages_tab_class tabname
+ # rubocop:disable Metrics/CyclomaticComplexity
+	def pages_tab_class(tabname)
 		about_actions = ["mission", "develop", "faq"]
 		impact_actions = ['impact', 'map', 'stats']
 		team_actions = %w(team)
@@ -46,8 +47,9 @@ module PagesHelper
 		end
 
 	end
+ # rubocop:enable Metrics/CyclomaticComplexity
 
-	def subtab_class tabname
+	def subtab_class(tabname)
 		if action_name == tabname
 			"active"
 		else

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -16,6 +16,7 @@ module QuillAuthentication
     signed_in!
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def current_user
     begin
       if session[:preview_student_id]
@@ -36,6 +37,7 @@ module QuillAuthentication
       nil
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def classroom_owner!(classroom_id)
     return if ClassroomsTeacher.exists?(classroom_id: classroom_id, user: current_user, role: 'owner')
@@ -55,6 +57,7 @@ module QuillAuthentication
     auth_failed
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def sign_in(user)
     remote_ip = (request.present? ? request.remote_ip : nil)
 
@@ -71,6 +74,7 @@ module QuillAuthentication
     session[:admin_id] = user.id if user.admin?
     @current_user = user
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def current_user_demo_id=(demo_id)
     session[:demo_id] = demo_id

--- a/services/QuillLMS/app/lib/universal_rule_loader.rb
+++ b/services/QuillLMS/app/lib/universal_rule_loader.rb
@@ -13,6 +13,7 @@ class UniversalRuleLoader
     opinion: 'Opinion API'
   }
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.update_from_csv(type:, iostream:)
     if !Evidence::Rule::TYPES.include?(type) || TYPE_LOOKUP[type.to_sym].nil?
       raise ArgumentError, "Invalid rule type: #{type}"
@@ -56,4 +57,5 @@ class UniversalRuleLoader
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -219,6 +219,7 @@ class ActivitySession < ApplicationRecord
     super || unit_activity&.activity
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def determine_if_final_score
     return if state != 'finished' || (percentage.nil? && !activity.is_evidence?)
 
@@ -239,6 +240,7 @@ class ActivitySession < ApplicationRecord
     # return true otherwise save will be prevented
     true
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def formatted_due_date
     return nil if unit_activity&.due_date.nil?
@@ -311,6 +313,7 @@ class ActivitySession < ApplicationRecord
     percentage
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def parse_for_results
     concept_results_by_concept = concept_results.group_by { |c| c.concept_id }
 
@@ -340,6 +343,7 @@ class ActivitySession < ApplicationRecord
 
     results
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   alias owner user
 
@@ -515,6 +519,7 @@ class ActivitySession < ApplicationRecord
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.search_sort_sql(sort)
     if sort.blank? or sort[:field].blank?
       sort = {
@@ -548,6 +553,7 @@ class ActivitySession < ApplicationRecord
       "standards.name #{order}"
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def trigger_events
     yield # http://stackoverflow.com/questions/4998553/rails-around-callbacks

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -67,6 +67,7 @@ class Classroom < ApplicationRecord
     super
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def validate_name
     return unless name_changed?
 
@@ -77,6 +78,7 @@ class Classroom < ApplicationRecord
 
     errors.add(:name, :taken)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.create_with_join(classroom_attributes, teacher_id)
     classroom = Classroom.new(classroom_attributes)

--- a/services/QuillLMS/app/models/concerns/lessons_cache.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_cache.rb
@@ -15,6 +15,7 @@ module LessonsCache
       "visible" => cua.unit_activity.visible}
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def update_lessons_cache(cua)
     classroom_id = cua.classroom_unit.classroom_id
     classroom = Classroom.find_by(id: classroom_id)
@@ -45,6 +46,7 @@ module LessonsCache
       $redis.set("user_id:#{user_id}_lessons_array", lessons_cache.to_json)
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def format_initial_lessons_cache(teacher)
     cuas = []

--- a/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
@@ -18,6 +18,7 @@ module LessonsRecommendations
       PublicProgressReports.activity_sessions_with_counted_concepts(@activity_sessions)
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def recommendations
       LessonRecommendationsQuery.new(
         @activity_id,
@@ -43,6 +44,7 @@ module LessonsRecommendations
         return_value_for_lesson_recommendation(lessons_rec, fail_count, students_needing_instruction)
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def return_value_for_lesson_recommendation(lessons_rec, fail_count, students_needing_instruction)
       {

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -42,6 +42,7 @@ module PublicProgressReports
       end
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def results_by_question(activity_id)
       activity = Activity.includes(:classification).find(activity_id)
       questions = Hash.new{|h,k| h[k]={} }
@@ -74,7 +75,9 @@ module PublicProgressReports
 
       questions_arr
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def classrooms_with_students_for_report(unit_id, activity_id)
       h = {}
       unit = Unit.find_by(id: unit_id)
@@ -108,7 +111,9 @@ module PublicProgressReports
         []
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def results_for_classroom(unit_id, activity_id, classroom_id)
       classroom_unit = ClassroomUnit.find_by(
         classroom_id: classroom_id,
@@ -164,6 +169,7 @@ module PublicProgressReports
 
       scores
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     private def unfinished_key(state)
       return :missed_names if state&.completed
@@ -200,6 +206,7 @@ module PublicProgressReports
       time > 60 ? '> 60' : time
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def format_concept_results(activity_session, concept_results)
       concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
         # if we don't sort them, we can't rely on the first result being the first attemptNum
@@ -234,6 +241,7 @@ module PublicProgressReports
         hash
       }
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def get_score_for_question(concept_results)
       if !concept_results.empty? && concept_results.first[:metadata]['questionScore']
@@ -251,6 +259,7 @@ module PublicProgressReports
       end
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def get_feedback_from_feedback_history(activity_session, prompt_text, attempt_number)
       feedback_histories = activity_session.feedback_histories
       return "" if feedback_histories.empty? || prompt_text.blank? || attempt_number.blank?
@@ -260,7 +269,9 @@ module PublicProgressReports
       feedback_history = feedback_histories.select {|fh| fh.attempt == attempt_number.to_i && fh.prompt_id == prompt&.id }&.first
       feedback_history&.feedback_text
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def generate_recommendations_for_classroom(current_user, unit_id, classroom_id, activity_id)
       set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id)
       diagnostic = Activity.find(activity_id)
@@ -293,6 +304,7 @@ module PublicProgressReports
         recommendations: recommendations
       }
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def return_value_for_recommendation(students, activity_pack_recommendation)
       {

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -134,6 +134,7 @@ module Student
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def merge_activity_sessions(secondary_account, teacher_id=nil)
     primary_account_activity_sessions = activity_sessions
     secondary_account_activity_sessions = secondary_account.activity_sessions
@@ -158,6 +159,7 @@ module Student
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def remove_student_classrooms(teacher_id=nil)
     students_classrooms = StudentsClassrooms.where(student_id: id)

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -68,6 +68,7 @@ module Teacher
     Set.new.tap { |ids| all_ids.each { |row| ids.merge(row.values) } }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def ids_of_classroom_teachers_and_coteacher_invitations_that_i_coteach_or_am_the_invitee_of(classrooms_ids_to_check=nil)
     if classrooms_ids_to_check && classrooms_ids_to_check.any?
       # if there are specific ids passed it will only return those that match
@@ -113,6 +114,7 @@ module Teacher
       classrooms_teachers_ids: classrooms_teachers_ids.to_a
     }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def affiliated_with_unit?(unit_id)
     RawSqlRunner.execute(
@@ -145,6 +147,7 @@ module Teacher
     Classroom.find_by_sql("#{base_sql_for_teacher_classrooms(only_visible_classrooms: false)} AND ct.role = 'owner' AND classrooms.visible = false")
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def handle_negative_classrooms_from_update_coteachers(classroom_ids=nil)
     return unless classroom_ids && classroom_ids.any?
 
@@ -158,6 +161,7 @@ module Teacher
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def handle_positive_classrooms_from_update_coteachers(classroom_ids, inviter_id)
     return unless classroom_ids && classroom_ids.any?
@@ -333,6 +337,7 @@ module Teacher
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def update_teacher params
     return if !teacher?
     params[:role] = 'teacher' if params[:role] != 'student'
@@ -400,7 +405,9 @@ module Teacher
     end
     response
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def updated_school(school_id)
     school = School.find_by(id: school_id)
     if subscription && subscription.school_subscriptions.any? && !has_matching_subscription?(id, school&.subscription&.id)
@@ -415,6 +422,7 @@ module Teacher
     # then we let the user subscription handle everything else
     UserSubscription.create_user_sub_from_school_sub_if_they_do_not_have_that_school_sub(id, school.subscription.id)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def has_matching_subscription?(user_id, subscription_id)
     UserSubscription.where(user_id: user_id, subscription_id: subscription_id).exists?

--- a/services/QuillLMS/app/models/csv_export.rb
+++ b/services/QuillLMS/app/models/csv_export.rb
@@ -61,6 +61,7 @@ class CsvExport < ApplicationRecord
     save!
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def csv_exporter
     @exporter ||=
       case export_type.to_sym
@@ -80,6 +81,7 @@ class CsvExport < ApplicationRecord
         raise "Export type named #{export_type} could not be found!"
       end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def csv_basename
     "csv_#{teacher_id}_#{export_type}"

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -200,6 +200,7 @@ class FeedbackHistory < ApplicationRecord
   end
   # rubocop:enable Lint/DuplicateBranch
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.list_by_activity_session(activity_id: nil, page: 1, start_date: nil, end_date: nil, page_size: DEFAULT_PAGE_SIZE, turk_session_id: nil, filter_type: nil)
     query = select(
       <<-SQL
@@ -244,6 +245,7 @@ class FeedbackHistory < ApplicationRecord
     query = query.offset((page.to_i - 1) * page_size.to_i) if page && page.to_i > 1
     query
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.get_total_count(activity_id: nil, start_date: nil, end_date: nil, turk_session_id: nil)
     query = FeedbackHistory.select(:feedback_session_uid)
@@ -260,6 +262,7 @@ class FeedbackHistory < ApplicationRecord
     query.length
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.serialize_detail_by_activity_session(feedback_session_uid)
     history = FeedbackHistory.list_by_activity_session.where(feedback_session_uid: feedback_session_uid).first
     return nil unless history
@@ -286,4 +289,5 @@ class FeedbackHistory < ApplicationRecord
     output[:prompts] = prompt_groups
     output.symbolize_keys
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -15,6 +15,7 @@ class QuestionHealthObj
     @tool = tool
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def run
     health_dashboard = QuestionHealthDashboard.new(@activity.id, @question_number, @question.uid)
     data = @question.data
@@ -30,6 +31,7 @@ class QuestionHealthObj
       percent_reached_optimal: health_dashboard.percent_reached_optimal_for_question&.round(2)
     }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def question_url
     QUESTION_TYPE_TO_URL[@question.question_type.to_sym]

--- a/services/QuillLMS/app/models/raw_score.rb
+++ b/services/QuillLMS/app/models/raw_score.rb
@@ -24,6 +24,7 @@ class RawScore < ApplicationRecord
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def readability_grade_level(activity_classification_id=nil)
     activity_classification = ActivityClassification.find_by_id(activity_classification_id)
     case name
@@ -59,4 +60,5 @@ class RawScore < ApplicationRecord
       ""
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/models/zipcode_info.rb
+++ b/services/QuillLMS/app/models/zipcode_info.rb
@@ -24,12 +24,14 @@
 #
 class ZipcodeInfo < ApplicationRecord
 
-  
+
   # Takes a tuple of (lat, lng) where lng and lat are floats, and a distance in
   # miles. Returns a list of zipcodes near the point.
+
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.isinradius(point, distance)
-    
-    zips_in_radius = [] 
+
+    zips_in_radius = []
 
     unless point.is_a? Array and point.length == 2 and point.all? { |e| e.is_a?(Float) }
       # point should be a tuple of floats lat, lon, like (40.7694, -73.9609)
@@ -76,4 +78,5 @@ class ZipcodeInfo < ApplicationRecord
     zips_in_radius
 
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/queries/dashboard.rb
+++ b/services/QuillLMS/app/queries/dashboard.rb
@@ -4,6 +4,7 @@ class Dashboard
   SUFFICIENT_DATA_AMOUNT = 30
   RESULT_LIMITS = 5
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.queries(user)
     get_redis_values(user)
     strug_stud = @@cached_strug_stud
@@ -32,6 +33,7 @@ class Dashboard
               {header: 'Difficult Concepts', results: diff_con}
 ]
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.completed_activity_count(user_id)
     RawSqlRunner.execute(

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -48,6 +48,7 @@ class SegmentAnalytics
     })
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def track_activity_pack_assignment(teacher_id, unit_id)
     unit = Unit.find_by_id(unit_id)
 
@@ -79,6 +80,7 @@ class SegmentAnalytics
       }
     })
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def track_activity_completion(user, student_id, activity)
     track({
@@ -88,6 +90,7 @@ class SegmentAnalytics
     })
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def track_classroom_creation(classroom)
     # TODO: Remove early return once this bug is fixed
     # https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
@@ -109,6 +112,7 @@ class SegmentAnalytics
       }
     })
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def track_activity_search(user_id, search_query)
     track({

--- a/services/QuillLMS/app/services/associators/students_to_classrooms.rb
+++ b/services/QuillLMS/app/services/associators/students_to_classrooms.rb
@@ -2,6 +2,7 @@
 
 module Associators::StudentsToClassrooms
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.run(student, classroom)
     @@classroom = classroom
     if legit_classroom && legit_teacher && (student&.role == 'student')
@@ -22,8 +23,8 @@ module Associators::StudentsToClassrooms
     end
     student
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
-  
   def self.update_classroom_units(student_classroom)
     cus = ClassroomUnit.where(classroom_id: student_classroom.classroom_id)
     cus.each{|cu| cu.validate_assigned_student(student_classroom.student_id)}

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -17,7 +17,7 @@ class Demo::CreateAdminReport
   private :email_safe_school_name
   private :teacher_email
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   private def create_demo
     # Create the school
     school = School.create!(name: name)
@@ -192,5 +192,5 @@ class Demo::CreateAdminReport
 
     admin_teacher
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -61,9 +61,11 @@ class SerializeActivityHealth
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def diagnostics
     @activity.unit_templates&.map {|ut| ut.recommendations}&.map{|r| r.map{|rr| rr.activity.name}}&.reject{|n| n == ''}&.flatten
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def average(list, attribute)
     return nil if list.empty?

--- a/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
+++ b/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
@@ -134,6 +134,7 @@ class UnitTemplatePseudoSerializer
     activity_hashes.uniq { |a| a[:id] }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def type
     acts = @unit_template.activities
     if acts.any? { |act| act&.classification&.key == ActivityClassification::LESSONS_KEY }
@@ -153,4 +154,5 @@ class UnitTemplatePseudoSerializer
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -24,6 +24,7 @@ module Units::Updater
     update_helper(unit_id, activities_data, classrooms_data, current_user_id || teacher_id)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.matching_or_new_classroom_unit(classroom, extant_classroom_units, new_cus, hidden_cus_ids, unit_id, concatenate_extant_student_ids)
     classroom_id = classroom[:id].to_i || classroom['id'].to_i
     matching_cu = extant_classroom_units.find{|cu| cu.classroom_id == classroom_id}
@@ -47,6 +48,7 @@ module Units::Updater
          assigned_student_ids: classroom[:student_ids]})
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.matching_or_new_unit_activity(activity_data, extant_unit_activities, new_uas, hidden_ua_ids, unit_id, order_number)
     activity_data_id = activity_data[:id].to_i || activity_data['id'].to_i
@@ -65,6 +67,7 @@ module Units::Updater
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.update_helper(unit_id, activities_data, classrooms_data, current_user_id, concatenate_extant_student_ids: false)
     extant_classroom_units = ClassroomUnit.where(unit_id: unit_id)
     new_cus = []
@@ -93,5 +96,6 @@ module Units::Updater
     end
     AssignActivityWorker.perform_async(current_user_id, unit_id)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -9,6 +9,7 @@ class SerializeVitallySalesUser
     @user = user
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def data
     current_time = Time.zone.now
     school_year_start = School.school_year_start(current_time)
@@ -88,6 +89,7 @@ class SerializeVitallySalesUser
       }.merge(account_data_params)
     }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def evidence_id
     ActivityClassification.evidence.id

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -4,6 +4,7 @@ class AssignRecommendationsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(options={})
     options = options.with_indifferent_access
     unit_template_id = options["unit_template_id"]
@@ -35,6 +36,7 @@ class AssignRecommendationsWorker
     PusherRecommendationCompleted.run(classroom, unit_template_id, lesson)
     track_assign_all_recommendations(teacher) if assigning_all_recommended_packs
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def assign_unit_to_one_class(unit, classroom_id, classroom_data, unit_template_id, teacher_id)
     if unit.present?

--- a/services/QuillLMS/app/workers/classroom_activities_to_unit_activities_and_classroom_units_worker.rb
+++ b/services/QuillLMS/app/workers/classroom_activities_to_unit_activities_and_classroom_units_worker.rb
@@ -3,6 +3,7 @@
 class ClassroomActivitiesToUnitActivitiesAndClassroomUnitsWorker
   include Sidekiq::Worker
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(unit_id)
     UnitActivity.skip_callback(:save, :after, :teacher_checkbox)
     ClassroomActivity.unscoped.where(unit_id: unit_id).each do |ca|
@@ -52,5 +53,6 @@ class ClassroomActivitiesToUnitActivitiesAndClassroomUnitsWorker
     end
     UnitActivity.set_callback(:save, :after, :teacher_checkbox)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
 end

--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -13,6 +13,7 @@ class ConceptReplacementConnectWorker
     replace_questions_in_connect('diagnostic_fillInBlankQuestions', original_concept_uid, new_concept_uid)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def replace_questions_in_connect(endpoint, original_concept_uid, new_concept_uid)
     questions = HTTParty.get("#{ENV['FIREBASE_DATABASE_URL']}/v2/#{endpoint}.json").parsed_response
     questions.each do |key, q|
@@ -46,7 +47,9 @@ class ConceptReplacementConnectWorker
 
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def replace_focus_points_for_question(fp_obj, original_concept_uid, new_concept_uid)
     return if fp_obj.none? { |k, v| v['conceptResults'] && v['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
 
@@ -71,7 +74,9 @@ class ConceptReplacementConnectWorker
     end
     new_fp_obj
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def replace_incorrect_sequences_for_question(is_array, original_concept_uid, new_concept_uid)
     return if is_array.none? { |is| is['conceptResults'] && is['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
 
@@ -97,4 +102,5 @@ class ConceptReplacementConnectWorker
     end
     new_is_array
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -4,6 +4,7 @@ class ConceptReplacementGrammarWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(original_concept_uid, new_concept_uid)
     activities = HTTParty.get("#{ENV['FIREBASE_DATABASE_URL']}/v3/grammarActivities.json").parsed_response
     activities.each do |key, act|
@@ -45,7 +46,9 @@ class ConceptReplacementGrammarWorker
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def replace_focus_points_or_incorrect_sequences_for_question(fp_or_is, original_concept_uid, new_concept_uid)
     return unless fp_or_is.any? { |k, v| v['conceptResults'] && v['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
 
@@ -70,4 +73,5 @@ class ConceptReplacementGrammarWorker
     end
     new_fp_or_is
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -4,6 +4,7 @@ class GetConceptsInUseIndividualConceptWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(id)
     @sc_questions = JSON.parse($redis.get('SC_QUESTIONS'))
     @fib_questions = JSON.parse($redis.get('FIB_QUESTIONS'))
@@ -71,6 +72,7 @@ class GetConceptsInUseIndividualConceptWorker
 
     set_concepts_in_use_cache
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def get_activity_rows(id)
     begin

--- a/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
+++ b/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
@@ -31,6 +31,7 @@ class QuillStaffAccountsChangedWorker
     JSON.parse($redis.get(STAFF_ACCOUNTS_CACHE_KEY) || '[]')
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def notify_staff(current_staff_accounts, previous_staff_accounts)
     body = ''.dup
 
@@ -63,4 +64,5 @@ class QuillStaffAccountsChangedWorker
       body: body
     ).deliver
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -7,6 +7,7 @@ class SyncVitallyWorker
   FIRST_DAY_OF_SCHOOL_YEAR_MONTH = 7
   FIRST_DAY_OF_SCHOOL_YEAR_DAY = 1
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform
     if Date.today.month == FIRST_DAY_OF_SCHOOL_YEAR_MONTH && Date.today.day == FIRST_DAY_OF_SCHOOL_YEAR_DAY
       PopulateAnnualVitallyWorker.perform_async
@@ -22,6 +23,7 @@ class SyncVitallyWorker
       SyncVitallyUsersWorker.perform_async(user_ids)
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def schools_to_sync
     School.select(:id).distinct.joins(:users).where('users.role = ?', 'teacher')

--- a/services/QuillLMS/app/workers/test_for_earned_checkboxes_worker.rb
+++ b/services/QuillLMS/app/workers/test_for_earned_checkboxes_worker.rb
@@ -4,10 +4,11 @@ class TestForEarnedCheckboxesWorker
   include Sidekiq::Worker
   include CheckboxCallback
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(id)
     teacher = User.find_by(id: id)
     return unless teacher
-    
+
     #we don't want to trigger analtyics since this is used as a callback after login
     find_or_create_checkbox(Objective::CREATE_A_CLASSROOM, teacher) if teacher.classrooms_i_teach.any?
     find_or_create_checkbox(Objective::ADD_STUDENTS, teacher) if teacher.classrooms_i_teach.find{|classroom| classroom.students.any?}
@@ -15,5 +16,5 @@ class TestForEarnedCheckboxesWorker
     assigned_unit_types = teacher.units.map(&:unit_activities).flatten.map(&:checkbox_type).uniq.each{|type| find_or_create_checkbox(type, teacher)}
     find_or_create_checkbox('Add School', teacher) if teacher.school.present?
   end
-
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/workers/update_milestones_worker.rb
+++ b/services/QuillLMS/app/workers/update_milestones_worker.rb
@@ -3,6 +3,7 @@
 class UpdateMilestonesWorker
   include Sidekiq::Worker
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(activity_session_uid)
     activity_session = ActivitySession.find_by_uid(activity_session_uid)
     return unless activity_session
@@ -18,4 +19,5 @@ class UpdateMilestonesWorker
 
     teacher_milestones.push(Milestone.find_by(name: 'Complete Diagnostic'))
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class MigrateLessonsToActivity < ActiveRecord::Migration[4.2]
+  # rubocop:disable Metrics/CyclomaticComplexity
   def change
     # Before running this part, make sure that the inconsistent names in this
     # spreadsheet are resolved:
@@ -67,6 +68,6 @@ class MigrateLessonsToActivity < ActiveRecord::Migration[4.2]
       a.data = data
       a.save!
     end
-
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -6,17 +6,17 @@ module Evidence
   class FeedbackController < ApiController
     before_action :set_params, only: [:automl, :plagiarism, :regex, :spelling]
 
-    def grammar 
+    def grammar
       grammar_client = Grammar::Client.new(entry: params['entry'], prompt_text: params['prompt_text'])
       render json: Grammar::FeedbackAssembler.run(grammar_client.post)
     end
 
-    def opinion 
+    def opinion
       oapi_client = Opinion::Client.new(entry: params['entry'], prompt_text: params['prompt_text'])
       render json: Opinion::FeedbackAssembler.run(oapi_client.post)
-    end 
+    end
 
-    def prefilter 
+    def prefilter
       prefilter_check = Evidence::PrefilterCheck.new(prefilter_params)
       render json: prefilter_check.feedback_object
     end
@@ -72,10 +72,12 @@ module Evidence
       @previous_feedback = params[:previous_feedback]
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     private def get_plagiarism_feedback_from_previous_feedback(prev, rule)
       previous_plagiarism = prev.select {|f| f["feedback_type"] == Evidence::Rule::TYPE_PLAGIARISM && f["optimal"] == false }
       feedbacks = rule&.feedbacks
       previous_plagiarism.empty? ? feedbacks&.find_by(order: 0)&.text : feedbacks&.find_by(order: 1)&.text
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -9,7 +9,7 @@ module Evidence
     def index
       @rules = Evidence::Rule
       @rules = @rules.includes(:prompts_rules).where(comprehension_prompts_rules: {prompt_id: params[:prompt_id].split(',')}) if params[:prompt_id]
-      @rules = @rules.where(rule_type: index_params['rule_type']) 
+      @rules = @rules.where(rule_type: index_params['rule_type'])
 
       # some rules will apply to multiple prompts so we only want to return them once
       render json: @rules.distinct.all
@@ -49,6 +49,7 @@ module Evidence
       head :no_content
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def update_rule_order
       ordered_rules = ordered_rules_params[:ordered_rule_ids].map.with_index do |id, index|
         rule = Evidence::Rule.find_by_id(id)
@@ -63,6 +64,7 @@ module Evidence
         render json: {error_messages: ordered_rules.map { |r| r&.errors }.join('; ')}, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     private def set_rule
       if params[:id].present?

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -46,6 +46,7 @@ module Evidence
       state == STATE_ACTIVE
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def activate
       AutomlModel.transaction do
         prompt.automl_models.update_all(state: STATE_INACTIVE)
@@ -61,6 +62,8 @@ module Evidence
       raise e unless e.is_a?(ActiveRecord::RecordInvalid)
       return false
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
 
     def fetch_automl_label(text)
       automl_payload = {

--- a/services/QuillLMS/engines/evidence/app/models/evidence/label.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/label.rb
@@ -24,11 +24,13 @@ module Evidence
       ))
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     private def name_unique_for_prompt
       prompt_labels = rule&.prompts&.first&.rules&.map { |r| r.label }
       return unless prompt_labels&.map { |l| l&.name }&.include?(name)
 
       errors.add(:name, "can't be the same as any other labels related to the same prompt")
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/services/QuillLMS/engines/evidence/config/initializers/backport_pg_support_to_rails4.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/backport_pg_support_to_rails4.rb
@@ -18,6 +18,7 @@ module ActiveRecord
     module PostgreSQL
       module SchemaStatements
         # Resets the sequence of a table's primary key to the maximum value.
+        # rubocop:disable Metrics/CyclomaticComplexity
         def reset_pk_sequence!(table, primary_key = nil, sequence = nil) #:nodoc:
           unless primary_key && sequence
             default_pk, default_sequence = pk_and_sequence_for(table)
@@ -46,6 +47,7 @@ module ActiveRecord
             SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})
           SQL
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -116,12 +116,14 @@ module Evidence
       identify_first_matched_substring(passage_word_arrays, slices)
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     private def identify_first_matched_substring(slices_to_assemble, slices_to_match)
       combined_matched_slices = []
       # Placeholder to be overridden during the first run of the loop that makes it past the confirm_minimum_overlap? guard statement.  If that never happens, we don't have to calculate this value
       slices_to_match_strings = nil
       slices_to_assemble.each do |slice|
         next false unless confirm_minimum_overlap?(slice, slices_to_match)
+
         slice_string = slice.join(' ')
         slices_to_match_strings ||= slices_to_match.map { |s| s.join(' ') }
         match = slices_to_match_strings.any? { |match_string| DidYouMean::Levenshtein.distance(slice_string, match_string) <= FUZZY_CHARACTER_THRESHOLD }
@@ -143,6 +145,7 @@ module Evidence
       end
       combined_matched_slices
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     private def confirm_minimum_overlap?(target_array, source_arrays)
       # Since we allow character deviation that's smaller than the total number of words compared

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -157,6 +157,7 @@ module Evidence
       @passage_word_arrays ||= clean_passage.split.each_cons(MATCH_MINIMUM).to_a
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     private def get_highlight(text, cleaned_text, matched_slice)
       extra_space_indexes = []
       cleaned_text.each_char.with_index { |c, i| extra_space_indexes.push(i) if c == ' ' && cleaned_text[i+1] == ' ' }
@@ -172,5 +173,6 @@ module Evidence
       char_positions = text.enum_for(:scan, /[A-Za-z0-9\s]/).map { |c| Regexp.last_match.begin(0) }
       text[char_positions[start_index]..char_positions[end_index]]
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/services/QuillLMS/lib/eg_form_builder.rb
+++ b/services/QuillLMS/lib/eg_form_builder.rb
@@ -157,6 +157,7 @@ class EgFormBuilder < CMS::FormBuilder
     @template.content_tag :div, options, &block
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def field(*args, &block)
     type, name, options = _extract_field_args(args)
     out = ''.html_safe
@@ -210,6 +211,7 @@ class EgFormBuilder < CMS::FormBuilder
       out
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   # simple helper method for extracting and applying default options.
   def _apply_default_options(args, defaults)
@@ -236,6 +238,7 @@ class EgFormBuilder < CMS::FormBuilder
     [type, name, options]
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def _field_types(type)
     case type
     when :string, :location
@@ -258,6 +261,7 @@ class EgFormBuilder < CMS::FormBuilder
       :select
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def error_messages
     return if object.errors.none?

--- a/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
+++ b/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
@@ -89,6 +89,7 @@ def find_rule_number(uid, grammar_concepts)
   concept["ruleNumber"]
 end
 
+# rubocop:disable Metrics/CyclomaticComplexity
 def find_categorized_connect_questions(uid, sc_questions, sf_questions, d_questions, fib_questions)
   questions = []
   sc_questions.values.each do |q|
@@ -109,6 +110,7 @@ def find_categorized_connect_questions(uid, sc_questions, sf_questions, d_questi
 
   questions
 end
+# rubocop:enable Metrics/CyclomaticComplexity
 
 concepts.each do |c|
   uid = c["concept_uid"]


### PR DESCRIPTION
## WHAT
Turn the Rubocop Metrics/CyclomaticComplexity cop back to its original default of 7 (it was at 27).

## WHY
Cyclomatic Complexity is a metric used to assess the complexity of a program by looking for all possible paths that the program might take through a given method.  Switching the setting back to its original will enforce simple procedures that promote less risk in our codebase: 
![Screen Shot 2022-01-28 at 9 26 45 AM](https://user-images.githubusercontent.com/2057805/151580008-0b701faf-0286-4a3e-9f19-7380f99b966a.png)

(The reasoning here is future code modifications on higher complexity methods will require more paths that to be accounted for, making it more likely that mistakes will be made)

## HOW
Add setting to .rubocop.yml and then add disable/enable wrappers around all existing methods that violate the limit of 7.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Non-app change.
Have you deployed to Staging? | NO - non-app change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
