### PR TITLE
Fix a bug with QuillStaffAccountsChangedWorker

### DIFF
--- a/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
+++ b/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
@@ -14,7 +14,7 @@ class QuillStaffAccountsChangedWorker
     current_staff_accounts = current_staff_account_data
     previous_staff_accounts = cached_staff_account_data
     notify_staff(current_staff_accounts, previous_staff_accounts) unless current_staff_accounts == previous_staff_accounts
-    $redis.set(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json)
+    $redis.set(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json, ex: 25.hours.to_i)
   end
 
   def current_staff_account_data

--- a/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
@@ -14,7 +14,7 @@ describe QuillStaffAccountsChangedWorker, type: :worker do
       expect(worker).to receive(:current_staff_account_data).and_return([staff_json])
       expect(worker).to receive(:cached_staff_account_data).and_return({})
       expect(worker).to receive(:notify_staff)
-      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json)
+      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, ex: 25.hours.to_i)
       worker.perform
     end
 

--- a/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
@@ -22,7 +22,7 @@ describe QuillStaffAccountsChangedWorker, type: :worker do
       expect(worker).to receive(:current_staff_account_data).and_return([staff_json])
       expect(worker).to receive(:cached_staff_account_data).and_return([staff_json])
       expect(worker).not_to receive(:notify_staff)
-      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json)
+      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, ex: 25.hours.to_i)
       worker.perform
     end
 


### PR DESCRIPTION
## WHAT
Add an explicit expiration value for the cache key `STAFF_ACCOUNTS_CACHE_KEY` at 25 hours. (Since the cron job runs the `QuillStaffAccountsChangedWorker` every ~24 hours)

## WHY
The cached value is likely being cleared before the job is run the next day.

## HOW
Include the `ex` option to set the expiration in [seconds](https://www.rubydoc.info/github/redis/redis-rb/Redis:set).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
