### PR TITLE
lms/report-downloads-bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -11,6 +11,11 @@ function formatData(data) {
   })
 }
 
+const unclickedDownloadBtnClass = "btn button-green"
+const clickedDownloadBtnClass = "quill-button medium primary contained focus-on-light"
+const printBtnClass = "print-button"
+const printImgClass = "print-img"
+
 export default class CSVDownloadForProgressReports extends React.Component {
   constructor(props) {
     super(props)
@@ -75,7 +80,8 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   closeDropdownIfOpen(e) {
-    if (this.state.showDropdown && e.target.classList.value !== 'btn button-green' && e.target.classList.value !== 'print-button' && e.target.classList.value !== 'print-img') {
+    const ignoreClasses = [printBtnClass, printImgClass, clickedDownloadBtnClass, unclickedDownloadBtnClass]
+    if (this.state.showDropdown && !ignoreClasses.includes(e.target.classList.value)) {
       this.setState({ showDropdown: false})
     }
   }
@@ -89,9 +95,7 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   toggleDropdown = () => {
-    this.setState({
-      showDropdown: !this.state.showDropdown
-    })
+    this.setState({ showDropdown: !this.state.showDropdown })
   };
 
   render() {
@@ -120,10 +124,10 @@ export default class CSVDownloadForProgressReports extends React.Component {
 
             <div className='button-wrapper'>
 
-              <button className="print-button" onClick={window.print}>
+              <button className={printBtnClass} onClick={window.print}>
                 <img
                   alt="print"
-                  className="print-img"
+                  className={printImgClass}
                   src="https://assets.quill.org/images/icons/download-report-premium.svg"
                 />PDF
               </button>
@@ -145,13 +149,13 @@ export default class CSVDownloadForProgressReports extends React.Component {
       }
       return (
         <div className='download-button-wrapper'>
-          <button className="quill-button medium primary contained focus-on-light" onClick={this.toggleDropdown} style={style}>{this.props.buttonCopy || "Download Report"}</button>
+          <button className={clickedDownloadBtnClass} onClick={this.toggleDropdown} style={style}>{this.props.buttonCopy || "Download Report"}</button>
           {dropdown}
         </div>
       )
     } else {
       return (<button
-        className={this.props.className || 'btn button-green'}
+        className={this.props.className || unclickedDownloadBtnClass}
         onClick={this.handleClick}
         style={{
         display: 'block'

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -80,7 +80,8 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   closeDropdownIfOpen(e) {
-    const ignoreClasses = [printBtnClass, printImgClass, clickedDownloadBtnClass, unclickedDownloadBtnClass]
+    const { className, } = this.props
+    const ignoreClasses = [printBtnClass, printImgClass, clickedDownloadBtnClass, unclickedDownloadBtnClass, className]
     if (this.state.showDropdown && !ignoreClasses.includes(e.target.classList.value)) {
       this.setState({ showDropdown: false})
     }


### PR DESCRIPTION
## WHAT
Refactor some of the logic that toggles download links
## WHY
Pretty sure there's some sort of conditional race condition going on.  On some pages, this always component works exactly as intended, but on some pages it always seems to mis-identify the state that the page is in when it checks to see if it should hide the download links.  The updated code consistently works on all pages.
## HOW
1. Move all of our relevant class names into constants
2. Add one new class name to our set of constants
3. Reference the new constants when deciding if the element triggering the global `click` handler instead of copies of the classNames as strings

### Screenshots
Current result of clicking on "Download Report" button
![image](https://user-images.githubusercontent.com/331565/152035520-e94d32f0-e96e-4d2a-a7cc-0289cf6d9213.png)
Updated result of clicking on "Download Report" button
![image](https://user-images.githubusercontent.com/331565/152035472-899ef076-8ef4-4e1f-9e0c-a6815d2224f2.png)


### Notion Card Links
https://www.notion.so/quill/Admin-Dashboard-Reports-Download-Button-Not-Working-e8fdaa83e649429395c1aabf88601228
https://www.notion.so/quill/Download-report-button-does-not-work-on-Concepts-report-043f42744afb41a88d2c9e28f174f428

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No clear way to update the tests since we don't fully understand what causes the discrepancy in behavior between pages.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
