### PR TITLE
LMS Adjust Time Tracking Outliers

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -110,7 +110,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
     if timespent && timespent > 3600
       begin
-        raise "#{timespent} seconds for user #{@activity_session.user_id} and activity session #{@activity_session.id}"
+        raise "#{timespent} seconds for user #{@activity_session&.user_id} and activity session #{@activity_session&.id}"
       rescue => e
         Raven.capture_exception(e)
       end

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -102,7 +102,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   private def activity_session_params
     params.delete(:activity_session)
     data = params.delete(:data)&.permit!
-    clean_data = TimeTrackingCleaner.new(data).clean
+    clean_data = TimeTrackingCleaner.run(data)
     time_tracking = clean_data&.fetch(ActivitySession::TIME_TRACKING_KEY, nil)
     timespent = ActivitySession.calculate_timespent(@activity_session, time_tracking)
 

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -110,7 +110,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
 
     params
       .permit(activity_session_permitted_params)
-      .merge(data: clean_data)
+      .merge(data: clean_data&.permit!)
       .reject { |_, v| v.nil? }
       .merge(timespent: timespent)
   end

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -122,7 +122,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     begin
       raise ActivitySession::LongTimeTrackingError, "#{timespent} seconds for user #{user_id} and activity session #{activity_session_id}"
     rescue => e
-      Raven.capture_exception(e)
+      ErrorNotifier.report(e)
     end
   end
 

--- a/services/QuillLMS/app/lib/extensions/array.rb
+++ b/services/QuillLMS/app/lib/extensions/array.rb
@@ -1,4 +1,7 @@
 class Array
+  # return middle element of sorted array
+  # for even-sized non-number arrays, return larger of middle two
+  # for even-sized number arrays, return average of middle two
   def median
     return nil if self.size == 0
     return self[0] if self.size == 1

--- a/services/QuillLMS/app/lib/extensions/array.rb
+++ b/services/QuillLMS/app/lib/extensions/array.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class Array
   # return middle element of sorted array
   # for even-sized non-number arrays, return larger of middle two
   # for even-sized number arrays, return average of middle two
   def median
-    return nil if self.size == 0
-    return self[0] if self.size == 1
+    return nil if empty?
+    return self[0] if size == 1
 
-    dup = self.sort
+    dup = sort
     mid = (dup.size / 2).to_i
 
     return dup[mid] if dup.size.odd?

--- a/services/QuillLMS/app/lib/extensions/array.rb
+++ b/services/QuillLMS/app/lib/extensions/array.rb
@@ -1,0 +1,14 @@
+class Array
+  def median
+    return nil if self.size == 0
+    return self[0] if self.size == 1
+
+    dup = self.sort
+    mid = (dup.size / 2).to_i
+
+    return dup[mid] if dup.size.odd?
+    return dup[mid] if !dup[0].is_a?(Numeric)
+
+    (dup[mid] + dup[mid - 1])/2.0
+  end
+end

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -1,4 +1,6 @@
-class TimeTrackingCleaner
+# frozen_string_literal: true
+
+class TimeTrackingCleaner < ApplicationService
   OUTLIER_MULTIPLIER = 40
 
   attr_reader :time_tracking, :data_params
@@ -8,7 +10,7 @@ class TimeTrackingCleaner
     @time_tracking = data_params&.fetch(ActivitySession::TIME_TRACKING_KEY, nil)
   end
 
-  def clean
+  def run
     return data_params unless time_tracking.respond_to?(:values)
     return data_params if outliers.empty?
 

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -11,7 +11,6 @@ class TimeTrackingCleaner < ApplicationService
     @time_tracking_edits = data_params&.fetch(ActivitySession::TIME_TRACKING_EDITS_KEY, {})
   end
 
