### PR TITLE
Create Plan model

### DIFF
--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -10,7 +10,7 @@
 #  interval        :string
 #  interval_count  :integer
 #  name            :string           not null
-#  paid            :boolean          not null
+#  price           :integer          default(0)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  stripe_price_id :string
@@ -33,6 +33,7 @@ class Plan < ApplicationRecord
   ]
 
   validates :name, presence: true, uniqueness: true
+  validates :price, numericality: { greater_than_or_equal_to: 0 }
   validates :audience, presence: true, inclusion: { in: AUDIENCE_TYPES }
   validates :interval, presence: true, inclusion: { in: INTERVAL_TYPES }
   validates :interval_count, numericality: { greater_than_or_equal_to: 0 }

--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -32,6 +32,8 @@ class Plan < ApplicationRecord
     DAILY_INTERVAL_TYPE = 'daily'
   ]
 
+  attr_readonly :audience, :interval, :interval_count, :name, :price, :stripe_price_id
+
   validates :name, presence: true, uniqueness: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }
   validates :audience, presence: true, inclusion: { in: AUDIENCE_TYPES }
@@ -40,8 +42,4 @@ class Plan < ApplicationRecord
   validates :stripe_price_id, allow_blank: true, format: { with: /\Aprice_[0-9a-zA-Z]*\z/ }
 
   before_destroy { |record| raise ActiveRecord::ReadOnlyRecord }
-
-  def readonly?
-    !new_record?
-  end
 end

--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -38,4 +38,10 @@ class Plan < ApplicationRecord
   validates :interval, presence: true, inclusion: { in: INTERVAL_TYPES }
   validates :interval_count, numericality: { greater_than_or_equal_to: 0 }
   validates :stripe_price_id, allow_blank: true, format: { with: /\Aprice_[0-9a-zA-Z]*\z/ }
+
+  before_destroy { |record| raise ActiveRecord::ReadOnlyRecord }
+
+  def readonly?
+    !new_record?
+  end
 end

--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: plans
+#
+#  id              :bigint           not null, primary key
+#  audience        :string           not null
+#  display_name    :string           not null
+#  interval        :string
+#  interval_count  :integer
+#  name            :string           not null
+#  paid            :boolean          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  stripe_price_id :string
+#
+# Indexes
+#
+#  index_plans_on_name  (name) UNIQUE
+#
+class Plan < ApplicationRecord
+  AUDIENCE_TYPES = [
+    DISTRICT_AUDIENCE_TYPE = 'district',
+    TEACHER_AUDIENCE_TYPE = 'teacher',
+    SCHOOL_AUDIENCE_TYPE = 'school'
+  ]
+
+  INTERVAL_TYPES = [
+    YEARLY_INTERVAL_TYPE = 'yearly',
+    WEEKLY_INTERVAL_TYPE = 'weekly',
+    DAILY_INTERVAL_TYPE = 'daily'
+  ]
+
+  validates :name, presence: true, uniqueness: true
+  validates :audience, presence: true, inclusion: { in: AUDIENCE_TYPES }
+  validates :interval, presence: true, inclusion: { in: INTERVAL_TYPES }
+  validates :interval_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :stripe_price_id, allow_blank: true, format: { with: /\Aprice_[0-9a-zA-Z]*\z/ }
+end

--- a/services/QuillLMS/db/migrate/20220315131616_create_plans.rb
+++ b/services/QuillLMS/db/migrate/20220315131616_create_plans.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreatePlans < ActiveRecord::Migration[5.1]
+  def change
+    create_table :plans do |t|
+      t.string :name, null: false
+      t.string :display_name, null: false
+      t.boolean :paid, null: false
+      t.string :audience, null: false
+      t.string :interval
+      t.integer :interval_count
+      t.string :stripe_price_id
+
+      t.timestamps
+    end
+
+    add_index :plans, :name, unique: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20220315131616_create_plans.rb
+++ b/services/QuillLMS/db/migrate/20220315131616_create_plans.rb
@@ -5,7 +5,7 @@ class CreatePlans < ActiveRecord::Migration[5.1]
     create_table :plans do |t|
       t.string :name, null: false
       t.string :display_name, null: false
