### PR TITLE
Evidence/fix highlight validation

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -63,7 +63,7 @@ module Evidence
       return unless highlight_type == 'passage'
 
       related_passages = feedback.rule.prompts.map(&:activity).uniq.map(&:passages).flatten
-      invalid_ids = related_passages.reject {|p| p.text.include?(text)}.map {|p| p.activity.id}
+      invalid_ids = related_passages.reject {|p| strip_tags(p.text).include?(text)}.map {|p| p.activity.id}
       return if invalid_ids.empty?
 
       invalid_ids
@@ -79,6 +79,10 @@ module Evidence
 
     private def second_order
       feedback.order == 1
+    end
+
+    private def strip_tags(input)
+      ::ActionController::Base.helpers.strip_tags(input)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -63,7 +63,7 @@ module Evidence
       return unless highlight_type == 'passage'
 
       related_passages = feedback.rule.prompts.map(&:activity).uniq.map(&:passages).flatten
-      invalid_ids = related_passages.reject {|p| strip_tags(p.text).include?(text)}.map {|p| p.activity.id}
+      invalid_ids = related_passages.reject {|p| strip_tags(p.text).include?(strip_tags(text))}.map {|p| p.activity.id}
       return if invalid_ids.empty?
 
       invalid_ids

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220201131639) do
+ActiveRecord::Schema.define(version: 20220201161535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,8 @@ ActiveRecord::Schema.define(version: 20220201131639) do
     t.text "max_attempts_feedback"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_strong_example", default: ""
+    t.string "second_strong_example", default: ""
     t.index ["activity_id"], name: "index_comprehension_prompts_on_activity_id"
   end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
@@ -44,6 +44,12 @@ module Evidence
         expect(highlight.invalid_activity_ids).to be_nil
       end
 
+      it 'should return nil if the is contained n the passage after HTML tags are stripped from the highlight' do
+        tag_wrapped_words = highlight.text.split.map{ |word| "<b>#{word}</b>" }.join(" ")
+        highlight.update(text: tag_wrapped_words)
+        expect(highlight.invalid_activity_ids).to be_nil
+      end
+
       it 'should return an array of activity_ids for activities that have unmatched passages' do
         highlight.update(text: 'text that definitely is not in the passage')
         expect(highlight.invalid_activity_ids).to include(activity.id)

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
@@ -38,6 +38,12 @@ module Evidence
         expect(highlight.invalid_activity_ids).to be_nil
       end
 
+      it 'should return nil if the passages include HTML tags but otherwise contain the highlight' do
+        tag_wrapped_words = highlight.text.split.map{ |word| "<b>#{word}</b>" }.join(" ")
+        activity.passages.first.update(text: tag_wrapped_words)
+        expect(highlight.invalid_activity_ids).to be_nil
+      end
+
       it 'should return an array of activity_ids for activities that have unmatched passages' do
         highlight.update(text: 'text that definitely is not in the passage')
         expect(highlight.invalid_activity_ids).to include(activity.id)


### PR DESCRIPTION
## WHAT
Strip HTML from both the Passage text and Highlight text before comparing the two to make sure that passage Highlights are referencing text actually found in the Passage.
NOTE: The changes to `engines/evidence/spec/models/evidence/highlight_spec.rb` are triggered by running a migration from an earlier PR, so doesn't need to be reviewed here.
## WHY
We "invisibly" include HTML tags on both the Passage text and Highlight text due to the components we use to create and edit them.  But the fact that highlights were sub-strings of passages meant that they had closing tags in places the Passage text didn't.  Stripping HTML tags from both sides before making the comparison matches the behavior that we do on the front-end
## HOW
Use the Rails helper to strip tags from both segments of text before comparing them to make sure that the Passage text includes the Highlight text when checking for highlight validity.  (Note, this is not a commit-level validation, despite the terminology.)

### Screenshots
Old validation results with Staging data:
![image](https://user-images.githubusercontent.com/331565/154369839-5350fd01-e460-4353-9b22-3a7e9aed23be.png)
New validation results with Staging data:
![image](https://user-images.githubusercontent.com/331565/154369885-c590df51-3f68-4e90-8cca-91a245da9ee0.png)

### Notion Card Links
https://www.notion.so/quill/Evidence-highlight-validation-flags-every-rule-with-highlighting-497933720ca14fcfb1083abce0d459d1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
