### PR TITLE
Evidence Regex Rules - Refactor to remove N+1 query

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
@@ -49,6 +49,10 @@ module Evidence
       "Regex Rule Regex"
     end
 
+    def unconditional
+      !conditional
+    end
+
     def url
       rule.url
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
@@ -24,6 +24,9 @@ module Evidence
     validates :case_sensitive, inclusion: CASE_SENSITIVE_ALLOWED_VALUES
     validates :sequence_type, inclusion: SEQUENCE_TYPES
 
+    scope :required_sequences, -> { where(sequence_type: TYPE_REQUIRED) }
+    scope :incorrect_sequences, -> { where(sequence_type: TYPE_INCORRECT) }
+
     def serializable_hash(options = nil)
       options ||= {}
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -81,7 +81,7 @@ module Evidence
     end
 
     def regex_is_passing?(entry)
-      return true if regex_rules.empty?
+      return true if incorrect_sequences.empty? && required_sequences.empty?
 
       grade_sequences(entry)
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -169,17 +169,15 @@ module Evidence
     end
 
     private def at_least_one_conditional_required_sequence_passing?(entry)
-      return false if required_sequences.where(conditional: true).empty?
-
-      required_sequences.where(conditional: true).any? do |regex_rule|
+      required_sequences.select(&:conditional).any? do |regex_rule|
         !regex_rule.entry_failing?(entry)
       end
     end
 
     private def one_non_conditional_required_sequences_passing?(entry)
-      return true if required_sequences.where(conditional: false).empty?
+      return true if required_sequences.select(&:unconditional).empty?
 
-      required_sequences.where(conditional: false).any? do |regex_rule|
+      required_sequences.select(&:unconditional).any? do |regex_rule|
         !regex_rule.entry_failing?(entry)
       end
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -41,7 +41,11 @@ module Evidence
     has_one :label, inverse_of: :rule, dependent: :destroy
     has_many :prompts_rules, inverse_of: :rule
     has_many :prompts, through: :prompts_rules, inverse_of: :rules
+
     has_many :regex_rules, inverse_of: :rule, dependent: :destroy
+    has_many :required_sequences, -> { required_sequences }, class_name: 'Evidence::RegexRule'
+    has_many :incorrect_sequences, -> { incorrect_sequences }, class_name: 'Evidence::RegexRule'
+
     has_one :hint, inverse_of: :rule, dependent: :destroy
 
     accepts_nested_attributes_for :plagiarism_texts, allow_destroy: true
@@ -178,14 +182,6 @@ module Evidence
       required_sequences.where(conditional: false).any? do |regex_rule|
         !regex_rule.entry_failing?(entry)
       end
-    end
-
-    private def incorrect_sequences
-      regex_rules.where(sequence_type: RegexRule::TYPE_INCORRECT)
-    end
-
-    private def required_sequences
-      regex_rules.where(sequence_type: RegexRule::TYPE_REQUIRED)
     end
 
     private def assign_uid_if_missing

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
@@ -64,7 +64,10 @@ module Evidence
     end
 
     private def first_failing_regex_rule
-      rules = @prompt.rules.where(rule_type: @rule_type).order(:suborder)
+      rules = @prompt.rules
+        .where(rule_type: @rule_type)
+        .includes(:required_sequences, :incorrect_sequences)
+        .order(:suborder)
 
       rules.find {|rule| !rule.regex_is_passing?(@entry) }
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
@@ -65,10 +65,8 @@ module Evidence
 
     private def first_failing_regex_rule
       rules = @prompt.rules.where(rule_type: @rule_type).order(:suborder)
-      rules.each do |rule|
-        return rule unless rule.regex_is_passing?(@entry)
-      end
-      nil
+
+      rules.find {|rule| !rule.regex_is_passing?(@entry) }
     end
   end
 end


### PR DESCRIPTION
## WHAT
During testing, I found the `regex_rules` are firing off a lot of DB queries that can be condensed to a few.
## WHY
Small performance improvement
## HOW
Define the `required_sequences` and `incorrect_sequences`, eager load them, and use those preloaded items for analysis.
### Screenshots
Before
![Screen Shot 2022-03-25 at 5 28 31 PM](https://user-images.githubusercontent.com/1304933/160210510-760ed4f9-3cf7-4008-98ac-e6c6016fd2b4.png)


After
![Screen Shot 2022-03-25 at 6 29 53 PM](https://user-images.githubusercontent.com/1304933/160210528-7de619e5-abf5-4354-94cf-6c6e7b49b609.png)



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   NO, pure refactor, no functionality change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
