### PR TITLE
lms/fix-inconsistent-diagnostic-reports-test

### DIFF
--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -58,15 +58,15 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to eq([student1, student2, student3])
-        expect(@activity_sessions).to eq([activity_session1, activity_session2])
+        expect(@assigned_students).to include(student1, student2, student3)
+        expect(@activity_sessions).to include(activity_session1, activity_session2)
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit.remove_assigned_student(student1.id)
         classroom_unit.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
-        expect(@assigned_students).to eq([student2, student3])
+        expect(@assigned_students).to include(student2, student3)
         expect(@activity_sessions).to eq([activity_session2])
       end
     end
@@ -91,15 +91,15 @@ describe DiagnosticReports do
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit, with only one per student' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to eq([student1, student2, student3])
-        expect(@activity_sessions).to eq([activity_session3, activity_session1])
+        expect(@assigned_students).to include(student1, student2, student3)
+        expect(@activity_sessions).to include(activity_session3, activity_session1)
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
         classroom_unit1.remove_assigned_student(student1.id)
         classroom_unit1.reload
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
-        expect(@assigned_students).to eq([student2, student3])
+        expect(@assigned_students).to include(student2, student3)
         expect(@activity_sessions).to eq([activity_session3])
       end
 


### PR DESCRIPTION
## WHAT
Use `include` instead of `eq` when testing array contents
## WHY
We don't use an explicit sort when retrieving this data, so we can't guarantee the order that the array will return in.  Most of the time, it returns in the order the test expects, but sometimes it doesn't and that triggers spurious failures.
## HOW
Replace `eq` comparisons with `include` in cases where the `eq` is comparing against a multi-element array

### Notion Card Links
https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/14572/workflows/324ea59e-2017-4aa7-a78c-e5a12bfc323d/jobs/210323

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.  Only tests have changed
Have you deployed to Staging? | No, this is only a change to tests
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
