### PR TITLE
School admin/ fix issue with CSV filtered exports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -52,30 +52,28 @@ export class CSVDownloadForProgressReport extends React.Component {
   }
 
   cleanData(data) {
-    console.log("🚀 ~ file: csv_download_for_progress_report.jsx ~ line 55 ~ CSVDownloadForProgressReport ~ cleanData ~ data", data)
+    const { keysToOmit, valuesToChange, preserveCasing } = this.props;
     let finalValue
-    const formattedData = formatData(data);
-    if (!Array.isArray(formattedData[0])) {
-      const copiedData = JSON.parse(JSON.stringify(formattedData))
+    if (!Array.isArray(data[0])) {
+      const copiedData = JSON.parse(JSON.stringify(data))
       let newData = []
       copiedData.forEach(row => {
-        if (this.props.keysToOmit) {
+        if (keysToOmit) {
           row = this.omitKeys(row)
         }
-        if (this.props.valuesToChange) {
+        if (valuesToChange) {
           this.changeValues(row)
         }
-        if (!this.props.preserveCasing) {
+        if (!preserveCasing) {
           this.getRidOfCamelCase(row)
         }
         newData.push(row)
       })
       finalValue = newData
     } else {
-      finalValue = formattedData
+      finalValue = data
     }
-    console.log("🚀 ~ file: csv_download_for_progress_report.jsx ~ line 76 ~ CSVDownloadForProgressReport ~ cleanData ~ finalValue", finalValue)
-    return finalValue
+    return formatData(finalValue)
   }
 
   closeDropdownIfOpen(e) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {CSVDownload, CSVLink} from 'react-csv'
+import {CSVLink} from 'react-csv'
 import userIsPremium from '../modules/user_is_premium'
 import _ from 'underscore'
 import _l from 'lodash'
@@ -16,7 +16,7 @@ const clickedDownloadBtnClass = "quill-button medium primary contained focus-on-
 const printBtnClass = "print-button"
 const printImgClass = "print-img"
 
-export default class CSVDownloadForProgressReports extends React.Component {
+export class CSVDownloadForProgressReport extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -25,11 +25,6 @@ export default class CSVDownloadForProgressReports extends React.Component {
     }
 
     document.addEventListener('click', this.closeDropdownIfOpen.bind(this))
-  }
-
-
-  componentDidMount() {
-    this.cleanData(this.props.data)
   }
 
   componentWillUnmount() {
@@ -46,7 +41,8 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   changeValues(row) {
-    this.props.valuesToChange.forEach(keyFunction => {
+    const { valuesToChange } = this.props
+    valuesToChange.forEach(keyFunction => {
       row[keyFunction.key] = keyFunction.function(row[keyFunction.key])
     })
   }
@@ -56,9 +52,11 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   cleanData(data) {
+    console.log("🚀 ~ file: csv_download_for_progress_report.jsx ~ line 55 ~ CSVDownloadForProgressReport ~ cleanData ~ data", data)
     let finalValue
-    if (!Array.isArray(data[0])) {
-      const copiedData = JSON.parse(JSON.stringify(data))
+    const formattedData = formatData(data);
+    if (!Array.isArray(formattedData[0])) {
+      const copiedData = JSON.parse(JSON.stringify(formattedData))
       let newData = []
       copiedData.forEach(row => {
         if (this.props.keysToOmit) {
@@ -74,15 +72,17 @@ export default class CSVDownloadForProgressReports extends React.Component {
       })
       finalValue = newData
     } else {
-      finalValue = data
+      finalValue = formattedData
     }
-    this.setState({data: finalValue})
+    console.log("🚀 ~ file: csv_download_for_progress_report.jsx ~ line 76 ~ CSVDownloadForProgressReport ~ cleanData ~ finalValue", finalValue)
+    return finalValue
   }
 
   closeDropdownIfOpen(e) {
     const { className, } = this.props
+    const { showDropdown } = this.state
     const ignoreClasses = [printBtnClass, printImgClass, clickedDownloadBtnClass, unclickedDownloadBtnClass, className]
-    if (this.state.showDropdown && !ignoreClasses.includes(e.target.classList.value)) {
+    if (showDropdown && !ignoreClasses.includes(e.target.classList.value)) {
       this.setState({ showDropdown: false})
     }
   }
@@ -92,19 +92,23 @@ export default class CSVDownloadForProgressReports extends React.Component {
   }
 
   omitKeys(row) {
-    return _.omit(row, this.props.keysToOmit)
+    const { keysToOmit } = this.props
+    return _.omit(row, keysToOmit)
   }
 
   toggleDropdown = () => {
-    this.setState({ showDropdown: !this.state.showDropdown })
+    const { showDropdown } = this.state
+    this.setState({ showDropdown: !showDropdown })
   };
 
   render() {
-    if (this.state.userIsPremium && this.props.data) {
+    const { userIsPremium, showDropdown } = this.state;
+    const { buttonCopy, className, data, studentName } = this.props;
+    if (userIsPremium && data) {
       let dropdown,
         style,
         c
-      if (this.state.showDropdown) {
+      if (showDropdown) {
         style = {
           // border: "solid 1px #00c2a2",
           boxShadow: "0 0 0 1px #00c2a2",
@@ -134,8 +138,8 @@ export default class CSVDownloadForProgressReports extends React.Component {
               </button>
 
               <CSVLink
-                data={formatData(this.state.data)}
-                filename={this.formatFilename(this.props.studentName)}
+                data={this.cleanData(data)}
+                filename={this.formatFilename(studentName)}
                 target="_blank"
               >
                 <button>
@@ -150,20 +154,22 @@ export default class CSVDownloadForProgressReports extends React.Component {
       }
       return (
         <div className='download-button-wrapper'>
-          <button className={clickedDownloadBtnClass} onClick={this.toggleDropdown} style={style}>{this.props.buttonCopy || "Download Report"}</button>
+          <button className={clickedDownloadBtnClass} onClick={this.toggleDropdown} style={style}>{buttonCopy || "Download Report"}</button>
           {dropdown}
         </div>
       )
     } else {
       return (
         <button
-          className={this.props.className || unclickedDownloadBtnClass}
+          className={className || unclickedDownloadBtnClass}
           onClick={this.handleClick}
           style={{display: 'block'}}
         >
-          {this.props.buttonCopy || "Download Report"}
+          {buttonCopy || "Download Report"}
         </button>
       )
     }
   }
 }
+
+export default CSVDownloadForProgressReport;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/csv_download_for_progress_report.jsx
@@ -108,7 +108,6 @@ export class CSVDownloadForProgressReport extends React.Component {
         c
       if (showDropdown) {
         style = {
-          // border: "solid 1px #00c2a2",
           boxShadow: "0 0 0 1px #00c2a2",
           backgroundColor: '#fff',
           color: '#00c2a2'

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/__snapshots__/csvDownloadForProgressReport.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/__snapshots__/csvDownloadForProgressReport.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActivitySurvey Component should match snapshot 1`] = `
+<CSVDownloadForProgressReport
+  data={
+    Array [
+      Array [
+        "Classroom Name",
+        "Student Name",
+        "School Name",
+        "Teacher Name",
+        "Average Score",
+        "Activity Count",
+        "Last Active",
+      ],
+      Array [
+        "Test Class",
+        "Jen Penn",
+        "Drag Rage Academy",
+        "Jane Fonda",
+        "99%",
+        2,
+        "2022-03-29 15:13:19",
+      ],
+    ]
+  }
+>
+  <div
+    className="download-button-wrapper"
+  >
+    <button
+      className="quill-button medium primary contained focus-on-light"
+      onClick={[Function]}
+    >
+      Download Report
+    </button>
+  </div>
+</CSVDownloadForProgressReport>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/csvDownloadForProgressReport.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/csvDownloadForProgressReport.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import _ from 'underscore';
+import _l from 'lodash';
+import { CSVLink } from 'react-csv'
+
+import { CSVDownloadForProgressReport } from '../../../components/progress_reports/csv_download_for_progress_report'
+
+jest.mock('../../../components/modules/user_is_premium', () => jest.fn(() => true));
+
+describe('ActivitySurvey Component', () => {
+  const mockData = [
+    ['Classroom Name', 'Student Name', 'School Name', 'Teacher Name', 'Average Score', 'Activity Count', 'Last Active'],
+    ['Test Class', 'Jen Penn', 'Drag Rage Academy', 'Jane Fonda', '99%', 2, '2022-03-29 15:13:19']
+  ];
+  let component = mount(<CSVDownloadForProgressReport data={mockData} />);
+
+  it('should match snapshot', () => {
+    expect(component).toMatchSnapshot();
+  });
+  it('should pass expected data', () => {
+    component.setState({ showDropdown: true });
+    component.update();
+    console.log(component.debug())
+    console.log(component.find(CSVLink).props().data)
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/csvDownloadForProgressReport.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/progressReports/csvDownloadForProgressReport.test.tsx
@@ -18,10 +18,4 @@ describe('ActivitySurvey Component', () => {
   it('should match snapshot', () => {
     expect(component).toMatchSnapshot();
   });
-  it('should pass expected data', () => {
-    component.setState({ showDropdown: true });
-    component.update();
-    console.log(component.debug())
-    console.log(component.find(CSVLink).props().data)
-  });
 });


### PR DESCRIPTION
## WHAT
fix issue where selected filters weren't being persisted for CSV downloads for school admins

## WHY
we want admins to be able to correctly filter CSV downloads

## HOW
use the `data` prop instead of using state which was causing a race condition

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Admin-Dash-Activity-Scores-filter-view-not-keeping-in-CSV-downloads-e68055087e9e45d6b51fd25a2d07c9fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
