### PR TITLE
Evidence AutoML - Only perform auth once in predict call.

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -14,6 +14,8 @@ module Evidence
       STATE_INACTIVE = 'inactive'
     ]
     PREDICT_API_TIMEOUT = 5.0
+    GOOGLE_PROJECT_ID = ENV['AUTOML_GOOGLE_PROJECT_ID']
+    GOOGLE_LOCATION = ENV['AUTOML_GOOGLE_LOCATION']
 
     attr_readonly :automl_model_id, :name, :labels
 
@@ -73,7 +75,7 @@ module Evidence
           content: text
         }
       }
-      results = automl_prediction_client.predict(name: automl_model_full_id, payload: automl_payload)
+      results = automl_prediction_client.predict(name: automl_prediction_model_path, payload: automl_payload)
       sorted_results = results.payload.sort_by { |i| i.classification.score }.reverse
       sorted_results[0].display_name
     end
@@ -132,17 +134,25 @@ module Evidence
       end
     end
 
-    private def automl_model_full_id
-      @model_full_id ||= automl_client.model_path(project: ENV['AUTOML_GOOGLE_PROJECT_ID'], location: ENV['AUTOML_GOOGLE_LOCATION'], model: automl_model_id.strip)
+    private def automl_model_path
+      @automl_model_path ||= automl_client.model_path(**model_path_args)
+    end
+
+    private def automl_prediction_model_path
+      @automl_prediction_model_path ||= automl_prediction_client.model_path(**model_path_args)
+    end
+
+    private def model_path_args
+      {project: GOOGLE_PROJECT_ID, location: GOOGLE_LOCATION, model: automl_model_id.strip}
     end
 
     private def automl_labels
-      evaluations = automl_client.list_model_evaluations(parent: automl_model_full_id)
+      evaluations = automl_client.list_model_evaluations(parent: automl_model_path)
       evaluations.map { |e| e.display_name }.reject { |l| l.empty? }
     end
 
     private def automl_name
-      model = automl_client.get_model(name: automl_model_full_id)
+      model = automl_client.get_model(name: automl_model_path)
       model.display_name
     end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
@@ -164,8 +164,9 @@ module Evidence
       end
 
       it 'should strip any whitespace that is on "automl_model_id" before looking records up via Google' do
-        ENV['AUTOML_GOOGLE_PROJECT_ID'] = 'PROJECT_ID'
-        ENV['AUTOML_GOOGLE_LOCATION'] = 'LOCATION'
+        stub_const("AutomlModel::GOOGLE_PROJECT_ID", 'PROJECT_ID')
+        stub_const("AutomlModel::GOOGLE_LOCATION", 'LOCATION')
+
         automl_model_id = '   HAS_SPACES   '
         stripped_automl_model_id = automl_model_id.strip
         automl_model = build(:evidence_automl_model, automl_model_id: automl_model_id)
@@ -173,7 +174,7 @@ module Evidence
         auto_ml_stub = double
         expect(Google::Cloud::AutoML).to receive(:auto_ml).and_return(auto_ml_stub)
         expect(auto_ml_stub).to receive(:model_path).with(project: ENV['AUTOML_GOOGLE_PROJECT_ID'], location: ENV['AUTOML_GOOGLE_LOCATION'], model: stripped_automl_model_id)
-        automl_model.send(:automl_model_full_id)
+        automl_model.send(:automl_model_path)
       end
     end
 
@@ -214,10 +215,7 @@ module Evidence
 
         expect(prediction_client).to receive(:predict).and_return( MockPayload.new([result1, result2]) )
         expect(Google::Cloud::AutoML).to receive(:prediction_service).and_return(prediction_client)
-
-        client = double
-        expect(client).to receive(:model_path).and_return("the_path")
-        expect(Google::Cloud::AutoML).to receive(:auto_ml).and_return(client)
+        expect(prediction_client).to receive(:model_path).and_return("the_path")
 
         expect(automl_model.fetch_automl_label('some text')).to eq 'result1'
       end
@@ -227,29 +225,24 @@ module Evidence
 
         expect(prediction_client).to receive(:predict).and_raise(Google::Cloud::Error)
         expect(Google::Cloud::AutoML).to receive(:prediction_service).and_return(prediction_client)
-
-        client = double
-        expect(client).to receive(:model_path).and_return("the_path")
-        expect(Google::Cloud::AutoML).to receive(:auto_ml).and_return(client)
+        expect(prediction_client).to receive(:model_path).and_return("the_path")
 
         expect { automl_model.fetch_automl_label('some text')}.to(raise_error(Google::Cloud::Error))
       end
     end
 
 
-    context 'should #automl_model_full_id' do
+    context 'should #automl_model_path' do
 
       it 'should call model_path on the automl_client with specified values' do
-        project_id = "PROJECT"
-        location = "us-central1"
         model = create(:evidence_automl_model)
-        ENV["AUTOML_GOOGLE_PROJECT_ID"] = project_id
-        ENV["AUTOML_GOOGLE_LOCATION"] = location
+        stub_const("AutomlModel::GOOGLE_PROJECT_ID", 'PROJECT')
+        stub_const("AutomlModel::GOOGLE_LOCATION", "us-central1")
 
         client = double
         allow(client).to receive(:model_path).and_return("the_path")
         expect(Google::Cloud::AutoML).to receive(:auto_ml).and_return(client)
-        expect(model.send(:automl_model_full_id)).to eq "the_path"
+        expect(model.send(:automl_model_path)).to eq "the_path"
       end
     end
 


### PR DESCRIPTION
## WHAT
The current AutoML `fetch_labels` task uses two API clients: one to fetch the model path, one to get the prediction. This changes it to use one client for both.
## WHY
This is causing us to authenticate with google twice for each prediction.
## HOW
The `prediction_client` also has a `model_path` method. Use that. Update tests to be more isolated as well.
### Screenshots
Before
![Screen Shot 2022-03-25 at 1 09 32 PM](https://user-images.githubusercontent.com/1304933/160187067-43b0337e-b0fe-418b-838c-0622211abdcb.png)




After
![Screen Shot 2022-03-25 at 3 09 39 PM](https://user-images.githubusercontent.com/1304933/160187027-06907c6b-b1f2-4c33-a243-b5498d66ce89.png)



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
