### PR TITLE
Add "private" flag to Evidence CMS dropdowns

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -37,6 +37,10 @@ exports[`Activity Form component should render Activities 1`] = `
             "value": "alpha",
           },
           Object {
+            "label": "private",
+            "value": "private",
+          },
+          Object {
             "label": "beta",
             "value": "beta",
           },

--- a/services/QuillLMS/client/app/constants/evidence.ts
+++ b/services/QuillLMS/client/app/constants/evidence.ts
@@ -48,6 +48,10 @@ export const flagOptions = [
     value: 'alpha'
   },
   {
+    label: 'private',
+    value: 'private'
+  },
+  {
     label: 'beta',
     value: 'beta'
   },


### PR DESCRIPTION
## WHAT
Add this flag in for admin to select the attribute flag: "private".

## WHY
So admin can select this flag for activities.

## HOW
Just add the flag into the options hash.

### Screenshots
<img width="907" alt="Screen Shot 2022-03-02 at 10 35 16 AM" src="https://user-images.githubusercontent.com/57366100/156412723-52f3bfec-5f17-49c6-a9b5-c637e63eea3c.png">

### Notion Card Links
https://www.notion.so/quill/Add-all-user-flags-to-the-Evidence-CMS-dropdown-9ecdf29bea6c434d9fcbbebead1b97c7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
