### PR TITLE
Evidence/ fix onClick handler for prompt steps

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/rightPanel.tsx
@@ -96,7 +96,7 @@ const RightPanel = ({
       <div className="steps-outer-container step-overview-container" onScroll={resetTimers}>
         <StepOverview
           activeStep={activeStep}
-          handleClick={onStartPromptSteps}
+          handleClick={toggleShowStepsSummary}
         />
         {bottomNavigation}
       </div>
@@ -120,6 +120,7 @@ const RightPanel = ({
       session={session}
       showReadTheDirectionsButton={showReadTheDirectionsButton}
       submitResponse={submitResponse}
+
     />
   )
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
@@ -36,7 +36,7 @@ const Step = ({ active, completed, handleClick, step }: StepProps) => {
   if (active) {
     return (
       <section className="step-overview-step-container">
-        <button className="step-overview-step active" onClick={handleClick} type="button">
+        <button className="step-overview-step active focus-on-dark" onClick={handleClick} type="button">
           <div className="left-side-container">
             <div className={`evidence-step-number-small ${active ? 'active' : ''}`}>{stepNumber}</div>
             {html}
@@ -100,21 +100,25 @@ const StepOverview = ({ activeStep, handleClick, }) => {
       <Step
         active={false}
         completed={activeStep > READ_PASSAGE_STEP_NUMBER}
+        handleClick={handleClick}
         step={steps[READ_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === BECAUSE_PASSAGE_STEP_NUMBER}
         completed={activeStep > BECAUSE_PASSAGE_STEP_NUMBER}
+        handleClick={handleClick}
         step={steps[BECAUSE_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === BUT_PASSAGE_STEP_NUMBER}
         completed={activeStep > BUT_PASSAGE_STEP_NUMBER}
+        handleClick={handleClick}
         step={steps[BUT_PASSAGE_STEP_NUMBER]}
       />
       <Step
         active={activeStep === SO_PASSAGE_STEP_NUMBER}
         completed={activeStep > SO_PASSAGE_STEP_NUMBER}
+        handleClick={handleClick}
         step={steps[SO_PASSAGE_STEP_NUMBER]}
       />
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`StepOverview component when the student is on step one renders 1`] = `
         className="step-overview-step-container"
       >
         <button
-          className="step-overview-step active"
+          className="step-overview-step active focus-on-dark"
           onClick={[Function]}
           type="button"
         >
@@ -177,6 +177,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     <Step
       active={false}
       completed={true}
+      handleClick={[Function]}
       step={
         Object {
           "html": <p>
@@ -205,6 +206,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     <Step
       active={true}
       completed={false}
+      handleClick={[Function]}
       step={
         Object {
           "html": <p>
@@ -222,7 +224,8 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
         className="step-overview-step-container"
       >
         <button
-          className="step-overview-step active"
+          className="step-overview-step active focus-on-dark"
+          onClick={[Function]}
           type="button"
         >
           <div
@@ -252,6 +255,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     <Step
       active={false}
       completed={false}
+      handleClick={[Function]}
       step={
         Object {
           "html": <p>
@@ -289,6 +293,7 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
     <Step
       active={false}
       completed={false}
+      handleClick={[Function]}
       step={
         Object {
           "html": <p>


### PR DESCRIPTION
## WHAT
fix onClick handler for interstitial prompt steps in Evidence

## WHY
we want students to be able to use click and keyboard events for these buttons

## HOW
pass the correct `onClick` prop and also add focus indicator

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="670" alt="Screen Shot 2022-03-28 at 3 02 29 PM" src="https://user-images.githubusercontent.com/25959584/160471136-95592593-45a1-41ff-861f-71c8c6ac1ae4.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Pressing-Enter-on-the-step-overview-buttons-doesn-t-do-anything-24afd47f3fdd44aaba71290157afc1e2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
