### PR TITLE
lms/default-cache-timeout

### DIFF
--- a/services/QuillLMS/app/models/concerns/user_cacheable.rb
+++ b/services/QuillLMS/app/models/concerns/user_cacheable.rb
@@ -18,22 +18,24 @@
 module UserCacheable
   extend ActiveSupport::Concern
 
-  def all_classrooms_cache(key:, groups: {}, &block)
-    model_cache(last_updated_classroom, key: key, groups: groups, &block)
+  DEFAULT_EXPIRATION = 24.hours
+
+  def all_classrooms_cache(key:, groups: {}, expires_in: DEFAULT_EXPIRATION, &block)
+    model_cache(last_updated_classroom, key: key, groups: groups, expires_in: expires_in, &block)
   end
 
-  def classroom_cache(classroom, key:, groups: {}, &block)
-    model_cache(classroom, key: key, groups: groups, &block)
+  def classroom_cache(classroom, key:, groups: {}, expires_in: DEFAULT_EXPIRATION, &block)
+    model_cache(classroom, key: key, groups: groups, expires_in: expires_in, &block)
   end
 
-  def classroom_unit_cache(classroom_unit, key:, groups: {}, &block)
-    model_cache(classroom_unit, key: key, groups: groups, &block)
+  def classroom_unit_cache(classroom_unit, key:, groups: {}, expires_in: DEFAULT_EXPIRATION, &block)
+    model_cache(classroom_unit, key: key, groups: groups, expires_in: expires_in, &block)
   end
 
-  def classroom_unit_by_ids_cache(classroom_id:, unit_id:, activity_id:, key:, groups: {}, &block)
+  def classroom_unit_by_ids_cache(classroom_id:, unit_id:, activity_id:, key:, groups: {}, expires_in: DEFAULT_EXPIRATION, &block)
     classroom_unit = classroom_unit_for_ids(classroom_id: classroom_id, unit_id: unit_id, activity_id: activity_id)
 
-    model_cache(classroom_unit, key: key, groups: groups, &block)
+    model_cache(classroom_unit, key: key, groups: groups, expires_in: expires_in, &block)
   end
 
   # NOTE: object for caching defaults to the 'user'
@@ -44,10 +46,10 @@ module UserCacheable
     [key, *group_array, object || self]
   end
 
-  private def model_cache(object, key:, groups:, &block)
+  private def model_cache(object, key:, groups:, expires_in: DEFAULT_EXPIRATION, &block)
     raise LocalJumpError unless block_given?
 
-    Rails.cache.fetch(model_cache_key(object, key: key, groups: groups), &block)
+    Rails.cache.fetch(model_cache_key(object, key: key, groups: groups), expires_in: expires_in, &block)
   end
 
   private def last_updated_classroom

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -80,14 +80,21 @@ RSpec.describe UserCacheable, type: :model do
       let!(:newer_classroom) { create(:classroom, updated_at: older_classroom.updated_at + 10.days) }
       let!(:older_classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: 'owner', classroom: older_classroom) }
       let!(:newer_classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: 'owner', classroom: newer_classroom) }
+      let(:key) { 'test.key' }
+      let(:groups) { {page: 1} }
 
       it 'should use the most recently updated_at classroom for caching' do
-        key = 'test.key'
-        groups = {page: 1}
-
-        expect(teacher).to receive(:model_cache).with(newer_classroom, key: key, groups: groups)
+        expect(teacher).to receive(:model_cache).with(newer_classroom, key: key, groups: groups, expires_in: subject::DEFAULT_EXPIRATION)
 
         teacher.all_classrooms_cache(key: key, groups: groups)
+      end
+
+      it 'should pass through custom expiration if provided' do
+        expires_in = 1.hour
+
+        expect(teacher).to receive(:model_cache).with(newer_classroom, key: key, groups: groups, expires_in: expires_in)
+
+        teacher.all_classrooms_cache(key: key, groups: groups, expires_in: expires_in)
       end
     end
   end
@@ -97,9 +104,17 @@ RSpec.describe UserCacheable, type: :model do
     let(:classroom) {create(:classroom) }
 
     it 'should call model_cache' do
-      expect(teacher).to receive(:model_cache).with(classroom, key: 'test.key', groups: {page: 1})
+      expect(teacher).to receive(:model_cache).with(classroom, key: 'test.key', groups: {page: 1}, expires_in: subject::DEFAULT_EXPIRATION)
 
       teacher.classroom_cache(classroom, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should pass through custom expiration if provided' do
+      expires_in = 1.hour
+
+      expect(teacher).to receive(:model_cache).with(classroom, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
+
+      teacher.classroom_cache(classroom, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
     end
 
     it 'should yield to model_cache' do
@@ -126,9 +141,17 @@ RSpec.describe UserCacheable, type: :model do
     let(:classroom_unit) {create(:classroom_unit) }
 
     it 'should call model_cache' do
-      expect(teacher).to receive(:model_cache).with(classroom_unit, key: 'test.key', groups: {page: 1})
+      expect(teacher).to receive(:model_cache).with(classroom_unit, key: 'test.key', groups: {page: 1}, expires_in: subject::DEFAULT_EXPIRATION)
 
       teacher.classroom_unit_cache(classroom_unit, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should pass through custom expiration if provided' do
+      expires_in = 1.hour
+
+      expect(teacher).to receive(:model_cache).with(classroom_unit, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
+
+      teacher.classroom_unit_cache(classroom_unit, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
     end
 
     it 'should yield to model_cache' do
@@ -161,15 +184,23 @@ RSpec.describe UserCacheable, type: :model do
     let(:classroom_unit2) {create(:classroom_unit, classroom: classroom, unit: unit_activity2.unit) }
 
     it 'should call model_cache with last updated unit if no unit_id' do
-      expect(teacher).to receive(:model_cache).with(classroom_unit2, key: 'test.key', groups: {page: 1})
+      expect(teacher).to receive(:model_cache).with(classroom_unit2, key: 'test.key', groups: {page: 1}, expires_in: subject::DEFAULT_EXPIRATION)
 
       teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key', groups: {page: 1})
     end
 
     it 'should call model_cache with first matching unit if there is a unit_id' do
-      expect(teacher).to receive(:model_cache).with(classroom_unit1, key: 'test.key', groups: {page: 1})
+      expect(teacher).to receive(:model_cache).with(classroom_unit1, key: 'test.key', groups: {page: 1}, expires_in: subject::DEFAULT_EXPIRATION)
 
       teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: unit_activity1.unit_id, activity_id: activity.id, key: 'test.key', groups: {page: 1})
+    end
+
+    it 'should pass through custom expiration if provided' do
+      expires_in = 1.hour
+
+      expect(teacher).to receive(:model_cache).with(classroom_unit2, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
+
+      teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key', groups: {page: 1}, expires_in: expires_in)
     end
 
     it 'should yield to model_cache' do


### PR DESCRIPTION
## WHAT
Allow user_cacheable to take expires_at and provide a default
## WHY
So that we can be confident about the maximum TTL of a key in the cache in case we cache something improperly
## HOW
Add a default `expires_in` param to all the caching functions and pass the value through to the cache call

### Notion Card Links
https://www.notion.so/quill/Investigate-and-Implement-a-Default-Timeout-for-Caching-9a3ddc266a4e456f8b5835b6fbaebf54

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A