### PR TITLE
Fix Null headers 'content-type' bug on frontend.

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/request.ts
@@ -17,6 +17,11 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
     if (!response.ok) {
       throw response
     }
+
+    if (response.headers === null) {
+      return ""
+    }
+
     const contentType = String(response.headers.get('content-type'))
 
     if (contentType.startsWith('application/json;')) {

--- a/services/QuillLMS/client/app/bundles/Connect/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/request.ts
@@ -17,7 +17,9 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
     if (!response.ok) {
       throw response
     }
-    if (response.headers.get('content-type').startsWith('application/json;')) {
+    const contentType = String(response.headers.get('content-type'))
+
+    if (contentType.startsWith('application/json;')) {
       return response.json()
     }
     return response.text()

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/request.ts
@@ -17,7 +17,10 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
     if (!response.ok) {
       throw response
     }
-    if (response.headers.get('content-type').startsWith('application/json;')) {
+
+    const contentType = String(response.headers.get('content-type'))
+
+    if (contentType.startsWith('application/json;')) {
       return response.json()
     }
     return response.text()

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/request.ts
@@ -18,6 +18,10 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
       throw response
     }
 
+    if (response.headers === null) {
+      return ""
+    }
+
     const contentType = String(response.headers.get('content-type'))
 
     if (contentType.startsWith('application/json;')) {

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/request.ts
@@ -17,6 +17,11 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
     if (!response.ok) {
       throw response
     }
+
+    if (response.headers === null) {
+      return ""
+    }
+
     const contentType = String(response.headers.get('content-type'))
 
     if (contentType.startsWith('application/json;')) {

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/request.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/request.ts
@@ -17,7 +17,9 @@ async function handleFetch(url: string, method: string, payload?: object): Promi
     if (!response.ok) {
       throw response
     }
-    if (response.headers.get('content-type').startsWith('application/json;')) {
+    const contentType = String(response.headers.get('content-type'))
+
+    if (contentType.startsWith('application/json;')) {
       return response.json()
     }
     return response.text()


### PR DESCRIPTION
## WHAT
We recently updated the `active_activity_sessions#update` endpoint to return `head :no_content`. This is causing millions of frontend `null` errors when the response is parsed. Adding `null` checking.
## WHY
This wouldn't effect users, but these errors destroy our Sentry quota. 
## HOW
Adding some `null` checking and casting to a `String` since `.startsWith` is a string specific method. Note, `String(null)` returns `'null'`.
### Screenshots
![Screen Shot 2022-03-01 at 5 00 44 PM](https://user-images.githubusercontent.com/1304933/156256537-fc60b024-200a-4a39-ad56-aae4f44fbed3.png)

[Sentry Error 1](https://sentry.io/organizations/quillorg-5s/issues/2634873458/?project=210579&query=is%3Aunresolved)

[Sentry Error 2](https://sentry.io/organizations/quillorg-5s/issues/2634873465/?project=210579&query=is%3Aunresolved)

[Sentry Error 3](https://sentry.io/organizations/quillorg-5s/issues/2634873374/?project=210579&query=is%3Aunresolved)

[Sentry Error 4](https://sentry.io/organizations/quillorg-5s/issues/2634873433/?project=210579&query=is%3Aunresolved)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  These methods are untested. I'd love to add tests, but still looking for a pattern in our code base for mocking these requests.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
