### PR TITLE
Evidence - Add AutoML predict timeout

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -13,6 +13,7 @@ module Evidence
       STATE_ACTIVE = 'active',
       STATE_INACTIVE = 'inactive'
     ]
+    PREDICT_API_TIMEOUT = 5.0
 
     attr_readonly :automl_model_id, :name, :labels
 
@@ -126,7 +127,9 @@ module Evidence
     end
 
     private def automl_prediction_client
-      @automl_prediction_client ||= Google::Cloud::AutoML.prediction_service
+      @automl_prediction_client ||= Google::Cloud::AutoML.prediction_service do |config|
+        config.timeout = PREDICT_API_TIMEOUT
+      end
     end
 
     private def automl_model_full_id

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
@@ -221,6 +221,19 @@ module Evidence
 
         expect(automl_model.fetch_automl_label('some text')).to eq 'result1'
       end
+
+      it "should raise if the google api a raises for a timeout" do
+        prediction_client = double
+
+        expect(prediction_client).to receive(:predict).and_raise(Google::Cloud::Error)
+        expect(Google::Cloud::AutoML).to receive(:prediction_service).and_return(prediction_client)
+
+        client = double
+        expect(client).to receive(:model_path).and_return("the_path")
+        expect(Google::Cloud::AutoML).to receive(:auto_ml).and_return(client)
+
+        expect { automl_model.fetch_automl_label('some text')}.to(raise_error(Google::Cloud::Error))
+      end
     end
 
 


### PR DESCRIPTION
## WHAT
We discussed adding a time out to the Evidence APIs generically, but I've found a few sources (e.g. https://adamhooper.medium.com/in-ruby-dont-use-timeout-77d9d4e5a001) that convinced me that a generic ruby timeout has issues and is less ideal than scoping a timeout to specific actions, like an `http` request. 

So I'm adding timeouts to the `http` calls instead.  AutoML is the only one without a timeout, so adding that one.
## WHY

If the AutoML API takes more that 5 seconds, it's likely an issue with Google's service, so we shouldn't stop the student from continuing on an activity.
## HOW
Add an `config.timeout = 5.0` setting specifically to the Prediction Service.

Note, I couldn't find a way to trigger the timeout in smoke testing, but from the google api code and [this guide](https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts#google-cloud), it will raise a `Google::Cloud::Error` so that's what I'm expecting.

### Notion Card Links
https://www.notion.so/quill/Add-timeouts-to-Ruby-feedback-endpoint-code-2459e2cc99b94e6fa2c5b3018eb8a970

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'. 
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | n/a
