### PR TITLE
Revert caching on progress reports concepts endpoint

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/students_controller.rb
@@ -9,12 +9,10 @@ class Teachers::ProgressReports::Concepts::StudentsController < Teachers::Progre
   end
 
   private def json_payload
-    current_user.all_classrooms_cache(key: 'teachers.progress_reports.concepts.students') do
-      {
-        students: students_as_json,
-        classrooms_with_student_ids: current_user.classrooms_i_teach_with_student_ids
-      }
-    end
+    {
+      students: students_as_json,
+      classrooms_with_student_ids: current_user.classrooms_i_teach_with_student_ids
+    }
   end
 
   private def students_as_json


### PR DESCRIPTION
## WHAT
Caching on this endpoint is not always invalidating correctly. Reverting this caching behavior for now.

## WHY
Teachers are seeing empty Concepts reports for their classes, even though the classes have finished activities. It looks like the cache is not updating the correct students in a classroom for some reason (the cache still shows a class has 4 students, when it has 31 students).

## HOW
Revert to our old non-caching logic for now.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Concepts-report-missing-data-df9befa99e6d40fead625f240f6db7fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
