### PR TITLE
Remove references to unused subscription types in code base

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -421,7 +421,7 @@ class PagesController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   def premium
     @user_is_eligible_for_new_subscription= current_user&.eligible_for_new_subscription?
-    @user_is_eligible_for_trial = current_user&.subscriptions&.where&.not(account_type: Subscription::COVID_TYPES)&.none?
+    @user_is_eligible_for_trial = current_user&.subscriptions&.none?
 
     @user_has_school = !!current_user&.school && ['home school', 'us higher ed', 'international', 'other', 'not listed'].exclude?(current_user&.school&.name)
     @user_belongs_to_school_that_has_paid = current_user&.school ? Subscription.school_or_user_has_ever_paid?(current_user&.school) : false

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -414,8 +414,6 @@ module Teacher
     if subscription && subscription.school_subscriptions.any? && !has_matching_subscription?(id, school&.subscription&.id)
       # then they were previously in a school with a subscription, so we destroy the relationship
       UserSubscription.find_by(user_id: id, subscription_id: subscription.id).destroy
-    elsif school && self&.subscription&.account_type == "Purchase Missing School"
-      SchoolSubscription.create(school_id: school_id, subscription_id: subscription.id)
     end
 
     return unless school && school.subscription
@@ -481,7 +479,7 @@ module Teacher
 
   def premium_state
     if subscription
-      (Subscription::TRIAL_TYPES | Subscription::COVID_TYPES).include?(subscription.account_type) ? 'trial' : 'paid'
+      Subscription::TRIAL_TYPES.include?(subscription.account_type) ? 'trial' : 'paid'
     elsif subscriptions.exists?
       # then they have an expired or 'locked' sub
       'locked'

--- a/services/QuillLMS/app/models/school_subscription.rb
+++ b/services/QuillLMS/app/models/school_subscription.rb
@@ -20,7 +20,7 @@ class SchoolSubscription < ApplicationRecord
   belongs_to :school
   belongs_to :subscription
   after_commit :update_schools_users
-  after_create :send_premium_emails, :update_subscription
+  after_create :send_premium_emails
 
   def update_schools_users
     return unless school&.users
@@ -42,9 +42,5 @@ class SchoolSubscription < ApplicationRecord
         PremiumSchoolSubscriptionEmailWorker.perform_async(u.id) if u.email.match('quill.org')
       end
     end
-  end
-
-  def update_subscription
-    subscription.update(account_type: 'School Paid')
   end
 end

--- a/services/QuillLMS/app/models/school_subscription.rb
+++ b/services/QuillLMS/app/models/school_subscription.rb
@@ -45,8 +45,6 @@ class SchoolSubscription < ApplicationRecord
   end
 
   def update_subscription
-    return if subscription.account_type != 'Purchase Missing School'
-
     subscription.update(account_type: 'School Paid')
   end
 end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -44,56 +44,30 @@ class Subscription < ApplicationRecord
 
   CB_LIFETIME_DURATION = 365 * 50 # In days, this is approximately 50 years
 
-  COVID_19_SUBSCRIPTION_TYPE = 'Quill Premium for School Closures'
-  COVID_19_SCHOOL_SUBSCRIPTION_TYPE = 'Quill School Premium for School Closures'
   CB_LIFETIME_SUBSCRIPTION_TYPE = 'College Board Educator Lifetime Premium'
 
   OFFICIAL_PAID_TYPES = ['School District Paid',
-                         'School NYC Paid',
-                         'School Strategic Paid',
                          'School Paid',
                          'Teacher Paid',
-                         'Purchase Missing School',
                          'Premium Credit',
                          CB_LIFETIME_SUBSCRIPTION_TYPE]
 
-  OFFICIAL_FREE_TYPES = ['School NYC Free',
-                         'School Research',
-                         'School Sponsored Free',
-                         'School Strategic Free',
-                         'Teacher Contributor Free',
+  OFFICIAL_FREE_TYPES = ['School Sponsored Free',
                          'Teacher Sponsored Free',
-                         'Teacher Trial',
-                         COVID_19_SUBSCRIPTION_TYPE,
-                         COVID_19_SCHOOL_SUBSCRIPTION_TYPE]
+                         'Teacher Trial']
 
   OFFICIAL_SCHOOL_TYPES = ['School District Paid',
-                           'School NYC Paid',
-                           'School Strategic Paid',
                            'School Paid',
-                           'Purchase Missing School',
-                           'School NYC Free',
-                           'School Research',
-                           'School Sponsored Free',
-                           'School Strategic Free',
-                           COVID_19_SCHOOL_SUBSCRIPTION_TYPE]
+                           'School Sponsored Free']
 
   OFFICIAL_TEACHER_TYPES = ['Teacher Paid',
                             'Premium Credit',
-                            'Teacher Contributor Free',
                             'Teacher Sponsored Free',
                             'Teacher Trial',
-                            COVID_19_SUBSCRIPTION_TYPE,
                             CB_LIFETIME_SUBSCRIPTION_TYPE]
 
