### PR TITLE
lms/cache-activities-scores-by-classroom

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -5,12 +5,13 @@ class Api::V1::ProgressReportsController < Api::ApiController
 
   def activities_scores_by_classroom_data
     classroom_ids = current_user&.classrooms_i_teach&.map(&:id)
-    if classroom_ids.empty?
-      render json: { data: [] }
-    else
-      data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
-      render json: { data: data }
+    return render json: { data: [] } if classroom_ids.empty?
+
+    data = current_user.all_classrooms_cache(key: 'api.v1.progress_reports.activities_scores_by_classroom_data') do
+      ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
     end
+
+    render json: { data: data }
   end
 
   def district_activity_scores


### PR DESCRIPTION
## WHAT
Cache the results of the activities_scores_by_classroom_data action
## WHY
To improve performance for commonly-loaded reports
## HOW
1. Use an early return instead of an if/else, just while we're here making changes
2. Wrap the code that generates `data` for the return payload in a cache call

### Notion Card Links
https://www.notion.so/quill/Implement-Caching-on-3-endpoints-07b97e6538134ea090ba0f7fd5df3d8b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for no behavior changes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
