### PR TITLE
Bug fix/ fix issue with adding teachers to schools for admins

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/create_new_accounts.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/create_new_accounts.tsx
@@ -55,7 +55,7 @@ class CreateNewAccounts extends React.Component<any, any> {
         last_name: lastName,
         email
       },
-      id: school.value
+      id: school.value || school.id
     }
     addTeacherAccount(data)
   }
@@ -104,7 +104,7 @@ class CreateNewAccounts extends React.Component<any, any> {
               handleChange={this.updateSchool}
               options={this.schoolOptions()}
               placeholder='Select School for Teacher'
-              value={this.schoolOptions().find(s => s.value === school.id)}
+              value={this.schoolOptions().find(s => s.value === school.id || s.value === school.value)}
             />
             <button className="button-green pull-right" onClick={this.handleAddTeacherAccountClick} type="button">Add Teacher Account</button>
           </div>

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
@@ -63,17 +63,17 @@ export default class AdminDashboard extends React.Component {
   };
 
   addTeacherAccount = (data) => {
-    const that = this;
-    that.setState({ message: '', error: '', });
+    const { adminId } = this.props;
+    this.setState({ message: '', error: '', });
     data.authenticity_token = getAuthToken();
-    request.post(`${process.env.DEFAULT_URL}/admins/${that.props.id}/teachers`, {
+    request.post(`${process.env.DEFAULT_URL}/admins/${adminId}/teachers`, {
       json: data,
     },
     (e, r, response) => {
       if (response.error) {
-        that.setState({ error: response.error, });
+        this.setState({ error: response.error, });
       } else if (r.statusCode === 200) {
-        that.setState({ message: response.message, }, () => that.getData());
+        this.setState({ message: response.message, }, () => this.getData());
       } else {
         // to do, use Sentry to capture error
       }


### PR DESCRIPTION
## WHAT
fix issue where school admins are unable to invite teachers to sign up for Quill from their admin dashboards

## WHY
we want admins to be able to have this functionality

## HOW
check for both an `id` or a `value` depending on whether the dropdown school value has changed; also pass the `adminId` value in the API call because we were passing a non existent `id` prop prior to this

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/School-admins-can-t-add-teacher-accounts-716b9b8af25d40f2b591e5a2ff25f4d2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
