### PR TITLE
Update mini_racer

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -199,7 +199,7 @@ group :test do
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
   gem 'codecov'
-  gem 'mini_racer', '= 0.3.1'
+  gem 'mini_racer', '= 0.4.0'
   gem 'fakeredis', '~> 0.7.0'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -199,7 +199,7 @@ group :test do
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
   gem 'codecov'
-  gem 'mini_racer', '= 0.4.0'
+  gem 'mini_racer'
   gem 'fakeredis', '~> 0.7.0'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libsqreen (1.0.4.0.0)
-    libv8-node (15.14.0.1)
+    libv8-node (16.10.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -388,8 +388,8 @@ GEM
       rake
     mini_mime (1.1.0)
     mini_portile2 (2.7.1)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
+    mini_racer (0.6.2)
+      libv8-node (~> 16.10.0.0)
     minisyntax (0.2.5)
     minitest (5.15.0)
     multi_json (1.15.0)
@@ -835,7 +835,7 @@ DEPENDENCIES
   letter_opener
   livingstyleguide
   lograge
-  mini_racer (= 0.4.0)
+  mini_racer
   newrelic_rpm
   nokogiri (>= 1.10.4)
   omniauth

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libsqreen (1.0.4.0.0)
-    libv8 (8.4.255.0)
+    libv8-node (15.14.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -388,8 +388,8 @@ GEM
       rake
     mini_mime (1.1.0)
     mini_portile2 (2.7.1)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minisyntax (0.2.5)
     minitest (5.15.0)
     multi_json (1.15.0)
@@ -716,10 +716,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sq_mini_racer (0.3.1.0.6)
-    sqreen (1.24.2)
+    sqreen (1.25.1)
       libsqreen (~> 1.0)
-      sq_mini_racer (~> 0.2, < 0.5.a)
+      mini_racer (>= 0.4.0)
       sqreen-backport (~> 0.1.0)
       sqreen-kit (~> 0.2.4)
     sqreen-backport (0.1.0)
@@ -836,7 +835,7 @@ DEPENDENCIES
   letter_opener
   livingstyleguide
   lograge
-  mini_racer (= 0.3.1)
+  mini_racer (= 0.4.0)
   newrelic_rpm
   nokogiri (>= 1.10.4)
   omniauth


### PR DESCRIPTION
## WHAT
Update mini_racer gem

## WHY
The libv8-node dependency is outdated.

## HOW
Change the version pegged in the Gemfile.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A