-
   # replace outlier time_tracking values with the list's median value
   # if they are 40x larger than the median
   # keep track of original data in data['time_tracking_edits']

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -1,0 +1,38 @@
+class TimeTrackingCleaner
+  TIME_TRACKING_KEY = 'time_tracking'
+  EDITS_KEY = 'time_tracking_edits'
+  OUTLIER_MULTIPLIER = 40
+
+  attr_accessor :time_tracking, :time_tracking_edits, :data_params
+
+  def initialize(data_params)
+    @time_tracking = data_params && data_params[TIME_TRACKING_KEY]
+    @data_params = data_params
+  end
+
+  def clean
+    return data_params unless time_tracking.respond_to?(:values)
+    return data_params if outliers.empty?
+
+    data_params.merge(
+      TIME_TRACKING_KEY => cleaned_time_tracking,
+      EDITS_KEY => outliers
+    )
+  end
+
+  def cleaned_time_tracking
+    time_tracking.merge(outliers.transform_values {|_| median_value})
+  end
+
+  def outliers
+    @outliers ||= time_tracking.select {|_, v| v > outlier_threshold}
+  end
+
+  private def median_value
+    @median_value ||= time_tracking.values.compact.median
+  end
+
+  private def outlier_threshold
+    @outlier_threshold ||= median_value * OUTLIER_MULTIPLIER
+  end
+end

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -2,6 +2,9 @@
 
 class TimeTrackingCleaner < ApplicationService
   OUTLIER_MULTIPLIER = 40
+  # There are some keys that it doesn't make sense to use the median as a backfill
+  # So skipping them for now, until we have a more robust solution.
+  IGNORE_KEYS = ['proofreading_the_passage']
 
   attr_reader :time_tracking, :data_params, :time_tracking_edits
 
@@ -30,7 +33,7 @@ class TimeTrackingCleaner < ApplicationService
   end
 
   private def outliers
-    @outliers ||= time_tracking.select {|_, v| v > outlier_threshold}
+    @outliers ||= time_tracking.select {|_, v| v > outlier_threshold}.except(*IGNORE_KEYS)
   end
 
   private def median_value

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -3,11 +3,12 @@
 class TimeTrackingCleaner < ApplicationService
   OUTLIER_MULTIPLIER = 40
 
-  attr_reader :time_tracking, :data_params
+  attr_reader :time_tracking, :data_params, :time_tracking_edits
 
   def initialize(data_params)
     @data_params = data_params
     @time_tracking = data_params&.fetch(ActivitySession::TIME_TRACKING_KEY, nil)
+    @time_tracking_edits = data_params&.fetch(ActivitySession::TIME_TRACKING_EDITS_KEY, {})
   end
 
 
@@ -21,7 +22,7 @@ class TimeTrackingCleaner < ApplicationService
 
     data_params.merge(
       ActivitySession::TIME_TRACKING_KEY => time_tracking_outliers_replaced,
-      ActivitySession::TIME_TRACKING_EDITS_KEY => outliers
+      ActivitySession::TIME_TRACKING_EDITS_KEY => time_tracking_edits.merge(outliers)
     )
   end
 

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -34,7 +34,7 @@ class TimeTrackingCleaner < ApplicationService
   end
 
   private def median_value
-    @median_value ||= time_tracking.values.compact.median
+    @median_value ||= time_tracking.values.compact.median.to_i
   end
 
   private def outlier_threshold

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -1,13 +1,11 @@
 class TimeTrackingCleaner
-  TIME_TRACKING_KEY = 'time_tracking'
-  EDITS_KEY = 'time_tracking_edits'
   OUTLIER_MULTIPLIER = 40
 
-  attr_accessor :time_tracking, :time_tracking_edits, :data_params
+  attr_reader :time_tracking, :data_params
 
   def initialize(data_params)
-    @time_tracking = data_params && data_params[TIME_TRACKING_KEY]
     @data_params = data_params
+    @time_tracking = data_params&.fetch(ActivitySession::TIME_TRACKING_KEY, nil)
   end
 
   def clean
