### PR TITLE
Evidence/ fix CSS for exemplars on smaller viewports 

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/postActivitySlide.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/postActivitySlide.scss
@@ -186,7 +186,7 @@
           margin: 0;
           padding: 0px 16px 0px 16px;
           .response-box, .exemplar-box {
-            width: 100%;
+            width: 60vw;
           }
           .exemplar-box:last-of-type {
             margin-bottom: 40px
@@ -223,6 +223,15 @@
         margin: 0px 38px 24px 38px;
         #grade-badge {
           display: none;
+        }
+      }
+    }
+    .responses-exemplars-container {
+      .response-exemplars-section {
+        .response-section, .exemplars-section {
+          .response-box, .exemplar-box {
+            width: 75vw;
+          }
         }
       }
     }


### PR DESCRIPTION
## WHAT
fix CSS for exemplars on smaller viewports 

## WHY
we want the exemplar boxes to display the same size

## HOW
just add `vw` property instead of percentage for the box widths at certain breakpoints

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1010" alt="Screen Shot 2022-03-28 at 11 10 52 AM" src="https://user-images.githubusercontent.com/25959584/160429498-3e836366-1c8d-4b83-843b-5e7ea9cf9ab4.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Sizing-of-exemplars-is-inconsistent-in-Evidence-post-activity-1eebbe17880e410082e161315e6a2885

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes