### PR TITLE
LMS - Don't record large params in NR

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -8,8 +8,6 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
   end
 
   def update
-    # TODO: remove testing sleep
-    sleep 5
     retried = false
     begin
       @activity_session = ActiveActivitySession.find_or_initialize_by(uid: params[:id])

--- a/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/active_activity_sessions_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::ActiveActivitySessionsController < Api::ApiController
   end
 
   def update
+    # TODO: remove testing sleep
+    sleep 5
     retried = false
     begin
       @activity_session = ActiveActivitySession.find_or_initialize_by(uid: params[:id])

--- a/services/QuillLMS/config/newrelic.yml
+++ b/services/QuillLMS/config/newrelic.yml
@@ -27,7 +27,7 @@ common: &default_settings
   # https://docs.newrelic.com/docs/apm/agents/ruby-agent/attributes/ruby-attribute-examples/
   attributes.include: request.parameters.*
   # Note, excluding 'active_activity_session' and 'activity_session' to cut down on NR data usage. They are very large params.
-  attributes.exclude: [request.parameters.password, request.parameters.password_confirmation, request.parameters.email, request.parameters.name, request.parameters.active_activity_session, request.parameters.activity_session]
+  attributes.exclude: [request.parameters.password, request.parameters.password_confirmation, request.parameters.email, request.parameters.name, request.parameters.active_activity_session.*, request.parameters.activity_session.*]
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.


### PR DESCRIPTION
## WHAT
Add wildcard to param to exclude `request.parameters.active_activity_session.*` and `request.parameters.active_activity_session.*` from New relic. This is a second attempt (first attempt [here](https://github.com/empirical-org/Empirical-Core/pull/9038) didn't work)
## WHY
Data
## HOW
Change exclude param from `request.parameters.active_activity_session` (didn't work) to `request.parameters.active_activity_session.*`
### Screenshots
Confirmed on staging this is ignoring the param.
![Screen Shot 2022-04-12 at 1 20 33 PM](https://user-images.githubusercontent.com/1304933/163018765-4e9d88c9-b726-4b54-81cd-2331b9a80747.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'NO', api config change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes, really impressive.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
