### PR TITLE
new grammar bolding algorithm

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -105,8 +105,6 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     return submittedResponses.map(r => r.entry).concat(text)
   }
 
-  stripHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>|<br>|<br\/>/g, '').replace(/&nbsp;/g, ' ')
-
   formattedPrompt = (submittedResponses?: Array<string>) => {
     if (submittedResponses && submittedResponses.length) {
       const lastSubmission = submittedResponses[submittedResponses.length - 1]

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -145,7 +145,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     return highlightSpelling(str, wordsToFormat)
   }
 
-  formatStudentResponse = (str: string) => {
+  formatStudentResponse = (str: string, promptLength: number) => {
     const { prompt, submittedResponses, } = this.props
     const lastSubmittedResponse = this.lastSubmittedResponse()
 
@@ -164,7 +164,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     if (lastSubmittedResponse.feedback_type === 'plagiarism') {
       return this.formatPlagiarismHighlight(str, wordsToFormat)
     } else if (lastSubmittedResponse.feedback_type === 'grammar') {
-      return highlightGrammar(str, filteredHighlights)
+      return highlightGrammar(str, filteredHighlights, promptLength)
     } else {
       return highlightSpelling(str, wordsToFormat)
     }
@@ -319,7 +319,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     const textForCharacterCount = stripHtml(textWithoutStem);
     const spaceAtEnd = text.match(/\s$/m) ? '&nbsp;' : ''
     return {
-      htmlWithBolding: `<p>${this.highlightsAddedPrompt(this.htmlStrippedPrompt())}${this.formatStudentResponse(textWithoutStem)}${spaceAtEnd}</p>`,
+      htmlWithBolding: `<p>${this.highlightsAddedPrompt(this.htmlStrippedPrompt())}${this.formatStudentResponse(textWithoutStem, prompt.text.length)}${spaceAtEnd}</p>`,
       rawTextWithoutStem: textWithoutStem,
       textForCharacterCount
     }

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -50,7 +50,7 @@ describe('stringFormatting', () => {
       expect(result).toEqual('lorem ipsum <b>ipsum</b>')
     });
 
-    it('should not bold a phrase after the given character', () => {
+    it('should not bold a phrase twice', () => {
       const result = highlightGrammar('lorem ipsum ipsum', [{character: 1, text: "ipsum"}])
       expect(result).toEqual('lorem <b>ipsum</b> ipsum')
     });

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -64,5 +64,14 @@ describe('stringFormatting', () => {
       expect(result).toEqual('lorem <b>ipsum</b> ipsum <b>lorem</b>')
     });
 
+    it('should play', () => {
+      const highlights = [
+        { offset: 0, text: "they" },
+        { offset: 73, text: "is" }
+      ]
+      const result = highlightGrammar('they is great.', highlights)
+      expect(result).toEqual("<b>they</b> is great.")
+    });
+
   });
 });

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -41,36 +41,38 @@ describe('stringFormatting', () => {
     });
 
     it('should bold, given 1 highlight', () => {
-      const result = highlightGrammar('lorem ipsum', [{offset: 6, text: "ipsum"}])
+      const result = highlightGrammar('lorem ipsum', [{character: 6, text: "ipsum"}])
       expect(result).toEqual('lorem <b>ipsum</b>')
     });
 
-    it('should not bold a phrase before the given offset', () => {
-      const result = highlightGrammar('lorem ipsum ipsum', [{offset: 8, text: "ipsum"}])
+    it('should not bold a phrase before the given character', () => {
+      const result = highlightGrammar('lorem ipsum ipsum', [{character: 8, text: "ipsum"}])
       expect(result).toEqual('lorem ipsum <b>ipsum</b>')
     });
 
-    it('should not bold a phrase after the given offset', () => {
-      const result = highlightGrammar('lorem ipsum ipsum', [{offset: 0, text: "ipsum"}])
+    it('should not bold a phrase after the given character', () => {
+      const result = highlightGrammar('lorem ipsum ipsum', [{character: 0, text: "ipsum"}])
       expect(result).toEqual('lorem <b>ipsum</b> ipsum')
     });
 
     it('should handle multiple, offsorted highlights', () => {
       const highlights = [
-        { offset: 18, text: "lorem" },
-        { offset: 6, text: "ipsum" }
+        { character: 18, text: "lorem" },
+        { character: 6, text: "ipsum" }
       ]
       const result = highlightGrammar('lorem ipsum ipsum lorem', highlights)
       expect(result).toEqual('lorem <b>ipsum</b> ipsum <b>lorem</b>')
     });
 
-    it('should play', () => {
+    // This is because the offsets are calculated from the start of the prompt + entry string,
+    // not just the entry
+    it('should incorporate promptLength param', () => {
       const highlights = [
-        { offset: 0, text: "they" },
-        { offset: 73, text: "is" }
+        { character: 10, text: "they" },
+        { character: 15, text: "is" }
       ]
-      const result = highlightGrammar('they is great.', highlights)
-      expect(result).toEqual("<b>they</b> is great.")
+      const result = highlightGrammar('they is great.', highlights, 10)
+      expect(result).toEqual("<b>they</b> <b>is</b> great.")
     });
 
   });

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -51,8 +51,8 @@ describe('stringFormatting', () => {
     });
 
     it('should not bold a phrase after the given character', () => {
-      const result = highlightGrammar('lorem ipsum ipsum', [{character: 0, text: "ipsum"}])
-      expect(result).toEqual('lorem ipsum ipsum')
+      const result = highlightGrammar('lorem ipsum ipsum', [{character: 1, text: "ipsum"}])
+      expect(result).toEqual('lorem <b>ipsum</b> ipsum')
     });
 
     it('should handle multiple, offsorted highlights', () => {

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -1,34 +1,68 @@
-import { highlightSpellingGrammar } from "./stringFormatting"
+import { iteratee } from "lodash";
+
+import { highlightGrammar, highlightSpelling } from "./stringFormatting"
 
 
 describe('stringFormatting', () => {
-  describe('highlightSpellingGrammar', () => {
+  describe('highlightSpelling', () => {
     it('basic', () => {
-      const result = highlightSpellingGrammar('lorem ipsum', 'ipsum')
+      const result = highlightSpelling('lorem ipsum', 'ipsum')
       expect(result).toEqual("lorem <b>ipsum</b>")
     });
 
     it('should accept an array for wordsToFormat arg', () => {
-      const result = highlightSpellingGrammar('lorem ipsum foo', ['ipsum', 'foo'])
+      const result = highlightSpelling('lorem ipsum foo', ['ipsum', 'foo'])
       expect(result).toEqual("lorem <b>ipsum</b> <b>foo</b>")
     });
 
     it('should highlight all instances of a matchword', () => {
-      const result = highlightSpellingGrammar(`lorem ipsum lorem`, 'lorem')
+      const result = highlightSpelling(`lorem ipsum lorem`, 'lorem')
       expect(result).toEqual(`<b>lorem</b> ipsum <b>lorem</b>`)
     });
 
     it('should highlight all of a word when a word substring is matched', () => {
-      const result = highlightSpellingGrammar("lorem shouldn't ipsum", 'should')
+      const result = highlightSpelling("lorem shouldn't ipsum", 'should')
       expect(result).toEqual(`lorem <b>shouldn't</b> ipsum`)
     });
     it('should highlight all of a word when a word substring is matched', () => {
-      const result = highlightSpellingGrammar("lorem shouldn't ipsum", 'should')
+      const result = highlightSpelling("lorem shouldn't ipsum", 'should')
       expect(result).toEqual(`lorem <b>shouldn't</b> ipsum`)
     });
     it('should not highlight nonbreaking space character', () => {
-      const result = highlightSpellingGrammar("&nbsp lorem ipsum shouldn't", "&nbsp")
+      const result = highlightSpelling("&nbsp lorem ipsum shouldn't", "&nbsp")
       expect(result).toEqual(`&nbsp lorem ipsum shouldn't`)
     });
+  });
+
+  describe('highlightGrammar', () => {
+    it('return the original string input when highlights are empty', () => {
+      const result = highlightGrammar('lorem ipsum', [])
+      expect(result).toEqual('lorem ipsum')
+    });
+
+    it('should bold, given 1 highlight', () => {
+      const result = highlightGrammar('lorem ipsum', [{offset: 6, text: "ipsum"}])
+      expect(result).toEqual('lorem <b>ipsum</b>')
+    });
+
+    it('should not bold a phrase before the given offset', () => {
+      const result = highlightGrammar('lorem ipsum ipsum', [{offset: 8, text: "ipsum"}])
+      expect(result).toEqual('lorem ipsum <b>ipsum</b>')
+    });
+
+    it('should not bold a phrase after the given offset', () => {
+      const result = highlightGrammar('lorem ipsum ipsum', [{offset: 0, text: "ipsum"}])
+      expect(result).toEqual('lorem <b>ipsum</b> ipsum')
+    });
+
+    it('should handle multiple, offsorted highlights', () => {
+      const highlights = [
+        { offset: 18, text: "lorem" },
+        { offset: 6, text: "ipsum" }
+      ]
+      const result = highlightGrammar('lorem ipsum ipsum lorem', highlights)
+      expect(result).toEqual('lorem <b>ipsum</b> ipsum <b>lorem</b>')
+    });
+
   });
 });

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.test.ts
@@ -52,7 +52,7 @@ describe('stringFormatting', () => {
 
     it('should not bold a phrase after the given character', () => {
       const result = highlightGrammar('lorem ipsum ipsum', [{character: 0, text: "ipsum"}])
-      expect(result).toEqual('lorem <b>ipsum</b> ipsum')
+      expect(result).toEqual('lorem ipsum ipsum')
     });
 
     it('should handle multiple, offsorted highlights', () => {
@@ -68,8 +68,8 @@ describe('stringFormatting', () => {
     // not just the entry
     it('should incorporate promptLength param', () => {
       const highlights = [
-        { character: 10, text: "they" },
-        { character: 15, text: "is" }
+        { character: 11, text: "they" },
+        { character: 16, text: "is" }
       ]
       const result = highlightGrammar('they is great.', highlights, 10)
       expect(result).toEqual("<b>they</b> <b>is</b> great.")

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -12,15 +12,16 @@ export const highlightSpelling = (str: string, wordsToFormat: string | string[])
   return newString
 }
 
-export const highlightGrammar = (oldStr: string, highlightArray=[]) => {
-  let str = oldStr
+export const highlightGrammar = (str: string, highlightArray, promptLength: number=0) => {
 
   if (highlightArray.length < 1) { return str }
 
   highlightArray.sort(descendingOffsetComparator)
 
   highlightArray.forEach((highlight) => {
-    let offset = highlight.offset
+    let offset = highlight.character - promptLength
+    console.log("offset: ", offset)
+    console.log("promptLength:", promptLength, "char", highlight.character)
     let stringAfterOffset = str.slice(offset)
     let stringBeforeOffset = offset === 0 ? '' : str.slice(0, offset)
 
@@ -33,10 +34,10 @@ export const highlightGrammar = (oldStr: string, highlightArray=[]) => {
     }
 
     str = stringBeforeOffset + stringAfterOffset;
-    console.log(" interim: ", str, "before:", stringBeforeOffset, "after:", stringAfterOffset)
+    console.log(" interim: ", str, "\nbefore:", stringBeforeOffset, "\nafter:", stringAfterOffset)
   })
 
-
+  console.log("\n end loop \n")
   return str
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -1,4 +1,4 @@
-export const highlightSpellingGrammar = (str: string, wordsToFormat: string | string[]) => {
+export const highlightSpelling = (str: string, wordsToFormat: string | string[]) => {
   let wordArray = [].concat(wordsToFormat)
   let newString = str
   wordArray.forEach((word) => {
@@ -10,3 +10,34 @@ export const highlightSpellingGrammar = (str: string, wordsToFormat: string | st
   })
   return newString
 }
+
+export const highlightGrammar = (str: string, highlightArray=[]) => {
+  if (highlightArray.length < 1) { return str }
+
+  highlightArray.sort(descendingOffsetComparator)
+
+  highlightArray.forEach((highlight) => {
+    let offset = highlight.offset
+    let stringAfterOffset = str.slice(offset)
+    let stringBeforeOffset = offset === 0 ? '' : str.slice(0, offset)
+
+    const phraseToFormat = stripEvidenceHtml(highlight.text)
+    const matched = stringAfterOffset.match(`${phraseToFormat}[\\w\']*`)
+
+    if (matched && matched[0] &&  matched[0] !== '&nbsp') {
+      const augmentedRegex = new RegExp(`${matched[0]}`)
+      stringAfterOffset = stringAfterOffset.replace(augmentedRegex, `<b>${matched[0]}</b>`)
+    }
+
+    str = stringBeforeOffset + stringAfterOffset;
+  })
+
+  return str
+}
+
+export const stripEvidenceHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<\/u>|<b>|<\/b>|<br>|<br\/>/g, '').replace(/&nbsp;/g, ' ')
+
+const descendingOffsetComparator = (a, b) => {
+  return (a['offset'] - b['offset']) * (-1)
+}
+

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -1,5 +1,4 @@
 export const highlightSpelling = (str: string, wordsToFormat: string | string[]) => {
-  console.log("highlighSpelling: ", str)
   let wordArray = [].concat(wordsToFormat)
   let newString = str
   wordArray.forEach((word) => {
@@ -13,17 +12,14 @@ export const highlightSpelling = (str: string, wordsToFormat: string | string[])
 }
 
 export const highlightGrammar = (str: string, highlightArray, promptLength: number=0) => {
-
   if (highlightArray.length < 1) { return str }
 
   highlightArray.sort(descendingOffsetComparator)
 
   highlightArray.forEach((highlight) => {
-    let offset = highlight.character - promptLength
-    console.log("offset: ", offset)
-    console.log("promptLength:", promptLength, "char", highlight.character)
+    let offset = highlight.character - promptLength - 1
     let stringAfterOffset = str.slice(offset)
-    let stringBeforeOffset = offset === 0 ? '' : str.slice(0, offset)
+    let stringBeforeOffset = str.slice(0, offset)
 
     const phraseToFormat = stripEvidenceHtml(highlight.text)
     const matched = stringAfterOffset.match(`${phraseToFormat}[\\w\']*`)
@@ -34,10 +30,8 @@ export const highlightGrammar = (str: string, highlightArray, promptLength: numb
     }
 
     str = stringBeforeOffset + stringAfterOffset;
-    console.log(" interim: ", str, "\nbefore:", stringBeforeOffset, "\nafter:", stringAfterOffset)
   })
 
-  console.log("\n end loop \n")
   return str
 }
 
@@ -46,4 +40,3 @@ export const stripEvidenceHtml = (html: string) => html.replace(/<p>|<\/p>|<u>|<
 const descendingOffsetComparator = (a, b) => {
   return (a['offset'] - b['offset']) * (-1)
 }
-

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -12,8 +12,9 @@ export const highlightSpelling = (str: string, wordsToFormat: string | string[])
   return newString
 }
 
-export const highlightGrammar = (str: string, highlightArray=[]) => {
-  console.log("highlightGrammar: ", str)
+export const highlightGrammar = (oldStr: string, highlightArray=[]) => {
+  let str = oldStr
+
   if (highlightArray.length < 1) { return str }
 
   highlightArray.sort(descendingOffsetComparator)
@@ -32,7 +33,9 @@ export const highlightGrammar = (str: string, highlightArray=[]) => {
     }
 
     str = stringBeforeOffset + stringAfterOffset;
+    console.log(" interim: ", str, "before:", stringBeforeOffset, "after:", stringAfterOffset)
   })
+
 
   return str
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -1,4 +1,5 @@
 export const highlightSpelling = (str: string, wordsToFormat: string | string[]) => {
+  console.log("highlighSpelling: ", str)
   let wordArray = [].concat(wordsToFormat)
   let newString = str
   wordArray.forEach((word) => {
@@ -12,6 +13,7 @@ export const highlightSpelling = (str: string, wordsToFormat: string | string[])
 }
 
 export const highlightGrammar = (str: string, highlightArray=[]) => {
+  console.log("highlightGrammar: ", str)
   if (highlightArray.length < 1) { return str }
 
   highlightArray.sort(descendingOffsetComparator)

--- a/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/stringFormatting.ts
@@ -17,9 +17,9 @@ export const highlightGrammar = (str: string, highlightArray, promptLength: numb
   highlightArray.sort(descendingOffsetComparator)
 
   highlightArray.forEach((highlight) => {
-    let offset = highlight.character - promptLength - 1
-    let stringAfterOffset = str.slice(offset)
-    let stringBeforeOffset = str.slice(0, offset)
+    const offset = highlight.character - promptLength - 1
+    const stringAfterOffset = str.slice(offset)
+    const stringBeforeOffset = str.slice(0, offset)
 
     const phraseToFormat = stripEvidenceHtml(highlight.text)
     const matched = stringAfterOffset.match(`${phraseToFormat}[\\w\']*`)

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
@@ -4,6 +4,7 @@ import toJson from 'enzyme-to-json';
 
 import { activityOne, optimalSubmittedResponse, suboptimalSubmittedResponse, } from './data'
 
+import { stripEvidenceHtml } from '../../../libs/stringFormatting'
 import PromptStep from '../../../components/studentView/promptStep'
 import EditorContainer from '../../../components/studentView/editorContainer'
 
@@ -71,10 +72,10 @@ describe('PromptStep component', () => {
         })
       })
 
-      describe('#stripHtml', () => {
+      describe('#stripEvidenceHtml', () => {
         it('should return a string stripped of all u and p tags', () => {
           const htmlString = '<p>I am a paragraph<u> with an underline</u></p>'
-          expect(wrapper.instance().stripHtml(htmlString)).toEqual('I am a paragraph with an underline')
+          expect(stripEvidenceHtml(htmlString)).toEqual('I am a paragraph with an underline')
         })
       })
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -3,15 +3,15 @@
 module Evidence
   module Check
     ALL_CHECKS = [
-      #Prefilter,
-      #RegexSentence,
-      #Opinion,
-      #Plagiarism,
+      Prefilter,
+      RegexSentence,
+      Opinion,
+      Plagiarism,
       AutoML,
-      #RegexPostTopic,
+      RegexPostTopic,
       Grammar,
-      #Spelling,
-      #RegexTypo
+      Spelling,
+      RegexTypo
     ]
 
     FALLBACK_RESPONSE = {

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -3,15 +3,15 @@
 module Evidence
   module Check
     ALL_CHECKS = [
-      Prefilter,
-      RegexSentence,
-      Opinion,
-      Plagiarism,
+      #Prefilter,
+      #RegexSentence,
+      #Opinion,
+      #Plagiarism,
       AutoML,
-      RegexPostTopic,
+      #RegexPostTopic,
       Grammar,
-      Spelling,
-      RegexTypo
+      #Spelling,
+      #RegexTypo
     ]
 
     FALLBACK_RESPONSE = {


### PR DESCRIPTION
## WHAT
1. Implements a new grammar highlighting algorithm that incorporates offsets. Without offsets, words that occur twice in the student entry would be bolded. We only want to bold the specific words designated by the grammar engine. 
2. Also refactors stripEvidenceHtml into a shared library.

## WHY
So that user-facing highlighting is correct. 

## HOW

### Screenshots
Working examples after the fix:
<img width="650" alt="Screen Shot 2022-05-03 at 1 27 47 PM" src="https://user-images.githubusercontent.com/90669/166552200-03be47e5-7e4c-48ec-87e7-31dacf534334.png">
<img width="708" alt="Screen Shot 2022-05-03 at 10 15 06 AM" src="https://user-images.githubusercontent.com/90669/166552221-eaab3876-4df2-4879-829a-2981b6f678e6.png">


### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=3ceb2291f228404197b124d7dd7f8923

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
