### PR TITLE
Cache `/teachers/progress_reports/activity_with_recommendations_ids`

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -105,7 +105,9 @@ class Activity < ApplicationRecord
   end
 
   def self.activity_with_recommendations_ids
-    Recommendation.all.map(&:activity_id).uniq
+    Rails.cache.fetch('all_recommendation_activity_ids', expires_in: 24.hours) do
+      Recommendation.all.map(&:activity_id).uniq
+    end
   end
 
   def self.find_by_id_or_uid(arg)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -608,7 +608,7 @@ describe Activity, type: :model, redis: true do
     let!(:recommendation1) { create(:recommendation) }
     let!(:recommendation2) { create(:recommendation) }
 
-    after(:each) do
+    after do
       Rails.cache.clear
     end
 

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -603,4 +603,26 @@ describe Activity, type: :model, redis: true do
       end
     end
   end
+
+  context '#activity_with_recommendations_ids' do
+    let!(:recommendation1) { create(:recommendation) }
+    let!(:recommendation2) { create(:recommendation) }
+
+    after(:each) do
+      Rails.cache.clear
+    end
+
+    it 'should return an array of all recommendation activity_ids' do
+      expect(Activity.activity_with_recommendations_ids).to eq([recommendation1.activity_id, recommendation2.activity_id])
+    end
+
+    it 'should cache the activity_ids' do
+      Rails.cache.clear
+      expect(Recommendation).to receive(:all).with(any_args).once.and_call_original
+
+      2.times do |i|
+        expect(Activity.activity_with_recommendations_ids).to eq([recommendation1.activity_id, recommendation2.activity_id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Cache `/teachers/progress_reports/activity_with_recommendations_ids`
## WHY
In our effort to cache all of our reporting endpoints to reduce db load
## HOW
Since this is actually a set of global data (basically it's a unique list of all `activity_ids` that are in the `Recommendations` table), we can cache this farther away from the controller.  IN this case, I've added caching within the class method that's used to retrieve this data since it's the same for all users.

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