@@ -15,8 +13,8 @@ class TimeTrackingCleaner
     return data_params if outliers.empty?
 
     data_params.merge(
-      TIME_TRACKING_KEY => cleaned_time_tracking,
-      EDITS_KEY => outliers
+      ActivitySession::TIME_TRACKING_KEY => cleaned_time_tracking,
+      ActivitySession::TIME_TRACKING_EDITS_KEY => outliers
     )
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -161,7 +161,7 @@ class ActivitySession < ApplicationRecord
   OUTLIER_MULTIPLIER = 50
 
   def self.calculate_timespent(time_tracking)
-    return nil unless time_tracking&.respond_to?(:values)
+    return nil unless time_tracking.respond_to?(:values)
 
     compact_values = time_tracking.values.compact
     median = compact_values.median

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -166,7 +166,7 @@ class ActivitySession < ApplicationRecord
   end
 
   def self.time_tracking_sum(time_tracking)
-    return nil unless time_tracking&.respond_to?(:values)
+    return nil unless time_tracking.respond_to?(:values)
 
     time_tracking.values.compact.sum
   end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -161,8 +161,7 @@ class ActivitySession < ApplicationRecord
   OUTLIER_MULTIPLIER = 50
 
   def self.calculate_timespent(time_tracking)
-    return nil unless time_tracking
-    return nil unless time_tracking.respond_to?(:values)
+    return nil unless time_tracking&.respond_to?(:values)
 
     compact_values = time_tracking.values.compact
     median = compact_values.median

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -166,7 +166,9 @@ class ActivitySession < ApplicationRecord
   end
 
   def self.time_tracking_sum(time_tracking)
-    time_tracking&.values&.compact&.sum
+    return nil unless time_tracking&.respond_to?(:values)
+
+    time_tracking.values.compact.sum
   end
 
   def self.calculate_timespent(activity_session, time_tracking)

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -41,6 +41,8 @@ require 'new_relic/agent'
 
 class ActivitySession < ApplicationRecord
 
+  class LongTimeTrackingError < StandardError; end
+
   include ::NewRelic::Agent
 
   include Uid

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -158,8 +158,18 @@ class ActivitySession < ApplicationRecord
     state == FINISHED_STATE
   end
 
+  OUTLIER_MULTIPLIER = 50
+
   def self.calculate_timespent(time_tracking)
-    time_tracking&.values&.compact&.sum
+    return nil unless time_tracking
+    return nil unless time_tracking.is_a?(Hash)
+
+    compact_values = time_tracking.values.compact
+    median = compact_values.median
+    outlier_threshold = median * OUTLIER_MULTIPLIER
+
+    # replace values 50x the median with median, since they are likely bad data
+    compact_values.sum {|v| v > outlier_threshold ? median.to_i : v}
   end
 
   def eligible_for_tracking?

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -162,7 +162,7 @@ class ActivitySession < ApplicationRecord
 
   def self.calculate_timespent(time_tracking)
     return nil unless time_tracking
-    return nil unless time_tracking.is_a?(Hash)
+    return nil unless time_tracking.respond_to?(:values)
 
     compact_values = time_tracking.values.compact
     median = compact_values.median

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -21,7 +21,7 @@ module EmpiricalGrammar
     # -- all .rb files in that directory are automatically loaded.
 
     # load custom extensions
