### PR TITLE
Evidence/ show steps summary after each prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
@@ -52,8 +52,11 @@ const BottomNavigation = ({
   handleStartPromptStepsClick,
   handleStartReadingPassageClick,
   inReflection,
-  showReadTheDirectionsButton
+  showReadTheDirectionsButton,
+  showStepsSummary,
+  toggleShowStepsSummary
 }) => {
+
   if (!hasStartedReadPassageStep) {
     return (
       <div className="bottom-navigation">
@@ -86,6 +89,15 @@ const BottomNavigation = ({
     return (
       <div className="bottom-navigation">
         <button className="quill-button outlined secondary large focus-on-dark" onClick={handleStartPromptStepsClick} type="button">Next</button>
+      </div>
+    )
+  }
+
+  if (showStepsSummary) {
+    console.log("🚀 ~ file: bottomNavigation.tsx ~ line 97 ~ showStepsSummary", showStepsSummary)
+    return (
+      <div className="bottom-navigation">
+        <button className="quill-button outlined secondary large focus-on-dark" onClick={toggleShowStepsSummary} type="button">Next</button>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
@@ -94,7 +94,6 @@ const BottomNavigation = ({
   }
 
   if (showStepsSummary) {
-    console.log("🚀 ~ file: bottomNavigation.tsx ~ line 97 ~ showStepsSummary", showStepsSummary)
     return (
       <div className="bottom-navigation">
         <button className="quill-button outlined secondary large focus-on-dark" onClick={toggleShowStepsSummary} type="button">Next</button>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -329,6 +329,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     const uniqueCompletedSteps = Array.from(new Set(newCompletedSteps))
     trackCurrentPromptCompletedEvent()
     setCompletedSteps(uniqueCompletedSteps)
+    // we only want to render the step summary list again after completing the because and but prompts
     if(stepNumber > READ_PASSAGE_STEP_NUMBER && stepNumber < SO_PASSAGE_STEP_NUMBER) {
       setShowStepsSummary(true);
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -21,7 +21,7 @@ import getParameterByName from '../../helpers/getParameterByName';
 import { getUrlParam, onMobile, outOfAttemptsForActivePrompt, getCurrentStepDataForEventTracking, everyOtherStepCompleted, getStrippedPassageHighlights } from '../../helpers/containerActionHelpers';
 import { renderReadPassageContainer, renderDirections} from '../../helpers/containerRenderHelpers';
 import { postTurkSession } from '../../utils/turkAPI';
-import { roundMillisecondsToSeconds, KEYDOWN, MOUSEMOVE, MOUSEDOWN, CLICK, KEYPRESS, VISIBILITYCHANGE } from '../../../Shared/index'
+import { roundMillisecondsToSeconds, KEYDOWN, MOUSEMOVE, MOUSEDOWN, CLICK, KEYPRESS, VISIBILITYCHANGE, READ_PASSAGE_STEP_NUMBER, SO_PASSAGE_STEP_NUMBER } from '../../../Shared/index'
 
 interface StudentViewContainerProps {
   dispatch: Function;
@@ -49,13 +49,12 @@ interface StudentViewContainerState {
 }
 
 const ONBOARDING = 'onboarding'
-const READ_PASSAGE_STEP = 1
-const ALL_STEPS = [READ_PASSAGE_STEP, 2, 3, 4]
+const ALL_STEPS = [READ_PASSAGE_STEP_NUMBER, 2, 3, 4]
 const MINIMUM_STUDENT_HIGHLIGHT_COUNT = 2
 
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user, }: StudentViewContainerProps) => {
   const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts')
-  const defaultCompletedSteps = shouldSkipToPrompts ? [READ_PASSAGE_STEP] : []
+  const defaultCompletedSteps = shouldSkipToPrompts ? [READ_PASSAGE_STEP_NUMBER] : []
 
   const refs = {
     step1: React.useRef(),
@@ -70,6 +69,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   const [completeButtonClicked, setCompleteButtonClicked] = React.useState(false)
   const [completedSteps, setCompletedSteps] = React.useState(defaultCompletedSteps)
   const [showFocusState, setShowFocusState] = React.useState(false)
+  const [showStepsSummary, setShowStepsSummary] = React.useState(false)
   const [startTime, setStartTime] = React.useState(Date.now())
   const [isIdle, setIsIdle] = React.useState(false)
   const [studentHighlights, setStudentHighlights] = React.useState([])
@@ -163,7 +163,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       // don't activate a step if it's already active
       if (activeStep == nextStep) return
       // // don't activate nextSteps before Done reading button has been clicked
-      if (nextStep && nextStep > 1 && !completedSteps.includes(READ_PASSAGE_STEP)) return
+      if (nextStep && nextStep > 1 && !completedSteps.includes(READ_PASSAGE_STEP_NUMBER)) return
 
       dispatch(setActiveStepForSession(nextStep))
       setStartTime(Date.now())
@@ -175,7 +175,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   React.useEffect(() => {
     const { activeStep } = session;
-    activeStep !== READ_PASSAGE_STEP ? scrollToStep(`step${activeStep}`) : null
+    activeStep !== READ_PASSAGE_STEP_NUMBER ? scrollToStep(`step${activeStep}`) : null
   }, [session.activeStep])
 
   function handleReadPassageContainerScroll(e=null) {
@@ -189,7 +189,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     const { activeStep } = session;
     if (completedSteps.includes(activeStep)) { return } // don't want to add time if a user is revisiting a previously completed step
     if (outOfAttemptsForActivePrompt(activeStep, session, activities)) { return } // or if they are finished submitting responses for the current active step
-    if (activeStep > READ_PASSAGE_STEP && !hasStartedPromptSteps) { return } // or if they are between the read passage step and starting the prompts
+    if (activeStep > READ_PASSAGE_STEP_NUMBER && !hasStartedPromptSteps) { return } // or if they are between the read passage step and starting the prompts
 
     let elapsedTime = now - startTime
     if (isIdle) {
@@ -236,7 +236,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     const data = {
       time_tracking: {
         onboarding: roundMillisecondsToSeconds(timeTracking[ONBOARDING]),
-        reading: roundMillisecondsToSeconds(timeTracking[READ_PASSAGE_STEP]),
+        reading: roundMillisecondsToSeconds(timeTracking[READ_PASSAGE_STEP_NUMBER]),
         because: roundMillisecondsToSeconds(timeTracking[2]),
         but: roundMillisecondsToSeconds(timeTracking[3]),
         so: roundMillisecondsToSeconds(timeTracking[4]),
@@ -329,6 +329,9 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     const uniqueCompletedSteps = Array.from(new Set(newCompletedSteps))
     trackCurrentPromptCompletedEvent()
     setCompletedSteps(uniqueCompletedSteps)
+    if(stepNumber > READ_PASSAGE_STEP_NUMBER && stepNumber < SO_PASSAGE_STEP_NUMBER) {
+      setShowStepsSummary(true);
+    }
   }
 
   function handleClick(e) {
@@ -346,7 +349,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   }
 
   function handleDoneReadingClick() {
-    completeStep(READ_PASSAGE_STEP)
+    completeStep(READ_PASSAGE_STEP_NUMBER)
     const scrollContainer = document.getElementsByClassName("read-passage-container")[0]
     scrollContainer.scrollTo(0, 0)
     trackPassageReadEvent();
@@ -444,6 +447,10 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     callback && callback()
   }
 
+  function toggleShowStepsSummary() {
+    setShowStepsSummary(!showStepsSummary)
+  }
+
   React.useEffect(() => {
     if (studentHighlights.length === 0 ) { return }
     callSaveActiveActivitySession()
@@ -496,7 +503,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   if (!activities.hasReceivedData) { return <LoadingSpinner /> }
 
-  const className = `activity-container ${showFocusState ? '' : 'hide-focus-outline'} ${activeStep === READ_PASSAGE_STEP ? 'on-read-passage' : ''}`
+  const className = `activity-container ${showFocusState ? '' : 'hide-focus-outline'} ${activeStep === READ_PASSAGE_STEP_NUMBER ? 'on-read-passage' : ''}`
 
   if(!explanationSlidesCompleted) {
     if (explanationSlideStep === 0) {
@@ -559,8 +566,10 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         scrolledToEndOfPassage={scrolledToEndOfPassage}
         session={session}
         showReadTheDirectionsButton={showReadTheDirectionsButton}
+        showStepsSummary={showStepsSummary}
         studentHighlights={studentHighlights}
         submitResponse={submitResponse}
+        toggleShowStepsSummary={toggleShowStepsSummary}
         toggleStudentHighlight={toggleStudentHighlight}
       />
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -46,8 +46,8 @@ const RightPanel = ({
     hasStartedReadPassageStep={hasStartedReadPassageStep}
     inReflection={doneHighlighting && activeStep === READ_PASSAGE_STEP}
     scrolledToEndOfPassage={scrolledToEndOfPassage}
-    showStepsSummary={showStepsSummary}
     showReadTheDirectionsButton={showReadTheDirectionsButton}
+    showStepsSummary={showStepsSummary}
     studentHighlights={studentHighlights}
     toggleShowStepsSummary={toggleShowStepsSummary}
   />)

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -28,8 +28,10 @@ const RightPanel = ({
   scrolledToEndOfPassage,
   session,
   showReadTheDirectionsButton,
+  showStepsSummary,
   studentHighlights,
   submitResponse,
+  toggleShowStepsSummary,
   toggleStudentHighlight,
 }) => {
 
@@ -44,8 +46,10 @@ const RightPanel = ({
     hasStartedReadPassageStep={hasStartedReadPassageStep}
     inReflection={doneHighlighting && activeStep === READ_PASSAGE_STEP}
     scrolledToEndOfPassage={scrolledToEndOfPassage}
+    showStepsSummary={showStepsSummary}
     showReadTheDirectionsButton={showReadTheDirectionsButton}
     studentHighlights={studentHighlights}
+    toggleShowStepsSummary={toggleShowStepsSummary}
   />)
 
   if (!hasStartedReadPassageStep) {
@@ -76,6 +80,18 @@ const RightPanel = ({
   }
 
   if (!hasStartedPromptSteps) {
+    return (
+      <div className="steps-outer-container step-overview-container" onScroll={resetTimers}>
+        <StepOverview
+          activeStep={activeStep}
+          handleClick={onStartPromptSteps}
+        />
+        {bottomNavigation}
+      </div>
+    )
+  }
+
+  if (showStepsSummary) {
     return (
       <div className="steps-outer-container step-overview-container" onScroll={resetTimers}>
         <StepOverview

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
@@ -99,19 +99,22 @@ const StepOverview = ({ activeStep, handleClick, }) => {
       <h1>Nice! Keep going!</h1>
       <Step
         active={false}
-        completed={true}
+        completed={activeStep > READ_PASSAGE_STEP_NUMBER}
         step={steps[READ_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === BECAUSE_PASSAGE_STEP_NUMBER}
+        completed={activeStep > BECAUSE_PASSAGE_STEP_NUMBER}
         step={steps[BECAUSE_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === BUT_PASSAGE_STEP_NUMBER}
+        completed={activeStep > BUT_PASSAGE_STEP_NUMBER}
         step={steps[BUT_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === SO_PASSAGE_STEP_NUMBER}
+        completed={activeStep > SO_PASSAGE_STEP_NUMBER}
         step={steps[SO_PASSAGE_STEP_NUMBER]}
       />
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
@@ -204,6 +204,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     </Step>
     <Step
       active={true}
+      completed={false}
       step={
         Object {
           "html": <p>
@@ -250,6 +251,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     </Step>
     <Step
       active={false}
+      completed={false}
       step={
         Object {
           "html": <p>
@@ -286,6 +288,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     </Step>
     <Step
       active={false}
+      completed={false}
       step={
         Object {
           "html": <p>


### PR DESCRIPTION
## WHAT
make sure we show the steps summary after each prompt in Evidence

## WHY
we want to be showing this list after each prompt

## HOW
added some additional logic for rendering the step summary list in between each prompt

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1430" alt="Screen Shot 2022-02-08 at 7 23 40 PM" src="https://user-images.githubusercontent.com/25959584/153085812-47f24e51-7e23-4199-814c-1de537b714bb.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Progress-Menu-Show-after-each-prompt-71c7de987ed44fa583dd264051540a9a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
