### PR TITLE
lms/cache-teacher-units-skills-growth

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -114,7 +114,17 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def skills_growth
-    render json: { skills_growth: skills_growth_by_classroom_for_post_tests(params[:classroom_id], params[:post_test_activity_id], params[:pre_test_activity_id]) }
+    classroom = Classroom.find(params[:classroom_id])
+    cache_keys = {
+      pre_test: params[:pre_test_activity_id],
+      post_test: params[:post_test_activity_id]
+    }
+
+    json = current_user.classroom_cache(classroom, key: 'teachers.progress_reports.diagnostic_reports.skills_growth', groups: cache_keys) do
+      { skills_growth: skills_growth_by_classroom_for_post_tests(params[:classroom_id], params[:post_test_activity_id], params[:pre_test_activity_id]) }
+    end
+
+    render json: json
   end
 
   def redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -112,7 +112,11 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def diagnostic_units
-    render json: diagnostics_organized_by_classroom.to_json
+    json = current_user.all_classrooms_cache(key: 'teachers.units.diagnostic_units') do
+      diagnostics_organized_by_classroom.to_json
+    end
+
+    render json: json
   end
 
   # Get all Units containing lessons, and only retrieve the classroom activities for lessons.


### PR DESCRIPTION
## WHAT
Cache both the diagnostics list for teachers and the skills growth
## WHY
While this set of reports is fairly new, it's also quite popular, so caching it should reduce load on the database during repeated loads
## HOW
Just add cache wrappers to the two controllers that are used to populate this reports page

### Notion Card Links
https://www.notion.so/quill/Implement-Caching-on-3-endpoints-07b97e6538134ea090ba0f7fd5df3d8b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