-    Dir[Rails.root.join("app/lib/extensions/**/*.rb")].each { |f| require f }
+    Dir[Rails.root.join("app/lib/extensions/**/*.rb")].sort.each { |f| require f }
 
     config.cache_store = :redis_store, ENV["REDISCLOUD_URL"]
 

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -20,6 +20,9 @@ module EmpiricalGrammar
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # load custom extensions
+    Dir[Rails.root.join("app/lib/extensions/**/*.rb")].each { |f| require f }
+
     config.cache_store = :redis_store, ENV["REDISCLOUD_URL"]
 
     config.paperclip_defaults = {

--- a/services/QuillLMS/spec/lib/extensions/array_spec.rb
+++ b/services/QuillLMS/spec/lib/extensions/array_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Array do
+  describe '#median' do
+    let(:odd_sized_letters) { %w{e a b c d} }
+    let(:even_sized_letters) {%w{f e a b c d} }
+    let(:odd_sized_numbers) { [3,2,1] }
+    let(:even_sized_numbers) { [4,3,2,1] }
+    let(:one_number) { [1] }
+    let(:two_numbers) { [1,2] }
+    let(:mixed_types) { [3,'a',1] }
+
+    it 'should return middle in odd-sized letters' do
+      expect(odd_sized_letters.median).to eq 'c'
+    end
+
+    it 'should return larger of middle two in even-sized' do
+      expect(even_sized_letters.median).to eq 'd'
+    end
+
+    it 'should return middle in odd-sized numbers' do
+      expect(odd_sized_numbers.median).to eq 2
+    end
+
+    it 'should return avg of middle two in even-sized numbers' do
+      expect(even_sized_numbers.median).to eq 2.5
+    end
+
+    it 'should return the one element for size == 1' do
+      expect(one_number.median).to eq 1
+    end
+
+    it 'should return the average for two number elements' do
+      expect(two_numbers.median).to eq 1.5
+    end
+
+    it 'should raise an error for mixed type lists' do
+      expect {mixed_types.median}.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -21,7 +21,8 @@ describe TimeTrackingCleaner do
       'time_tracking' => {
         'so' => 9999999,
         'but' => 10,
-        'because' => 9
+        'because' => 9,
+        'passage' => 8
       }
     }
   end
@@ -29,9 +30,10 @@ describe TimeTrackingCleaner do
   let(:modified_data) do
     {
       'time_tracking' => {
-        'so' => 10,
+        'so' => 9,
         'but' => 10,
-        'because' => 9
+        'because' => 9,
+        'passage' => 8
       },
       'time_tracking_edits' => {
         'so' => 9999999
@@ -139,6 +141,13 @@ describe TimeTrackingCleaner do
     it 'should not modify hash with existing edits no outliers' do
       expect(TimeTrackingCleaner.run(data_with_existing_edits_no_outliers)).to eq(data_with_existing_edits_no_outliers)
     end
+  end
 
+  describe '#median_value' do
+    let(:time_tracking) { {'time_tracking' => {'a'=>1,'b'=> 2}} }
+
+    it 'should round median to integer' do
+      expect(TimeTrackingCleaner.new(time_tracking).send(:median_value)).to eq(1)
+    end
   end
 end

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -67,8 +67,6 @@ describe TimeTrackingCleaner do
     }
   end
 
-
-
   describe '#clean' do
     it 'should return nil if passed nil' do
       expect(TimeTrackingCleaner.new(nil).clean).to be_nil
@@ -89,7 +87,6 @@ describe TimeTrackingCleaner do
     it 'should modify a hash with outliers and record the edits' do
       expect(TimeTrackingCleaner.new(data_with_outliers).clean).to eq(modified_data)
     end
-
 
     it 'should modify a hash with mulitple outliers and record the edits' do
       expect(TimeTrackingCleaner.new(data_with_multiple_outliers).clean).to eq(modified_data_multiple)

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -23,7 +23,8 @@ describe TimeTrackingCleaner do
         'but' => 10,
         'because' => 9,
         'passage' => 8
-      }
+      },
+      'other_key' => 1
     }
   end
 
@@ -35,6 +36,7 @@ describe TimeTrackingCleaner do
         'because' => 9,
         'passage' => 8
       },
+      'other_key' => 1,
       'time_tracking_edits' => {
         'so' => 9999999
       }
@@ -126,7 +128,7 @@ describe TimeTrackingCleaner do
       expect(TimeTrackingCleaner.run(data_without_outliers)).to eq(data_without_outliers)
     end
 
