### PR TITLE
Fix evidence bug with backspace over prompt in student response

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -132,7 +132,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
     let wordsToFormat = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).map(hl => this.stripHtml(hl.text))
     wordsToFormat = wordsToFormat.length === 1 ? wordsToFormat[0] : wordsToFormat
-    if (lastSubmittedResponse.feedback_type == 'plagiarism') {
+    if (lastSubmittedResponse.feedback_type === 'plagiarism') {
       return this.formatPlagiarismHighlight(str, wordsToFormat)
     } else {
       return highlightSpellingGrammar(str, wordsToFormat)
@@ -155,8 +155,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   promptAsRegex = () => new RegExp(`^${this.htmlStrippedPrompt(true)}`)
 
   onTextChange = (e) => {
-    const { html, } = this.state
-    const { value, } = e.target
+    const { value } = e.target
     const text = value.replace(/<b>|<\/b>|<p>|<\/p>|<br>/g, '')
     const regex = this.promptAsRegex()
     const caretPosition = EditCaretPositioning.saveSelection(this.editor)
@@ -199,9 +198,11 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
           if (diffWordWithoutHtmlLettersArray) {
             const diffWordEquivalentWithoutHtmlLettersArray = this.stripHtml(diffWordEquivalent)
             const indexOfLettersToKeepFromDiffWord = diffWordWithoutHtmlLettersArray.findIndex((letter: string, i: number) => letter !== diffWordEquivalentWithoutHtmlLettersArray[i])
-            const partOfDiffWordToKeep = diffWordWithoutHtmlLettersArray.slice(indexOfLettersToKeepFromDiffWord).join('').replace(/(&nbsp;)|(<u>)|(<\/u>)/g, '')
-            // keeping track of what they'd modified it to be, so we don't lose those changes
-            textToAddAfterPromptText.push(partOfDiffWordToKeep)
+            if (indexOfLettersToKeepFromDiffWord !== -1) {
+              const partOfDiffWordToKeep = diffWordWithoutHtmlLettersArray.slice(indexOfLettersToKeepFromDiffWord).join('').replace(/(&nbsp;)|(<u>)|(<\/u>)/g, '')
+              // keeping track of what they'd modified it to be, so we don't lose those changes
+              textToAddAfterPromptText.push(partOfDiffWordToKeep)
+            }
           }
         })
 


### PR DESCRIPTION
## WHAT
This PR fixes a bug where a user attempts to delete their response and a portion of the prompt, and then the text box is replaced with the prompt followed by the first letter of the prompt that the user did not delete.

## WHY
This is unexpected behavior.

## HOW
There's an assignment for `indexOfLettersToKeepFromDiffWord` which will return `-1` if the index is not found.  In this case there's no text after the prompt that we need to add therefore we should continue on in the loop.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Extra-e-added-when-typing-a-student-response-in-Evidence-on-Firefox-5ae25574ac58412d9d2d8bf4d693463c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
