### PR TITLE
Fix bug involving Stripe API retrieval of last_four

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -304,7 +304,7 @@ class User < ApplicationRecord
   def last_four
     return unless stripe_customer?
 
-    Stripe::Customer.retrieve(stripe_customer_id).sources.data.first&.last4
+    Stripe::Customer.retrieve(id: stripe_customer_id, expand: ['sources']).sources.data.first&.last4
   end
 
   def stripe_customer?


### PR DESCRIPTION
## WHAT
Update the method `last_four` on the user model.

## WHY
We upgraded the Stripe API last week, but there was a breaking change missed from the [changelog](https://stripe.com/docs/upgrades#2020-08-27):  "The sources property on Customers is no longer included by default."

## HOW
To get the sources data, we have to add an `expand` configuration (see [docs](https://stripe.com/docs/api/expanding_objects))

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
