### PR TITLE
Revert "revert cache (#8793)"

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -137,12 +137,27 @@ class Teachers::ClassroomManagerController < ApplicationController
   end
 
   def scores
-    scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
-    last_page = scores.length < 200
-    render json: {
-      scores: scores,
-      is_last_page: last_page
+    classroom = Classroom.find(params[:classroom_id])
+    cache_groups = {
+      unit: params[:unit_id],
+      page: params[:current_page],
+      begin: params[:begin_date],
+      end: params[:end_date],
+      offset: current_user.utc_offset
     }
+
+    json = current_user.classroom_cache(classroom, key: 'classroom_manager.scores', groups: cache_groups) do
+      scores = Scorebook::Query.run(params[:classroom_id], params[:current_page], params[:unit_id], params[:begin_date], params[:end_date], current_user.utc_offset)
+
+      last_page = scores.length < 200
+
+      {
+        scores: scores,
+        is_last_page: last_page
+      }
+    end
+
+    render json: json
   end
 
   def my_account


### PR DESCRIPTION
## WHAT
Revert "revert cache (#8793)"
## WHY
Now that we think we've resolved the `touch` chain issue with cache invalidation, we're ready to turn a report cache back on to test that.  I talked to Support, and this was the report that they thought was the best candidate to confirm that caching is working as expected in production.
## HOW
Revert the removal of this caching code so that it is reinstated.

### Notion Card Links
https://www.notion.so/quill/Cache-invalidation-fix-a5902d4aa1f04598926a635949ba098b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  This is a reversion to code that was already in production
Have you deployed to Staging? | Doing so now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
