### PR TITLE
Cache `/teachers/classrooms/classrooms_i_teach`

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -31,8 +31,11 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   def classrooms_i_teach
-    @classrooms = current_user.classrooms_i_teach
-    render json: @classrooms.sort_by { |c| c[:update_at] }, each_serializer: ClassroomSerializer
+    data = current_user.all_classrooms_cache(key: 'teachers.classrooms.classrooms_i_teach') do
+      @classrooms = current_user.classrooms_i_teach
+      @classrooms.sort_by { |c| c[:update_at] }
+    end
+    render json: data, each_serializer: ClassroomSerializer
   end
 
   def regenerate_code

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -160,7 +160,6 @@ class Teachers::ClassroomsController < ApplicationController
   private def fetch_classrooms_i_teach_cache
     current_user.all_classrooms_cache(key: 'teachers.classrooms.classrooms_i_teach') do
       @classrooms = current_user.classrooms_i_teach
-      @classrooms.sort_by { |c| c[:update_at] }
     end
   end
 

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -31,11 +31,7 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   def classrooms_i_teach
-    data = current_user.all_classrooms_cache(key: 'teachers.classrooms.classrooms_i_teach') do
-      @classrooms = current_user.classrooms_i_teach
-      @classrooms.sort_by { |c| c[:update_at] }
-    end
-    render json: data, each_serializer: ClassroomSerializer
+    render json: fetch_classrooms_i_teach_cache, each_serializer: ClassroomSerializer
   end
 
   def regenerate_code
@@ -159,6 +155,13 @@ class Teachers::ClassroomsController < ApplicationController
     end
 
     render json: {}
+  end
+
+  private def fetch_classrooms_i_teach_cache
+    current_user.all_classrooms_cache(key: 'teachers.classrooms.classrooms_i_teach') do
+      @classrooms = current_user.classrooms_i_teach
+      @classrooms.sort_by { |c| c[:update_at] }
+    end
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -316,7 +316,7 @@ describe Teachers::ClassroomsController, type: :controller do
     let(:classroom) { create(:classroom) }
 
     before do
-      allow(teacher).to receive(:classrooms_i_teach) { [classroom] }
+      allow(teacher).to receive(:classrooms_i_teach).once { [classroom] }
       allow(controller).to receive(:current_user) { teacher }
     end
 
@@ -326,10 +326,13 @@ describe Teachers::ClassroomsController, type: :controller do
     end
 
     it 'should provide valid data when making fresh and cached queries' do
+
       2.times do
         get :classrooms_i_teach
         expect(response.status).to eq(200)
-        expect(assigns(:classrooms)).to eq [classroom]
+        classrooms_payload = JSON.parse(response.body)['classrooms']
+        expect(classrooms_payload.length).to eq(1)
+        expect(classrooms_payload[0]['id']).to eq(classroom.id)
       end
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -316,7 +316,7 @@ describe Teachers::ClassroomsController, type: :controller do
     let(:classroom) { create(:classroom) }
 
     before do
-      allow(teacher).to receive(:classrooms_i_teach).once { [classroom] }
+      allow(teacher).to receive(:classrooms_i_teach).once.and_return([classroom])
       allow(controller).to receive(:current_user) { teacher }
     end
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -324,6 +324,14 @@ describe Teachers::ClassroomsController, type: :controller do
       get :classrooms_i_teach
       expect(assigns(:classrooms)).to eq [classroom]
     end
+
+    it 'should provide valid data when making fresh and cached queries' do
+      2.times do
+        get :classrooms_i_teach
+        expect(response.status).to eq(200)
+        expect(assigns(:classrooms)).to eq [classroom]
+      end
+    end
   end
 
   describe '#regenerate_code' do


### PR DESCRIPTION
## WHAT
Cache `/teachers/classrooms/classrooms_i_teach` payload
## WHY
In our effort to cache all of our reporting endpoints to reduce db load
## HOW
Wrap the code that generates the payload in a cache call at the all classrooms level

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