-      t.boolean :paid, null: false
+      t.integer :price, default: 0
       t.string :audience, null: false
       t.string :interval
       t.integer :interval_count

--- a/services/QuillLMS/lib/tasks/temporary/plans.rake
+++ b/services/QuillLMS/lib/tasks/temporary/plans.rake
@@ -1,0 +1,84 @@
+namespace :plans do
+  task seed: :environment do
+    ActiveRecord::Base.transaction do
+      [
+        {
+          name: 'Teacher Paid',
+          display_name: 'Teacher Premium',
+          paid: true,
+          audience: 'teacher',
+          interval: 'yearly',
+          interval_count: 1
+        },
+        {
+          name: 'School Paid (via Stripe)',
+          display_name: 'School Premium',
+          paid: true,
+          audience: 'school',
+          interval: 'yearly',
+          interval_count: 1
+        },
+        {
+          name: 'School Paid (via invoice)',
+          display_name: 'School Premium',
+        paid: true,
+        audience: 'school',
+        interval: 'yearly',
+        interval_count: 1
+        },
+        {
+          name: 'School District Paid',
+          display_name: 'District Premium',
+          paid: true,
+          audience: 'district',
+          interval: 'yearly',
+          interval_count: 1
+        },
+        {
+          name: 'Premium Credit',
+          display_name: 'Teacher Premium Credit',
+          paid: true,
+          audience: 'teacher',
+          interval: 'weekly',
+          interval_count: 4
+        },
+        {
+          name: 'College Board Educator Lifetime Premium',
+          display_name: 'Teacher Premium',
+          paid: false,
+          audience: 'teacher',
+          interval: 'yearly',
+          interval_count: 50
+        },
+        {
+          name: 'School Sponsored Free',
+          display_name: 'School Premium (Scholarship)',
+          paid: false,
+          audience: 'school',
+          interval: 'yearly',
+          interval_count: 1
+        },
+        {
+          name: 'Teacher Sponsored Free',
+          display_name: 'Teacher Premium (Scholarship)',
+          paid: false,
+          audience: 'teacher',
+          interval: 'yearly',
+          interval_count: 1
+        },
+        {
+          name: 'Teacher Trial',
+          display_name: 'Teacher Premium Trial',
+          paid: false,
+          audience: 'teacher',
+          interval: 'daily',
+          interval_count: 30
+        }
+      ].each do |plan_attrs|
+        Plan.find_or_create_by!(plan_attrs)
+      end
+
+      puts "\nBase plans were added to the database"
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/plans.rake
+++ b/services/QuillLMS/lib/tasks/temporary/plans.rake
@@ -5,31 +5,33 @@ namespace :plans do
         {
           name: 'Teacher Paid',
           display_name: 'Teacher Premium',
-          paid: true,
+          price: 8000,
           audience: 'teacher',
           interval: 'yearly',
-          interval_count: 1
+          interval_count: 1,
+          stripe_price_id: ENV.fetch('STRIPE_TEACHER_PREMIUM_PRICE_ID', '')
         },
         {
           name: 'School Paid (via Stripe)',
           display_name: 'School Premium',
-          paid: true,
+          price: 8000,
+          audience: 'school',
+          interval: 'yearly',
+          interval_count: 1,
+          stripe_price_id: ENV.fetch('STRIPE_SCHOOL_PREMIUM_PRICE_ID', '')
+        },
+        {
+          name: 'School Paid (via invoice)',
+          display_name: 'School Premium',
+          price: 180000,
           audience: 'school',
           interval: 'yearly',
           interval_count: 1
         },
         {
-          name: 'School Paid (via invoice)',
-          display_name: 'School Premium',
-        paid: true,
-        audience: 'school',
-        interval: 'yearly',
-        interval_count: 1
-        },
-        {
           name: 'School District Paid',
           display_name: 'District Premium',
-          paid: true,
+          price: 180000,
           audience: 'district',
           interval: 'yearly',
           interval_count: 1
@@ -37,7 +39,7 @@ namespace :plans do
         {
           name: 'Premium Credit',
           display_name: 'Teacher Premium Credit',
-          paid: true,
+          price: 0,
           audience: 'teacher',
           interval: 'weekly',
           interval_count: 4
@@ -45,7 +47,7 @@ namespace :plans do
         {
           name: 'College Board Educator Lifetime Premium',
           display_name: 'Teacher Premium',
-          paid: false,
+          price: 0,
           audience: 'teacher',
           interval: 'yearly',
           interval_count: 50
@@ -53,7 +55,7 @@ namespace :plans do
         {
           name: 'School Sponsored Free',
           display_name: 'School Premium (Scholarship)',
-          paid: false,
+          price: 0,
           audience: 'school',
           interval: 'yearly',
           interval_count: 1
@@ -61,7 +63,7 @@ namespace :plans do
         {
           name: 'Teacher Sponsored Free',
           display_name: 'Teacher Premium (Scholarship)',
-          paid: false,
+          price: 0,
           audience: 'teacher',
           interval: 'yearly',
           interval_count: 1
@@ -69,7 +71,7 @@ namespace :plans do
         {
           name: 'Teacher Trial',
           display_name: 'Teacher Premium Trial',
-          paid: false,
+          price: 0,
           audience: 'teacher',
           interval: 'daily',
           interval_count: 30

--- a/services/QuillLMS/lib/tasks/temporary/plans.rake
+++ b/services/QuillLMS/lib/tasks/temporary/plans.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :plans do
   task seed: :environment do
     ActiveRecord::Base.transaction do

--- a/services/QuillLMS/spec/factories/plans.rb
+++ b/services/QuillLMS/spec/factories/plans.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: plans
+#
+#  id              :bigint           not null, primary key
+#  audience        :string           not null
+#  display_name    :string           not null
+#  interval        :string
+#  interval_count  :integer
+#  name            :string           not null
+#  paid            :boolean          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  stripe_price_id :string
+#
+# Indexes
+#
+#  index_plans_on_name  (name) UNIQUE
+#
+require 'rails_helper'
+
+FactoryBot.define do
+  factory :plan, aliases: [:teacher_paid] do
+    name { 'Teacher Paid' }
+    display_name { 'Teacher Premium' }
+    paid { true }
+    audience { Plan::TEACHER_AUDIENCE_TYPE }
+    interval { Plan::YEARLY_INTERVAL_TYPE }
+    interval_count { 1 }
+    stripe_price_id { 'price_A0B1C2D3E4f5ghijk'}
+  end
+end

--- a/services/QuillLMS/spec/factories/plans.rb
+++ b/services/QuillLMS/spec/factories/plans.rb
@@ -10,7 +10,7 @@
 #  interval        :string
 #  interval_count  :integer
 #  name            :string           not null
-#  paid            :boolean          not null
+#  price           :integer          default(0)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  stripe_price_id :string
@@ -25,7 +25,7 @@ FactoryBot.define do
   factory :plan, aliases: [:teacher_paid] do
     name { 'Teacher Paid' }
     display_name { 'Teacher Premium' }
-    paid { true }
+    price { 9000 }
     audience { Plan::TEACHER_AUDIENCE_TYPE }
     interval { Plan::YEARLY_INTERVAL_TYPE }
     interval_count { 1 }

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: plans
+#
+#  id              :bigint           not null, primary key
+#  audience        :string           not null
+#  display_name    :string           not null
+#  interval        :string
+#  interval_count  :integer
+#  name            :string           not null
+#  paid            :boolean          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  stripe_price_id :string
+#
+# Indexes
+#
+#  index_plans_on_name  (name) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe Plan, type: :model do
+  context 'validations' do
+    let(:plan) { build(:plan) }
+
+    it { expect(plan).to be_valid }
+
+    it 'expects name to be unique' do
+      existing_plan = create(:plan, name: plan.name)
+      expect(plan).not_to be_valid
+    end
+
+    it 'expects audience to be one of AUDIENCE_TYPES' do
+      plan.audience = 'student'
+      expect(plan).not_to be_valid
+    end
+
+    it 'expects interval to be in INTERVAL_TYPES' do
+      plan.interval = 'biweekly'
+      expect(plan).not_to be_valid
+    end
+
+    it 'expects interval_count to be nonnegative' do
+      plan.interval_count = '-10'
+      expect(plan).not_to be_valid
+    end
+
+    it 'expects stripe_price_id to be of a given format' do
+      plan.stripe_price_id = 'not_the_price_format'
+      expect(plan).not_to be_valid
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: plans
@@ -8,7 +10,7 @@
 #  interval        :string
 #  interval_count  :integer
 #  name            :string           not null
-#  paid            :boolean          not null
+#  price           :integer          default(0)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  stripe_price_id :string
@@ -30,6 +32,11 @@ RSpec.describe Plan, type: :model do
       expect(plan).not_to be_valid
     end
 
+    it 'expects a nonnegative price' do
+      plan.price = '-10'
+      expect(plan).not_to be_valid
+    end
+
     it 'expects audience to be one of AUDIENCE_TYPES' do
       plan.audience = 'student'
       expect(plan).not_to be_valid
@@ -40,8 +47,8 @@ RSpec.describe Plan, type: :model do
       expect(plan).not_to be_valid
     end
 
-    it 'expects interval_count to be nonnegative' do
-      plan.interval_count = '-10'
+    it 'expects a nonnegative interval count' do
+      plan.interval_count = '-5'
       expect(plan).not_to be_valid
     end
 

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -57,4 +57,12 @@ RSpec.describe Plan, type: :model do
       expect(plan).not_to be_valid
     end
   end
+
+  context 'readonly protection' do
+    let(:plan) { create(:plan) }
+
+    it { expect { plan.destroy }.to raise_error ActiveRecord::ReadOnlyRecord }
+    it { expect { plan.update(price: 10) }.to raise_error ActiveRecord::ReadOnlyRecord }
+    it { expect { plan.update(name: plan.name) }.to raise_error ActiveRecord::ReadOnlyRecord }
+  end
 end

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -58,11 +58,16 @@ RSpec.describe Plan, type: :model do
     end
   end
 
-  context 'readonly protection' do
+  context 'readonly' do
     let(:plan) { create(:plan) }
 
     it { expect { plan.destroy }.to raise_error ActiveRecord::ReadOnlyRecord }
-    it { expect { plan.update(price: 10) }.to raise_error ActiveRecord::ReadOnlyRecord }
-    it { expect { plan.update(name: plan.name) }.to raise_error ActiveRecord::ReadOnlyRecord }
+
+    it { should have_readonly_attribute(:audience) }
+    it { should have_readonly_attribute(:interval) }
+    it { should have_readonly_attribute(:interval_count) }
+    it { should have_readonly_attribute(:name) }
+    it { should have_readonly_attribute(:price) }
+    it { should have_readonly_attribute(:stripe_price_id) }
   end
 end


### PR DESCRIPTION
## WHAT
As part of the [Stripe Schema RFC](https://www.notion.so/quill/Stripe-Schema-RFC-96821751a3ad4205b497ea32c1373b79) this commit establishes the `Plan` model which will be added as a foreign key to Subscriptions object.

For greater transparency as well as auditing purposes, the Plan object is readonly since we don't want the Plans to be updated or destroyed after creation.

## WHY
Each plan instance will capture relevant details associated with that plan will streamline the integration of plan details in the UI.  In the case of the two Stripe-related plans, we'll also associate the `price_id` found on Stripe with the respective object.

## HOW
1. `rails generate migration Plan  [attributes]`
2.  Add validations to the model. 
2. Using the Stripe CLI creating products and prices for teacher and school premium plans, noting the returned `price_id`.
4. Run the rake task the seeds these plans using the price_id found in the previous step.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
