### PR TITLE
Quill Locker/ create Locker model

### DIFF
--- a/services/QuillLMS/app/models/locker.rb
+++ b/services/QuillLMS/app/models/locker.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: lockers
+#
+#  id          :bigint           not null, primary key
+#  label       :string
+#  preferences :jsonb
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :integer
+#
+class Locker < ApplicationRecord
+  has_one :user
+
+  validates :user_id, presence: true, uniqueness: true
+  validates :label, presence: true
+  validates :preferences, presence: true
+end

--- a/services/QuillLMS/db/migrate/20220321215816_create_lockers.rb
+++ b/services/QuillLMS/db/migrate/20220321215816_create_lockers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateLockers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lockers do |t|
+      t.integer :user_id, unique: true
+      t.string :label
+      t.jsonb :preferences, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/locker.rb
+++ b/services/QuillLMS/spec/factories/locker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 require 'rails_helper'
 
 FactoryBot.define do

--- a/services/QuillLMS/spec/factories/locker.rb
+++ b/services/QuillLMS/spec/factories/locker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+#
+require 'rails_helper'
+
+FactoryBot.define do
+  factory :locker do
+    user_id { create(:user).id }
+    label { 'Test locker label'}
+    preferences { { 'test locker section': [] } }
+  end
+end

--- a/services/QuillLMS/spec/models/locker_spec.rb
+++ b/services/QuillLMS/spec/models/locker_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: lockers
+#
+#  id          :bigint           not null, primary key
+#  label       :string
+#  preferences :jsonb
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :integer
+#
+require 'rails_helper'
+
+RSpec.describe Locker, type: :model do
+  context 'validations' do
+    let(:locker) { build(:locker) }
+
+    it { expect(locker).to be_valid }
+    it { should validate_uniqueness_of(:user_id) }
+    it { should validate_presence_of(:label) }
+    it { should validate_presence_of(:preferences) }
+  end
+end


### PR DESCRIPTION
## WHAT
add Locker model and migration in order to store personal locker data for staff

## WHY
we want staff to be able to add personal, customizable lockers

## HOW
add migration and model for `Locker`; the main locker content data will be stored in the `preferences` as a JSON blob. An example blob would look something like this (the keys being the titles of individual sections):

```
{
  'quick fixes': [
     {
       title: 'user fixes',
       link: 'https://www.quill.org/cms/users',
       emoji: ':D'
     },
     {
       title: 'classroom fixes',
       link: 'https://www.quill.org/teacher_fix/recover_classroom_units',
       emoji: ':P'
     },
  ],
    'dev resources': [
     {
       title: 'flexbox guide',
       link: 'https://css-tricks.com/snippets/css/a-guide-to-flexbox/',
       emoji: ':D'
     },
     {
       title: 'terminal shortcuts',
       link: 'https://docs.google.com/document/d/1JHI60X64iujhasd',
       emoji: ':)'
     },
  ],
}
```

Note: if this weren't only applicable to small subset of users (staff), I would opt to break this out into several relation models (i.e. `Locker` has many `LockerSections`, `LockerSections` has many `LockerItems`)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-functionality-to-create-personal-locker-3e3f872cff804d83977dd850cc558e39

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
