### PR TITLE
add rule to lookup table

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -55,7 +55,7 @@ module Evidence
         'subject_verb_agreement_with_simple_noun_singular_noun_with_singular_to_have_verb_optimal_and_error_is_plural_to_have_verb' => '3feb708d-b789-42dc-8b7a-7288a0945fff',
         'than_versus_then_than_optimal' => '4aa3f48b-7be9-414b-91e0-ffa92c85f323',
         'than_versus_then_then_optimal' => 'ad97bd7a-1215-4c52-91ec-8973d646a381',
-        'their_vs_there_vs_they_re_they_optimal' => 'e4cf078b-a838-445e-a873-c795da9f7ed8',
+        'their_vs_there_vs_they_re_they_re_optimal' => 'e4cf078b-a838-445e-a873-c795da9f7ed8',
         'their_vs_there_vs_they_re_their_optimal' => '6ca8f080-c4a2-470e-8171-0fa72f0b18da',
         'their_vs_there_vs_they_re_there_optimal' => 'f257a25f-8bc3-46ce-b811-82cbd98fad2a',
         'there_no' => 'd1ffc7b1-12a6-43c5-9eb8-593215a04eb5',

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
@@ -18,6 +18,23 @@ module Evidence
           }
         end
 
+        context 'specific rule checks' do
+          context 'their_vs_there_vs_they_re_they_re_optimal' do
+            let!(:rule) do
+              create(:evidence_rule, uid: 'e4cf078b-a838-445e-a873-c795da9f7ed8', optimal: false, rule_type: 'grammar')
+            end
+
+            it 'should return the expected rule uid' do
+              error_name = 'their_vs_there_vs_they_re_they_re_optimal'
+              expect(
+                FeedbackAssembler.run(
+                  client_response.merge({FeedbackAssembler.error_name => error_name})
+                )[:rule_uid]
+              ).to eq rule.uid
+            end
+          end
+        end
+
         context 'detects no grammar' do
           it 'should return optimal=true' do
             expect(


### PR DESCRIPTION
## WHAT
Adds rule to lookup table so that FeedbackAssembler can find the corresponding Evidence::Rule

## WHY
Lack of the lookup is causing an error in Evidence plays: https://sentry.io/organizations/quillorg-5s/issues/3168357514/?project=11238&referrer=slack 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=ebd86db4f61a46e8be8bf078f1430d0b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
