### PR TITLE
Remove caching code on activities_scores_by_classroom

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -5,13 +5,12 @@ class Api::V1::ProgressReportsController < Api::ApiController
 
   def activities_scores_by_classroom_data
     classroom_ids = current_user&.classrooms_i_teach&.map(&:id)
-    return render json: { data: [] } if classroom_ids.empty?
-
-    data = current_user.all_classrooms_cache(key: 'api.v1.progress_reports.activities_scores_by_classroom_data') do
-      ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
+    if classroom_ids.empty?
+      render json: { data: [] }
+    else
+      data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
+      render json: { data: data }
     end
-
-    render json: { data: data }
   end
 
   def district_activity_scores


### PR DESCRIPTION
## WHAT
Revert caching on the `activities_scores_by_classroom` endpoint. This has been causing inaccurate reports because the `last_active` dates on the report are outdated. 

There must be some caching issue where the cache is not actually invalidated each time a student is active, but we're not sure where the fix is yet. So I'm reverting for now to give teachers accurate reports. 

## WHY
Teachers should always see accurate reports on this page.

## HOW
Revert the caching code we implemented last week.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Student-s-last-active-date-on-Activity-Scores-report-not-accurate-d921e3422eb74868a845443c2dc4413d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tests should remain same.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
