### PR TITLE
Evidence/specify error rule type

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -37,6 +37,7 @@ class FeedbackHistory < ApplicationRecord
   MIN_FEEDBACK_LENGTH = 10
   MAX_FEEDBACK_LENGTH = 500
   FEEDBACK_TYPES = [
+    ERROR = "error",
     GRAMMAR = "grammar",
     PLAGIARISM = "plagiarism",
     RULES_BASED_ONE = "rules-based-1",

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -16,6 +16,7 @@ module Evidence
     ]
     TYPES = [
       TYPE_AUTOML       = 'autoML',
+      TYPE_ERROR	= 'error',
       TYPE_GRAMMAR      = 'grammar',
       TYPE_OPINION      = 'opinion',
       TYPE_PLAGIARISM   = 'plagiarism',

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -15,7 +15,7 @@ module Evidence
     ]
 
     FALLBACK_RESPONSE = {
-      feedback: "Thank you for your response.",
+      feedback: "<p>Thank you for your response.</p>",
       feedback_type: Rule::TYPE_ERROR,
       optimal: true,
     }

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -48,11 +48,11 @@ module Evidence
     end
 
     def self.fallback_feedback
-      @@error_rule ||= Rule.find_by(rule_type: Rule::TYPE_ERROR)
+      @error_rule ||= Rule.find_by(rule_type: Rule::TYPE_ERROR)
       {
-        feedback: @@error_rule.feedbacks.first.text,
-        feedback_type: @@error_rule.rule_type,
-        optimal: @@error_rule.optimal,
+        feedback: @error_rule.feedbacks.first.text,
+        feedback_type: @error_rule.rule_type,
+        optimal: @error_rule.optimal,
       }
     rescue
       FALLBACK_RESPONSE

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -14,17 +14,16 @@ module Evidence
       RegexTypo
     ]
 
-    ERROR_RULE = Rule.find_by(rule_type: Rule::TYPE_ERROR)
     FALLBACK_RESPONSE = {
-      feedback: ERROR_RULE.feedbacks.first.text,
-      feedback_type: ERROR_RULE.rule_type,
-      optimal: ERROR_RULE.optimal,
+      feedback: "Thank you for your response.",
+      feedback_type: Rule::TYPE_ERROR,
+      optimal: true,
     }
 
     def self.get_feedback(entry, prompt, previous_feedback)
       triggered_check = find_triggered_check(entry, prompt, previous_feedback)
 
-      triggered_check&.response || FALLBACK_RESPONSE
+      triggered_check&.response || fallback_feedback
     end
 
     # returns first nonoptimal feedback, and if all are optimal, returns automl feedback
@@ -46,6 +45,17 @@ module Evidence
       end
 
       first_nonoptimal_check || auto_ml_check
+    end
+
+    def self.fallback_feedback
+      @@error_rule ||= Rule.find_by(rule_type: Rule::TYPE_ERROR)
+      {
+        feedback: @@error_rule.feedbacks.first.text,
+        feedback_type: @@error_rule.rule_type,
+        optimal: @@error_rule.optimal,
+      }
+    rescue
+      FALLBACK_RESPONSE
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -14,10 +14,11 @@ module Evidence
       RegexTypo
     ]
 
+    ERROR_RULE = Rule.find_by(rule_type: Rule::TYPE_ERROR)
     FALLBACK_RESPONSE = {
-      feedback: "Thank you for your response.",
-      feedback_type: "autoML",
-      optimal: true,
+      feedback: ERROR_RULE.feedbacks.first.text,
+      feedback_type: ERROR_RULE.rule_type,
+      optimal: ERROR_RULE.optimal,
     }
 
     def self.get_feedback(entry, prompt, previous_feedback)

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -15,7 +15,7 @@ module Evidence
     ]
 
     FALLBACK_RESPONSE = {
-      feedback: "<p>Thank you for your response.</p>",
+      feedback: "<p>Thank you for your response! Something went wrong on our end and our feedback system doesn’t understand your response. Move on to the next prompt!</p>",
       feedback_type: Rule::TYPE_ERROR,
       optimal: true,
     }

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -26,7 +26,7 @@ module Evidence
 
         feedback = Check.get_feedback(entry, prompt, previous_feedback)
 
-        expect(feedback).to eq(Check::FALLBACK_RESPONSE)
+        expect(feedback).to eq(Check.fallback_feedback)
       end
     end
 
@@ -83,6 +83,45 @@ module Evidence
 
           expect(feedback.class).to be(second_check_class)
         end
+      end
+    end
+
+    context "fallback_feedback" do
+      before do
+        Check::ALL_CHECKS.each do |check_class|
+          if check_class == Check::AutoML
+            expect_any_instance_of(check_class).to receive(:run).and_raise("some error")
+          else
+            expect_any_instance_of(check_class).to receive(:run)
+            expect_any_instance_of(check_class).to receive(:optimal?).and_return(true)
+          end
+        end
+      end
+
+      it 'should construct feedback based on an error-type rule if it exists' do
+        rule = create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
+        feedback = create(:evidence_feedback, rule: rule)
+
+        result = Check.get_feedback(entry, prompt, previous_feedback)
+
+        expect(result[:feedback]).to eq(feedback.text)
+        expect(result[:feedback_type]).to eq(rule.rule_type)
+        expect(result[:optimal]).to eq(rule.optimal)
+      end
+
+      it 'provides constant-based feedback if there is no error-type rule' do
+        result = Check.get_feedback(entry, prompt, previous_feedback)
+
+        expect(result).to eq(Check::FALLBACK_RESPONSE)
+      end
+
+      it 'provides constant-based feedback if there are multiple error-type rules' do
+        create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
+        create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
+
+        result = Check.get_feedback(entry, prompt, previous_feedback)
+
+        expect(result).to eq(Check::FALLBACK_RESPONSE)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -87,7 +87,7 @@ module Evidence
     end
 
     context "fallback_feedback" do
