### PR TITLE
cms/drop-unused-response-question-uid-index

### DIFF
--- a/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
+++ b/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
@@ -1,5 +1,5 @@
 class DropResponseQuestionUidIndex < ActiveRecord::Migration[6.1]
-  def up 
+  def up
     remove_index :responses, :question_uid
   end
 

--- a/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
+++ b/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
@@ -1,0 +1,9 @@
+class DropResponseQuestionUidIndex < ActiveRecord::Migration[6.1]
+  def up 
+    remove_index :responses, :question_uid
+  end
+
+  def down
+    add_index :responses, :question_uid
+  end
+end

--- a/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
+++ b/services/QuillCMS/db/migrate/20220218165350_drop_response_question_uid_index.rb
@@ -4,6 +4,21 @@ class DropResponseQuestionUidIndex < ActiveRecord::Migration[6.1]
   end
 
   def down
+    original_timeout = db_timeout
+    db_set_timeout(RefreshResponsesViewWorker::REFRESH_TIMEOUT)
+
     add_index :responses, :question_uid
+  ensure
+    db_set_timeout(original_timeout)
+  end
+
+  private def db_set_timeout(time_string)
+    escaped_time_string = quote(time_string)
+
+    execute("SET statement_timeout = #{escaped_time_string}")
+  end
+
+  private def db_timeout
+    execute('SHOW statement_timeout').first['statement_timeout']
   end
 end

--- a/services/QuillCMS/db/schema.rb
+++ b/services/QuillCMS/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_12_215158) do
+ActiveRecord::Schema.define(version: 2022_02_18_165350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,9 +35,7 @@ ActiveRecord::Schema.define(version: 2021_08_12_215158) do
     t.index ["count"], name: "index_responses_on_count"
     t.index ["optimal"], name: "index_responses_on_optimal"
     t.index ["parent_id"], name: "index_responses_on_parent_id"
-    t.index ["parent_uid"], name: "index_responses_on_parent_uid"
-    t.index ["question_uid"], name: "index_responses_on_question_uid"
-    t.index ["text"], name: "index_responses_on_text"
+    t.index ["question_uid", "text"], name: "index_responses_on_question_uid_and_text", unique: true
     t.index ["uid"], name: "index_responses_on_uid"
   end
 


### PR DESCRIPTION
## WHAT
Add a migration to drop the unused responses (question_uid) index
## WHY
It is superceded in all queries by the (question_uid, text) index
## HOW
Just add a migration file

### Notion Card Links
https://www.notion.so/quill/CMS-Database-Drop-Indexes-9a32c35a20cb4e46a6921f278ef33d44

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No functionality changes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
