### PR TITLE
lms/cache-teachers-units-scores-info

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -144,7 +144,7 @@ class Teachers::UnitsController < ApplicationController
       activity: params[:activity_id]
     }
 
-    json = current_user.classroom_unit_cache(classroom_unit, key: 'units.score_info' , groups: cache_groups) do
+    json = current_user.classroom_unit_cache(classroom_unit, key: 'units.score_info', groups: cache_groups) do
       completed = ActivitySession.where(
         classroom_unit_id: params[:classroom_unit_id],
         activity_id: params[:activity_id],

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -139,12 +139,14 @@ class Teachers::UnitsController < ApplicationController
   # :activity_id (in url)
   # :classroom_unit_id
   def score_info
-    classroom_unit = ClassroomUnit.find(params[:classroom_unit_id])
+    classroom_unit = ClassroomUnit.find_by(id: params[:classroom_unit_id])
+    return render json: { cumulative_score: 0, completed_count: 0 } unless classroom_unit
+
     cache_groups = {
       activity: params[:activity_id]
     }
 
-    json = current_user.classroom_unit_cache(classroom_unit, key: 'units.score_info', groups: cache_groups) do
+    json = current_user.classroom_unit_cache(classroom_unit, key: 'teachers.units.score_info', groups: cache_groups) do
       completed = ActivitySession.where(
         classroom_unit_id: params[:classroom_unit_id],
         activity_id: params[:activity_id],
@@ -159,11 +161,6 @@ class Teachers::UnitsController < ApplicationController
     end
 
     render json: json
-  rescue ActiveRecord::RecordNotFound
-    render json: {
-      cumulative_score: 0,
-      completed_count: 0
-    }
   end
 
   private def lessons_with_current_user_and_activity


### PR DESCRIPTION
## WHAT
Update controller to cache on classroom_unit
## WHY
It takes half the time to load the cached version of this common reporting endpoint
## HOW
1. Wrap the controller payload code in a cache block
2. Add a `rescue` clause to handle cases where `classroom_id` is not present or valid (the tests make it clear that we expect a specific static payload in those cases, nice job, tests!)

### Notion Card Links
https://www.notion.so/quill/Implement-Caching-on-3-endpoints-07b97e6538134ea090ba0f7fd5df3d8b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes, so no need to update tests
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
