### PR TITLE
avoid calling .role on undefined with early return

### DIFF
--- a/services/QuillLessonsServer/src/index.js
+++ b/services/QuillLessonsServer/src/index.js
@@ -129,6 +129,8 @@ function disconnect({
   client,
   connection,
 }) {
+  if (!currentConnections[client.id]) { return }
+  
   if (currentConnections[client.id].role === 'teacher') {
     let session = {
       id: currentConnections[client.id].classroomSessionId,
@@ -674,4 +676,3 @@ app.on('error', err => {
 });
 
 app.listen(port, () => {});
-


### PR DESCRIPTION
## WHAT
Early return from `disconnect` function to avoid calling `.role` on undefined.

## WHY
We are having issues with the Lessons Server this morning and the logs indicate that the error is coming from here.

## HOW
Just call an early return if `currentConnections[client.id]` is falsy.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually testing
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A