### PR TITLE
LMS Evidence - Use specific errors for API Net::ReadTimeout errors

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "evidence/engine"
+require 'net/http'
 
 module Evidence
   HTTP_TIMEOUT_ERRORS = [::Net::OpenTimeout, ::Net::ReadTimeout]

--- a/services/QuillLMS/engines/evidence/lib/evidence.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence.rb
@@ -3,6 +3,8 @@
 require "evidence/engine"
 
 module Evidence
+  HTTP_TIMEOUT_ERRORS = [::Net::OpenTimeout, ::Net::ReadTimeout]
+
   mattr_accessor :parent_activity_class
   mattr_accessor :parent_activity_classification_class
   mattr_accessor :change_log_class

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -36,7 +36,7 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-      rescue Net::OpenTimeout
+      rescue *Evidence::HTTP_TIMEOUT_ERRORS
         raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/opinion/client.rb
@@ -36,7 +36,7 @@ module Evidence
           }.to_json,
           timeout: API_TIMEOUT
         )
-      rescue Net::OpenTimeout
+      rescue *Evidence::HTTP_TIMEOUT_ERRORS
         raise APITimeoutError, TIMEOUT_ERROR_MESSAGE
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -95,7 +95,7 @@ module Evidence
       raise BingRateLimitException if @response.code == 429
 
       JSON.parse(@response.body)
-    rescue Net::OpenTimeout
+    rescue *Evidence::HTTP_TIMEOUT_ERRORS
       raise BingTimeoutError, TIMEOUT_ERROR_MESSAGE
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/client_spec.rb
@@ -32,6 +32,12 @@ module Evidence
 
         expect { client.post }.to raise_error(Evidence::Grammar::Client::APITimeoutError, "request took longer than 5 seconds")
       end
+
+      it 'should raise error on Net::ReadTimeout timeout' do
+        stub_request(:post, mock_endpoint).to_raise(Net::ReadTimeout)
+
+        expect { client.post }.to raise_error(Evidence::Grammar::Client::APITimeoutError, "request took longer than 5 seconds")
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -32,6 +32,12 @@ module Evidence
 
         expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError, "request took longer than 5 seconds")
       end
+
+      it 'should raise error on Net::ReadTimeout timeout' do
+        stub_request(:post, mock_endpoint).to_raise(Net::ReadTimeout)
+
+        expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError, "request took longer than 5 seconds")
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -73,6 +73,15 @@ module Evidence
         expect {spelling_check.feedback_object}.to raise_error(Evidence::SpellingCheck::BingTimeoutError, "request took longer than 5 seconds")
       end
 
+      it 'should raise error if the Bing API request times out with a Net::ReadTimeout' do
+        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_raise(Net::ReadTimeout)
+        entry = "there is no spelling error here"
+        spelling_check = Evidence::SpellingCheck.new(entry)
+
+        expect {spelling_check.feedback_object}.to raise_error(Evidence::SpellingCheck::BingTimeoutError, "request took longer than 5 seconds")
+      end
+
+
       it 'should return appropriate error if the endpoint returns an error' do
         stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"


### PR DESCRIPTION
## WHAT
Follow on to PR #9058, capture `Net::ReadTimeout` in addition to `Net::OpenTimeout`
## WHY
Bing seems to return `Net::ReadTimeout`, we want these to also be grouped by specific APIs for error tracking
## HOW
Make a `HTTP_TIMEOUT_ERRORS` that all APIs use. Add tests.
### Screenshots
<img width="726" alt="Screen Shot 2022-04-12 at 1 45 26 PM" src="https://user-images.githubusercontent.com/1304933/163023429-26611fe2-bbc2-4fc3-8871-53e10b911392.png">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   Yes
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
