### PR TITLE
autofix what can be fixed and add new rules to staged file linter

### DIFF
--- a/packages/quill-marking-logic/config/rollup.js
+++ b/packages/quill-marking-logic/config/rollup.js
@@ -1,16 +1,16 @@
-var fs = require('fs');
-var zlib = require('zlib');
-var rollup = require('rollup');
-var uglify = require('uglify-js');
-var commonjs = require('rollup-plugin-commonjs');
-var nodeResolve = require('rollup-plugin-node-resolve');
-var typescript = require('rollup-plugin-typescript2');
-var json = require('rollup-plugin-json');
-var nodeGlobals = require('rollup-plugin-node-globals')
-var builtins = require('rollup-plugin-node-builtins-brofs');
-var uglifyPlugin = require('rollup-plugin-uglify')
-var version = process.env.VERSION || require('../package.json').version;
-var banner =
+let fs = require('fs');
+let zlib = require('zlib');
+let rollup = require('rollup');
+let uglify = require('uglify-js');
+let commonjs = require('rollup-plugin-commonjs');
+let nodeResolve = require('rollup-plugin-node-resolve');
+let typescript = require('rollup-plugin-typescript2');
+let json = require('rollup-plugin-json');
+let nodeGlobals = require('rollup-plugin-node-globals')
+let builtins = require('rollup-plugin-node-builtins-brofs');
+let uglifyPlugin = require('rollup-plugin-uglify')
+let version = process.env.VERSION || require('../package.json').version;
+let banner =
     '/*!\n' +
     ' * {LIB} v' + version + '\n' +
     ' * (c) ' + new Date().getFullYear() + ' {NAME}\n' +

--- a/packages/quill-marking-logic/karma.conf.js
+++ b/packages/quill-marking-logic/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration
 // Generated on Mon Jan 23 2017 01:17:51 GMT+0100 (Paris, Madrid)
 
-var webpackConfig = require('./webpack.config');
+let webpackConfig = require('./webpack.config');
 webpackConfig.entry = {};
 webpackConfig.plugins = [];
 webpackConfig.devtool = 'inline-source-map';

