### PR TITLE
fix post activity slide regex parsing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
@@ -17,7 +17,7 @@ export const PostActivitySlide = ({ handleClick, prompts, responses }: PostActiv
   function getStrongExemplar(conjunction: string, property: string) {
     const prompt = prompts.filter(prompt => prompt.conjunction === conjunction)[0];
     if (!prompt) { return }
-    const conjunctionRegex = new RegExp(`\\s${conjunction}\\s`)
+    const conjunctionRegex = new RegExp(`${conjunction}$`)
     const stemWithoutConjunction = prompt.text.replace(conjunctionRegex, '');
     const exemplar = prompt[property];
     return <p>{stemWithoutConjunction}<strong>{`${conjunction} `}</strong><br /><u>{exemplar}</u></p>;
@@ -36,7 +36,7 @@ export const PostActivitySlide = ({ handleClick, prompts, responses }: PostActiv
     const lastResponseText = responses[responses.length - 1].entry;
     const conjunctionRegex = new RegExp(`\\s${conjunction}\\s`)
     const splitResponse = lastResponseText.split(conjunctionRegex);
-    return <p>{splitResponse[0]}<strong>{`${conjunction} `}</strong><br /><u>{splitResponse[1]}</u></p>
+    return <p>{splitResponse[0]}<strong>{` ${conjunction} `}</strong><br /><u>{splitResponse[1]}</u></p>
   }
 
   function renderResponseAndExamplarsSection(conjunction: string) {

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
@@ -17,7 +17,8 @@ export const PostActivitySlide = ({ handleClick, prompts, responses }: PostActiv
   function getStrongExemplar(conjunction: string, property: string) {
     const prompt = prompts.filter(prompt => prompt.conjunction === conjunction)[0];
     if (!prompt) { return }
-    const stemWithoutConjunction = prompt.text.replace(conjunction, '');
+    const conjunctionRegex = new RegExp(`\\s${conjunction}\\s`)
+    const stemWithoutConjunction = prompt.text.replace(conjunctionRegex, '');
     const exemplar = prompt[property];
     return <p>{stemWithoutConjunction}<strong>{`${conjunction} `}</strong><br /><u>{exemplar}</u></p>;
   }
@@ -33,7 +34,8 @@ export const PostActivitySlide = ({ handleClick, prompts, responses }: PostActiv
     const responses = getResponsesForConjunction(conjunction)
     if(!responses) { return }
     const lastResponseText = responses[responses.length - 1].entry;
-    const splitResponse = lastResponseText.split(conjunction);
+    const conjunctionRegex = new RegExp(`\\s${conjunction}\\s`)
+    const splitResponse = lastResponseText.split(conjunctionRegex);
     return <p>{splitResponse[0]}<strong>{`${conjunction} `}</strong><br /><u>{splitResponse[1]}</u></p>
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/postActivitySlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/postActivitySlide.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`PostActivitySlide Component should match snapshot 1`] = `
           <p>
             test1
             <strong>
-              because 
+               because 
             </strong>
             <br />
             <u />
@@ -151,7 +151,7 @@ exports[`PostActivitySlide Component should match snapshot 1`] = `
           <p>
             test2
             <strong>
-              but 
+               but 
             </strong>
             <br />
             <u />
@@ -217,7 +217,7 @@ exports[`PostActivitySlide Component should match snapshot 1`] = `
           <p>
             test3
             <strong>
-              so 
+               so 
             </strong>
             <br />
             <u />


### PR DESCRIPTION
## WHAT
Use more sophisticated means of stripping out prompt conjunctions in the post-activity slide exemplars in Evidence.

## WHY
So that we avoid the case where a conjunction appears inside another word (ex: "but" in "contribution").

## HOW
Look specifically for the conjunction surrounded by whitespace in the student's entry, and for the conjunction that appears before the end of the string in the prompt stem. 

### Screenshots
<img width="1222" alt="Screen Shot 2022-03-24 at 10 25 07 AM" src="https://user-images.githubusercontent.com/18669014/159938758-fdd40623-5459-41d9-8661-5228b75e487d.png">

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=fd9af26021b549ebb2517065edffd70d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | No, but tested with staging data locally (thanks @happythenewsad!)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A