### PR TITLE
evidence/skip-intro-on-resume

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/reducers/sessionReducer.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/reducers/sessionReducer.ts
@@ -48,7 +48,7 @@ export default (
         return Object.assign({}, currentState, { hasReceivedData: true });
       case ActionTypes.SET_SUBMITTED_RESPONSES:
         const { submittedResponses, } = action
-        return Object.assign({}, currentState, { submittedResponses, hasReceivedData: true });
+        return Object.assign({}, currentState, { explanationSlidesCompleted: true, submittedResponses, hasReceivedData: true });
       case ActionTypes.RECORD_FEEDBACK:
         const { promptID, feedbackObj, } = action
         const submittedResponsesForPrompt = currentState.submittedResponses[promptID] || []


### PR DESCRIPTION
## WHAT
Skip the onboarding step when resuming an activity
## WHY
When a student resumes an activity, they don't need to be onboarded for it again
## HOW
Tweak the code so that when an `ActiveActivitySession` is successfully loaded from the API and put into the React session, also flag the session with `explanationSlidesCompleted`

### Notion Card Links
https://www.notion.so/quill/When-resuming-an-activity-take-the-student-to-their-last-response-skip-onboarding-1d26c3d3d34f45a0afcbdd86e99366a8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on session resumption
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
