### PR TITLE
Evidence/ update activities index for the internal tool

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -284,9 +284,12 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     let linkDisplayText
     if (sectionText && sectionText.type === 'a' && sectionText.props.children && sectionText.props.children[1] && sectionText.props.children[1].props) {
       linkDisplayText = sectionText.props.children[1].props.children
+    } else if(sectionText && sectionText.type && sectionText.type.displayName === 'Link' && sectionText.props && sectionText.props.children) {
+      linkDisplayText = sectionText.props.children
     }
 
     const rowDisplayText = linkDisplayText || sectionText
+
     if (!header.noTooltip && (String(rowDisplayText).length * averageFontWidth) >= headerWidthNumber) {
       return (
         <Tooltip

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
@@ -19,12 +19,14 @@ const Activities = ({ location, match }) => {
   const filteredActivities = activitiesData && activitiesData.activities && activitiesData.activities.filter(act => flag === 'All Flags' || act.flag === flag) || []
 
   const formattedRows = filteredActivities.map((activity: ActivityInterface) => {
-    const { id, title, invalid_highlights } = activity;
+    const { id, title, invalid_highlights, parent_activity_id, notes } = activity;
     const activityLink = (<Link to={`/activities/${id}`}>{title}</Link>);
     const highlightLabel = (<Link to={`/activities/${id}`}>{getCheckIcon(!(invalid_highlights && invalid_highlights.length))}</Link>);
     return {
       id,
+      parent_activity_id,
       title: activityLink,
+      notes,
       valid_highlights: highlightLabel
     }
   });
@@ -51,8 +53,10 @@ const Activities = ({ location, match }) => {
   }
 
   const dataTableFields = [
-    { name: "Title", attribute:"title", width: "800px" },
-    { name: "Highlight Validation", attribute:"valid_highlights", width: "100px" }
+    { name: "Parent Activity ID", attribute:"parent_activity_id", width: "100px" },
+    { name: "Internal Name", attribute:"notes", width: "450px" },
+    { name: "Name", attribute:"title", width: "350px" },
+    { name: "Highlight Validation", attribute:"valid_highlights", width: "100px", noTooltip: true }
   ];
 
   return(

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activities.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activities.scss
@@ -5,9 +5,11 @@
     width: 100%;
     align-self: flex-start;
     .data-table-body{
+      min-height: 30vh;
       max-height: 70vh;
       .data-table-row {
         span {
+          text-align: left !important;
           a {
             color: #00c2a2;
           }


### PR DESCRIPTION
## WHAT
update the activities index view for the internal tool (also adds ability for React router `Link` elements to have a tooltip on hover)

## WHY
we want to display the most useful information

## HOW
add a field for `parent_activity_id`, update "Title" to "Name" and display `notes` property as "Internal Name"

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1335" alt="Screen Shot 2022-03-08 at 5 30 28 PM" src="https://user-images.githubusercontent.com/25959584/157321148-9d5dc35e-db6b-4522-9cd2-266d7240a09b.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Show-the-Internal-Name-for-Activities-80e49ffe9f824d3e8816ee00844aec38

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
