### PR TITLE
lms/confirm-touch-chains

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -38,8 +38,9 @@ class ClassroomUnit < ApplicationRecord
   validates :unit, uniqueness: { scope: :classroom }
   before_save :check_for_assign_on_join_and_update_students_array_if_true
   after_save  :hide_appropriate_activity_sessions
-  after_touch :touch_classroom_without_callbacks
-  after_save :touch_classroom_without_callbacks
+  # Using an after_commit hook here because we want to trigger the callback
+  # on save or touch, and touch explicitly bypasses after_save hooks
+  after_commit :touch_classroom_without_callbacks
 
   # this method does not seem to be getting used, but leaving it in for the tests for now
   def assigned_students

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -38,6 +38,7 @@ class ClassroomUnit < ApplicationRecord
   validates :unit, uniqueness: { scope: :classroom }
   before_save :check_for_assign_on_join_and_update_students_array_if_true
   after_save  :hide_appropriate_activity_sessions
+  after_touch :touch_classroom_without_callbacks
   after_save :touch_classroom_without_callbacks
 
   # this method does not seem to be getting used, but leaving it in for the tests for now

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -119,6 +119,6 @@ class ClassroomUnit < ApplicationRecord
   end
 
   private def touch_classroom_without_callbacks
-    classroom&.update_columns(updated_at: current_time_from_proper_timezone)
+    classroom&.update_columns(updated_at: current_time_from_proper_timezone) unless classroom&.destroyed?
   end
 end

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -44,8 +44,9 @@ class Unit < ApplicationRecord
   belongs_to :unit_template
   after_save :hide_classroom_units_and_unit_activities_if_visible_false
   after_save :create_any_new_classroom_unit_activity_states
-  after_touch :touch_all_classrooms_and_classroom_units
-  after_save :touch_all_classrooms_and_classroom_units
+  # Using an after_commit hook here because we want to trigger the callback
+  # on save or touch, and touch explicitly bypasses after_save hooks
+  after_commit :touch_all_classrooms_and_classroom_units
 
   def hide_if_no_visible_unit_activities
     return if unit_activities.where(visible: true).exists?

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -44,7 +44,7 @@ class Unit < ApplicationRecord
   belongs_to :unit_template
   after_save :hide_classroom_units_and_unit_activities_if_visible_false
   after_save :create_any_new_classroom_unit_activity_states
-  after_touch :save
+  after_touch :touch_all_classrooms_and_classroom_units
   after_save :touch_all_classrooms_and_classroom_units
 
   def hide_if_no_visible_unit_activities

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -157,14 +157,19 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
 
   describe '#unpin_and_lock_activity' do
     let(:unit_activity) { UnitActivity.find_by(unit: classroom_unit.unit, activity: activity) }
+    let!(:classroom_unit_activity_state) do
+      create(:classroom_unit_activity_state,
+        classroom_unit: classroom_unit,
+        unit_activity: unit_activity,
+        pinned: true,
+        locked: false
+      )
+    end
 
     before { session[:user_id] = teacher.id }
 
 
     it 'should unpin and lock the state of classroom unit activity' do
-      classroom_unit_activity_state = ClassroomUnitActivityState.find_by(unit_activity_id: unit_activity.id, classroom_unit_id: classroom_unit.id)
-      classroom_unit_activity_state.update_columns(pinned: true, locked: false)
-
       put :unpin_and_lock_activity,
         params: {
           activity_id: activity.uid,

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -171,6 +171,15 @@ describe ClassroomUnit, type: :model, redis: true do
       expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
     end
 
+    it "should update classrooms updated_t on classroom_unit touch" do
+      classroom.update_columns(updated_at: initial_time)
+      classroom_updated_at = classroom.reload.updated_at
+
+      classroom_unit.touch
+
+      expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
+    end
+
     context "with a hidden classroom" do
       let(:classroom) { create(:classroom, visible: false) }
       let(:classroom_unit) { create(:classroom_unit, classroom: classroom)}

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -153,4 +153,35 @@ describe Unit, type: :model do
       expect{ unit.email_lesson_plan }.to change(LessonPlanEmailWorker.jobs, :size).by 1
     end
   end
+
+  describe '#touch_all_classrooms_and_classroom_units' do
+    let(:initial_time) { Time.now - 1.day}
+    let!(:unit) { create(:unit) }
+    let!(:classroom) { create(:classroom) }
+    let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, unit: unit)}
+
+    it "should update classrooms and classroom_units updated_at on unit save" do
+      classroom.update_columns(updated_at: initial_time)
+      classroom_updated_at = classroom.reload.updated_at
+      classroom_unit.update_columns(updated_at: initial_time)
+      classroom_unit_updated_at = classroom_unit.reload.updated_at
+
+      unit.save
+
+      expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
+      expect(classroom_unit.reload.updated_at.to_i).not_to equal(classroom_unit_updated_at.to_i)
+    end
+
+    it "should update classrooms updated_t on classroom_unit touch" do
+      classroom.update_columns(updated_at: initial_time)
+      classroom_updated_at = classroom.reload.updated_at
+      classroom_unit.update_columns(updated_at: initial_time)
+      classroom_unit_updated_at = classroom_unit.reload.updated_at
+
+      unit.touch
+
+      expect(classroom.reload.updated_at.to_i).not_to equal(classroom_updated_at.to_i)
+      expect(classroom_unit.reload.updated_at.to_i).not_to equal(classroom_unit_updated_at.to_i)
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Update the way we bubble-up touches with custom callbacks
## WHY
To avoid some performance issues, we've had to write some custom callbacks to simulate `touch` behavior on a couple of models.  One of those custom callbacks wasn't being called in all situations.  The hope is that this fixes our cache invalidation process so that we can turn caching back on if this code doesn't cause performance issues of its own.
## HOW
1. Add an `after_touch` hook to `ClassroomUnit` as this is a likely cause of our failure to invalidate caches (`ActivitySession` calls `touch` on `ClassroomUnit`, but that wasn't triggering the `touch_classroom_without_callbacks` function, so we weren't managing to update the `Classroom.updated_at` values which are the key value in our current caching regime).
2. Instead of using `after_touch :save` in `Unit`, call our custom touch function directly.  `save` may trigger other callbacks which we don't want to pay the overhead for, so this is a little bit safer (even though the original way we were doing it didn't seem to be causing issues at the moment).
3. Add tests to our models to ensure that our touch callbacks trigger on `save` AND `touch`

### Notion Card Links
https://www.notion.so/quill/Cache-invalidation-fix-a5902d4aa1f04598926a635949ba098b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
