### PR TITLE
Add bonus day subscription policy back in for School Subscriptions

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -253,8 +253,8 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     # available to users who have never paid before
-    # if today's month is before august, it expires end of July, else December
-    exp_month_and_day = Date.today.month < 8 ? "30-6" : "31-12"
+    # if today's month is before july, it expires end of June, else December
+    exp_month_and_day = Date.today.month < 7 ? "30-6" : "31-12"
     {expiration: Date::strptime("#{exp_month_and_day}-#{Date.today.year+1}","%d-%m-%Y"),
     start_date: Date.today}
   end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -164,7 +164,7 @@ class Subscription < ApplicationRecord
   end
 
   def self.new_school_premium_sub(school, user)
-    expiration = Date.today + 1.year
+    expiration = school_or_user_has_ever_paid?(school) ? (Date.today + 1.year) : promotional_dates[:expiration]
     new(expiration: expiration, start_date: Date.today, account_type: 'School Paid', recurring: true, purchaser_id: user.id)
   end
 
@@ -201,6 +201,8 @@ class Subscription < ApplicationRecord
     last_subscription = school_or_user.subscriptions.active.first
     if last_subscription.present?
       redemption_start_date(school_or_user) + 1.year
+    elsif school_or_user.class.name == 'School'
+      promotional_dates[:expiration]
     else
       Date.today + 1.year
     end
@@ -249,6 +251,14 @@ class Subscription < ApplicationRecord
     end
   end
 
+  def self.promotional_dates
+    # available to users who have never paid before
+    # if today's month is before august, it expires end of July, else December
+    exp_month_and_day = Date.today.month < 8 ? "30-6" : "31-12"
+    {expiration: Date::strptime("#{exp_month_and_day}-#{Date.today.year+1}","%d-%m-%Y"),
+    start_date: Date.today}
+  end
+
   protected def charge_user_for_teacher_premium
     return unless purchaser&.stripe_customer?
 
@@ -270,7 +280,12 @@ class Subscription < ApplicationRecord
   end
 
   def self.set_premium_expiration_and_start_date(school_or_user)
-    if school_or_user.subscription
+    if !Subscription.school_or_user_has_ever_paid?(school_or_user) && school_or_user.class.name == 'School'
+      # We end their trial if they have one
+      school_or_user.subscription&.update(de_activated_date: Date.today)
+      # Then they get the promotional subscription
+      promotional_dates
+    elsif school_or_user.subscription
       # Expire one year later, start at end of sub
       old_sub = school_or_user.subscription
       {expiration: old_sub.expiration + 1.year, start_date: old_sub.expiration}

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -253,7 +253,7 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     # available to users who have never paid before
-    # if today's month is before august, it expires end of July, else December
+    # if today's month is before august, it expires end of June, else December
     exp_month_and_day = Date.today.month < 8 ? "30-6" : "31-12"
     {expiration: Date::strptime("#{exp_month_and_day}-#{Date.today.year+1}","%d-%m-%Y"),
     start_date: Date.today}

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -201,7 +201,7 @@ class Subscription < ApplicationRecord
     last_subscription = school_or_user.subscriptions.active.first
     if last_subscription.present?
       redemption_start_date(school_or_user) + 1.year
-    elsif school_or_user.class.name == 'School'
+    elsif school_or_user.instance_of?(School)
       promotional_dates[:expiration]
     else
       Date.today + 1.year
@@ -280,7 +280,7 @@ class Subscription < ApplicationRecord
   end
 
   def self.set_premium_expiration_and_start_date(school_or_user)