-    it 'should modify a hash with outliers and record the edits' do
+    it 'should modify a hash with outliers and record the edits, while not touching other keys' do
       expect(TimeTrackingCleaner.run(data_with_outliers)).to eq(modified_data)
     end
 
@@ -141,6 +143,102 @@ describe TimeTrackingCleaner do
     it 'should not modify hash with existing edits no outliers' do
       expect(TimeTrackingCleaner.run(data_with_existing_edits_no_outliers)).to eq(data_with_existing_edits_no_outliers)
     end
+
+    context 'ignored keys' do
+      let(:proofreader_data_no_outlier) do
+        {
+          'time_tracking'=> {
+          'landing'=>4,
+           'prompt_1'=>60,
+           'prompt_2'=>65,
+           'prompt_3'=>25,
+           'prompt_4'=>23,
+           'prompt_5'=>17,
+           'prompt_6'=>42,
+           'proofreading_the_passage'=>176
+         }
+        }
+      end
+
+      let(:proofreader_data_with_outlier) do
+        {
+          'time_tracking'=> {
+          'landing'=>4,
+           'prompt_1'=>60,
+           'prompt_2'=>65,
+           'prompt_3'=>9999999,
+           'prompt_4'=>23,
+           'prompt_5'=>17,
+           'prompt_6'=>42,
+           'proofreading_the_passage'=>176
+         }
+        }
+      end
+
+      let(:modified_proofreader_data_with_outlier) do
+        {
+          'time_tracking'=> {
+          'landing'=>4,
+           'prompt_1'=>60,
+           'prompt_2'=>65,
+           'prompt_3'=>51,
+           'prompt_4'=>23,
+           'prompt_5'=>17,
+           'prompt_6'=>42,
+           'proofreading_the_passage'=>176
+          },
+          'time_tracking_edits' => {
+            'prompt_3'=>9999999
+          }
+        }
+      end
+
+      let(:proofreader_data_with_outlier_passage) do
+        {
+          'time_tracking'=> {
+          'landing'=>4,
+           'prompt_1'=>60,
+           'prompt_2'=>65,
+           'prompt_3'=>9999999,
+           'prompt_4'=>23,
+           'prompt_5'=>17,
+           'prompt_6'=>42,
+           'proofreading_the_passage'=>99999
+         }
+        }
+      end
+
+      let(:modified_proofreader_data_with_outlier_passage) do
+        {
+          'time_tracking'=> {
+          'landing'=>4,
+           'prompt_1'=>60,
+           'prompt_2'=>65,
+           'prompt_3'=>51,
+           'prompt_4'=>23,
+           'prompt_5'=>17,
+           'prompt_6'=>42,
+           'proofreading_the_passage'=>99999
+         },
+          'time_tracking_edits' => {
+            'prompt_3'=>9999999
+          }
+        }
+      end
+
+      it 'should not modify IGNORE_KEY data without outliers' do
+        expect(TimeTrackingCleaner.run(proofreader_data_no_outlier)).to eq(proofreader_data_no_outlier)
+      end
+
+      it 'should modify outliers that isnt in IGNORE_KEY' do
+        expect(TimeTrackingCleaner.run(proofreader_data_with_outlier)).to eq(modified_proofreader_data_with_outlier)
+      end
+
+      it 'should modify outliers that isnt in IGNORE_KEY, and ignore outlier in IGNORE_KEY' do
+        expect(TimeTrackingCleaner.run(proofreader_data_with_outlier_passage)).to eq(modified_proofreader_data_with_outlier_passage)
+      end
+    end
+
   end
 
   describe '#median_value' do

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -67,6 +67,46 @@ describe TimeTrackingCleaner do
     }
   end
 
