### PR TITLE
Unlink users from vitally when they are unlinked on Quill

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -466,6 +466,7 @@ module Teacher
   end
 
   def unlink
+    VitallyIntegration::UnlinkUserWorker.perform_async(id, school&.id)
     self.school = nil
     updated_school(nil)
     save

--- a/services/QuillLMS/app/services/vitally_integration/vitally_api.rb
+++ b/services/QuillLMS/app/services/vitally_integration/vitally_api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class VitallyApi
-  VITALLY_API_BASE_URL = 'https://api.vitally.io/analytics/v1/'
+  VITALLY_API_BASE_URL = 'https://api.vitally.io/analytics/v1'
 
   def initialize
     @api_key = ENV['VITALLY_API_KEY']
@@ -11,8 +11,12 @@ class VitallyApi
     send('batch', payload)
   end
 
+  def unlink(payload)
+    send('unlink', payload)
+  end
+
   private def send(command, payload)
-    HTTParty.post("#{VITALLY_API_BASE_URL}#{command}",
+    HTTParty.post("#{VITALLY_API_BASE_URL}/#{command}",
       headers: {
         Authorization: "Basic #{@api_key}",
         "Content-Type": "application/json"

--- a/services/QuillLMS/app/workers/vitally_integration/unlink_user_worker.rb
+++ b/services/QuillLMS/app/workers/vitally_integration/unlink_user_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module VitallyIntegration
+  class UnlinkUserWorker
+    include Sidekiq::Worker
+
+    def perform(user_id, school_id)
+      return if user_id.nil? || school_id.nil?
+
+      VitallyApi.new.unlink(
+        userId: user_id,
+        accountId: school_id,
+        messageId: SecureRandom.uuid
+      )
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/vitally_integration/vitally_api_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/vitally_api_spec.rb
@@ -3,29 +3,47 @@
 require 'rails_helper'
 
 describe VitallyApi do
+  let(:api)  { VitallyApi.new }
+
   describe '#batch' do
     it 'should post the payload to the batch endpoint' do
-      api = VitallyApi.new
       mock_payload = 'payload'
       expect(api).to receive(:send).with('batch', mock_payload)
       api.batch(mock_payload)
     end
-  end
 
-  describe '#send' do
     it 'should make a POST call to the Vitally API with the specified command and payload' do
       ENV['VITALLY_API_KEY'] = 'test api key'
       payload = 'test payload'
-      expect(HTTParty).to receive(:post).with("#{VitallyApi::VITALLY_API_BASE_URL}batch",
+      expect(HTTParty).to receive(:post).with("#{VitallyApi::VITALLY_API_BASE_URL}/batch",
         headers: {
           Authorization: "Basic #{ENV['VITALLY_API_KEY']}",
           "Content-Type": "application/json"
         },
         body: payload.to_json
       )
-      api = VitallyApi.new
-      # "send" is a private method, so we get to it through the public "batch" method
       api.batch(payload)
+    end
+  end
+
+  describe '#unlink' do
+    it 'should post the payload to the unlink endpoint' do
+      mock_payload = 'payload'
+      expect(api).to receive(:send).with('unlink', mock_payload)
+      api.unlink(mock_payload)
+    end
+
+    it 'should make a POST call to the Vitally API with the specified command and payload' do
+      ENV['VITALLY_API_KEY'] = 'test api key'
+      payload = 'test payload'
+      expect(HTTParty).to receive(:post).with("#{VitallyApi::VITALLY_API_BASE_URL}/unlink",
+        headers: {
+          Authorization: "Basic #{ENV['VITALLY_API_KEY']}",
+          "Content-Type": "application/json"
+        },
+        body: payload.to_json
+      )
+      api.unlink(payload)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/vitally_integration/unlink_user_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/vitally_integration/unlink_user_worker_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VitallyIntegration::UnlinkUserWorker do
+  subject { described_class.new.perform(user_id, school_id) }
+
+  context 'valid user_id' do
+    let(:user_id) { '123' }
+
+    context 'valid school_id' do
+      let(:school_id) { '456' }
+      let(:uuid) { 'abcdefg' }
+      let(:payload) { { userId: user_id, accountId: school_id, messageId: uuid } }
+
+      before { allow(SecureRandom).to receive(:uuid).and_return(uuid) }
+
+      it 'should unlink the user from vitally' do
+        api = double(:vitally_api)
+        expect(VitallyApi).to receive(:new).and_return(api)
+        expect(api).to receive(:unlink).with(payload)
+        subject
+      end
+    end
+
+    context 'invalid school_id' do
+      let(:school_id) { nil }
+
+      it { should_not_unlink_user }
+    end
+  end
+
+  context 'invalid user_id' do
+    let(:user_id) { nil }
+
+    context 'valid school_id' do
+      let(:school_id) { '456' }
+
+      it { should_not_unlink_user }
+    end
+
+    context 'invalid school_id' do
+      let(:school_id) { nil }
+
+      it { should_not_unlink_user }
+    end
+  end
+
+  def should_not_unlink_user
+    expect(VitallyApi).not_to receive(:new)
+    subject
+  end
+end
+
+


### PR DESCRIPTION
## WHAT
Fix a bug so that teachers who are unlinked from the Quill UI admin dashboard are also unlinked from vitally.

## WHY
There's a mismatch between teachers listed with a school on Quill and Vitally

## HOW
Add a worker that hits the `unlink` api [endpoint](https://docs.vitally.io/pushing-data-to-vitally/using-the-vitally-api/https-analytics-api/analytics-api-unlink) when a teacher is unlinked.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/School-user-lists-in-Vitally-do-not-match-user-lists-in-Quill-0d9ad26bf2b44bd7bfea1399334ed10b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
