### PR TITLE
Add caching for `classrooms_with_students`

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -82,8 +82,18 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def classrooms_with_students
-    classrooms = classrooms_with_students_for_report(params[:unit_id], params[:activity_id])
-    render json: classrooms.to_json
+    render json: fetch_classrooms_with_students_cache
+  end
+
+  private def fetch_classrooms_with_students_cache
+    cache_groups = {
+      unit_id: params[:unit_id],
+      activity_id: params[:activity_id]
+    }
+
+    current_user.all_classrooms_cache(key: 'teachers.progress_reports.diagnostic_reports.classrooms_with_students', groups: cache_groups) do
+      classrooms_with_students_for_report(params[:unit_id], params[:activity_id]).to_json
+    end
   end
 
   def recommendations_for_classroom

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -205,6 +205,10 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         create(:activity_session, :started, user: student3, activity: activity, classroom_unit: cu)
       end
 
+      after do
+        Rails.cache.clear
+      end
+
       it 'should return report data for completed student sessions' do
         Rails.logger.info "\n\n\nStart"
         get :classrooms_with_students, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
@@ -215,6 +219,21 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         expect(json.count).to eq 1
         expect(json.first['students'].count).to eq 2
+      end
+
+      it 'should cache response data' do
+        expect(controller).to receive(:classrooms_with_students_for_report).with(any_args).once.and_call_original
+
+        2.times do
+          get :classrooms_with_students, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
+
+          expect(response).to be_success
+
+          json = JSON.parse(response.body)
+
+          expect(json.count).to eq 1
+          expect(json.first['students'].count).to eq 2
+        end
       end
     end
   end


### PR DESCRIPTION
## WHAT
Cache `/teachers/progress_reports/classrooms_with_students`
## WHY
In our effort to cache all of our reporting endpoints to reduce db load
## HOW
Wrap the code that generates the payload in a cache call at the all classrooms level

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
