### PR TITLE
Evidence/make default feedback html

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
@@ -30,7 +30,7 @@ module Evidence
         'response_id': '0', # not currently used, but part of Evidence payload spec
         'labels': '',       # not currently used, but part of Evidence payload spec
         'concept_uid': '',
-        'feedback': '',
+        'feedback': '<p></p>',
         'optimal': true,
         'highlight': '',
         'rule_uid': ''

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/plagiarism_check.rb
@@ -5,7 +5,7 @@ require 'hotwater'
 module Evidence
   class PlagiarismCheck
 
-    ALL_CORRECT_FEEDBACK = 'All plagiarism checks passed.'
+    ALL_CORRECT_FEEDBACK = '<p>All plagiarism checks passed.</p>'
     PASSAGE_TYPE = 'passage'
     ENTRY_TYPE = 'response'
     MATCH_MINIMUM = 10

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/regex_check.rb
@@ -3,7 +3,7 @@
 module Evidence
   class RegexCheck
 
-    ALL_CORRECT_FEEDBACK = 'All regex checks passed.'
+    ALL_CORRECT_FEEDBACK = '<p>All regex checks passed.</p>'
     OPTIMAL_RULE_KEY = 'optimal_regex_rule_uid'
     attr_reader :entry, :prompt, :rule_type
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -5,8 +5,8 @@ module Evidence
     class BingRateLimitException < StandardError; end
 
     API_TIMEOUT = 5
-    ALL_CORRECT_FEEDBACK = 'Correct spelling!'
-    FALLBACK_INCORRECT_FEEDBACK = 'Update the spelling of the bolded word(s).'
+    ALL_CORRECT_FEEDBACK = '<p>Correct spelling!</p>'
+    FALLBACK_INCORRECT_FEEDBACK = '<p>Update the spelling of the bolded word(s).</p>'
     FEEDBACK_TYPE = Rule::TYPE_SPELLING
     RESPONSE_TYPE = 'response'
     BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'


### PR DESCRIPTION
## WHAT
Use HTML for hard-coded feedback that might get served
## WHY
We want to unify all of our feedback around HTML in case it ever matters that we're 100% consistent
## HOW
Just update the hard-coded strings to be wrapped in `<p>` tags the way that our HTML feedback is

### Notion Card Links
https://www.notion.so/quill/Make-all-feedback-HTML-42a134d164e04ce083667002fde29af0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
