### PR TITLE
Evidence - Add spelling exception hot fix.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -11,6 +11,10 @@ module Evidence
     RESPONSE_TYPE = 'response'
     BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'
     SPELLING_CONCEPT_UID = 'H-2lrblngQAQ8_s-ctye4g'
+
+    # TODO: replace with better exception code
+    EXCEPTIONS = ['solartogether']
+
     attr_reader :entry
 
     def initialize(entry)
@@ -58,7 +62,7 @@ module Evidence
     end
 
     private def misspelled
-      bing_response['flaggedTokens'] || []
+      bing_response['flaggedTokens']&.reject {|r| r['token']&.downcase&.in?(EXCEPTIONS)} || []
     end
 
     private def bing_response

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -22,6 +22,23 @@ module Evidence
         expect(feedback[:highlight][0][:text]).to(be_truthy)
       end
 
+      it 'should not flag error if the spelling error downcased is in exception list' do
+        spelling_error = "SpeliN"
+        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
+        stub_const("Evidence::SpellingCheck::EXCEPTIONS", [spelling_error.downcase])
+        entry = "there is a spelin error here"
+        spelling_check = Evidence::SpellingCheck.new(entry)
+        feedback = spelling_check.feedback_object
+
+        expect(feedback[:feedback]).to(be_truthy)
+        expect(feedback[:feedback_type]).to(be_truthy)
+        expect(feedback[:optimal]).to be true
+        expect(feedback[:entry]).to(be_truthy)
+        expect(feedback[:rule_uid]).to(be_truthy)
+        expect(feedback[:concept_uid]).to(be_truthy)
+        expect(feedback[:highlight]).to be_empty
+      end
+
       it 'should return appropriate feedback attributes if there is no spelling error' do
         stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"


### PR DESCRIPTION
## WHAT
The curriculum team has a passage that has a brand name that keeps getting flagged by Bing (`SolarTogether`). This is a quick hotfix for now, so students could finish the activity.
## WHY
We want students to be able to finish this activity.
## HOW
Ignore any returned `token`s that are in the exception list. Downcase it to avoid case differences.

### Notion Card Links
https://www.notion.so/quill/Spelling-Exceptions-0350baca8ed941ae8c84bb2c0e14560a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!,
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
