### PR TITLE
Have overnight pre_cache use the DEFAULT Sidekiq queue.

### DIFF
--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -8,7 +8,7 @@ class PreCacheAdminDashboardsWorker
     active_admin_ids = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).pluck(:id)
 
     active_admin_ids.each do |id|
-      FindAdminUsersWorker.perform_async(id)
+      FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -13,21 +13,26 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     create(:schools_admins, user: old_admin)
     create(:schools_admins, user: current_admin1)
     create(:schools_admins, user: current_admin2)
+
+    allow(FindAdminUsersWorker).to receive(:set).and_return(mock_worker)
   end
 
+  let(:mock_worker) {double(:perform_async)}
+
   it 'enqueues FindAdminUsersWorker for all active admins' do
-    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin1.id).once
-    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin2.id).once
+
+    expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-admins' do
-    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(not_admin.id)
+    expect(mock_worker).not_to receive(:perform_async).with(not_admin.id)
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-active admins' do
-    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(old_admin.id)
+    expect(mock_worker).not_to receive(:perform_async).with(old_admin.id)
     worker.perform
   end
 end

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -14,13 +14,12 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     create(:schools_admins, user: current_admin1)
     create(:schools_admins, user: current_admin2)
 
-    allow(FindAdminUsersWorker).to receive(:set).and_return(mock_worker)
+    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_worker)
   end
 
   let(:mock_worker) {double(:perform_async)}
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
-
     expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
     expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -8,6 +8,7 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
   let!(:current_admin1) { create(:user, last_sign_in: Time.now) }
   let!(:current_admin2) { create(:user, last_sign_in: Time.now) }
   let!(:not_admin) { create(:user, last_sign_in: Time.now) }
+  let(:mock_worker) {double(:perform_async)}
 
   before do
     create(:schools_admins, user: old_admin)
@@ -16,8 +17,6 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
 
     allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_worker)
   end
-
-  let(:mock_worker) {double(:perform_async)}
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
     expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once


### PR DESCRIPTION
## WHAT
Change the Sidekiq queue for overnight pre_cache `FindAdminUsersWorker` jobs from `critical` to `default` 
## WHY
These jobs are long-running and clog up the `critical` and `critical_external` queue. This is bad since it blocks `critical` jobs by users who are currently on the site (like importing a classroom), in favor of pre-caching for users who aren't currently on the site.

We have alerts that go off of every night about this. These are legitimate alerts flagging that users can't do things like import classrooms. This should "silence" those alerts by fixing that bad scenario, and allowing `critical` jobs to go through.

## HOW
You can override the queue for a job when you call it.
### Screenshots
<img width="741" alt="Screen Shot 2022-04-18 at 5 31 52 PM" src="https://user-images.githubusercontent.com/1304933/163881204-d1c54fe1-91d3-4890-8aec-af9f9b3c5501.png">


![Screen Shot 2022-04-18 at 5 27 19 PM](https://user-images.githubusercontent.com/1304933/163880698-89fffbb8-f6f3-489d-8da3-b433d8169c40.png)



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'. 
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
