### PR TITLE
lms/expose-sidekiq-retry-queue-in-status-controller

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -33,7 +33,11 @@ class StatusesController < ApplicationController
   end
 
   def sidekiq_queue_length
-    render json: Sidekiq::Stats.new.queues
+    queues_hash = Sidekiq::Stats.new.queues
+    retry_hash = {
+      "retry" => Sidekiq::RetrySet.new.size
+    }
+    render json: queues_hash.merge(retry_hash)
   end
 
   def deployment_notification

--- a/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
@@ -52,4 +52,44 @@ describe StatusesController, type: :controller do
     end
   end
 
+  describe "#sidekiq_queue_length" do
+    let(:queues_hash) do
+      {
+        "critical" => 0,
+        "critical_external" => 0,
+        "default" => 0,
+        "google" => 0,
+        "low" => 0
+      }
+    end
+    let(:retry_size) { 0 }
+
+    before do
+      stats = double
+      allow(stats).to receive(:queues).and_return(queues_hash)
+      allow(Sidekiq::Stats).to receive(:new).and_return(stats)
+
+      retry_set = double
+      allow(retry_set).to receive(:size).and_return(retry_size)
+      allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+    end
+
+    it 'should include Sidekiq queues' do
+        get :sidekiq_queue_length
+
+        parsed_response = JSON.parse(response.body)
+
+        expect(response.status).to eq 200
+        expect(parsed_response).to include(queues_hash)
+    end
+
+    it 'should include accumulated retry count across all queues' do
+        get :sidekiq_queue_length
+
+        parsed_response = JSON.parse(response.body)
+
+        expect(response.status).to eq 200
+        expect(parsed_response["retry"]).to eq(retry_size)
+    end
+  end
 end

--- a/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
@@ -75,21 +75,21 @@ describe StatusesController, type: :controller do
     end
 
     it 'should include Sidekiq queues' do
-        get :sidekiq_queue_length
+      get :sidekiq_queue_length
 
-        parsed_response = JSON.parse(response.body)
+      parsed_response = JSON.parse(response.body)
 
-        expect(response.status).to eq 200
-        expect(parsed_response).to include(queues_hash)
+      expect(response.status).to eq 200
+      expect(parsed_response).to include(queues_hash)
     end
 
     it 'should include accumulated retry count across all queues' do
-        get :sidekiq_queue_length
+      get :sidekiq_queue_length
 
-        parsed_response = JSON.parse(response.body)
+      parsed_response = JSON.parse(response.body)
 
-        expect(response.status).to eq 200
-        expect(parsed_response["retry"]).to eq(retry_size)
+      expect(response.status).to eq 200
+      expect(parsed_response["retry"]).to eq(retry_size)
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add a "retry" key to the sidekiq queue statuses endpoint
## WHY
So that we can set up synthetic monitors in New Relic (and/or other platforms) to send alerts if the retry queue gets too big
## HOW
Create a new hash that pulls from Sidekiq's `RetrySet` size, then merge that hash with the one we're already taking from Sidekiq's queue stats data.  Return the merged hash as our JSON payload.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
