### PR TITLE
lms/activity-score-caching-issue

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -7,9 +7,7 @@ class Api::V1::ProgressReportsController < Api::ApiController
     classroom_ids = current_user&.classrooms_i_teach&.map(&:id)
     return render json: { data: [] } if classroom_ids.empty?
 
-    data = current_user.all_classrooms_cache(key: 'api.v1.progress_reports.activities_scores_by_classroom_data') do
-      ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
-    end
+    data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
 
     render json: { data: data }
   end


### PR DESCRIPTION
## WHAT
Remove caching for endpoint
## WHY
Since it doesn't seem to be invalidating as expected
## HOW
Just remove the caching wrapper for now

### Notion Card Links
https://www.notion.so/quill/Activity-Score-last-active-date-incorrect-a1aa9d73d5cf49348a7ed64f78c20e09

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
