### PR TITLE
Enable Style/UnlessLogicalOperators cop

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -767,5 +767,8 @@ Style/WhileUntilDo:
 Style/UnlessElse:
   Enabled: true
 
+Style/UnlessLogicalOperators:
+  Enabled: true
+
 Style/ZeroLengthPredicate:
   Enabled: true

--- a/services/QuillLMS/app/models/referrals_user.rb
+++ b/services/QuillLMS/app/models/referrals_user.rb
@@ -57,8 +57,14 @@ class ReferralsUser < ApplicationRecord
     ).to_a
 
     referrer_hash = user_info.first
+    referrer_match = referrer_hash['email'].match('quill.org')
+
     referral_hash = user_info.last
-    return unless Rails.env.production? || (referrer_hash['email'].match('quill.org') && referral_hash['email'].match('quill.org'))
+    referral_match = referral_hash['email'].match('quill.org')
+
+    email_match = referrer_match && referral_match
+
+    return if !Rails.env.production? && !email_match
 
     UserMailer.activated_referral_email(referrer_hash, referral_hash).deliver_now!
   end


### PR DESCRIPTION
## WHAT
Add a cop that prevents unless with multiple conditions (e.g.  `unless a || c`)

## WHY
The enforcement would be consistent with our [style guide.](https://github.com/empirical-org/ruby#unless-with-multiple-conditions)

## HOW
Add to `.rubocop.yml`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No new functionality added, just refactoring.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
