### PR TITLE
Bump rubocop version in CircleCI and Locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
   rubocop_lint:
     working_directory: ~/Empirical-Core
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: circleci/ruby:2.6.6-node
     steps:
       - checkout
       - run:

--- a/services/rubocop.sh
+++ b/services/rubocop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rbenv local 2.5.1
+rbenv local 2.6.6
 gem install rubocop -v 1.25.0
 gem install rubocop-rspec -v 2.8.0
 rubocop


### PR DESCRIPTION
## WHAT
Bump up the rubocop ruby version to 2.6.6

## WHY
We want the rubocop ruby version to match the LMS ruby version.

## HOW
Bump up the CircleCI image we use and the local ruby version

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Rubocop-Ruby-version-25fdbbf75484402f9bc9f09cbe6a31a6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, version change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