+  let(:data_with_existing_edits) do
+    {
+      'time_tracking' => {
+        'so' => 10,
+        'but' => 999999,
+        'because' => 9
+      },
+      'time_tracking_edits' => {
+        'so' => 9999999
+      }
+    }
+  end
+
+  let(:modified_data_with_existing_edits) do
+    {
+      'time_tracking' => {
+        'so' => 10,
+        'but' => 10,
+        'because' => 9
+      },
+      'time_tracking_edits' => {
+        'so' => 9999999,
+        'but' => 999999,
+      }
+    }
+  end
+
+   let(:data_with_existing_edits_no_outliers) do
+    {
+      'time_tracking' => {
+        'so' => 10,
+        'but' => 10,
+        'because' => 9
+      },
+      'time_tracking_edits' => {
+        'so' => 9999999
+      }
+    }
+  end
+
   describe '#clean' do
     it 'should return nil if passed nil' do
       expect(TimeTrackingCleaner.run(nil)).to be_nil
@@ -91,5 +131,14 @@ describe TimeTrackingCleaner do
     it 'should modify a hash with mulitple outliers and record the edits' do
       expect(TimeTrackingCleaner.run(data_with_multiple_outliers)).to eq(modified_data_multiple)
     end
+
+    it 'should modify a hash with existing edits and preserve previous edits' do
+      expect(TimeTrackingCleaner.run(data_with_existing_edits)).to eq(modified_data_with_existing_edits)
+    end
+
+    it 'should not modify hash with existing edits no outliers' do
+      expect(TimeTrackingCleaner.run(data_with_existing_edits_no_outliers)).to eq(data_with_existing_edits_no_outliers)
+    end
+
   end
 end

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe TimeTrackingCleaner do
   let(:empty_data) { ({}) }
-  let(:data_with_time_tracking) { ({'other_key' => 'other_value'}) }
+  let(:data_without_time_tracking) { ({'other_key' => 'other_value'}) }
 
   let(:data_without_outliers) do
     {
@@ -77,7 +77,7 @@ describe TimeTrackingCleaner do
     end
 
     it 'should not modify an a hash without time_tracking' do
-      expect(TimeTrackingCleaner.new(data_with_time_tracking).clean).to eq (data_with_time_tracking)
+      expect(TimeTrackingCleaner.new(data_without_time_tracking).clean).to eq (data_without_time_tracking)
     end
 
     it 'should not modify a hash with no outliers' do

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -24,7 +24,7 @@ describe TimeTrackingCleaner do
         'because' => 9
       }
     }
