### PR TITLE
remove math.random key

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -483,14 +483,13 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       const innerElements = node.children.map((n, i) => convertNodeToElement(n, i, transformMarkTags))
       const stringifiedInnerElements = node.children.map(n => n.data ? n.data : n.children[0].data).join('')
       let className = ''
-      const key = `${Math.random()}`;
       if(activeStep === 1) {
         className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
       }
       className += shouldBeHighlightable  ? ' highlightable' : ''
-      if (!shouldBeHighlightable) { return <mark className={className} key={key}>{innerElements}</mark>}
+      if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
       /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-      return <mark className={className} key={key} onClick={handleHighlightClick} onKeyDown={handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
+      return <mark className={className} onClick={handleHighlightClick} onKeyDown={handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
     }
   }
 


### PR DESCRIPTION
## WHAT
Remove a `Math.random()` key that was making it so that students couldn't select highlights.

## WHY
We want students to be able to do this part of Evidence activities.

## HOW
Remove key that was added yesterday.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Highlighting-feature-does-not-work-on-Evidence-activities-9ac4038044ad46bd89c1bea35ac2e7db

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
