### PR TITLE
fix subscription page bugs part one (#8839)

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/subscriptions.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/subscriptions.scss
@@ -140,6 +140,10 @@
         font-weight: 600;
         color: #666666;
       }
+      a {
+        color: #666;
+        text-decoration: underline;
+      }
     }
   }
 

--- a/services/QuillLMS/app/controllers/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/subscriptions_controller.rb
@@ -74,9 +74,12 @@ class SubscriptionsController < ApplicationController
     if current_subscription
       @subscription_status_obj = current_subscription
       expired = false
-    else
+    elsif current_user.last_expired_subscription
       @subscription_status_obj = current_user.last_expired_subscription
       expired = true
+    else
+      @subscription_status = nil
+      return
     end
     attributes_for_front_end = {
       expired: expired,

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -100,6 +100,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     @subscription_type = current_user.premium_state
     render json: {
       hasPremium: @subscription_type,
+      last_subscription_was_trial: current_user.last_expired_subscription&.is_trial?,
       trial_days_remaining: current_user.trial_days_remaining,
       first_day_of_premium_or_trial: current_user.premium_updated_or_created_today?
     }

--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -41,7 +41,7 @@ module NavigationHelper
     when 'trial'
       "Premium  <i class='fas fa-star'></i> #{current_user.trial_days_remaining} Days Left"
     when 'locked'
-      "Premium  <i class='fas fa-star'></i> Trial Expired"
+      current_user.last_expired_subscription&.is_trial? ? "Premium  <i class='fas fa-star'></i> Trial Expired" : "Premium  <i class='fas fa-star'></i> Subscription Expired"
     when 'none', nil
       "Try Premium <i class='fas fa-star'></i>"
     end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/free_trial_status.jsx
@@ -1,41 +1,40 @@
-import React from 'react'
+import * as React from 'react'
 
-export default class extends React.Component {
-  stateSpecificComponents = () => {
-    if (this.props.status == 'trial') {
+const FreeTrialStatus = ({ status, originPage, handleClickUpgradeNow, lastSubscriptionWasTrial, data, }) => {
+  const stateSpecificComponents = () => {
+    if (status == 'trial') {
       return (
-        <h4>You have {this.props.data} days left in your trial.</h4>
+        <h4>You have {data} days left in your trial.</h4>
       );
-    } else if (this.props.status == 'locked') {
+    } else if (status == 'locked') {
       return (
-        <h4>Your Premium Trial Has Expired</h4>
+        <h4>Your Premium {lastSubscriptionWasTrial ? 'Trial' : 'Subscription'} Has Expired</h4>
       );
     }
   };
 
-  render() {
-    const { originPage, upgradeNow } = this.props
-    const premiumButton = originPage == 'premium' ?
-      (
-        <button className='btn-orange' onClick={upgradeNow} type='button'>Upgrade to Premium Now</button>
-      ) :
-      (
-        <a href='/premium'>
-          <button className='btn-orange' type='button'>Upgrade to Premium Now</button>
-        </a>
-      )
-    return (
-      <div className='row'>
-        <div className='col-md-9 col-xs-12 pull-left'>
-          {this.stateSpecificComponents()}
-          <span>Getting value out of Premium? <a href='/premium'>Check out our pricing plans.</a></span>
-        </div>
-        <div className='col-md-3 col-xs-12 pull-right'>
-          <div className='premium-button-box text-center'>
-            {premiumButton}
-          </div>
+  const premiumButton = originPage == 'premium' ?
+    (
+      <button className='btn-orange' onClick={handleClickUpgradeNow} type='button'>Upgrade to Premium Now</button>
+    ) :
+    (
+      <a href='/premium'>
+        <button className='btn-orange' type='button'>Upgrade to Premium Now</button>
+      </a>
+    )
+  return (
+    <div className='row'>
+      <div className='col-md-9 col-xs-12 pull-left'>
+        {stateSpecificComponents()}
+        <span>Getting value out of Premium? <a href='/premium'>Check out our pricing plans.</a></span>
+      </div>
+      <div className='col-md-3 col-xs-12 pull-right'>
+        <div className='premium-button-box text-center'>
+          {premiumButton}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+export default FreeTrialStatus

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import $ from 'jquery'
+
 import FreeTrialBanner from './free_trial_banner.jsx'
 import NewSignUpBanner from './new_signup_banner.jsx'
 import FreeTrialStatus from './free_trial_status.jsx'
@@ -24,22 +25,20 @@ export default class PremiumBannerBuilder extends React.Component {
     $.get('/teachers/classrooms/premium')
       .done(function(data) {
         that.setState({
+          last_subscription_was_trial: data.last_subscription_was_trial,
           has_premium: data['hasPremium'],
           trial_days_remaining: data['trial_days_remaining'],
           first_day_of_premium_or_trial: data['first_day_of_premium_or_trial']});});
   };
 
-  handleClickUpgradeNow = () => {
+  onClickUpgradeNow = () => {
     const { showPurchaseModal } = this.props
     showPurchaseModal()
   };
 
   stateSpecificComponents = () => {
-    // //////  if loading this banner becomes slow, uncomment this.
-    // if (this.state.has_premium === null){
-    //   return <EC.LoadingIndicator/>;
-    // }
-    const { has_premium, first_day_of_premium_or_trial, trial_days_remaining } = this.state
+    const { has_premium, first_day_of_premium_or_trial, trial_days_remaining, last_subscription_was_trial, } = this.state
+
     const { originPage } = this.props
     if (has_premium === 'none'){
       return(<FreeTrialBanner status={has_premium} />);
@@ -50,7 +49,13 @@ export default class PremiumBannerBuilder extends React.Component {
     else if ((has_premium === 'trial') || (has_premium === 'locked')){
       return(
         <span>
-          <FreeTrialStatus data={trial_days_remaining} originPage={originPage} status={has_premium} upgradeNow={this.handleClickUpgradeNow} />
+          <FreeTrialStatus
+            data={trial_days_remaining}
+            handleClickUpgradeNow={this.onClickUpgradeNow}
+            lastSubscriptionWasTrial={last_subscription_was_trial}
+            originPage={originPage}
+            status={has_premium}
+          />
         </span>
       );
     }
@@ -60,7 +65,8 @@ export default class PremiumBannerBuilder extends React.Component {
   };
 
   stateSpecificBackGroundColor = () => {
-    if (this.props.daysLeft == 30){
+    const { daysLeft, } = this.props
+    if (daysLeft === 30){
       return('#d0ffc6');
     } else {
       return('#ffe7c0');
@@ -68,7 +74,8 @@ export default class PremiumBannerBuilder extends React.Component {
   };
 
   stateSpecificBackGroundImage = () => {
-    if (this.props.daysLeft == 30){
+    const { daysLeft, } = this.props
+    if (daysLeft === 30){
       return('none');
     } else {
       return('url(/images/star_pattern_5.png)');
@@ -76,13 +83,14 @@ export default class PremiumBannerBuilder extends React.Component {
   };
 
   hasPremium = () => {
+    const { has_premium, first_day_of_premium_or_trial, } = this.state
     let color = this.stateSpecificBackGroundColor();
     let img = this.stateSpecificBackGroundImage();
     let divStyle = {
       backgroundColor: color,
       backgroundImage: img
     };
-    if ((this.state.has_premium === null) || (this.state.has_premium === 'school') || ((this.state.has_premium === 'paid') && (this.state.first_day_of_premium_or_trial === false))) {
+    if ((has_premium === null) || (has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {
       return (<span />);
     } else
     {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/available_credits.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/available_credits.test.jsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AvailableCredits container should render when there are no premium credits 1`] = `
+<AvailableCredits
+  availableCredits={0}
+  redeemPremiumCredits={[Function]}
+  userHasValidSub={false}
+>
+  <div
+    className="no-credits available-credit flex-row vertically-centered space-between"
+  >
+    <div
+      className="credit-quantity"
+    >
+      You have 
+      <span>
+        0 weeks 
+      </span>
+       of Teacher Premium Credit available.
+    </div>
+    <a
+      className="q-button button cta-button bg-orange"
+      href="/referrals"
+    >
+      Earn Premium Credits
+    </a>
+  </div>
+</AvailableCredits>
+`;
+
+exports[`AvailableCredits container should render when there are premium credits 1`] = `
+<AvailableCredits
+  availableCredits={28}
+  redeemPremiumCredits={[Function]}
+  userHasValidSub={false}
+>
+  <div
+    className="null available-credit flex-row vertically-centered space-between"
+  >
+    <div
+      className="credit-quantity"
+    >
+      You have 
+      <span>
+        4 weeks 
+      </span>
+       of Teacher Premium Credit available.
+    </div>
+    <button
+      className="q-button cta-button bg-orange has-credit"
+      onClick={[Function]}
+      type="button"
+    >
+      Redeem Premium Credits
+    </button>
+  </div>
+</AvailableCredits>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -1,0 +1,546 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurrentSubscription container should render when the subscription is expired 1`] = `
+<CurrentSubscription
+  subscriptionStatus={
+    Object {
+      "account_type": "Teacher Paid",
+      "created_at": "2022-02-15T16:43:30.344Z",
+      "de_activated_date": null,
+      "expiration": "2022-02-15",
+      "expired": true,
+      "id": 5,
+      "mail_to": null,
+      "payment_amount": null,
+      "payment_method": null,
+      "purchaser_email": null,
+      "purchaser_id": null,
+      "purchaser_name": null,
+      "recurring": false,
+      "start_date": "2022-02-15",
+      "subscription_type_id": null,
+      "updated_at": "2022-02-15T16:43:30.344Z",
+    }
+  }
+>
+  <span />
+</CurrentSubscription>
+`;
+
+exports[`CurrentSubscription container should render when there is no subscription 1`] = `
+<CurrentSubscription
+  subscriptionStatus={null}
+>
+  <span />
+</CurrentSubscription>
+`;
+
+exports[`CurrentSubscription container when there is a current subscription should render when the purchaserNameOrEmail is an empty string 1`] = `
+<CurrentSubscription
+  authorityLevel={null}
+  lastFour={null}
+  purchaserNameOrEmail=""
+  subscriptionStatus={
+    Object {
+      "account_type": "School Paid",
+      "created_at": "2022-02-16T14: 07: 25.976Z",
+      "de_activated_date": null,
+      "expiration": "2023-07-31",
+      "expired": false,
+      "id": 7,
+      "mail_to": "emilia+3@quill.org",
+      "payment_amount": null,
+      "payment_method": null,
+      "purchaser_email": "emilia+3@quill.org",
+      "purchaser_id": null,
+      "purchaser_name": null,
+      "recurring": false,
+      "start_date": "2022-02-16",
+      "subscription_type_id": null,
+      "updated_at": "2022-02-16T14: 07: 25.976Z",
+    }
+  }
+  subscriptionType="School"
+  userIsContact={false}
+>
+  <section>
+    <h2>
+      Subscription Information
+    </h2>
+    <div
+      className="current-subscription-information-and-cta"
+    >
+      <div
+        className="current-subscription-information"
+      >
+        <div
+          className="sub-meta-info"
+        >
+          <div
+            className="meta-section"
+          >
+            <h3>
+              CURRENT SUBSCRIPTION
+            </h3>
+            <div
+              className="flex-row space-between"
+            >
+              <div>
+                <_default
+                  content="School Paid"
+                  title="Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Plan
+                    </span>
+                    <span>
+                      School Paid
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div>
+                <_default
+                  content="February 16th, 2022"
+                  title="Start Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Start Date
+                    </span>
+                    <span>
+                      February 16th, 2022
+                    </span>
+                  </div>
+                </_default>
+                <_default
+                  content="July 31st, 2023"
+                  title="End Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      End Date
+                    </span>
+                    <span>
+                      July 31st, 2023
+                    </span>
+                  </div>
+                </_default>
+              </div>
+            </div>
+          </div>
+          <div
+            className="meta-section payment"
+          >
+            <h3>
+              PAYMENT METHOD ON FILE
+            </h3>
+            <span>
+              Invoice
+            </span>
+          </div>
+          <div
+            className="meta-section"
+          >
+            <h3>
+              NEXT SUBSCRIPTION
+            </h3>
+            <div>
+              <div
+                className="flex-row space-between"
+              >
+                <_default
+                  content={
+                    <span>
+                      <span>
+                        Quill Basic - Free 
+                      </span>
+                    </span>
+                  }
+                  title="Next Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Next Plan
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          Quill Basic - Free 
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div
+                className="next-plan-alert flex-row vertically-centered"
+              >
+                <i
+                  className="fas fa-icon fa-lightbulb-o"
+                />
+                Once your current School Premium subscription expires, you will be downgraded to the Quill Basic subscription.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span />
+    </div>
+  </section>
+</CurrentSubscription>
+`;
+
+exports[`CurrentSubscription container when there is a current subscription should render when there is a purchaserNameOrEmail 1`] = `
+<CurrentSubscription
+  authorityLevel={null}
+  lastFour={null}
+  purchaserNameOrEmail="emilia+3@quill.org"
+  subscriptionStatus={
+    Object {
+      "account_type": "School Paid",
+      "created_at": "2022-02-16T14: 07: 25.976Z",
+      "de_activated_date": null,
+      "expiration": "2023-07-31",
+      "expired": false,
+      "id": 7,
+      "mail_to": "emilia+3@quill.org",
+      "payment_amount": null,
+      "payment_method": null,
+      "purchaser_email": "emilia+3@quill.org",
+      "purchaser_id": null,
+      "purchaser_name": null,
+      "recurring": false,
+      "start_date": "2022-02-16",
+      "subscription_type_id": null,
+      "updated_at": "2022-02-16T14: 07: 25.976Z",
+    }
+  }
+  subscriptionType="School"
+  userIsContact={false}
+>
+  <section>
+    <h2>
+      Subscription Information
+    </h2>
+    <div
+      className="current-subscription-information-and-cta"
+    >
+      <div
+        className="current-subscription-information"
+      >
+        <div
+          className="sub-meta-info"
+        >
+          <div
+            className="meta-section"
+          >
+            <h3>
+              CURRENT SUBSCRIPTION
+            </h3>
+            <div
+              className="flex-row space-between"
+            >
+              <div>
+                <_default
+                  content="School Paid"
+                  title="Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Plan
+                    </span>
+                    <span>
+                      School Paid
+                    </span>
+                  </div>
+                </_default>
+                <_default
+                  content="emilia+3@quill.org"
+                  title="Purchaser"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Purchaser
+                    </span>
+                    <span>
+                      emilia+3@quill.org
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div>
+                <_default
+                  content="February 16th, 2022"
+                  title="Start Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Start Date
+                    </span>
+                    <span>
+                      February 16th, 2022
+                    </span>
+                  </div>
+                </_default>
+                <_default
+                  content="July 31st, 2023"
+                  title="End Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      End Date
+                    </span>
+                    <span>
+                      July 31st, 2023
+                    </span>
+                  </div>
+                </_default>
+              </div>
+            </div>
+          </div>
+          <div
+            className="meta-section payment"
+          >
+            <h3>
+              PAYMENT METHOD ON FILE
+            </h3>
+            <span>
+              Invoice
+            </span>
+          </div>
+          <div
+            className="meta-section"
+          >
+            <h3>
+              NEXT SUBSCRIPTION
+            </h3>
+            <div>
+              <div
+                className="flex-row space-between"
+              >
+                <_default
+                  content={
+                    <span>
+                      <span>
+                        Quill Basic - Free 
+                      </span>
+                    </span>
+                  }
+                  title="Next Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Next Plan
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          Quill Basic - Free 
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div
+                className="next-plan-alert flex-row vertically-centered"
+              >
+                <i
+                  className="fas fa-icon fa-lightbulb-o"
+                />
+                Once your current School Premium subscription expires, you will be downgraded to the Quill Basic subscription.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span />
+    </div>
+  </section>
+</CurrentSubscription>
+`;
+
+exports[`CurrentSubscription container when there is a current subscription should render when there is no purchaserNameOrEmail 1`] = `
+<CurrentSubscription
+  authorityLevel={null}
+  lastFour={null}
+  purchaserNameOrEmail={null}
+  subscriptionStatus={
+    Object {
+      "account_type": "School Paid",
+      "created_at": "2022-02-16T14: 07: 25.976Z",
+      "de_activated_date": null,
+      "expiration": "2023-07-31",
+      "expired": false,
+      "id": 7,
+      "mail_to": "emilia+3@quill.org",
+      "payment_amount": null,
+      "payment_method": null,
+      "purchaser_email": "emilia+3@quill.org",
+      "purchaser_id": null,
+      "purchaser_name": null,
+      "recurring": false,
+      "start_date": "2022-02-16",
+      "subscription_type_id": null,
+      "updated_at": "2022-02-16T14: 07: 25.976Z",
+    }
+  }
+  subscriptionType="School"
+  userIsContact={false}
+>
+  <section>
+    <h2>
+      Subscription Information
+    </h2>
+    <div
+      className="current-subscription-information-and-cta"
+    >
+      <div
+        className="current-subscription-information"
+      >
+        <div
+          className="sub-meta-info"
+        >
+          <div
+            className="meta-section"
+          >
+            <h3>
+              CURRENT SUBSCRIPTION
+            </h3>
+            <div
+              className="flex-row space-between"
+            >
+              <div>
+                <_default
+                  content="School Paid"
+                  title="Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Plan
+                    </span>
+                    <span>
+                      School Paid
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div>
+                <_default
+                  content="February 16th, 2022"
+                  title="Start Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Start Date
+                    </span>
+                    <span>
+                      February 16th, 2022
+                    </span>
+                  </div>
+                </_default>
+                <_default
+                  content="July 31st, 2023"
+                  title="End Date"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      End Date
+                    </span>
+                    <span>
+                      July 31st, 2023
+                    </span>
+                  </div>
+                </_default>
+              </div>
+            </div>
+          </div>
+          <div
+            className="meta-section payment"
+          >
+            <h3>
+              PAYMENT METHOD ON FILE
+            </h3>
+            <span>
+              Invoice
+            </span>
+          </div>
+          <div
+            className="meta-section"
+          >
+            <h3>
+              NEXT SUBSCRIPTION
+            </h3>
+            <div>
+              <div
+                className="flex-row space-between"
+              >
+                <_default
+                  content={
+                    <span>
+                      <span>
+                        Quill Basic - Free 
+                      </span>
+                    </span>
+                  }
+                  title="Next Plan"
+                >
+                  <div>
+                    <span
+                      className="title"
+                    >
+                      Next Plan
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          Quill Basic - Free 
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </_default>
+              </div>
+              <div
+                className="next-plan-alert flex-row vertically-centered"
+              >
+                <i
+                  className="fas fa-icon fa-lightbulb-o"
+                />
+                Once your current School Premium subscription expires, you will be downgraded to the Quill Basic subscription.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span />
+    </div>
+  </section>
+</CurrentSubscription>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/premium_credits_table.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/premium_credits_table.test.jsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PremiumCreditsTable container should render when there are no premium credits 1`] = `
+<PremiumCreditsTable
+  earnedCredits={0}
+  premiumCredits={Array []}
+>
+  <section>
+    <div
+      className="flex-row space-between"
+    >
+      <h2>
+        Earned Premium Credits History
+      </h2>
+      <a
+        className="green-link"
+        href="/referrals"
+      >
+        How to earn more Premium credit
+      </a>
+    </div>
+    <table
+      className="premium-credits-table"
+    >
+      <tbody>
+        <tr>
+          <th>
+            Date Received
+          </th>
+          <th>
+            Amount Credited
+          </th>
+          <th>
+            Action
+          </th>
+        </tr>
+      </tbody>
+    </table>
+    <span
+      className="total-premium-credits"
+    >
+      <span
+        className="total-header"
+      >
+        Total Premium Credits Earned:
+      </span>
+       
+      0 weeks
+    </span>
+  </section>
+</PremiumCreditsTable>
+`;
+
+exports[`PremiumCreditsTable container should render when there are premium credits 1`] = `
+<PremiumCreditsTable
+  earnedCredits={0}
+  premiumCredits={
+    Array [
+      Object {
+        "action": null,
+        "amount": 28,
+        "created_at": "2022-02-16T13:31:38.332Z",
+        "id": 1,
+        "source_id": 2,
+        "source_type": "User",
+        "updated_at": "2022-02-16T13:31:38.332Z",
+        "user_id": 25,
+      },
+      Object {
+        "action": "You subscribed to Quill Premium",
+        "amount": -28,
+        "created_at": "2022-02-16T13:37:24.517Z",
+        "id": 2,
+        "source_id": 6,
+        "source_type": "Subscription",
+        "updated_at": "2022-02-16T13:37:24.517Z",
+        "user_id": 25,
+      },
+    ]
+  }
+>
+  <section>
+    <div
+      className="flex-row space-between"
+    >
+      <h2>
+        Earned Premium Credits History
+      </h2>
+      <a
+        className="green-link"
+        href="/referrals"
+      >
+        How to earn more Premium credit
+      </a>
+    </div>
+    <table
+      className="premium-credits-table"
+    >
+      <tbody>
+        <tr>
+          <th>
+            Date Received
+          </th>
+          <th>
+            Amount Credited
+          </th>
+          <th>
+            Action
+          </th>
+        </tr>
+        <tr
+          key="credit-1-premium-credit-table"
+        >
+          <td
+            className="date-received"
+          >
+            February 16th, 2022
+          </td>
+          <td
+            className="amount-credited"
+          >
+            4 weeks
+          </td>
+          <td
+            className="action"
+          />
+        </tr>
+        <tr
+          key="credit-2-premium-credit-table"
+        >
+          <td
+            className="date-received"
+          >
+            February 16th, 2022
+          </td>
+          <td
+            className="amount-credited"
+          >
+            -4 weeks
+          </td>
+          <td
+            className="action"
+          >
+            You subscribed to Quill Premium
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <span
+      className="total-premium-credits"
+    >
+      <span
+        className="total-header"
+      >
+        Total Premium Credits Earned:
+      </span>
+       
+      0 weeks
+    </span>
+  </section>
+</PremiumCreditsTable>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/subscription_history.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/subscription_history.test.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SubscriptionHistory container should render when there is no subscription history 1`] = `
+<SubscriptionHistory
+  authorityLevel={null}
+  premiumCredits={Array []}
+  subscriptions={Array []}
+>
+  <section
+    className="subscription-history"
+  >
+    <h2>
+      Premium Subscription History
+    </h2>
+    <div
+      className="empty-state flex-row justify-content"
+    >
+      <h3>
+        You have not yet started a Quill Premium Subscription
+      </h3>
+      <p>
+        <a
+          href="/premium"
+        >
+          Purchase Quill Premium
+        </a>
+         or apply credits to get access to Premium reports.
+      </p>
+    </div>
+  </section>
+</SubscriptionHistory>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/subscription_status.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/subscription_status.test.jsx.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SubscriptionStatus container should render when the subscription is expired 1`] = `
+<SubscriptionStatus
+  showPurchaseModal={[Function]}
+  subscriptionStatus={
+    Object {
+      "account_type": "Teacher Paid",
+      "created_at": "2022-02-15T16:43:30.344Z",
+      "de_activated_date": null,
+      "expiration": "2022-02-15",
+      "expired": true,
+      "id": 5,
+      "mail_to": null,
+      "payment_amount": null,
+      "payment_method": null,
+      "purchaser_email": null,
+      "purchaser_id": null,
+      "purchaser_name": null,
+      "recurring": false,
+      "start_date": "2022-02-15",
+      "subscription_type_id": null,
+      "updated_at": "2022-02-15T16:43:30.344Z",
+    }
+  }
+  subscriptionType="teacher"
+  userIsContact={false}
+>
+  <section
+    className="subscription-status"
+  >
+    <div
+      className="flex-row space-between"
+    >
+      <div
+        className="box-and-h2 flex-row space-between"
+      >
+        <div
+          className="box"
+          style={
+            Object {
+              "backgroundColor": "#ff4542",
+            }
+          }
+        />
+        <h2>
+          <h2>
+            <i
+              className="fas fa-exclamation-triangle"
+            />
+            Your teacher Premium subscription has expired
+          </h2>
+        </h2>
+      </div>
+      <button
+        className="renew-subscription q-button bg-orange text-white cta-button"
+        onClick={[Function]}
+        type="button"
+      >
+        Renew Subscription
+      </button>
+    </div>
+    <p>
+      <span>
+        <strong>
+          Your 
+          teacher
+           Premium subscription (
+          02/15/22
+           - 
+          02/15/22
+          ) has expired and you are back to Quill Basic.
+        </strong>
+        <span>
+          Quill Basic provides access to all of Quill's content. To access Quill Premium, you can purchase an individual teacher subscription or a school subscription.
+        </span>
+      </span>
+    </p>
+  </section>
+</SubscriptionStatus>
+`;
+
+exports[`SubscriptionStatus container should render when there is no subscription 1`] = `
+<SubscriptionStatus
+  showPurchaseModal={[Function]}
+  subscriptionType="Basic"
+  userIsContact={false}
+>
+  <section
+    className="subscription-status"
+  >
+    <div
+      className="flex-row space-between"
+    >
+      <div
+        className="box-and-h2 flex-row space-between"
+      >
+        <div
+          className="box"
+          style={
+            Object {
+              "backgroundColor": "#00c2a2",
+            }
+          }
+        />
+        <h2>
+          <h2>
+            You have a Basic subscription
+            <img
+              alt="Basic"
+              src="https://assets.quill.org/images/shared/basic_icon.png"
+            />
+          </h2>
+        </h2>
+      </div>
+      <a
+        className="q-button cta-button bg-orange text-white"
+        href="/premium"
+      >
+        Learn More About Quill Premium
+      </a>
+    </div>
+    <p>
+      <span>
+        Quill Basic provides access to all of Quill's content. To access Quill Premium, you can purchase an individual teacher subscription or a school subscription.
+      </span>
+    </p>
+  </section>
+</SubscriptionStatus>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/available_credits.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/available_credits.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import AvailableCredits from '../available_credits';
+
+const sharedProps = {
+  availableCredits: 0,
+  redeemPremiumCredits: () => {},
+  userHasValidSub: false
+}
+
+describe('AvailableCredits container', () => {
+
+  it('should render when there are no premium credits', () => {
+    const wrapper = mount(<AvailableCredits {...sharedProps} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+  it('should render when there are premium credits', () => {
+    const wrapper = mount(<AvailableCredits {...sharedProps} availableCredits={28} />);
+    expect(wrapper).toMatchSnapshot()
+  })
+
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/current_subscription.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/current_subscription.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { expiredSubscriptionStatus, } from './data'
+
+import CurrentSubscription from '../current_subscription';
+
+describe('CurrentSubscription container', () => {
+
+  it('should render when there is no subscription', () => {
+    const wrapper = mount(<CurrentSubscription subscriptionStatus={null} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+  it('should render when the subscription is expired', () => {
+    const wrapper = mount(<CurrentSubscription subscriptionStatus={expiredSubscriptionStatus} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+  describe('when there is a current subscription', () => {
+    const sharedProps = {
+      "authorityLevel": null,
+      "lastFour": null,
+      "purchaserNameOrEmail": "emilia+3@quill.org",
+      "subscriptionStatus":  {
+        "id": 7,
+        "expiration": "2023-07-31",
+        "created_at": "2022-02-16T14: 07: 25.976Z",
+        "updated_at": "2022-02-16T14: 07: 25.976Z",
+        "account_type": "School Paid",
+        "purchaser_email": "emilia+3@quill.org",
+        "start_date": "2022-02-16",
+        "subscription_type_id": null,
+        "purchaser_id": null,
+        "recurring": false,
+        "de_activated_date": null,
+        "payment_method": null,
+        "payment_amount": null,
+        "expired": false,
+        "purchaser_name": null,
+        "mail_to": "emilia+3@quill.org"
+      },
+      "subscriptionType": "School",
+      "userIsContact": false
+    }
+
+    it('should render when there is a purchaserNameOrEmail', () => {
+      const wrapper = mount(<CurrentSubscription {...sharedProps} />);
+      expect(wrapper).toMatchSnapshot()
+    });
+
+    it('should render when there is no purchaserNameOrEmail', () => {
+      const wrapper = mount(<CurrentSubscription {...sharedProps} purchaserNameOrEmail={null} />);
+      expect(wrapper).toMatchSnapshot()
+    });
+
+    it('should render when the purchaserNameOrEmail is an empty string', () => {
+      const wrapper = mount(<CurrentSubscription {...sharedProps} purchaserNameOrEmail="" />);
+      expect(wrapper).toMatchSnapshot()
+    });
+
+  })
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/data.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/data.ts
@@ -1,0 +1,18 @@
+export const expiredSubscriptionStatus = {
+  "id": 5,
+  "expiration": "2022-02-15",
+  "created_at": "2022-02-15T16:43:30.344Z",
+  "updated_at": "2022-02-15T16:43:30.344Z",
+  "account_type": "Teacher Paid",
+  "purchaser_email": null,
+  "start_date": "2022-02-15",
+  "subscription_type_id": null,
+  "purchaser_id": null,
+  "recurring": false,
+  "de_activated_date": null,
+  "payment_method": null,
+  "payment_amount": null,
+  "expired": true,
+  "purchaser_name": null,
+  "mail_to": null
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/premium_credits_table.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/premium_credits_table.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import PremiumCreditsTable from '../premium_credits_table';
+
+const sharedProps = {
+  earnedCredits: 0,
+  premiumCredits: [],
+}
+
+describe('PremiumCreditsTable container', () => {
+
+  it('should render when there are no premium credits', () => {
+    const wrapper = mount(<PremiumCreditsTable {...sharedProps} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+  it('should render when there are premium credits', () => {
+    const premiumCredits = [{"id":1,"amount":28,"user_id":25,"source_id":2,"source_type":"User","created_at":"2022-02-16T13:31:38.332Z","updated_at":"2022-02-16T13:31:38.332Z","action":null},{"id":2,"amount":-28,"user_id":25,"source_id":6,"source_type":"Subscription","created_at":"2022-02-16T13:37:24.517Z","updated_at":"2022-02-16T13:37:24.517Z","action":"You subscribed to Quill Premium"}]
+    const wrapper = mount(<PremiumCreditsTable {...sharedProps} premiumCredits={premiumCredits} />);
+    expect(wrapper).toMatchSnapshot()
+  })
+
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/subscription_history.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/subscription_history.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SubscriptionHistory from '../subscription_history';
+
+const sharedProps = {
+  authorityLevel: null,
+  premiumCredits: [],
+  subscriptions: []
+}
+
+describe('SubscriptionHistory container', () => {
+
+  it('should render when there is no subscription history', () => {
+    const wrapper = mount(<SubscriptionHistory {...sharedProps} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/subscription_status.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/subscription_status.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { expiredSubscriptionStatus, } from './data'
+
+import SubscriptionStatus from '../subscription_status';
+
+const sharedProps = {
+  userIsContact: false,
+  subscriptionType: 'Basic',
+  showPurchaseModal: () => {}
+}
+
+describe('SubscriptionStatus container', () => {
+
+  it('should render when there is no subscription', () => {
+    const wrapper = mount(<SubscriptionStatus {...sharedProps} />);
+    expect(wrapper).toMatchSnapshot()
+  });
+
+  it('should render when the subscription is expired', () => {
+    const wrapper = mount(<SubscriptionStatus {...sharedProps} subscriptionStatus={expiredSubscriptionStatus} subscriptionType="teacher" />);
+    expect(wrapper).toMatchSnapshot()
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/available_credits.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/available_credits.jsx
@@ -2,31 +2,31 @@ import React from 'react';
 import moment from 'moment';
 import pluralize from 'pluralize';
 
-export default class extends React.Component {
-  redeemIfNoCurrentSub = () => {
-    if (this.props.userHasValidSub) {
+const AvailableCredits = ({ userHasValidSub, redeemPremiumCredits, availableCredits, }) => {
+  const redeemIfNoCurrentSub = () => {
+    if (userHasValidSub) {
       alert('You cannot redeem credits while you have a valid subscription. You must wait until your current subscription has expired to redeem them.');
     } else {
-      this.props.redeemPremiumCredits();
+      redeemPremiumCredits();
     }
   };
 
-  render() {
-    let button;
-    if (this.props.availableCredits > 0) {
-      button = <button className="q-button cta-button bg-orange has-credit" onClick={this.redeemIfNoCurrentSub}>Redeem Premium Credits</button>;
-    } else {
-      button = <a className="q-button button cta-button bg-orange" href="/referrals">Earn Premium Credits</a>;
-    }
-    const monthsOfCredit = Math.round((this.props.availableCredits / 30.42) * 10) / 10;
-    const whiteIfNoCredit = monthsOfCredit === 0 ? 'no-credits' : null;
-    return (
-      <div className={`${whiteIfNoCredit} available-credit flex-row vertically-centered space-between`}>
-        <div className="credit-quantity">
-          You have <span>{`${monthsOfCredit} ${pluralize('month', monthsOfCredit)} `}</span> of Teacher Premium Credit available.
-        </div>
-        {button}
-      </div>
-    );
+  let button;
+  if (availableCredits > 0) {
+    button = <button className="q-button cta-button bg-orange has-credit" onClick={redeemIfNoCurrentSub} type="button">Redeem Premium Credits</button>;
+  } else {
+    button = <a className="q-button button cta-button bg-orange" href="/referrals">Earn Premium Credits</a>;
   }
+  const weeksOfCredit = Math.round(availableCredits / 7)
+  const whiteIfNoCredit = weeksOfCredit === 0 ? 'no-credits' : null;
+  return (
+    <div className={`${whiteIfNoCredit} available-credit flex-row vertically-centered space-between`}>
+      <div className="credit-quantity">
+        You have <span>{`${weeksOfCredit} ${pluralize('week', weeksOfCredit)} `}</span> of Teacher Premium Credit available.
+      </div>
+      {button}
+    </div>
+  );
 }
+
+export default AvailableCredits

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/premium_credits_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/premium_credits_table.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import pluralize from 'pluralize';
 
-export default class extends React.Component {
-
-  premiumCreditsTable() {
-    const creditRows = this.props.premiumCredits.map((credit) => {
+const PremiumCreditsTable = ({ premiumCredits, earnedCredits, }) => {
+  const renderPremiumCreditsTable = () => {
+    const creditRows = premiumCredits.map((credit) => {
       // if it is less than one week, we round up to 1
       let amountCredited = credit.amount;
       if (amountCredited > 0) {
@@ -39,18 +38,17 @@ export default class extends React.Component {
     );
   }
 
-  render() {
-    const monthsOfCredit = Math.round(((this.props.earnedCredits / 30.42) * 10) / 10);
-    return (
-      <section>
-        <div className="flex-row space-between">
-          <h2>Earned Premium Credits History</h2>
-          <a className="green-link" href="">How to earn more Premium credit</a>
-        </div>
-        {this.premiumCreditsTable()}
-        <span className="total-premium-credits"><span className="total-header">Total Premium Credits Earned:</span> {`${monthsOfCredit} ${pluralize('month', monthsOfCredit)}`}</span>
-      </section>
-    );
-  }
-
+  const weeksOfCredit = Math.round(earnedCredits / 7);
+  return (
+    <section>
+      <div className="flex-row space-between">
+        <h2>Earned Premium Credits History</h2>
+        <a className="green-link" href="/referrals">How to earn more Premium credit</a>
+      </div>
+      {renderPremiumCreditsTable()}
+      <span className="total-premium-credits"><span className="total-header">Total Premium Credits Earned:</span> {`${weeksOfCredit} ${pluralize('week', weeksOfCredit)}`}</span>
+    </section>
+  );
 }
+
+export default PremiumCreditsTable

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import pluralize from 'pluralize';
 
-export default class extends React.Component {
+export default class SubscriptionHistory extends React.Component {
 
   content() {
     const subscriptionHistoryRows = this.subscriptionHistoryRows();
@@ -21,13 +21,14 @@ export default class extends React.Component {
     return (
       <div className="empty-state flex-row justify-content">
         <h3>You have not yet started a Quill Premium Subscription</h3>
-        <p>Purchase Quill Premium or apply credits to get access to Premium reports.</p>
+        <p><a href="/premium">Purchase Quill Premium</a> or apply credits to get access to Premium reports.</p>
       </div>
     );
   }
 
   paymentContent(subscription) {
-    if (this.props.authorityLevel) {
+    const { authorityLevel, } = this.props
+    if (authorityLevel) {
       if (subscription.payment_amount) {
         return `$${subscription.payment_amount / 100}`;
       } else if (subscription.payment_method === 'Premium Credit') {
@@ -38,14 +39,16 @@ export default class extends React.Component {
   }
 
   subscriptionHistoryRows() {
+    const { subscriptions, premiumCredits, view, } = this.props
+
     const rows = [];
-    this.props.subscriptions.forEach((sub) => {
+    subscriptions.forEach((sub) => {
       const startD = moment(sub.start_date);
       const endD = moment(sub.expiration);
       const calculatedDuration = endD.diff(startD, 'months');
       // if duration is calculated as 0, make it 1
       const duration = Math.max(calculatedDuration, 1);
-      const matchingTransaction = this.props.premiumCredits.find(transaction => (transaction.source_id === sub.id && transaction.source_type === 'Subscription' && transaction.amount > 0));
+      const matchingTransaction = premiumCredits.find(transaction => (transaction.source_id === sub.id && transaction.source_type === 'Subscription' && transaction.amount > 0));
       if (matchingTransaction) {
         const amountCredited = matchingTransaction.amount > 6
           ? Math.round(matchingTransaction.amount / 7)
@@ -65,7 +68,7 @@ export default class extends React.Component {
         <td key={`${sub.id}-4-row`}>{`${duration} ${pluralize('month', duration)}`}</td>,
         <td key={`${sub.id}-5-row`}>{`${startD.format('MM/DD/YY')} - ${endD.format('MM/DD/YY')}`}</td>
       ];
-      if (this.props.view === 'subscriptionHistory') {
+      if (view === 'subscriptionHistory') {
         tds.push(<td key={`${sub.id}-6-row`}><a href={`${process.env.DEFAULT_URL}/cms/subscriptions/${sub.id}/edit`}>Edit Subscription</a></td>);
       }
       rows.push(
@@ -76,8 +79,10 @@ export default class extends React.Component {
   }
 
   tableHeaders() {
+    const { view, } = this.props
+
     const tableHeaders = ['Purchase Date', 'Subscription', 'Payment', 'Length', 'Start & End Date'];
-    if (this.props.view === 'subscriptionHistory') {
+    if (view === 'subscriptionHistory') {
       tableHeaders.push('Edit Link');
     }
     return tableHeaders.map((content, i) => <th key={`${i}-table-header`}>{content}</th>);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_status.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_status.jsx
@@ -21,89 +21,89 @@ const teacherPremiumCopy = (
   <span>With Quill Teacher Premium, you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. <a className="green-link" href="https://support.quill.org/quill-premium">Here’s more information</a> about your Teacher Premium features.</span>
 );
 
-export default class extends React.Component {
+const SubscriptionStatus = ({ subscriptionType, showPurchaseModal, subscriptionStatus, userIsContact, }) => {
+  const content = {};
+  let image
+  let expiration
+  let remainingDays
 
-  getContent() {
-    const content = {};
-    let image,
-      expiration,
-      remainingDays;
-    let subscriptionType = this.props.subscriptionType;
-    if (this.props.subscriptionType !== 'Basic') {
-      expiration = moment(this.props.subscriptionStatus.expiration);
-      remainingDays = expiration.diff(moment(), 'days');
-    }
-    switch (this.props.subscriptionType) {
-      case 'Basic':
-        image = 'basic_icon.png';
-        content.pCopy = quillBasicCopy;
-        content.boxColor = '#00c2a2';
-        content.buttonOrDate = <a className="q-button cta-button bg-orange text-white" href="/premium">Learn More About Quill Premium</a>;
-        subscriptionType = 'Quill Basic';
-        content.status = <h2>{`You have a ${subscriptionType} subscription`}<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
-        break;
-      case 'Teacher':
-        image = 'teacher_premium_icon.png';
-        content.pCopy = teacherPremiumCopy;
-        if (remainingDays < 0) {
-          content.boxColor = '#ff4542';
-        } else {
-          content.boxColor = '#348fdf';
-        }
-        break;
-      case 'Trial':
-        content.pCopy = teacherPremiumCopy;
-        image = 'teacher_premium_icon.png';
-        content.status = <h2>You have a Teacher Premium subscription<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
+  let subscriptionTypeText = subscriptionType;
+
+  if (subscriptionType !== 'Basic') {
+    expiration = moment(subscriptionStatus.expiration);
+    remainingDays = expiration.diff(moment(), 'days');
+  }
+
+  switch (subscriptionType) {
+    case 'Basic':
+      image = 'basic_icon.png';
+      content.pCopy = quillBasicCopy;
+      content.boxColor = '#00c2a2';
+      content.buttonOrDate = <a className="q-button cta-button bg-orange text-white" href="/premium">Learn More About Quill Premium</a>;
+      subscriptionTypeText = 'Quill Basic';
+      content.status = <h2>{`You have a ${subscriptionType} subscription`}<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
+      break;
+    case 'Teacher':
+      image = 'teacher_premium_icon.png';
+      content.pCopy = teacherPremiumCopy;
+      if (remainingDays < 0) {
+        content.boxColor = '#ff4542';
+      } else {
         content.boxColor = '#348fdf';
-        break;
-      case 'School':
-        content.pCopy = schoolPremiumCopy;
-        content.boxColor = '#9c2bde';
-        image = 'school_premium_icon.png';
-        if (remainingDays < 90 && !this.props.subscriptionStatus.recurring) {
-          if (this.props.userIsContact) {
-            content.buttonOrDate = <button className="q-button bg-orange text-white cta-button" onClick={this.props.showPurchaseModal}>Renew School Premium</button>;
-          } else {
-            content.buttonOrDate = <button>Contact {this.props.subscriptionStatus.contact_name} to Renew</button>;
-          }
+      }
+      break;
+    case 'Trial':
+      content.pCopy = teacherPremiumCopy;
+      image = 'teacher_premium_icon.png';
+      content.status = <h2>You have a Teacher Premium subscription<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
+      content.boxColor = '#348fdf';
+      break;
+    case 'School':
+      content.pCopy = schoolPremiumCopy;
+      content.boxColor = '#9c2bde';
+      image = 'school_premium_icon.png';
+      if (remainingDays < 90 && !subscriptionStatus.recurring) {
+        if (userIsContact) {
+          content.buttonOrDate = <button className="q-button bg-orange text-white cta-button" onClick={showPurchaseModal} type="button">Renew School Premium</button>;
+        } else {
+          content.buttonOrDate = <button type="button">Contact {subscriptionStatus.contact_name} to Renew</button>;
         }
-        break;
-    }
-    this.handleExpired(content, remainingDays);
-    content.buttonOrDate = content.buttonOrDate || (<span className="expiration-date">
-      <span>Valid Until:</span> <span>{`${expiration.format('MMMM Do, YYYY')}`}</span><span className="time-left-in-days"> | {`${remainingDays} ${pluralize('days', remainingDays)}`}</span>
-    </span>);
-    content.status = content.status || <h2>{`You have a ${subscriptionType} Premium subscription`}<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
-    return content;
+      }
+      break;
   }
 
-  handleExpired(content, remainingDays) {
-    if (remainingDays < 1) {
-      content.boxColor = '#ff4542';
-      content.status = <h2><i className="fas fa-exclamation-triangle" />{`Your ${this.props.subscriptionType} Premium subscription has expired`}</h2>;
-      content.pCopy = (
-        <span>
-          <strong>Your {this.props.subscriptionType} Premium subscription has expired and you are back to Quill Basic.</strong>
-          {quillBasicCopy}
-        </span>);
-      content.buttonOrDate = <button className="renew-subscription q-button bg-orange text-white cta-button" onClick={this.props.showPurchaseModal}>Renew Subscription</button>;
-    }
+  if (remainingDays < 1) {
+    const dateFormat = "MM/DD/YY"
+
+    const formattedStartDate = subscriptionStatus && moment(subscriptionStatus.start_date).format(dateFormat)
+    const formattedExpirationDate = expiration && expiration.format(dateFormat)
+    content.boxColor = '#ff4542';
+    content.status = <h2><i className="fas fa-exclamation-triangle" />{`Your ${subscriptionType} Premium subscription has expired`}</h2>;
+    content.pCopy = (
+      <span>
+        <strong>Your {subscriptionType} Premium subscription ({formattedStartDate} - {formattedExpirationDate}) has expired and you are back to Quill Basic.</strong>
+        {quillBasicCopy}
+      </span>);
+    content.buttonOrDate = <button className="renew-subscription q-button bg-orange text-white cta-button" onClick={showPurchaseModal} type="button">Renew Subscription</button>;
   }
 
-  render() {
-    const content = this.getContent();
-    return (
-      <section className="subscription-status">
-        <div className="flex-row space-between">
-          <div className="box-and-h2 flex-row space-between">
-            <div className="box" style={{ backgroundColor: content.boxColor, }} />
-            <h2>{content.status}</h2>
-          </div>
-          {content.buttonOrDate}
+  content.buttonOrDate = content.buttonOrDate || (<span className="expiration-date">
+    <span>Valid Until:</span> <span>{`${expiration.format('MMMM Do, YYYY')}`}</span><span className="time-left-in-days"> | {`${remainingDays} ${pluralize('days', remainingDays)}`}</span>
+  </span>);
+  content.status = content.status || <h2>{`You have a ${subscriptionTypeText} Premium subscription`}<img alt={`${subscriptionTypeText}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
+
+  return (
+    <section className="subscription-status">
+      <div className="flex-row space-between">
+        <div className="box-and-h2 flex-row space-between">
+          <div className="box" style={{ backgroundColor: content.boxColor, }} />
+          <h2>{content.status}</h2>
         </div>
-        <p>{content.pCopy}</p>
-      </section>
-    );
-  }
+        {content.buttonOrDate}
+      </div>
+      <p>{content.pCopy}</p>
+    </section>
+  );
 }
+
+export default SubscriptionStatus

--- a/services/QuillLMS/spec/controllers/subscriptions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/subscriptions_controller_spec.rb
@@ -32,6 +32,12 @@ describe SubscriptionsController do
         get :index
         expect(response.status).to eq(200)
       end
+
+      it 'sets subscription status to nil' do
+        get :index
+        expect(assigns(:subscription_status)).to eq nil
+
+      end
     end
 
     describe "#purchaser_name" do

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -514,6 +514,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
       expect(assigns(:subscription_type)).to eq "some subscription"
       expect(response.body).to eq({
         hasPremium: "some subscription",
+        last_subscription_was_trial: nil,
         trial_days_remaining: 10,
         first_day_of_premium_or_trial: true
       }.to_json)

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -83,9 +83,13 @@ describe NavigationHelper do
 
   describe '#Premium_tab_copy' do
     it 'should return the correct values' do
+      trial_subscription = create(:subscription)
+      premium_subscription = create(:subscription, account_type: 'Not A Trial')
       allow(helper).to receive(:current_user) { double(:user, premium_state: "trial", trial_days_remaining: 5) }
       expect(helper.premium_tab_copy).to eq "Premium  <i class='fas fa-star'></i> 5 Days Left"
-      allow(helper).to receive(:current_user) { double(:user, premium_state: "locked") }
+      allow(helper).to receive(:current_user) { double(:user, premium_state: "locked", last_expired_subscription: premium_subscription) }
+      expect(helper.premium_tab_copy).to eq "Premium  <i class='fas fa-star'></i> Subscription Expired"
+      allow(helper).to receive(:current_user) { double(:user, premium_state: "locked", last_expired_subscription: trial_subscription) }
       expect(helper.premium_tab_copy).to eq "Premium  <i class='fas fa-star'></i> Trial Expired"
       allow(helper).to receive(:current_user) { double(:user, premium_state: nil) }
       expect(helper.premium_tab_copy).to eq "Try Premium <i class='fas fa-star'></i>"


### PR DESCRIPTION
* fix bug where users with no subscription saw expired message

* only show current subscription when a user has an active one

* test for subscriptions controller

* add expiration date to expired header

* tests

* fix/add links and test

* update premium credit copy and test

* update purchaser and invoice copy and test

* correct copy for expired subscription in navigation menu

* display correct copy in premium reports for users with expired sub

* fixing tests

* nil not null

* fix bug where we weren't actually setting this correctly

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
