### PR TITLE
Lms/re enable report caching

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -5,12 +5,13 @@ class Api::V1::ProgressReportsController < Api::ApiController
 
   def activities_scores_by_classroom_data
     classroom_ids = current_user&.classrooms_i_teach&.map(&:id)
-    if classroom_ids.empty?
-      render json: { data: [] }
-    else
-      data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
-      render json: { data: data }
+    return render json: { data: [] } if classroom_ids.empty?
+
+    data = current_user.all_classrooms_cache(key: 'api.v1.progress_reports.activities_scores_by_classroom_data') do
+      ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
     end
+
+    render json: { data: data }
   end
 
   def district_activity_scores

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/students_controller.rb
@@ -9,10 +9,12 @@ class Teachers::ProgressReports::Concepts::StudentsController < Teachers::Progre
   end
 
   private def json_payload
-    {
-      students: students_as_json,
-      classrooms_with_student_ids: current_user.classrooms_i_teach_with_student_ids
-    }
+    current_user.all_classrooms_cache(key: 'teachers.progress_reports.concepts.students') do
+      {
+        students: students_as_json,
+        classrooms_with_student_ids: current_user.classrooms_i_teach_with_student_ids
+      }
+    end
   end
 
   private def students_as_json

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -113,7 +113,11 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def diagnostic_units
-    render json: diagnostics_organized_by_classroom.to_json
+    json = current_user.all_classrooms_cache(key: 'teachers.units.diagnostic_units') do
+      diagnostics_organized_by_classroom.to_json
+    end
+
+    render json: json
   end
 
   # Get all Units containing lessons, and only retrieve the classroom activities for lessons.


### PR DESCRIPTION
## WHAT
Revert some caching reversions
## WHY
In conjunction with support, we've monitored caching impact on the Activity Summary report on production, and have confirmed that it seems to be invalidating as expected.  We want to gain the benefits of caching our other reports now that we think we've fixed the invalidation problem.
## HOW
Just revert the reversions that pulled out the original caching code.

### Notion Card Links
https://www.notion.so/quill/Cache-invalidation-fix-a5902d4aa1f04598926a635949ba098b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around caching
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
