### PR TITLE
Add Rubocop/Indentation{Style, Width} cops

### DIFF
--- a/services/.rubocop_todo.yml
+++ b/services/.rubocop_todo.yml
@@ -141,13 +141,6 @@ Layout/FirstHashElementIndentation:
 Layout/HashAlignment:
   Enabled: false
 
-# Offense count: 574
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth, EnforcedStyle.
-# SupportedStyles: spaces, tabs
-Layout/IndentationStyle:
-  Enabled: false
-
 # Offense count: 50
 # Cop supports --auto-correct.
 # Configuration parameters: AllowDoxygenCommentStyle, AllowGemfileRubyComment.

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -17,8 +17,8 @@ module PagesHelper
     getting_started_actions = ['teacher-center']
     media_actions = ['news', 'press', 'blog_posts']
     case tabname
-  when "about"
-    about_actions.include?(action_name) ? 'active' : ''
+    when "about"
+      about_actions.include?(action_name) ? 'active' : ''
     when 'faq'
       faq_actions.include?(action_name) ? 'active' : ''
     when 'press'
@@ -30,7 +30,7 @@ module PagesHelper
     when "team"
       team_actions.include?(action_name) ? 'active' : ''
     when 'getting-started'
-       # TODO: revert this when we launch front end of knowlege center
+      # TODO: revert this when we launch front end of knowlege center
       action_name == 'temporarily_render_old_teacher_resources' ? 'active' : ''
     when 'news'
       news_actions.include?(action_name) ? 'active' : ''

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -3,59 +3,59 @@
 module PagesHelper
 
   # rubocop:disable Metrics/CyclomaticComplexity
-	 def pages_tab_class(tabname)
- 		 about_actions = ["mission", "develop", "faq"]
- 		 impact_actions = ['impact', 'map', 'stats']
- 		 team_actions = %w(team)
- 		 partners_actions = %w(partners)
- 		 news_actions = %w(news)
- 		 press_actions = %w(press)
- 		 standards_actions = ['activities']
- 		 topics_actions = ['index']
- 		 faq_actions = ['faq']
- 		 media_kit_actions = ['media_kit']
- 		 getting_started_actions = ['teacher-center']
- 		 media_actions = ['news', 'press', 'blog_posts']
- 		 case tabname
-    when "about"
-  			 about_actions.include?(action_name) ? 'active' : ''
-  		when 'faq'
-  			 faq_actions.include?(action_name) ? 'active' : ''
-  		when 'press'
-  			 press_actions.include?(action_name) ? 'active' : ''
-  		when 'partners'
-  			 partners_actions.include?(action_name) ? 'active' : ''
-  		when "media"
-  			 media_actions.include?(action_name) ? 'active' : ''
-  		when "team"
-  			 team_actions.include?(action_name) ? 'active' : ''
-  		when 'getting-started'
-  			 # TODO: revert this when we launch front end of knowlege center
-  			 action_name == 'temporarily_render_old_teacher_resources' ? 'active' : ''
-  		when 'news'
-  			 news_actions.include?(action_name) ? 'active' : ''
-  		when 'media_kit'
-  			 media_kit_actions.include?(action_name) ? 'active' : ''
-  		when "impact"
-  			 impact_actions.include?(action_name) ? 'active' : ''
-  		when 'standards'
-  			 standards_actions.include?(action_name) ? 'active' : ''
-  		when 'topics'
-  			 topics_actions.include?(action_name) ? 'active' : ''
-  		when 'premium'
-  			 action_name == 'premium_from_discover' ? "premium-tab active" : ''
-  		end
+  def pages_tab_class(tabname)
+    about_actions = ["mission", "develop", "faq"]
+    impact_actions = ['impact', 'map', 'stats']
+    team_actions = %w(team)
+    partners_actions = %w(partners)
+    news_actions = %w(news)
+    press_actions = %w(press)
+    standards_actions = ['activities']
+    topics_actions = ['index']
+    faq_actions = ['faq']
+    media_kit_actions = ['media_kit']
+    getting_started_actions = ['teacher-center']
+    media_actions = ['news', 'press', 'blog_posts']
+    case tabname
+  when "about"
+    about_actions.include?(action_name) ? 'active' : ''
+    when 'faq'
+      faq_actions.include?(action_name) ? 'active' : ''
+    when 'press'
+      press_actions.include?(action_name) ? 'active' : ''
+    when 'partners'
+      partners_actions.include?(action_name) ? 'active' : ''
+    when "media"
+      media_actions.include?(action_name) ? 'active' : ''
+    when "team"
+      team_actions.include?(action_name) ? 'active' : ''
+    when 'getting-started'
+       # TODO: revert this when we launch front end of knowlege center
+      action_name == 'temporarily_render_old_teacher_resources' ? 'active' : ''
+    when 'news'
+      news_actions.include?(action_name) ? 'active' : ''
+    when 'media_kit'
+      media_kit_actions.include?(action_name) ? 'active' : ''
+    when "impact"
+      impact_actions.include?(action_name) ? 'active' : ''
+    when 'standards'
+      standards_actions.include?(action_name) ? 'active' : ''
+    when 'topics'
+      topics_actions.include?(action_name) ? 'active' : ''
+    when 'premium'
+      action_name == 'premium_from_discover' ? "premium-tab active" : ''
+    end
 
