### PR TITLE
Remove "CCSS" column from Activities in Activity Pack editor for Staff

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
@@ -52,7 +52,7 @@
       width: 400px;
     }
     .description-search-box {
-      width: 490px;
+      width: 420px;
     }
     .activity-packs-search-box {
       width: 300px;
@@ -137,24 +137,24 @@
         }
 
         .ut-activity-name-col {
-          min-width: 300px !important;
+          width: 300px !important;
         }
 
         .ut-activity-flag-col {
-          min-width: 135px !important;
+          width: 135px !important;
         }
 
         .ut-activity-readability-col {
-          min-width: 125px !important;
+          width: 125px !important;
         }
 
         .ut-activity-cat-col {
-          min-width: 115px !important;
+          width: 115px !important;
           padding-left: 4px;
         }
 
         .ut-activity-class-col {
-          min-width: 100px !important;
+          width: 100px !important;
         }
       }
 

--- a/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/unit_template_editor.scss
@@ -48,7 +48,7 @@
       margin-right: 15px;
       margin-top: 15px;
     }
-    .name-search-box, .ccss-search-box {
+    .name-search-box {
       width: 400px;
     }
     .description-search-box {
@@ -92,10 +92,6 @@
 
     .ut-readability-col {
       width: 125px !important;
-    }
-
-    .ut-ccss-col {
-      width: 155px !important;
     }
 
     .ut-concept-col {
@@ -150,10 +146,6 @@
 
         .ut-activity-readability-col {
           min-width: 125px !important;
-        }
-
-        .ut-activity-ccss-col {
-          min-width: 155px !important;
         }
 
         .ut-activity-cat-col {

--- a/services/QuillLMS/app/serializers/cms/activity_serializer.rb
+++ b/services/QuillLMS/app/serializers/cms/activity_serializer.rb
@@ -4,7 +4,6 @@ class Cms::ActivitySerializer < ActiveModel::Serializer
   attributes :uid, :id, :name, :description, :flags, :data, :created_at, :updated_at, :supporting_info, :activity_category, :readability_grade_level, :unit_template_names
 
   has_one :classification, serializer: ClassificationSerializer
-  has_one :standard
 
   def activity_category
     return unless object.id

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_data_row.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_data_row.tsx
@@ -41,7 +41,6 @@ const UnitTemplateActivityDataRow = ({activity, handleAdd, handleRemove, type}) 
         <td className="ut-activity-name-col">{activity.name}</td>
         <td className="ut-activity-flag-col">{activity.data && activity.data["flag"]}</td>
         <td className="ut-activity-readability-col">{activity.readability_grade_level}</td>
-        <td className="ut-activity-ccss-col">{activity.standard && activity.standard.name}</td>
         <td className="ut-activity-cat-col">{activity.activity_category && activity.activity_category.name}</td>
         <td className="ut-activity-class-col">{activity.classification && activity.classification.name}</td>
       </tr>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_selector.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unit_templates/unit_template_activity_selector.tsx
@@ -31,7 +31,6 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
   const [currentPage, setCurrentPage] = React.useState<Number>(1);
   const [nameSearch, setNameSearch] = React.useState<string>('')
   const [descriptionSearch, setDescriptionSearch] = React.useState<string>('')
-  const [ccssSearch, setCCSSSearch] = React.useState<string>('')
   const [conceptSearch, setConceptSearch] = React.useState<string>('')
   const [activityPacksSearch, setActivityPacksSearch] = React.useState<string>('')
   const [flagSearch, setFlagSearch] = React.useState<string>(DEFAULT_FLAG)
@@ -69,7 +68,6 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
     return activities.filter(act => {
       const nameMatch = nameSearch === '' || (act.name && act.name.toLowerCase().includes(nameSearch.toLowerCase()))
       const descriptionMatch = descriptionSearch === '' || (act.description && act.description.toLowerCase().includes(descriptionSearch.toLowerCase()))
-      const ccssMatch = ccssSearch === '' || (act.standard && act.standard.name.toLowerCase().includes(ccssSearch.toLowerCase()))
       const conceptMatch = conceptSearch === '' || (act.activity_category && act.activity_category.name.toLowerCase().includes(conceptSearch.toLowerCase()))
       const activityPackMatch = activityPacksSearch === '' || (act.unit_template_names && act.unit_template_names.some(ut => ut.toLowerCase().includes(activityPacksSearch.toLowerCase())))
       const flagMatch = flagSearch === DEFAULT_FLAG || (act.data && act.data['flag'] && act.data['flag'] === flagSearch)
@@ -78,7 +76,7 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
       const selectedActivitiesMatch = selectedActivities.length === 0 || !selectedActivities.map(a => a.id).includes(act.id)
       const showNoActivityPacksMatch = showNoActivityPacks === false || (act.unit_template_names && act.unit_template_names.length === 0)
       return (
-        nameMatch && descriptionMatch && ccssMatch && conceptMatch && activityPackMatch &&
+        nameMatch && descriptionMatch && conceptMatch && activityPackMatch &&
         flagMatch && toolMatch && readabilityMatch && selectedActivitiesMatch && showNoActivityPacksMatch
       );
     })
@@ -108,7 +106,6 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
       <th className="ut-name-col">Name</th>
       <th className="ut-flag-col">Flag</th>
       <th className="ut-readability-col">Readability</th>
-      <th className="ut-ccss-col">CCSS</th>
       <th className="ut-concept-col">Concept</th>
       <th className="ut-tool-col">Tool</th>
     </tr>
@@ -117,13 +114,15 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
 
   const activityRows = currentPageActivities().map((act) => {
     return (
-      <UnitTemplateActivityDataRow
-        activity={act}
-        handleAdd={handleAddActivity}
-        handleRemove={handleRemoveActivity}
-        key={act.id}
-        type={UNSELECTED_TYPE}
-      />
+      <div>
+        <UnitTemplateActivityDataRow
+          activity={act}
+          handleAdd={handleAddActivity}
+          handleRemove={handleRemoveActivity}
+          key={act.id}
+          type={UNSELECTED_TYPE}
+        />
+      </div>
     )
   })
 
@@ -133,10 +132,6 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
 
   function handleDescriptionSearch(e) {
     setDescriptionSearch(e.target.value)
-  }
-
-  function handleCCSSSearch(e) {
-    setCCSSSearch(e.target.value)
   }
 
   function handleConceptSearch(e) {
@@ -217,14 +212,6 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
         value={descriptionSearch || ""}
       />
       <input
-        aria-label="Search by CCSS"
-        className="ccss-search-box"
-        name="ccssInput"
-        onChange={handleCCSSSearch}
-        placeholder="Search by CCSS"
-        value={ccssSearch || ""}
-      />
-      <input
         aria-label="Search by concept"
         className="concept-search-box"
         name="conceptInput"
@@ -271,8 +258,8 @@ const UnitTemplateActivitySelector = ({ parentActivities, setParentActivities, t
       <h4>All Activities:</h4>
       {filterInputs}
       <div className="unit-template-activities-table">
-        {tableHeaders}
         <table className="unit-template-activities-table-rows">
+          {tableHeaders}
           <tbody className="unit-template-activities-tbody">
             {activityRows}
           </tbody>

--- a/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
@@ -22,7 +22,6 @@ describe Cms::ActivitySerializer do
         readability_grade_level
         unit_template_names
         classification
-        standard
       }
     end
   end


### PR DESCRIPTION
## WHAT
Remove this column on the front end and stop sending this column in the payload.

## WHY
Curriculum thinks it makes the table look too busy, and they don't need it.

## HOW
Just remove the column and all references, and stop sending the data in the serializer.

### Screenshots
<img width="936" alt="Screen Shot 2022-03-07 at 2 03 15 PM" src="https://user-images.githubusercontent.com/57366100/157109247-f7c10237-9727-40bb-905a-4320ea8c7c68.png">


### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
