### PR TITLE
Temporarily disable daily cron job RenewExpiringRecurringSubscriptionWorker

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -21,7 +21,8 @@ class Cron
 
     DailyStatsEmailJob.perform_async(date)
     QuillStaffAccountsChangedWorker.perform_async
-    RenewExpiringRecurringSubscriptionsWorker.perform_async
+    # Temporarily disable
+    # RenewExpiringRecurringSubscriptionsWorker.perform_async
     ResetDemoAccountWorker.perform_async
     SyncVitallyWorker.perform_async
     MaterializedViewRefreshWorker.perform_async

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -21,7 +21,7 @@ class Cron
 
     DailyStatsEmailJob.perform_async(date)
     QuillStaffAccountsChangedWorker.perform_async
-    # TODO Temporarily disable
+    # TODO: Re-enable this soon
     # RenewExpiringRecurringSubscriptionsWorker.perform_async
     ResetDemoAccountWorker.perform_async
     SyncVitallyWorker.perform_async

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -21,7 +21,7 @@ class Cron
 
     DailyStatsEmailJob.perform_async(date)
     QuillStaffAccountsChangedWorker.perform_async
-    # Temporarily disable
+    # TODO Temporarily disable
     # RenewExpiringRecurringSubscriptionsWorker.perform_async
     ResetDemoAccountWorker.perform_async
     SyncVitallyWorker.perform_async

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -44,7 +44,7 @@ describe "Cron", type: :model do
       Cron.interval_1_day
     end
 
-    # TODO re-enable
+    # TODO: RE-ENABLE THIS SOON
     # it "enqueues RenewExpiringRecurringSubscriptionsWorker" do
     #   expect(RenewExpiringRecurringSubscriptionsWorker).to receive(:perform_async)
     #   Cron.interval_1_day

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -44,10 +44,11 @@ describe "Cron", type: :model do
       Cron.interval_1_day
     end
 
-    it "enqueues RenewExpiringRecurringSubscriptionsWorker" do
-      expect(RenewExpiringRecurringSubscriptionsWorker).to receive(:perform_async)
-      Cron.interval_1_day
-    end
+    # TODO re-enable
+    # it "enqueues RenewExpiringRecurringSubscriptionsWorker" do
+    #   expect(RenewExpiringRecurringSubscriptionsWorker).to receive(:perform_async)
+    #   Cron.interval_1_day
+    # end
 
     it "enqueues DailyStatsEmailJob" do
       expect(DailyStatsEmailJob).to receive(:perform_async)


### PR DESCRIPTION
## WHAT
Temporarily turn off a background job until the underlying mechanism is working properly

## WHY
We are charging users with multiple subscriptions

## HOW
Comment out the job

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