-   end
+  end
 
   let(:modified_data) do
     {
@@ -69,27 +69,27 @@ describe TimeTrackingCleaner do
 
   describe '#clean' do
     it 'should return nil if passed nil' do
-      expect(TimeTrackingCleaner.new(nil).clean).to be_nil
+      expect(TimeTrackingCleaner.run(nil)).to be_nil
     end
 
     it 'should not modify an empty hash' do
-      expect(TimeTrackingCleaner.new(empty_data).clean).to eq ({})
+      expect(TimeTrackingCleaner.run(empty_data)).to eq({})
     end
 
     it 'should not modify an a hash without time_tracking' do
-      expect(TimeTrackingCleaner.new(data_without_time_tracking).clean).to eq (data_without_time_tracking)
+      expect(TimeTrackingCleaner.run(data_without_time_tracking)).to eq(data_without_time_tracking)
     end
 
     it 'should not modify a hash with no outliers' do
-      expect(TimeTrackingCleaner.new(data_without_outliers).clean).to eq(data_without_outliers)
+      expect(TimeTrackingCleaner.run(data_without_outliers)).to eq(data_without_outliers)
     end
 
     it 'should modify a hash with outliers and record the edits' do
-      expect(TimeTrackingCleaner.new(data_with_outliers).clean).to eq(modified_data)
+      expect(TimeTrackingCleaner.run(data_with_outliers)).to eq(modified_data)
     end
 
     it 'should modify a hash with mulitple outliers and record the edits' do
-      expect(TimeTrackingCleaner.new(data_with_multiple_outliers).clean).to eq(modified_data_multiple)
+      expect(TimeTrackingCleaner.run(data_with_multiple_outliers)).to eq(modified_data_multiple)
     end
   end
 end

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TimeTrackingCleaner do
+  let(:empty_data) { ({}) }
+  let(:data_with_time_tracking) { ({'other_key' => 'other_value'}) }
+
+  let(:data_without_outliers) do
+    {
+      'time_tracking' => {
+        'so' => 1,
+        'but' => 2,
+        'because' => 3
+      }
+    }
+  end
+
+  let(:data_with_outliers) do
+    {
+      'time_tracking' => {
+        'so' => 9999999,
+        'but' => 10,
+        'because' => 9
+      }
+    }
+   end
+
+  let(:modified_data) do
+    {
+      'time_tracking' => {
+        'so' => 10,
+        'but' => 10,
+        'because' => 9
+      },
+      'time_tracking_edits' => {
+        'so' => 9999999
+      }
+    }
+  end
+
+  let(:data_with_multiple_outliers) do
+    {
+      'time_tracking' => {
+        'since' => 99999,
+        'so' => 9999999,
+        'henceforth' => 10,
+        'but' => 10,
+        'because' => 9
+      }
+    }
+  end
+
+  let(:modified_data_multiple) do
+    {
+      'time_tracking' => {
+        'since' => 10,
+        'so' => 10,
+        'henceforth' => 10,
+        'but' => 10,
+        'because' => 9
+      },
+      'time_tracking_edits' => {
+        'since' => 99999,
+        'so' => 9999999,
+      }
+    }
+  end
+
+
+
+  describe '#clean' do
+    it 'should return nil if passed nil' do
+      expect(TimeTrackingCleaner.new(nil).clean).to be_nil
+    end
+
+    it 'should not modify an empty hash' do
+      expect(TimeTrackingCleaner.new(empty_data).clean).to eq ({})
+    end
+
+    it 'should not modify an a hash without time_tracking' do
+      expect(TimeTrackingCleaner.new(data_with_time_tracking).clean).to eq (data_with_time_tracking)
+    end
+
+    it 'should not modify a hash with no outliers' do
+      expect(TimeTrackingCleaner.new(data_without_outliers).clean).to eq(data_without_outliers)
+    end
+
+    it 'should modify a hash with outliers and record the edits' do
+      expect(TimeTrackingCleaner.new(data_with_outliers).clean).to eq(modified_data)
+    end
+
+
+    it 'should modify a hash with mulitple outliers and record the edits' do
+      expect(TimeTrackingCleaner.new(data_with_multiple_outliers).clean).to eq(modified_data_multiple)
+    end
+  end
+end

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -96,7 +96,7 @@ describe TimeTrackingCleaner do
     }
   end
 
