### PR TITLE
Cache `/teachers/progress_reports/activity_sessions`

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -21,9 +21,9 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     end
   end
 
-  private def fetch_index_cache(as_json)
+  private def fetch_index_cache(should_return_json)
     cache_groups = {
-      json_format: as_json,
+      json_format: should_return_json,
       classroom_id: params[:classroom_id],
       student_id: params[:student_id],
       unit_id: params[:unit_id],
@@ -34,7 +34,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     }
 
     current_user.all_classrooms_cache(key: 'teachers.progress_reports.activity_sessions', groups: cache_groups) do
-      return_data(as_json)
+      return_data(should_return_json)
     end
   end
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -13,10 +13,10 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
           flash[:warning] = 'Downloadable reports are only available to Premium users.'
           return redirect_to premium_path
         end
-        return_data(false)
+        render plain: return_data(false)
       end
       format.json do
-        return_data(true)
+        render json: return_data(true)
       end
     end
   end
@@ -139,12 +139,12 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
         page_count = (count.to_f / PAGE_SIZE).ceil
 
         if params[:without_filters]
-          render json: {
+          {
             activity_sessions: activity_sessions,
             page_count: page_count,
           }
         else
-          render json: {
+          {
             classrooms: current_user.ids_and_names_of_affiliated_classrooms,
             students: current_user.ids_and_names_of_affiliated_students,
             units: current_user.ids_and_names_of_affiliated_units,
@@ -153,7 +153,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
           }
         end
       else
-        render plain: csv_string(activity_sessions)
+        csv_string(activity_sessions)
       end
     end
   end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -23,83 +23,58 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
 
   # rubocop:disable Metrics/CyclomaticComplexity
   private def return_data(should_return_json)
-    classroom_units_filter = params[:classroom_id].blank? ? '' : "AND classroom_units.classroom_id = #{params[:classroom_id].to_i}"
-    student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
-    unit_filter = params[:unit_id].blank? ? '' : " AND classroom_units.unit_id = #{params[:unit_id].to_i}"
+    cache_groups = {
+      json_format: should_return_json,
+      classroom_id: params[:classroom_id],
+      student_id: params[:student_id],
+      unit_id: params[:unit_id],
+      sort_param: params[:sort_param],
+      sort_descending: params[:sort_descending],
+      page: params[:page],
+      without_filters: params[:without_filters]
+    }
 
-    case (params[:sort_param])
-    when 'student_id'
-      sort_field = 'sorting_name'
-    when 'activity_name'
-      sort_field = 'activity_name'
-    when 'percentage'
-      sort_field = 'percentage'
-    when 'standard'
-      sort_field = 'standard'
-    when 'activity_classification_name'
-      sort_field = 'activity_classification_name'
-    else
-      sort_field = 'completed_at'
-    end
-    sort_direction = params[:sort_descending] && params[:sort_descending] != 'true' ? 'ASC' : 'DESC'
+    current_user.all_classrooms_cache(key: 'teachers.progress_reports.activity_sessions', groups: cache_groups) do
+      classroom_units_filter = params[:classroom_id].blank? ? '' : "AND classroom_units.classroom_id = #{params[:classroom_id].to_i}"
+      student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
+      unit_filter = params[:unit_id].blank? ? '' : " AND classroom_units.unit_id = #{params[:unit_id].to_i}"
 
-    query_limit = should_return_json ? "LIMIT #{PAGE_SIZE}" : ''
-    query_offset = should_return_json ? "OFFSET #{PAGE_SIZE * (params['page'].to_i - 1)}" : ''
+      case (params[:sort_param])
+      when 'student_id'
+        sort_field = 'sorting_name'
+      when 'activity_name'
+        sort_field = 'activity_name'
+      when 'percentage'
+        sort_field = 'percentage'
+      when 'standard'
+        sort_field = 'standard'
+      when 'activity_classification_name'
+        sort_field = 'activity_classification_name'
+      else
+        sort_field = 'completed_at'
+      end
+      sort_direction = params[:sort_descending] && params[:sort_descending] != 'true' ? 'ASC' : 'DESC'
 
-    # Note to maintainers: if you update this query, please be sure to
-    # also update the page count query below if applicable.
-    activity_sessions = RawSqlRunner.execute(
-      <<-SQL
-        SELECT
-          activity_sessions.id AS activity_session_id,
-          activity_classifications.name AS activity_classification_name,
-          classrooms_teachers.classroom_id AS classroom_id,
-          EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
-          activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
-          activity_sessions.timespent AS timespent,
-          (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
-          standards.name AS standard,
-          activity_sessions.user_id AS student_id,
-          activities.name AS activity_name,
-          users.name AS student_name,
-          substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
-        FROM classrooms_teachers
-        JOIN classrooms
-          ON classrooms.id = classrooms_teachers.classroom_id
-          AND classrooms.visible = true
-        JOIN classroom_units
-          ON classroom_units.classroom_id = classrooms.id
-          #{classroom_units_filter}
-          #{unit_filter}
-          AND classroom_units.visible = true
-        JOIN students_classrooms
-          ON students_classrooms.classroom_id = classrooms.id
-          AND students_classrooms.visible = true
-        JOIN users
-          ON users.id = students_classrooms.student_id
-        JOIN activity_sessions
-          ON activity_sessions.classroom_unit_id = classroom_units.id
-          AND activity_sessions.state = 'finished'
-          AND activity_sessions.visible = true
-          AND activity_sessions.user_id = users.id
-          #{student_filter}
-        JOIN activities
-          ON activities.id = activity_sessions.activity_id
-        JOIN activity_classifications
-          ON activity_classifications.id = activities.activity_classification_id
-        LEFT JOIN standards
-          ON standards.id = activities.standard_id
-        WHERE classrooms_teachers.user_id = #{current_user.id}
-        ORDER BY #{sort_field} #{sort_direction}
-        #{query_limit}
-        #{query_offset}
-      SQL
-    ).to_a
+      query_limit = should_return_json ? "LIMIT #{PAGE_SIZE}" : ''
+      query_offset = should_return_json ? "OFFSET #{PAGE_SIZE * (params['page'].to_i - 1)}" : ''
 
-    if should_return_json
-      count = RawSqlRunner.execute(
+      # Note to maintainers: if you update this query, please be sure to
+      # also update the page count query below if applicable.
+      activity_sessions = RawSqlRunner.execute(
         <<-SQL
-          SELECT count(activity_sessions.id)
+          SELECT
+            activity_sessions.id AS activity_session_id,
+            activity_classifications.name AS activity_classification_name,
+            classrooms_teachers.classroom_id AS classroom_id,
+            EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
+            activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
+            activity_sessions.timespent AS timespent,
+            (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
+            standards.name AS standard,
+            activity_sessions.user_id AS student_id,
+            activities.name AS activity_name,
+            users.name AS student_name,
+            substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
           FROM classrooms_teachers
           JOIN classrooms
             ON classrooms.id = classrooms_teachers.classroom_id
@@ -120,28 +95,66 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
             AND activity_sessions.visible = true
             AND activity_sessions.user_id = users.id
             #{student_filter}
+          JOIN activities
+            ON activities.id = activity_sessions.activity_id
+          JOIN activity_classifications
+            ON activity_classifications.id = activities.activity_classification_id
+          LEFT JOIN standards
+            ON standards.id = activities.standard_id
           WHERE classrooms_teachers.user_id = #{current_user.id}
+          ORDER BY #{sort_field} #{sort_direction}
+          #{query_limit}
+          #{query_offset}
         SQL
-      ).to_a[0]['count']
+      ).to_a
 
-      page_count = (count.to_f / PAGE_SIZE).ceil
+      if should_return_json
+        count = RawSqlRunner.execute(
+          <<-SQL
+            SELECT count(activity_sessions.id)
+            FROM classrooms_teachers
+            JOIN classrooms
+              ON classrooms.id = classrooms_teachers.classroom_id
+              AND classrooms.visible = true
+            JOIN classroom_units
+              ON classroom_units.classroom_id = classrooms.id
+              #{classroom_units_filter}
+              #{unit_filter}
+              AND classroom_units.visible = true
+            JOIN students_classrooms
+              ON students_classrooms.classroom_id = classrooms.id
+              AND students_classrooms.visible = true
+            JOIN users
+              ON users.id = students_classrooms.student_id
+            JOIN activity_sessions
+              ON activity_sessions.classroom_unit_id = classroom_units.id
+              AND activity_sessions.state = 'finished'
+              AND activity_sessions.visible = true
+              AND activity_sessions.user_id = users.id
+              #{student_filter}
+            WHERE classrooms_teachers.user_id = #{current_user.id}
+          SQL
+        ).to_a[0]['count']
 
-      if params[:without_filters]
-        render json: {
-          activity_sessions: activity_sessions,
-          page_count: page_count,
-        }
+        page_count = (count.to_f / PAGE_SIZE).ceil
+
+        if params[:without_filters]
+          render json: {
+            activity_sessions: activity_sessions,
+            page_count: page_count,
+          }
+        else
+          render json: {
+            classrooms: current_user.ids_and_names_of_affiliated_classrooms,
+            students: current_user.ids_and_names_of_affiliated_students,
+            units: current_user.ids_and_names_of_affiliated_units,
+            activity_sessions: activity_sessions,
+            page_count: page_count,
+          }
+        end
       else
-        render json: {
-          classrooms: current_user.ids_and_names_of_affiliated_classrooms,
-          students: current_user.ids_and_names_of_affiliated_students,
-          units: current_user.ids_and_names_of_affiliated_units,
-          activity_sessions: activity_sessions,
-          page_count: page_count,
-        }
+        render plain: csv_string(activity_sessions)
       end
-    else
-      render plain: csv_string(activity_sessions)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -13,18 +13,17 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
           flash[:warning] = 'Downloadable reports are only available to Premium users.'
           return redirect_to premium_path
         end
-        render plain: return_data(false)
+        render plain: fetch_index_cache(false)
       end
       format.json do
-        render json: return_data(true)
+        render json: fetch_index_cache(true)
       end
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  private def return_data(should_return_json)
+  private def fetch_index_cache(as_json)
     cache_groups = {
-      json_format: should_return_json,
+      json_format: as_json,
       classroom_id: params[:classroom_id],
       student_id: params[:student_id],
       unit_id: params[:unit_id],
@@ -35,46 +34,89 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     }
 
     current_user.all_classrooms_cache(key: 'teachers.progress_reports.activity_sessions', groups: cache_groups) do
-      classroom_units_filter = params[:classroom_id].blank? ? '' : "AND classroom_units.classroom_id = #{params[:classroom_id].to_i}"
-      student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
-      unit_filter = params[:unit_id].blank? ? '' : " AND classroom_units.unit_id = #{params[:unit_id].to_i}"
+      return_data(as_json)
+    end
+  end
 
-      case (params[:sort_param])
-      when 'student_id'
-        sort_field = 'sorting_name'
-      when 'activity_name'
-        sort_field = 'activity_name'
-      when 'percentage'
-        sort_field = 'percentage'
-      when 'standard'
-        sort_field = 'standard'
-      when 'activity_classification_name'
-        sort_field = 'activity_classification_name'
-      else
-        sort_field = 'completed_at'
-      end
-      sort_direction = params[:sort_descending] && params[:sort_descending] != 'true' ? 'ASC' : 'DESC'
+  # rubocop:disable Metrics/CyclomaticComplexity
+  private def return_data(should_return_json)
+    classroom_units_filter = params[:classroom_id].blank? ? '' : "AND classroom_units.classroom_id = #{params[:classroom_id].to_i}"
+    student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
+    unit_filter = params[:unit_id].blank? ? '' : " AND classroom_units.unit_id = #{params[:unit_id].to_i}"
 
-      query_limit = should_return_json ? "LIMIT #{PAGE_SIZE}" : ''
-      query_offset = should_return_json ? "OFFSET #{PAGE_SIZE * (params['page'].to_i - 1)}" : ''
+    case (params[:sort_param])
+    when 'student_id'
+      sort_field = 'sorting_name'
+    when 'activity_name'
+      sort_field = 'activity_name'
+    when 'percentage'
+      sort_field = 'percentage'
+    when 'standard'
+      sort_field = 'standard'
+    when 'activity_classification_name'
+      sort_field = 'activity_classification_name'
+    else
+      sort_field = 'completed_at'
+    end
+    sort_direction = params[:sort_descending] && params[:sort_descending] != 'true' ? 'ASC' : 'DESC'
 
-      # Note to maintainers: if you update this query, please be sure to
-      # also update the page count query below if applicable.
-      activity_sessions = RawSqlRunner.execute(
+    query_limit = should_return_json ? "LIMIT #{PAGE_SIZE}" : ''
+    query_offset = should_return_json ? "OFFSET #{PAGE_SIZE * (params['page'].to_i - 1)}" : ''
+
+    # Note to maintainers: if you update this query, please be sure to
+    # also update the page count query below if applicable.
+    activity_sessions = RawSqlRunner.execute(
+      <<-SQL
+        SELECT
+          activity_sessions.id AS activity_session_id,
+          activity_classifications.name AS activity_classification_name,
+          classrooms_teachers.classroom_id AS classroom_id,
+          EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
+          activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
+          activity_sessions.timespent AS timespent,
+          (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
+          standards.name AS standard,
+          activity_sessions.user_id AS student_id,
+          activities.name AS activity_name,
+          users.name AS student_name,
+          substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
+        FROM classrooms_teachers
+        JOIN classrooms
+          ON classrooms.id = classrooms_teachers.classroom_id
+          AND classrooms.visible = true
+        JOIN classroom_units
+          ON classroom_units.classroom_id = classrooms.id
+          #{classroom_units_filter}
+          #{unit_filter}
+          AND classroom_units.visible = true
+        JOIN students_classrooms
+          ON students_classrooms.classroom_id = classrooms.id
+          AND students_classrooms.visible = true
+        JOIN users
+          ON users.id = students_classrooms.student_id
+        JOIN activity_sessions
+          ON activity_sessions.classroom_unit_id = classroom_units.id
+          AND activity_sessions.state = 'finished'
+          AND activity_sessions.visible = true
+          AND activity_sessions.user_id = users.id
+          #{student_filter}
+        JOIN activities
+          ON activities.id = activity_sessions.activity_id
+        JOIN activity_classifications
+          ON activity_classifications.id = activities.activity_classification_id
+        LEFT JOIN standards
+          ON standards.id = activities.standard_id
+        WHERE classrooms_teachers.user_id = #{current_user.id}
+        ORDER BY #{sort_field} #{sort_direction}
+        #{query_limit}
+        #{query_offset}
+      SQL
+    ).to_a
+
+    if should_return_json
+      count = RawSqlRunner.execute(
         <<-SQL
-          SELECT
-            activity_sessions.id AS activity_session_id,
-            activity_classifications.name AS activity_classification_name,
-            classrooms_teachers.classroom_id AS classroom_id,
-            EXTRACT(EPOCH FROM (activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds')) AS completed_at,
-            activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS visual_date,
-            activity_sessions.timespent AS timespent,
-            (CASE WHEN activity_classifications.scored THEN activity_sessions.percentage ELSE -1 END) AS percentage,
-            standards.name AS standard,
-            activity_sessions.user_id AS student_id,
-            activities.name AS activity_name,
-            users.name AS student_name,
-            substring(users.name from (position(' ' in users.name) + 1) for (char_length(users.name))) || substring(users.name from (1) for (position(' ' in users.name))) AS sorting_name
+          SELECT count(activity_sessions.id)
           FROM classrooms_teachers
           JOIN classrooms
             ON classrooms.id = classrooms_teachers.classroom_id
@@ -95,66 +137,28 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
             AND activity_sessions.visible = true
             AND activity_sessions.user_id = users.id
             #{student_filter}
-          JOIN activities
-            ON activities.id = activity_sessions.activity_id
-          JOIN activity_classifications
-            ON activity_classifications.id = activities.activity_classification_id
-          LEFT JOIN standards
-            ON standards.id = activities.standard_id
           WHERE classrooms_teachers.user_id = #{current_user.id}
-          ORDER BY #{sort_field} #{sort_direction}
-          #{query_limit}
-          #{query_offset}
         SQL
-      ).to_a
+      ).to_a[0]['count']
 
-      if should_return_json
-        count = RawSqlRunner.execute(
-          <<-SQL
-            SELECT count(activity_sessions.id)
-            FROM classrooms_teachers
-            JOIN classrooms
-              ON classrooms.id = classrooms_teachers.classroom_id
-              AND classrooms.visible = true
-            JOIN classroom_units
-              ON classroom_units.classroom_id = classrooms.id
-              #{classroom_units_filter}
-              #{unit_filter}
-              AND classroom_units.visible = true
-            JOIN students_classrooms
-              ON students_classrooms.classroom_id = classrooms.id
-              AND students_classrooms.visible = true
-            JOIN users
-              ON users.id = students_classrooms.student_id
-            JOIN activity_sessions
-              ON activity_sessions.classroom_unit_id = classroom_units.id
-              AND activity_sessions.state = 'finished'
-              AND activity_sessions.visible = true
-              AND activity_sessions.user_id = users.id
-              #{student_filter}
-            WHERE classrooms_teachers.user_id = #{current_user.id}
-          SQL
-        ).to_a[0]['count']
+      page_count = (count.to_f / PAGE_SIZE).ceil
 
-        page_count = (count.to_f / PAGE_SIZE).ceil
-
-        if params[:without_filters]
-          {
-            activity_sessions: activity_sessions,
-            page_count: page_count,
-          }
-        else
-          {
-            classrooms: current_user.ids_and_names_of_affiliated_classrooms,
-            students: current_user.ids_and_names_of_affiliated_students,
-            units: current_user.ids_and_names_of_affiliated_units,
-            activity_sessions: activity_sessions,
-            page_count: page_count,
-          }
-        end
+      if params[:without_filters]
+        {
+          activity_sessions: activity_sessions,
+          page_count: page_count,
+        }
       else
-        csv_string(activity_sessions)
+        {
+          classrooms: current_user.ids_and_names_of_affiliated_classrooms,
+          students: current_user.ids_and_names_of_affiliated_students,
+          units: current_user.ids_and_names_of_affiliated_units,
+          activity_sessions: activity_sessions,
+          page_count: page_count,
+        }
       end
+    else
+      csv_string(activity_sessions)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -49,6 +49,14 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
         expect(json['students']).to eq(teacher.ids_and_names_of_affiliated_students)
         expect(json['units']).to eq(teacher.ids_and_names_of_affiliated_units)
       end
+
+      it 'renders the same data fresh and from cache' do
+        2.times do
+          get :index, params: { page: 1 }, as: :json
+          expect(response.status).to eq(200)
+          expect(json['activity_sessions'][0]['activity_classification_name']).to_not be_nil
+        end
+      end
     end
   end
 

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -51,6 +51,7 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
       end
 
       it 'renders the same data fresh and from cache' do
+        expect(controller).to receive(:return_data).with(any_args).once.and_call_original
         2.times do
           get :index, params: { page: 1 }, as: :json
           expect(response.status).to eq(200)


### PR DESCRIPTION
## WHAT
Cache `/teachers/progress_reports/activity_sessions`
## WHY
In our effort to cache all of our reporting endpoints to reduce db load
## HOW
Wrap the code that generates the payload in a cache call at the all classrooms level

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
