### PR TITLE
LMS add prefilter checks should return concept uids (#9019)

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/prefilter_check.rb
@@ -62,7 +62,8 @@ module Evidence
           optimal: false,
           rule_uid: @violated_rule.uid,
           hint: @violated_rule.hint,
-          highlight: highlights
+          highlight: highlights,
+          concept_uid: @violated_rule.concept_uid
         }
       )
     end

--- a/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/prefilter_check_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 module Evidence
   RSpec.describe(PrefilterCheck) do
-    let(:rule_factory_overrides) { {rule_type: 'prefilter', universal: true, optimal: false} }
+    let(:rule_factory_overrides) do
+      { rule_type: 'prefilter', universal: true, optimal: false, concept_uid: 'a_concept_uid' }
+    end
 
     describe '#initialize' do
       it 'should retrieve associated Rules' do
@@ -90,6 +92,7 @@ module Evidence
             expect(response[:rule_uid]).to eq violation[:rule_uid]
             expect(response[:optimal]).to eq false
             expect(response[:feedback]).to eq "#{violation[:name]} feedback"
+            expect(response[:concept_uid]).to eq rule_factory_overrides[:concept_uid]
           end
         end
       end


### PR DESCRIPTION
* prefilter checks should return concept uids

* make concept_uid provenance clearer in spec

Co-authored-by: Peter Kong <pkong@quill.org>

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