-   let(:data_with_existing_edits_no_outliers) do
+  let(:data_with_existing_edits_no_outliers) do
     {
       'time_tracking' => {
         'so' => 10,

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -864,24 +864,25 @@ end
   end
 
   describe '#calculate_timespent' do
+    let(:time_tracking) {{"1"=>1, "2"=>2, "3"=>3, "4" => 4}}
+    let(:time_tracking_with_nulls) { {"1"=>188484, "2"=>94405, "3"=>89076, "4"=>120504, "onboarding"=>nil} }
+
     it 'should return nil for nil' do
-      expect(ActivitySession.calculate_timespent(nil)).to be_nil
+      expect(ActivitySession.calculate_timespent(nil, nil)).to be_nil
     end
 
     it 'should return nil for a string' do
-      expect(ActivitySession.calculate_timespent('hello')).to be_nil
+      expect(ActivitySession.calculate_timespent(nil, 'hello')).to be_nil
+    end
+
+    it 'should return timestamp of session passed in' do
+      session = double(timespent: 100)
+
+      expect(ActivitySession.calculate_timespent(session, time_tracking)).to eq(100)
     end
 
     it 'should save timetracking data even if one of the values is nil' do
-      time_tracking = {"1"=>188484, "2"=>94405, "3"=>89076, "4"=>120504, "onboarding"=>nil}
-      expect(ActivitySession.calculate_timespent(time_tracking)).to eq(492469)
-    end
-
-    it 'should replace a large outlier with the median' do
-      time_tracking = {"1"=>1, "2"=>2, "3"=>3, "4" => 4, "onboarding"=>nil, "outlier" => 99999}
-      median = [1,2,3,4,99999].median
-      adjusted_total = 1 + 2 + 3 + 4 + median
-      expect(ActivitySession.calculate_timespent(time_tracking)).to eq(adjusted_total)
+      expect(ActivitySession.calculate_timespent(nil, time_tracking_with_nulls)).to eq(492469)
     end
   end
 

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -875,7 +875,7 @@ end
       expect(ActivitySession.calculate_timespent(nil, 'hello')).to be_nil
     end
 
-    it 'should return timestamp of session passed in' do
+    it 'should return timespent of session passed in' do
       session = double(timespent: 100)
 
       expect(ActivitySession.calculate_timespent(session, time_tracking)).to eq(100)

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -864,9 +864,24 @@ end
   end
 
   describe '#calculate_timespent' do
+    it 'should return nil for nil' do
+      expect(ActivitySession.calculate_timespent(nil)).to be_nil
+    end
+
+    it 'should return nil for a string' do
+      expect(ActivitySession.calculate_timespent('hello')).to be_nil
+    end
+
     it 'should save timetracking data even if one of the values is nil' do
       time_tracking = {"1"=>188484, "2"=>94405, "3"=>89076, "4"=>120504, "onboarding"=>nil}
       expect(ActivitySession.calculate_timespent(time_tracking)).to eq(492469)
+    end
+
+    it 'should replace a large outlier with the median' do
+      time_tracking = {"1"=>1, "2"=>2, "3"=>3, "4" => 4, "onboarding"=>nil, "outlier" => 99999}
+      median = [1,2,3,4,99999].median
+      adjusted_total = 1 + 2 + 3 + 4 + median
+      expect(ActivitySession.calculate_timespent(time_tracking)).to eq(adjusted_total)
     end
   end
 


### PR DESCRIPTION
## WHAT
We are doing nuanced time-tracking per prompt on the front end, but there is an existing bug in that calculation which is causing many time-tracking lists to have one element that is a very large number (likely from a resumed session). 

We should fix the bug on the frontend, but the code here is a backstop against clearly bad data being recorded. It replaces any individual time element that is 40x the median with the median, e.g. the total for the list `[1,2,3,4,999999]` would be calculated as `[1,2,3,4,3].sum`
## WHY
Time tracking is important to teachers, but these large outliers really distort the data. Replacing with the median of the other values seems like a reasonable stopgap.
## HOW
Add Array extension for `Array.median`. Add a bunch of tests. Replace individual outliers with median.

Edit:
I added a `TimeTrackingCleaner` class and am editing the granular time_tracking data, and I've returned the `timespent` calculation to just be a `sum`.

Note `40x median` was my initial guess at a reasonable outlier threshold. It's likely that could be lower.

### Screenshots
Examples (time is in seconds)
![Screen Shot 2022-04-06 at 12 30 24 PM](https://user-images.githubusercontent.com/1304933/162023107-23b2982f-ab2e-433b-996d-04c567644700.png)
![Screen Shot 2022-04-06 at 12 29 59 PM](https://user-images.githubusercontent.com/1304933/162023110-11a2206d-8fe5-4078-82f4-637a10f61a2e.png)
![Screen Shot 2022-04-06 at 12 30 12 PM](https://user-images.githubusercontent.com/1304933/162023111-8d7f74b9-5e71-4a8a-b35a-48ec569bf76c.png)


### Notion Card Links
https://www.notion.so/quill/ActivitySession-Time-Tracking-Outliers-Backend-mitigation-dbf94350104d460f8a6f8ce5c95799a4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | (Possible answers:Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YEs
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
