### PR TITLE
make data table headers accessible

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -131,49 +131,57 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
     const allDisabled = rows.every(row => row.checkDisabled)
     if (allDisabled) {
-      return <span className={`quill-checkbox disabled ${dataTableHeaderClassName}`} />
+      return <th aria-label="Disabled checkbox" className={`quill-checkbox disabled ${dataTableHeaderClassName}`} />
     }
 
     const allChecked = rows.every(row => row.checked)
     if (allChecked) {
       return (
-        <button className={`quill-checkbox selected ${dataTableHeaderClassName}`} onClick={uncheckAllRows} type="button">
-          <img alt="check" src={smallWhiteCheckSrc} />
-        </button>
+        <th className={dataTableHeaderClassName}>
+          <button className="quill-checkbox selected" onClick={uncheckAllRows} type="button">
+            <img alt="Checked checkbox" src={smallWhiteCheckSrc} />
+          </button>
+        </th>
       )
     }
 
     const anyChecked = rows.some(row => row.checked)
     if (anyChecked) {
       return (
-        <button className={`quill-checkbox selected ${dataTableHeaderClassName}`} onClick={uncheckAllRows} type="button">
-          <img alt="check" src={indeterminateSrc} />
-        </button>
+        <th className={dataTableHeaderClassName}>
+          <button className="quill-checkbox selected" onClick={uncheckAllRows} type="button">
+            <img alt="Checked checkbox" src={indeterminateSrc} />
+          </button>
+        </th>
       )
     }
 
-    return <button aria-label="Unchecked checkbox" className={`quill-checkbox unselected ${dataTableHeaderClassName}`} onClick={checkAllRows} type="button" />
+    return (
+      <th className={dataTableHeaderClassName}>
+        <button aria-label="Unchecked checkbox" className="quill-checkbox unselected" onClick={checkAllRows} type="button" />
+      </th>
+    )
   }
 
   renderHeaderForRemoval() {
     const { showRemoveIcon } = this.props
     if (!showRemoveIcon) { return null }
 
-    return <span className={dataTableHeaderClassName} />
+    return <th aria-label="Header for remove column" className={dataTableHeaderClassName} />
   }
 
   renderHeaderForOrder() {
     const { isReorderable } = this.props
     if (!isReorderable) { return }
 
-    return <span className={`${dataTableHeaderClassName} reorder-header`}>Order</span>
+    return <th className={`${dataTableHeaderClassName} reorder-header`}>Order</th>
   }
 
   renderActionsHeader(header) {
     const { showActions } = this.props
     if (!showActions) { return null }
 
-    return <span className={`${dataTableHeaderClassName} actions-header`}>{header.name || 'Actions'}</span>
+    return <th className={`${dataTableHeaderClassName} actions-header`}>{header.name || 'Actions'}</th>
   }
 
   renderRowCheckbox(row) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -241,28 +241,24 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     if (header.isActions) { return this.renderActionsHeader(header) }
 
     const { sortAscending, sortAttribute, } = this.state
-    let sortArrow, onClick
-    let tabIndex = -1
     let className = `${dataTableHeaderClassName} ${header.headerClassName}`
     let style: React.CSSProperties = { width: `${header.width}`, minWidth: `${header.width}`, textAlign: `${this.attributeAlignment(header.attribute)}` as CSS.TextAlignProperty }
+    let headerContent = header.name
     if (header.isSortable) {
       const sortDirection = sortAscending ? ascending : descending
-      onClick = () => this.changeSort(header.sortAttribute || header.attribute)
-      sortArrow = [header.attribute, header.sortAttribute].includes(sortAttribute) ? <img alt="arrow" className={`sort-arrow ${sortDirection}`} src={arrowSrc} /> : null
+      const onClick = () => this.changeSort(header.sortAttribute || header.attribute)
+      const sortArrow = [header.attribute, header.sortAttribute].includes(sortAttribute) ? <img alt="arrow" className={`sort-arrow ${sortDirection}`} src={arrowSrc} /> : null
       className+= ' sortable'
-      tabIndex = 0
+      headerContent = <button className="interactive-wrapper focus-on-light" onClick={onClick} type="button">{header.name}{sortArrow}</button>
     }
+
     return (
-      <button
+      <th
         className={className}
-        onClick={onClick}
         style={style as any}
-        tabIndex={tabIndex}
-        type="button"
       >
-        {header.name}
-        {sortArrow}
-      </button>
+        {headerContent}
+      </th>
     )
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/libs/copyToClipboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/copyToClipboard.tsx
@@ -1,5 +1,5 @@
 export function copyToClipboard(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, setterFunction) {
-  navigator.clipboard.writeText(e.currentTarget.value)
+  navigator.clipboard && navigator.clipboard.writeText(e.currentTarget.value)
   setterFunction(true);
   setTimeout(() => setterFunction(false), 3000);
 };

