### PR TITLE
fix issue with querycache not being a thing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettingsWrapper.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettingsWrapper.test.tsx
@@ -13,6 +13,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/editOrDeleteTurkSession.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/editOrDeleteTurkSession.test.tsx
@@ -4,6 +4,10 @@ import 'whatwg-fetch';
 
 import EditOrDeleteTurkSession from '../gatherResponses/editOrDeleteTurkSession';
 
+jest.mock("react-query", () => ({
+  useQueryClient: jest.fn(() => ({})),
+}));
+
 describe('EditOrDeleteTurkSession component', () => {
   const mockProps = {
     activityId: 1,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/model.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/model.test.tsx
@@ -13,6 +13,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesRouter.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesRouter.test.tsx
@@ -12,6 +12,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/promptTable.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/promptTable.test.tsx
@@ -4,6 +4,10 @@ import { shallow } from 'enzyme';
 
 import PromptTable from '../activitySessions/promptTable';
 
+jest.mock("react-query", () => ({
+  useQueryClient: jest.fn(() => ({})),
+}));
+
 jest.mock('string-strip-html', () => ({
   default: jest.fn()
 }));

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
@@ -14,6 +14,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 const { firstBy } = jest.requireActual('thenby');
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesRouter.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesRouter.test.tsx
@@ -12,6 +12,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticLabelsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticLabelsIndex.test.tsx
@@ -12,6 +12,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
@@ -12,6 +12,7 @@ jest.mock("react-query", () => ({
     status: "success",
     isFetching: true,
   })),
+  useQueryClient: jest.fn(() => ({})),
 }));
 
 describe('TurkSessions component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/promptTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/promptTable.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import stripHtml from "string-strip-html";
 import { Link } from 'react-router-dom';
-import { queryCache } from 'react-query';
+import { useQueryClient, } from 'react-query';
 
 import { createOrUpdateFeedbackHistoryRating } from '../../../utils/evidence/feedbackHistoryRatingAPIs';
 import { DataTable, Spinner, ButtonLoadingSpinner } from '../../../../Shared/index';
@@ -18,6 +18,8 @@ interface PromptTableProps {
 const PromptTable = ({ activity, rules, prompt, showHeader, sessionId }: PromptTableProps) => {
 
   const [loadingType, setLoadingType] = React.useState<string>(null);
+
+  const queryClient = useQueryClient()
 
   function formatFirstTableData(prompt: any) {
     const { attempts } = prompt;
@@ -51,7 +53,7 @@ const PromptTable = ({ activity, rules, prompt, showHeader, sessionId }: PromptT
   async function updateFeedbackHistoryRatingStrength(responseId, rating, type) {
     setLoadingType(type);
     createOrUpdateFeedbackHistoryRating({ rating, feedback_history_id: responseId}).then((response) => {
-      queryCache.refetchQueries(`activity-${activity.id}-session-${sessionId}`).then(() => {
+      queryClient.refetchQueries(`activity-${activity.id}-session-${sessionId}`).then(() => {
         setLoadingType(null);
       });
     });
@@ -60,7 +62,7 @@ const PromptTable = ({ activity, rules, prompt, showHeader, sessionId }: PromptT
   function getRuleName(ruleUID: string) {
     if (!rules) return null;
 
-    const rule = rules.find((rule) => { return rule.uid == ruleUID });
+    const rule = rules.find((rule) => { return rule.uid === ruleUID });
     return rule ? rule.name: ''
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rule.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import { Link } from 'react-router-dom';
 import stripHtml from "string-strip-html";
 
@@ -19,6 +19,8 @@ const Rule = ({ history, match }) => {
   const [showDeleteRuleModal, setShowDeleteRuleModal] = React.useState<boolean>(false);
   const [showEditRuleModal, setShowEditRuleModal] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
+
+  const queryClient = useQueryClient()
 
   // get cached activity data to pass to ruleForm
   const { data: activityData } = useQuery({
@@ -117,7 +119,7 @@ const Rule = ({ history, match }) => {
       } else {
         setErrors([]);
         // update rule cache to display newly updated rule
-        queryCache.refetchQueries(`rule-${ruleId}`);
+        queryClient.refetchQueries(`rule-${ruleId}`);
         toggleShowEditRuleModal();
       }
     });
@@ -131,7 +133,7 @@ const Rule = ({ history, match }) => {
       } else {
         setErrors([]);
         // update ruleSets cache to remove delete ruleSet
-        queryCache.refetchQueries(`rules-${activityId}`);
+        queryClient.refetchQueries(`rules-${activityId}`);
         history.push(`/activities/${activityId}/rules`);
         toggleShowDeleteRuleModal();
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { Link, withRouter } from 'react-router-dom';
 
 import RuleGenericAttributes from '../configureRules/ruleGenericAttributes';
@@ -87,6 +87,8 @@ const RuleViewForm = ({
   const [showDeleteRuleModal, setShowDeleteRuleModal] = React.useState<boolean>(false);
   const [universalRulesCount, setUniversalRulesCount] = React.useState<number>(null);
 
+  const queryClient = useQueryClient()
+
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
     queryKey: [`rules-${activityId}`, activityId],
@@ -164,7 +166,7 @@ const RuleViewForm = ({
     deleteRule(ruleId).then((response) => {
       toggleShowDeleteRuleModal();
       // update ruleSets cache to remove delete ruleSet
-      queryCache.refetchQueries(`rules-${activityId}`);
+      queryClient.refetchQueries(`rules-${activityId}`);
       history.push(`/activities/${activityId}/${returnLinkRuleType}`);
     });
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rules.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from 'react-router-dom';
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import { firstBy } from "thenby";
 
 import RuleViewForm from './ruleViewForm';
@@ -31,6 +31,8 @@ const Rules = ({ activityId, history, prompt }: RulesProps) => {
   const [ruleToEdit, setRuleToEdit] = React.useState<RuleInterface>(null);
   const [errors, setErrors] = React.useState<string[]>([]);
   const [sortedRules, setSortedRules] = React.useState<[]>(null);
+
+  const queryClient = useQueryClient()
 
   // get cached activity data to pass to rule
   const { data: activityData } = useQuery({
@@ -97,7 +99,7 @@ const Rules = ({ activityId, history, prompt }: RulesProps) => {
       } else {
         setErrors([]);
         // clear rule cache to display newly created rule
-        queryCache.clear();
+        queryClient.clear();
         history.push(`/activities/${activityId}/rules/${rule.id}`);
         toggleAddRuleModal();
       }
@@ -113,7 +115,7 @@ const Rules = ({ activityId, history, prompt }: RulesProps) => {
       } else {
         setErrors([]);
         // clear rule cache to display newly updated rule
-        queryCache.clear();
+        queryClient.clear();
         toggleEditRuleModal();
       }
     });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activitySettings.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activitySettings.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { queryCache } from 'react-query';
+import { useQueryClient, } from 'react-query';
 import { withRouter } from 'react-router-dom';
 
 import ActivityForm from './activityForm';
@@ -16,12 +16,14 @@ const ActivitySettings = ({ activity, history }: {activity: ActivityInterface, h
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
 
+  const queryClient = useQueryClient()
+
   function handleClickArchiveActivity() {
     if (window.confirm('Are you sure you want to archive? If you archive, it will not be displayed on the "View Activities" page. Please also make sure that the activity has the correct parent activity id, because the parent activity will be archived as well.')) {
       archiveParentActivity(activity.parent_activity_id).then((response) => {
         const { error } = response;
         error && setErrorOrSuccessMessage(error);
-        queryCache.refetchQueries(`activity-${id}`)
+        queryClient.refetchQueries(`activity-${id}`)
         if(!error) {
           // reset errorOrSuccessMessage in case of subsequent submission
           setErrorOrSuccessMessage('Activity successfully archived!');
@@ -38,8 +40,8 @@ const ActivitySettings = ({ activity, history }: {activity: ActivityInterface, h
       if(errors && errors.length) {
         setErrors(errors);
       } else {
-        queryCache.refetchQueries(`activity-${id}`)
-        queryCache.removeQueries('activities')
+        queryClient.refetchQueries(`activity-${id}`)
+        queryClient.removeQueries('activities')
         setErrors([]);
         // reset errorOrSuccessMessage in case of subsequent submission
         setErrorOrSuccessMessage('Activity successfully updated!');
@@ -55,7 +57,7 @@ const ActivitySettings = ({ activity, history }: {activity: ActivityInterface, h
         setErrors(errors);
       } else {
         // update activities cache to display newly created activity
-        queryCache.refetchQueries('activities');
+        queryClient.refetchQueries('activities');
         setErrors([]);
         setErrorOrSuccessMessage('Activity successfully created!');
         toggleSubmissionModal();

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/gatherResponses/editOrDeleteTurkSession.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/gatherResponses/editOrDeleteTurkSession.tsx
@@ -2,13 +2,15 @@ import * as React from "react";
 import "react-dates/initialize";
 import { SingleDatePicker } from 'react-dates';
 import * as moment from 'moment';
-import { queryCache } from 'react-query';
+import { useQueryClient, } from 'react-query';
 
 import { deleteTurkSession, editTurkSession } from '../../../utils/evidence/turkAPIs';
 
 const EditTurkSession = ({ activityId, closeModal, originalSessionDate, setMessage, turkSessionId }) => {
   const [turkSessionDate, setTurkSessionDate] = React.useState<object>(moment(originalSessionDate));
   const [focused, setFocusedState] = React.useState<boolean>(false);
+
+  const queryClient = useQueryClient()
 
   const handleDateChange = (date: {}) => { setTurkSessionDate(date) };
 
@@ -23,7 +25,7 @@ const EditTurkSession = ({ activityId, closeModal, originalSessionDate, setMessa
         setMessage('Turk session successfully edited!')
       }
       // update turk sessions cache to display edited turk session
-      queryCache.refetchQueries(`turk-sessions-${activityId}`);
+      queryClient.refetchQueries(`turk-sessions-${activityId}`);
       closeModal();
     });
   }
@@ -37,7 +39,7 @@ const EditTurkSession = ({ activityId, closeModal, originalSessionDate, setMessa
         setMessage('Turk session successfully deleted!')
       }
       // update turk sessions cache to reflect deleted turk session
-      queryCache.refetchQueries(`turk-sessions-${activityId}`);
+      queryClient.refetchQueries(`turk-sessions-${activityId}`);
       closeModal();
     });
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/gatherResponses/turkSessions.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/gatherResponses/turkSessions.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import "react-dates/initialize";
 import { SingleDatePicker } from 'react-dates';
 import * as moment from 'moment';
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 
 import EditOrDeleteTurkSession from './editOrDeleteTurkSession';
 import TurkSessionButton from './turkSessionButton';
@@ -27,6 +27,8 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
   const [snackBarVisible, setSnackBarVisible] = React.useState(false);
   const { params } = match;
   const { activityId } = params;
+
+  const queryClient = useQueryClient()
 
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -54,7 +56,7 @@ const TurkSessions: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match
         setDateError('');
         setShowSubmissionModal(true);
         // update turk sessions cache to display newly created turk session
-        queryCache.refetchQueries(`turk-sessions-${activityId}`)
+        queryClient.refetchQueries(`turk-sessions-${activityId}`)
       });
     }
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesRouter.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesRouter.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { Route, Switch, withRouter } from 'react-router-dom';
 
 import PlagiarismRulesIndex from './plagiarismRulesIndex';
@@ -23,6 +23,8 @@ const PlagiarismRulesRouter = ({ history, match }) => {
     queryFn: fetchActivity
   });
 
+  const queryClient = useQueryClient()
+
   function renderActivityName({ activity }) {
     if(!activity) {
       return;
@@ -40,7 +42,7 @@ const PlagiarismRulesRouter = ({ history, match }) => {
         setErrors([]);
         const queryString = getRefetchQueryString(rule, activityId);
         // update rules cache to display newly created rule
-        queryCache.refetchQueries(queryString).then(() => {
+        queryClient.refetchQueries(queryString).then(() => {
           history.push(`/activities/${activityId}/plagiarism-rules`);
         });
       }
@@ -56,7 +58,7 @@ const PlagiarismRulesRouter = ({ history, match }) => {
       } else {
         setErrors([]);
         // update rules cache to display newly updated rule
-        queryCache.refetchQueries(`rule-${ruleId}`).then(() => {
+        queryClient.refetchQueries(`rule-${ruleId}`).then(() => {
           history.push(`/activities/${activityId}/plagiarism-rules`);
         });
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link, RouteComponentProps } from 'react-router-dom'
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import { firstBy } from 'thenby';
 
 import { renderHeader } from '../../../helpers/evidence/renderHelpers';
@@ -17,6 +17,8 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
   const { activityId } = params;
 
   const [promptIds, setPromptIds] = React.useState<string>(null);
+
+  const queryClient = useQueryClient()
 
   // get cached activity data to pass to rule
   const { data: activityData } = useQuery({
@@ -53,9 +55,9 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
   function handleReorder(sortInfo) {
     const idsInOrder = sortInfo.map(item => item.key)
     updateRuleOrders(idsInOrder).then((response) => {
-      queryCache.refetchQueries([`rules-${activityId}-${RULES_BASED_1}`])
-      queryCache.refetchQueries([`rules-${activityId}-${RULES_BASED_2}`])
-      queryCache.refetchQueries([`rules-${activityId}-${RULES_BASED_3}`])
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_1}`])
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_2}`])
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_3}`])
     });
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesRouter.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesRouter.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient, } from 'react-query';
 import { Route, Switch, withRouter } from 'react-router-dom';
 
 import RegexRulesIndex from './regexRulesIndex';
@@ -17,6 +17,8 @@ const RegexRulesRouter = ({ history, match }) => {
 
   const [errors, setErrors] = React.useState<string[]>([]);
 
+  const queryClient = useQueryClient()
+
   // get cached activity data to pass to ruleForm
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -32,7 +34,7 @@ const RegexRulesRouter = ({ history, match }) => {
         const queryString = getRefetchQueryString(rule, activityId);
         setErrors([]);
         // update rules cache to display newly created rule
-        queryCache.refetchQueries(queryString).then(() => {
+        queryClient.refetchQueries(queryString).then(() => {
           history.push(`/activities/${activityId}/regex-rules`);
         });
       }
@@ -48,7 +50,7 @@ const RegexRulesRouter = ({ history, match }) => {
       } else {
         setErrors([]);
         // update rules cache to display newly updated rule
-        queryCache.refetchQueries(`rule-${ruleId}`).then(() => {
+        queryClient.refetchQueries(`rule-${ruleId}`).then(() => {
           history.push(`/activities/${activityId}/regex-rules`);
         });
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import ReactTable from 'react-table';
@@ -43,6 +43,8 @@ const RuleAnalysis = ({ match }) => {
   const [endDateForQuery, setEndDate] = React.useState<string>(initialEndDateString);
   const [turkSessionID, setTurkSessionID] = React.useState<string>(initialTurkSessionId);
   const [turkSessionIDForQuery, setTurkSessionIDForQuery] = React.useState<string>(initialTurkSessionId);
+
+  const queryClient = useQueryClient()
 
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -129,7 +131,7 @@ const RuleAnalysis = ({ match }) => {
   async function massMark(rating) {
     setSelectedIds([])
     massCreateOrUpdateFeedbackHistoryRating({ rating, feedback_history_ids: selectedIds}).then((response) => {
-      queryCache.refetchQueries([`rule-feedback-histories-by-rule-${ruleId}-${promptId}`, ruleId, promptId, startDateForQuery, endDateForQuery]);
+      queryClient.refetchQueries([`rule-feedback-histories-by-rule-${ruleId}-${promptId}`, ruleId, promptId, startDateForQuery, endDateForQuery]);
     });
   }
 
@@ -139,7 +141,7 @@ const RuleAnalysis = ({ match }) => {
 
   async function updateFeedbackHistoryRatingStrength(responseId, rating) {
     createOrUpdateFeedbackHistoryRating({ rating, feedback_history_id: responseId}).then((response) => {
-      queryCache.refetchQueries([`rule-feedback-histories-by-rule-${ruleId}-${promptId}`, ruleId, promptId, startDateForQuery, endDateForQuery]);
+      queryClient.refetchQueries([`rule-feedback-histories-by-rule-${ruleId}-${promptId}`, ruleId, promptId, startDateForQuery, endDateForQuery]);
     });
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient, } from 'react-query';
 import { withRouter, Link, useHistory } from 'react-router-dom';
 import { EditorState, ContentState } from 'draft-js';
 
@@ -12,6 +12,8 @@ const Model = ({ match }) => {
 
   const [errors, setErrors] = React.useState<object>({});
   let history = useHistory();
+
+  const queryClient = useQueryClient()
 
   // cache ruleSets data for handling rule suborder
   const { data: modelData } = useQuery({
@@ -33,7 +35,7 @@ const Model = ({ match }) => {
         updatedErrors['Model Submission Error'] = error;
         setErrors(updatedErrors);
       } else {
-        queryCache.clear();
+        queryClient.clear();
         history.push(`/activities/${activityId}/semantic-labels/all`);
       }
     });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient, } from 'react-query';
 import { Link, withRouter } from 'react-router-dom';
 
 import RuleGenericAttributes from '../configureRules/ruleGenericAttributes';
@@ -66,6 +66,8 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
   const [ruleType, setRuleType] = React.useState<DropdownObjectInterface>(initialRuleType);
   const [showDeleteRuleModal, setShowDeleteRuleModal] = React.useState<boolean>(false);
   const [universalRulesCount, setUniversalRulesCount] = React.useState<number>(null);
+
+  const queryClient = useQueryClient()
 
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -154,7 +156,7 @@ const SemanticLabelForm = ({ activityId, isSemantic, isUniversal, requestErrors,
     deleteRule(ruleId).then((response) => {
       toggleShowDeleteRuleModal();
       // update ruleSets cache to remove delete ruleSet
-      queryCache.refetchQueries(`rules-${activityId}`);
+      queryClient.refetchQueries(`rules-${activityId}`);
       history.push(`/activities/${activityId}/semantic-labels/all`);
     });
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/semanticLabelsIndex.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery, queryCache } from 'react-query';
+import { useQuery, useQueryClient, } from 'react-query';
 import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 
 import SemanticLabelsOverview from './semanticLabelsOverview'
@@ -23,6 +23,8 @@ const SemanticLabelsIndex = ({ location, history, match }) => {
 
   const [errors, setErrors] = React.useState<string[]>([]);
 
+  const queryClient = useQueryClient()
+
   // get cached activity data to pass to ruleForm
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -38,7 +40,7 @@ const SemanticLabelsIndex = ({ location, history, match }) => {
         const { prompt_ids } = rule;
         const conjunction = getPromptConjunction(activityData, prompt_ids[0]);
         setErrors([]);
-        queryCache.clear();
+        queryClient.clear();
         history.push(`/activities/${activityId}/semantic-labels/${conjunction}`);
       }
       return rule;
@@ -54,7 +56,7 @@ const SemanticLabelsIndex = ({ location, history, match }) => {
         const { prompt_ids } = rule;
         const conjunction = getPromptConjunction(activityData, prompt_ids[0]);
         setErrors([]);
-        queryCache.clear();
+        queryClient.clear();
         history.push(`/activities/${activityId}/semantic-labels/${conjunction}`);
       }
       return rule;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRule.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from 'react-router-dom';
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import stripHtml from "string-strip-html";
 
 import Navigation from '../navigation'
@@ -17,6 +17,8 @@ const UniversalRule = ({ history, location, match }) => {
   const [showDeleteRuleModal, setShowDeleteRuleModal] = React.useState<boolean>(false);
   const [showEditRuleModal, setShowEditRuleModal] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
+
+  const queryClient = useQueryClient()
 
   // cache rule data
   const { data: ruleData } = useQuery({
@@ -86,8 +88,8 @@ const UniversalRule = ({ history, location, match }) => {
       } else {
         setErrors([]);
         // update rule caches to display newly updated rule
-        queryCache.refetchQueries(`rule-${ruleId}`);
-        queryCache.refetchQueries('universal-rules');
+        queryClient.refetchQueries(`rule-${ruleId}`);
+        queryClient.refetchQueries('universal-rules');
         toggleShowEditRuleModal();
       }
     });
@@ -101,7 +103,7 @@ const UniversalRule = ({ history, location, match }) => {
       } else {
         setErrors([]);
         toggleShowDeleteRuleModal();
-        queryCache.refetchQueries('universal-rules').then(() => {
+        queryClient.refetchQueries('universal-rules').then(() => {
           history.push({
             pathname: '/universal-rules',
             state: { ruleDeleted: true }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from 'react-router-dom';
-import { queryCache, useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 
 import Navigation from '../navigation'
 import { createRule, fetchUniversalRules } from '../../../utils/evidence/ruleAPIs';
@@ -20,6 +20,8 @@ const UniversalRulesIndex = ({ location, match }) => {
   const [rulesUpdated, setRulesUpdated] = React.useState<boolean>(false);
   const [showAddRuleModal, setShowAddRuleModal] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<string[]>([]);
+
+  const queryClient = useQueryClient()
 
   // cache ruleSets data for handling universal rule suborder
   const { data: rules } = useQuery("universal-rules", fetchUniversalRules);
@@ -89,7 +91,7 @@ const UniversalRulesIndex = ({ location, match }) => {
       } else {
         setErrors([]);
         toggleAddRuleModal();
-        queryCache.refetchQueries(`universal-rules`).then(() => {
+        queryClient.refetchQueries(`universal-rules`).then(() => {
           handleUpdateRulesList(rule);
         });
       }


### PR DESCRIPTION
## WHAT
Fix issue I missed where we have to use `queryClient` instead of `queryCache` for certain `react-query` actions now.

## WHY
To make sure data reloads as expected in the Evidence CMS.

## HOW
Just update all the places we were using `queryCache` to use the new structure.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A