### PR TITLE
Fix Select School for new teachers

### DIFF
--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -101,8 +101,9 @@ class SchoolsController < ApplicationController
             name: school_params[:school_id_or_type]
           )
         end
-        school_user = SchoolsUsers.find_or_initialize_by(
-          user_id: current_user.id
+        school_user = SchoolsUsers.find_or_create_by(
+          user_id: current_user.id,
+          school_id: school.id
         )
         find_or_create_checkbox('Add School', current_user)
         render json: {}

--- a/services/QuillLMS/spec/controllers/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/schools_controller_spec.rb
@@ -52,4 +52,20 @@ describe SchoolsController, type: :controller do
 
   end
 
+  context "there is a current user" do
+
+    describe '#select_school' do
+      let(:user) { create(:user) }
+
+      before { allow(controller).to receive(:current_user) { user } }
+
+      it 'should attach the user to school' do
+        expect(SchoolsUsers).to receive(:find_or_create_by).with(user_id: user.id, school_id: @school1.id)
+
+        put :select_school, params: { school_id_or_type: @school1.id }, as: :json
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
## WHAT
We are not creating a new `SchoolsUsers` record when teachers sign up, instead we're just initializing the object but not saving it. This means teachers are not getting their schools saved when they sign up for Quill.

## WHY
We want teacher data to be saved and updated.

## HOW
Change the initialize call to a create call so the object gets saved in the database.

### Screenshots
<img width="673" alt="Screen Shot 2022-02-11 at 4 06 30 PM" src="https://user-images.githubusercontent.com/57366100/153672809-d2fcd0f6-f1e8-4eb2-8f25-2b7d2dd3e383.png">

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=8afc588b010d44f2b136f7883215a961

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
