### PR TITLE
lms/fix-add-activity-questions-grammar

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
@@ -155,7 +155,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
           onChange={this.handleQuestionChange}
           options={formatted}
           placeholder="Search for a question"
-          search=true
+          search={true}
         />
       );
     }

--- a/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import QuestionSelector from 'react-select-search';
+import { fuzzySearch } from 'react-select-search';
 import { connect } from 'react-redux';
 import { EditorState, ContentState } from 'draft-js'
 
@@ -61,10 +62,6 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
     const changes: LessonFormState = {};
     changes[key] = event.target.value;
     this.setState(changes);
-  }
-
-  handleSearchChange = (e) => {
-    this.handleQuestionChange(e.value);
   }
 
   addConcept = (concept: { value: string }) => {
@@ -154,9 +151,11 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
       formatted = options.map(opt => ({ name: opt.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, ''), value: opt.key, }));
       return (
         <QuestionSelector
-          onChange={this.handleSearchChange}
+          filterOptions={fuzzySearch}
+          onChange={this.handleQuestionChange}
           options={formatted}
           placeholder="Search for a question"
+          search=true
         />
       );
     }


### PR DESCRIPTION
## WHAT
Update search picking for Grammar activities
## WHY
We went from 0.X to 3.X (a four or five year gap) on the `react-select-search` lib as part of the general React upgrades.  Since we only use this component for one very specific, not-commonly-used workflow, testing missed that it was broken.  (It rendered fine, but did not behave as intended.). This refactor updates the way we use the component so that it works as intended.
## HOW
- Modify how we expect to handle `onChange` functions (it used to be passed an event, but now is passed a value directly)
- Add the `search=true` attribute to the component since it now defaults to `false`
- Add a `filterOptions` attribute to the component and use the lib's reference filter for it

### Screenshots
Current Production (search box can not be interacted with):
<img width="599" alt="image" src="https://user-images.githubusercontent.com/331565/161793336-75cf4156-335c-4e1b-8183-11602a948a99.png">
Updated Version (search box works):
<img width="461" alt="image" src="https://user-images.githubusercontent.com/331565/161793544-2dcbc41c-53b8-4a12-b192-f5be8cc51cc6.png">

### Notion Card Links
https://www.notion.so/quill/Grammar-questions-not-searchable-047bff6aad85466aae46409030df7dcc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior change, so no test updates
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
