### PR TITLE
Evidence/ QA bugs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -180,8 +180,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
   promptAsRegex = () => new RegExp(`^${this.htmlStrippedPrompt(true)}`)
 
-  resetEditorCursorPosition = (value) => {
-    this.editor.innerHTML = value
+  resetEditorCursorPosition = () => {
     const range = document.createRange();
     range.selectNodeContents(this.editor);
     range.collapse(false);
@@ -197,7 +196,8 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
     if (text.match(regex)) {
       this.setState({ html: value, }, () => {
-        this.resetEditorCursorPosition(value)
+        this.editor.innerHTML = value
+        this.resetEditorCursorPosition()
       })
       // if the student has deleted everything, we want to remove everything but the prompt stem
     } else if (!text.length) {
@@ -263,7 +263,8 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   resetText = () => {
     const html = this.formattedStem()
     this.setState({ html }, () => {
-      this.resetEditorCursorPosition(html)
+      this.editor.innerHTML = html
+      this.resetEditorCursorPosition()
     })
   }
 
@@ -275,12 +276,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
       const el = this.editor
       // retrieved from https://stackoverflow.com/a/4238971
       if (typeof window.getSelection != "undefined" && typeof document.createRange != "undefined") {
-        const range = document.createRange();
-        range.selectNodeContents(el);
-        range.collapse(false);
-        const sel = window.getSelection();
-        sel.removeAllRanges();
-        sel.addRange(range);
+        this.resetEditorCursorPosition()
       } else if (typeof document.body.createTextRange != "undefined") {
         const textRange = document.body.createTextRange();
         textRange.moveToElementText(el);

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -180,13 +180,25 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
   promptAsRegex = () => new RegExp(`^${this.htmlStrippedPrompt(true)}`)
 
+  resetEditorCursorPosition = (value) => {
+    this.editor.innerHTML = value
+    const range = document.createRange();
+    range.selectNodeContents(this.editor);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+
   onTextChange = (e) => {
     const { value } = e.target
     const text = value.replace(/<b>|<\/b>|<p>|<\/p>|<br>/g, '')
     const regex = this.promptAsRegex()
-    const caretPosition = EditCaretPositioning.saveSelection(this.editor)
+
     if (text.match(regex)) {
-      this.setState({ html: value, }, () => EditCaretPositioning.restoreSelection(this.editor, caretPosition))
+      this.setState({ html: value, }, () => {
+        this.resetEditorCursorPosition(value)
+      })
       // if the student has deleted everything, we want to remove everything but the prompt stem
     } else if (!text.length) {
       this.resetText()
@@ -250,7 +262,9 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
   resetText = () => {
     const html = this.formattedStem()
-    this.setState({ html }, () => this.editor.innerHTML = html)
+    this.setState({ html }, () => {
+      this.resetEditorCursorPosition(html)
+    })
   }
 
   setEditorRef = (node: JSX.Element) => this.editor = node

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -46,6 +46,7 @@ const FEEDBACK_LOADING_LIMIT = 30000;
 export class PromptStep extends React.Component<PromptStepProps, PromptStepState> {
   private editor: any // eslint-disable-line react/sort-comp
   private interval: any // eslint-disable-line react/sort-comp
+  private button: any // eslint-disable-line react/sort-comp
 
   constructor(props: PromptStepProps) {
     super(props)
@@ -64,6 +65,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     };
 
     this.editor = React.createRef()
+    this.button = React.createRef()
     this.interval = null;
   }
 
@@ -72,6 +74,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     const { submittedResponses } = this.props;
     const { numberOfSubmissions, submissionTime, timeAtLastFeedbackSubmissionCheck, failedToLoadFeedback } = this.state;
     const timeLapsed = Math.abs(timeAtLastFeedbackSubmissionCheck - submissionTime)
+    const awaitingFeedback = (numberOfSubmissions !== submittedResponses.length) && !failedToLoadFeedback
 
     if(submissionTime && numberOfSubmissions === submittedResponses.length) {
       this.setState({ submissionTime: 0, timeAtLastFeedbackSubmissionCheck: 0 });
@@ -80,6 +83,9 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     if(timeAtLastFeedbackSubmissionCheck && timeLapsed >= FEEDBACK_LOADING_LIMIT && !failedToLoadFeedback) {
       const feedbackFailedToLoadText = 'Sorry, our feedback did not load properly. Please try again or refresh the page.'
       this.setState({ failedToLoadFeedback: true, customFeedback: feedbackFailedToLoadText, customFeedbackKey: 'feedback failed' });
+    }
+    if(awaitingFeedback) {
+      this.button.current.focus()
     }
   }
 
@@ -250,21 +256,23 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
   setEditorRef = (node: JSX.Element) => this.editor = node
 
   onFocus = () => {
-    // following code ensures tabbing into editor always puts cursor at the end of the text
-    const el = this.editor
-    // retrieved from https://stackoverflow.com/a/4238971
-    if (typeof window.getSelection != "undefined" && typeof document.createRange != "undefined") {
-      const range = document.createRange();
-      range.selectNodeContents(el);
-      range.collapse(false);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
-    } else if (typeof document.body.createTextRange != "undefined") {
-      const textRange = document.body.createTextRange();
-      textRange.moveToElementText(el);
-      textRange.collapse(false);
-      textRange.select();
+    if(document.activeElement !== this.button.current) {
+      // following code ensures tabbing into editor always puts cursor at the end of the text
+      const el = this.editor
+      // retrieved from https://stackoverflow.com/a/4238971
+      if (typeof window.getSelection != "undefined" && typeof document.createRange != "undefined") {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      } else if (typeof document.body.createTextRange != "undefined") {
+        const textRange = document.body.createTextRange();
+        textRange.moveToElementText(el);
+        textRange.collapse(false);
+        textRange.select();
+      }
     }
   }
 
@@ -357,7 +365,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     return(
       <div className="feedback-details-section">
         {this.getFeedbackLoadingDetails()}
-        <button className={className} onClick={onClick} type="button">{buttonLoadingSpinner}<span>{buttonCopy}</span></button>
+        <button className={className} onClick={onClick} ref={this.button} type="button">{buttonLoadingSpinner}<span>{buttonCopy}</span></button>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
@@ -4,7 +4,7 @@
   align-items: center;
   text-align: center;
   background-color: #005341;
-  min-height: calc(100% - 60px);
+  min-height: calc(100vh - 60px);
   .subtext {
     font-size: 20px;
     font-weight: 600;
@@ -81,7 +81,8 @@
     width: 100%;
     padding: 16px;
     background-color: #005341;
-
+    position: fixed;
+    bottom: 0;
     button {
       margin-left: 96px;
     }
@@ -102,6 +103,11 @@
         }
       }
     }
+  }
+  #button-container {
+    justify-content: space-between;
+    position: fixed;
+    bottom: 0;
   }
 }
 
@@ -137,17 +143,6 @@
         .instruction-container:nth-child(3) {
           margin-bottom: 80px;
         }
-      }
-    }
-    #button-container {
-      justify-content: space-between;
-      position: fixed;
-      bottom: 0;
-      span {
-        display: none;
-      }
-      button {
-        margin-left: 0px;
       }
     }
   }


### PR DESCRIPTION
## WHAT
fix several small bugs found during a QA pass: extra white space being displayed on Firefox, ability to rapidly click through activities on Safari and incorrect cursor positioning after text deletion across all browsers

## WHY
we want to take care of these last issues coming into the Evidence launch

## HOW
various CSS updates, onFocus updates and adding a `resetEditorCursorPosition` that correctly handles cursor insertion on text deletion

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/QE-on-Firefox-White-space-boxes-on-onboarding-slides-15c4ad2a088943bbbfd4fcb3bf8d314d
https://www.notion.so/quill/QE-on-Safari-Able-to-click-through-submissions-quickly-417b2ee64f3240cd8a23c49b417b0099
https://www.notion.so/quill/First-letter-of-response-sometimes-skipped-on-QE-activities-7d6e6218fee346668a2aa7a1e266b740

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