-  # TODO: ultimately these should be cleaned up so we just have OFFICIAL_TYPES but until then, we keep them here
-  GRANDFATHERED_PAID_TYPES = ['paid', 'school', 'premium', 'school', 'School']
-  GRANDFATHERED_FREE_TYPES = ['trial']
-  ALL_FREE_TYPES = GRANDFATHERED_FREE_TYPES.dup.concat(OFFICIAL_FREE_TYPES)
-  ALL_PAID_TYPES = GRANDFATHERED_PAID_TYPES.dup.concat(OFFICIAL_PAID_TYPES)
   ALL_OFFICIAL_TYPES = OFFICIAL_PAID_TYPES.dup.concat(OFFICIAL_FREE_TYPES)
-  TRIAL_TYPES = ['Teacher Trial', 'trial']
-  COVID_TYPES = [COVID_19_SCHOOL_SUBSCRIPTION_TYPE, COVID_19_SUBSCRIPTION_TYPE]
+  TRIAL_TYPES = ['Teacher Trial']
   SCHOOL_RENEWAL_PRICE = 90000
 
   TYPES_HASH = {
@@ -107,12 +81,12 @@ class Subscription < ApplicationRecord
   TEACHER_PRICE = 8000
   ALL_PRICES = [TEACHER_PRICE, SCHOOL_RENEWAL_PRICE]
   PAYMENT_METHODS = ['Invoice', 'Credit Card', 'Premium Credit']
-  ALL_TYPES = ALL_FREE_TYPES.dup.concat(ALL_PAID_TYPES)
+  ALL_TYPES = OFFICIAL_FREE_TYPES.dup.concat(OFFICIAL_PAID_TYPES)
 
   scope :active, -> { where(de_activated_date: nil).where("expiration > ?", Date.today).order(expiration: :asc) }
 
   def is_trial?
-    account_type && (TRIAL_TYPES | COVID_TYPES).include?(account_type)
+    account_type && TRIAL_TYPES.include?(account_type)
   end
 
   def check_if_purchaser_email_is_in_database
@@ -180,7 +154,7 @@ class Subscription < ApplicationRecord
 
   def self.school_or_user_has_ever_paid?(school_or_user)
     # TODO: 'subscription type spot'
-    paid_accounts = school_or_user.subscriptions.pluck(:account_type) & ALL_PAID_TYPES
+    paid_accounts = school_or_user.subscriptions.pluck(:account_type) & OFFICIAL_PAID_TYPES
     paid_accounts.any?
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -245,7 +245,7 @@ class User < ApplicationRecord
   def eligible_for_new_subscription?
     if subscription
       # if they have a subscription it must be a trial one
-      Subscription::TRIAL_TYPES.include?(subscription.account_type) || Subscription::COVID_TYPES.include?(subscription.account_type)
+      Subscription::TRIAL_TYPES.include?(subscription.account_type)
     else
       # otherwise they are good for purchase
       true

--- a/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
+++ b/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :migrate_subscriptions do
+  desc 'migrates all subscriptions of one type to another type'
+  task :run, [:old_sub, :new_sub] => :environment do |t, args|
+    ActiveRecord::Base.transaction do
+      old_subscriptions = Subscription.where(account_type: args[:old_sub].to_s)
+      old_subscriptions.each do |sub|
+        puts "Updating subscription #{sub.id} from #{args[:old_sub].to_s} to #{args[:new_sub].to_s}"
+        sub.update!(account_type: args[:new_sub].to_s)
+      end
+    end
+ end
+end

--- a/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
+++ b/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
@@ -2,12 +2,31 @@
 
 namespace :migrate_subscriptions do
   desc 'migrates all subscriptions of one type to another type'
-  task :run, [:old_sub, :new_sub] => :environment do |t, args|
+  task :run => :environment do
+    old_sub_to_new = {
+      'trial': 'Teacher Trial',
+      'paid': 'Teacher Paid',
+      'premium': 'Teacher Paid',
+      'Quill Premium for School Closures': 'Teacher Sponsored Free',
+      'Teacher Contributor Free': 'Teacher Sponsored Free',
+      'Teacher Free Partner': 'Teacher Sponsored Free',
+      'school': 'School Paid',
+      'School': 'School Paid',
+      'Quill School Premium for School Closures': 'School Sponsored Free',
+      'Purchase Missing School': 'School Sponsored Free',
+      'School NYC Paid': 'School Sponsored Free',
+      'School NYC Free': 'School Sponsored Free',
+      'School Strategic Free': 'School Sponsored Free',
+      'School Strategic Paid': 'School Sponsored Free',
+      'School Research': 'School Sponsored Free'
+    }
     ActiveRecord::Base.transaction do
-      old_subscriptions = Subscription.where(account_type: args[:old_sub].to_s)
-      old_subscriptions.each do |sub|
-        puts "Updating subscription #{sub.id} from #{args[:old_sub]} to #{args[:new_sub]}"
-        sub.update!(account_type: args[:new_sub].to_s)
+      old_sub_to_new.each do |old_sub, new_sub|
+        old_subscriptions = Subscription.where(account_type: old_sub.to_s)
+        old_subscriptions.each do |sub|
+          puts "Updating subscription #{sub.id} from #{old_sub} to #{new_sub}"
+          sub.update!(account_type: new_sub.to_s)
+        end
       end
     end
   end

--- a/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
+++ b/services/QuillLMS/lib/tasks/migrate_subscriptions.rake
@@ -6,9 +6,9 @@ namespace :migrate_subscriptions do
     ActiveRecord::Base.transaction do
       old_subscriptions = Subscription.where(account_type: args[:old_sub].to_s)
       old_subscriptions.each do |sub|
-        puts "Updating subscription #{sub.id} from #{args[:old_sub].to_s} to #{args[:new_sub].to_s}"
+        puts "Updating subscription #{sub.id} from #{args[:old_sub]} to #{args[:new_sub]}"
         sub.update!(account_type: args[:new_sub].to_s)
       end
     end
- end
+  end
 end

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -186,12 +186,6 @@ describe PagesController do
       expect(assigns(:user_belongs_to_school_that_has_paid)).to eq user&.school ? Subscription.school_or_user_has_ever_paid?(user&.school) : false
       expect(assigns(:last_four)).to eq user.last_four
     end
-
-    it 'should make the user eligible for trial even if they have a covid subscription' do
-      Subscription.create_with_user_join(user.id, account_type: Subscription::COVID_19_SUBSCRIPTION_TYPE)
-      get :premium
-      expect(assigns(:user_is_eligible_for_trial)).to eq true
-    end
   end
 
   describe '#press' do

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -393,16 +393,6 @@ describe User, type: :model do
           end
         end
 
-        context 'user has been on a COVID premium subscription' do
-          it "returns 'trial'" do
-            subscription.update(account_type: Subscription::COVID_19_SUBSCRIPTION_TYPE)
-            expect(teacher.premium_state).to eq('trial')
-
-            subscription.update(account_type: Subscription::COVID_19_SCHOOL_SUBSCRIPTION_TYPE)
-            expect(teacher.premium_state).to eq('trial')
-          end
-        end
-
         context 'user is on a paid plan' do
           it "returns 'paid'" do
             subscription.update(account_type: 'Teacher Paid')

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -385,9 +385,6 @@ describe User, type: :model do
 
         context 'user is on a valid trial' do
           it "returns 'trial'" do
-            subscription.update(account_type: 'trial')
-            expect(teacher.premium_state).to eq('trial')
-
             subscription.update(account_type: 'Teacher Trial')
             expect(teacher.premium_state).to eq('trial')
           end

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -42,7 +42,7 @@ describe Subscription, type: :model do
     end
 
     it "returns false if the subscription is not Subscription::TRIAL_TYPES" do
-      Subscription::ALL_PAID_TYPES.each do |tt|
+      Subscription::OFFICIAL_PAID_TYPES.each do |tt|
         subscription.update(account_type: tt)
         expect(subscription.is_trial?).not_to be
       end
@@ -250,15 +250,15 @@ describe Subscription, type: :model do
     let!(:user) { create(:user) }
     let!(:user_subscription) { create(:user_subscription, subscription: subscription, user: user) }
 
-    it "responds with true if school or user has ever had anything in the ALL_PAID_TYPES_LIST" do
-      Subscription::ALL_PAID_TYPES.each do |type|
+    it "responds with true if school or user has ever had anything in the OFFICIAL_PAID_TYPES_LIST" do
+      Subscription::OFFICIAL_PAID_TYPES.each do |type|
         subscription.update(account_type: type)
         expect(Subscription.school_or_user_has_ever_paid?(user)).to be
       end
     end
 
-    it "responds with false if school or user has only had things in the ALL_FREE_TYPES_LIST" do
-      Subscription::ALL_FREE_TYPES.each do |type|
+    it "responds with false if school or user has only had things in the OFFICIAL_FREE_TYPES_LIST" do
+      Subscription::OFFICIAL_FREE_TYPES.each do |type|
         subscription.update(account_type: type)
         expect(Subscription.school_or_user_has_ever_paid?(user)).not_to be
       end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -288,7 +288,7 @@ describe User, type: :model do
         end
 
         it "returns false if the user has a subscription that does not have a trial account type" do
-          (Subscription::ALL_PAID_TYPES).each do |type|
+          (Subscription::OFFICIAL_PAID_TYPES).each do |type|
             subscription.update(account_type: type)
             expect(user.reload.eligible_for_new_subscription?).to be false
           end


### PR DESCRIPTION
## WHAT
Remove all references to subscription types that we no longer use in the code base.

## WHY
This cleanup is part of the Stripe/Subscription cleanup and improvement project.

## HOW
Find references to these old subscription types and remove them.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=159cc9f998694a179db6acc908573a2b)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
