### PR TITLE
fix diagnostic results popover

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -2761,6 +2761,7 @@ exports[`StudentResultsTable component should render when there is student data 
           }
         >
           <tr
+            id={7}
             key="Angie Thomas"
           >
             <th

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthResults.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthResults.tsx
@@ -61,7 +61,8 @@ export const GrowthResults = ({ passedStudentResults, passedSkillGroupSummaries,
     if (!openPopover.studentId) { return }
 
     const popoverElements = document.getElementsByClassName('student-results-popover')
-    if (popoverElements && !popoverElements[0].contains(e.target)) {
+    const studentRow = document.getElementById(String(openPopover.studentId))
+    if (popoverElements && (!popoverElements[0].contains(e.target) && !studentRow.contains(e.target))) {
       setOpenPopover({})
     }
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/results.tsx
@@ -66,7 +66,8 @@ export const Results = ({ passedStudentResults, passedSkillGroupSummaries, match
     if (!openPopover.studentId) { return }
 
     const popoverElements = document.getElementsByClassName('student-results-popover')
-    if (popoverElements && (!popoverElements[0].contains(e.target) || e.target.classList.includes('interactive-wrapper'))) {
+    const studentRow = document.getElementById(String(openPopover.studentId))
+    if (popoverElements && (!popoverElements[0].contains(e.target) && !studentRow.contains(e.target))) {
       setOpenPopover({})
     }
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -130,7 +130,7 @@ const StudentRow = ({ studentResult, skillGroupSummaries, openPopover, setOpenPo
       />)
     )
   }
-  return <tr key={name}>{firstCell}{skillGroupCells}</tr>
+  return <tr id={id} key={name}>{firstCell}{skillGroupCells}</tr>
 }
 
 const StudentResultsTable = ({ skillGroupSummaries, studentResults, openPopover, setOpenPopover, responsesLink, }: StudentResultsTableProps) => {


### PR DESCRIPTION
## WHAT
Slightly change how we handle event firing for the diagnostic results popover.

## WHY
At some unknown moment (my guess is when we upgraded to React 17 last week) either the way that events propagate in React or the order in which hooks are fired changed slightly, meaning that our diagnostic results popovers were always being closed as soon as they were opened. We don't want that to happen.

## HOW
Just update the logic so that clicking anywhere in the selected student's row won't close the popover (including the location of the original click). 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Student-Results-report-Diagnostic-pop-up-with-skill-breakdown-is-not-showing-5ed3cbb9cb6b46f692c9582c735a8bc2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
