### PR TITLE
Evidence/resume on correct prompt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -154,6 +154,11 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
     const uniqueCompletedSteps = Array.from(new Set(completedSteps))
     const { activeStep } = session;
+
+    // Don't go to the next step if we haven't flagged the current step as completed
+    // This particular condition can occur when loading data from a partially-completed session which triggers this effect
+    if (!uniqueCompletedSteps.includes(activeStep)) return
+
     let nextStep: number|undefined = activeStep + 1
     if (nextStep > ALL_STEPS.length || uniqueCompletedSteps.includes(nextStep)) {
       nextStep = ALL_STEPS.find(s => !uniqueCompletedSteps.includes(s))

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -173,6 +173,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       dispatch(setActiveStepForSession(nextStep))
       setStartTime(Date.now())
       trackCurrentPromptStartedEvent()
+      callSaveActiveActivitySession()
     } else {
       trackActivityCompletedEvent(); // If there is no next step, the activity is done
     }


### PR DESCRIPTION
## WHAT
- Add another early exit condition to incrementing the active step to prevent incrementing active step if the current step is not marked as completed
- Make sure we update `ActiveActivitySession` when we set a new activeStep so that students resuming activities will wind up on the step they expect
## WHY
We want students to be able to resume activities seamlessly and successfully
## HOW
The code that loaded existing partially-completed sessions on resume was interacting with the code that figured out if the student needed to be sent to the next step, and thus resuming an activity always set the student to the step AFTER the one they were most recently on.  This change stops that from happening.

### Notion Card Links
https://www.notion.so/quill/Resuming-an-Evidence-activity-takes-student-to-the-next-stem-even-if-5-attempts-were-submitted-7dc8f44d9cc944739be466eb8f49739b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, there are no tests that I could find around the student view behavior
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A