### PR TITLE
Question report bug

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -40,13 +40,13 @@ module DiagnosticReports
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  private def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id=nil, hashify_activity_sessions: false)
+  def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id=nil, hashify_activity_sessions: false)
     if unit_id
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
         .includes(:concept_results, activity: {skills: :concepts})
-        .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids)
+        .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids, activity_id: activity_id)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -45,16 +45,17 @@ module PublicProgressReports
   # rubocop:disable Metrics/CyclomaticComplexity
   def results_by_question(activity_id)
     activity = Activity.includes(:classification).find(activity_id)
-    questions = Hash.new{|h,k| h[k]={} }
+    questions = {}
+
     all_answers = ActivitySession.activity_session_metadata(@activity_sessions) #concept_result metadatas
+
     all_answers.each do |answer|
       curr_quest = questions[answer["questionNumber"]]
       curr_quest[:correct] ||= 0
       curr_quest[:total] ||= 0
       curr_quest[:correct] += answer["questionScore"] || answer["correct"]
       curr_quest[:total] += 1
-      puts "curr_quest #{curr_quest}"
-      curr_quest[:prompt] ||= 'foo' #answer["prompt"]
+      curr_quest[:prompt] ||= answer["prompt"]
       curr_quest[:question_number] ||= answer["question_number"]
       if answer["attemptNumber"] == 1 || !curr_quest[:instructions]
         direct = answer["directions"] || answer["instructions"] || ""
@@ -73,7 +74,6 @@ module PublicProgressReports
     if questions_arr.empty?
       questions_arr = generic_questions_for_report(params[:activity_id])
     end
-
     questions_arr
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -45,7 +45,7 @@ module PublicProgressReports
   # rubocop:disable Metrics/CyclomaticComplexity
   def results_by_question(activity_id)
     activity = Activity.includes(:classification).find(activity_id)
-    questions = {}
+    questions = Hash.new{|h,k| h[k]={} }
 
     all_answers = ActivitySession.activity_session_metadata(@activity_sessions) #concept_result metadatas
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -46,14 +46,15 @@ module PublicProgressReports
   def results_by_question(activity_id)
     activity = Activity.includes(:classification).find(activity_id)
     questions = Hash.new{|h,k| h[k]={} }
-    all_answers = ActivitySession.activity_session_metadata(@activity_sessions)
+    all_answers = ActivitySession.activity_session_metadata(@activity_sessions) #concept_result metadatas
     all_answers.each do |answer|
       curr_quest = questions[answer["questionNumber"]]
       curr_quest[:correct] ||= 0
       curr_quest[:total] ||= 0
       curr_quest[:correct] += answer["questionScore"] || answer["correct"]
       curr_quest[:total] += 1
-      curr_quest[:prompt] ||= answer["prompt"]
+      puts "curr_quest #{curr_quest}"
+      curr_quest[:prompt] ||= 'foo' #answer["prompt"]
       curr_quest[:question_number] ||= answer["question_number"]
       if answer["attemptNumber"] == 1 || !curr_quest[:instructions]
         direct = answer["directions"] || answer["instructions"] || ""

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -47,7 +47,7 @@ module PublicProgressReports
     activity = Activity.includes(:classification).find(activity_id)
     questions = Hash.new{|h,k| h[k]={} }
 
-    all_answers = ActivitySession.activity_session_metadata(@activity_sessions) #concept_result metadatas
+    all_answers = ActivitySession.activity_session_metadata(@activity_sessions)
 
     all_answers.each do |answer|
       curr_quest = questions[answer["questionNumber"]]

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -53,13 +53,24 @@ describe DiagnosticReports do
       let!(:students_classroom3) { create(:students_classrooms, classroom: classroom, student: student3)}
       let!(:classroom_unit) { create(:classroom_unit, unit: unit, classroom: classroom, assigned_student_ids: [student1.id, student2.id, student3.id]) }
       let!(:unit_activity) { create(:unit_activity, unit: unit) }
+      let!(:unrelated_unit_activity) { create(:unit_activity) }
+
       let!(:activity_session1) { create(:activity_session, :finished, user: student1, classroom_unit: classroom_unit, activity: unit_activity.activity) }
       let!(:activity_session2) { create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit, activity: unit_activity.activity) }
+      let!(:unrelated_activity_session) do
+        create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit, activity: unrelated_unit_activity.activity)
+      end
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
         expect(@assigned_students).to include(student1, student2, student3)
         expect(@activity_sessions).to include(activity_session1, activity_session2)
+      end
+
+      it 'should only return activity sessions belonging to the specified activity' do
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity.activity_id, classroom.id, unit.id)
+        expect(@activity_sessions.count).to eq 2
+        expect(@activity_sessions.filter {|as| as.id == unrelated_activity_session.id}).to eq []
       end
 
       it 'should not include a student or their activity session if they are no longer in the assigned student ids array' do
@@ -69,6 +80,7 @@ describe DiagnosticReports do
         expect(@assigned_students).to include(student2, student3)
         expect(@activity_sessions).to include(activity_session2)
       end