-    if !Subscription.school_or_user_has_ever_paid?(school_or_user) && school_or_user.class.name == 'School'
+    if !Subscription.school_or_user_has_ever_paid?(school_or_user) && school_or_user.instance_of?(School)
       # We end their trial if they have one
       school_or_user.subscription&.update(de_activated_date: Date.today)
       # Then they get the promotional subscription

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -202,8 +202,7 @@ export default class EditOrCreateSubscription extends React.Component {
   }
 
   render() {
-    const { firstFocused, secondFocused, subscription, } = this.state
-    const { user, school, view, premiumTypes, subscriptionPaymentMethods, } = this.props
+    const { user, school, view, premiumTypes, subscriptionPaymentMethods, promoExpiration, } = this.props
     const schoolOrUser = school || user || null;
     const submitAction = school ? this.submitConfirmation : this.submit;
     const subscriptionPaymentOptions = subscriptionPaymentMethods.concat('N/A')
@@ -255,6 +254,9 @@ export default class EditOrCreateSubscription extends React.Component {
           onFocusChange={() => this.setState({ firstFocused: !firstFocused })}
         />
         <label htmlFor="">End Date</label>
+        <p>
+          If this a school's first paid subscription, the default end date is {promoExpiration}. This value just stated will update automatically depending on the time of year.
+        </p>
         <SingleDatePicker
           date={subscription.expiration ? moment(subscription.expiration) : null}
           focused={secondFocused}

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -143,10 +143,10 @@ describe Cms::SchoolsController do
 
 
     describe 'when there is no existing subscription' do
-      it 'should create a new subscription that starts today and ends exactly 1 year later' do
+      it 'should create a new subscription that starts today and ends at the promotional expiration date' do
         get :new_subscription, params: { id: school_with_no_subscription.id }
         expect(assigns(:subscription).start_date).to eq Date.today
-        expect(assigns(:subscription).expiration).to eq Date.today + 1.year
+        expect(assigns(:subscription).expiration).to eq Subscription.promotional_dates[:expiration]
       end
     end
 

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -262,12 +262,12 @@ describe Subscription, type: :model do
   end
 
   describe ".promotional_dates" do
-    context 'when called on a day prior to August, 1' do
+    context 'when called on a day prior to July, 1' do
       before do
         allow(Date).to receive(:today).and_return Date.new(2018,4,4)
       end
 
-      it "returns an expiration date of June 30 the next year when called on a day prior to August" do
+      it "returns an expiration date of June 30 the next year when called on a day prior to July" do
         expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,6,30))
       end
 
@@ -276,12 +276,12 @@ describe Subscription, type: :model do
       end
     end
 
-    context 'when called on a day after July 31' do
+    context 'when called on a day after June 30' do
       before do
         allow(Date).to receive(:today).and_return Date.new(2018,10,4)
       end
 
-      it "returns an expiration date of December 31 the next year when called on a day prior to August" do
+      it "returns an expiration date of December 31 the next year when called on a day prior to July" do
         expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,12,31))
       end
 

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -261,6 +261,36 @@ describe Subscription, type: :model do
     end
   end
 
+  describe ".promotional_dates" do
+    context 'when called on a day prior to August, 1' do
+      before do
+        allow(Date).to receive(:today).and_return Date.new(2018,4,4)
+      end
+
+      it "returns an expiration date of June 30 the next year when called on a day prior to August" do
+        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,6,30))
+      end
+
+      it "returns a start date one year from the day it was called" do
+        expect(Subscription.promotional_dates[:start_date]).to eq(Date.today)
+      end
+    end
+
+    context 'when called on a day after July 31' do
+      before do
+        allow(Date).to receive(:today).and_return Date.new(2018,10,4)
+      end
+
+      it "returns an expiration date of December 31 the next year when called on a day prior to August" do
+        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,12,31))
+      end
+
+      it "returns a start date one year from the day it was called" do
+        expect(Subscription.promotional_dates[:start_date]).to eq(Date.today)
+      end
+    end
+  end
+
   describe 'create_with_user_join' do
     let!(:user) { create(:user) }
     let(:old_sub) { Subscription.create_with_user_join(user.id, expiration: Date.yesterday, account_type: 'Teacher Paid') }


### PR DESCRIPTION
## WHAT
I accidentally removed bonus days for school subscriptions as well as teacher subscriptions. Actually we want to keep the bonus days subscription program for schools, but remove it for teachers. So I added the school subscription bonus days back in.

## WHY
We still want to keep bonus days as a feature of school subscriptions, just not teacher subscriptions.

## HOW
Add the old promotional dates code back in for schools.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=032a2a2a2eec4a3eb66bb407185fdedd)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