--- a/packages/quill-marking-logic/src/libs/spellchecker/edits.ts
+++ b/packages/quill-marking-logic/src/libs/spellchecker/edits.ts
@@ -1,7 +1,7 @@
 import {letters} from './letters'
 
 export function edits(word): string[] {
-  var i, results: string[] = [];
+  let i, results: string[] = [];
   // deletion
   for (i=0; i < word.length; i+=1)
     results.push(word.slice(0, i) + word.slice(i+1));

--- a/packages/quill-marking-logic/src/libs/spellchecker/max.ts
+++ b/packages/quill-marking-logic/src/libs/spellchecker/max.ts
@@ -1,5 +1,5 @@
 export function max(candidates) {
-  var candidate, arr = [];
+  let candidate, arr = [];
   for (candidate in candidates)
     if (candidates.hasOwnProperty(candidate))
       arr.push(candidate);

--- a/packages/quill-marking-logic/webpack.config.js
+++ b/packages/quill-marking-logic/webpack.config.js
@@ -1,4 +1,4 @@
-var path = require('path'),
+let path = require('path'),
   webpack = require('webpack');
 
 module.exports = {

--- a/services/QuillLMS/app/assets/javascripts/cms_activity_page.js
+++ b/services/QuillLMS/app/assets/javascripts/cms_activity_page.js
@@ -3,10 +3,10 @@ $(function() {
     return;
   }
 
-  var $form = $('.activity-form form')
+  let $form = $('.activity-form form')
     , saved = false;
 
-  var iframeSrc = $('iframe').prop('src');
+  let iframeSrc = $('iframe').prop('src');
   window.quill = new Quill(iframeSrc, {
     afterIframeActivitySaved: function () {
       saved = true;

--- a/services/QuillLMS/app/assets/javascripts/loadingbutton.js
+++ b/services/QuillLMS/app/assets/javascripts/loadingbutton.js
@@ -4,13 +4,13 @@
  */
 (function ( $ ) { // This extends JQuery with the function loadingButton
   $.fn.loadingButton = function() {
-    var loadingSpinnerClass = 'loading-spinner',
+    let loadingSpinnerClass = 'loading-spinner',
       container = this,
       parent = {};
 
     this.addClass('loading-btn');
     $('body').append('<span class="' + loadingSpinnerClass + '"></span>');
-    var buttonPosition = this.offset();
+    let buttonPosition = this.offset();
 
     // buttonPosition.left + 40 --->  Hackey centering but it works for now.
     $('.' + loadingSpinnerClass).css('left', buttonPosition.left + 40).css('top', buttonPosition.top);
@@ -20,7 +20,7 @@
 
 (function ( $ ) {
   $.fn.removeLoadingButton = function() {
-    var loadingSpinnerClass = 'loading-spinner',
+    let loadingSpinnerClass = 'loading-spinner',
       container = this,
       parent = {};
 

--- a/services/QuillLMS/client/app/bundles/Connect/actions/filters.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/filters.js
@@ -1,4 +1,4 @@
-var C = require("../constants").default;
+let C = require("../constants").default;
 
 module.exports = {
   toggleExpandSingleResponse: function (rkey) {

--- a/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/activityHealth.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/activityHealth.tsx
@@ -40,7 +40,7 @@ interface ActivityHealthState {
 function addCommasToThousands(num)
 {
   if (!num) return ""
-  var num_parts = num.toString().split(".");
+  let num_parts = num.toString().split(".");
   num_parts[0] = num_parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   return num_parts.join(".");
 }

--- a/services/QuillLMS/client/app/bundles/Connect/components/itemLevels/itemLevelForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/itemLevels/itemLevelForm.jsx
@@ -41,7 +41,7 @@ class ItemLevelForm extends React.Component {
       alert("You must choose a name for this item level")
       return
     }
-    var newItemLevel = {
+    let newItemLevel = {
       name: this.refs.newItemLevelName.value,
       integerValue: this.refs.integerValue.value,
     }

--- a/services/QuillLMS/client/app/bundles/Connect/components/renderForQuestions/generateFeedbackString.js
+++ b/services/QuillLMS/client/app/bundles/Connect/components/renderForQuestions/generateFeedbackString.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import _ from 'underscore'
-var C = require("../../constants").default
+let C = require("../../constants").default
 
 
 const feedbackStrings = C.FEEDBACK_STRINGS
@@ -10,7 +10,7 @@ export default function generateFeedbackString(attempt) {
   const errors = _.pick(attempt, ...C.ERROR_TYPES);
 
   // add keys for react list elements
-  var errorComponents = _.values(_.mapObject(errors, (val, key) => {
+  let errorComponents = _.values(_.mapObject(errors, (val, key) => {
     if (val) {
       return feedbackStrings[key]
     }

--- a/services/QuillLMS/client/app/bundles/Connect/libs/partsOfSpeechTagging.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/partsOfSpeechTagging.js
@@ -14,7 +14,7 @@ export function getPartsOfSpeech (input) {
 }
 
 export function getPartsOfSpeechTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[1]
@@ -24,7 +24,7 @@ export function getPartsOfSpeechTags(input){
 }
 
 export function getPartsOfSpeechWords(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[0]
@@ -33,7 +33,7 @@ export function getPartsOfSpeechWords(input){
 }
 
 export function getPartsOfSpeechWordsWithTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return [b[0], b[1]]
@@ -54,8 +54,8 @@ export function getPOSTagPairs (input, target) {
 }
 
 export function getPOSTransformations(input,target){
-  var arraytagger = getPOSTagPairs(input,target);
-  var arrayDifference = arraytagger.filter((b)=>{
+  let arraytagger = getPOSTagPairs(input,target);
+  let arrayDifference = arraytagger.filter((b)=>{
     return b[0] != b[1];
   });
   return arrayDifference.map((b)=> {

--- a/services/QuillLMS/client/app/bundles/Connect/libs/sentenceFragmentML.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/sentenceFragmentML.js
@@ -395,7 +395,7 @@ export default class POSMatcher {
   }
 
   checkMLMatch(userSubmission, returnValue, utl) {
-    var options = {
+    let options = {
       method: 'POST',
       uri: `${process.env.QUILL_CMS}/fragments/is_sentence`,
       form: {

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/concepts-feedback.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/concepts-feedback.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_CONCEPTS_FEEDBACK_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/concepts.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/concepts.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_CONCEPTS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/item-levels.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/item-levels.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_ITEM_LEVELS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/lessons.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/lessons.js
@@ -12,7 +12,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_LESSONS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/sentenceFragments.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/sentenceFragments.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_SENTENCE_FRAGMENTS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Connect/test/examples/bitterChocolate.test.js
+++ b/services/QuillLMS/client/app/bundles/Connect/test/examples/bitterChocolate.test.js
@@ -46,13 +46,13 @@ describe("The question object", () => {
   });
 
   it("should not match really different sentences", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The completely irrelevent sentences doesn't match.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The completely irrelevent sentences doesn't match.");
     expect(correctResponse).toNotExist()
   });
 
 
   it("example 1", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("Chocolate is bitter and it's sweetened.");
+    let correctResponse = question.checkChangeObjectRigidMatch("Chocolate is bitter and it's sweetened.");
     expect(correctResponse).toNotExist()
   });
 
@@ -79,13 +79,13 @@ describe("The surfer question", () => {
   });
 
   it("should not match really different sentences", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The completely irrelevent sentences doesn't match.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The completely irrelevent sentences doesn't match.");
     expect(correctResponse).toNotExist()
   });
 
 
   it("example 1", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("If surfers catch the wave, they ride it to the shore.");
+    let correctResponse = question.checkChangeObjectRigidMatch("If surfers catch the wave, they ride it to the shore.");
     expect(correctResponse).toExist()
   });
 

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/diffTests.test.js
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/diffTests.test.js
@@ -28,42 +28,42 @@ describe("The question object", () => {
   });
 
   it("should be able to check for an additional word.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The fox ran away.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The fox ran away.");
     expect(correctResponse).toExist()
   });
 
   it("should be able to check for an additional word. 2", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The fox away ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The fox away ran.");
     expect(correctResponse).toExist()
   });
 
   it("should be able to check for an additional word. 3", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The away fox ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The away fox ran.");
     expect(correctResponse).toExist()
   });
 
   it("should be able to check for a missing word.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The ran.");
     expect(correctResponse).toExist()
   });
 
   it("should be able to check for a modified word.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The dog ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The dog ran.");
     expect(correctResponse).toExist()
   });
 
   it("should be able to check no change.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The fox ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The fox ran.");
     expect(correctResponse).toExist()
   });
 
   it("should not match more than one missing word.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The.");
     expect(correctResponse).toNotExist()
   });
 
   it("should not match more than one additional word.", () => {
-    var correctResponse = question.checkChangeObjectRigidMatch("The fleeting fast fox ran.");
+    let correctResponse = question.checkChangeObjectRigidMatch("The fleeting fast fox ran.");
     expect(correctResponse).toNotExist()
   });
 

--- a/services/QuillLMS/client/app/bundles/Connect/test/libs/quotationTest.spec.js
+++ b/services/QuillLMS/client/app/bundles/Connect/test/libs/quotationTest.spec.js
@@ -23,16 +23,16 @@ describe("The question object", () => {
   });
 
   it("should be able to check for an exact match in the responses.", () => {
-    var correctResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called “The Blue House” because it is painted a bright cobalt blue.");
+    let correctResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called “The Blue House” because it is painted a bright cobalt blue.");
     expect(correctResponse).toExist()
-    var alternateQuotationResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called \"The Blue House\" because it is painted a bright cobalt blue.");
+    let alternateQuotationResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called \"The Blue House\" because it is painted a bright cobalt blue.");
     expect(alternateQuotationResponse).toExist();
   });
 
   it("should be able to check for an exact match in the responses.", () => {
-    var correctResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called “The Blue House” because it is painted a bright cobalt blue.");
+    let correctResponse = question.checkExactMatch("Frida Kahlo’s childhood home is called “The Blue House” because it is painted a bright cobalt blue.");
     expect(correctResponse).toExist()
-    var alternateQuotationResponse = question.checkExactMatch("Frida Kahlo's childhood home is called \"The Blue House\" because it is painted a bright cobalt blue.");
+    let alternateQuotationResponse = question.checkExactMatch("Frida Kahlo's childhood home is called \"The Blue House\" because it is painted a bright cobalt blue.");
     expect(alternateQuotationResponse).toExist();
   });
 });

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/filters.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/filters.js
@@ -1,4 +1,4 @@
-var C = require("../constants").default;
+let C = require("../constants").default;
 
 module.exports = {
   toggleExpandSingleResponse: function (rkey) {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/POSForResponsesList.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/POSForResponsesList.jsx
@@ -36,11 +36,11 @@ export default class extends React.Component {
   };
 
   renderPOSTagsList = () => {
-    var posTagsList = this.sortResponses(this.props.posTagsList)
+    let posTagsList = this.sortResponses(this.props.posTagsList)
 
     return _.map(posTagsList, (tag, index) => {
-      var bgColor;
-      var icon;
+      let bgColor;
+      let icon;
       if (!tag.responses[0].feedback) {
         bgColor = "not-found-response";
       } else if (!!tag.responses[0].parentID) {
@@ -53,13 +53,13 @@ export default class extends React.Component {
         icon = "⚠️";
       }
 
-      var tagsToRender = [];
+      let tagsToRender = [];
       const posTagKeys = keysForPOS()
 
       tag.tags.forEach((index) => {
         tagsToRender.push(posTagKeys[index])
       })
-      var headerStyle = {
+      let headerStyle = {
         "padding": "10px 20px",
         "borderBottom": "0.2px solid #e6e6e6"
       }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/renderForQuestions/generateFeedbackString.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/renderForQuestions/generateFeedbackString.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import _ from 'underscore'
-var C = require("../../constants").default
+let C = require("../../constants").default
 
 
 const feedbackStrings = C.FEEDBACK_STRINGS
@@ -10,7 +10,7 @@ export default function generateFeedbackString(attempt) {
   const errors = _.pick(attempt, ...C.ERROR_TYPES);
 
   // add keys for react list elements
-  var errorComponents = _.values(_.mapObject(errors, (val, key) => {
+  let errorComponents = _.values(_.mapObject(errors, (val, key) => {
     if (val) {
       return feedbackStrings[key]
     }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/partsOfSpeechTagging.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/partsOfSpeechTagging.js
@@ -14,7 +14,7 @@ export function getPartsOfSpeech (input) {
 }
 
 export function getPartsOfSpeechTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[1]
@@ -24,7 +24,7 @@ export function getPartsOfSpeechTags(input){
 }
 
 export function getPartsOfSpeechWords(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[0]
@@ -33,7 +33,7 @@ export function getPartsOfSpeechWords(input){
 }
 
 export function getPartsOfSpeechWordsWithTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return [b[0], b[1]]
@@ -54,8 +54,8 @@ export function getPOSTagPairs (input, target) {
 }
 
 export function getPOSTransformations(input,target){
-  var arraytagger = getPOSTagPairs(input,target);
-  var arrayDifference = arraytagger.filter((b)=>{
+  let arraytagger = getPOSTagPairs(input,target);
+  let arrayDifference = arraytagger.filter((b)=>{
     return b[0] != b[1];
   });
   return arrayDifference.map((b)=> {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/sentenceFragmentML.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/sentenceFragmentML.js
@@ -395,7 +395,7 @@ export default class POSMatcher {
   }
 
   checkMLMatch(userSubmission, returnValue, utl) {
-    var options = {
+    let options = {
       method: 'POST',
       uri: `${process.env.QUILL_CMS}/fragments/is_sentence`,
       form: {

--- a/services/QuillLMS/client/app/bundles/Home/tabslet.js
+++ b/services/QuillLMS/client/app/bundles/Home/tabslet.js
@@ -37,7 +37,7 @@
 
   $.fn.tabslet = function(options) {
 
-    var defaults = {
+    let defaults = {
       mouseevent:   'click',
       activeclass:  'active',
       attribute:    'href',
@@ -58,15 +58,15 @@
 
     return this.each(function() {
 
-      var $this      = $(this), _cache_li = [], _cache_div = [];
-      var _container = options.container ? $(options.container) : $this;
-      var _tabs      = _container.find('> div');
+      let $this      = $(this), _cache_li = [], _cache_div = [];
+      let _container = options.container ? $(options.container) : $this;
+      let _tabs      = _container.find('> div');
 
       // Caching
       _tabs.each(function() { _cache_div.push($(this).css('display')); });
 
       // Autorotate
-      var elements = $this.find('> ul > li'), i = options.active - 1; // ungly
+      let elements = $this.find('> ul > li'), i = options.active - 1; // ungly
 
       if ( !$this.data( 'tabslet-init' ) ) {
 
@@ -87,10 +87,10 @@
           elements.eq($this.opts.active - 1).addClass(options.activeclass);
         }
 
-        var fn = eval(
+        let fn = eval(
 
           function(e, tab) {
-            var _this = tab ? elements.find('a[' + $this.opts.attribute + '="' + tab +'"]').parent() : $(this);
+            let _this = tab ? elements.find('a[' + $this.opts.attribute + '="' + tab +'"]').parent() : $(this);
 
             _this.trigger('_before');
 
@@ -100,7 +100,7 @@
 
             i = elements.index(_this);
 
-            var currentTab = tab || _this.find('a').attr($this.opts.attribute);
+            let currentTab = tab || _this.find('a').attr($this.opts.attribute);
 
             if ($this.opts.deeplinking) location.hash = currentTab;
 
@@ -123,11 +123,11 @@
 
         );
 
-        var init = eval("elements." + $this.opts.mouseevent + "(fn)");
+        let init = eval("elements." + $this.opts.mouseevent + "(fn)");
 
         init;
 
-        var t;
+        let t;
 
         var forward = function() {
 
@@ -171,11 +171,11 @@
 
         function deep_link() {
 
-          var ids = [];
+          let ids = [];
 
           elements.find('a').each(function() { ids.push($(this).attr($this.opts.attribute)); });
 
-          var index = $.inArray(location.hash, ids)
+          let index = $.inArray(location.hash, ids)
 
           if (index > -1) {
 
@@ -189,7 +189,7 @@
 
         }
 
-        var move = function(direction) {
+        let move = function(direction) {
 
           if (direction == 'forward') i = i+=1 % elements.length; // wrap around
 

--- a/services/QuillLMS/client/app/bundles/Lessons/actions/filters.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/actions/filters.js
@@ -1,4 +1,4 @@
-var C = require("../constants").default;
+let C = require("../constants").default;
 
 module.exports = {
   toggleExpandSingleResponse: function (rkey) {

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/sidebar.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/sidebar.tsx
@@ -75,7 +75,7 @@ class Sidebar extends React.Component<ReducerSidebarProps & PassedSidebarProps &
     if (count > 15) {
       return;
     }
-    var y = elem.scrollTop;
+    let y = elem.scrollTop;
     y += Math.round( ( pos - y ) * 0.3 );
     if (Math.abs(y-pos) <= 2) {
       elem.scrollTop = pos;

--- a/services/QuillLMS/client/app/bundles/Lessons/components/renderForQuestions/generateFeedbackString.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/renderForQuestions/generateFeedbackString.js
@@ -1,5 +1,5 @@
 import _ from 'underscore'
-var C = require("../../constants").default
+let C = require("../../constants").default
 
 
 const feedbackStrings = C.FEEDBACK_STRINGS
@@ -9,7 +9,7 @@ export default function generateFeedbackString(attempt) {
   const errors = _.pick(attempt, ...C.ERROR_TYPES);
 
   // add keys for react list elements
-  var errorComponents = _.values(_.mapObject(errors, (val, key) => {
+  let errorComponents = _.values(_.mapObject(errors, (val, key) => {
     if (val) {
       return feedbackStrings[key]
     }

--- a/services/QuillLMS/client/app/bundles/Lessons/libs/partsOfSpeechTagging.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/libs/partsOfSpeechTagging.js
@@ -14,7 +14,7 @@ export function getPartsOfSpeech (input) {
 }
 
 export function getPartsOfSpeechTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[1]
@@ -24,7 +24,7 @@ export function getPartsOfSpeechTags(input){
 }
 
 export function getPartsOfSpeechWords(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return b[0]
@@ -33,7 +33,7 @@ export function getPartsOfSpeechWords(input){
 }
 
 export function getPartsOfSpeechWordsWithTags(input){
-  var wordsTags = getPartsOfSpeech(input);
+  let wordsTags = getPartsOfSpeech(input);
   if (wordsTags) {
     return wordsTags.map((b) => {
       return [b[0], b[1]]
@@ -54,8 +54,8 @@ export function getPOSTagPairs (input, target) {
 }
 
 export function getPOSTransformations(input,target){
-  var arraytagger = getPOSTagPairs(input,target);
-  var arrayDifference = arraytagger.filter((b)=>{
+  let arraytagger = getPOSTagPairs(input,target);
+  let arrayDifference = arraytagger.filter((b)=>{
     return b[0] != b[1];
   });
   return arrayDifference.map((b)=> {

--- a/services/QuillLMS/client/app/bundles/Lessons/libs/sentenceFragmentML.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/libs/sentenceFragmentML.js
@@ -395,7 +395,7 @@ export default class POSMatcher {
   }
 
   checkMLMatch(userSubmission, returnValue, utl) {
-    var options = {
+    let options = {
       method: 'POST',
       uri: `${process.env.QUILL_CMS}/fragments/is_sentence`,
       form: {

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/concepts-feedback.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/concepts-feedback.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_CONCEPTS_FEEDBACK_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/concepts.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/concepts.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_CONCEPTS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/diagnosticQuestions.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/diagnosticQuestions.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_DIAGNOSTIC_QUESTIONS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/item-levels.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/item-levels.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_ITEM_LEVELS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/lessons.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/lessons.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_LESSONS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Lessons/reducers/sentenceFragments.js
+++ b/services/QuillLMS/client/app/bundles/Lessons/reducers/sentenceFragments.js
@@ -11,7 +11,7 @@ const initialState = {
 }
 
 export default function(currentstate,action){
-  var newstate;
+  let newstate;
   switch(action.type){
     case C.RECEIVE_SENTENCE_FRAGMENTS_DATA:
       return Object.assign({},currentstate,{

--- a/services/QuillLMS/client/app/bundles/Teacher/components/activity_classifications/activity_classification.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/activity_classifications/activity_classification.jsx
@@ -38,8 +38,8 @@ export default class ActivityClassification extends React.Component {
   }
 
   initializeModules() {
-    var fnl = new Fnl();
-    var server = new Server(this.resourceNameSingular, this.resourceNamePlural, '/cms');
+    let fnl = new Fnl();
+    let server = new Server(this.resourceNameSingular, this.resourceNamePlural, '/cms');
     this.modules = {
       textInputGenerator: new TextInputGenerator(this, this.updateModelState),
       server: server,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -384,8 +384,8 @@ export default class CreateOrEditBlogPost extends React.Component {
     const container = document.getElementById('markdown-content');
     let newValue = body;
     if (container.selectionStart || container.selectionStart === 0) {
-      var startPos = container.selectionStart;
-      var endPos = container.selectionEnd;
+      let startPos = container.selectionStart;
+      let endPos = container.selectionEnd;
       newValue = container.value.substring(0, startPos);
       newValue += startChar;
       newValue += container.value.substring(startPos, endPos);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table.jsx
@@ -7,7 +7,7 @@ import { SortableList, } from '../../../../Shared/index'
 
 export default class CmsIndexTable extends React.Component {
   furnishRows = () => {
-    var rows = this.props.data.resources.map((resource, index) => this.furnishRow(resource, index) );
+    let rows = this.props.data.resources.map((resource, index) => this.furnishRow(resource, index) );
     return rows;
   };
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/cms_index_table/cms_index_table_row.jsx
@@ -7,7 +7,7 @@ export default class CmsIndexTableRow extends React.Component {
   };
 
   delete = () => {
-    var confirm = window.confirm('are you sure you want to delete ' + this.props.data.resource[this.identifier()] + '?');
+    let confirm = window.confirm('are you sure you want to delete ' + this.props.data.resource[this.identifier()] + '?');
     if (confirm) {
       this.props.actions.delete(this.props.data.resource);
     }
@@ -28,10 +28,10 @@ export default class CmsIndexTableRow extends React.Component {
   };
 
   render() {
-    var edit_and_delete;
+    let edit_and_delete;
     edit_and_delete = _.reduce(['edit', 'delete'], function (acc, ele) {
       if (this.props.actions[ele]) {
-        var el = <div className='col-xs-4' key={ele} onClick={this[ele]}>{ele}</div>
+        let el = <div className='col-xs-4' key={ele} onClick={this[ele]}>{ele}</div>
         return _.chain(acc).push(el).value();
       } else {
         return acc

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/resources/newNestedResource.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/resources/newNestedResource.jsx
@@ -14,7 +14,7 @@ export default class NewNestedResource extends React.Component {
   }
 
   updateModelState = (key, value) => {
-    var model = this.state.model;
+    let model = this.state.model;
     model[key] = value;
     this.setState({model: model});
   };
@@ -24,7 +24,7 @@ export default class NewNestedResource extends React.Component {
   };
 
   render() {
-    var inputs = this.modules.textInputGenerator.generate(this.props.data.formFields)
+    let inputs = this.modules.textInputGenerator.generate(this.props.data.formFields)
     return (
       <div>
         <h5> Add New : </h5>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/resources/resource.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/resources/resource.jsx
@@ -7,9 +7,9 @@ export default class Resource extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.initializeModules();
-    var model1 = _.extend(props.initialModel, props.resource);
+    let model1 = _.extend(props.initialModel, props.resource);
 
-    var hash = {
+    let hash = {
       model: model1
     };
     this.state = hash;
@@ -33,24 +33,24 @@ export default class Resource extends React.Component {
   };
 
   updateModelState = (key, value) => {
-    var newState = this.state;
+    let newState = this.state;
     newState.model[key] = value;
     this.setState(newState);
   };
 
   addNestedResource = (kind, resource) => {
-    var newModel = this.modules.nestedResources[kind].add(resource)
+    let newModel = this.modules.nestedResources[kind].add(resource)
     this.nestedResourceSaveHelper(newModel)
   };
 
   removeNestedResourceAndSave = (kind, resource) => {
-    var newModel = this.modules.nestedResources[kind].remove(resource)
+    let newModel = this.modules.nestedResources[kind].remove(resource)
     this.nestedResourceSaveHelper(newModel)
   };
 
   nestedResourceSaveHelper = (newModel) => {
-    var data = _.pick(newModel, this.props.savingKeys)
-    var options = {
+    let data = _.pick(newModel, this.props.savingKeys)
+    let options = {
       callback: this.updateModelSaveCallback,
       savingKeys: this.props.savingKeys,
       fieldsToNormalize: this.props.fieldsToNormalize
@@ -63,8 +63,8 @@ export default class Resource extends React.Component {
   };
 
   save = () => {
-    var data = _.pick(this.state.model, this.props.savingKeys);
-    var options = {
+    let data = _.pick(this.state.model, this.props.savingKeys);
+    let options = {
       callback: this.props.returnToIndex,
       savingKeys: this.props.savingKeys,
       fieldsToNormalize: this.props.fieldsToNormalize
@@ -73,12 +73,12 @@ export default class Resource extends React.Component {
   };
 
   render() {
-    var inputs = this.modules.textInputGenerator.generate(this.props.formFields);
+    let inputs = this.modules.textInputGenerator.generate(this.props.formFields);
     let nestedResources
     if (this.props.nestedResources) {
       nestedResources = this.props.nestedResources.map((nr, index)=>{
-        var resources = this.state.model[nr.name];
-        var data = _.extend(nr, {resources: resources});
+        let resources = this.state.model[nr.name];
+        let data = _.extend(nr, {resources: resources});
         return <CmsNestedResource actions={{save: this.addNestedResource, delete: this.removeNestedResourceAndSave}} data={data} key={index} />;
       });
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/check_boxes/check_boxes.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/check_boxes/check_boxes.jsx
@@ -4,7 +4,7 @@ import _ from 'underscore'
 
 export default class CheckBoxes extends React.Component {
   determineIfChecked = (item) => {
-    var val = _.contains(this.props.selectedItems, item);
+    let val = _.contains(this.props.selectedItems, item);
     return val;
   };
 
@@ -13,7 +13,7 @@ export default class CheckBoxes extends React.Component {
   };
 
   render() {
-    var checkBoxes = _.map(this.props.items, this.generateCheckBox, this);
+    let checkBoxes = _.map(this.props.items, this.generateCheckBox, this);
     return (
       <div className='vertical-checkboxes'>
         <h3>{this.props.label}</h3>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/dropdown_date_selector.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/dropdown_date_selector.jsx
@@ -3,7 +3,7 @@ import _ from 'underscore'
 
 export default class DropdownDateSelector extends React.Component {
   getDateParts = () => {
-    var dateParts, year, month, day;
+    let dateParts, year, month, day;
     if (this.props.date != null) {
       year = this.props.date.slice(0,4);
       month = this.props.date.slice(5,7);
@@ -25,12 +25,12 @@ export default class DropdownDateSelector extends React.Component {
   };
 
   createDateString = (dateParts) => {
-    var str = dateParts.year + "-" + dateParts.month + "-"  + dateParts.day
+    let str = dateParts.year + "-" + dateParts.month + "-"  + dateParts.day
     return str;
   };
 
   updateDatePart = (part) => {
-    var value, dateParts, str;
+    let value, dateParts, str;
     value = $(this.refs[part]).val();
     dateParts = this.getDateParts();
     dateParts[part] = value;
@@ -51,10 +51,10 @@ export default class DropdownDateSelector extends React.Component {
   };
 
   getYearOptions = () => {
-    var years, yearOptions;
+    let years, yearOptions;
     years = [];
     _.times(20, function (i) {
-      var next = 2015 + i;
+      let next = 2015 + i;
       years.push(next);
     });
     yearOptions = _.map(years, function (year) {
@@ -64,7 +64,7 @@ export default class DropdownDateSelector extends React.Component {
   };
 
   getMonthOptions = () => {
-    var monthNames, monthNumbers, months, monthOptions;
+    let monthNames, monthNumbers, months, monthOptions;
     monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
     monthNumbers = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
     months = _.map(monthNames, function (name, index) {
@@ -80,7 +80,7 @@ export default class DropdownDateSelector extends React.Component {
   };
 
   getDayOptions = (month) => {
-    var numDays, days, shortMonths, dayOptions;
+    let numDays, days, shortMonths, dayOptions;
     shortMonths = ['04', '06', '09', '11'];
     if (month == '02') {
       numDays = 28;
@@ -91,12 +91,12 @@ export default class DropdownDateSelector extends React.Component {
     }
     days = [];
     _.times(numDays, function (i) {
-      var number = i+1;
-      var numberName = '' + number
+      let number = i+1;
+      let numberName = '' + number
       if (number < 10) {
         number = '0' + number;
       }
-      var next = {
+      let next = {
         name: '' + numberName,
         number: '' + number
       }
@@ -109,7 +109,7 @@ export default class DropdownDateSelector extends React.Component {
   };
 
   render() {
-    var dateParts, yearOptions, monthOptions, dayOptions;
+    let dateParts, yearOptions, monthOptions, dayOptions;
     dateParts = this.getDateParts();
     yearOptions = this.getYearOptions();
     monthOptions = this.getMonthOptions();

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/dropdown_selectors/dropdown_selector.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/dropdown_selectors/dropdown_selector.jsx
@@ -3,13 +3,13 @@ import _ from 'underscore';
 
 export default class DropdownSeletor extends React.Component {
   select = () => {
-    var id = $(this.refs.select).val();
+    let id = $(this.refs.select).val();
     this.props.select(id);
   };
 
   generateOption = (option) => {
-    var id = (option.id ? option.id : option)
-    var name = (option.name ? option.name : option)
+    let id = (option.id ? option.id : option)
+    let name = (option.name ? option.name : option)
     return (
       <option key={id} value={id}>{name}</option>
     );
@@ -17,9 +17,9 @@ export default class DropdownSeletor extends React.Component {
 
   render() {
     // makes shallow copy of array
-    var opt = this.props.options.slice(0);
+    let opt = this.props.options.slice(0);
     opt.unshift('Select');
-    var options = _.map(opt, this.generateOption, this);
+    let options = _.map(opt, this.generateOption, this);
     return (
       <div className='dropdown-select-and-label'>
         <h3 className='dropdown-select-label'>{this.props.label}</h3>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/list_filter_options/list_filter_option.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/list_filter_options/list_filter_option.jsx
@@ -14,7 +14,7 @@ export default class ListFilterOption extends React.Component {
   };
 
   getClassName = () => {
-    var name;
+    let name;
     if (this.props.isSelected) {
       name = 'list-filter-option selected'
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/table/sortable_table/sortable_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/table/sortable_table/sortable_table.jsx
@@ -21,7 +21,7 @@ export default class SortableTable extends React.Component {
 
   columns = () => {
     return _.map(this.props.columns, function (column, i) {
-      var isCurrentSort = (column.sortByField === this.props.currentSort.field);
+      let isCurrentSort = (column.sortByField === this.props.currentSort.field);
       return (
         <SortableTh
           displayClass={column.className}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/table/sortable_table/sortable_th.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/table/sortable_table/sortable_th.jsx
@@ -10,7 +10,7 @@ export default class SortableTh extends React.Component {
     if (_.isEmpty(this.props.displayName)) {
       return;
     }
-    var newDirection;
+    let newDirection;
     if (this.props.isCurrentSort) {
     // Toggle the sort direction if it has already been selected.
       newDirection = (this.props.sortDirection === 'asc') ? 'desc' : 'asc';
@@ -23,7 +23,7 @@ export default class SortableTh extends React.Component {
   };
 
   render() {
-    var arrow,
+    let arrow,
       className = 'sorter';
     if (this.props.isCurrentSort && !_.isEmpty(this.props.displayName)) {
       arrow = <i className={this.arrowClass()} />;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/text_input.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/text_input.jsx
@@ -4,12 +4,12 @@ import _ from 'underscore'
 
 export default class TextInput extends React.Component {
   componentDidMount() {
-    var that = this;
+    let that = this;
     if (this.determineType() == 'file') {
       $('#' + this.getId()).fileupload({
         dataType: 'json',
         add: function (e, data) {
-          var file = data.files[0]
+          let file = data.files[0]
           that.props.update(that.props.name, file);
         }
       });
@@ -21,11 +21,11 @@ export default class TextInput extends React.Component {
   };
 
   titleCase = (string) => {
-    var words = string.split(' ')
-    var TitleCaseWords = _.map(words, function (word) {
+    let words = string.split(' ')
+    let TitleCaseWords = _.map(words, function (word) {
       return this.titleCaseHelper(word)
     }, this);
-    var result = _.reduce(TitleCaseWords, function (acc, word) {
+    let result = _.reduce(TitleCaseWords, function (acc, word) {
       return acc + ' ' + word;
     }, '')
 
@@ -41,7 +41,7 @@ export default class TextInput extends React.Component {
   };
 
   determineType = () => {
-    var type = null;
+    let type = null;
     if (this.props.type != undefined) {
       type = this.props.type
     } else if (this.props.name === 'password') {
@@ -71,7 +71,7 @@ export default class TextInput extends React.Component {
   };
 
   determineError = () => {
-    var errorKey, error;
+    let errorKey, error;
     errorKey = this.determineErrorKey();
     if ((this.props.errors) && (this.props.errors[errorKey])) {
       error = this.props.errors[errorKey][0];
@@ -82,7 +82,7 @@ export default class TextInput extends React.Component {
   };
 
   displayErrors = () => {
-    var error, result;
+    let error, result;
     error = this.determineError();
 
     if ((error !== null) && (error !== undefined)) {
@@ -98,7 +98,7 @@ export default class TextInput extends React.Component {
   };
 
   getUpdateFn = () => {
-    var fn = null
+    let fn = null
     if (this.determineType() !== 'file') {
       fn = this.update;
     }
@@ -106,7 +106,7 @@ export default class TextInput extends React.Component {
   };
 
   determineInputTag = () => {
-    var result;
+    let result;
     if (this.props.size == 'medium') {
       result = (<textarea
         defaultValue={this.determine('default', null)}
@@ -146,7 +146,7 @@ export default class TextInput extends React.Component {
   };
 
   render() {
-    var result;
+    let result;
     if (this.props.isSingleRow) {
       result = this.determineInputTag();
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/text_input_generator.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/text_input_generator.jsx
@@ -5,7 +5,7 @@ import TextInput from '../../general_components/text_input'
 
 export default function (component, update, options) {
 
-  var config = {
+  let config = {
     errors: [],
     update: update
   };
@@ -14,8 +14,8 @@ export default function (component, update, options) {
     config = _.merge(config, options)
   }
 
-  var _fun1 = function (ele) {
-    var default1;
+  let _fun1 = function (ele) {
+    let default1;
     if (ele.default) {
       default1 = ele.default
     } else if (component.state.model) {
@@ -47,7 +47,7 @@ export default function (component, update, options) {
   };
 
   this.generate = function (fieldObjs) {
-    var inputs;
+    let inputs;
     if (config.update !== null) {
       inputs = _.map(fieldObjs, _fun1)
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/fnl.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/fnl.jsx
@@ -5,7 +5,7 @@ import _ from 'underscore'
 export default  function () {
 
   this.toggle = function (array, item) {
-    var newArray, alreadyThere;
+    let newArray, alreadyThere;
     alreadyThere = _.contains(array, item)
     if (alreadyThere) {
       newArray = _.reject(array, function (ele) {return ele == item});
@@ -16,7 +16,7 @@ export default  function () {
   };
 
   this.toggleById = function (array, item) {
-    var newArray, alreadyThere, extant;
+    let newArray, alreadyThere, extant;
     extant = _.find(array, function (ele) { return ele.id === item.id })
     alreadyThere = (extant != undefined)
     if (alreadyThere) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/indicator_generator.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/indicator_generator.jsx
@@ -3,7 +3,7 @@ export default function (getModelState, setModelState, fnl) {
 
   this.stateItemToggler = function (key) {
     return function (item, boolean) {
-      var x = fnl.toggle(getModelState(key), item);
+      let x = fnl.toggle(getModelState(key), item);
       setModelState(key, x);
     }
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/nested_resource.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/nested_resource.jsx
@@ -3,16 +3,16 @@ import _ from 'underscore'
 export default function (component, kind) {
   // returns a set of data, options
   this.add = function (resource) {
-    var newModel = component.state.model
-    var newNest = _.chain(newModel[kind]).push(resource).value()
+    let newModel = component.state.model
+    let newNest = _.chain(newModel[kind]).push(resource).value()
     newModel[kind] = newNest;
     return newModel
   }
 
 
   this.remove = function (resource) {
-    var newModel = component.state.model
-    var newNest = _.reject(newModel[kind], function (r) { return r.id == resource.id })
+    let newModel = component.state.model
+    let newNest = _.reject(newModel[kind], function (r) { return r.id == resource.id })
     newModel[kind] = newNest;
     return newModel
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/option_loader.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/option_loader.jsx
@@ -3,16 +3,16 @@ import _ from 'underscore'
 
 export default function (modelOptions, setStateByKey, server) {
 
-  var optionTypesObjArr;
+  let optionTypesObjArr;
 
-  var results = {};
+  let results = {};
 
-  var updateState = function () {
-    var total = {...initialOptions, ...results}
+  let updateState = function () {
+    let total = {...initialOptions, ...results}
     setStateByKey('options', total);
   }
 
-  var updater = function (optionType) {
+  let updater = function (optionType) {
     return function (data) {
       results[optionType] = data[optionType];
       if (Object.keys(results).length == optionTypesObjArr.length) {
@@ -21,9 +21,9 @@ export default function (modelOptions, setStateByKey, server) {
     }
   }
 
-  var retrieve = function (optionTypeObj) {
-    var optionType = optionTypeObj.name;
-    var url = (optionTypeObj.cmsController ? ['/cms/', optionType].join('') : null)
+  let retrieve = function (optionTypeObj) {
+    let optionType = optionTypeObj.name;
+    let url = (optionTypeObj.cmsController ? ['/cms/', optionType].join('') : null)
     server.getStateFromServer(optionType, url, updater);
   }
 
@@ -32,8 +32,8 @@ export default function (modelOptions, setStateByKey, server) {
     _.each(optionTypesObjArr, retrieve)
   }
 
-  var initialOptions;
-  var initialOptionsMaker = function () {
+  let initialOptions;
+  let initialOptionsMaker = function () {
     initialOptions = _.reduce(modelOptions, function (hash, ele) {
       hash[ele.name] = ele.value;
       return hash

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/scrollify.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/scrollify.jsx
@@ -14,14 +14,14 @@ import _ from 'underscore'
 import $ from 'jquery'
 export default function () {
 
-  var _scrollComputation = function (selector, component) {
-    var y = $(selector).height();
-    var w = 1/(component.state.currentPage + 1);
-    var z = y*(1 - w);
+  let _scrollComputation = function (selector, component) {
+    let y = $(selector).height();
+    let w = 1/(component.state.currentPage + 1);
+    let z = y*(1 - w);
     return z;
   };
 
-  var _loadMore = function (component) {
+  let _loadMore = function (component) {
     component.fetchData();
   };
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/data.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/data.jsx
@@ -6,28 +6,28 @@ import Normalizer from './normalizer'
 
 export default function () {
 
-  var _modules = {
+  let _modules = {
     fileProcessor: new FileProcessor(),
     normalizer: new Normalizer()
   }
 
-  var _constructData = function (resourceNameSingular) {
+  let _constructData = function (resourceNameSingular) {
     return function (data) {
-      var hash = {}
+      let hash = {}
       hash[resourceNameSingular] = data
       return hash;
     }
   }
 
-  var _normalizer = function (fieldDatas) {
+  let _normalizer = function (fieldDatas) {
     return function (data) {
       return _modules.normalizer.process(data, fieldDatas);
     }
   }
 
-  var _partsPicker = function (savingKeys) {
+  let _partsPicker = function (savingKeys) {
     return function (data) {
-      var result;
+      let result;
       if (savingKeys && savingKeys.length) {
         result = _.pick(data, savingKeys);
       } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/file_processor.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/file_processor.jsx
@@ -8,15 +8,15 @@ export default  function () {
 
   // can probably move this into EC.fnl
   var _getAllValues = function (value) {
-    var values;
-    var total;
+    let values;
+    let total;
 
     if (value instanceof Object) {
       values = _.values(value);
-      var next = _.map(values, function (val) {
+      let next = _.map(values, function (val) {
         return _getAllValues(val);
       })
-      var flattenedNext = _.flattenDeep(next);
+      let flattenedNext = _.flattenDeep(next);
       total = _(values).concat(flattenedNext).value();
     } else {
       total = [value];
@@ -24,11 +24,11 @@ export default  function () {
     return total;
   }
 
-  var _isFile = function (item) {
+  let _isFile = function (item) {
     return item instanceof File;
   }
 
-  var _includesFile = function (array) {
+  let _includesFile = function (array) {
     return (_.filter(array, _isFile).length !== 0)
   }
 
@@ -36,10 +36,10 @@ export default  function () {
   var _intoFormData = function (obj, form, namespace) {
     // FROM : (with correction that commenter pointed out aboug passing in namespace to recursive call) : https://gist.github.com/ghinda/8442a57f22099bdb2e34
     // works because of http://stackoverflow.com/questions/12854259/square-brackets-in-name-attribute-of-input-tag
-    var fd = form || new FormData();
-    var formKey;
+    let fd = form || new FormData();
+    let formKey;
 
-    for(var property in obj) {
+    for(let property in obj) {
       if(obj.hasOwnProperty(property)) {
 
         if(namespace) {
@@ -68,7 +68,7 @@ export default  function () {
 
 
   this.process = function (data) {
-    var values, newData;
+    let values, newData;
 
     values = _getAllValues(data);
     if (_includesFile(values)) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/normalizer.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/data/normalizer.jsx
@@ -4,15 +4,15 @@ import _ from 'lodash'
 
 export default function () {
 
-  var _replace = function (obj, oldField, newField, newValue) {
+  let _replace = function (obj, oldField, newField, newValue) {
     var newObject = {}
     newObject[newField] = newValue;
     var newObject = _.chain(newObject).merge(obj).omit(oldField).value();
     return newObject
   }
 
-  var _getValue = function (object, oldField) {
-    var oldVal, newVal;
+  let _getValue = function (object, oldField) {
+    let oldVal, newVal;
     oldVal = object[oldField]
     if (oldVal instanceof Array) {
       newVal = oldVal.map((el) => el.id)
@@ -22,11 +22,11 @@ export default function () {
     return newVal;
   }
 
-  var _normalizeField = function (object, fieldData) {
-    var fieldName = fieldData.name;
-    var fieldIdName = fieldData.idName;
-    var value = _getValue(object, fieldName)
-    var newObject = _replace(object, fieldName, fieldIdName, value)
+  let _normalizeField = function (object, fieldData) {
+    let fieldName = fieldData.name;
+    let fieldIdName = fieldData.idName;
+    let value = _getValue(object, fieldName)
+    let newObject = _replace(object, fieldName, fieldIdName, value)
     return newObject
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/params.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/params.jsx
@@ -23,21 +23,21 @@ export default  function () {
   }
 
   var _paramAdder = function (fn) {
-    var hash = fn.apply(null, _.rest(arguments));
+    let hash = fn.apply(null, _.rest(arguments));
     return function (params) {
-      var result = _.extend({}, params, hash)
+      let result = _.extend({}, params, hash)
       return result
     }
   }
 
   var _paramAdder2 = function (fn) {
     return function (params) {
-      var hash = fn.apply(null, [params]);
+      let hash = fn.apply(null, [params]);
       return _.extend({}, params, hash)
     }
   }
 
-  var _defaultCallback = function (data) {}
+  let _defaultCallback = function (data) {}
   var _callbackParam = function (callback) {
     var callback = (callback? callback : _defaultCallback)
     return {success: callback}
@@ -48,13 +48,13 @@ export default  function () {
   }
 
   var _urlParam = function (id, resourceNamePlural, urlPrefix) {
-    var suffix = id ? ('/' + id) : null;
-    var url = [urlPrefix, '/', resourceNamePlural, suffix].join('');
+    let suffix = id ? ('/' + id) : null;
+    let url = [urlPrefix, '/', resourceNamePlural, suffix].join('');
     return {url: url}
   }
 
   var _typeParam = function (id) {
-    var type = id ? 'PUT' : 'POST'
+    let type = id ? 'PUT' : 'POST'
     return {type: type}
   }
 
@@ -64,8 +64,8 @@ export default  function () {
 
 
   var _paramsForFormOrNot = function (params) {
-    var extras
-    var dataObj = params.data // data is of the form {resourceNameSingular: hash | FormData}
+    let extras
+    let dataObj = params.data // data is of the form {resourceNameSingular: hash | FormData}
     if (dataObj instanceof FormData) {
       extras = {processData: false, contentType: false}
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/saver.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/saver.jsx
@@ -6,7 +6,7 @@ import _ from 'underscore'
 
 export default  function () {
 
-  var _modules = {
+  let _modules = {
     data:   new Data(),
     params: new Params()
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/server.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/server/server.jsx
@@ -7,22 +7,22 @@ import $ from 'jquery'
 
 export default  function (resourceNameSingular, resourceNamePlural, urlPrefix) {
 
-  var _urlPrefix = urlPrefix;
+  let _urlPrefix = urlPrefix;
 
-  var _modules = {
+  let _modules = {
     saver: new Saver()
   }
 
-  var _saveCallback = function () {}
+  let _saveCallback = function () {}
 
-  var _destroyHelper = function (url, callback) {
+  let _destroyHelper = function (url, callback) {
     var callback = (callback ? callback : _saveCallback);
     $.ajax({url: url, type: 'DELETE', success: callback})
   }
 
-  var _indexCallbackGenerator = function (updater) {
+  let _indexCallbackGenerator = function (updater) {
     return function (data) {
-      var gold = data[resourceNamePlural];
+      let gold = data[resourceNamePlural];
       updater(gold)
     }
   }
@@ -35,8 +35,8 @@ export default  function (resourceNameSingular, resourceNamePlural, urlPrefix) {
   // SAVE
   this.save = function (data, options) {
     var options = _.merge({}, options, {urlPrefix: _urlPrefix});
-    var hash = _modules.saver.process(data, resourceNameSingular, resourceNamePlural, options);
-    var ajax = options.ajax ? options.ajax : $.ajax // so we can stub out in tests
+    let hash = _modules.saver.process(data, resourceNameSingular, resourceNamePlural, options);
+    let ajax = options.ajax ? options.ajax : $.ajax // so we can stub out in tests
     return ajax(hash); // return for tests purposes
   }
 
@@ -46,13 +46,13 @@ export default  function (resourceNameSingular, resourceNamePlural, urlPrefix) {
     $.get(url, {}, callback(resource), 'json');
   };
   this.getModels = function (updater) {
-    var url = [_urlPrefix, '/', resourceNamePlural].join('');
+    let url = [_urlPrefix, '/', resourceNamePlural].join('');
     $.get(url, {}, _indexCallbackGenerator(updater), 'json');
   }
 
   // DESTROY
   this.cmsDestroy = function (id, callback) {
-    var url = ['/cms/', resourceNamePlural, '/', id].join('');
+    let url = ['/cms/', resourceNamePlural, '/', id].join('');
     _destroyHelper(url, callback)
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/setter.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/setter.jsx
@@ -5,9 +5,9 @@
 import _ from 'underscore'
 
 //http://stackoverflow.com/questions/14843815/recursive-deep-extend-assign-in-underscore-js
-var _deepFunction = function(mergeArrays) {
+let _deepFunction = function(mergeArrays) {
   var f = function(a, b) {
-    var result;
+    let result;
     if (_.isArray(a) && _.isArray(b)) {
       if (mergeArrays) {
         result = a.concat(b)
@@ -25,7 +25,7 @@ var _deepFunction = function(mergeArrays) {
 }
 
 export default function (object, path, value, mergeArrays) {
-  var pathArr, len, keysExceptLastKey, lastKey, _deep;
+  let pathArr, len, keysExceptLastKey, lastKey, _deep;
   _deep = _deepFunction(mergeArrays)
 
   if (!path) {
@@ -36,7 +36,7 @@ export default function (object, path, value, mergeArrays) {
     keysExceptLastKey = _.take(pathArr, len -1);
     lastKey = pathArr[len - 1]
 
-    var nestedItem = _.reduce(keysExceptLastKey, function (acc, ele) {
+    let nestedItem = _.reduce(keysExceptLastKey, function (acc, ele) {
       if (! acc[ele]) acc[ele] = {}
       return acc[ele]
     }, object)

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/string.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/string.jsx
@@ -4,7 +4,7 @@
 export default  function () {
 
   this.sayNumberOfThings = function (number, singular, plural) {
-    var value;
+    let value;
     if (number == 1) {
       value = singular;
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/updater.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/updater.jsx
@@ -6,7 +6,7 @@ import setter from './setter'
 export default function (component) {
   this.updater = function (path) {
     return function (value) {
-      var x = setter(component.state, path, value)
+      let x = setter(component.state, path, value)
       component.setState(x)
     }
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/progress_report.jsx
@@ -54,7 +54,7 @@ export default createReactClass({
   },
 
   componentDidMount: function() {
-    var sortDefinitions = this.props.sortDefinitions();
+    let sortDefinitions = this.props.sortDefinitions();
     this.defineSorting(sortDefinitions.config, sortDefinitions.default);
     // Pass true to fetchData on mount becuase we only want to use the query params on the first load.
     this.fetchData(true);
@@ -81,7 +81,7 @@ export default createReactClass({
 
   // Get results with all filters, sorting
   getFilteredResults: function() {
-    var allResults = this.state.results;
+    let allResults = this.state.results;
     return this.applySorting(allResults);
   },
 
@@ -91,7 +91,7 @@ export default createReactClass({
   },
 
   goToPage: function(page) {
-    var newState = {
+    let newState = {
       currentPage: page
     };
     this.setState(newState, this.fetchData);
@@ -130,7 +130,7 @@ export default createReactClass({
   },
 
   requestParams: function() {
-    var requestParams = _.extend(this.state.currentFilters, {});
+    let requestParams = _.extend(this.state.currentFilters, {});
     if (this.props.pagination) {
       requestParams = _.extend(requestParams, {page: this.state.currentPage});
     }
@@ -183,7 +183,7 @@ export default createReactClass({
   // Depending upon whether or not pagination is implemented,
   // sort results client-side or fetch sorted data from server.
   handleSort: function() {
-    var cb;
+    let cb;
     if (this.props.pagination) {
       cb = this.fetchData;
     } else {
@@ -207,15 +207,15 @@ export default createReactClass({
   },
 
   render: function() {
-    var pagination,
+    let pagination,
       csvExport,
       mainSection,
       faqLink;
-    var filteredResults = this.getFilteredResults();
+    let filteredResults = this.getFilteredResults();
     if (this.props.pagination) {
       pagination = <Pagination currentPage={this.state.currentPage} maxPageNumber={this.props.maxPageNumber} numberOfPages={this.state.numPages} selectPageNumber={this.goToPage} />;
     }
-    var visibleResults = this.getVisibleResults(filteredResults);
+    let visibleResults = this.getVisibleResults(filteredResults);
 
     if (this.props.exportCsv) {
       csvExport = <ExportCsv disabled={!!this.state.disabled} exportType={this.props.exportCsv} filters={this.state.currentFilters} reportUrl={this.props.sourceUrl} teacher={this.state.teacher} />;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/progress_report_filters.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/progress_report_filters.jsx
@@ -37,7 +37,7 @@ export default class ProgressReportFilters extends React.Component {
   };
 
   render() {
-    var filters = [];
+    let filters = [];
     if (_.include(this.props.filterTypes, 'classroom')) {
       filters.push(this.classroomFilter());
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -20,7 +20,7 @@ export default class PremiumBannerBuilder extends React.Component {
   }
 
   fetchData = () => {
-    var that = this;
+    let that = this;
     $.get('/teachers/classrooms/premium')
       .done(function(data) {
         that.setState({
@@ -76,9 +76,9 @@ export default class PremiumBannerBuilder extends React.Component {
   };
 
   hasPremium = () => {
-    var color = this.stateSpecificBackGroundColor();
-    var img = this.stateSpecificBackGroundImage();
-    var divStyle = {
+    let color = this.stateSpecificBackGroundColor();
+    let img = this.stateSpecificBackGroundImage();
+    let divStyle = {
       backgroundColor: color,
       backgroundImage: img
     };

--- a/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/checkbox_sections.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/checkbox_sections.jsx
@@ -28,7 +28,7 @@ export default class CheckboxSections extends React.Component {
   };
 
   pageBasedHelpInfo = (url) => {
-    var text = this.props.dashboard ? 'Guide' : 'View the Guide'
+    let text = this.props.dashboard ? 'Guide' : 'View the Guide'
     return <a href={url}>{text}</a>
   };
 
@@ -37,7 +37,7 @@ export default class CheckboxSections extends React.Component {
   };
 
   optionalInfo = (box) => {
-    var info = [];
+    let info = [];
     if (box.help_info) {
       info.push(<td className='text-right help-info' key={'help-info ' + box.action_url}>{this.pageBasedHelpInfo(box.help_info)}</td>);
     }
@@ -58,8 +58,8 @@ export default class CheckboxSections extends React.Component {
   };
 
   section = () => {
-    var that = this;
-    var boxes = this.sortBoxes().map(box =>
+    let that = this;
+    let boxes = this.sortBoxes().map(box =>
       (<tr className={'completed-' + box.completed} key={box.id}>
         <td className='check-or-number'>{that.checkOrNumber(box)}</td>
         <td className='text-left'><a href={box.action_url}>{box.name}</a></td>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_template_categories/unit_template_category.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_template_categories/unit_template_category.tsx
@@ -90,7 +90,7 @@ export default class UnitTemplateCategory extends React.Component<UnitTemplateCa
 
   render() {
     const { modules, formFields } = this.state
-    var inputs = modules.textInputGenerator.generate(formFields);
+    let inputs = modules.textInputGenerator.generate(formFields);
     return(
       <div className='edit_activity_classification cms-form'>
         {inputs}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccounts.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccounts.jsx
@@ -6,22 +6,22 @@ import React from 'react'
 export default class extends React.Component {
   resourceComponentGenerator = (cmsComponent) => {
 
-    var initialModel = {
+    let initialModel = {
       id: null,
       name: null,
       admins: []
     };
 
-    var savingKeys = ['id', 'name', 'admins', 'teachers'];
-    var fieldsToNormalize = [];
+    let savingKeys = ['id', 'name', 'admins', 'teachers'];
+    let fieldsToNormalize = [];
 
-    var formFields = [
+    let formFields = [
       {
         name: 'name'
       }
     ];
 
-    var nestedResources = [
+    let nestedResources = [
       {
         name: 'admins',
         message: 'must be an existing admin (can create one in the Admin cms)',

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/AdminsEditor.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/AdminsEditor.jsx
@@ -6,17 +6,17 @@ import Cms from './Cms.jsx'
 export default class extends React.Component {
   resourceComponentGenerator = (cmsComponent) => {
 
-    var initialModel = {
+    let initialModel = {
       id: null,
       name: null,
       email: null,
       password: null
     };
 
-    var savingKeys = ['id', 'name', 'email', 'password']
-    var fieldsToNormalize = []
+    let savingKeys = ['id', 'name', 'email', 'password']
+    let fieldsToNormalize = []
 
-    var formFields = [
+    let formFields = [
       {name: 'name'},
       {name: 'email'},
 

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Cms.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Cms.jsx
@@ -10,7 +10,7 @@ export default class Cms extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.initializeModules()
-    var hash1 = {
+    let hash1 = {
       crudState: 'index',
       resourceToEdit: null,
       flag: 'All'
@@ -24,7 +24,7 @@ export default class Cms extends React.Component {
   }
 
   initializeModules = () => {
-    var server = new Server(this.props.resourceNameSingular, this.props.resourceNamePlural);
+    let server = new Server(this.props.resourceNameSingular, this.props.resourceNamePlural);
     this.modules = {
       server: server
     }
@@ -32,7 +32,7 @@ export default class Cms extends React.Component {
 
   // TODO: abstract out below method
   updateState = (key, value) => {
-    var newState = this.state;
+    let newState = this.state;
     newState[key] = value;
     this.setState(newState);
   };
@@ -49,7 +49,7 @@ export default class Cms extends React.Component {
     // FIXME this fn does not have to be so complicated, need to change server module
     let that = this;
     return function (data) {
-      var newState = that.state;
+      let newState = that.state;
       newState[that.props.resourceNamePlural] = data[that.props.resourceNamePlural];
       that.setState(newState);
     }
@@ -181,7 +181,7 @@ export default class Cms extends React.Component {
   };
 
   render() {
-    var result;
+    let result;
     switch (this.state.crudState) {
       case 'index':
         result = this.indexTable();

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/LessonPlanner.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/LessonPlanner.jsx
@@ -151,7 +151,7 @@ export default class LessonPlanner extends React.Component {
 
   filterByGrade = () => {
     const { grade, models, } = this.state.unitTemplatesManager;
-    var uts;
+    let uts;
     if (grade) {
       uts = this._modelsInGrade(grade)
     } else {
@@ -232,14 +232,14 @@ export default class LessonPlanner extends React.Component {
         id: activity.id
       });
     }
-    var sas = this.modules.fnl.toggleById(this.getSelectedActivities(), activity);
+    let sas = this.modules.fnl.toggleById(this.getSelectedActivities(), activity);
     this.updateCreateUnitModel({selectedActivities: sas});
   };
 
   clickAssignButton = () => this.updateUnitTemplatesManager({firstAssignButtonClicked: true});
 
   onFastAssignSuccess = () => {
-    var lastActivity = this.state.unitTemplatesManager.model;
+    let lastActivity = this.state.unitTemplatesManager.model;
     this.analytics().track('click Create Unit', {});
     this.deepExtendState(this.blankState());
     this.updateUnitTemplatesManager({lastActivityAssigned: lastActivity});
@@ -284,7 +284,7 @@ export default class LessonPlanner extends React.Component {
   };
 
   render() {
-    var tabSpecificComponents;
+    let tabSpecificComponents;
     // Ultimately, none of the tab state should exist, and we should transfer
     // entirely to react-router for managing that, along with redux for
     // the general state in this section

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PublicActivityPacks.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PublicActivityPacks.jsx
@@ -27,7 +27,7 @@ export default class PublicActivityPacks extends React.Component {
     this.updateCreateUnitModel = this.modules.updaterGenerator.updater('createUnit.model');
     this.updateUnitTemplatesManager = this.modules.updaterGenerator.updater('unitTemplatesManager');
 
-    var state = {
+    let state = {
       tab: 'manageUnits', // 'createUnit', 'exploreActivityPacks'
       createUnit: {
         stage: 1,
@@ -52,7 +52,7 @@ export default class PublicActivityPacks extends React.Component {
     }
     state.unitTemplatesManager.non_authenticated = !($('#public-activity-packs').data('authenticated'));
     //FIXME: this concern should be handled with a react-router
-    var individualUnitTemplate = $('.teachers-unit-template')[0]
+    let individualUnitTemplate = $('.teachers-unit-template')[0]
     if (individualUnitTemplate) {
       state.tab = 'exploreActivityPacks';
       state.unitTemplatesManager.model_id = $('.teachers-unit-template').data('id');
@@ -65,7 +65,7 @@ export default class PublicActivityPacks extends React.Component {
   }
 
   selectModel = (ut) => {
-    var relatedModels = this._modelsInCategory(ut.unit_template_category.id)
+    let relatedModels = this._modelsInCategory(ut.unit_template_category.id)
     this.updateUnitTemplatesManager({stage: 'profile', model: ut, relatedModels: relatedModels})
     this.modules.windowPosition.reset();
   };
@@ -79,17 +79,17 @@ export default class PublicActivityPacks extends React.Component {
   };
 
   updateUnitTemplateModels = (models) => {
-    var categories =  _.chain(models)
+    let categories =  _.chain(models)
       .pluck('unit_template_category')
       .uniq(_.property('id'))
       .value();
 
-    var newHash = {
+    let newHash = {
       models: models,
       displayedModels: models,
       categories: categories
     }
-    var model_id = this.state.unitTemplatesManager.model_id // would be set if we arrived here from a deep link
+    let model_id = this.state.unitTemplatesManager.model_id // would be set if we arrived here from a deep link
     if (model_id) {
       newHash.model = _.findWhere(models, {id: model_id});
       newHash.stage = 'profile'
@@ -116,7 +116,7 @@ export default class PublicActivityPacks extends React.Component {
   };
 
   fetchClassrooms = () => {
-    var that = this;
+    let that = this;
     requestGet('/teachers/classrooms/retrieve_classrooms_for_assigning_activities',
       (data) => {
         that.updateCreateUnit({options: {classrooms: data.classrooms_and_their_students}})
@@ -130,9 +130,9 @@ export default class PublicActivityPacks extends React.Component {
 
   assign = () => {
     this.fetchClassrooms()
-    var unitTemplate = this.state.unitTemplatesManager.model;
-    var state = this.state;
-    var hash = {
+    let unitTemplate = this.state.unitTemplatesManager.model;
+    let state = this.state;
+    let hash = {
       tab: 'createUnit',
       createUnit: {
         stage: 2,
@@ -160,7 +160,7 @@ export default class PublicActivityPacks extends React.Component {
   };
 
   render() {
-    var tabSpecificComponents;
+    let tabSpecificComponents;
 
     tabSpecificComponents = (<UnitTemplatesManager
       actions={this.unitTemplatesManagerActions()}

--- a/staged_files_eslint.json
+++ b/staged_files_eslint.json
@@ -1,5 +1,7 @@
 {
   "rules": {
+    "eqeqeq": ["error", "smart"],
+    "no-var": "error",
     "jsx-a11y/anchor-is-valid": "error",
     "jsx-a11y/click-events-have-key-events": "error",
     "jsx-a11y/control-has-associated-label": "error",


### PR DESCRIPTION
## WHAT
Add `eqeqeq` and `no-var` rules to the staged files linter.

## WHY
These are two JS linter rules that are part of our styleguide but not something we were actively linting for.

## HOW
Autofix what can be fixed and add new rules to staged file linter. I initially tried to add them to the regular linter, but there were a lot of non-fixable violations and since they do present potential difficult-to-reproduce bugs (like if you have an unexpected datatype for something), I didn't want to just blindly fix all of them and there were too many to test.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-no-var-rule-762833084e494c299998b18b329d17fb
https://www.notion.so/quill/Add-eqeqeq-rule-b0c9e30e48f947648889c15067031306

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - non-app change
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