-      before do
+      it 'should construct feedback based on an error-type rule if it exists' do
         Check::ALL_CHECKS.each do |check_class|
           if check_class == Check::AutoML
             expect_any_instance_of(check_class).to receive(:run).and_raise("some error")
@@ -96,9 +96,6 @@ module Evidence
             expect_any_instance_of(check_class).to receive(:optimal?).and_return(true)
           end
         end
-      end
-
-      it 'should construct feedback based on an error-type rule if it exists' do
         rule = create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
         feedback = create(:evidence_feedback, rule: rule)
 
@@ -110,12 +107,28 @@ module Evidence
       end
 
       it 'provides constant-based feedback if there is no error-type rule' do
+        Check::ALL_CHECKS.each do |check_class|
+          if check_class == Check::AutoML
+            expect_any_instance_of(check_class).to receive(:run).and_raise("some error")
+          else
+            expect_any_instance_of(check_class).to receive(:run)
+            expect_any_instance_of(check_class).to receive(:optimal?).and_return(true)
+          end
+        end
         result = Check.get_feedback(entry, prompt, previous_feedback)
 
         expect(result).to eq(Check::FALLBACK_RESPONSE)
       end
 
       it 'provides constant-based feedback if there are multiple error-type rules' do
+        Check::ALL_CHECKS.each do |check_class|
+          if check_class == Check::AutoML
+            expect_any_instance_of(check_class).to receive(:run).and_raise("some error")
+          else
+            expect_any_instance_of(check_class).to receive(:run)
+            expect_any_instance_of(check_class).to receive(:optimal?).and_return(true)
+          end
+        end
         create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
         create(:evidence_rule, rule_type: Rule::TYPE_ERROR)
 

--- a/services/QuillLMS/lib/tasks/feedback_histories.rake
+++ b/services/QuillLMS/lib/tasks/feedback_histories.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :feedback_histories do
+  desc 'Change feedback_type to the ERROR type for any feedback history with the error feedback_text'
+  task :set_error_type => :environment do
+    error_feedback_text = 'Thank you for your response.'
+    # We're doing this with raw SQL because the FeedbackHistory model is flagged as read-only
+    # so ActiveRecord-based calls will refuse to update values
+    sql = <<-SQL
+      UPDATE feedback_histories
+        SET feedback_type = '#{FeedbackHistory::ERROR}'
+        WHERE feedback_text = '#{error_feedback_text}'
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/services/QuillLMS/lib/tasks/universal_rules.rake
+++ b/services/QuillLMS/lib/tasks/universal_rules.rake
@@ -20,7 +20,7 @@ namespace :universal_rules do
         universal: true,
         optimal: true,
         rule_type: Evidence::Rule::TYPE_ERROR,
-        state: Evidence::Rule::STATE_ACTIVE,
+        state: Evidence::Rule::STATE_ACTIVE
       )
       error_rule.feedbacks = [Evidence::Feedback.new(
         order: 0,

--- a/services/QuillLMS/lib/tasks/universal_rules.rake
+++ b/services/QuillLMS/lib/tasks/universal_rules.rake
@@ -7,5 +7,26 @@ namespace :universal_rules do
     iostream = File.read(args[:filename])
     UniversalRuleLoader.update_from_csv(type: args[:type], iostream: iostream)
   end
-end
 
+  desc 'Data migration to add or update the ERROR type universal rule'
+  task :set_error_feedback, [:feedback_text] => :environment do |t, args|
+    error_rule = Evidence::Rule.find_by(rule_type: Evidence::Rule::TYPE_ERROR)
+    if error_rule
+      error_rule.feedbacks.first.update!(text: args[:feedback_text])
+    else
+      error_rule = Evidence::Rule.new(
+        uid: SecureRandom.uuid,
+        name: 'API Error',
+        universal: true,
+        optimal: true,
+        rule_type: Evidence::Rule::TYPE_ERROR,
+        state: Evidence::Rule::STATE_ACTIVE,
+      )
+      error_rule.feedbacks = [Evidence::Feedback.new(
+        order: 0,
+        text: args[:feedback_text]
+      )]
+      error_rule.save!
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
- Add a new `rule_type` to `Evidence::Rule` and a corresponding `feedback_type` to `FeedbackHistories`.
- Modify the `Check` library in Evidence so that it uses Rule with type `error` if one exists so that we can manage error feedback the same way we manage all other feedback types.
- Update all existing `FeedbackHistory` records with our error feedback to have the new `feedback_type` assigned to them.
## WHY
The current approach of assigning the `feedback_type` of `autoML` when there's an error can be misleading when reviewing data.  This makes it clear when there's really AutoML feedback vs when there's an error.
## HOW
- Modify the `Evidence::Rule` and `FeedbackHistory` models to add new types to their validators.
- Update `Check` to attempt to load an `Evidence::Rule` with `rule_type` of `error` when it needs to send error-triggered feedback
- Add a rake task to either create a new `Evidence::Rule` for the `error` type if one doesn't exist, or update the feedback assigned if one does exist so that it's easy to manage this feedback
- Add a rake task to change the `feedback_type` for all existing `FeedbackHisoty` records that have the text of our error feedback.

### Notion Card Links
https://www.notion.so/quill/Create-new-type-for-error-feedback-f38d5b47cbde4c6a955469c9644379c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
