### PR TITLE
Remove the default behavior the displays "Invoice" when there's no payment method

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -143,7 +143,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
               PAYMENT METHOD ON FILE
             </h3>
             <span>
-              Invoice
+              No Payment Method on File
             </span>
           </div>
           <div
@@ -323,7 +323,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
               PAYMENT METHOD ON FILE
             </h3>
             <span>
-              Invoice
+              No Payment Method on File
             </span>
           </div>
           <div
@@ -488,7 +488,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
               PAYMENT METHOD ON FILE
             </h3>
             <span>
-              Invoice
+              No Payment Method on File
             </span>
           </div>
           <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -44,7 +44,7 @@ export default class CurrentSubscription extends React.Component {
       return <span>Credit Card</span>;
     } else if (subscriptionType === 'School Sponsored' || subscriptionType === 'Trial') {
       return <span>No Payment Method on File</span>;
-    } else if (subscriptionStatus && (!subscriptionStatus.payment_method || subscriptionStatus.payment_method === 'School Invoice')) {
+    } else if (subscriptionStatus && ['Invoice', 'School Invoice'].includes(subscriptionStatus.payment_method)) {
       return <span>Invoice</span>;
     } else if (!subscriptionStatus && lastFour) {
       return this.editCreditCardElement();

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -51,7 +51,8 @@ export default class EditOrCreateSubscription extends React.Component {
   changePaymentMethod = (e) => {
     const { subscription, } = this.state
     const newSub = Object.assign({}, subscription);
-    newSub.payment_method = e;
+    const newPaymentMethod = e === 'N/A' ? null : e
+    newSub.payment_method = newPaymentMethod;
     this.setState({ subscription: newSub, });
   }
 
@@ -205,6 +206,7 @@ export default class EditOrCreateSubscription extends React.Component {
     const { user, school, view, premiumTypes, subscriptionPaymentMethods, promoExpiration, } = this.props
     const schoolOrUser = school || user || null;
     const submitAction = school ? this.submitConfirmation : this.submit;
+    const subscriptionPaymentOptions = subscriptionPaymentMethods.concat('N/A')
     return (
       <div className="cms-subscription">
         <h1>{view === 'edit' ? 'Edit' : 'New'} Subscription: {_.get(schoolOrUser, 'name')}</h1>
@@ -223,8 +225,8 @@ export default class EditOrCreateSubscription extends React.Component {
         <ItemDropdown
           callback={this.changePaymentMethod}
           className="subscription-dropdown"
-          items={subscriptionPaymentMethods}
-          selectedItem={subscription.payment_method || ''}
+          items={subscriptionPaymentOptions}
+          selectedItem={subscription.payment_method || 'N/A'}
         />
         <label>Purchase Amount (dollar value as integer -- no decimal or symbol)</label>
         <input onChange={this.handlePaymentAmountChange} type="text" value={subscription.payment_amount / 100} />


### PR DESCRIPTION
## WHAT
Remove this default behavior that displays "Invoice" when there's no payment method. This is technically incorrect because we did not charge these people by an invoice.

## WHY
This displays inaccurate and confusing data to our users.

## HOW
Just remove the case check for when `payment_method` is null.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Display-No-Payment-Method-on-File-for-all-free-plans-on-the-My-Subscriptions-page-5afce2f77ded4347b1827efbdb2927b3)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
