### PR TITLE
Upgrade bundler to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           name: Bundle Install if cache isn't present.
           command: |
             cd services/QuillLMS
+            gem install bundler:2.2.33
             # BUNDLE_GEMS__CONTRIBSYS__COM defined in https://circleci.com/gh/empirical-org/Empirical-Core/edit#env-vars
             bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
             bundle check || bundle install --path vendor/bundle

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -199,7 +199,7 @@ group :test do
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
   gem 'codecov'
-  gem 'mini_racer', '= 0.3.1'
+  gem 'mini_racer', '= 0.4.0'
   gem 'fakeredis', '~> 0.7.0'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -8,8 +8,14 @@ PATH
       rails (= 5.1.7)
 
 GEM
-  remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
+  specs:
+    sidekiq-pro (4.0.5)
+      concurrent-ruby (>= 1.0.5)
+      sidekiq (>= 5.2.1)
+
+GEM
+  remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.3)
     actioncable (5.1.7)
@@ -680,9 +686,6 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
-    sidekiq-pro (4.0.5)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.1)
     sidekiq-retries (0.4.0)
       sidekiq (>= 3.2.4)
     signet (0.12.0)
@@ -924,4 +927,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.3
+   2.2.33

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libsqreen (1.0.4.0.0)
-    libv8 (8.4.255.0)
+    libv8-node (15.14.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -388,8 +388,8 @@ GEM
       rake
     mini_mime (1.1.0)
     mini_portile2 (2.7.1)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minisyntax (0.2.5)
     minitest (5.15.0)
     multi_json (1.15.0)
@@ -716,10 +716,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sq_mini_racer (0.3.1.0.6)
-    sqreen (1.24.2)
+    sqreen (1.25.1)
       libsqreen (~> 1.0)
-      sq_mini_racer (~> 0.2, < 0.5.a)
+      mini_racer (>= 0.4.0)
       sqreen-backport (~> 0.1.0)
       sqreen-kit (~> 0.2.4)
     sqreen-backport (0.1.0)
@@ -836,7 +835,7 @@ DEPENDENCIES
   letter_opener
   livingstyleguide
   lograge
-  mini_racer (= 0.3.1)
+  mini_racer (= 0.4.0)
   newrelic_rpm
   nokogiri (>= 1.10.4)
   omniauth

--- a/services/QuillLMS/bin/dev/bootstrap.sh
+++ b/services/QuillLMS/bin/dev/bootstrap.sh
@@ -84,7 +84,7 @@ git remote add quill-lms-prod  https://git.heroku.com/empirical-grammar.git
 
 echo 'Install Bundler'
 # there are breaking changes in bundler 2.0, so pin to this version for now.
-gem install bundler -v 1.17.3
+gem install bundler -v 2.2.33
 gem install foreman -v 0.87.2
 
 # set bundle config, needed for sidekiq-pro


### PR DESCRIPTION
## WHAT
Upgrade bundler from 1.17.3 to 2.2.33.

## WHY
There's an [incompatibility](https://github.com/rubyjs/mini_racer/issues/218) with M1 ARM architecture and our current version of `mini_racer` and the dependency [libv8](https://github.com/rubyjs/libv8/issues/319#issuecomment-969179803).  One workaround involves using the rosetta2 emulator to build gems using the older intel architecture.  However, this eliminates the benefit of the ARM processor.  By upgrading bundler we don't have to use rosetta2 anymore.  A more standard solution is simply upgrading bundler to v2.

Also, Heroku supports bundler v2 and future upgrades to ruby will be streamlined with using a newer version of bundler.

## HOW
After `gem install -v 2.2.33`, run `bundle update --bundler`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A