### PR TITLE
fix bug with changing recurring status on subscriptions page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default class extends React.Component {
+export default class ChangePlan extends React.Component {
   handleChange = e => {
     // So it turns out that `value={false}` below doesn't set the value to a boolean, but to the string "false" which, of course, evaluates as truth-y.  This meant that both checking the truthiness of the value itself is the same in both cases, and the buttons won't toggle.
     this.props.changeRecurringStatus(e.target.value !== 'false');

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -307,8 +307,9 @@ export default class CurrentSubscription extends React.Component {
     this.setState({ lastFour: newLastFour, });
   };
 
-  updateRecurring = (recurring) => {
+  updateRecurring = () => {
     const { updateSubscription, subscriptionStatus, } = this.props
+    const { recurring, } = this.state
     updateSubscription(
       { recurring, }, _.get(subscriptionStatus, 'id'));
   };


### PR DESCRIPTION
## WHAT
Fix bug with changing recurring status on subscriptions page.

## WHY
We want teachers to be able to do this.

## HOW
Just update it to use the value in state rather than a passed-in value, which was actually a mouse event.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Change-Plan-doesn-t-seem-to-be-working-3b3e40a93e32495cb68de41daac5c52f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
