### PR TITLE
Add exclusion filter for benchmarking specs

### DIFF
--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_session_controller_spec.rb
@@ -20,12 +20,9 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
   end
 
   describe "#update" do
-
-    # rubocop:disable RSpec/Pending, RSpec/ExampleLength
-    xit 'performance testing' do
-      100.times do |i|
-        create(:active_activity_session)
-      end
+    # rubocop:disable RSpec/ExampleLength
+    it 'performance testing', :benchmarking do
+      create_list(:active_activity_session, 100)
 
       data = {
           "updatedAt": 1593741284430,
@@ -341,7 +338,7 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
         end
       end
     end
-    # rubocop:enable RSpec/Pending, RSpec/ExampleLength
+    # rubocop:enable RSpec/ExampleLength
 
     it "should update the existing record" do
       data = {"foo" => "bar"}

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
 
   # focus tests
   config.filter_run focus: true
+  config.filter_run_excluding benchmarking: true
   config.silence_filter_announcements = true
   config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
## WHAT
Add a metadata tag `benchmarking` that can be applied to performance related specs.

## WHY
We'd like to exclude benchmarking specs from being run in circleci flow without using `xit` labeling.

## HOW
Update the rails_helper with the appropriate [exclusion config](https://relishapp.com/rspec/rspec-core/v/3-10/docs/filtering/exclusion-filters) and then apply the tag to the relevant spec.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