- 	end
+  end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-	 def subtab_class(tabname)
- 		 if action_name == tabname
-  			 "active"
-  		else
-  			 ""
-  		end
- 	end
+  def subtab_class(tabname)
+    if action_name == tabname
+      "active"
+    else
+      ""
+    end
+  end
 
   def team_info
     [

--- a/services/QuillLMS/app/models/standard_category.rb
+++ b/services/QuillLMS/app/models/standard_category.rb
@@ -15,11 +15,11 @@ class StandardCategory < ApplicationRecord
   include Uid
   include ArchiveAssociatedStandards
 
-	 has_many :standards
+  has_many :standards
   has_many :activities, through: :standards
   has_many :change_logs, as: :changed_record
 
-	 validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 
   accepts_nested_attributes_for :change_logs
 

--- a/services/QuillLMS/db/migrate/20130429171512_add_emailactivation_to_user.rb
+++ b/services/QuillLMS/db/migrate/20130429171512_add_emailactivation_to_user.rb
@@ -2,8 +2,8 @@
 
 class AddEmailactivationToUser < ActiveRecord::Migration[4.2]
   def change
-  	 add_column :users, :email_activation_token, :string
-  	 add_column :users, :active, :boolean, default: false
-  	 add_column :users, :confirmable_set_at, :datetime
+    add_column :users, :email_activation_token, :string
+    add_column :users, :active, :boolean, default: false
+    add_column :users, :confirmable_set_at, :datetime
   end
 end

--- a/services/QuillLMS/db/migrate/20130517024024_fix_rules_model.rb
+++ b/services/QuillLMS/db/migrate/20130517024024_fix_rules_model.rb
@@ -2,10 +2,10 @@
 
 class FixRulesModel < ActiveRecord::Migration[4.2]
   def change
-  	 add_column :rules, :category_id, :integer
-  	 add_column :rules, :workbook_id, :integer, default: 1
-  	 remove_column :rules, :chapter_id
-  	 remove_column :rules, :order
-  	 rename_column :rules, :body, :title
+    add_column :rules, :category_id, :integer
+    add_column :rules, :workbook_id, :integer, default: 1
+    remove_column :rules, :chapter_id
+    remove_column :rules, :order
+    rename_column :rules, :body, :title
   end
 end

--- a/services/QuillLMS/db/migrate/20130517024604_remove_description_from_chapter.rb
+++ b/services/QuillLMS/db/migrate/20130517024604_remove_description_from_chapter.rb
@@ -2,10 +2,10 @@
 
 class RemoveDescriptionFromChapter < ActiveRecord::Migration[4.2]
   def up
-  	 remove_column :chapters, :description
+    remove_column :chapters, :description
   end
 
   def down
-  	 add_column :chapters, :description, :text
+    add_column :chapters, :description, :text
   end
 end

--- a/services/QuillLMS/db/migrate/20130517024731_remove_title_from_assessment.rb
+++ b/services/QuillLMS/db/migrate/20130517024731_remove_title_from_assessment.rb
@@ -2,10 +2,10 @@
 
 class RemoveTitleFromAssessment < ActiveRecord::Migration[4.2]
   def up
-  	 remove_column :assessments, :title
+    remove_column :assessments, :title
   end
 
   def down
-  	 add_column :assessments, :title, :string
+    add_column :assessments, :title, :string
   end
 end

--- a/services/QuillLMS/db/migrate/20130517024855_remove_order_chapter_id_from_lesson.rb
+++ b/services/QuillLMS/db/migrate/20130517024855_remove_order_chapter_id_from_lesson.rb
@@ -2,12 +2,12 @@
 
 class RemoveOrderChapterIdFromLesson < ActiveRecord::Migration[4.2]
   def up
-  	 remove_column :lessons, :order
-  	 remove_column :lessons, :chapter_id
+    remove_column :lessons, :order
+    remove_column :lessons, :chapter_id
   end
 
   def down
-  	 add_column :lessons, :order, :integer
-  	 add_column :lessons, :chapter_id, :integer
+    add_column :lessons, :order, :integer
+    add_column :lessons, :chapter_id, :integer
   end
 end

--- a/services/QuillLMS/db/migrate/20130522193452_add_prompt_to_lessons.rb
+++ b/services/QuillLMS/db/migrate/20130522193452_add_prompt_to_lessons.rb
@@ -2,10 +2,10 @@
 
 class AddPromptToLessons < ActiveRecord::Migration[4.2]
   def up
-  	 add_column :lessons, :prompt, :text
+    add_column :lessons, :prompt, :text
   end
 
   def down
-  	 remove_column :lessons, :prompt
+    remove_column :lessons, :prompt
   end
 end

--- a/services/QuillLMS/db/migrate/20130522193814_add_description_to_rules.rb
+++ b/services/QuillLMS/db/migrate/20130522193814_add_description_to_rules.rb
@@ -2,10 +2,10 @@
 
 class AddDescriptionToRules < ActiveRecord::Migration[4.2]
   def up
-  	 add_column :rules, :description, :text
+    add_column :rules, :description, :text
   end
 
   def down
-  	 remove_column :rules, :description
+    remove_column :rules, :description
   end
 end

--- a/services/QuillLMS/db/migrate/20130609214734_add_pseudotitle_to_chapters.rb
+++ b/services/QuillLMS/db/migrate/20130609214734_add_pseudotitle_to_chapters.rb
@@ -2,10 +2,10 @@
 
 class AddPseudotitleToChapters < ActiveRecord::Migration[4.2]
   def up
-  	 add_column :chapters, :description, :text
+    add_column :chapters, :description, :text
   end
 
   def down
-  	 remove_column :chapters, :description
+    remove_column :chapters, :description
   end
 end

--- a/services/QuillLMS/db/migrate/20140114233647_migrate_to_new_formats.rb
+++ b/services/QuillLMS/db/migrate/20140114233647_migrate_to_new_formats.rb
@@ -53,7 +53,7 @@ class MigrateToNewFormats < ActiveRecord::Migration[4.2]
       t.float :percentage
       t.string :state, default: 'unstarted', null: false
       t.timestamp :completed_at
-			   t.integer :time_spent
+      t.integer :time_spent
       t.string :uid
       t.boolean :temporary
 

--- a/services/QuillLMS/db/migrate/20150204201702_create_topic_categories.rb
+++ b/services/QuillLMS/db/migrate/20150204201702_create_topic_categories.rb
@@ -3,8 +3,8 @@
 class CreateTopicCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :topic_categories do |t|
-    	 t.string :name
-    	 t.timestamps
+      t.string :name
+      t.timestamps
     end
 
     add_index :topic_categories, :name

--- a/services/QuillLMS/db/migrate/20150206184619_add_is_retry_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20150206184619_add_is_retry_to_activity_sessions.rb
@@ -2,6 +2,6 @@
 
 class AddIsRetryToActivitySessions < ActiveRecord::Migration[4.2]
   def change
-  	 add_column :activity_sessions, :is_retry, :boolean, default: false
+    add_column :activity_sessions, :is_retry, :boolean, default: false
   end
 end

--- a/services/QuillLMS/db/migrate/20150317200555_add_is_final_score_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20150317200555_add_is_final_score_to_activity_sessions.rb
@@ -2,6 +2,6 @@
 
 class AddIsFinalScoreToActivitySessions < ActiveRecord::Migration[4.2]
   def change
-  	 add_column :activity_sessions, :is_final_score, :boolean, default: false
+    add_column :activity_sessions, :is_final_score, :boolean, default: false
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/generators/controller_tests/controller_tests_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/generators/controller_tests/controller_tests_generator.rb
@@ -25,15 +25,15 @@ class ControllerTestsGenerator < TestUnit::Generators::Base # :nodoc:
 
   private
 
-    def attributes_hash
-      return if attributes_names.empty?
+  def attributes_hash
+    return if attributes_names.empty?
 
-      attributes_names.map do |name|
-        if %w(password password_confirmation).include?(name) && attributes.any?(&:password_digest?)
-          "#{name}: 'secret'"
-        else
-          "#{name}: @#{singular_table_name}.#{name}"
-        end
-      end.sort.join(', ')
-    end
+    attributes_names.map do |name|
+      if %w(password password_confirmation).include?(name) && attributes.any?(&:password_digest?)
+        "#{name}: 'secret'"
+      else
+        "#{name}: @#{singular_table_name}.#{name}"
+      end
+    end.sort.join(', ')
+  end
 end

--- a/services/QuillLMS/engines/evidence/lib/generators/model_tests/model_tests_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/generators/model_tests/model_tests_generator.rb
@@ -17,11 +17,11 @@ class ModelTestsGenerator < TestUnit::Generators::Base # :nodoc:
   hook_for :fixture_replacement
 
   private
-    def yaml_key_value(key, value)
-      if RESERVED_YAML_KEYWORDS.include?(key.downcase)
-        "'#{key}': #{value}"
-      else
-        "#{key}: #{value}"
-      end
+  def yaml_key_value(key, value)
+    if RESERVED_YAML_KEYWORDS.include?(key.downcase)
+      "'#{key}': #{value}"
+    else
+      "#{key}: #{value}"
     end
+  end
 end

--- a/services/QuillLMS/lib/tasks/localize_classification_module_urls.rake
+++ b/services/QuillLMS/lib/tasks/localize_classification_module_urls.rake
@@ -3,15 +3,15 @@
 namespace :local do
   desc 'Update seed / prod dump\'d ActivityClassifications so that redirects point to localhost'
   task :localize_classification_module_urls => :environment do
-  	 def change_url_domain(original, domain='http://localhost:3000')
-   	  original.gsub('https://www.quill.org', domain)
-   	end
+    def change_url_domain(original, domain='http://localhost:3000')
+      original.gsub('https://www.quill.org', domain)
+    end
 
-  	 ActivityClassification.all.each do |ac|
-   	  ac.update!(**{
-   	  	module_url: change_url_domain(ac.module_url),
-   	  	form_url: change_url_domain(ac.form_url)
-   	  })
-   	end
+    ActivityClassification.all.each do |ac|
+      ac.update!(**{
+        module_url: change_url_domain(ac.module_url),
+        form_url: change_url_domain(ac.form_url)
+      })
+    end
   end
 end

--- a/services/QuillLMS/lib/tasks/standard_category.rake
+++ b/services/QuillLMS/lib/tasks/standard_category.rake
@@ -1,278 +1,278 @@
 # frozen_string_literal: true
 
 namespace :standard_category do
-	 desc 'create standard category'
-	 task :seed => :environment do
-
- 		 arr1 = [
-
-  			{
-  				standard: "1.1b. Use Common, Proper, and Possessive Nouns",
-  				category: "Nouns and Pronouns"
-  			},
-
-  			{
-  				standard: "1.1c. Use Singular and Plural Nouns with Matching Verbs in Basic Sentences"	,
-  				category: "Verbs"
-  			},
-
-  			{
-  				standard: "1.1e. Use Verbs to Convey a Sense of Past, Present, and Future"	,
-  				category: "Verbs"
-  			},
-
-  			{
-  				standard: "1.1g. Conjunctions: And, But, Or, So",
-  				category: "Conjunctions"
-  			},
-
-  			{
-  				standard: "1.1h. Use Determiners: Articles, Demonstratives",
-  				category: "Determiners"
-  			},
-
-  			{
-  				standard: "1.1i. Frequently Occurring Prepositions",
-  				category: "Prepositions"
-  			},
-
-  			{
-  				standard: "1.2a. Capitalize Dates and Names of People"	,
-  				category: "Capitalization"
-  			},
-
-  			{
-  				standard: "1.2c. Use Commas for Dates and Lists."	,
-  				category: "Comma Usage"
-  			},
-
-  			{
-  				standard: "2.1b. Use Irregular Plural Nouns",
-  				category: "Nouns and Pronouns"
-  			},
-
-  			{
-  				standard: "2.1c. Use Reflexive Pronouns"	,
-  				category: "Nouns and Pronouns"
-  			},
-
-  			{
-
-  				standard: "2.1d. Form and Use the Past Tense of Frequently Occurring Irregular Verbs.",
-  				category: "Verbs"
-  			},
-
-  			{
-  				standard:	"2.1e. Use Adjectives and Adverbs",
-  				category:	"Adjectives & Adverbs"
-  			},
-
-  			{
-
-  				standard:	"2.2a. Capitalize Holidays, Product Names, and Geographic Names",
-  				category:	"Adjectives & Adverbs"
-  			},
-
-  			{
-
-  				standard:	"3.1g. Form and Use Comparative and Superlative Adjectives"	,
-  				category:	"Adjectives & Adverbs"
-  			},
-
-  			{
-
-  				standard:	"3.2a. Capitalize Words in Titles"	,
-  				category:	"Capitalization"
-  			},
-
-  			{
-  				standard:	"3.2b. Use Commas in Addresses",
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"3.2c. Use Commas and Quotation Marks in Dialogue",
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"3.2d. Form and use Possessives",
-  				category: "Nouns & Pronouns"
-
-  			},
-
-  			{
-  				standard:	"4.1a. Use Relative Pronouns",
-  				category:	"Nouns & Pronouns"
-  			},
-
-  			{
-  				standard:	"4.1b. The Progressive Tense",
-  				category:	"Verbs"
-  			},
-
-  			{
-  				standard:	"4.1c. Can/May vs. Should/Must",
-  				category:	"Verbs"
-  			},
-
-  			{
-  				standard:	"4.1e. Prepositional Phrases",
-  				category:	"Prepositions"
-  			},
-
-  			{
-  				standard:	"4.1g. Commonly Confused Words",
-  				category:	"Commonly Confused Words"
-  			},
-
-  			{
-  				standard:	"4.2a. Use Correct Capitalization"	,
-  				category:	"Capitalization"
-  			},
-
-  			{
-  				standard:	"5.1b. Use Past Participles",
-  				category:	"Verbs"
-  			},
-
-  			{
-  				standard:	"5.1e. Correlative Conjunctions",
-  				category:	"Conjunctions"
-  			},
-
-  			{
-  				standard:	"5.2a. Use Colons and Commas in a List",
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"5.2b. Use Commas after Introductory Words",
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"5.2c. Use a Comma to Set off the Words \"Yes\" and \"No\""	,
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"6.1a. Subjective, Objective, and Possessive Pronouns",
-  				category:	"Nouns & Pronouns"
-  			},
-
-  			{
-  				standard:	"6.1b. Intensive Pronouns",
-  				category:	"Nouns & Pronouns"
-  			},
-
-  			{
-  				standard:	"6.1c. Recognizing Inappropriate Shifts in Pronoun Number or Gender",
-  				category:	"Nouns & Pronouns"
-  			},
-
-  			{
-  				standard:	"7.1c. Misplaced Modifiers",
-  				category:	"Structure"
-  			},
-
-  			{
-  				standard:	"7.2a. Use a Comma to Separate Coordinate Adjectives",
-  				category:	"Comma Usage"
-  			},
-
-  			{
-  				standard:	"8.1b. Form and Use Verbs in the Active and Passive Voice",
-  				category:	"Verbs"
-  			},
-
-  			{
-  				standard:	"8.1d. Recognize and Correct Innapropriate Shifts in Verb Voice and Mood",
-  				category:	"Verbs"
-  			},
-
-  			{
-  				standard:	"9.1a. Use Parallel Structure",
-  				category:	"Structure"
-  			},
-
-
-  			{
-  				standard: 		"2.2c. Use an Apostrophe to Form Contractions",
-  				category: 	"Punctuation"
-  			},
-
-  			{
-  				standard:		"CCSS Grade 1 Summative Assessments",
-  				category:	"Summative Assessments"
-  			},
-
-  			{
-  				standard:		"CCSS Grade 2 Summative Assessments",
-  				category:	"Summative Assessments"
-  			},
-
-  			{
-  				standard:		"M1. Using Spaces With Quotation Marks",
-  				category:	"Punctuation"
-  			},
-
-  			{
-  				standard:		"M2. Using Spaces with Punctuation",
-  				category:	"Punctuation"
-  			},
-
-  			{
-
-  				standard:		"Quill Tutorial Lessons",
-  				category:	"Punctuation"
-  			},
-
-  			{
-
-  				standard:		"University: Commonly Confused Words",
-  				category:	"Commonly Confused Words"
-  			},
-
-  			{
-  				standard:		"University Grammar Test: A Man and His Mouse",
-  				category:	"Summative Assessments"
-  			},
-
-  			{
-  				standard:		"University Grammar Test: The First Spacewalk",
-  				category:	"Summative Assessments"
-  			}
-  		]
-
-
- 		 arr1.each do |pair|
-  			 puts ''
-  			 puts 'standard to associate : '
-  			 puts pair[:standard]
-  			 puts 'category to associate : '
-  			 puts pair[:category]
-
-
-  			 standard = Standard.find_by_name pair[:standard]
-  			 standard_category = StandardCategory.where(name: pair[:category]).first_or_create!
-
-  			 if standard.nil?
-   				 puts 'couldnt find standard'
-   			elsif standard_category.nil?
-   				 puts 'couldnt find standard category'
-   			else
-   				 puts 'successfully created standard category relation : '
-   				 standard.standard_category = standard_category
-   				 standard.save
-   				 puts standard.inspect
-   			end
-
-  		end
-
-
-
-
-
- 	end
+  desc 'create standard category'
+  task :seed => :environment do
+
+    arr1 = [
+
+      {
+        standard: "1.1b. Use Common, Proper, and Possessive Nouns",
+        category: "Nouns and Pronouns"
+      },
+
+      {
+        standard: "1.1c. Use Singular and Plural Nouns with Matching Verbs in Basic Sentences"	,
+        category: "Verbs"
+      },
+
+      {
+        standard: "1.1e. Use Verbs to Convey a Sense of Past, Present, and Future"	,
+        category: "Verbs"
+      },
+
+      {
+        standard: "1.1g. Conjunctions: And, But, Or, So",
+        category: "Conjunctions"
+      },
+
+      {
+        standard: "1.1h. Use Determiners: Articles, Demonstratives",
+        category: "Determiners"
+      },
+
+      {
+        standard: "1.1i. Frequently Occurring Prepositions",
+        category: "Prepositions"
+      },
+
+      {
+        standard: "1.2a. Capitalize Dates and Names of People"	,
+        category: "Capitalization"
+      },
+
+      {
+        standard: "1.2c. Use Commas for Dates and Lists."	,
+        category: "Comma Usage"
+      },
+
+      {
+        standard: "2.1b. Use Irregular Plural Nouns",
+        category: "Nouns and Pronouns"
+      },
+
+      {
+        standard: "2.1c. Use Reflexive Pronouns"	,
+        category: "Nouns and Pronouns"
+      },
+
+      {
+
+        standard: "2.1d. Form and Use the Past Tense of Frequently Occurring Irregular Verbs.",
+        category: "Verbs"
+      },
+
+      {
+        standard:	"2.1e. Use Adjectives and Adverbs",
+        category:	"Adjectives & Adverbs"
+      },
+
+      {
+
+        standard:	"2.2a. Capitalize Holidays, Product Names, and Geographic Names",
+        category:	"Adjectives & Adverbs"
+      },
+
+      {
+
+        standard:	"3.1g. Form and Use Comparative and Superlative Adjectives"	,
+        category:	"Adjectives & Adverbs"
+      },
+
+      {
+
+        standard:	"3.2a. Capitalize Words in Titles"	,
+        category:	"Capitalization"
+      },
+
+      {
+        standard:	"3.2b. Use Commas in Addresses",
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"3.2c. Use Commas and Quotation Marks in Dialogue",
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"3.2d. Form and use Possessives",
+        category: "Nouns & Pronouns"
+
+      },
+
+      {
+        standard:	"4.1a. Use Relative Pronouns",
+        category:	"Nouns & Pronouns"
+      },
+
+      {
+        standard:	"4.1b. The Progressive Tense",
+        category:	"Verbs"
+      },
+
+      {
+        standard:	"4.1c. Can/May vs. Should/Must",
+        category:	"Verbs"
+      },
+
+      {
+        standard:	"4.1e. Prepositional Phrases",
+        category:	"Prepositions"
+      },
+
+      {
+        standard:	"4.1g. Commonly Confused Words",
+        category:	"Commonly Confused Words"
+      },
+
+      {
+        standard:	"4.2a. Use Correct Capitalization"	,
+        category:	"Capitalization"
+      },
+
+      {
+        standard:	"5.1b. Use Past Participles",
+        category:	"Verbs"
+      },
+
+      {
+        standard:	"5.1e. Correlative Conjunctions",
+        category:	"Conjunctions"
+      },
+
+      {
+        standard:	"5.2a. Use Colons and Commas in a List",
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"5.2b. Use Commas after Introductory Words",
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"5.2c. Use a Comma to Set off the Words \"Yes\" and \"No\""	,
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"6.1a. Subjective, Objective, and Possessive Pronouns",
+        category:	"Nouns & Pronouns"
+      },
+
+      {
+        standard:	"6.1b. Intensive Pronouns",
+        category:	"Nouns & Pronouns"
+      },
+
+      {
+        standard:	"6.1c. Recognizing Inappropriate Shifts in Pronoun Number or Gender",
+        category:	"Nouns & Pronouns"
+      },
+
+      {
+        standard:	"7.1c. Misplaced Modifiers",
+        category:	"Structure"
+      },
+
+      {
+        standard:	"7.2a. Use a Comma to Separate Coordinate Adjectives",
+        category:	"Comma Usage"
+      },
+
+      {
+        standard:	"8.1b. Form and Use Verbs in the Active and Passive Voice",
+        category:	"Verbs"
+      },
+
+      {
+        standard:	"8.1d. Recognize and Correct Innapropriate Shifts in Verb Voice and Mood",
+        category:	"Verbs"
+      },
+
+      {
+        standard:	"9.1a. Use Parallel Structure",
+        category:	"Structure"
+      },
+
+
+      {
+        standard: 		"2.2c. Use an Apostrophe to Form Contractions",
+        category: 	"Punctuation"
+      },
+
+      {
+        standard:		"CCSS Grade 1 Summative Assessments",
+        category:	"Summative Assessments"
+      },
+
+      {
+        standard:		"CCSS Grade 2 Summative Assessments",
+        category:	"Summative Assessments"
+      },
+
+      {
+        standard:		"M1. Using Spaces With Quotation Marks",
+        category:	"Punctuation"
+      },
+
+      {
+        standard:		"M2. Using Spaces with Punctuation",
+        category:	"Punctuation"
+      },
+
+      {
+
+        standard:		"Quill Tutorial Lessons",
+        category:	"Punctuation"
+      },
+
+      {
+
+        standard:		"University: Commonly Confused Words",
+        category:	"Commonly Confused Words"
+      },
+
+      {
+        standard:		"University Grammar Test: A Man and His Mouse",
+        category:	"Summative Assessments"
+      },
+
+      {
+        standard:		"University Grammar Test: The First Spacewalk",
+        category:	"Summative Assessments"
+      }
+    ]
+
+
+    arr1.each do |pair|
+      puts ''
+      puts 'standard to associate : '
+      puts pair[:standard]
+      puts 'category to associate : '
+      puts pair[:category]
+
+
+      standard = Standard.find_by_name pair[:standard]
+      standard_category = StandardCategory.where(name: pair[:category]).first_or_create!
+
+      if standard.nil?
+        puts 'couldnt find standard'
+      elsif standard_category.nil?
+        puts 'couldnt find standard category'
+      else
+        puts 'successfully created standard category relation : '
+        standard.standard_category = standard_category
+        standard.save
+        puts standard.inspect
+      end
+
+    end
+
+
+
+
+
+  end
 end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -270,16 +270,16 @@ describe ActivitySession, type: :model, redis: true do
 
   describe "#activity" do
 
-  	 context "when there is a direct activity association" do
+    context "when there is a direct activity association" do
 
- 	  let(:activity){ create(:activity) }
- 		 let(:activity_session){ build(:activity_session,activity_id: activity.id) }
+    let(:activity){ create(:activity) }
+    let(:activity_session){ build(:activity_session,activity_id: activity.id) }
 
-   	it "must return the associated activity" do
-  			 expect(activity_session.activity).to eq activity
-  		end
+    it "must return the associated activity" do
+       expect(activity_session.activity).to eq activity
+     end
 
- 	end
+  end
 
     describe "#invalidate_activity_session_count_if_completed" do
       let!(:student){ create(:student, :in_one_classroom) }
@@ -304,33 +304,33 @@ describe ActivitySession, type: :model, redis: true do
 
     end
 
-	   context "when there's not an associated activity but there's a classroom unit and only one unit activity" do
+    context "when there's not an associated activity but there's a classroom unit and only one unit activity" do
 
-   	  let!(:activity){ create(:activity) }
-   	  let!(:student){ create(:student, :in_one_classroom) }
-   	  let!(:classroom_unit) { create(:classroom_unit, assigned_student_ids: [student.id], classroom_id: student.classrooms.first.id) }
+      let!(:activity){ create(:activity) }
+      let!(:student){ create(:student, :in_one_classroom) }
+      let!(:classroom_unit) { create(:classroom_unit, assigned_student_ids: [student.id], classroom_id: student.classrooms.first.id) }
       let!(:unit_activity ) { create(:unit_activity, activity: activity, unit: classroom_unit.unit)}
-   		 let(:activity_session){   build(:activity_session, classroom_unit: classroom_unit)                     }
+      let(:activity_session){   build(:activity_session, classroom_unit: classroom_unit)                     }
 
-     	it "must return the unit activity's activity" do
-    			 activity_session.activity_id=nil
-        unit_activity.unit.reload
-    			 expect(activity_session.activity).to eq unit_activity.activity
-    		end
+      it "must return the unit activity's activity" do
+         activity_session.activity_id=nil
+         unit_activity.unit.reload
+         expect(activity_session.activity).to eq unit_activity.activity
+       end
 
-   	end
+    end
 
   end
 
   describe "#activity_uid=" do
 
-  	 let(:activity){ create(:activity) }
+    let(:activity){ create(:activity) }
 
-  	 it "must associate activity by uid" do
-   		 activity_session.activity_id=nil
-   		 activity_session.activity_uid=activity.uid
-   		 expect(activity_session.activity_id).to eq activity.id
-   	end
+    it "must associate activity by uid" do
+      activity_session.activity_id=nil
+      activity_session.activity_uid=activity.uid
+      expect(activity_session.activity_id).to eq activity.id
+    end
 
   end
 
@@ -549,9 +549,9 @@ end
 
   describe "#activity_uid" do
 
-  	 it "must return an uid when activity is present" do
-   		 expect(activity_session.activity_uid).to be_present
-   	end
+    it "must return an uid when activity is present" do
+      expect(activity_session.activity_uid).to be_present
+    end
 
   end
 
@@ -570,14 +570,14 @@ end
   end
 
   describe "#completed?" do
-  	 it "must be true when completed_at is present" do
-   		 expect(activity_session).to be_completed
-   	end
+    it "must be true when completed_at is present" do
+      expect(activity_session).to be_completed
+    end
 
-  	 it "must be false when cmopleted_at is not present" do
-   		 activity_session.completed_at=nil
-   		 expect(activity_session).to_not be_completed
-   	end
+    it "must be false when cmopleted_at is not present" do
+      activity_session.completed_at=nil
+      expect(activity_session).to_not be_completed
+    end
   end
 
   describe "#by_teacher" do
@@ -607,38 +607,38 @@ end
   #--- legacy methods
 
   describe "#grade" do
-  	 it "must be equal to percentage" do
-   		 expect(activity_session.grade).to eq activity_session.percentage
-   	end
+    it "must be equal to percentage" do
+      expect(activity_session.grade).to eq activity_session.percentage
+    end
 
   end
 
   describe "#anonymous=" do
-  	 it "must be equal to temporary" do
-   		 expect(activity_session.anonymous=true).to eq activity_session.temporary
-   	end
+    it "must be equal to temporary" do
+      expect(activity_session.anonymous=true).to eq activity_session.temporary
+    end
 
-  	 it "must return temporary" do
-   		 activity_session.anonymous=true
-   		 expect(activity_session.anonymous).to eq activity_session.temporary
-   	end
+    it "must return temporary" do
+      activity_session.anonymous=true
+      expect(activity_session.anonymous).to eq activity_session.temporary
+    end
   end
 
 
   context "when before_create is fired" do
-  	 describe "#set_state" do
+    describe "#set_state" do
 
-   		 it "must set state as unstarted" do
-    			 activity_session.state=nil
-    			 activity_session.save!
-    			 expect(activity_session.state).to eq "unstarted"
-    		end
-   	end
+      it "must set state as unstarted" do
+        activity_session.state=nil
+        activity_session.save!
+        expect(activity_session.state).to eq "unstarted"
+      end
+    end
   end
 
   context "when before_save is triggered" do
 
-  	 describe "#set_completed_at when state = finished" do
+    describe "#set_completed_at when state = finished" do
       before do
         activity_session.save!
         activity_session.state="finished"
@@ -666,50 +666,50 @@ end
           expect(activity_session.completed_at).to_not be_nil
         end
       end
-   	end
+    end
 
   end
 
   context "when completed scope" do
-  	 describe ".completed" do
-   		 before { create_list(:activity_session, 3) }
+    describe ".completed" do
+      before { create_list(:activity_session, 3) }
 
-   		 it "must locate all the completed items" do
-    			 expect(ActivitySession.completed.count).to eq 3
-    		end
+      it "must locate all the completed items" do
+        expect(ActivitySession.completed.count).to eq 3
+      end
 
-   		 it "completed_at must be present" do
-    			 ActivitySession.completed.each do |item|
-     				 expect(item.completed_at).to be_present
-     			end
-    		end
+      it "completed_at must be present" do
+        ActivitySession.completed.each do |item|
+          expect(item.completed_at).to be_present
+        end
+      end
 
-   		 it "must order by date desc" do
-    			#TODO: This test is not passing cause the ordering is wrong
-    			# p completed=ActivitySession.completed
-    			# current_date=completed.first.completed_at
-    			# completed.each do |item|
-    			# 	expect(item.completed_at).to satisfy { |x| p x.to_s+" <= "+current_date.to_s ||x <= current_date  }
-    			# 	current_date=item.completed_at
-    			# end
-    		end
-   	end
+      it "must order by date desc" do
+        #TODO: This test is not passing cause the ordering is wrong
+        # p completed=ActivitySession.completed
+        # current_date=completed.first.completed_at
+        # completed.each do |item|
+        # 	expect(item.completed_at).to satisfy { |x| p x.to_s+" <= "+current_date.to_s ||x <= current_date  }
+        # 	current_date=item.completed_at
+        # end
+      end
+    end
   end
 
   context "when incompleted scope" do
-  	 describe ".incomplete" do
-   		 before { create_list(:activity_session, 2, :unstarted) }
+    describe ".incomplete" do
+      before { create_list(:activity_session, 2, :unstarted) }
 
-   		 it "must locate all the incompleted items" do
-    			 expect(ActivitySession.incomplete.count).to eq 2
-    		end
+      it "must locate all the incompleted items" do
+        expect(ActivitySession.incomplete.count).to eq 2
+      end
 
-   		 it "completed_at must be nil" do
-    			 ActivitySession.incomplete.each do |item|
-     				 expect(item.completed_at).to be_nil
-     			end
-    		end
-   	end
+      it "completed_at must be nil" do
+        ActivitySession.incomplete.each do |item|
+          expect(item.completed_at).to be_nil
+        end
+      end
+    end
   end
 
   describe '#determine_if_final_score' do

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -155,14 +155,14 @@ RSpec.describe FeedbackHistory, type: :model do
 
     it 'should save and return if all creations are valid' do
       expect(FeedbackHistory.count).to eq(0)
-	     FeedbackHistory.batch_create([@valid_fh_params, @valid_fh_params, @valid_fh_params])
-	     expect(FeedbackHistory.count).to eq(3)
+      FeedbackHistory.batch_create([@valid_fh_params, @valid_fh_params, @valid_fh_params])
+      expect(FeedbackHistory.count).to eq(3)
     end
 
     it 'should save any valid records if, but not any valid ones' do
       expect(FeedbackHistory.count).to eq(0)
-	     results = FeedbackHistory.batch_create([@invalid_fh_params, @valid_fh_params])
-	     expect(FeedbackHistory.count).to eq(1)
+      results = FeedbackHistory.batch_create([@invalid_fh_params, @valid_fh_params])
+      expect(FeedbackHistory.count).to eq(1)
       expect(results[0].errors[:entry].include?("can't be blank")).to be
       expect(results[1].valid?).to be
     end

--- a/services/QuillLMS/spec/models/standard_level_spec.rb
+++ b/services/QuillLMS/spec/models/standard_level_spec.rb
@@ -16,42 +16,42 @@ require 'rails_helper'
 
 describe StandardLevel, type: :model do
 
-	 let(:standard_level){ build(:standard_level) }
+  let(:standard_level){ build(:standard_level) }
 
   it_behaves_like 'uid'
 
-	 context "when it's created/updated" do
+  context "when it's created/updated" do
 
- 		 it "must be valid with valid info" do
-  			 expect(standard_level).to be_valid
-  		end
+    it "must be valid with valid info" do
+      expect(standard_level).to be_valid
+    end
 
- 		 context "when it runs validations" do
+    context "when it runs validations" do
 
-  			 it "must have a name" do
-   				 standard_level.name=nil
-   				 standard_level.valid?
-   				 expect(standard_level.errors[:name]).to include "can't be blank"
-   			end
+      it "must have a name" do
+        standard_level.name=nil
+        standard_level.valid?
+        expect(standard_level.errors[:name]).to include "can't be blank"
+      end
 
-  		end
- 	end
+    end
+  end
 
-	 describe 'callbacks' do
+  describe 'callbacks' do
 
- 		 context 'when a standardLevel is archived' do
-  			 it 'should archive all associated standards' do
-   				 standard = create(:standard, standard_level: standard_level)
-   				 standard_level.update(visible: false)
-   				 expect(standard.reload.visible).to eq(false)
-   			end
-  		end
+    context 'when a standardLevel is archived' do
+      it 'should archive all associated standards' do
+        standard = create(:standard, standard_level: standard_level)
+        standard_level.update(visible: false)
+        expect(standard.reload.visible).to eq(false)
+      end
+    end
 
- 		 context 'when standardLevel is committed' do
-  			 it "should send clear_activity_search_cache after commit" do
-   				 expect(Activity).to receive(:clear_activity_search_cache)
-   				 standard_level.run_callbacks(:commit)
-   			end
-  		end
- 	end
+    context 'when standardLevel is committed' do
+      it "should send clear_activity_search_cache after commit" do
+        expect(Activity).to receive(:clear_activity_search_cache)
+        standard_level.run_callbacks(:commit)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/standard_spec.rb
+++ b/services/QuillLMS/spec/models/standard_spec.rb
@@ -22,113 +22,113 @@ require 'rails_helper'
 
 describe Standard, type: :model do
 
-	 let!(:standard){create(:standard, name: "a")}
+  let!(:standard){create(:standard, name: "a")}
 
   it_behaves_like 'uid'
 
-	 context "when the default order is by name" do
+  context "when the default order is by name" do
 
- 		 let!(:standard1){create(:standard, name: "c")}
- 		 let!(:standard2){create(:standard, name: "b")}
+    let!(:standard1){create(:standard, name: "c")}
+    let!(:standard2){create(:standard, name: "b")}
 
- 		 it "must be ordered correctly" do
-  			 expect(Standard.all.map{|x| x.name}).to eq ["a", "b", "c"]
-  		end
- 	end
+    it "must be ordered correctly" do
+      expect(Standard.all.map{|x| x.name}).to eq ["a", "b", "c"]
+    end
+  end
 
-	 context "when it's updated/created" do
+  context "when it's updated/created" do
 
- 		 it "must be valid with valid info" do
-  			 expect(standard.valid?).to be_truthy
-  		end
+    it "must be valid with valid info" do
+      expect(standard.valid?).to be_truthy
+    end
 
- 		 context "when it runs validations" do
-  			 it "must have a name" do
-   				 standard.name=nil
-   				 standard.valid?
-   				 expect(standard.errors[:name]).to include "can't be blank"
-   			end
+    context "when it runs validations" do
+      it "must have a name" do
+        standard.name=nil
+        standard.valid?
+        expect(standard.errors[:name]).to include "can't be blank"
+      end
 
-  			 it "must have a unique name" do
-   				 t=Standard.first
-   				 n=build(:standard, name: t.name)
-   				 n.valid?
-   				 expect(n.errors[:name]).to include "has already been taken"
-   			end
+      it "must have a unique name" do
+        t=Standard.first
+        n=build(:standard, name: t.name)
+        n.valid?
+        expect(n.errors[:name]).to include "has already been taken"
+      end
 
-  			 it "must have a standard_level" do
-   				 standard.standard_level_id=nil
-   				 standard.valid?
-   				 expect(standard.errors[:standard_level]).to include "can't be blank"
-   			end
-  		end
- 	end
+      it "must have a standard_level" do
+        standard.standard_level_id=nil
+        standard.valid?
+        expect(standard.errors[:standard_level]).to include "can't be blank"
+      end
+    end
+  end
 
-	 context "when it is destroyed" do
+  context "when it is destroyed" do
 
- 		 it "must nullify associated activity records" do
-  			 activity = create(:activity, standard_id: standard.id)
-  			 standard.destroy!
-  			 expect(activity.reload.standard_id).to be(nil)
-  		end
- 	end
+    it "must nullify associated activity records" do
+      activity = create(:activity, standard_id: standard.id)
+      standard.destroy!
+      expect(activity.reload.standard_id).to be(nil)
+    end
+  end
 
-	 context "retrieving standards for the progress report" do
+  context "retrieving standards for the progress report" do
     let(:filters) { {} }
 
- 	  include_context 'Standard Progress Report'
+    include_context 'Standard Progress Report'
 
- 	  subject { ProgressReports::Standards::Standard.new(teacher).results(filters).to_a }
+    subject { ProgressReports::Standards::Standard.new(teacher).results(filters).to_a }
 
- 	  it "retrieves aggregated standards data" do
- 	  	 found_standards = subject
- 	  	 expect(found_standards.size).to eq(visible_standards.size)
+    it "retrieves aggregated standards data" do
+      found_standards = subject
+      expect(found_standards.size).to eq(visible_standards.size)
       expect(found_standards[0].name).to be_present
       expect(found_standards[0].total_student_count).to be_present
       expect(found_standards[0].proficient_student_count).to be_present
       expect(found_standards[0].not_proficient_student_count).to be_present
       expect(found_standards[0].total_activity_count).to be_present
       expect(found_standards[0].average_score).to be_present
- 	  end
+    end
 
- 	  context "when a classroom filter is provided" do
- 	    let(:filters) { {standard_level_id: standard_level.id, classroom_id: full_classroom.id} }
+    context "when a classroom filter is provided" do
+      let(:filters) { {standard_level_id: standard_level.id, classroom_id: full_classroom.id} }
 
- 	  	 it "filters by classroom" do
-  	  		 expect(subject.size).to eq(visible_standards.size)
-  	  	end
- 	  end
+      it "filters by classroom" do
+        expect(subject.size).to eq(visible_standards.size)
+      end
+    end
 
- 	  context "classroom filter for an empty classroom" do
- 	  	 let(:filters) { {standard_level_id: standard_level.id, classroom_id: empty_classroom.id} }
+    context "classroom filter for an empty classroom" do
+      let(:filters) { {standard_level_id: standard_level.id, classroom_id: empty_classroom.id} }
 
- 	  	 it "returns no results" do
-  	  		 expect(subject.size).to eq(0)
-  	  	end
- 	  end
+      it "returns no results" do
+        expect(subject.size).to eq(0)
+      end
+    end
 
- 	  context "classroom filter with no ID" do
-     	let(:filters) { {standard_level_id: standard_level.id, classroom_id: ""} }
+    context "classroom filter with no ID" do
+      let(:filters) { {standard_level_id: standard_level.id, classroom_id: ""} }
 
- 	  	 it "does not filter by classroom" do
-  	  		 expect(subject.size).to eq(visible_standards.size)
-  	  	end
- 	  end
+      it "does not filter by classroom" do
+        expect(subject.size).to eq(visible_standards.size)
+      end
+    end
 
- 	  context "when a unit filter is provided" do
-     	let(:filters) { {standard_level_id: standard_level.id, unit_id: unit1.id} }
+    context "when a unit filter is provided" do
+      let(:filters) { {standard_level_id: standard_level.id, unit_id: unit1.id} }
 
- 	  	 it "filters by unit" do
-  	  		 expect(subject.size).to eq(visible_standards.size)
-  	  	end
- 	  end
+      it "filters by unit" do
+        expect(subject.size).to eq(visible_standards.size)
+      end
+    end
 
- 	  context "when an empty unit filter is provided" do
-     	let(:filters) { {standard_level_id: standard_level.id, unit_id: ""} }
+    context "when an empty unit filter is provided" do
+      let(:filters) { {standard_level_id: standard_level.id, unit_id: ""} }
 
- 	  	 it "does not filter by unit" do
-  	  		 expect(subject.size).to eq(visible_standards.size)
-  	  	end
- 	  end
- 	end
+      it "does not filter by unit" do
+        expect(subject.size).to eq(visible_standards.size)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe PromptFeedbackHistory, type: :model do
       parsed_result = PromptFeedbackHistory.serialize_results(result)
 
       expect(parsed_result).to eq({
-	@prompt1.id => {
+  @prompt1.id => {
           prompt_id: @prompt1.id,
           total_responses: 2,
           session_count: 1,
@@ -202,8 +202,8 @@ RSpec.describe PromptFeedbackHistory, type: :model do
           num_sessions_with_non_consecutive_repeated_rule: 0.0,
           num_first_attempt_optimal: 0,
           num_first_attempt_not_optimal: 1
-	}.stringify_keys,
-	@prompt2.id => {
+  }.stringify_keys,
+  @prompt2.id => {
           prompt_id: @prompt2.id,
           total_responses: 1,
           session_count: 1,
@@ -215,7 +215,7 @@ RSpec.describe PromptFeedbackHistory, type: :model do
           num_sessions_with_non_consecutive_repeated_rule: 0.0,
           num_first_attempt_optimal: 1,
           num_first_attempt_not_optimal: 0
-	}.stringify_keys
+  }.stringify_keys
       })
     end
   end

--- a/services/QuillLMS/spec/support/shared/flagged.rb
+++ b/services/QuillLMS/spec/support/shared/flagged.rb
@@ -3,83 +3,83 @@
 shared_examples_for "flagged" do
 
   let(:flagged) do
-  	 described_class.new
+    described_class.new
   end
 
-	 describe "#flag" do
- 		 it "must act as a push" do
-  			 expect(flagged.flag(:alpha)).to eq [:alpha]
-  		end
- 	end
+  describe "#flag" do
+    it "must act as a push" do
+      expect(flagged.flag(:alpha)).to eq [:alpha]
+    end
+  end
 
-	 context "when 2 elements are pushed" do
- 		 describe "#flags" do
-  			 before do
-   				 flagged.flag :alpha
-   				 flagged.flag :betha
-   			end
+  context "when 2 elements are pushed" do
+    describe "#flags" do
+      before do
+        flagged.flag :alpha
+        flagged.flag :betha
+      end
 
-  			 it "must be an array" do
-   				 expect(flagged.flags).to an_instance_of Array
-   			end
+      it "must be an array" do
+        expect(flagged.flags).to an_instance_of Array
+      end
 
-  			 it "must to contains 2 elements" do
-   				 expect(flagged.flags.count).to eq 2
-   			end
-  		end
- 	end
+      it "must to contains 2 elements" do
+        expect(flagged.flags.count).to eq 2
+      end
+    end
+  end
 
-	 context "when alpha and betha are pushed" do
- 		 describe "#unflag" do
-  			 before do
-   				 flagged.flag :alpha
-   				 flagged.flag :betha
-   			end
+  context "when alpha and betha are pushed" do
+    describe "#unflag" do
+      before do
+        flagged.flag :alpha
+        flagged.flag :betha
+      end
 
-  			 it "must pop the passed flag as argument" do
-   				 flagged.unflag :alpha
-   				 expect( flagged.flags ).to eq [:betha]
-   			end
+      it "must pop the passed flag as argument" do
+        flagged.unflag :alpha
+        expect( flagged.flags ).to eq [:betha]
+      end
 
-  			 it "must to contains 1 elements" do
-   				 flagged.unflag :alpha
-   				 expect( flagged.flags.count ).to eq 1
-   			end
-  		end
- 	end
+      it "must to contains 1 elements" do
+        flagged.unflag :alpha
+        expect( flagged.flags.count ).to eq 1
+      end
+    end
+  end
 
-	 context "when methods preserve the changes" do
- 		 after do
-  				expect(flagged).to be_persisted
-  		end
+  context "when methods preserve the changes" do
+    after do
+      expect(flagged).to be_persisted
+    end
 
- 		 describe "#flag!" do
-  			 it "must push the flag and save the instance" do
-   				 expect(flagged.flag!(:alpha)).to eq true
-   			end
-  		end
+    describe "#flag!" do
+      it "must push the flag and save the instance" do
+        expect(flagged.flag!(:alpha)).to eq true
+      end
+    end
 
 
- 		 describe "#unflag!" do
-  			 it "must pop the flag and save the instance" do
-   				 expect(flagged.unflag!(:alpha)).to eq true
-   			end
-  		end
+    describe "#unflag!" do
+      it "must pop the flag and save the instance" do
+        expect(flagged.unflag!(:alpha)).to eq true
+      end
+    end
 
- 		 describe "#archive!" do
-  			 it "must push the archived flag and save the instance" do
-   				 flagged.archive!
-   				 expect(flagged.flags).to eq [:archived]
-   			end
-  		end
+    describe "#archive!" do
+      it "must push the archived flag and save the instance" do
+        flagged.archive!
+        expect(flagged.flags).to eq [:archived]
+      end
+    end
 
- 		 describe "#unarchive!" do
-  			 it "must pop the archived flag and save the instance" do
-   				 flagged.archive!
-   				 flagged.unarchive!
-   				 expect(flagged.flags).to eq []
-   			end
-  		end
- 	end
+    describe "#unarchive!" do
+      it "must pop the archived flag and save the instance" do
+        flagged.archive!
+        flagged.unarchive!
+        expect(flagged.flags).to eq []
+      end
+    end
+  end
 
 end

--- a/services/QuillLMS/spec/support/shared/uid.rb
+++ b/services/QuillLMS/spec/support/shared/uid.rb
@@ -4,7 +4,7 @@ shared_examples_for "uid" do
 
 
   let(:parent) do
-  	 described_class.new
+    described_class.new
   end
 
   context 'when just invoked' do
@@ -18,7 +18,7 @@ shared_examples_for "uid" do
   context "when it's validated" do
 
     it 'uid must be present' do
-    	 parent.valid?
+      parent.valid?
       expect(parent.uid).to be_present
     end
 


### PR DESCRIPTION
## WHAT
Add `Rubocop/IndentationStyle` and `Rubocop/IndentationWidth` cops.

## WHY
These will enforce the use of spaces instead of tabs along with ensuring the proper indentation associated with any fixes.

## HOW
Remove the `Rubocop/IndentationStyle` configuration from .rubocop_todo.yml

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Whitespace change.
Have you deployed to Staging? | NO - non-app change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
