### PR TITLE
Add school data to TeacherData object

### DIFF
--- a/services/QuillLMS/app/queries/teachers_data.rb
+++ b/services/QuillLMS/app/queries/teachers_data.rb
@@ -63,6 +63,7 @@ module TeachersData
       combiner[row.id] = {
         name: row.name,
         email: row.email,
+        school: row.school,
         number_of_students: row.number_of_students
       }
     end
@@ -80,7 +81,8 @@ module TeachersData
       user = User.new(
         id: key,
         name: hash_value[:name],
-        email: hash_value[:email]
+        email: hash_value[:email],
+        school: hash_value[:school]
       )
       user.define_singleton_method(:number_of_students) do
         hash_value[:number_of_students]

--- a/services/QuillLMS/spec/queries/teachers_data_spec.rb
+++ b/services/QuillLMS/spec/queries/teachers_data_spec.rb
@@ -8,6 +8,9 @@ describe 'TeachersData' do
 
   let!(:classroom) { create(:classroom_with_a_couple_students) }
   let!(:teacher) { classroom.owner }
+  let!(:school) { create(:school) }
+  let!(:schools_user) {create(:schools_users, school: school, user: teacher) }
+
   let!(:teacher_ids) { [teacher.id] }
   let!(:unit) { create(:unit, user_id: teacher.id)}
   let!(:student1) { classroom.students.first }
@@ -42,6 +45,10 @@ describe 'TeachersData' do
 
   before do
     @results = teachers_data_module.run(teacher_ids)
+  end
+
+  it 'school works' do
+    expect(@results.first.school.name).to eq(school.name)
   end
 
   it 'number_of_students works' do


### PR DESCRIPTION
## WHAT
The query to fetch the `school` field for the `TeacherData` object was working, but it wasn't passing the data to the return payload. As a result, we weren't seeing this field in the front-facing teacher report.

## WHY
This field should show in the admin report table.

## HOW
Pass the field out to the return object.

### Screenshots
<img width="1087" alt="Screen Shot 2022-02-04 at 12 01 37 PM" src="https://user-images.githubusercontent.com/57366100/152571720-e7599003-95f0-42c1-9660-370bec9616a5.png">


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Admin-Dashboard-Overview-Page-School-Names-Not-Appearing-d222e10587374ec8a075f2fb23c7ac6d)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
