### PR TITLE
Fix admin show

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
@@ -20,14 +20,17 @@ class Api::V1::AppSettingsController < ApplicationController
     app_setting = AppSetting.find_by_name!(name)
     user_ids = app_setting.user_ids_allow_list
 
-    emails = User.where(id: user_ids).pluck(:email).compact.sort
+    users = User.where(id: user_ids)
+    emails = users.pluck(:email).compact.sort
+    users_without_emails = users.filter {|u| u.email.nil? }.map{|u| u.name}
 
     render(json: {
       name: name,
       enabled: app_setting.enabled,
       enabled_for_staff: app_setting.enabled_for_staff,
       user_emails_in_allow_list: emails,
-      percent_active: app_setting.percent_active
+      percent_active: app_setting.percent_active,
+      users_without_emails: users_without_emails
     })
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
@@ -20,7 +20,8 @@ class Api::V1::AppSettingsController < ApplicationController
     app_setting = AppSetting.find_by_name!(name)
     user_ids = app_setting.user_ids_allow_list
 
-    emails = User.where(id: user_ids).pluck(:email).sort
+    emails = User.where(id: user_ids).pluck(:email).compact.sort
+
     render(json: {
       name: name,
       enabled: app_setting.enabled,

--- a/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/app_settings_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::AppSettingsController < ApplicationController
 
     users = User.where(id: user_ids)
     emails = users.pluck(:email).compact.sort
-    users_without_emails = users.filter {|u| u.email.nil? }.map{|u| u.name}
+    users_without_emails = users.filter {|u| u.email.nil? }.map {|u| u.name }
 
     render(json: {
       name: name,

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -35,7 +35,7 @@ namespace :app_settings do
 
     app_setting = AppSetting.find_by_name!(args[:name])
 
-    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.uniq.concat(user_ids))
+    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.concat(user_ids).uniq)
     puts "AppSetting #{app_setting.name} has been updated with user list: #{user_ids}."
   end
 end

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -35,7 +35,7 @@ namespace :app_settings do
 
     app_setting = AppSetting.find_by_name!(args[:name])
 
-    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.concat(user_ids))
+    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.uniq.concat(user_ids))
     puts "AppSetting #{app_setting.name} has been updated with user list: #{user_ids}."
   end
 end

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       expect(response).to be_success
       expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com c@d.com))
     end
+
+    it 'should handle users with nil emails gracefully' do
+      user1 = create(:user, email: 'a@b.com')
+      user2 = create(:user, email: nil)
+
+      create(:app_setting, name: 'lorem', enabled: false, user_ids_allow_list: [user1.id, user2.id])
+
+      get :admin_show, params: { name: 'lorem' }, as: :json
+
+      expect(response).to be_success
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
+    end
   end
 
 

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       expect(response).to be_success
       expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
     end
+
+    it 'should return the names of users without emails' do
+      user1 = create(:user, email: 'a@b.com')
+      user2 = create(:user, name: 'No Email', email: nil)
+
+      create(:app_setting, name: 'lorem', enabled: false, user_ids_allow_list: [user1.id, user2.id])
+
+      get :admin_show, params: { name: 'lorem' }, as: :json
+
+      expect(response).to be_success
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
+      expect(JSON.parse(response.body)['users_without_emails']).to eq([user2.name])
+    end
   end
 
 


### PR DESCRIPTION
## WHAT
- adds nil guard so that quill.org/api/v1/app_settings/comprehension/admin_show does not throw exception when `User.email` is nil
- adds additional diagnostic property to the admin json payload: users without emails
- dedupes `AppSetting.user_ids_allow_list` during the rake task upload (duplicates were invisibly accumulating in the database)

## WHY
So that the admin AppSetting tool can become usable
So that unnecessary data does not accumulate in AppSetting.user_ids_allow_list 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/app_settings-admin_show-throws-exception-40f76a502b2a4dc1ad33e917aece999c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
