### PR TITLE
LMS - Send error context to Sentry. Add more error context to Evidence Errors.

### DIFF
--- a/services/QuillLMS/app/lib/error_notifier.rb
+++ b/services/QuillLMS/app/lib/error_notifier.rb
@@ -3,7 +3,7 @@
 module ErrorNotifier
   # pass an exception
   def self.report(error, options = {})
-    Raven.capture_exception(error)
+    Raven.capture_exception(error, extra: options)
     NewRelic::Agent.notice_error(error, options)
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/base.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/base.rb
@@ -22,7 +22,8 @@ module Evidence
         begin
           check.run
         rescue => e
-          Evidence.error_notifier.report(e)
+          context = {entry: entry, prompt_id: prompt&.id, prompt_text: prompt&.text}
+          Evidence.error_notifier.report(e, context)
 
           @error = e
         end

--- a/services/QuillLMS/engines/evidence/spec/dummy/app/models/error_notifier.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/app/models/error_notifier.rb
@@ -1,6 +1,6 @@
 class ErrorNotifier
 
-  def self.report(error)
+  def self.report(error, options = {})
 
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 module Evidence
   RSpec.describe(Check, type: :module) do
     let(:entry) { 'this is the entry'}
-    let(:prompt) {'some prompt'}
+    let(:prompt) { double(id: 123, text: 'some prompt') }
     let(:previous_feedback) { []}
     let(:error) {Evidence::Check::Spelling::BingException}
+    let(:error_context) { {entry: entry, prompt_id: prompt.id, prompt_text: prompt.text}}
 
     context "get_feedback" do
       let(:response) { {key: 'value'} }
@@ -71,7 +72,7 @@ module Evidence
           first_check_class = Evidence::Check::ALL_CHECKS.first
           second_check_class = Evidence::Check::ALL_CHECKS.second
 
-          expect(Evidence.error_notifier).to receive(:report).with(error).once
+          expect(Evidence.error_notifier).to receive(:report).with(error, error_context).once
           expect_any_instance_of(first_check_class).to receive(:run).once.and_raise(error)
           expect_any_instance_of(second_check_class).to receive(:run).once
           expect_any_instance_of(second_check_class).to receive(:optimal?).once.and_return(false)
@@ -89,7 +90,7 @@ module Evidence
 
     context "fallback_feedback" do
       it 'should construct feedback based on an error-type rule if it exists' do
-        expect(Evidence.error_notifier).to receive(:report).with(error).once
+        expect(Evidence.error_notifier).to receive(:report).with(error, error_context).once
 
         Check::ALL_CHECKS.each do |check_class|
           if check_class == Check::AutoML
@@ -110,7 +111,7 @@ module Evidence
       end
 
       it 'provides constant-based feedback if there is no error-type rule' do
-        expect(Evidence.error_notifier).to receive(:report).with(error).once
+        expect(Evidence.error_notifier).to receive(:report).with(error, error_context).once
 
         Check::ALL_CHECKS.each do |check_class|
           if check_class == Check::AutoML

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -182,7 +182,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           }
         }
 
-        expect(Raven).to receive(:capture_exception).with(ActivitySession::LongTimeTrackingError).once
+        expect(ErrorNotifier).to receive(:report).with(ActivitySession::LongTimeTrackingError).once
 
         put :update, params: { id: activity_session.uid, data: data }, as: :json
       end

--- a/services/QuillLMS/spec/lib/error_notifier_spec.rb
+++ b/services/QuillLMS/spec/lib/error_notifier_spec.rb
@@ -5,12 +5,20 @@ require 'rails_helper'
 describe ErrorNotifier do
   describe '#report' do
     let(:error) { StandardError }
+    let(:key_values) { {key: 'value', key2: 'value2'}}
 
     it 'should notify Sentry (Raven) and New Relic' do
-      expect(Raven).to receive(:capture_exception).with(error).once
+      expect(Raven).to receive(:capture_exception).with(error, extra: {}).once
       expect(NewRelic::Agent).to receive(:notice_error).with(error, {}).once
 
       ErrorNotifier.report(error)
+    end
+
+    it 'should notify Sentry (Raven) and New Relic with additional context' do
+      expect(Raven).to receive(:capture_exception).with(error, extra: key_values).once
+      expect(NewRelic::Agent).to receive(:notice_error).with(error, key_values).once
+
+      ErrorNotifier.report(error, key_values)
     end
   end
 


### PR DESCRIPTION
## WHAT
Add more context to Evidence errors. Send additional context to `Sentry` as well as `New Relic`.
## WHY
Helpful context in an error report makes it much easier to debug.
## HOW
Use the `Raven.capture(e, extra: )` key as documented here:
https://docs.sentry.io/clients/ruby/usage/

This
```ruby
begin
  raise StandardError, 'test message'
rescue => e
  Raven.capture_exception(e, extra: {entry: 'hello', prompt_id: 5}) 
end
```
comes through as this:
![Screen Shot 2022-04-13 at 2 45 03 PM](https://user-images.githubusercontent.com/1304933/163249291-1329e9e1-3ba5-4ae6-b985-37247968f332.png)






PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? |  NO - tiny change, did manual testing
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
