### PR TITLE
final PR for react table upgrades - upgrade final component; remove old package; cleanup

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/activityHealth.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/activityHealth.tsx
@@ -332,8 +332,6 @@ class ActivityHealth extends React.Component<ActivityHealthProps, ActivityHealth
         data={dataToUse}
         defaultSorted={[{id: 'name', desc: false}]}
         filterable
-        showPageSizeOptions={false}
-        showPagination={false}
         SubComponent={(row) => {
           return (
             <PromptHealth

--- a/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/promptHealth.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/activityHealth/promptHealth.tsx
@@ -88,8 +88,6 @@ class PromptHealth extends React.Component<PromptHealthProps, PromptHealthState>
         defaultPageSize={dataResults.length}
         loading={false}
         pages={1}
-        showPageSizeOptions={false}
-        showPagination={false}
       />)
     } else {
       tableOrEmptyMessage = NO_DATA_FOUND_MESSAGE

--- a/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useTable, useSortBy, usePagination, useFilters, useExpanded, } from "react-table";
+import { useTable, useSortBy, usePagination, useFilters, useExpanded, useGroupBy, } from "react-table";
 
 import ReactTablePagination from './reactTablePagination'
 
@@ -56,6 +56,7 @@ export const ReactTable = ({
   manualSortBy,
   manualPagination,
   manualPageCount,
+  defaultGroupBy,
   SubComponent,
 }) => {
   const defaultColumn = {
@@ -83,9 +84,10 @@ export const ReactTable = ({
       columns,
       autoResetSortBy: false,
       pageCount: manualPageCount,
-      initialState: { pageIndex: currentPage || 0, pageSize: defaultPageSize || data.length, sortBy: defaultSorted || [], }
+      initialState: { pageIndex: currentPage || 0, pageSize: defaultPageSize || data.length || 0, sortBy: defaultSorted || [], groupBy: defaultGroupBy || [], }
     },
     useFilters,
+    useGroupBy,
     useSortBy,
     useExpanded,
     usePagination,
@@ -141,12 +143,12 @@ export const ReactTable = ({
                         })}
                         className="rt-td"
                       >
-                        {cell.render('Cell')}
+                        {cell.isAggregated ? cell.render("Aggregated") : cell.render('Cell')}
                       </td>
                     );
                   })}
                 </tr>
-                {row.isExpanded && SubComponent ? SubComponent(row) : null}
+                {row.isExpanded && row.original && SubComponent ? SubComponent(row) : null}
               </div>
             );
           })}

