### PR TITLE
Make Evidence API Timeout Errors more specific

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -7,7 +7,9 @@ module Evidence
       ALLOWED_PAYLOAD_KEYS = ['gapi_error', 'highlight']
       API_ENDPOINT = ENV['GRAMMAR_API_DOMAIN']
 
-      class GrammarAPIError < StandardError; end
+      class APIError < StandardError; end
+      class APITimeoutError < StandardError; end
+      TIMEOUT_ERROR_MESSAGE = "request took longer than #{API_TIMEOUT} seconds"
 
       def initialize(entry:, prompt_text:)
         @entry = entry
@@ -15,7 +17,17 @@ module Evidence
       end
 
       def post
-        response = HTTParty.post(
+        response = api_request
+
+        if !response.success?
+          raise APIError, "Encountered upstream error: #{response}"
+        end
+
+        response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
+      end
+
+      private def api_request
+        HTTParty.post(
           API_ENDPOINT,
           headers:  {'Content-Type': 'application/json'},
           body:     {
@@ -24,13 +36,8 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-
-        if !response.success?
-          raise GrammarAPIError, "Encountered upstream error: #{response}"
-        end
-
-        response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
-
+      rescue Net::OpenTimeout => e
+        raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -36,11 +36,10 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-      rescue Net::OpenTimeout => e
+      rescue Net::OpenTimeout
         raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end
-
   end
 end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
@@ -36,7 +36,7 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-      rescue Net::OpenTimeout => e
+      rescue Net::OpenTimeout
         raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
@@ -7,7 +7,9 @@ module Evidence
       ALLOWED_PAYLOAD_KEYS = ['oapi_error', 'highlight']
       API_ENDPOINT = ENV['OPINION_API_DOMAIN']
 
-      class OpinionAPIError < StandardError; end
+      class APIError < StandardError; end
+      class APITimeoutError < StandardError; end
+      TIMEOUT_ERROR_MESSAGE = "request took longer than #{API_TIMEOUT} seconds"
 
       def initialize(entry:, prompt_text:)
         @entry = entry
@@ -15,7 +17,17 @@ module Evidence
       end
 
       def post
-        response = HTTParty.post(
+        response = api_request
+
+        if !response.success?
+          raise APIError, "Encountered upstream error: #{response}"
+        end
+
+        response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
+      end
+
+      private def api_request
+        HTTParty.post(
           API_ENDPOINT,
           headers:  {'Content-Type': 'application/json'},
           body:     {
@@ -24,16 +36,10 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-
-        if !response.success?
-          raise OpinionAPIError, "Encountered upstream error: #{response}"
-        end
-
-        response.filter { |k,v| ALLOWED_PAYLOAD_KEYS.include?(k) }
-
+      rescue Net::OpenTimeout => e
+        raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end
-
   end
 end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -2,8 +2,6 @@
 
 module Evidence
   class SpellingCheck
-    class BingRateLimitException < StandardError; end
-
     API_TIMEOUT = 5
     ALL_CORRECT_FEEDBACK = '<p>Correct spelling!</p>'
     FALLBACK_INCORRECT_FEEDBACK = '<p>Update the spelling of the bolded word(s).</p>'
@@ -11,6 +9,10 @@ module Evidence
     RESPONSE_TYPE = 'response'
     BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'
     SPELLING_CONCEPT_UID = 'H-2lrblngQAQ8_s-ctye4g'
+
+    class BingRateLimitException < StandardError; end
+    class BingTimeoutError < StandardError; end
+    TIMEOUT_ERROR_MESSAGE = "request took longer than #{API_TIMEOUT} seconds"
 
     # TODO: replace with better exception code
     EXCEPTIONS = [
@@ -94,7 +96,7 @@ module Evidence
 
       JSON.parse(@response.body)
     rescue Net::OpenTimeout
-      {}
+      raise BingTimeoutError, TIMEOUT_ERROR_MESSAGE
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
@@ -24,13 +24,13 @@ module Evidence
         errored_response = sample_response.merge(status: 500)
         stub_request(:post, mock_endpoint).to_return(errored_response)
 
-        expect { client.post}.to raise_error(Evidence::Grammar::Client::GrammarAPIError)
+        expect { client.post}.to raise_error(Evidence::Grammar::Client::APIError)
       end
 
       it 'should raise error on timeout' do
         stub_request(:post, mock_endpoint).to_timeout
 
-        expect { client.post }.to raise_error(Net::OpenTimeout)
+        expect { client.post }.to raise_error(Evidence::Grammar::Client::APITimeoutError, "request took longer than 5 seconds")
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -24,13 +24,13 @@ module Evidence
         errored_response = sample_response.merge(status: 500)
         stub_request(:post, mock_endpoint).to_return(errored_response)
 
-        expect { client.post}.to raise_error(Evidence::Opinion::Client::OpinionAPIError)
+        expect { client.post}.to raise_error(Evidence::Opinion::Client::APIError)
       end
 
       it 'should raise error on timeout' do
         stub_request(:post, mock_endpoint).to_timeout
 
-        expect { client.post }.to raise_error(Net::OpenTimeout)
+        expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError, "request took longer than 5 seconds")
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -65,17 +65,12 @@ module Evidence
         expect(feedback[:concept_uid]).to(be_truthy)
       end
 
-      it 'should return appropriate feedback attributes if there the API request times out on the client side' do
+      it 'should raise error if the Bing API request times out' do
         stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
-        feedback = spelling_check.feedback_object
-        expect(feedback[:feedback]).to(be_truthy)
-        expect(feedback[:feedback_type]).to(be_truthy)
-        expect(feedback[:optimal]).to(be_truthy)
-        expect(feedback[:entry]).to(be_truthy)
-        expect(feedback[:rule_uid]).to(be_truthy)
-        expect(feedback[:concept_uid]).to(be_truthy)
+
+        expect {spelling_check.feedback_object}.to raise_error(Evidence::SpellingCheck::BingTimeoutError, "request took longer than 5 seconds")
       end
 
       it 'should return appropriate error if the endpoint returns an error' do


### PR DESCRIPTION
## WHAT
Replace generic `Net::OpenTimeout` with API-specific timeouts, e.g. `Evidence::Grammar::Client::APITimeoutError`
## WHY
The goal is to make error tracking easier. In the current code you can't see which API timed out in the top-line error report (you see `Net::OpenTimeout` and you have to click through the trace to see the line it was raised on to determine the API). `Evidence::Grammar::Client::APITimeoutError` is a clear, specific error, that will make that easier to parse. This will also keep errors grouped by API to make frequency tracking easier.
## HOW
```ruby
rescue Net::OpenTimeout
  raise SpecificError, message
end
```
### Screenshots

Current error in Slack
<img width="681" alt="Screen Shot 2022-04-12 at 10 23 05 AM" src="https://user-images.githubusercontent.com/1304933/162984367-c717519d-e762-4443-a6e6-27dcc775e25e.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 