### PR TITLE
Fix bug where Create Subscription front end page wasn't rendering

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -203,6 +203,7 @@ export default class EditOrCreateSubscription extends React.Component {
 
   render() {
     const { user, school, view, premiumTypes, subscriptionPaymentMethods, promoExpiration, } = this.props
+    const { subscription, firstFocused, secondFocused } = this.state
     const schoolOrUser = school || user || null;
     const submitAction = school ? this.submitConfirmation : this.submit;
     const subscriptionPaymentOptions = subscriptionPaymentMethods.concat('N/A')

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -204,6 +204,7 @@ export default class EditOrCreateSubscription extends React.Component {
   render() {
     const { user, school, view, premiumTypes, subscriptionPaymentMethods, promoExpiration, } = this.props
     const { subscription, firstFocused, secondFocused } = this.state
+
     const schoolOrUser = school || user || null;
     const submitAction = school ? this.submitConfirmation : this.submit;
     const subscriptionPaymentOptions = subscriptionPaymentMethods.concat('N/A')


### PR DESCRIPTION
## WHAT
I accidentally removed a line of code that wasn't supposed to be removed, causing the New Subscription page and Edit Subscription pages for staff not to render.

## WHY
This page needs to render so Partnerships can create and edit subscriptions.

## HOW
Add the line of code I accidentally removed back.

### Screenshots
<img width="947" alt="Screen Shot 2022-03-24 at 4 06 16 PM" src="https://user-images.githubusercontent.com/57366100/160010273-6a8caed1-b6fc-484d-8de1-bf469ce59075.png">

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/New-Subscription-internal-page-not-loading-0c0b0eeecce04e73af4e4df7b85b3c56)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
