### PR TITLE
lms/pre-cache-admin-dashboards

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -26,6 +26,7 @@ class Cron
     SyncVitallyWorker.perform_async
     MaterializedViewRefreshWorker.perform_async
     RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
+    PreCacheAdminDashboardsWorker.perform_async
 
     Question::TYPES.each { |type| RefreshQuestionCacheWorker.perform_async(type) }
   end

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -5,10 +5,10 @@ class PreCacheAdminDashboardsWorker
   sidekiq_options queue: SidekiqQueue::DEFAULT
 
   def perform
-    active_admins = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).all
+    active_admin_ids = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).pluck(:id)
 
-    active_admins.each do |user|
-      FindAdminUsersWorker.perform_async(user.id)
+    active_admin_ids.each do |id|
+      FindAdminUsersWorker.perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PreCacheAdminDashboardsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::DEFAULT
+
+  def perform()
+    active_admins = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).all
+
+    active_admins.each do |user|
+      FindAdminUsersWorker.perform_async(user.id)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -4,7 +4,7 @@ class PreCacheAdminDashboardsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::DEFAULT
 
-  def perform()
+  def perform
     active_admins = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).all
 
     active_admins.each do |user|

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -68,7 +68,7 @@ describe "Cron", type: :model do
       expect(RefreshQuestionCacheWorker).to receive(:perform_async).exactly(7).times
       Cron.interval_1_day
     end
-    
+
     it "enqueues PreCacheAdminDashboardsWorker" do
       expect(PreCacheAdminDashboardsWorker).to receive(:perform_async)
       Cron.interval_1_day

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -70,7 +70,7 @@ describe "Cron", type: :model do
     end
     
     it "enqueues PreCacheAdminDashboardsWorker" do
-      expect(PreCacheAdminDashboardsWorker.to receive(:perform_async)
+      expect(PreCacheAdminDashboardsWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
   end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -68,6 +68,11 @@ describe "Cron", type: :model do
       expect(RefreshQuestionCacheWorker).to receive(:perform_async).exactly(7).times
       Cron.interval_1_day
     end
+    
+    it "enqueues PreCacheAdminDashboardsWorker" do
+      expect(PreCacheAdminDashboardsWorker.to receive(:perform_async)
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_saturday" do

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PreCacheAdminDashboardsWorker, type: :worker do
+  let(:worker) { described_class.new }
+  let!(:old_admin) { create(:user, last_sign_in: Time.now - 1.year) }
+  let!(:current_admin1) { create(:user, last_sign_in: Time.now) }
+  let!(:current_admin2) { create(:user, last_sign_in: Time.now) }
+  let!(:not_admin) { create(:user, last_sign_in: Time.now) }
+
+  before do
+    create(:schools_admins, user: old_admin)
+    create(:schools_admins, user: current_admin1)
+    create(:schools_admins, user: current_admin2)
+  end
+
+  it 'enqueues FindAdminUsersWorker for all active admins' do
+    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin1.id).once
+    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'does not enqueue FindAdminUsersWorker for non-admins' do
+    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(not_admin.id)
+    worker.perform
+  end
+
+  it 'does not enqueue FindAdminUsersWorker for non-active admins' do
+    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(old_admin.id)
+    worker.perform
+  end
+end


### PR DESCRIPTION
## WHAT
Add a cron job to pre-cache admin dashboards overnight
## WHY
This data can take from a couple of seconds up to a handful of minutes to generate, and while we do cache it, we don't currently generate it until the first time an admin logs in.  This makes the first interaction that an admin has with our system each day incredibly frustrating.  By generating the cache data overnight, we can ensure that the first interaction an admin has with our system each day feels performant.
## HOW
Get a list of all admin users who have logged in this academic year and pre-generate their dashboard data during our nightly cron jobs

### Notion Card Links
https://www.notion.so/quill/School-Admin-Report-Caching-Pre-caching-d9182688be4c4fe78f13ef4d16d15bf2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