--- a/services/QuillLMS/client/app/bundles/Shared/styles/react_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/react_table.scss
@@ -1,3 +1,488 @@
+// copied from built version of last published version of react-table-6 https://github.com/TanStack/react-table/tree/v6
+.ReactTable {
+	position: relative;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.ReactTable * {
+	box-sizing: border-box
+}
+
+.ReactTable .rt-table {
+	-webkit-box-flex: 1;
+	-ms-flex: auto 1;
+	flex: auto 1;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	-webkit-box-align: stretch;
+	-ms-flex-align: stretch;
+	align-items: stretch;
+	width: 100%;
+	border-collapse: collapse;
+	overflow: auto
+}
+
+.ReactTable .rt-thead {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 0 auto;
+	flex: 1 0 auto;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.ReactTable .rt-thead.-headerGroups {
+	background: rgba(0, 0, 0, 0.03);
+	border-bottom: 1px solid rgba(0, 0, 0, 0.05)
+}
+
+.ReactTable .rt-thead.-filters {
+	border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.ReactTable .rt-thead.-filters input,
+.ReactTable .rt-thead.-filters select {
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	background: #fff;
+	padding: 5px 7px;
+	font-size: inherit;
+	border-radius: 3px;
+	font-weight: normal;
+	outline-width: 0
+}
+
+.ReactTable .rt-thead.-filters .rt-th {
+	border-right: 1px solid rgba(0, 0, 0, 0.02)
+}
+
+.ReactTable .rt-thead.-header {
+	box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.15)
+}
+
+.ReactTable .rt-thead .rt-tr {
+	text-align: center
+}
+
+.ReactTable .rt-thead .rt-th,
+.ReactTable .rt-thead .rt-td {
+	padding: 5px 5px;
+	line-height: normal;
+	position: relative;
+	border-right: 1px solid rgba(0, 0, 0, 0.05);
+	transition: box-shadow .3s cubic-bezier(.175, .885, .32, 1.275);
+	box-shadow: inset 0 0 0 0 transparent;
+}
+
+.ReactTable .rt-thead .rt-th.-sort-asc,
+.ReactTable .rt-thead .rt-td.-sort-asc {
+	box-shadow: inset 0 3px 0 0 rgba(0, 0, 0, 0.6)
+}
+
+.ReactTable .rt-thead .rt-th.-sort-desc,
+.ReactTable .rt-thead .rt-td.-sort-desc {
+	box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.6)
+}
+
+.ReactTable .rt-thead .rt-th.-cursor-pointer,
+.ReactTable .rt-thead .rt-td.-cursor-pointer {
+	cursor: pointer
+}
+
+.ReactTable .rt-thead .rt-th:last-child,
+.ReactTable .rt-thead .rt-td:last-child {
+	border-right: 0
+}
+
+.ReactTable .rt-thead .rt-th:focus {
+	outline-width: 0
+}
+
+.ReactTable .rt-thead .rt-resizable-header {
+	overflow: visible;
+}
+
+.ReactTable .rt-thead .rt-resizable-header:last-child {
+	overflow: hidden
+}
+
+.ReactTable .rt-thead .rt-resizable-header-content {
+	overflow: hidden;
+	text-overflow: ellipsis
+}
+
+.ReactTable .rt-thead .rt-header-pivot {
+	border-right-color: #f7f7f7
+}
+
+.ReactTable .rt-thead .rt-header-pivot:after,
+.ReactTable .rt-thead .rt-header-pivot:before {
+	left: 100%;
+	top: 50%;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none
+}
+
+.ReactTable .rt-thead .rt-header-pivot:after {
+	border-color: rgba(255, 255, 255, 0);
+	border-left-color: #fff;
+	border-width: 8px;
+	margin-top: -8px
+}
+
+.ReactTable .rt-thead .rt-header-pivot:before {
+	border-color: rgba(102, 102, 102, 0);
+	border-left-color: #f7f7f7;
+	border-width: 10px;
+	margin-top: -10px
+}
+
+.ReactTable .rt-tbody {
+	-webkit-box-flex: 99999;
+	-ms-flex: 99999 1 auto;
+	flex: 99999 1 auto;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	overflow: auto;
+}
+
+.ReactTable .rt-tbody .rt-tr-group {
+	border-bottom: solid 1px rgba(0, 0, 0, 0.05);
+}
+
+.ReactTable .rt-tbody .rt-tr-group:last-child {
+	border-bottom: 0
+}
+
+.ReactTable .rt-tbody .rt-td {
+	border-right: 1px solid rgba(0, 0, 0, 0.02);
+}
+
+.ReactTable .rt-tbody .rt-td:last-child {
+	border-right: 0
+}
+
+.ReactTable .rt-tbody .rt-expandable {
+	cursor: pointer;
+	text-overflow: clip
+}
+
+.ReactTable .rt-tr-group {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 0 auto;
+	flex: 1 0 auto;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	-webkit-box-align: stretch;
+	-ms-flex-align: stretch;
+	align-items: stretch
+}
+
+.ReactTable .rt-tr {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 0 auto;
+	flex: 1 0 auto;
+	display: -webkit-inline-box;
+	display: -ms-inline-flexbox;
+	display: inline-flex
+}
+
+.ReactTable .rt-th,
+.ReactTable .rt-td {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 0 0px;
+	flex: 1 0 0;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	padding: 7px 5px;
+	overflow: hidden;
+	transition: .3s ease;
+	transition-property: width, min-width, padding, opacity;
+}
+
+.ReactTable .rt-th.-hidden,
+.ReactTable .rt-td.-hidden {
+	width: 0 !important;
+	min-width: 0 !important;
+	padding: 0 !important;
+	border: 0 !important;
+	opacity: 0 !important
+}
+
+.ReactTable .rt-expander {
+	display: inline-block;
+	position: relative;
+	margin: 0;
+	color: transparent;
+	margin: 0 10px;
+}
+
+.ReactTable .rt-expander:after {
+	content: '';
+	position: absolute;
+	width: 0;
+	height: 0;
+	top: 50%;
+	left: 50%;
+	-webkit-transform: translate(-50%, -50%) rotate(-90deg);
+	transform: translate(-50%, -50%) rotate(-90deg);
+	border-left: 5.04px solid transparent;
+	border-right: 5.04px solid transparent;
+	border-top: 7px solid rgba(0, 0, 0, 0.8);
+	transition: all .3s cubic-bezier(.175, .885, .32, 1.275);
+	cursor: pointer
+}
+
+.ReactTable .rt-expander.-open:after {
+	-webkit-transform: translate(-50%, -50%) rotate(0);
+	transform: translate(-50%, -50%) rotate(0)
+}
+
+.ReactTable .rt-resizer {
+	display: inline-block;
+	position: absolute;
+	width: 36px;
+	top: 0;
+	bottom: 0;
+	right: -18px;
+	cursor: col-resize;
+	z-index: 10
+}
+
+.ReactTable .rt-tfoot {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 0 auto;
+	flex: 1 0 auto;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.15);
+}
+
+.ReactTable .rt-tfoot .rt-td {
+	border-right: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.ReactTable .rt-tfoot .rt-td:last-child {
+	border-right: 0
+}
+
+.ReactTable.-striped .rt-tr.-odd {
+	background: rgba(0, 0, 0, 0.03)
+}
+
+.ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
+	background: rgba(0, 0, 0, 0.05)
+}
+
+.ReactTable .-pagination {
+	z-index: 1;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-pack: justify;
+	-ms-flex-pack: justify;
+	justify-content: space-between;
+	-webkit-box-align: stretch;
+	-ms-flex-align: stretch;
+	align-items: stretch;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	padding: 3px;
+	box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.1);
+	border-top: 2px solid rgba(0, 0, 0, 0.1);
+}
+
+.ReactTable .-pagination input,
+.ReactTable .-pagination select {
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	background: #fff;
+	padding: 5px 7px;
+	font-size: inherit;
+	border-radius: 3px;
+	font-weight: normal;
+	outline-width: 0
+}
+
+.ReactTable .-pagination .-btn {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	display: block;
+	width: 100%;
+	height: 100%;
+	border: 0;
+	border-radius: 3px;
+	padding: 6px;
+	font-size: 1em;
+	color: rgba(0, 0, 0, 0.6);
+	background: rgba(0, 0, 0, 0.1);
+	transition: all .1s ease;
+	cursor: pointer;
+	outline-width: 0;
+}
+
+.ReactTable .-pagination .-btn[disabled] {
+	opacity: .5;
+	cursor: default
+}
+
+.ReactTable .-pagination .-btn:not([disabled]):hover {
+	background: rgba(0, 0, 0, 0.3);
+	color: #fff
+}
+
+.ReactTable .-pagination .-previous,
+.ReactTable .-pagination .-next {
+	-webkit-box-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
+	text-align: center
+}
+
+.ReactTable .-pagination .-center {
+	-webkit-box-flex: 1.5;
+	-ms-flex: 1.5;
+	flex: 1.5;
+	text-align: center;
+	margin-bottom: 0;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	-ms-flex-pack: distribute;
+	justify-content: space-around
+}
+
+.ReactTable .-pagination .-pageInfo {
+	display: inline-block;
+	margin: 3px 10px;
+	white-space: nowrap
+}
+
+.ReactTable .-pagination .-pageJump {
+	display: inline-block;
+}
+
+.ReactTable .-pagination .-pageJump input {
+	width: 70px;
+	text-align: center
+}
+
+.ReactTable .-pagination .-pageSizeOptions {
+	margin: 3px 10px
+}
+
+.ReactTable .rt-noData {
+	display: block;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	-webkit-transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
+	background: rgba(255, 255, 255, 0.8);
+	transition: all .3s ease;
+	z-index: 1;
+	pointer-events: none;
+	padding: 20px;
+	color: rgba(0, 0, 0, 0.5)
+}
+
+.ReactTable .-loading {
+	display: block;
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	background: rgba(255, 255, 255, 0.8);
+	transition: all .3s ease;
+	z-index: -1;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.ReactTable .-loading>div {
+	position: absolute;
+	display: block;
+	text-align: center;
+	width: 100%;
+	top: 50%;
+	left: 0;
+	font-size: 15px;
+	color: rgba(0, 0, 0, 0.6);
+	-webkit-transform: translateY(-52%);
+	transform: translateY(-52%);
+	transition: all .3s cubic-bezier(.25, .46, .45, .94)
+}
+
+.ReactTable .-loading.-active {
+	opacity: 1;
+	z-index: 2;
+	pointer-events: all;
+}
+
+.ReactTable .-loading.-active>div {
+	-webkit-transform: translateY(50%);
+	transform: translateY(50%)
+}
+
+.ReactTable .rt-resizing .rt-th,
+.ReactTable .rt-resizing .rt-td {
+	transition: none !important;
+	cursor: col-resize;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none
+}
+
+// custom
 .ReactTable {
   table {
     font-size: 14px;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
@@ -1,5 +1,3 @@
-@import '~react-table-6/react-table.css';
-
 @import './button.scss';
 @import './spinner.scss';
 @import './input.scss';

--- a/services/QuillLMS/client/app/bundles/Staff/components/ChangeLogTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ChangeLogTable.tsx
@@ -110,8 +110,6 @@ const ChangeLogsTable: React.SFC<ChangeLogsTableProps> = ({changeLogs}) => {
       className="concepts-table"
       columns={columns()}
       data={data}
-      defaultPageSize={data.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptsTable.tsx
@@ -83,8 +83,6 @@ const ConceptsTable: React.SFC<ConceptsTableProps> = ({concepts, visible, select
       className="concepts-table"
       columns={columns(selectConcept)}
       data={data}
-      defaultPageSize={data.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
@@ -70,7 +70,6 @@ const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, 
         data={options}
         defaultFilterMethod={(filter, row) => row._original.name ? row._original.name.toLowerCase().includes(filter.value.toLowerCase()) : ''}
         filterable
-        showPagination={false}
       />
       {newTopicField}
     </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/contentPartners/contentPartnersTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/contentPartners/contentPartnersTable.tsx
@@ -82,7 +82,6 @@ const ContentPartnersTable = ({ visible, contentPartners, saveContentPartnerChan
         className="records-table"
         columns={columns(selectRecord, visible)}
         data={filteredRecords}
-        showPagination={false}
       />
       <div className="record-box-container">
         {recordBox}

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/readability/activityClassificationConversionChart.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/readability/activityClassificationConversionChart.tsx
@@ -6,17 +6,20 @@ const columns = [
   {
     Header: 'Raw Score',
     accessor: 'raw_score',
-    key: 'raw_score'
+    key: 'raw_score',
+    width: 100
   },
   {
     Header: 'Grade Band',
     accessor: 'grade_band',
-    key: 'grade_band'
+    key: 'grade_band',
+    width: 100
   },
   {
     Header: 'Activities',
     accessor: 'activity_count',
-    key: 'activity_count'
+    key: 'activity_count',
+    width: 100
   },
 ]
 
@@ -29,7 +32,6 @@ const ActivityClassificationConversionChart = ({ classificationName, conversionC
         columns={columns}
         data={conversionChart}
         defaultPageSize={conversionChart.length}
-        showPagination={false}
       />
     </div>
   );

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/changeLogTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/changeLogTable.tsx
@@ -110,7 +110,6 @@ const ChangeLogsTable: React.SFC<ChangeLogsTableProps> = ({changeLogs}) => {
       columns={columns()}
       data={data}
       defaultPageSize={data.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/recordColumn.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/recordColumn.tsx
@@ -38,7 +38,6 @@ const RecordColumn: React.SFC<RecordColumnProps> = ({ records, selectRecord, rec
       columns={columns(selectRecord, recordType, records)}
       data={records}
       defaultPageSize={records.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/standardsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/standards/standardsTable.tsx
@@ -130,7 +130,6 @@ const StandardsTable = ({ searchValue, standardCategories, standardLevels, recor
         columns={columns(selectRecord, filteredRecords)}
         data={filteredRecords}
         defaultPageSize={filteredRecords.length}
-        showPagination={false}
       />
       <div className="record-box-container">
         {recordBox}

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/topics/changeLogTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/topics/changeLogTable.tsx
@@ -101,8 +101,6 @@ const ChangeLogsTable: React.SFC<ChangeLogsTableProps> = ({changeLogs}) => {
       className="change-log-table"
       columns={columns()}
       data={data}
-      defaultPageSize={data.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/topics/topicLevelTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/attributesManager/topics/topicLevelTable.tsx
@@ -69,8 +69,6 @@ const TopicLevelTable: React.SFC<TopicLevelTableProps> = ({ topics, selectTopic,
       className="topics-table"
       columns={columns(levelNumber, selectTopic, showExtraColumns, data)}
       data={data}
-      defaultPageSize={data.length}
-      showPagination={false}
     />
   );
 };

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -244,6 +244,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       id: "expander",
       resizable: false,
       className: "text-center",
+      maxWidth: 60,
       Cell: ({ row }) => {
         if (row.isGrouped) { return <span /> }
         return (

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsSchoolIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsSchoolIndexAppClient.jsx
@@ -192,10 +192,6 @@ export default class CmsSchoolIndex extends React.Component {
             manualSortBy={true}
             minRows={1}
             onSortedChange={this.setSort}
-            showPageSizeOptions={false}
-            showPagination={false}
-            showPaginationBottom={false}
-            showPaginationTop={false}
           />
           <div className='cms-pagination-container'>
             {this.renderPageSelector()}

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -198,10 +198,6 @@ export default class CmsUserIndex extends React.Component {
             manualSortBy={true}
             minRows={1}
             onSortedChange={this.setSort}
-            showPageSizeOptions={false}
-            showPagination={false}
-            showPaginationBottom={false}
-            showPaginationTop={false}
           />
           <div className='cms-pagination-container'>
             {this.renderPageSelector()}

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -4882,11 +4882,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -13711,14 +13706,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
       "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA=="
-    },
-    "react-table-6": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-table-6/-/react-table-6-6.11.0.tgz",
-      "integrity": "sha512-zO24J+1Qg2AHxtSNMfHeGW1dxFcmLJQrAeLJyCAENdNdwJt+YolDDtJEBdZlukon7rZeAdB3d5gUH6eb9Dn5Ug==",
-      "requires": {
-        "classnames": "^2.2.5"
-      }
     },
     "react-test-renderer": {
       "version": "17.0.2",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -113,7 +113,6 @@
     "react-simple-pie-chart": "^0.5.0",
     "react-sortable-hoc": "^2.0.0",
     "react-table": "^7.7.0",
-    "react-table-6": "^6.11.0",
     "react-textarea-autosize": "^4.3.2",
     "react-tooltip": "^4.1.2",
     "react-visibility-sensor": "^5.1.1",


### PR DESCRIPTION
## WHAT
Upgrade a final component (`RulesAnalysis`, which required adding supporting for grouping and aggregation); copy the CSS from the `react-table-6` library into our repo and remove the `react-table-6` package; cleanup.

## WHY
This is the final step to completely remove the `react-table-6` library so we can just be on the most up to date version of `react-table`.

## HOW
Update the `ReactTable` component to handle aggregation and wire up the `RulesAnalysis` component to use it; un-minify the built CSS from the `react-table-6` package and add it to the shared `react_table.scss` file; remove the package; audit and cleanup the already-changed files to make sure the final CSS change didn't break things.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Upgrade-aggregated-instance-of-React-Table-to-use-latest-version-and-remove-react-table-6-ac73f84edb4f461cb9a2b192db713bee

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Having Heroku problems, will test once I have those figured out
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES