### PR TITLE
Remove the promotional_dates feature for new subscribers

### DIFF
--- a/services/QuillLMS/app/controllers/cms/cms_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/cms_controller.rb
@@ -15,7 +15,7 @@ class Cms::CmsController < ApplicationController
     @subscription_payment_methods = Subscription::PAYMENT_METHODS.dup
     # we do not want credit card here as it should only occur automatically
     @subscription_payment_methods.delete('Credit Card')
-    @promo_expiration_date = Subscription.promotional_dates[:expiration]
+    @promo_expiration_date = Date.today + 1.year
     # get the user's colleagues at the same school if user subscription, or the school if we are editing a school subscription
     @school ||= (@user && @user.school)
 

--- a/services/QuillLMS/app/controllers/cms/cms_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/cms_controller.rb
@@ -15,7 +15,6 @@ class Cms::CmsController < ApplicationController
     @subscription_payment_methods = Subscription::PAYMENT_METHODS.dup
     # we do not want credit card here as it should only occur automatically
     @subscription_payment_methods.delete('Credit Card')
-    @promo_expiration_date = Date.today + 1.year
     # get the user's colleagues at the same school if user subscription, or the school if we are editing a school subscription
     @school ||= (@user && @user.school)
 

--- a/services/QuillLMS/app/views/cms/schools/edit_subscription.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/edit_subscription.html.erb
@@ -1,4 +1,4 @@
 <div class='container'>
   <%= react_component('SubscriptionApp', props: {view: 'edit', school: @school, subscription: @subscription, premiumTypes: @premium_types,
-  promoExpiration: @promo_expiration_date, subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
+  subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
 </div>

--- a/services/QuillLMS/app/views/cms/schools/new_subscription.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/new_subscription.html.erb
@@ -1,4 +1,4 @@
 <div class='container'>
   <%= react_component('SubscriptionApp', props: {view: 'new', school: @school, schoolOrUser: 'school', subscription: @subscription, premiumTypes: @premium_types,
-  promoExpiration: @promo_expiration_date, subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
+  subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
 </div>

--- a/services/QuillLMS/app/views/cms/subscriptions/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/subscriptions/edit.html.erb
@@ -1,4 +1,4 @@
 <div class='container'>
   <%= react_component('SubscriptionApp', props: {view: 'edit', school: @school || nil, subscription: @subscription, premiumTypes: @premium_types,
-  promoExpiration: @promo_expiration_date, subscriptionPaymentMethods: @subscription_payment_methods })%>
+  subscriptionPaymentMethods: @subscription_payment_methods })%>
 </div>

--- a/services/QuillLMS/app/views/cms/users/edit_subscription.html.erb
+++ b/services/QuillLMS/app/views/cms/users/edit_subscription.html.erb
@@ -1,4 +1,4 @@
 <div class='container'>
   <%= react_component('SubscriptionApp', props: {view: 'edit', user: @user, subscription: @subscription, premiumTypes: @premium_types,
-  promoExpiration: @promo_expiration_date, subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
+  subscriptionPaymentMethods: @subscription_payment_methods, purchaserEmail: @purchaser_email, schoolsUsers: @schools_users })%>
 </div>

--- a/services/QuillLMS/app/views/cms/users/new_subscription.html.erb
+++ b/services/QuillLMS/app/views/cms/users/new_subscription.html.erb
@@ -1,4 +1,4 @@
 <div class='container'>
   <%= react_component('SubscriptionApp', props: {view: 'new', user: @user, schoolOrUser: 'user', subscription: @subscription, premiumTypes: @premium_types,
-  promoExpiration: @promo_expiration_date, subscriptionPaymentMethods: @subscription_payment_methods, schoolsUsers: @schools_users })%>
+  subscriptionPaymentMethods: @subscription_payment_methods, schoolsUsers: @schools_users })%>
 </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -202,7 +202,7 @@ export default class EditOrCreateSubscription extends React.Component {
 
   render() {
     const { firstFocused, secondFocused, subscription, } = this.state
-    const { user, school, view, premiumTypes, subscriptionPaymentMethods, promoExpiration, } = this.props
+    const { user, school, view, premiumTypes, subscriptionPaymentMethods, } = this.props
     const schoolOrUser = school || user || null;
     const submitAction = school ? this.submitConfirmation : this.submit;
     return (
@@ -253,9 +253,6 @@ export default class EditOrCreateSubscription extends React.Component {
           onFocusChange={() => this.setState({ firstFocused: !firstFocused })}
         />
         <label htmlFor="">End Date</label>
-        <p>
-          If this a school or users first paid subscription, the default end date is {promoExpiration}. This value just stated will update automatically depending on the time of year.
-        </p>
         <SingleDatePicker
           date={subscription.expiration ? moment(subscription.expiration) : null}
           focused={secondFocused}

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -143,10 +143,10 @@ describe Cms::SchoolsController do
 
 
     describe 'when there is no existing subscription' do
-      it 'should create a new subscription that starts today and ends at the promotional expiration date' do
+      it 'should create a new subscription that starts today and ends exactly 1 year later' do
         get :new_subscription, params: { id: school_with_no_subscription.id }
         expect(assigns(:subscription).start_date).to eq Date.today
-        expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
+        expect(assigns(:subscription).expiration).to eq Date.today + 1.year
       end
     end
 

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -207,10 +207,10 @@ describe Cms::UsersController do
     let!(:user_subscription) { create(:user_subscription, user: another_user, subscription: subscription) }
 
     describe 'when there is no existing subscription' do
-      it 'should create a new subscription that starts today and ends at the promotional expiration date' do
+      it 'should create a new subscription that starts today and ends exactly 1 year later' do
         get :new_subscription, params: { id: user_with_no_subscription.id }
         expect(assigns(:subscription).start_date).to eq Date.today
-        expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
+        expect(assigns(:subscription).expiration).to eq Date.today + 1.year
       end
     end
 

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -261,36 +261,6 @@ describe Subscription, type: :model do
     end
   end
 
-  describe ".promotional_dates" do
-    context 'when called on a day prior to August, 1' do
-      before do
-        allow(Date).to receive(:today).and_return Date.new(2018,4,4)
-      end
-
-      it "returns an expiration date of July 31 the next year when called on a day prior to August" do
-        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,7,31))
-      end
-
-      it "returns a start date one year from the day it was called" do
-        expect(Subscription.promotional_dates[:start_date]).to eq(Date.today)
-      end
-    end
-
-    context 'when called on a day after July 31' do
-      before do
-        allow(Date).to receive(:today).and_return Date.new(2018,10,4)
-      end
-
-      it "returns an expiration date of July 31 the next year when called on a day prior to August" do
-        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,12,31))
-      end
-
-      it "returns a start date one year from the day it was called" do
-        expect(Subscription.promotional_dates[:start_date]).to eq(Date.today)
-      end
-    end
-  end
-
   describe 'create_with_user_join' do
     let!(:user) { create(:user) }
     let(:old_sub) { Subscription.create_with_user_join(user.id, expiration: Date.yesterday, account_type: 'Teacher Paid') }


### PR DESCRIPTION
## WHAT
Remove all references to `Subscriptions.promotional_dates` because we no longer want to give new subscribers bonus days on the end of their subscriptions.

## WHY
We want to end this feature, as part of our Subscriptions revamp project.

## HOW
Remove all references to the function `promotional_dates` which calculated an extended promotional subscription period for new subscribers.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Stop-adding-bonus-days-to-subscriptions-dc0a85d7f6194753be2bd0b25f656a7a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes