### PR TITLE
put @redux-devtools in regular dependencies

### DIFF
--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -1904,7 +1904,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@redux-devtools/log-monitor/-/log-monitor-3.1.0.tgz",
       "integrity": "sha512-T5NXzasj7250tJmQPiXzFkxlY0Rg0W7feR1eZj8VrdePvVkeXTP5k9VjxkVqtba5EmZR8swGec+Z1eD71ZgUsA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.7",
         "@types/lodash.debounce": "^4.0.6",
@@ -1920,7 +1919,6 @@
           "version": "7.17.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
           "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -1929,7 +1927,6 @@
           "version": "15.8.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -2093,8 +2090,7 @@
     "@types/base16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/base16/-/base16-1.0.2.tgz",
-      "integrity": "sha512-oYO/U4VD1DavwrKuCSQWdLG+5K22SLPem2OQaHmFcQuwHoVeGC+JGVRji2MUqZUAIQZHEonOeVfAX09hYiLsdg==",
-      "dev": true
+      "integrity": "sha512-oYO/U4VD1DavwrKuCSQWdLG+5K22SLPem2OQaHmFcQuwHoVeGC+JGVRji2MUqZUAIQZHEonOeVfAX09hYiLsdg=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2259,14 +2255,12 @@
     "@types/lodash": {
       "version": "4.14.179",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
-      "dev": true
+      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w=="
     },
     "@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -2417,7 +2411,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/redux-devtools-themes/-/redux-devtools-themes-1.0.0.tgz",
       "integrity": "sha512-ul3x0MYM5Nzj57Fh9wINyHFne8vZL04RC4nWAUWLYcL105vHoa/oJyopuKOrQmqVmhqmDiL4c9FfLbUmIB7TWQ==",
-      "dev": true,
       "requires": {
         "@types/base16": "*"
       }
@@ -4196,8 +4189,7 @@
     "base16": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=",
-      "dev": true
+      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
     },
     "base64-arraybuffer": {
       "version": "0.1.4",
@@ -4999,7 +4991,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
       "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
@@ -10155,8 +10146,7 @@
     "lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA=",
-      "dev": true
+      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -13231,7 +13221,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.9.1.tgz",
       "integrity": "sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.7",
         "@types/base16": "^1.0.2",
@@ -13246,7 +13235,6 @@
           "version": "7.17.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
           "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -13254,8 +13242,7 @@
         "csstype": {
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
-          "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
-          "dev": true
+          "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
         }
       }
     },
@@ -13449,7 +13436,6 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.16.1.tgz",
       "integrity": "sha512-VYvU/tgekJUrPhEVR6ZC789b3x9QPO7LmRX1YMZfWpqbC8pvXb7D74S0+CE6RVk55bXOS2VH1+8ZWA2PioEyqg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.7",
         "@types/prop-types": "^15.7.4",
@@ -13461,7 +13447,6 @@
           "version": "7.17.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
           "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -13470,7 +13455,6 @@
           "version": "15.8.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -14055,7 +14039,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redux-devtools-themes/-/redux-devtools-themes-1.0.0.tgz",
       "integrity": "sha1-xILc48U3OXYEX0ATSQfZ3LOuPV0=",
-      "dev": true,
       "requires": {
         "base16": "^1.0.0"
       }

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -1853,7 +1853,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@redux-devtools/core/-/core-3.11.0.tgz",
       "integrity": "sha512-LE8GF/9pttlIOYJWqOfwbAvYAokRNHCEtCu0DfA11tksYVwIX79CpB2jIJH/KH7n1LzwXPCCl4MOFnyZH4przg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.7",
         "@redux-devtools/instrument": "^2.1.0",
@@ -1866,7 +1865,6 @@
           "version": "7.17.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
           "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -1875,7 +1873,6 @@
           "version": "15.8.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -1888,7 +1885,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@redux-devtools/instrument/-/instrument-2.1.0.tgz",
       "integrity": "sha512-e8fo88kuq/zWqfNf6S/GNfaQMjF4WSPpucmYfRhzZyyXHC3PCLd/xgz7zooPErDh9QwUXK6sTVYvrkq7hPbsFA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.7",
         "lodash": "^4.17.21"
@@ -1898,7 +1894,6 @@
           "version": "7.17.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
           "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-react": "^7.0.0",
     "@draft-js-plugins/editor": "^4.1.0",
     "@redux-devtools/core": "^3.11.0",
+    "@redux-devtools/log-monitor": "^3.1.0",
     "@sentry/browser": "^5.20.0",
     "@types/react": "^16.0.40",
     "@types/react-dom": "^16.9.4",
@@ -146,7 +147,6 @@
     "xlsx": "^0.17.0"
   },
   "devDependencies": {
-    "@redux-devtools/log-monitor": "^3.1.0",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/jest": "^22.2.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@draft-js-plugins/editor": "^4.1.0",
+    "@redux-devtools/core": "^3.11.0",
     "@sentry/browser": "^5.20.0",
     "@types/react": "^16.0.40",
     "@types/react-dom": "^16.9.4",
@@ -145,7 +146,6 @@
     "xlsx": "^0.17.0"
   },
   "devDependencies": {
-    "@redux-devtools/core": "^3.11.0",
     "@redux-devtools/log-monitor": "^3.1.0",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/jest": "^22.2.0",


### PR DESCRIPTION
## WHAT
Move @redux-devtools to regular dependencies (from devDependencies).

## WHY
Our production build strips out devDependencies, so it was failing on the absence of these modules (failed build here: https://dashboard.heroku.com/apps/empirical-grammar/activity/builds/8039f81c-640d-44c8-8701-e6fc754a0269). I didn't realize that our build for staging works differently.

## HOW
Just update which dependency list these packages belong to. I updated the `NODE_ENV` for my personal staging environment to production temporarily to replicate the actual production build, and am currently deploying to make sure this compiles successfully.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
