### PR TITLE
Evidence/ exemplars migrations

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`PromptStep component active state before any responses have been submit
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -139,7 +139,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -272,7 +272,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -384,7 +384,7 @@ exports[`PromptStep component active state when an optimal response has been sub
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -489,6 +489,7 @@ exports[`PromptStep component active state when an optimal response has been sub
           <div
             className="feedback-details-section"
           >
+<<<<<<< HEAD
             <span />
             <button
               className="quill-button focus-on-light"
@@ -500,6 +501,12 @@ exports[`PromptStep component active state when an optimal response has been sub
               </span>
             </button>
           </div>
+=======
+            <span>
+              Next
+            </span>
+          </button>
+>>>>>>> a59a51ad5 (small cosmetic changes)
         </div>
         <Feedback
           customFeedback={null}
@@ -517,7 +524,7 @@ exports[`PromptStep component active state when an optimal response has been sub
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -629,7 +636,7 @@ exports[`PromptStep component active state when the max attempts have been reach
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -762,6 +769,7 @@ exports[`PromptStep component active state when the max attempts have been reach
           <div
             className="feedback-details-section"
           >
+<<<<<<< HEAD
             <span />
             <button
               className="quill-button focus-on-light"
@@ -773,6 +781,12 @@ exports[`PromptStep component active state when the max attempts have been reach
               </span>
             </button>
           </div>
+=======
+            <span>
+              Next
+            </span>
+          </button>
+>>>>>>> a59a51ad5 (small cosmetic changes)
         </div>
         <Feedback
           customFeedback={null}
@@ -790,7 +804,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -887,7 +901,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                         className="feedback-text"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+                            "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
                           }
@@ -954,7 +968,7 @@ exports[`PromptStep component active state when the max attempts have been reach
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -1086,7 +1100,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -1197,7 +1211,7 @@ exports[`PromptStep component inactive state renders 1`] = `
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`PromptStep component active state before any responses have been submit
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -139,7 +139,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -272,7 +272,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -384,7 +384,7 @@ exports[`PromptStep component active state when an optimal response has been sub
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -489,7 +489,6 @@ exports[`PromptStep component active state when an optimal response has been sub
           <div
             className="feedback-details-section"
           >
-<<<<<<< HEAD
             <span />
             <button
               className="quill-button focus-on-light"
@@ -501,12 +500,6 @@ exports[`PromptStep component active state when an optimal response has been sub
               </span>
             </button>
           </div>
-=======
-            <span>
-              Next
-            </span>
-          </button>
->>>>>>> a59a51ad5 (small cosmetic changes)
         </div>
         <Feedback
           customFeedback={null}
@@ -524,7 +517,7 @@ exports[`PromptStep component active state when an optimal response has been sub
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -636,7 +629,7 @@ exports[`PromptStep component active state when the max attempts have been reach
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -769,7 +762,6 @@ exports[`PromptStep component active state when the max attempts have been reach
           <div
             className="feedback-details-section"
           >
-<<<<<<< HEAD
             <span />
             <button
               className="quill-button focus-on-light"
@@ -781,12 +773,6 @@ exports[`PromptStep component active state when the max attempts have been reach
               </span>
             </button>
           </div>
-=======
-            <span>
-              Next
-            </span>
-          </button>
->>>>>>> a59a51ad5 (small cosmetic changes)
         </div>
         <Feedback
           customFeedback={null}
@@ -804,7 +790,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -901,7 +887,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                         className="feedback-text"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+                            "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
                           }
@@ -968,7 +954,7 @@ exports[`PromptStep component active state when the max attempts have been reach
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,
@@ -1100,7 +1086,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             Object {
               "conjunction": "because",
               "max_attempts": 5,
-              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+              "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
               "prompt_id": 1,
@@ -1211,7 +1197,7 @@ exports[`PromptStep component inactive state renders 1`] = `
     Object {
       "conjunction": "because",
       "max_attempts": 5,
-      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response?
+      "max_attempts_feedback": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
       "prompt_id": 1,

--- a/services/QuillLMS/db/migrate/20220201161514_add_strong_examples_to_evidence_prompt.rb
+++ b/services/QuillLMS/db/migrate/20220201161514_add_strong_examples_to_evidence_prompt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStrongExamplesToEvidencePrompt < ActiveRecord::Migration[5.1]
   def change
     add_column :comprehension_prompts, :first_strong_example, :string, default: ''

--- a/services/QuillLMS/db/migrate/20220201161514_add_strong_examples_to_evidence_prompt.rb
+++ b/services/QuillLMS/db/migrate/20220201161514_add_strong_examples_to_evidence_prompt.rb
@@ -1,0 +1,6 @@
+class AddStrongExamplesToEvidencePrompt < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comprehension_prompts, :first_strong_example, :string, default: ''
+    add_column :comprehension_prompts, :second_strong_example, :string, default: ''
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20220201161535_add_strong_examples_to_evidence_prompt.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20220201161535_add_strong_examples_to_evidence_prompt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStrongExamplesToEvidencePrompt < ActiveRecord::Migration[5.1]
   def change
     add_column :comprehension_prompts, :first_strong_example, :string, default: ''

--- a/services/QuillLMS/engines/evidence/db/migrate/20220201161535_add_strong_examples_to_evidence_prompt.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20220201161535_add_strong_examples_to_evidence_prompt.rb
@@ -1,0 +1,6 @@
+class AddStrongExamplesToEvidencePrompt < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comprehension_prompts, :first_strong_example, :string, default: ''
+    add_column :comprehension_prompts, :second_strong_example, :string, default: ''
+  end
+end


### PR DESCRIPTION
## WHAT
add migrations for Evidence prompt exemplars

## WHY
we want to show these after a student completes an activity

## HOW
add `first_strong_example` and `second_strong_example` to Evidence prompt

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Update-the-Completion-Page-efe12085e4c4470d921a5f1f095d6eed

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- migration files PR
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
