### PR TITLE
Evidence/ fix tooltip for mobile

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
                 className="hide-on-mobile beta-tag focus-on-dark"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
                 tabIndex={0}
               >
                 <div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -84,6 +84,8 @@ exports[`ReadAndHighlightInstructions component when the student has not started
               className="undefined"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
               tabIndex={0}
             >
               <img
@@ -201,6 +203,8 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
               className="undefined"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
               tabIndex={0}
             >
               <img

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -80,8 +80,8 @@ export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: 
           className={`${tooltipTriggerTextClass}`}
           onMouseEnter={isOnMobile ? () => false : this.showTooltip}
           onMouseLeave={isOnMobile ? () => false : this.startTimer}
-          onTouchStart={isOnMobile ? this.showTooltip : () => false}
           onTouchEnd={isOnMobile ? this.startTimer : () => false}
+          onTouchStart={isOnMobile ? this.showTooltip : () => false}
           style={tooltipTriggerTextStyle}
           tabIndex={tabIndex}
         >

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -63,6 +63,7 @@ export class Tooltip extends React.Component<TooltipProps, {}> {
   render() {
     const { tooltipTriggerText, tooltipTriggerTextClass, tooltipTriggerStyle, tooltipTriggerTextStyle, isTabbable } = this.props
     const tabIndex = isTabbable ? 0 : null;
+    const isOnMobile = window.innerWidth < 770;
     return (
       <span
         className="quill-tooltip-trigger"
@@ -71,8 +72,10 @@ export class Tooltip extends React.Component<TooltipProps, {}> {
       >
         <span
           className={`${tooltipTriggerTextClass}`}
-          onMouseEnter={this.showTooltip}
-          onMouseLeave={this.startTimer}
+          onMouseEnter={isOnMobile ? null : this.showTooltip}
+          onMouseLeave={isOnMobile ? null : this.startTimer}
+          onTouchStart={isOnMobile ? this.showTooltip: null}
+          onTouchEnd={isOnMobile ? this.startTimer: null}
           style={tooltipTriggerTextStyle}
           tabIndex={tabIndex}
         >

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -10,13 +10,15 @@ interface TooltipProps {
   tooltipTriggerStyle?: { [key:string]: any }
 }
 
-export class Tooltip extends React.Component<TooltipProps, {}> {
+export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean }> {
   private timer: any // eslint-disable-line react/sort-comp
   private tooltip: any // eslint-disable-line react/sort-comp
   private tooltipTrigger: any // eslint-disable-line react/sort-comp
 
   constructor(props) {
     super(props)
+
+    this.state = { clickedFromMobile: false }
 
     document.addEventListener('click', this.hideTooltipOnClick.bind(this));
 
@@ -33,13 +35,17 @@ export class Tooltip extends React.Component<TooltipProps, {}> {
   }
 
   hideTooltipOnClick(e) {
+    const { clickedFromMobile } = this.state;
     const { handleClick } = this.props;
-    if (this.tooltip && e.target !== this.tooltip && e.target !== this.tooltipTrigger) {
+    const secondClickFromMobile = clickedFromMobile && e.pointerType === 'touch'
+    const shouldHideTooltip = (this.tooltip && e.target !== this.tooltip && e.target !== this.tooltipTrigger && e.pointerType !== 'touch') || secondClickFromMobile
+    if (shouldHideTooltip) {
       this.hideTooltip()
     }
     if(handleClick) {
       handleClick(e);
     }
+    this.setState(prevState => ({clickedFromMobile: !prevState.clickedFromMobile}));
   }
 
   showTooltip() {
@@ -72,10 +78,10 @@ export class Tooltip extends React.Component<TooltipProps, {}> {
       >
         <span
           className={`${tooltipTriggerTextClass}`}
-          onMouseEnter={isOnMobile ? null : this.showTooltip}
-          onMouseLeave={isOnMobile ? null : this.startTimer}
-          onTouchStart={isOnMobile ? this.showTooltip: null}
-          onTouchEnd={isOnMobile ? this.startTimer: null}
+          onMouseEnter={isOnMobile ? () => false : this.showTooltip}
+          onMouseLeave={isOnMobile ? () => false : this.startTimer}
+          onTouchStart={isOnMobile ? this.showTooltip : () => false}
+          onTouchEnd={isOnMobile ? this.startTimer : () => false}
           style={tooltipTriggerTextStyle}
           tabIndex={tabIndex}
         >

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1540,6 +1540,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "100px",
@@ -1623,6 +1625,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "100px",
@@ -1704,6 +1708,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "100px",

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`Tooltip component should render when it is not searchable 1`] = `
       className="undefined"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
       tabIndex={null}
     >
       I have a lot of text

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -586,6 +586,8 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           className="undefined"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
                           tabIndex={null}
                         >
                           <button
@@ -858,6 +860,8 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           className="undefined"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
                           tabIndex={null}
                         >
                           <button

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
@@ -17821,6 +17821,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 className="tooltip-trigger-text"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
                 tabIndex={null}
               >
                 History: Causes of the American Revolution
@@ -44644,6 +44646,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 className="tooltip-trigger-text"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
                 tabIndex={null}
               >
                 History: Causes of the American Revolution

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
@@ -45879,6 +45879,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     className="tooltip-trigger-text"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
                     tabIndex={null}
                   >
                     History: Causes of the American Revolution

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -63518,6 +63518,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         className="tooltip-trigger-text"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         History: Causes of the American Revolution

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
@@ -44,6 +44,8 @@ exports[`OverrideWarningModal component should render 1`] = `
                 className="undefined"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
                 tabIndex={null}
               >
                 1 student

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
@@ -44,6 +44,8 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
                 className="undefined"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
                 tabIndex={null}
               >
                 1 student

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -430,6 +430,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "245px",
@@ -536,6 +538,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "245px",
@@ -902,6 +906,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "245px",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
@@ -436,6 +436,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "180px",
@@ -619,6 +621,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "180px",
@@ -731,6 +735,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "180px",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -724,6 +724,8 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "289px",
@@ -981,6 +983,8 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   className="data-table-row-section undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
                   style={
                     Object {
                       "minWidth": "289px",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
@@ -353,6 +353,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -403,6 +405,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -453,6 +457,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -503,6 +509,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -553,6 +561,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -603,6 +613,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -5026,6 +5038,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Gabriel De La Concordia Garcia
@@ -7389,6 +7403,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
@@ -8540,6 +8556,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Dehab Lee Kassis-washington
@@ -10660,6 +10678,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Henry Wadsworth Longfellow
@@ -11348,6 +11368,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -11398,6 +11420,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -11448,6 +11472,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -11498,6 +11524,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -11548,6 +11576,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -11598,6 +11628,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="undefined"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
                         tabIndex={null}
                       >
                         <img
@@ -19243,6 +19275,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Gabriel De La Concordia Garcia
@@ -23316,6 +23350,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
@@ -25256,6 +25292,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Dehab Lee Kassis-washington
@@ -28708,6 +28746,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="student-name"
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchStart={[Function]}
                             tabIndex={null}
                           >
                             Henry Wadsworth Longfellow

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
@@ -21,6 +21,8 @@ exports[`SkillGroupTooltip component should render 1`] = `
         className="undefined"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
         tabIndex={null}
       >
         <img

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
@@ -16,6 +16,8 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
         className="student-name"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
         tabIndex={null}
       >
         Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -130,6 +130,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -181,6 +183,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -232,6 +236,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -283,6 +289,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -334,6 +342,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -385,6 +395,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -436,6 +448,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -487,6 +501,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1561,6 +1577,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1620,6 +1638,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1680,6 +1700,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1740,6 +1762,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1800,6 +1824,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img
@@ -1859,6 +1885,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="undefined"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
                       tabIndex={null}
                     >
                       <img


### PR DESCRIPTION
## WHAT
fix our native tooltip to function on mobile

## WHY
we want users to be able to tap on the tooltip trigger to view it

## HOW
add 'onTouchStart` and `onTouchEnd` handlers as well as a new piece of state `clickedOnMobile` to handle different devices

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Image-credit-tooltip-doesn-t-work-on-mobile-afb46e6ac6a74016b713443a87dc8401

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
