### PR TITLE
evidence/make-all-feedback-html

### DIFF
--- a/services/QuillLMS/lib/tasks/evidence_feedback.rake
+++ b/services/QuillLMS/lib/tasks/evidence_feedback.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+namespace :evidence_feedback do
+  desc 'Find any feedback that is not in HTML format and update it'
+  task :ensure_html => :environment do
+    def htmlize(input)
+      return input if input.start_with?('<p>')
+      input = input.sub('\'', '&#x27;')
+      input = input.sub('"', '&quot;')
+      "<p>#{input}</p>"
+    end
+
+    Evidence::Feedback.where("text NOT LIKE '<p>%'").each do |feedback|
+      feedback.update(text: htmlize(feedback.text))
+    end
+
+    FeedbackHistory.where("feedback_text NOT LIKE '<p>%'").each do |feedback_history|
+      sql = <<-SQL
+        UPDATE feedback_histories
+          SET feedback_text = '#{htmlize(feedback_history.feedback_text)}'
+          WHERE id = #{feedback_history.id}
+      SQL
+      ActiveRecord::Base.connection.execute(sql)
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/evidence_feedback.rake
+++ b/services/QuillLMS/lib/tasks/evidence_feedback.rake
@@ -5,6 +5,7 @@ namespace :evidence_feedback do
   task :ensure_html => :environment do
     def htmlize(input)
       return input if input.start_with?('<p>')
+
       input = input.sub('\'', '&#x27;')
       input = input.sub('"', '&quot;')
       "<p>#{input}</p>"

--- a/services/QuillLMS/lib/tasks/evidence_feedback.rake
+++ b/services/QuillLMS/lib/tasks/evidence_feedback.rake
@@ -15,15 +15,13 @@ namespace :evidence_feedback do
       feedback.update(text: htmlize(feedback.text))
     end
 
-    FeedbackHistory.where("feedback_text NOT LIKE '<p>%'").each do |feedback_history|
-      # FeedbackHistory is a read-only model, so if we want to make changes to it
-      # we have to do so through raw SQL rather than ActiveRecord
-      sql = <<-SQL
-        UPDATE feedback_histories
-          SET feedback_text = '#{htmlize(feedback_history.feedback_text)}'
-          WHERE id = #{feedback_history.id}
-      SQL
-      ActiveRecord::Base.connection.execute(sql)
-    end
+    # FeedbackHistory is a read-only model, so if we want to make changes to it
+    # we have to do so through raw SQL rather than ActiveRecord
+    sql = <<-SQL
+      UPDATE feedback_histories
+        SET feedback_text = CONCAT('<p>', REPLACE(REPLACE(feedback_text, '''', '&x27;'), '"', '&quot;'), '</p>')
+        WHERE feedback_text NOT LIKE '<p>%'
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/services/QuillLMS/lib/tasks/evidence_feedback.rake
+++ b/services/QuillLMS/lib/tasks/evidence_feedback.rake
@@ -6,8 +6,8 @@ namespace :evidence_feedback do
     def htmlize(input)
       return input if input.start_with?('<p>')
 
-      input = input.sub('\'', '&#x27;')
-      input = input.sub('"', '&quot;')
+      input = input.gsub(/'/, '&#x27;')
+      input = input.gsub(/"/, '&quot;')
       "<p>#{input}</p>"
     end
 

--- a/services/QuillLMS/lib/tasks/evidence_feedback.rake
+++ b/services/QuillLMS/lib/tasks/evidence_feedback.rake
@@ -15,6 +15,8 @@ namespace :evidence_feedback do
     end
 
     FeedbackHistory.where("feedback_text NOT LIKE '<p>%'").each do |feedback_history|
+      # FeedbackHistory is a read-only model, so if we want to make changes to it
+      # we have to do so through raw SQL rather than ActiveRecord
       sql = <<-SQL
         UPDATE feedback_histories
           SET feedback_text = '#{htmlize(feedback_history.feedback_text)}'


### PR DESCRIPTION
## WHAT
Add a rake task to ensure Feedback is always stored as HTML in case we ever need to depend on it being consistent
## WHY
For consistency.  The instances where they aren't HTML come from feedbacks that weren't entered via the admin interface which makes them HTML by default.
## HOW
Write a rake task to look over the two places we store feedback (`Evidence::Feedback.text` and `FeedbackHistory.feedback_text`), find all entries that aren't in HTML (as determined by not starting with `<p>`).  Then for each of those items, update it as an HTML string by mirroring the transformation done by our front-end interface in Evidence admin:
1. Replacing single quotes with `&#x27;`
2. Replacing double quotes with `&quot;`
3. Wrapping the full string in `<p>` and `</p>`

### Notion Card Links
https://www.notion.so/quill/Make-all-feedback-HTML-42a134d164e04ce083667002fde29af0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for rake task
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
