### PR TITLE
Fix timeouts in Grammar and Opinion APIs. Add tests.

### DIFF
--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
@@ -7,7 +7,7 @@ module Evidence
     context '#post' do
       let(:mock_endpoint) { 'https://www.grammar.com' }
       let(:client) { Grammar::Client.new(entry: '', prompt_text: '') }
-       # include headers in response for proper parsing by HTTParty
+      # include headers in response for proper parsing by HTTParty
       let(:sample_response) { {body: '{}', headers: {content_type: 'application/json'}} }
 
       before do

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
@@ -27,7 +27,6 @@ module Evidence
         expect { client.post}.to raise_error(Evidence::Grammar::Client::GrammarAPIError)
       end
 
-
       it 'should raise error on timeout' do
         stub_request(:post, mock_endpoint).to_timeout
 

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
@@ -4,18 +4,34 @@ require 'rails_helper'
 
 module Evidence
   RSpec.describe(Grammar::Client) do
-    context 'GAPI response is not sucessful' do
+    context '#post' do
+      let(:mock_endpoint) { 'https://www.grammar.com' }
+      let(:client) { Grammar::Client.new(entry: '', prompt_text: '') }
+       # include headers in response for proper parsing by HTTParty
+      let(:sample_response) { {body: '{}', headers: {content_type: 'application/json'}} }
+
       before do
-        test_double = double
-        allow(test_double).to receive(:success?).once.and_return(false)
-        allow(::HTTParty).to receive(:post).and_return(test_double)
+        stub_const("Evidence::Grammar::Client::API_ENDPOINT", mock_endpoint)
       end
 
-      it 'should raise error' do
-        expect do
-          client = Grammar::Client.new(entry: '', prompt_text: '')
-          client.post
-        end.to raise_error(/Encountered upstream error/)
+      it "should process successfully" do
+        stub_request(:post, mock_endpoint).to_return(sample_response)
+
+        expect { client.post }.to_not raise_error
+      end
+
+      it 'should raise error if there is an error status' do
+        errored_response = sample_response.merge(status: 500)
+        stub_request(:post, mock_endpoint).to_return(errored_response)
+
+        expect { client.post}.to raise_error(Evidence::Grammar::Client::GrammarAPIError)
+      end
+
+
+      it 'should raise error on timeout' do
+        stub_request(:post, mock_endpoint).to_timeout
+
+        expect { client.post }.to raise_error(Net::OpenTimeout)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -7,7 +7,7 @@ module Evidence
     context '#post' do
       let(:mock_endpoint) { 'https://www.opinion.com' }
       let(:client) { Opinion::Client.new(entry: '', prompt_text: '') }
-       # include headers in response for proper parsing by HTTParty
+      # include headers in response for proper parsing by HTTParty
       let(:sample_response) { {body: '{}', headers: {content_type: 'application/json'}} }
 
       before do
@@ -26,7 +26,6 @@ module Evidence
 
         expect { client.post}.to raise_error(Evidence::Opinion::Client::OpinionAPIError)
       end
-
 
       it 'should raise error on timeout' do
         stub_request(:post, mock_endpoint).to_timeout

--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -4,18 +4,34 @@ require 'rails_helper'
 
 module Evidence
   RSpec.describe(Opinion::Client) do
-    context 'OAPI response is not sucessful' do
+    context '#post' do
+      let(:mock_endpoint) { 'https://www.opinion.com' }
+      let(:client) { Opinion::Client.new(entry: '', prompt_text: '') }
+       # include headers in response for proper parsing by HTTParty
+      let(:sample_response) { {body: '{}', headers: {content_type: 'application/json'}} }
+
       before do
-        test_double = double
-        allow(test_double).to receive(:success?).once.and_return(false)
-        allow(::HTTParty).to receive(:post).and_return(test_double)
+        stub_const("Evidence::Opinion::Client::API_ENDPOINT", mock_endpoint)
       end
 
-      it 'should raise error' do
-        expect do
-          client = Opinion::Client.new(entry: '', prompt_text: '')
-          client.post
-        end.to raise_error(/Encountered upstream error/)
+      it "should process successfully" do
+        stub_request(:post, mock_endpoint).to_return(sample_response)
+
+        expect { client.post }.to_not raise_error
+      end
+
+      it 'should raise error if there is an error status' do
+        errored_response = sample_response.merge(status: 500)
+        stub_request(:post, mock_endpoint).to_return(errored_response)
+
+        expect { client.post}.to raise_error(Evidence::Opinion::Client::OpinionAPIError)
+      end
+
+
+      it 'should raise error on timeout' do
+        stub_request(:post, mock_endpoint).to_timeout
+
+        expect { client.post }.to raise_error(Net::OpenTimeout)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix a bug with Opinion and Grammar timeouts and scope the timeouts to the web request. 
## WHY
The timeouts are in seconds (not milliseconds), so fix that. Ruby Timeout is a bit of a gotcha, in that it can cause
## HOW
Use HTTParty's native timeout. Use `WebMock` to allow granular error testing. 
### Screenshots
Example of long-running Opinion API request
![Screen Shot 2022-03-24 at 6 05 37 PM](https://user-images.githubusercontent.com/1304933/160146167-d0234ffb-c3f2-486a-a8fa-61a24bc545c0.png)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Set-Proper-timeouts-on-Grammar-and-Opinion-APIs-40bb17629fe943878cce432446a4d056)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'
Have you deployed to Staging? | (Possible answers:  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
