### PR TITLE
Lms/fix all classrooms cache

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -7,7 +7,9 @@ class Api::V1::ProgressReportsController < Api::ApiController
     classroom_ids = current_user&.classrooms_i_teach&.map(&:id)
     return render json: { data: [] } if classroom_ids.empty?
 
-    data = ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
+    data = current_user.all_classrooms_cache(key: 'api.v1.progress_reports.activities_scores_by_classroom_data') do
+      ProgressReports::ActivitiesScoresByClassroom.results(classroom_ids, current_user.time_zone)
+    end
 
     render json: { data: data }
   end

--- a/services/QuillLMS/app/models/concerns/user_cacheable.rb
+++ b/services/QuillLMS/app/models/concerns/user_cacheable.rb
@@ -56,6 +56,7 @@ module UserCacheable
       .unscoped
       .joins(:classrooms_teachers)
       .where(classrooms_teachers: {user_id: id})
+      .order(updated_at: :desc)
       .first
   end
 

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -73,6 +73,23 @@ RSpec.describe UserCacheable, type: :model do
         expect(post_update_second_page_fetch).to eq(4)
       end
     end
+
+    context 'teacher with multiple classrooms' do
+      let(:teacher) {create(:teacher_with_one_classroom) }
+      let!(:older_classroom) { create(:classroom) }
+      let!(:newer_classroom) { create(:classroom, updated_at: older_classroom.updated_at + 10.days) }
+      let!(:older_classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: 'owner', classroom: older_classroom) }
+      let!(:newer_classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: 'owner', classroom: newer_classroom) }
+
+      it 'should use the most recently updated_at classroom for caching' do
+        key = 'test.key'
+        groups = {page: 1}
+
+        expect(teacher).to receive(:model_cache).with(newer_classroom, key: key, groups: groups)
+
+        teacher.all_classrooms_cache(key: key, groups: groups)
+      end
+    end
   end
 
   describe '#classroom_cache' do

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -260,48 +260,49 @@ RSpec.describe UserCacheable, type: :model do
 
     context 'cache invalidation' do
       let(:teacher) { create(:teacher, :with_classrooms_students_and_activities) }
-      let!(:old_value) { teacher.all_classrooms_cache(key: 'test.key') { false } }
+      let(:key) { 'test.key' }
+      let!(:old_value) { teacher.all_classrooms_cache(key: key) { false } }
 
       it 'should invalidate when an ActivitySession is touched' do
         create(:activity_session, classroom_unit: teacher.classroom_units.first)
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a ClassroomUnit is touched' do
         teacher.classroom_units.first.touch
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a ClassroomsTeacher is touched' do
         teacher.classrooms_teachers.first.touch
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a ClassroomUnitActivityState is touched' do
         create(:classroom_unit_activity_state, classroom_unit: teacher.classroom_units.first)
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a StudentsClassrooms is touched' do
         teacher.students_i_teach.first.students_classrooms.first.touch
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a Unit is touched' do
         teacher.classrooms_i_teach.first.units.first.touch
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
 
       it 'should invalidate when a UnitActivity is touched' do
         teacher.classrooms_i_teach.first.units.first.unit_activities.first.touch
 
-        expect(teacher.all_classrooms_cache(key: 'test.key') { true }).not_to eq(old_value)
+        expect(teacher.all_classrooms_cache(key: key) { true }).not_to eq(old_value)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Add an `order` call to the lookup that finds the most recently updated classroom.
## WHY
The existing query gets classrooms back in an arbitrary order and may not find the classroom most recently affected by a bubbled-up `touch` call on a related model.
## HOW
Just add an `order` by `updated_at` to the query that looks up the `last_updated_classroom`

### Notion Card Links
https://www.notion.so/quill/Metrics-summary-not-updating-with-correct-number-of-completed-activities-3fb16f798e644c5c848cb7847ce60f49

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
