### PR TITLE
Bump redis and sidekiq LMS versions for Dependabot

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -88,8 +88,9 @@ gem 'addressable'
 source "https://gems.contribsys.com/" do
   gem 'sidekiq-pro'
 end
+gem 'sidekiq', '~> 5.2.10'
 gem 'sidekiq-retries', require: false
-gem 'redis', '3.3.5'
+gem 'redis', '~> 4.5'
 gem 'redis-namespace'
 gem 'redis-rails'
 gem 'redis-rack-cache'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -522,7 +522,7 @@ GEM
     rack-pjax (1.1.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
-    rack-protection (1.5.5)
+    rack-protection (2.2.0)
       rack
     rack-proxy (0.7.0)
       rack
@@ -592,7 +592,7 @@ GEM
       rails (>= 3.2)
       rainbow (~> 3.0)
     redcarpet (3.5.1)
-    redis (3.3.5)
+    redis (4.5.1)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
       redis-rack (>= 1, < 3)
@@ -689,11 +689,11 @@ GEM
       activesupport (>= 3)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    sidekiq (5.2.5)
+    sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (~> 4.5, < 4.6.0)
     sidekiq-retries (0.4.0)
       sidekiq (>= 3.2.4)
     signet (0.12.0)
@@ -888,7 +888,7 @@ DEPENDENCIES
   rb-readline
   react_on_rails (= 11.3.0)
   redcarpet (~> 3.5.1)
-  redis (= 3.3.5)
+  redis (~> 4.5)
   redis-namespace
   redis-rack-cache
   redis-rails
@@ -907,6 +907,7 @@ DEPENDENCIES
   sentry-raven (>= 0.12.2)
   shoulda-callback-matchers (~> 1.1.1)
   shoulda-matchers (~> 4)
+  sidekiq (~> 5.2.10)
   sidekiq-pro!
   sidekiq-retries
   simplecov

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -195,23 +195,23 @@ describe UnitTemplate, redis: true, type: :model do
       flag_types = ['beta_unit_templates', 'production_unit_templates', 'gamma_unit_templates', 'alpha_unit_templates']
       exist_count = 0
       flag_types.each do |flag|
-        exist_count += $redis.exists(flag) ? 1 : 0
+        exist_count += $redis.exists(flag) == 1 ? 1 : 0
       end
       exist_count
     end
 
     it "deletes the cache of the saved unit" do
       $redis.set("unit_template_id:#{unit_template.id}_serialized", 'something')
-      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to be
+      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(1)
       unit_template.update(name: 'something else')
-      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).not_to be
+      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(0)
     end
 
     it "deletes the cache of the saved unit's flag, or production before and after save" do
       expect(exist_count).to eq(4)
       unit_template.update(flag: 'beta')
       expect(exist_count).to eq(3)
-      expect($redis.exists('alpha_unit_templates')).to be
+      expect($redis.exists('alpha_unit_templates')).to eq(1)
       unit_template.update(flag: 'alpha')
       expect(exist_count).to eq(2)
     end


### PR DESCRIPTION
## WHAT
Bump the versions on these packages because we have a high severity security issue on the older version.

## WHY
To keep our app secure and up to date.

## HOW
Bump these versions in the Gemfile and Gemfile.lock files.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-LMS-Sidekiq-161905d0bd3e461f91a294286e3d523d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
