### PR TITLE
Remove caching on diagnostics_unit endpoint

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -113,11 +113,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def diagnostic_units
-    json = current_user.all_classrooms_cache(key: 'teachers.units.diagnostic_units') do
-      diagnostics_organized_by_classroom.to_json
-    end
-
-    render json: json
+    render json: diagnostics_organized_by_classroom.to_json
   end
 
   # Get all Units containing lessons, and only retrieve the classroom activities for lessons.


### PR DESCRIPTION
## WHAT
After implementing caching on this endpoint, we started seeing some errors on teacher facing reports. It looks like this cache is not being invalidated correctly. We're removing caching for now as we investigate.

## WHY
We don't want bugs to affect teachers.

## HOW
Revert this endpoint to the old, non-cached version.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-results-do-not-show-on-diagnostic-reports-30d5a4e85ca8443ea3443919b411155b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, old tests still apply.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes