### PR TITLE
fix css for bullets

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -220,10 +220,23 @@
         color: #5c5c5c;
         margin-bottom: 16px;
       }
+      p, ul {
+        font-size: 14px;
+        line-height: 1.43;
+        color: #5c5c5c;
+      }
+      ul {
+        list-style: inherit;
+      }
+      li {
+        display: list-item;
+        margin-left: 20px;
+      }
       .label-section p {
         margin-left: 12px;
         margin-bottom: 0px;
       }
+
     }
     .heads-up {
       border: solid 1px #9e9e9e;


### PR DESCRIPTION
## WHAT
Fix issue where list items weren't showing up with right font or bullets in Evidence hints.

## WHY
So that they render correctly.

## HOW
Just add some CSS to get them to render the way we want them to.

### Screenshots
<img width="640" alt="Screen Shot 2022-03-15 at 11 55 08 AM" src="https://user-images.githubusercontent.com/18669014/158425551-a0a52129-95eb-4e5c-a28a-51a46f765a13.png">

### Notion Card Links
https://www.notion.so/quill/Bullet-points-not-displaying-in-explanation-of-annotated-example-07d207402bb0482d83a8765a414f97c0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
