### PR TITLE
evidence/nil-check-previous-plagiarism

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/plagiarism.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/plagiarism.rb
@@ -22,7 +22,7 @@ module Evidence
 
     # rubocop:disable Metrics/CyclomaticComplexity
     private def get_plagiarism_feedback_from_previous_feedback(prev, rule)
-      previous_plagiarism = prev.select {|f| f["feedback_type"] == Evidence::Rule::TYPE_PLAGIARISM && f["optimal"] == false }
+      previous_plagiarism = prev&.select {|f| f["feedback_type"] == Evidence::Rule::TYPE_PLAGIARISM && f["optimal"] == false } || []
       feedbacks = rule&.feedbacks
       previous_plagiarism.empty? ? feedbacks&.find_by(order: 0)&.text : feedbacks&.find_by(order: 1)&.text
     end


### PR DESCRIPTION
## WHAT
Tweak plagiarism check to nil-check for previous feedback
## WHY
This actually shouldn't really ever be nil, but the fallback logic is straight-forward enough that it's probably worth adding for those weird edge cases where it is
## HOW
Nil check the input value, and if it's missing use an empty array to fill in the variable value

### Notion Card Links
https://sentry.io/organizations/quillorg-5s/issues/3193832495/?project=11238&referrer=slack

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this particular module
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
