### PR TITLE
check prompt param in FeedbackController

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -74,6 +74,8 @@ module Evidence
 
     private def set_params
       @entry = params[:entry]
+      return render(:body => nil, :status => 404) unless @entry
+
       begin
         @prompt = Evidence::Prompt.find(params[:prompt_id])
       rescue ActiveRecord::RecordNotFound

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -41,6 +41,12 @@ module Evidence
         expect(parsed_response['key1']).to eq('some value')
       end
 
+      it 'should return 404 when the entry is empty' do
+        post :create, params: {prompt_id: prompt.id, session_id: session_id, previous_feedback: ([]), attempt: attempt }, as: :json
+
+        expect(response.status).to eq 404
+      end
+
       context "fallback response" do
         let(:fallback_feedback) { Check::FALLBACK_RESPONSE }
 


### PR DESCRIPTION
## WHAT
404 and return early if entry does not exist in FeedbackController::create 

## WHY
So we can error early, and so that malformed requests are more easily distinguished from legitimate bugs.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=5aef295dee3d44ecbc5472d79ddc9df6)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
