### PR TITLE
update district index to use new react table

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactTable from 'react-table-6';
 
 import getAuthToken from '../components/modules/get_auth_token';
 import LoadingIndicator from '../components/shared/loading_indicator'
+import { ReactTable, } from '../../Shared/index'
 
 export default class CmsDistrictIndex extends React.Component {
   constructor(props) {
@@ -22,56 +22,48 @@ export default class CmsDistrictIndex extends React.Component {
         Header: 'Name',
         accessor: 'name',
         resizable: false,
-        minWidth: 190,
-        Cell: row => row.original.name
+        minWidth: 190
       }, {
         Header: "City",
         accessor: 'city',
         minWidth: 140,
-        resizable: false,
-        Cell: row => row.original.city
+        resizable: false
       }, {
         Header: "State",
         accessor: 'state',
         resizable: false,
-        minWidth: 60,
-        Cell: row => row.original.state,
+        minWidth: 60
       }, {
         Header: 'ZIP',
         accessor: 'zipcode',
         resizable: false,
-        minWidth: 60,
-        Cell: row => row.original.zipcode,
+        minWidth: 60
       }, {
         Header: 'Phone',
         accessor: 'phone',
         resizable: false,
-        minWidth: 130,
-        Cell: row => row.original.phone,
+        minWidth: 130
       }, {
         Header: "NCES ID",
         accessor: 'nces_id',
         resizable: false,
-        minWidth: 80,
-        Cell: row => row.original.nces_id
+        minWidth: 80
       }, {
         Header: "Schools",
         accessor: 'total_schools',
         resizable: false,
-        minWidth: 80,
-        Cell: row => Number(row.original.total_schools),
+        minWidth: 80
       }, {
         Header: "Students",
         accessor: 'total_students',
         resizable: false,
-        minWidth: 80,
-        Cell: row => Number(row.original.total_students),
+        minWidth: 80
       }, {
         Header: "Edit",
         accessor: 'edit',
         resizable: false,
         minWidth: 60,
-        Cell: (row) => {
+        Cell: ({row}) => {
           return <a href={`${process.env.DEFAULT_URL}/cms/districts/${row.original.id}`}>Edit</a>
         }
       }
@@ -79,6 +71,8 @@ export default class CmsDistrictIndex extends React.Component {
   }
 
   setSort = newSorted => {
+    if (!newSorted.length) { return }
+
     const { query } = this.state
 
     const sort = newSorted[0].id
@@ -176,12 +170,8 @@ export default class CmsDistrictIndex extends React.Component {
           data={data}
           defaultPageSize={100}
           defaultSorted={[{id: sort, desc: sortDescending}]}
-          minRows={1}
+          manualSortBy={true}
           onSortedChange={this.setSort}
-          showPageSizeOptions={false}
-          showPagination={false}
-          showPaginationBottom={false}
-          showPaginationTop={false}
         />
         <div className='cms-pagination-container'>
           {this.renderPageSelector()}

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -160,7 +160,7 @@ export default class CmsDistrictIndex extends React.Component {
       return <p>No records found for your query.</p>
     }
 
-    const sort = query.sort ? query.sort : 'number_teachers'
+    const sort = query.sort ? query.sort : 'name'
     const sortDescending = query.sort_direction ? query.sort_direction === 'desc' : true
     return (
       <div>


### PR DESCRIPTION
## WHAT
Update the new district index page to use the new React Table.

## WHY
I just finished an upgrade to all the existing instances of React Table, and removed the `react-table-6` package. However, this one was added between when I started that work and merged it just now, so it didn't get updated, and the app is currently undeployable.

## HOW
Minor updates to have this instance work with the newer version of React Table.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
