### PR TITLE
Add activities to activity pack feature redo for staff (#8848)

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
@@ -21,3 +21,156 @@
     background-color: white;
   }
 }
+
+.unit-template-activities {
+  .no-activity-packs-label {
+    padding-top: 13px;
+    font-weight: normal;
+  }
+
+  .unit-template-selected-activities-table {
+    margin-top: 10px;
+    margin-bottom: 30px;
+  }
+
+  .selected-activities-header {
+    margin-bottom: 10px;
+  }
+
+  .ut-activities-headers {
+    display: inline;
+    background: none;
+    font-size: 14px;
+  }
+
+  .unit-template-filters {
+    input {
+      margin-right: 15px;
+      margin-top: 15px;
+    }
+    .name-search-box, .ccss-search-box {
+      width: 400px;
+    }
+    .description-search-box {
+      width: 490px;
+    }
+    .activity-packs-search-box {
+      width: 300px;
+    }
+    .control {
+      margin-top: 10px;
+    }
+    .unit-template-dropdown-filters {
+      display: inline-flex;
+      .tool-dropdown {
+        margin: 10px;
+      }
+      .readability-dropdown {
+        margin: 10px;
+      }
+    }
+  }
+
+  .ellipses-button {
+    display: inline;
+  }
+
+  .unit-template-activities-table {
+
+    .ut-break {
+      width: 33px;
+      background: none;
+    }
+
+    .ut-name-col {
+      width: 300px;
+    }
+
+    .ut-flag-col {
+      width: 135px !important;
+    }
+
+    .ut-readability-col {
+      width: 125px !important;
+    }
+
+    .ut-ccss-col {
+      width: 155px !important;
+    }
+
+    .ut-concept-col {
+      width: 115px !important;
+    }
+
+    .ut-add-activity {
+      background-color: lightgreen;
+      padding: 1px;
+      border-radius: 5px;
+      padding-right: 10px;
+      padding-left: 10px;
+      color: white;
+      font-weight: bold;
+      border: 1px solid gray;
+      cursor: pointer;
+    }
+
+    .ut-remove-activity {
+      background-color: salmon;
+      padding: 1px;
+      border-radius: 5px;
+      padding-right: 10px;
+      padding-left: 10px;
+      color: white;
+      font-weight: bold;
+      border: 1px solid gray;
+      cursor: pointer;
+    }
+
+    .unit-template-activities-tbody {
+      background-color: white;
+      border-bottom: 1px solid black;
+
+      .ut-activity-row {
+        padding: 5px;
+        border-top: 1px solid gray;
+        border-left: 1px solid gray;
+        border-right: 1px solid gray;
+
+        .expand-collapse-button {
+          background-color: white;
+        }
+
+        .ut-activity-name-col {
+          min-width: 300px !important;
+        }
+
+        .ut-activity-flag-col {
+          min-width: 135px !important;
+        }
+
+        .ut-activity-readability-col {
+          min-width: 125px !important;
+        }
+
+        .ut-activity-ccss-col {
+          min-width: 155px !important;
+        }
+
+        .ut-activity-cat-col {
+          min-width: 115px !important;
+          padding-left: 4px;
+        }
+
+        .ut-activity-class-col {
+          min-width: 100px !important;
+        }
+      }
+
+      .ut-activity-second-row {
+        border-left: 1px solid gray;
+        border-right: 1px solid gray;
+        border-bottom: 1px solid gray;
+      }
+    }
+  }
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
@@ -303,7 +303,7 @@
     align-items: center;
     position: relative;
     width: 100%;
-    background-color: white;
+    background: none;
     .visible-error-message {
       color: red;
       i, svg {

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -14,6 +14,10 @@ class ActivitiesController < ApplicationController
     render json: search_result.to_json
   end
 
+  def index_with_unit_templates
+    render json: Activity.includes(:standard, :raw_score, :classification, :unit_templates, :activities_unit_templates).all.map{|a| Cms::ActivitySerializer.new(a).as_json(root: false)}
+  end
+
   def count
     @count = Activity.where(flags: '{production}').count
     render json: {count: @count}

--- a/services/QuillLMS/app/serializers/cms/activity_serializer.rb
+++ b/services/QuillLMS/app/serializers/cms/activity_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Cms::ActivitySerializer < ActiveModel::Serializer
+  attributes :uid, :id, :name, :description, :flags, :data, :created_at, :updated_at, :supporting_info, :activity_category, :readability_grade_level, :unit_template_names
+
+  has_one :classification, serializer: ClassificationSerializer
+  has_one :standard
+
+  def activity_category
+    return unless object.id
+
+    ActivityCategory
+      .joins("JOIN activity_category_activities ON activity_categories.id = activity_category_activities.activity_category_id")
+      .where("activity_category_activities.activity_id = #{object.id}")
+      .limit(1)
+      .to_a
+      .first
+  end
+
+  def unit_template_names
+    object.unit_templates.map {|ut| ut.name}
+  end
+end

--- a/services/QuillLMS/app/serializers/cms/unit_template_serializer.rb
+++ b/services/QuillLMS/app/serializers/cms/unit_template_serializer.rb
@@ -2,6 +2,6 @@
 
 class Cms::UnitTemplateSerializer < ActiveModel::Serializer
   attributes :id, :name, :author_id, :time, :unit_template_category_id, :grades, :flag, :order_number, :activity_info, :image_link, :readability, :diagnostic_names
-  has_many :activities, serializer: ActivitySerializer
+  has_many :activities, serializer: ::ActivitySerializer
   has_one :unit_template_category
 end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/__tests__/__snapshots__/unit_template.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/__tests__/__snapshots__/unit_template.test.jsx.snap
@@ -129,9 +129,8 @@ exports[`UnitTemplate component Markdown Preview should not render without activ
   <br />
   <br />
   <span>
-    <CustomActivityPack
-      clickContinue={[Function]}
-      selectedActivities={
+    <UnitTemplateActivitySelector
+      parentActivities={
         Array [
           Object {
             "anonymous_path": "/activity_sessions/anonymous?activity_id=303",
@@ -179,8 +178,8 @@ exports[`UnitTemplate component Markdown Preview should not render without activ
           },
         ]
       }
-      setSelectedActivities={[Function]}
-      toggleActivitySelection={[Function]}
+      setParentActivities={[Function]}
+      toggleParentActivity={[Function]}
     />
     <div
       className="error-message-and-button"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template.jsx
@@ -4,8 +4,8 @@ import { EditorState, ContentState } from 'draft-js';
 import Dropzone from 'react-dropzone'
 import _ from 'underscore';
 
+import UnitTemplateActivitySelector from './unit_template_activity_selector'
 import DropdownSelector from '../general_components/dropdown_selectors/dropdown_selector.jsx';
-import CustomActivityPack from '../assignment_flow/create_unit/custom_activity_pack/index';
 import Server from '../modules/server/server.jsx';
 import Fnl from '../modules/fnl.jsx';
 import { TextEditor } from '../../../Shared/index'
@@ -211,17 +211,6 @@ export default createReactClass({
     );
   },
 
-  getCustomActivityPack() {
-    return (
-      <CustomActivityPack
-        clickContinue={this.save}
-        selectedActivities={this.state.model.activities}
-        setSelectedActivities={this.handleNewSelectedActivities}
-        toggleActivitySelection={this.toggleActivitySelection}
-      />
-    );
-  },
-
   getActivityPackDescriptionEditor() {
     const { model } = this.state
     const { activity_info } = model
@@ -314,6 +303,7 @@ export default createReactClass({
   },
 
   render() {
+    const { model, } = this.state
     let inputs;
     inputs = this.modules.textInputGenerator.generate(this.formFields);
     return (
@@ -331,7 +321,11 @@ export default createReactClass({
         {this.getPdfUpload()}
         <br /><br />
         <span>
-          {this.getCustomActivityPack()}
+          <UnitTemplateActivitySelector
+            parentActivities={model.activities}
+            setParentActivities={this.handleNewSelectedActivities}
+            toggleParentActivity={this.toggleActivitySelection}
+          />
           {this.getErrorMessageAndButton()}
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_data_row.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_data_row.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+
+const UNSELECTED_TYPE = 'unselected'
+const UnitTemplateActivityDataRow = ({activity, handleAdd, handleRemove, type}) => {
+  const [showActivities, setShowActivities] = React.useState(false);
+
+  const showHideActivitiesRow = () => {
+    setShowActivities(!showActivities)
+  }
+
+  const expandOrCollapseButton = () => {
+    const buttonClass = 'focus-on-dark'
+    let innerElement;
+    const imageLink = showActivities ? 'collapse.svg' : 'expand.svg'
+    innerElement = <img alt="expand-and-collapse" src={`https://assets.quill.org/images/shared/${imageLink}`} />
+    return <button className={`expand-collapse-button ${buttonClass}`} onClick={showHideActivitiesRow} onKeyPress={showHideActivitiesRow} type="button">{innerElement}</button>
+  }
+
+  const secondRow = (
+    <tr className="ut-activity-second-row">
+      <td />
+      <td />
+      <td>Description: {activity.description}</td>
+      <td colSpan="2">In packs: {activity.unit_template_names.map((ut) => <span key={ut.id}><br />{ut}</span>)}</td>
+    </tr>
+  )
+
+  function handleAddRemove() {
+    if (type === UNSELECTED_TYPE) {
+      handleAdd(activity)
+    } else {
+      handleRemove(activity)
+    }
+  }
+
+  return (
+    <span>
+      <tr className="ut-activity-row">
+        <td onClick={handleAddRemove}>{type === UNSELECTED_TYPE ? <span className="ut-add-activity">+</span> : <span className="ut-remove-activity">-</span>}</td>
+        {expandOrCollapseButton()}
+        <td className="ut-activity-name-col">{activity.name}</td>
+        <td className="ut-activity-flag-col">{activity.data && activity.data["flag"]}</td>
+        <td className="ut-activity-readability-col">{activity.readability_grade_level}</td>
+        <td className="ut-activity-ccss-col">{activity.standard && activity.standard.name}</td>
+        <td className="ut-activity-cat-col">{activity.activity_category && activity.activity_category.name}</td>
+        <td className="ut-activity-class-col">{activity.classification && activity.classification.name}</td>
+      </tr>
+      {showActivities && secondRow}
+    </span>
+  )
+}
+
+export default UnitTemplateActivityDataRow

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_selector.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_selector.tsx
@@ -1,0 +1,286 @@
+import * as React from 'react'
+import request from 'request';
+
+import UnitTemplateActivityDataRow from './unit_template_activity_data_row'
+
+import { FlagDropdown, SortableList } from '../../../Shared/index'
+import Pagination from '../../../Teacher/components/assignment_flow/create_unit/custom_activity_pack/pagination'
+import { lowerBound, upperBound, } from '../../../Teacher/components/assignment_flow/create_unit/custom_activity_pack/shared'
+
+const ACTIVITIES_URL = `${process.env.DEFAULT_URL}/activities/index_with_unit_templates`
+const DEFAULT_FLAG = 'All Flags'
+const DEFAULT_TOOL = 'All Tools'
+const DEFAULT_READABILITY = 'All readability levels'
+const TOOL_OPTIONS = [
+  'All Tools',
+  'Quill Connect',
+  'Quill Grammar',
+  'Quill Proofreader',
+  'Quill Evidence',
+  'Quill Lessons',
+  'Quill Diagnostic'
+]
+const UNSELECTED_TYPE = 'unselected'
+const SELECTED_TYPE = 'selected'
+
+const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, toggleParentActivity }) => {
+
+  const [activities, setActivities] = React.useState<Array<any>>([])
+  const [selectedActivities, setSelectedActivities] = React.useState<Array<any>>(parentActivities)
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [currentPage, setCurrentPage] = React.useState<Number>(1);
+  const [nameSearch, setNameSearch] = React.useState<string>('')
+  const [descriptionSearch, setDescriptionSearch] = React.useState<string>('')
+  const [ccssSearch, setCCSSSearch] = React.useState<string>('')
+  const [conceptSearch, setConceptSearch] = React.useState<string>('')
+  const [activityPacksSearch, setActivityPacksSearch] = React.useState<string>('')
+  const [flagSearch, setFlagSearch] = React.useState<string>(DEFAULT_FLAG)
+  const [toolSearch, setToolSearch] = React.useState<string>(DEFAULT_TOOL)
+  const [readabilitySearch, setReadabilitySearch] = React.useState<string>(DEFAULT_READABILITY)
+  const [readabilityOptions, setReadabilityOptions] = React.useState<Array<any>>([])
+  const [showNoActivityPacks, setShowNoActivityPacks] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    if (loading) { getActivities() }
+  }, []);
+
+  function getActivities() {
+    request.get({
+      url: ACTIVITIES_URL,
+    }, (e, r, body) => {
+      if (e || r.statusCode !== 200) {
+        setLoading(false)
+      } else {
+        const data = JSON.parse(body);
+        setLoading(false)
+        setActivities(data.activities);
+
+        const readArr = data.activities.map(act => act.readability_grade_level)
+        const readUnique = Array.from(new Set(readArr))
+        const readFiltered = readUnique.filter(c => c !== '' && c !== null).sort()
+        readFiltered.push(DEFAULT_READABILITY)
+        setReadabilityOptions(readFiltered)
+      }
+    })
+  }
+
+  function getFilteredActivities() {
+
+    return activities.filter(act => {
+      const nameMatch = nameSearch === '' || (act.name && act.name.toLowerCase().includes(nameSearch.toLowerCase()))
+      const descriptionMatch = descriptionSearch === '' || (act.description && act.description.toLowerCase().includes(descriptionSearch.toLowerCase()))
+      const ccssMatch = ccssSearch === '' || (act.standard && act.standard.name.toLowerCase().includes(ccssSearch.toLowerCase()))
+      const conceptMatch = conceptSearch === '' || (act.activity_category && act.activity_category.name.toLowerCase().includes(conceptSearch.toLowerCase()))
+      const activityPackMatch = activityPacksSearch === '' || (act.unit_template_names && act.unit_template_names.some(ut => ut.toLowerCase().includes(activityPacksSearch.toLowerCase())))
+      const flagMatch = flagSearch === DEFAULT_FLAG || (act.data && act.data['flag'] && act.data['flag'] === flagSearch)
+      const toolMatch = toolSearch === DEFAULT_TOOL || (act.classification && act.classification.name === toolSearch)
+      const readabilityMatch = readabilitySearch === DEFAULT_READABILITY || (act.readability_grade_level && act.readability_grade_level === readabilitySearch)
+      const selectedActivitiesMatch = selectedActivities.length === 0 || !selectedActivities.map(a => a.id).includes(act.id)
+      const showNoActivityPacksMatch = showNoActivityPacks === false || (act.unit_template_names && act.unit_template_names.length === 0)
+      return (
+        nameMatch && descriptionMatch && ccssMatch && conceptMatch && activityPackMatch &&
+        flagMatch && toolMatch && readabilityMatch && selectedActivitiesMatch && showNoActivityPacksMatch
+      );
+    })
+  }
+
+  function currentPageActivities() {
+    return getFilteredActivities().slice(lowerBound(currentPage), upperBound(currentPage))
+  }
+
+  function handleAddActivity(activity) {
+    toggleParentActivity(activity)
+    const newSelectedActivities = selectedActivities.slice()
+    newSelectedActivities.push(activity)
+    setSelectedActivities(newSelectedActivities)
+  }
+
+  function handleRemoveActivity(activity) {
+    toggleParentActivity(activity)
+    const newSelectedActivities = selectedActivities.filter(a => a.id !== activity.id)
+    setSelectedActivities(newSelectedActivities)
+  }
+
+  const tableHeaders = (
+    <tr className="ut-activities-headers">
+      <th className="ut-break">&nbsp;</th>
+      <th className="ut-break">&nbsp;</th>
+      <th className="ut-name-col">Name</th>
+      <th className="ut-flag-col">Flag</th>
+      <th className="ut-readability-col">Readability</th>
+      <th className="ut-ccss-col">CCSS</th>
+      <th className="ut-concept-col">Concept</th>
+      <th className="ut-tool-col">Tool</th>
+    </tr>
+  )
+
+
+  const activityRows = currentPageActivities().map((act) => {
+    return (
+      <UnitTemplateActivityDataRow
+        activity={act}
+        handleAdd={handleAddActivity}
+        handleRemove={handleRemoveActivity}
+        key={act.id}
+        type={UNSELECTED_TYPE}
+      />
+    )
+  })
+
+  function handleNameSearch(e) {
+    setNameSearch(e.target.value)
+  }
+
+  function handleDescriptionSearch(e) {
+    setDescriptionSearch(e.target.value)
+  }
+
+  function handleCCSSSearch(e) {
+    setCCSSSearch(e.target.value)
+  }
+
+  function handleConceptSearch(e) {
+    setConceptSearch(e.target.value)
+  }
+
+  function handleActivityPacksSearch(e) {
+    setActivityPacksSearch(e.target.value)
+  }
+
+  function handleFlagSearch(e) {
+    setFlagSearch(e.target.value)
+  }
+
+  function handleToolSearch(e) {
+    setToolSearch(e.target.value)
+  }
+
+  function handleReadabilitySearch(e) {
+    setReadabilitySearch(e.target.value)
+  }
+
+  function updateOrder(sortInfo) {
+    const sortedIds = sortInfo.map(s => s.key)
+    const newOrderedActivities = sortedIds.map((s) => activities.find((a) => a.id === parseInt(s)))
+    setSelectedActivities(newOrderedActivities)
+
+    const selectedParentActivities = newOrderedActivities.map(act => parentActivities.find(a => a.id === act.id))
+    setParentActivities(selectedParentActivities)
+  }
+
+  function toggleShowNoActivityPacks() {
+    setShowNoActivityPacks(!showNoActivityPacks)
+  }
+
+  function selectedActivitiesTable() {
+    const fullSelectedActivities = activities.length ? selectedActivities.map((act) => activities.find(a => act.id === a.id)) : []
+    const rows = fullSelectedActivities.map((act) => {
+      return (
+        <UnitTemplateActivityDataRow
+          activity={act}
+          handleAdd={handleAddActivity}
+          handleRemove={handleRemoveActivity}
+          key={act.id}
+          type={SELECTED_TYPE}
+        />
+      )
+    })
+    return (
+      <div className="unit-template-activities-table unit-template-selected-activities-table">
+        <h4 className="selected-activities-header">Selected Activities:</h4>
+        <table className="unit-template-activities-table-rows">
+          {tableHeaders}
+          <tbody className="unit-template-activities-tbody">
+            <SortableList data={rows} sortCallback={updateOrder} />
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  const filterInputs = (
+    <div className="unit-template-filters">
+      <input
+        aria-label="Search by name"
+        className="name-search-box"
+        name="nameInput"
+        onChange={handleNameSearch}
+        placeholder="Search by name"
+        value={nameSearch || ""}
+      />
+      <input
+        aria-label="Search by description"
+        className="description-search-box"
+        name="descriptionInput"
+        onChange={handleDescriptionSearch}
+        placeholder="Search by description"
+        value={descriptionSearch || ""}
+      />
+      <input
+        aria-label="Search by CCSS"
+        className="ccss-search-box"
+        name="ccssInput"
+        onChange={handleCCSSSearch}
+        placeholder="Search by CCSS"
+        value={ccssSearch || ""}
+      />
+      <input
+        aria-label="Search by concept"
+        className="concept-search-box"
+        name="conceptInput"
+        onChange={handleConceptSearch}
+        placeholder="Search by concept"
+        value={conceptSearch || ""}
+      />
+      <input
+        aria-label="Search by activity pack"
+        className="activity-packs-search-box"
+        name="activityPacksInput"
+        onChange={handleActivityPacksSearch}
+        placeholder="Search by activity pack"
+        value={activityPacksSearch || ""}
+      />
+      <div className="unit-template-dropdown-filters">
+        <FlagDropdown
+          flag={flagSearch}
+          handleFlagChange={handleFlagSearch}
+          isLessons={true}
+        />
+        <span className="tool-dropdown select is-large">
+          <select onChange={handleToolSearch} value={toolSearch}>
+            {TOOL_OPTIONS.map(key => <option key={key} value={key}>{key}</option>)}
+          </select>
+        </span>
+        <span className="readability-dropdown select is-large">
+          <select onChange={handleReadabilitySearch} value={readabilitySearch}>
+            {readabilityOptions.map(key => <option key={key} value={key}>{key}</option>)}
+          </select>
+        </span>
+        <input aria-label="filter for activities without activity packs" id="no-activity-packs" name="no-activity-packs" onChange={toggleShowNoActivityPacks} type="checkbox" value="no-activity-packs" />
+        <label className="no-activity-packs-label" htmlFor="no-activity-packs">Only show activities without activity packs</label>
+      </div>
+
+
+    </div>
+  )
+
+  return (
+    <div className="unit-template-activities">
+      <h3>Activities in Pack:</h3>
+      {selectedActivitiesTable()}
+      <h4>All Activities:</h4>
+      {filterInputs}
+      <div className="unit-template-activities-table">
+        {tableHeaders}
+        <table className="unit-template-activities-table-rows">
+          <tbody className="unit-template-activities-tbody">
+            {activityRows}
+          </tbody>
+        </table>
+      </div>
+      <Pagination activities={getFilteredActivities()} currentPage={currentPage} setCurrentPage={setCurrentPage} />
+    </div>
+  )
+}
+
+export default UnitTemplateActivitySelector

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -122,6 +122,7 @@ EmpiricalGrammar::Application.routes.draw do
   resources :activities, only: [] do
     post :retry, on: :member
     get :search, on: :collection
+    get :index_with_unit_templates, on: :collection
   end
 
   resources :milestones, only: [] do

--- a/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Cms::ActivitySerializer do
+  it_behaves_like 'serializer' do
+    let(:record_instance) { create(:activity) }
+    let(:result_key) { "activity" }
+
+    let(:expected_serialized_keys) do
+      %w{
+        uid
+        id
+        name
+        description
+        flags
+        data
+        created_at
+        updated_at
+        supporting_info
+        activity_category
+        readability_grade_level
+        unit_template_names
+        classification
+        standard
+      }
+    end
+  end
+end


### PR DESCRIPTION
* add initial activity table skeleton files and code

* trying to add activity row with styling and a back end that sends the correct data

* fix up styling

* fix url pointer

* finish styling for all activities table

* start adding filter inputs

* add in all styled filter dropdowns

* add ability to add and remove activities from selected activities

* fix a linting error

* update snapshot

* drag to reorder added

* route back to default url

* update test

* add spec

* change from emma

* changes suggested

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
