### PR TITLE
Fix a couple of bugs with Google Student importing

### DIFF
--- a/services/QuillLMS/app/workers/google_student_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_classroom_worker.rb
@@ -5,11 +5,11 @@ class GoogleStudentClassroomWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   def perform(student_id)
-    begin
-      student = User.find(student_id)
-      GoogleIntegration::Classroom::Main.join_existing_google_classrooms(student)
-    rescue StandardError => e
-      NewRelic::Agent.notice_error(e, context: "Auth::GoogleController")
-    end
+    student = User.find(student_id)
+    return unless student.google_authorized?
+
+    GoogleIntegration::Classroom::Main.join_existing_google_classrooms(student)
+  rescue StandardError => e
+    NewRelic::Agent.notice_error(e, context: "Auth::GoogleController")
   end
 end

--- a/services/QuillLMS/app/workers/google_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_importer_worker.rb
@@ -8,13 +8,11 @@ class GoogleStudentImporterWorker
 
   def perform(teacher_id, context = "none", selected_classroom_ids=nil)
     teacher = User.find(teacher_id)
+    return unless teacher.google_authorized?
+
     GoogleIntegration::TeacherClassroomsStudentsImporter.run(teacher, selected_classroom_ids)
     PusherTrigger.run(teacher_id, PUSHER_EVENT_CHANNEL, "Google classroom students imported for #{teacher_id}.")
   rescue StandardError => e
-    if Rails.env.development?
-      puts 'ERROR', e
-    else
-      NewRelic::Agent.notice_error(e, context: context)
-    end
+    NewRelic::Agent.notice_error(e, context: context)
   end
 end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
@@ -181,7 +181,6 @@ export default class ActiveClassrooms extends React.Component<ActiveClassroomsPr
     }
   }
 
-
   initializePusherForGoogleClassrooms(id) {
     if (process.env.RAILS_ENV === 'development') { Pusher.logToConsole = true }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/import_google_classroom_students_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/import_google_classroom_students_modal.tsx
@@ -37,9 +37,15 @@ export default class ImportGoogleClassroomStudentsModal extends React.Component<
     const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, });
     const channelName = String(id)
     const channel = pusher.subscribe(channelName);
-    const that = this;
+    const { onSuccess } = this.props
+
     channel.bind('google-classroom-students-imported', () => {
-      that.props.onSuccess('Class re-synced')
+      onSuccess('Class re-synced')
+      pusher.unsubscribe(channelName)
+    });
+
+    channel.bind('google-account-reauthorization-required', () => {
+      onSuccess('Reauthorization needed from Google account before student import can be completed.')
       pusher.unsubscribe(channelName)
     });
   }

--- a/services/QuillLMS/spec/workers/google_student_classroom_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/google_student_classroom_worker_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GoogleStudentClassroomWorker do
+  describe '#perform' do
+    let(:student) { create(:student, :signed_up_with_google) }
+    let(:importer_class) { GoogleIntegration::Classroom::Main }
+
+    subject { described_class.new }
+
+    context 'no auth_credential' do
+      it 'should raise an error with an invalid student_id' do
+        expect(importer_class).not_to receive(:join_existing_google_classrooms)
+        subject.perform(nil)
+      end
+    end
+
+    context 'with an auth credential' do
+      before { create(:google_auth_credential, user: student) }
+
+      it 'should run importing with valid student id and no selected_classroom_ids' do
+        expect(importer_class).to receive(:join_existing_google_classrooms).with(student)
+        subject.perform(student.id)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/google_student_importer_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/google_student_importer_worker_spec.rb
@@ -6,23 +6,29 @@ describe GoogleStudentImporterWorker do
   describe '#perform' do
     let(:teacher) { create(:teacher, :signed_up_with_google) }
     let(:selected_classroom_ids) { [123, 456] }
+    let(:importer_class) { GoogleIntegration::TeacherClassroomsStudentsImporter }
 
-    it 'should raise an error with a invalid teacher_id' do
-      expect(GoogleIntegration::TeacherClassroomsStudentsImporter).not_to receive(:new)
+    subject { described_class.new }
 
-      subject.perform(nil)
+    context 'no auth_credential' do
+      it 'should raise an error with an invalid teacher_id' do
+        expect(importer_class).not_to receive(:new)
+        subject.perform(nil)
+      end
     end
 
-    it 'should run importing with valid teacher id and no selected_classroom_ids' do
-      expect(GoogleIntegration::TeacherClassroomsStudentsImporter).to receive(:new).with(teacher, nil)
+    context 'with an auth credential' do
+      before { create(:google_auth_credential, user: teacher) }
 
-      subject.perform(teacher.id)
-    end
+      it 'should run importing with valid teacher id and no selected_classroom_ids' do
+        expect(importer_class).to receive(:new).with(teacher, nil)
+        subject.perform(teacher.id)
+      end
 
-    it 'should run importing with valid teacher id and selected_classroom_ids' do
-      expect(GoogleIntegration::TeacherClassroomsStudentsImporter).to receive(:new).with(teacher, selected_classroom_ids)
-
-      GoogleStudentImporterWorker.new.perform(teacher.id, nil, selected_classroom_ids)
+      it 'should run importing with valid teacher id and selected_classroom_ids' do
+        expect(importer_class).to receive(:new).with(teacher, selected_classroom_ids)
+        subject.perform(teacher.id, nil, selected_classroom_ids)
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug involving workers that make calls to the Google Classroom when the access token is expired.

## WHY
The workers will fail and then run again and fail, etc, since the access token has expired.

## HOW
Add a check for `user.google_authorized?` to both workers.

### Screenshots
![Screen Shot 2022-02-01 at 12 29 25 PM](https://user-images.githubusercontent.com/2057805/152019921-c64ddf0d-4197-4447-bd54-090c0143227a.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
