### PR TITLE
lms/fix-inconsistent-test

### DIFF
--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -58,16 +58,16 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to eq([student1, student2, student3])
-        expect(@activity_sessions).to eq([activity_session1, activity_session2])
+        expect(@assigned_students).to include(*[student1, student2, student3])
+        expect(@activity_sessions).to include(*[activity_session1, activity_session2])
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit.remove_assigned_student(student1.id)
         classroom_unit.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to eq([student2, student3])
-        expect(@activity_sessions).to eq([activity_session2])
+        expect(@assigned_students).to include(*[student2, student3])
+        expect(@activity_sessions).to include(activity_session2)
       end
     end
 
@@ -91,16 +91,16 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit, with only one per student' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to eq([student1, student2, student3])
-        expect(@activity_sessions).to eq([activity_session3, activity_session1])
+        expect(@assigned_students).to include(*[student1, student2, student3])
+        expect(@activity_sessions).to include(*[activity_session3, activity_session1])
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit1.remove_assigned_student(student1.id)
         classroom_unit1.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to eq([student2, student3])
-        expect(@activity_sessions).to eq([activity_session3])
+        expect(@assigned_students).to include(*[student2, student3])
+        expect(@activity_sessions).to include(activity_session3)
       end
 
     end

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -58,15 +58,15 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to include(*[student1, student2, student3])
-        expect(@activity_sessions).to include(*[activity_session1, activity_session2])
+        expect(@assigned_students).to include(student1, student2, student3)
+        expect(@activity_sessions).to include(activity_session1, activity_session2)
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit.remove_assigned_student(student1.id)
         classroom_unit.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to include(*[student2, student3])
+        expect(@assigned_students).to include(student2, student3)
         expect(@activity_sessions).to include(activity_session2)
       end
     end
@@ -91,15 +91,15 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit, with only one per student' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to include(*[student1, student2, student3])
-        expect(@activity_sessions).to include(*[activity_session3, activity_session1])
+        expect(@assigned_students).to include(student1, student2, student3)
+        expect(@activity_sessions).to include(activity_session3, activity_session1)
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit1.remove_assigned_student(student1.id)
         classroom_unit1.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to include(*[student2, student3])
+        expect(@assigned_students).to include(student2, student3)
         expect(@activity_sessions).to include(activity_session3)
       end
 


### PR DESCRIPTION
## WHAT
Refactor tests to use include for array matching instead of eq
## WHY
This means that our tests will pass as long as the two arrays contain the same items even if they are in different orders.  The order may change depending on unpredicable factors at run time.
## HOW
Use `include(item1, item2)` as our test condition rather than `eq([item1, item2])` as the latter will error if the array comes back in the wrong order, but nothing in our code is designed to guarantee order so sometimes tests will spuriously fail if runtime differences cause things to come back in a different order.

See: https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/14560/workflows/c851016a-2d4e-4737-9d10-3e378da2f631/jobs/210249

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, test changes only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
