### PR TITLE
Add caching to `/api/v1/progress_reports/student_overview_data`

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -60,11 +60,15 @@ class Api::V1::ProgressReportsController < Api::ApiController
   end
 
   def student_overview_data
+    render json: fetch_student_overview_data_cache
+  end
+
+  private def fetch_student_overview_data_cache
     classroom = Classroom.find(params[:classroom_id].to_i)
     cache_groups = {
       student_id: params[:student_id]
     }
-    data = current_user.classroom_cache(classroom, key: 'api.v1.progress_reports.student_overview_data', groups: cache_groups) do
+    current_user.classroom_cache(classroom, key: 'api.v1.progress_reports.student_overview_data', groups: cache_groups) do
       student        = User.find(params[:student_id].to_i)
       report_data    = ProgressReports::StudentOverview.results(params[:classroom_id].to_i, params[:student_id].to_i)
       {
@@ -77,8 +81,6 @@ class Api::V1::ProgressReportsController < Api::ApiController
         classroom_name: classroom.name
       }
     end
-
-    render json: data
   end
 
   private def authorize!

--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -60,18 +60,23 @@ class Api::V1::ProgressReportsController < Api::ApiController
   end
 
   def student_overview_data
-    student        = User.find(params[:student_id].to_i)
-    report_data    = ProgressReports::StudentOverview.results(params[:classroom_id].to_i, params[:student_id].to_i)
-    classroom_name = Classroom.find(params[:classroom_id].to_i).name
-    data = {
-      report_data: report_data,
-      student_data: {
-        name: student.name,
-        id: student.id,
-        last_active: student.last_active
-      },
-      classroom_name: classroom_name
+    classroom = Classroom.find(params[:classroom_id].to_i)
+    cache_groups = {
+      student_id: params[:student_id]
     }
+    data = current_user.classroom_cache(classroom, key: 'api.v1.progress_reports.student_overview_data', groups: cache_groups) do
+      student        = User.find(params[:student_id].to_i)
+      report_data    = ProgressReports::StudentOverview.results(params[:classroom_id].to_i, params[:student_id].to_i)
+      {
+        report_data: report_data,
+        student_data: {
+          name: student.name,
+          id: student.id,
+          last_active: student.last_active
+        },
+        classroom_name: classroom.name
+      }
+    end
 
     render json: data
   end

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -52,6 +52,23 @@ describe Api::V1::ProgressReportsController, type: :controller do
         classroom_name: classroom.name
       }.to_json)
     end
+
+    it 'should successfully return fresh and cached payloads' do
+      session[:user_id] = teacher.id
+      2.times do
+        get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }, as: :json
+        expect(response.status).to eq(200)
+        expect(response.body).to eq({
+          report_data: ProgressReports::StudentOverview.results(classroom.id, student.id),
+          student_data: {
+            name: student.name,
+            id: student.id,
+            last_active: student.last_active
+          },
+          classroom_name: classroom.name
+        }.to_json)
+      end
+    end
   end
 
   describe '#district_activity_scores' do

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -54,12 +54,17 @@ describe Api::V1::ProgressReportsController, type: :controller do
     end
 
     it 'should successfully return fresh and cached payloads' do
+      # Storing payload data here before setting our 'call once' expectaton to confirm caching
+      report_results = ProgressReports::StudentOverview.results(classroom.id, student.id)
+
+      expect(ProgressReports::StudentOverview).to receive(:results).with(classroom.id, student.id).once.and_return(report_results)
+
       session[:user_id] = teacher.id
       2.times do
         get :student_overview_data, params: { student_id: student.id, classroom_id: classroom.id }, as: :json
         expect(response.status).to eq(200)
         expect(response.body).to eq({
-          report_data: ProgressReports::StudentOverview.results(classroom.id, student.id),
+          report_data: report_results,
           student_data: {
             name: student.name,
             id: student.id,


### PR DESCRIPTION
## WHAT
Add caching to `/api/v1/progress_reports/student_overview_data`
## WHY
In our effort to cache all of our reporting endpoints to reduce db load
## HOW
Wrap the code that generates the payload in a cache call at the classroom level.

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test pattern for caching
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