--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -74,8 +74,8 @@
     background-color: transparent;
     border: none;
     padding: 0px;
-    &:focus {
-      outline: none;
+    .interactive-wrapper {
+      display: flex;
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1388,7 +1388,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
         <div
           className="data-table-headers"
         >
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -1397,12 +1397,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                 "width": "500px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Link
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -1411,12 +1409,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                 "width": "200px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Expiration Date
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -1425,10 +1421,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                 "width": "100px",
               }
             }
-            tabIndex={-1}
-            type="button"
           />
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -1437,10 +1431,8 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                 "width": "100px",
               }
             }
-            tabIndex={-1}
-            type="button"
           />
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -1449,8 +1441,6 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                 "width": "100px",
               }
             }
-            tabIndex={-1}
-            type="button"
           />
         </div>
         <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
@@ -2416,11 +2416,11 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
           <div
             className="data-table-headers"
           >
-            <span
+            <th
               className="data-table-header reorder-header"
             >
               Order
-            </span>
+            </th>
             <th
               className="data-table-header undefined"
               style={
@@ -2471,7 +2471,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                 }
               }
             />
-            <span
+            <th
               className="data-table-header"
             />
           </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
@@ -2421,7 +2421,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
             >
               Order
             </span>
-            <button
+            <th
               className="data-table-header undefined"
               style={
                 Object {
@@ -2430,8 +2430,6 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   "width": "607px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             >
               <span
                 className="tool-and-name-header"
@@ -2443,8 +2441,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   Activity
                 </span>
               </span>
-            </button>
-            <button
+            </th>
+            <th
               className="data-table-header due-date-header-container"
               style={
                 Object {
@@ -2453,8 +2451,6 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   "width": "120px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             >
               <span
                 className="due-date-header"
@@ -2464,8 +2460,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   (optional)
                 </span>
               </span>
-            </button>
-            <button
+            </th>
+            <th
               className="data-table-header undefined"
               style={
                 Object {
@@ -2474,8 +2470,6 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   "width": "30px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             />
             <span
               className="data-table-header"
@@ -15758,7 +15752,7 @@ exports[`ActivityPack component renders if the current user did not create the u
           <div
             className="data-table-headers"
           >
-            <button
+            <th
               className="data-table-header undefined"
               style={
                 Object {
@@ -15767,8 +15761,6 @@ exports[`ActivityPack component renders if the current user did not create the u
                   "width": "724px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             >
               <span
                 className="tool-and-name-header"
@@ -15780,8 +15772,8 @@ exports[`ActivityPack component renders if the current user did not create the u
                   Activity
                 </span>
               </span>
-            </button>
-            <button
+            </th>
+            <th
               className="data-table-header due-date-header-container no-right-margin"
               style={
                 Object {
@@ -15790,8 +15782,6 @@ exports[`ActivityPack component renders if the current user did not create the u
                   "width": "110px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             >
               <span
                 className="due-date-header"
@@ -15801,8 +15791,8 @@ exports[`ActivityPack component renders if the current user did not create the u
                   (optional)
                 </span>
               </span>
-            </button>
-            <button
+            </th>
+            <th
               className="data-table-header undefined"
               style={
                 Object {
@@ -15811,8 +15801,6 @@ exports[`ActivityPack component renders if the current user did not create the u
                   "width": "30px",
                 }
               }
-              tabIndex={-1}
-              type="button"
             />
           </div>
           <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
@@ -2472,6 +2472,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               }
             />
             <th
+              aria-label="Header for remove column"
               className="data-table-header"
             />
           </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
@@ -1552,7 +1552,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
         >
           Order
         </span>
-        <button
+        <th
           className="data-table-header undefined"
           style={
             Object {
@@ -1561,8 +1561,6 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               "width": "607px",
             }
           }
-          tabIndex={-1}
-          type="button"
         >
           <span
             className="tool-and-name-header"
@@ -1574,8 +1572,8 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               Activity
             </span>
           </span>
-        </button>
-        <button
+        </th>
+        <th
           className="data-table-header due-date-header-container"
           style={
             Object {
@@ -1584,8 +1582,6 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               "width": "120px",
             }
           }
-          tabIndex={-1}
-          type="button"
         >
           <span
             className="due-date-header"
@@ -1595,8 +1591,8 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               (optional)
             </span>
           </span>
-        </button>
-        <button
+        </th>
+        <th
           className="data-table-header undefined"
           style={
             Object {
@@ -1605,8 +1601,6 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               "width": "30px",
             }
           }
-          tabIndex={-1}
-          type="button"
         />
         <span
           className="data-table-header"
@@ -14376,7 +14370,7 @@ exports[`ActivityTable component renders if the current user did not create the 
       <div
         className="data-table-headers"
       >
-        <button
+        <th
           className="data-table-header undefined"
           style={
             Object {
@@ -14385,8 +14379,6 @@ exports[`ActivityTable component renders if the current user did not create the 
               "width": "724px",
             }
           }
-          tabIndex={-1}
-          type="button"
         >
           <span
             className="tool-and-name-header"
@@ -14398,8 +14390,8 @@ exports[`ActivityTable component renders if the current user did not create the 
               Activity
             </span>
           </span>
-        </button>
-        <button
+        </th>
+        <th
           className="data-table-header due-date-header-container no-right-margin"
           style={
             Object {
@@ -14408,8 +14400,6 @@ exports[`ActivityTable component renders if the current user did not create the 
               "width": "110px",
             }
           }
-          tabIndex={-1}
-          type="button"
         >
           <span
             className="due-date-header"
@@ -14419,8 +14409,8 @@ exports[`ActivityTable component renders if the current user did not create the 
               (optional)
             </span>
           </span>
-        </button>
-        <button
+        </th>
+        <th
           className="data-table-header undefined"
           style={
             Object {
@@ -14429,8 +14419,6 @@ exports[`ActivityTable component renders if the current user did not create the 
               "width": "30px",
             }
           }
-          tabIndex={-1}
-          type="button"
         />
       </div>
       <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
@@ -1603,6 +1603,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
           }
         />
         <th
+          aria-label="Header for remove column"
           className="data-table-header"
         />
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
@@ -1547,11 +1547,11 @@ exports[`ActivityTable component renders if the current user created the unit 1`
       <div
         className="data-table-headers"
       >
-        <span
+        <th
           className="data-table-header reorder-header"
         >
           Order
-        </span>
+        </th>
         <th
           className="data-table-header undefined"
           style={
@@ -1602,7 +1602,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
             }
           }
         />
-        <span
+        <th
           className="data-table-header"
         />
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
@@ -215,7 +215,7 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
                   type="button"
                 >
                   <img
-                    alt="check"
+                    alt="Checked checkbox"
                     src="https://assets.quill.org/images/icons/indeterminate.svg"
                   />
                 </button>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
@@ -216,7 +216,7 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
                   src="https://assets.quill.org/images/icons/indeterminate.svg"
                 />
               </button>
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -225,12 +225,10 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
                     "width": "510px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Class
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -239,12 +237,10 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
                     "width": "110px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Grade
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -253,11 +249,9 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
                     "width": "51px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Students
-              </button>
+              </th>
             </div>
             <div
               className="data-table-body"
@@ -1885,7 +1879,7 @@ exports[`ImportCleverClassroomsModal component initial load should render 1`] = 
                 onClick={[Function]}
                 type="button"
               />
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -1894,12 +1888,10 @@ exports[`ImportCleverClassroomsModal component initial load should render 1`] = 
                     "width": "510px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Class
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -1908,12 +1900,10 @@ exports[`ImportCleverClassroomsModal component initial load should render 1`] = 
                     "width": "110px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Grade
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -1922,11 +1912,9 @@ exports[`ImportCleverClassroomsModal component initial load should render 1`] = 
                     "width": "51px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Students
-              </button>
+              </th>
             </div>
             <div
               className="data-table-body"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_clever_classrooms_modal.test.jsx.snap
@@ -206,16 +206,20 @@ exports[`ImportCleverClassroomsModal component #handleClickImportClasses should 
             <div
               className="data-table-headers"
             >
-              <button
-                className="quill-checkbox selected data-table-header"
-                onClick={[Function]}
-                type="button"
+              <th
+                className="data-table-header"
               >
-                <img
-                  alt="check"
-                  src="https://assets.quill.org/images/icons/indeterminate.svg"
-                />
-              </button>
+                <button
+                  className="quill-checkbox selected"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <img
+                    alt="check"
+                    src="https://assets.quill.org/images/icons/indeterminate.svg"
+                  />
+                </button>
+              </th>
               <th
                 className="data-table-header undefined"
                 style={
@@ -1873,12 +1877,16 @@ exports[`ImportCleverClassroomsModal component initial load should render 1`] = 
             <div
               className="data-table-headers"
             >
-              <button
-                aria-label="Unchecked checkbox"
-                className="quill-checkbox unselected data-table-header"
-                onClick={[Function]}
-                type="button"
-              />
+              <th
+                className="data-table-header"
+              >
+                <button
+                  aria-label="Unchecked checkbox"
+                  className="quill-checkbox unselected"
+                  onClick={[Function]}
+                  type="button"
+                />
+              </th>
               <th
                 className="data-table-header undefined"
                 style={

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
@@ -301,7 +301,7 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                   type="button"
                 >
                   <img
-                    alt="check"
+                    alt="Checked checkbox"
                     src="https://assets.quill.org/images/icons/indeterminate.svg"
                   />
                 </button>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
@@ -292,16 +292,20 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
             <div
               className="data-table-headers"
             >
-              <button
-                className="quill-checkbox selected data-table-header"
-                onClick={[Function]}
-                type="button"
+              <th
+                className="data-table-header"
               >
-                <img
-                  alt="check"
-                  src="https://assets.quill.org/images/icons/indeterminate.svg"
-                />
-              </button>
+                <button
+                  className="quill-checkbox selected"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <img
+                    alt="check"
+                    src="https://assets.quill.org/images/icons/indeterminate.svg"
+                  />
+                </button>
+              </th>
               <th
                 className="data-table-header undefined"
                 style={
@@ -2292,12 +2296,16 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
             <div
               className="data-table-headers"
             >
-              <button
-                aria-label="Unchecked checkbox"
-                className="quill-checkbox unselected data-table-header"
-                onClick={[Function]}
-                type="button"
-              />
+              <th
+                className="data-table-header"
+              >
+                <button
+                  aria-label="Unchecked checkbox"
+                  className="quill-checkbox unselected"
+                  onClick={[Function]}
+                  type="button"
+                />
+              </th>
               <th
                 className="data-table-header undefined"
                 style={

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/import_google_classrooms_modal.test.jsx.snap
@@ -302,7 +302,7 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                   src="https://assets.quill.org/images/icons/indeterminate.svg"
                 />
               </button>
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -311,12 +311,10 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                     "width": "510px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Class
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -325,12 +323,10 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                     "width": "110px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Grade
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -339,12 +335,10 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                     "width": "32px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Year
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -353,11 +347,9 @@ exports[`ImportGoogleClassroomsModal component #handleClickImportClasses should 
                     "width": "51px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Students
-              </button>
+              </th>
             </div>
             <div
               className="data-table-body"
@@ -2306,7 +2298,7 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
                 onClick={[Function]}
                 type="button"
               />
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2315,12 +2307,10 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
                     "width": "510px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Class
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2329,12 +2319,10 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
                     "width": "110px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Grade
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2343,12 +2331,10 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
                     "width": "32px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Year
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2357,11 +2343,9 @@ exports[`ImportGoogleClassroomsModal component initial load should render 1`] = 
                     "width": "51px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Students
-              </button>
+              </th>
             </div>
             <div
               className="data-table-body"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -318,7 +318,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
         <div
           className="data-table-headers"
         >
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -327,12 +327,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 "width": "125px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Student
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -341,12 +339,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 "width": "245px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Activity
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -355,12 +351,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 "width": "124px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Score
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header completed-section"
             style={
               Object {
@@ -369,11 +363,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 "width": "84px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Completed
-          </button>
+          </th>
         </div>
         <div
           className="data-table-body"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
@@ -325,7 +325,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
         <div
           className="data-table-headers"
         >
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -334,12 +334,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                 "width": "300px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Diagnostic
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -348,12 +346,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                 "width": "180px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Class
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -362,12 +358,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                 "width": "62px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Completed
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header last-header"
             style={
               Object {
@@ -376,11 +370,9 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                 "width": "62px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Results
-          </button>
+          </th>
         </div>
         <div
           className="data-table-body"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -635,7 +635,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
         <div
           className="data-table-headers"
         >
-          <button
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -644,12 +644,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                 "width": "289px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Quill Lesson
-          </button>
-          <button
+          </th>
+          <th
             className="data-table-header undefined"
             style={
               Object {
@@ -658,17 +656,15 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                 "width": "180px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Class
-          </button>
+          </th>
           <span
             className="data-table-header actions-header"
           >
             More
           </span>
-          <button
+          <th
             className="data-table-header last-header"
             style={
               Object {
@@ -677,11 +673,9 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                 "width": "78px",
               }
             }
-            tabIndex={-1}
-            type="button"
           >
             Present
-          </button>
+          </th>
         </div>
         <div
           className="data-table-body"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -659,11 +659,11 @@ exports[`LessonsMini component not on mobile should render when there are lesson
           >
             Class
           </th>
-          <span
+          <th
             className="data-table-header actions-header"
           >
             More
-          </span>
+          </th>
           <th
             className="data-table-header last-header"
             style={

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/__tests__/__snapshots__/view_as_student_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/__tests__/__snapshots__/view_as_student_modal.test.jsx.snap
@@ -2234,7 +2234,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
             <div
               className="data-table-headers"
             >
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2243,12 +2243,10 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "160px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Name
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -2257,12 +2255,10 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "361px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Username
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header view-button-section"
                 style={
                   Object {
@@ -2271,8 +2267,6 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "88px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               />
             </div>
             <div
@@ -4763,7 +4757,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
             <div
               className="data-table-headers"
             >
-              <button
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -4772,12 +4766,10 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "160px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Name
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header undefined"
                 style={
                   Object {
@@ -4786,12 +4778,10 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "361px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               >
                 Username
-              </button>
-              <button
+              </th>
+              <th
                 className="data-table-header view-button-section"
                 style={
                   Object {
@@ -4800,8 +4790,6 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                     "width": "88px",
                   }
                 }
-                tabIndex={-1}
-                type="button"
               />
             </div>
             <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -473,7 +473,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -482,12 +482,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -496,12 +494,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -510,12 +506,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -524,8 +518,6 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -1065,7 +1057,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -1074,12 +1066,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -1088,12 +1078,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -1102,12 +1090,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -1116,8 +1102,6 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -2110,7 +2094,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -2119,12 +2103,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -2133,12 +2115,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -2147,12 +2127,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -2161,8 +2139,6 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -2702,7 +2678,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -2711,12 +2687,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -2725,12 +2699,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -2739,12 +2711,10 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -2753,8 +2723,6 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -3837,7 +3805,7 @@ exports[`StudentProfileUnits component should render only completed activities i
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -3846,12 +3814,10 @@ exports[`StudentProfileUnits component should render only completed activities i
                       "width": "465px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header score-section tooltip-section"
                   style={
                     Object {
@@ -3860,12 +3826,10 @@ exports[`StudentProfileUnits component should render only completed activities i
                       "width": "144px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Score
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -3874,12 +3838,10 @@ exports[`StudentProfileUnits component should render only completed activities i
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header completed-due-date-section"
                   style={
                     Object {
@@ -3888,12 +3850,10 @@ exports[`StudentProfileUnits component should render only completed activities i
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -3902,8 +3862,6 @@ exports[`StudentProfileUnits component should render only completed activities i
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -4690,7 +4648,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -4699,12 +4657,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -4713,12 +4669,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -4727,12 +4681,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -4741,8 +4693,6 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -5343,7 +5293,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -5352,12 +5302,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -5366,12 +5314,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -5380,12 +5326,10 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -5394,8 +5338,6 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -6516,7 +6458,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -6525,12 +6467,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -6539,12 +6479,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -6553,12 +6491,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -6567,8 +6503,6 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -7169,7 +7103,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -7178,12 +7112,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -7192,12 +7124,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -7206,12 +7136,10 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -7220,8 +7148,6 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -8342,7 +8268,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -8351,12 +8277,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -8365,12 +8289,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -8379,12 +8301,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -8393,8 +8313,6 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div
@@ -8995,7 +8913,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
               <div
                 className="data-table-headers"
               >
-                <button
+                <th
                   className="data-table-header name-section"
                   style={
                     Object {
@@ -9004,12 +8922,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "633px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Activity
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header tool-icon-section"
                   style={
                     Object {
@@ -9018,12 +8934,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "24px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Tool
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header due-date-section"
                   style={
                     Object {
@@ -9032,12 +8946,10 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "85px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 >
                   Due date
-                </button>
-                <button
+                </th>
+                <th
                   className="data-table-header action-button-section"
                   style={
                     Object {
@@ -9046,8 +8958,6 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                       "width": "88px",
                     }
                   }
-                  tabIndex={-1}
-                  type="button"
                 />
               </div>
               <div


### PR DESCRIPTION
## WHAT
Make data table headers accessible by not using buttons where there is no text/action, and generally using a containing `<th>` tag so it's accessible to screenreaders.

## WHY
This was something that confused our accessibility auditor when we were doing our walkthrough.

## HOW
Only generate button elements when there is an action to take, and wrap all header elements in `<th>` tags so the screenreader can identify them properly.

### Screenshots
No visible change.

### Notion Card Links
https://www.notion.so/quill/Replace-unlabeled-button-for-columns-without-names-in-DataTable-component-b855ba48d2f44ad8adc9c02bb7651b83

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES - snapshots
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES