### PR TITLE
Roll back caching on teacher progress report scores

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -137,27 +137,12 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def scores
-    classroom = Classroom.find(params[:classroom_id])
-    cache_groups = {
-      unit: params[:unit_id],
-      page: params[:current_page],
-      begin: params[:begin_date],
-      end: params[:end_date],
-      offset: current_user.utc_offset
+    scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
+    last_page = scores.length < 200
+    render json: {
+      scores: scores,
+      is_last_page: last_page
     }
-
-    json = current_user.classroom_cache(classroom, key: 'classroom_manager.scores', groups: cache_groups) do
-      scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
-
-      last_page = scores.length < 200
-
-      {
-        scores: scores,
-        is_last_page: last_page
-      }
-    end
-
-    render json: json
   end
 
   def my_account


### PR DESCRIPTION
## WHAT
There's a bug here where teachers aren't seeing the most up-to-date data unless they choose a particular Unit. For the sake of time I'm going to roll back this change while we investigate the caching issue.

This bug is appearing when students complete an activity, and teachers are not able to see the activity marked as completed in Activity Summary. However, they are able to see the accurate data when they select a specific Unit, which means that the cache is accurate on that unit, but inaccurate for that score report when the unit is not passed in as a parameter.

The bug appears for Connect, Diagnostic, and Grammar activities.

## WHY
Teachers are reporting lag and inaccuracy in their Reports, which is not what we want them to see.

## HOW
Roll back this change for now.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-results-not-displayed-on-Activity-Summary-report-8b33152ba94e438ca729a0da5f3bae86

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tests still stay the same.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes