### PR TITLE
Add remover to app setting rake

### DIFF
--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -38,4 +38,21 @@ namespace :app_settings do
     app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list.concat(user_ids).uniq)
     puts "AppSetting #{app_setting.name} has been updated with user list: #{user_ids}."
   end
+
+  # Example usage: rake 'remove_user_ids_from_allow_list[theName, filename]'
+  # This task uses ids instead of emails, since some users do not have emails
+  task :remove_user_ids_from_allow_list, [:name, :filename] => :environment do |t, args|
+    iostream = File.read(args[:filename])
+    if (CSV.parse(iostream, headers: true).headers & ["id"]).count != 1
+      puts "Invalid headers. Exiting."
+      exit 1
+    end
+
+    removable_user_ids = CSV.parse(iostream, headers: true).map { |row| row['id'] }.map(&:to_i)
+
+    app_setting = AppSetting.find_by_name!(args[:name])
+
+    app_setting.update!(user_ids_allow_list: app_setting.user_ids_allow_list - removable_user_ids)
+    puts "AppSetting #{app_setting.name} has been updated with these users removed: #{removable_user_ids}."
+  end
 end

--- a/services/QuillLMS/lib/tasks/flags.rake
+++ b/services/QuillLMS/lib/tasks/flags.rake
@@ -26,5 +26,24 @@ namespace :flags do
       end
     end
 
+    desc 'remove specified flag for users from a CSV file'
+    task :remove_from_csv, [:filepath, :flag_name] => :environment do |t, args|
+      iostream = File.read(args[:filepath])
+      if (CSV.parse(iostream, headers: true).headers & ['id']).count != 1
+        puts "Invalid headers. Exiting."
+        exit 1
+      end
+
+      CSV.parse(iostream, headers: true) do |row|
+        user = User.find_by_id(row['id'])
+        if user.nil?
+          puts "Unable to locate user with id #{row['id']}"
+          next
+        end
+
+        user.update!(flags: user.flags - [args[:flag_name]])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## WHAT
Some students are bucketed in AppSettings::comprehension and flags.beta. We want to remove them in a standardized, repeatable way. 

https://data.quill.org/question/834-students-improperly-bucketed-in-app-setting-or-beta-flag

## WHY
Students should not be in these buckets.

## HOW
2 rake tasks

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=2ed4ccdc92714554be67d2d62937de15

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  rake tasks tested manually on staging
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
