### PR TITLE
Add Staff skip prompt shortcut back into the Evidence playthrough

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/editorContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/editorContainer.tsx
@@ -11,6 +11,7 @@ interface EditorContainerProps {
   html: string;
   disabled: boolean;
   handleFocus: (event: any) => void;
+  handleKeyDown: (event: any) => void;
   innerRef: Function;
   handleTextChange: (event: any) => void;
   className: string;
@@ -26,7 +27,7 @@ export default class EditorContainer extends React.Component<EditorContainerProp
   }
 
   render() {
-    const { disabled, html, innerRef, handleTextChange, className, handleFocus, } = this.props
+    const { disabled, html, innerRef, handleTextChange, className, handleFocus, handleKeyDown } = this.props
     return (
       <div className="editor-container">
         <ContentEditable
@@ -37,6 +38,7 @@ export default class EditorContainer extends React.Component<EditorContainerProp
           innerRef={innerRef}
           onChange={handleTextChange}
           onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
           spellCheck={true}
         />
       </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -259,7 +259,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     })
   }
 
-  handleStepInteraction = (e) => {
+  onStepInteraction = (e) => {
     const { key, ctrlKey, metaKey, } = e
     const { activateStep, stepNumber, } = this.props
 
@@ -406,6 +406,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
           className={className}
           disabled={disabled}
           handleFocus={this.onFocus}
+          handleKeyDown={this.onStepInteraction}
           handleTextChange={this.onTextChange}
           html={htmlWithBolding}
           innerRef={this.setEditorRef}

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`PromptStep component active state before any responses have been submit
             className="editor"
             disabled={false}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;</p>"
             innerRef={[Function]}
@@ -56,6 +57,7 @@ exports[`PromptStep component active state before any responses have been submit
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div
@@ -173,6 +175,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
             className="editor suboptimal"
             disabled={false}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;Governments should make voting compulsory, so that more voices are heard in elections.</p>"
             innerRef={[Function]}
@@ -192,6 +195,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div
@@ -418,6 +422,7 @@ exports[`PromptStep component active state when an optimal response has been sub
             className="editor optimal disabled"
             disabled={true}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;Governments should make voting compulsory, so that the elected government represents the majority of the population.</p>"
             innerRef={[Function]}
@@ -437,6 +442,7 @@ exports[`PromptStep component active state when an optimal response has been sub
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div
@@ -691,6 +697,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             className="editor suboptimal disabled"
             disabled={true}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;Governments should make voting compulsory, so that more voices are heard in elections.</p>"
             innerRef={[Function]}
@@ -710,6 +717,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div
@@ -988,6 +996,7 @@ exports[`PromptStep component active state when the max attempts have been reach
             className="editor optimal disabled"
             disabled={true}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;Governments should make voting compulsory, so that the elected government represents the majority of the population.</p>"
             innerRef={[Function]}
@@ -1007,6 +1016,7 @@ exports[`PromptStep component active state when the max attempts have been reach
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div
@@ -1221,6 +1231,7 @@ exports[`PromptStep component inactive state renders 1`] = `
             className="editor"
             disabled={false}
             handleFocus={[Function]}
+            handleKeyDown={[Function]}
             handleTextChange={[Function]}
             html="<p>Governments should make voting compulsory <u>because</u>&nbsp;</p>"
             innerRef={[Function]}
@@ -1240,6 +1251,7 @@ exports[`PromptStep component inactive state renders 1`] = `
                 innerRef={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
+                onKeyDown={[Function]}
                 spellCheck={true}
               >
                 <div


### PR DESCRIPTION
## WHAT
Somewhere along the line, we accidentally removed the code that calls `handleKeyDown` on the Evidence prompt boxes. This was allowing staff to skip through the prompts using CMD+CTRL+5. I'm adding that code back in now.

## WHY
Staff need this shortcut to be able to perform testing on Evidence activities.

## HOW
Add a keyDown handler prop back into the `ContentEditor` component and pass it the function that we previously wrote to handle skipping prompts.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/CMD-CTRL-5-keyboard-shortcut-is-disabled-7b28af424dc24288a137120f429e3a4b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
