### PR TITLE
grammar rule lookup modification

### DIFF
--- a/services/QuillLMS/.env-sample
+++ b/services/QuillLMS/.env-sample
@@ -37,3 +37,4 @@ AUTOML_CREDENTIALS=
 AUTOML_GOOGLE_PROJECT_ID=
 AUTOML_GOOGLE_LOCATION=
 OPINION_API_DOMAIN=https://opinion-api.quill.org
+GRAMMAR_API_DOMAIN=https://quill.spell.services/Quill/grammar/predict

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -14,6 +14,7 @@ module Evidence
         "cite_vs_sight_vs_site" => '110da2cc-9acd-43e9-a137-774b3b994f08',
         "contractions" => '112cc9e1-75db-47ab-9be1-7b9084838575',
         "council_vs_counsel" => '31c3118f-0952-485b-8318-c3feba9fb5c4',
+        "extra_space" => 'c745ca1f-b94f-41ea-912a-2012cc654054',
         "further_vs_farther" => 'ba42ab74-e0f8-4abe-998e-e11ffeb060a5',
         "in_regards_to" => 'b5068c7d-30f7-496b-832e-a6eca792ffe5',
         "its_versus_it_s_it_s_optimal" => '8d8fe106-e0a5-440a-8bd4-4e34d8d0a16e',


### PR DESCRIPTION
## WHAT
- Adds a grammar-api-emitted rule name to the LMS grammar rule lookup. 
- orthogonally, adds `GRAMMAR_API_DOMAIN` to `.env-sample`, which should have already been there

## WHY
So that LMS reaches parity with grammar-api with respect to the `extra spacing` error 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=362f7d20cb144da984904c9dfe56754d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
