### PR TITLE
LMS Evidence - Add more spelling exceptions to list.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -13,7 +13,19 @@ module Evidence
     SPELLING_CONCEPT_UID = 'H-2lrblngQAQ8_s-ctye4g'
 
     # TODO: replace with better exception code
-    EXCEPTIONS = ['solartogether']
+    EXCEPTIONS = [
+      'solartogether',
+      'jerom',
+      'espana',
+      'españa',
+      'cafebabel',
+      'cafébabel',
+      'sanchez',
+      'sánchez',
+      'kanaka',
+      'kānaka',
+      'worldwatch'
+    ]
 
     attr_reader :entry
 


### PR DESCRIPTION
## WHAT
Adding a few words to the spelling exception list. 
## WHY
There are a few words in Evidence passages that are triggering the spell check, which doesn't let students finish the activity.
## HOW
Add words to list. For spellings with non-latin characters, Include proper spelling and with only latin characters.



### Notion Card Links
https://www.notion.so/quill/Add-Evidence-spelling-exceptions-c31198d3639c440592b95179163518ec

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, this is covered by existing tests.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes, looks great.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
