### PR TITLE
LMS/ remove colon from activity pack description cards

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_first_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_first_row.jsx
@@ -35,7 +35,7 @@ export default class UnitTemplateFirstRow extends React.Component {
 
     return (
       <div className="tool-names">
-        <span>Contains activities from:</span>
+        <span>Contains activities from</span>
         <p>
           {toolRows}
         </p>


### PR DESCRIPTION
## WHAT
remove colon from activity pack description cards detailing which learning tools are included

## WHY
it was requested by Curriculum

## HOW
small text change

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1363" alt="Screen Shot 2022-03-28 at 11 52 46 AM" src="https://user-images.githubusercontent.com/25959584/160437864-f9d271b7-236d-4e78-a6f5-96824e2511cc.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Remove-colon-after-from-in-Evidence-activity-packs-b5003bb76f11466f931de94f67b533ab

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small text change, manually verified
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
