### PR TITLE
lms/revert-caching-until-we-fix-invalidation

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -113,11 +113,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def diagnostic_units
-    json = current_user.all_classrooms_cache(key: 'teachers.units.diagnostic_units') do
-      diagnostics_organized_by_classroom.to_json
-    end
-
-    render json: json
+    render json: diagnostics_organized_by_classroom.to_json
   end
 
   # Get all Units containing lessons, and only retrieve the classroom activities for lessons.


### PR DESCRIPTION
## WHAT
Temporarily turn off caching until we figure out why it's not invalidating
## WHY
So that reports work as expected until we resolve the cache invalidation logic
## HOW
Just revert to the pre-caching version of the code

### Notion Card Links
https://www.notion.so/quill/Recently-completed-diagnostic-results-not-accessible-through-Student-Reports-48e44bea3089439bab5a7454aa93f548

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around caching
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
