### PR TITLE
lms/remove-extraneous-identify-attribute

### DIFF
--- a/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
+++ b/services/QuillLMS/app/serializers/segment_analytics_user_serializer.rb
@@ -7,8 +7,7 @@ class SegmentAnalyticsUserSerializer < UserSerializer
     {
       userType: object.role,
       createdAt: object.created_at,
-      daysSinceJoining: ((Time.zone.now - object.created_at) / 60 / 60 / 24).to_i,
-      premiumType: object.subscription&.account_type
+      daysSinceJoining: ((Time.zone.now - object.created_at) / 60 / 60 / 24).to_i
     }
   end
 end

--- a/services/QuillLMS/spec/helpers/segment_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/segment_helper_spec.rb
@@ -21,8 +21,7 @@ describe SegmentioHelper do
       expected_serialization = {
         userType: user.role,
         createdAt: user.created_at,
-        daysSinceJoining: ((Time.zone.now - user.created_at) / 60 / 60 / 24).to_i,
-        premiumType: user.subscription.account_type
+        daysSinceJoining: ((Time.zone.now - user.created_at) / 60 / 60 / 24).to_i
       }
       expect(serialization).to eq(expected_serialization)
     end


### PR DESCRIPTION
## WHAT
Remove front-end identify attribute
## WHY
Since we already pass it in on back-end events, but with a slightly different name "premium_type" instead of "premiumType".  Peter S says that the former is preferred, and that both are making it into Intercom now, so we're removing the second path for setting the value.
## HOW
Just remove the key from the hash that's used to generate data sent in front-end `identify` calls

### Notion Card Links
https://www.notion.so/quill/BLOCKED-Determine-why-Premium-type-is-not-flowing-into-Intercom-as-an-attribute-and-resolve-the-p-36949960406b4330a5c9b4b46ffd977e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
