### PR TITLE
Add job to reset Ghost Inspector account

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -528,6 +528,9 @@ Style/CommentedKeyword:
 Style/DefWithParentheses:
   Enabled: true
 
+Style/Documentation:
+  Enabled: false
+
 Style/DocumentDynamicEvalDefinition:
   Enabled: true
 

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -3,6 +3,8 @@
 class Cron
   # Configured in Heroku Scheduler to run every 10 minutes
   def self.interval_10_min
+    run_at_20_minute_mark if Time.now.min == 20
+    run_at_50_minute_mark if Time.now.min == 50
   end
 
   # Configured in Heroku Scheduler to run every hour on the XX:30 mark
@@ -25,22 +27,22 @@ class Cron
     MaterializedViewRefreshWorker.perform_async
     RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
 
-    Question::TYPES.each {|type| RefreshQuestionCacheWorker.perform_async(type) }
+    Question::TYPES.each { |type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 
   # Configured in Heroku Scheduler to run at XX:20
-  def self.run_hourly_at_20_minute_mark
+  def self.run_at_20_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
   end
 
   # Configured in Heroku Scheduler to run at XX:50
-  def self.run_hourly_at_50_minute_mark
+  def self.run_at_50_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
   end
 
   def self.run_saturday
     SetImpactMetricsWorker.perform_async
-    UploadLeapReportWorker.perform_async(29087)
+    UploadLeapReportWorker.perform_async(29_087)
     PopulateAllActivityHealthsWorker.perform_async
     DeleteObsoleteActiveActivitySessionsWorker.perform_async
   end

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -28,8 +28,13 @@ class Cron
     Question::TYPES.each {|type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 
-  # Configured in Heroku Scheduler to run at XX:20 and XX:50 marks every hour
-  def self.run_at_20_and_50_on_the_hour
+  # Configured in Heroku Scheduler to run at XX:20
+  def self.run_hourly_at_20
+    ResetGhostInspectorAccountWorker.perform_async
+  end
+
+  # Configured in Heroku Scheduler to run at XX:50
+  def self.run_hourly_at_50
     ResetGhostInspectorAccountWorker.perform_async
   end
 

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -29,12 +29,12 @@ class Cron
   end
 
   # Configured in Heroku Scheduler to run at XX:20
-  def self.run_hourly_at_20
+  def self.run_hourly_at_20_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
   end
 
   # Configured in Heroku Scheduler to run at XX:50
-  def self.run_hourly_at_50
+  def self.run_hourly_at_50_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
   end
 

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -3,8 +3,8 @@
 class Cron
   # Configured in Heroku Scheduler to run every 10 minutes
   def self.interval_10_min
-    run_at_20_minute_mark if Time.now.min.between?(20, 29)
-    run_at_50_minute_mark if Time.now.min.between?(50, 59)
+    run_at_20_minute_mark if now.min.between?(20, 29)
+    run_at_50_minute_mark if now.min.between?(50, 59)
   end
 
   # Configured in Heroku Scheduler to run every hour on the XX:30 mark

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -3,8 +3,8 @@
 class Cron
   # Configured in Heroku Scheduler to run every 10 minutes
   def self.interval_10_min
-    run_at_20_minute_mark if Time.now.min == 20
-    run_at_50_minute_mark if Time.now.min == 50
+    run_at_20_minute_mark if Time.now.min.between?(20, 29)
+    run_at_50_minute_mark if Time.now.min.between?(50, 59)
   end
 
   # Configured in Heroku Scheduler to run every hour on the XX:30 mark

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -28,6 +28,11 @@ class Cron
     Question::TYPES.each {|type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 
+  # Configured in Heroku Scheduler to run at XX:20 and XX:50 marks every hour
+  def self.run_at_20_and_50_on_the_hour
+    ResetGhostInspectorAccountWorker.perform_async
+  end
+
   def self.run_saturday
     SetImpactMetricsWorker.perform_async
     UploadLeapReportWorker.perform_async(29087)

--- a/services/QuillLMS/app/services/ghost_inspector_account_resetter.rb
+++ b/services/QuillLMS/app/services/ghost_inspector_account_resetter.rb
@@ -14,7 +14,7 @@ class GhostInspectorAccountResetter < ApplicationService
   end
 
   private def ghost_inspector_account_email
-    ENV.fetch('GHOST_INSPECTOR_ACCOUNT_EMAIl', DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL)
+    ENV.fetch('GHOST_INSPECTOR_ACCOUNT_EMAIL', DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL)
   end
 
   private def hide_units

--- a/services/QuillLMS/app/services/ghost_inspector_account_resetter.rb
+++ b/services/QuillLMS/app/services/ghost_inspector_account_resetter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class GhostInspectorAccountResetter < ApplicationService
+  DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL = 'ghost_inspector_account_email@example.com'
+
+  def run
+    return unless ghost_inspector_account
+
+    hide_units
+  end
+
+  private def ghost_inspector_account
+    ghost_inspector_account_email && User.find_by(email: ghost_inspector_account_email)
+  end
+
+  private def ghost_inspector_account_email
+    ENV.fetch('GHOST_INSPECTOR_ACCOUNT_EMAIl', DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL)
+  end
+
+  private def hide_units
+    ghost_inspector_account.units.each do |unit|
+      unit.update(visible: false)
+      ArchiveUnitsClassroomUnitsWorker.perform_async(unit.id)
+      ResetLessonCacheWorker.perform_async(ghost_inspector_account.id)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/reset_ghost_inspector_account_worker.rb
+++ b/services/QuillLMS/app/workers/reset_ghost_inspector_account_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ResetGhostInspectorAccountWorker
+  include Sidekiq::Worker
+
+  def perform
+    GhostInspectorAccountResetter.run
+  end
+end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -8,7 +8,7 @@ describe "Cron", type: :model do
     [20, 50].each do |num_minutes|
       it "enqueues ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
         time = Time.now.midnight + num_minutes.minutes
-        expect(Cron).to receive(:now).exactly(4).times.and_return(time)
+        expect(Cron).to receive(:now).at_least(:twice).and_return(time)
         expect(ResetGhostInspectorAccountWorker).to receive(:perform_async)
         Cron.interval_10_min
       end
@@ -17,7 +17,7 @@ describe "Cron", type: :model do
     [0, 10, 30, 40].each do |num_minutes|
       it "does not enqueue ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
         time = Time.now.midnight + num_minutes.minutes
-        expect(Cron).to receive(:now).exactly(3).times.and_return(time)
+        expect(Cron).to receive(:now).at_least(:twice).and_return(time)
         expect(ResetGhostInspectorAccountWorker).not_to receive(:perform_async)
         Cron.interval_10_min
       end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -7,19 +7,19 @@ describe "Cron", type: :model do
   describe "#interval_10_min" do
     [20, 50].each do |num_minutes|
       it "enqueues ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
-        Timecop.freeze(Time.now.midnight + num_minutes.minutes) do
-          expect(ResetGhostInspectorAccountWorker).to receive(:perform_async)
-          Cron.interval_10_min
-        end
+        time = Time.now.midnight + num_minutes.minutes
+        expect(Cron).to receive(:now).exactly(4).times.and_return(time)
+        expect(ResetGhostInspectorAccountWorker).to receive(:perform_async)
+        Cron.interval_10_min
       end
     end
 
     [0, 10, 30, 40].each do |num_minutes|
       it "does not enqueue ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
-        Timecop.freeze(Time.now.midnight + num_minutes.minutes) do
-          expect(ResetGhostInspectorAccountWorker).not_to receive(:perform_async)
-          Cron.interval_10_min
-        end
+        time = Time.now.midnight + num_minutes.minutes
+        expect(Cron).to receive(:now).exactly(3).times.and_return(time)
+        expect(ResetGhostInspectorAccountWorker).not_to receive(:perform_async)
+        Cron.interval_10_min
       end
     end
   end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -4,6 +4,26 @@ require 'rails_helper'
 require 'sidekiq/testing'
 
 describe "Cron", type: :model do
+  describe "#interval_10_min" do
+    it "enqueues ResetGhostInspectorAccountWorker at :20 and :50 minute marks" do
+      [20, 50].each do |num_minutes|
+        Timecop.travel(Time.now.midnight + num_minutes.minutes) do
+          expect(ResetGhostInspectorAccountWorker).to receive(:perform_async)
+          Cron.interval_10_min
+        end
+      end
+    end
+
+    it "does not enqueue ResetGhostInspectorAccountWorker at :00, :10, :30, and :40 minute marks" do
+      [0, 10, 30, 40].each do |num_minutes|
+        Timecop.travel(Time.now.midnight + num_minutes.minutes) do
+          expect(ResetGhostInspectorAccountWorker).not_to receive(:perform_async)
+          Cron.interval_10_min
+        end
+      end
+    end
+  end
+
   describe "#interval_1_hour" do
     it "enqueues CreditReferringAccountsWorker" do
       expect(CreditReferringAccountsWorker).to receive(:perform_async)

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -5,18 +5,18 @@ require 'sidekiq/testing'
 
 describe "Cron", type: :model do
   describe "#interval_10_min" do
-    it "enqueues ResetGhostInspectorAccountWorker at :20 and :50 minute marks" do
-      [20, 50].each do |num_minutes|
-        Timecop.travel(Time.now.midnight + num_minutes.minutes) do
+    [20, 50].each do |num_minutes|
+      it "enqueues ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
+        Timecop.freeze(Time.now.midnight + num_minutes.minutes) do
           expect(ResetGhostInspectorAccountWorker).to receive(:perform_async)
           Cron.interval_10_min
         end
       end
     end
 
-    it "does not enqueue ResetGhostInspectorAccountWorker at :00, :10, :30, and :40 minute marks" do
-      [0, 10, 30, 40].each do |num_minutes|
-        Timecop.travel(Time.now.midnight + num_minutes.minutes) do
+    [0, 10, 30, 40].each do |num_minutes|
+      it "does not enqueue ResetGhostInspectorAccountWorker at #{num_minutes} minute marks" do
+        Timecop.freeze(Time.now.midnight + num_minutes.minutes) do
           expect(ResetGhostInspectorAccountWorker).not_to receive(:perform_async)
           Cron.interval_10_min
         end

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -87,7 +87,6 @@ RSpec.configure do |config|
     example.run
     ActionController::Base.perform_caching = caching
   end
-
 end
 
 if defined?(Coveralls)

--- a/services/QuillLMS/spec/services/ghost_inspector_account_resetter_spec.rb
+++ b/services/QuillLMS/spec/services/ghost_inspector_account_resetter_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GhostInspectorAccountResetter do
+  subject { described_class.run }
+
+  let!(:ghost_inspector_account) { create(:user, email: described_class::DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL) }
+
+  context 'no units associated with ghost_inspector account exist' do
+    it 'does reset anything' do
+      expect(ArchiveUnitsClassroomUnitsWorker).not_to receive(:perform_async)
+      expect(ResetLessonCacheWorker).not_to receive(:perform_async)
+      subject
+    end
+  end
+
+  context 'units associated with ghost_inspector account exist' do
+    let!(:unit) { create(:unit, user: ghost_inspector_account) }
+
+    it 'archives classroom units and resets lesson cache' do
+      expect(ArchiveUnitsClassroomUnitsWorker).to receive(:perform_async).with(unit.id)
+      expect(ResetLessonCacheWorker).to receive(:perform_async).with(ghost_inspector_account.id)
+      subject
+
+      expect(unit.reload.visible).to be false
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/ghost_inspector_account_resetter_spec.rb
+++ b/services/QuillLMS/spec/services/ghost_inspector_account_resetter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GhostInspectorAccountResetter do
   let!(:ghost_inspector_account) { create(:user, email: described_class::DEFAULT_GHOST_INSPECTOR_ACCOUNT_EMAIL) }
 
   context 'no units associated with ghost_inspector account exist' do
-    it 'does reset anything' do
+    it 'does not reset anything' do
       expect(ArchiveUnitsClassroomUnitsWorker).not_to receive(:perform_async)
       expect(ResetLessonCacheWorker).not_to receive(:perform_async)
       subject


### PR DESCRIPTION
## WHAT
Add a cron job that resets the Ghost Inspector account at :20 and :50 every hour.

## WHY
At the end of the ghost inspector test  "Student: (1) Assign Starter Diagnostic (2) Complete Starter Diagnostic (3) Delete Starter Diagnostic (v2)", there are a few steps that handle cleanup of the Ghost Inspector account.  
Periodically there are spurious failures with the test preventing the cleanup from happening.  Ultimately, the next run through of the test has previous state associated with the Ghost Inspector account resulting in a continually failing test.  We need to cleanup the account before running the next test.

## HOW
The test runs every 30 minutes at :00 and :30, so I've added a new cron job set to run at :20 and :50 that will cleanup the units associated with the ghost inspector account.  The cleanup adapts the [hide method](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/teachers/units_controller.rb#L126) across all units for that teacher.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A