+
     end
 
     describe 'if there is no unit_id' do

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -7,7 +7,6 @@ describe PublicProgressReports, type: :model do
   before do
     class FakeReports
       attr_accessor :session
-      attr_accessor :activity_sessions
 
       include PublicProgressReports
     end
@@ -263,65 +262,4 @@ describe PublicProgressReports, type: :model do
 
     end
   end
-
-  describe '#results_by_question' do
-    let(:concept_result_metadata) do
-      {
-        "correct":1,
-        "directions":"Rewrite the sentence with the correct capitalization.",
-        "lastFeedback":"Revise your work.",
-        "prompt":"i saw the mayor give a speech at richmond city hall.",
-        "attemptNumber":2,
-        "answer":"I saw the mayor give a speech at Richmond City Hall.",
-        "questionNumber":3,
-        "questionScore":0.8
-      }
-    end
-
-    let!(:activity) { create(:activity) }
-    let!(:activity_session1) { create(:activity_session_without_concept_results, activity_id: activity.id) }
-    let!(:activity_session2) { create(:activity_session_without_concept_results, activity_id: activity.id) }
-
-    let!(:a_s1_concept_result1) do
-      create(
-        :concept_result,
-        activity_session: activity_session1,
-        metadata: concept_result_metadata
-      )
-    end
-
-    let!(:a_s2_concept_result1) do
-      create(
-        :concept_result,
-        activity_session: activity_session2,
-        metadata: concept_result_metadata
-      )
-    end
-
-    let!(:a_s2_concept_result2_no_prompt) do
-      create(
-        :concept_result,
-        activity_session: activity_session2,
-        metadata: concept_result_metadata.reject {|k,v| k == 'prompt' }
-      )
-    end
-
-
-
-    it 'should foo' do
-      report = FakeReports.new
-      report.instance_variable_set(:@activity_sessions, ActivitySession.all)
-
-      results = report.results_by_question(activity.id)
-      binding.pry
-    end
-  end
 end
-
-
-
-# classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
-# @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
-# @activity_sessions = ActivitySession
-#   .includes(:concept_results, activity: {skills: :concepts})
-#   .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids)

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -7,6 +7,7 @@ describe PublicProgressReports, type: :model do
   before do
     class FakeReports
       attr_accessor :session
+      attr_accessor :activity_sessions
 
       include PublicProgressReports
     end
@@ -262,4 +263,65 @@ describe PublicProgressReports, type: :model do
 
     end
   end
+
+  describe '#results_by_question' do
+    let(:concept_result_metadata) do
+      {
+        "correct":1,
+        "directions":"Rewrite the sentence with the correct capitalization.",
+        "lastFeedback":"Revise your work.",
+        "prompt":"i saw the mayor give a speech at richmond city hall.",
+        "attemptNumber":2,
+        "answer":"I saw the mayor give a speech at Richmond City Hall.",
+        "questionNumber":3,
+        "questionScore":0.8
+      }
+    end
+
+    let!(:activity) { create(:activity) }
+    let!(:activity_session1) { create(:activity_session_without_concept_results, activity_id: activity.id) }
+    let!(:activity_session2) { create(:activity_session_without_concept_results, activity_id: activity.id) }
+
+    let!(:a_s1_concept_result1) do
+      create(
+        :concept_result,
+        activity_session: activity_session1,
+        metadata: concept_result_metadata
+      )
+    end
+
+    let!(:a_s2_concept_result1) do
+      create(
+        :concept_result,
+        activity_session: activity_session2,
+        metadata: concept_result_metadata
+      )
+    end
+
+    let!(:a_s2_concept_result2_no_prompt) do
+      create(
+        :concept_result,
+        activity_session: activity_session2,
+        metadata: concept_result_metadata.reject {|k,v| k == 'prompt' }
+      )
+    end
+
+
+
+    it 'should foo' do
+      report = FakeReports.new
+      report.instance_variable_set(:@activity_sessions, ActivitySession.all)
+
+      results = report.results_by_question(activity.id)
+      binding.pry
+    end
+  end
 end
+
+
+
+# classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
+# @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
+# @activity_sessions = ActivitySession
+#   .includes(:concept_results, activity: {skills: :concepts})
+#   .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids)


### PR DESCRIPTION
## WHAT
Avoids prompts of unrelated activities leaking into the Question View rollup data. 

## WHY
Because the rollup should only display data related to the specified activity.

## HOW
Add a filter in an intermediate ActiveRecord query. 

### Screenshots
Before bug fix:
![Quill org _ Interactive Writing and Grammar](https://user-images.githubusercontent.com/90669/157903799-8066893a-92b3-462f-bdb1-e4686303a3dc.png)

After bug fix:
<img width="1003" alt="Screen Shot 2022-03-11 at 8 55 56 AM" src="https://user-images.githubusercontent.com/90669/157904000-00ff5a7f-3006-46d3-b9b1-521cc0c91640.png">


### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=f1357b9141084d88a98faf591c9bc271

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.) yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A =
