### PR TITLE
Add Evidence activities to Demo account

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,7 +2,6 @@
 
 module Demo::ReportDemoCreator
 
-  COMPREHENSION_APP_SETTING = 'comprehension'
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
   ACTIVITY_PACKS_TEMPLATES = [
@@ -205,6 +204,42 @@ module Demo::ReportDemoCreator
           1664 => 9962377
         }
       ]
+    },
+    {
+      name: "Evidence-Based Writing: Ethics in Science [Beta]",
+      activity_ids: [1726, 1815, 1813, 1830],
+      activity_sessions: [
+        {
+          1726 => 139852750,
+          1815 => 140313798,
+          1813 => 140315090,
+          1830 => 140405696
+        },
+        {
+          1726 => 140325094,
+          1815 => 140316082,
+          1813 => 140317901,
+          1830 => 140321693
+        },
+        {
+          1726 => 140710875,
+          1815 => 140723229,
+          1813 => 140744041,
+          1830 => 140771018
+        },
+        {
+          1726 => 140534754,
+          1815 => 140536782,
+          1813 => 140544585,
+          1830 => 140547957
+        },
+        {
+          1726 => 140063048,
+          1815 => 140566540,
+          1813 => 140569206,
+          1830 => 140571188
+        }
+      ]
     }
   ]
 
@@ -233,17 +268,9 @@ module Demo::ReportDemoCreator
       role: "teacher",
       password: 'password',
       password_confirmation: 'password',
-      flags: ['beta']
     }
 
     teacher = User.create(values)
-    app_setting = AppSetting.find_by(name: COMPREHENSION_APP_SETTING)
-
-    return teacher if app_setting.blank?
-
-    app_setting.user_ids_allow_list << teacher.id
-    app_setting.save
-    teacher
   end
 
   def self.create_classroom(teacher)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -404,18 +404,19 @@ module Demo::ReportDemoCreator
             cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
             new_activity_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage, uid: SecureRandom.uuid})
 
-            temp.feedback_sessions.each do |feedback_session_to_copy|
-              values = {
-                activity_session_uid: new_activity_session.uid,
-                uid: SecureRandom.uuid
-              }
-              new_feedback_session = FeedbackSession.create(values)
+            feedback_session_to_copy = temp.feedback_sessions.first
 
-              feedback_session_to_copy.feedback_history.each do |fh|
-                new_feedback_history = fh.dup
-                new_feedback_history.feedback_session_uid = new_feedback_session.uid
-                new_feedback_history.save
-              end
+            values = {
+              activity_session_uid: new_activity_session.uid,
+              uid: SecureRandom.uuid
+            }
+            new_feedback_session = FeedbackSession.create(values)
+
+            feedback_session_to_copy.feedback_history.each do |fh|
+              new_feedback_history = fh.dup
+              new_feedback_history.feedback_session_uid = new_feedback_session.uid
+              new_feedback_history.save
+            end
             end
           end
         else
@@ -439,8 +440,5 @@ module Demo::ReportDemoCreator
         end
       end
     end
-  end
-
-  private def create_evidence_activity_sessions
   end
 end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -395,45 +395,21 @@ module Demo::ReportDemoCreator
       ACTIVITY_PACKS_TEMPLATES.each do |activity_pack|
         unit = Unit.where(name: activity_pack[:name]).last
         act_sessions = activity_pack[:activity_sessions]
-        if activity_pack[:is_evidence]
-          act_sessions[num].each do |act_id, user_id|
-            temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
-            next unless temp
+        act_sessions[num].each do |act_id, user_id|
+          temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
+          next unless temp
 
-            cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
-            new_activity_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage, uid: SecureRandom.uuid})
+          cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
+          act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
 
-            feedback_session_to_copy = temp.feedback_sessions.first
-
+          temp.concept_results.each do |cr|
             values = {
-              activity_session_uid: new_activity_session.uid,
-              uid: SecureRandom.uuid
+              activity_session_id: act_session.id,
+              concept_id: cr.concept_id,
+              metadata: cr.metadata,
+              question_type: cr.question_type
             }
-            new_feedback_session = FeedbackSession.create(values)
-
-            feedback_session_to_copy&.feedback_history&.each do |fh|
-              new_feedback_history = fh.dup
-              new_feedback_history.feedback_session_uid = new_feedback_session.uid
-              new_feedback_history.save
-            end
-          end
-        else
-          act_sessions[num].each do |act_id, user_id|
-            temp = ActivitySession.unscoped.where({activity_id: act_id, user_id: user_id, is_final_score: true}).first
-            next unless temp
-
-            cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
-            act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
-
-            temp.concept_results.each do |cr|
-              values = {
-                activity_session_id: act_session.id,
-                concept_id: cr.concept_id,
-                metadata: cr.metadata,
-                question_type: cr.question_type
-              }
-              ConceptResult.create(values)
-            end
+            ConceptResult.create(values)
           end
         end
       end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,6 +2,7 @@
 
 module Demo::ReportDemoCreator
 
+  COMPREHENSION_APP_SETTING = 'comprehension'
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
   ACTIVITY_PACKS_TEMPLATES = [
@@ -232,9 +233,17 @@ module Demo::ReportDemoCreator
       role: "teacher",
       password: 'password',
       password_confirmation: 'password',
+      flags: ['beta']
     }
 
     teacher = User.create(values)
+    app_setting = AppSetting.find_by(name: COMPREHENSION_APP_SETTING)
+
+    return teacher if app_setting.blank?
+
+    app_setting.user_ids_allow_list << teacher.id
+    app_setting.save
+    teacher
   end
 
   def self.create_classroom(teacher)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -417,7 +417,6 @@ module Demo::ReportDemoCreator
               new_feedback_history.feedback_session_uid = new_feedback_session.uid
               new_feedback_history.save
             end
-            end
           end
         else
           act_sessions[num].each do |act_id, user_id|

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,6 +2,7 @@
 
 module Demo::ReportDemoCreator
 
+  COMPREHENSION_APP_SETTING = "comprehension"
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
   ACTIVITY_PACKS_TEMPLATES = [
@@ -268,9 +269,17 @@ module Demo::ReportDemoCreator
       role: "teacher",
       password: 'password',
       password_confirmation: 'password',
+      flags: ["beta"]
     }
 
     teacher = User.create(values)
+    app_setting = AppSetting.find_by(name: COMPREHENSION_APP_SETTING)
+
+    return teacher if app_setting.blank?
+
+    app_setting.user_ids_allow_list << teacher.id
+    app_setting.save
+    teacher
   end
 
   def self.create_classroom(teacher)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -209,7 +209,6 @@ module Demo::ReportDemoCreator
     {
       name: "Evidence-Based Writing: Ethics in Science [Beta]",
       activity_ids: [1726, 1815, 1813, 1830],
-      is_evidence: true,
       activity_sessions: [
         {
           1726 => 139852750,
@@ -412,7 +411,7 @@ module Demo::ReportDemoCreator
             }
             new_feedback_session = FeedbackSession.create(values)
 
-            feedback_session_to_copy.feedback_history.each do |fh|
+            feedback_session_to_copy&.feedback_history&.each do |fh|
               new_feedback_history = fh.dup
               new_feedback_history.feedback_session_uid = new_feedback_session.uid
               new_feedback_history.save

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,7 +2,7 @@
 
 module Demo::ReportDemoCreator
 
-  COMPREHENSION_APP_SETTING = "comprehension"
+  EVIDENCE_APP_SETTING = "comprehension"
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
   ACTIVITY_PACKS_TEMPLATES = [
@@ -273,7 +273,7 @@ module Demo::ReportDemoCreator
     }
 
     teacher = User.create(values)
-    app_setting = AppSetting.find_by(name: COMPREHENSION_APP_SETTING)
+    app_setting = AppSetting.find_by(name: EVIDENCE_APP_SETTING)
 
     return teacher if app_setting.blank?
 

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -88,9 +88,12 @@ RSpec.describe Demo::ReportDemoCreator do
     units = Demo::ReportDemoCreator.create_units(teacher)
 
     Demo::ReportDemoCreator.create_classroom_units(classroom, units)
-    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(24)
+    # TODO: change this to dynamically calculate
+    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(28)
     act_sesh = ActivitySession.last
-    expect(act_sesh.activity_id).to eq(1664)
+
+    last_template = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.last
+    expect(act_sesh.activity_id).to eq(last_template[:activity_sessions][0].keys.last)
     expect(act_sesh.user_id).to eq(student.id)
     expect(act_sesh.state).to eq('finished')
     expect(act_sesh.percentage).to eq(temp.percentage)

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Demo::ReportDemoCreator do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |ap|
       ap[:activity_ids].each {|id| create(:activity, id: id)}
     end
+    AppSetting.create(name: Demo::ReportDemoCreator::COMPREHENSION_APP_SETTING)
   end
 
 
@@ -19,6 +20,8 @@ RSpec.describe Demo::ReportDemoCreator do
     expect(teacher.name).to eq("Demo Teacher")
     expect(teacher.email).to eq(email)
     expect(teacher.role).to eq("teacher")
+    expect(teacher.flags).to eq(["beta"])
+    expect(AppSetting.find_by(name: Demo::ReportDemoCreator::COMPREHENSION_APP_SETTING).user_ids_allow_list).to eq([teacher.id])
   end
 
   it 'creates a classroom for the teacher' do

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Demo::ReportDemoCreator do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |ap|
       ap[:activity_ids].each {|id| create(:activity, id: id)}
     end
-    AppSetting.create(name: Demo::ReportDemoCreator::COMPREHENSION_APP_SETTING)
+    AppSetting.create(name: Demo::ReportDemoCreator::EVIDENCE_APP_SETTING)
   end
 
 
@@ -21,7 +21,7 @@ RSpec.describe Demo::ReportDemoCreator do
     expect(teacher.email).to eq(email)
     expect(teacher.role).to eq("teacher")
     expect(teacher.flags).to eq(["beta"])
-    expect(AppSetting.find_by(name: Demo::ReportDemoCreator::COMPREHENSION_APP_SETTING).user_ids_allow_list).to eq([teacher.id])
+    expect(AppSetting.find_by(name: Demo::ReportDemoCreator::EVIDENCE_APP_SETTING).user_ids_allow_list).to eq([teacher.id])
   end
 
   it 'creates a classroom for the teacher' do

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Demo::ReportDemoCreator do
     units = Demo::ReportDemoCreator.create_units(teacher)
 
     Demo::ReportDemoCreator.create_classroom_units(classroom, units)
-    # TODO: change this to dynamically calculate
-    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(28)
+    total_act_sesh_count = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.map {|ap| ap[:activity_sessions][0].keys.count}.sum
+    expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom)}.to change {ActivitySession.count}.by(total_act_sesh_count)
     act_sesh = ActivitySession.last
 
     last_template = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.last

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe Demo::ReportDemoCreator do
       ap[:activity_sessions][0].each do |act_id, user_id|
         user = build(:user, id: user_id)
         user.save
-        create(:activity_session, state: 'finished', activity_id: act_id, user_id: user_id, is_final_score: true)
+        activity_session = create(:activity_session, state: 'finished', activity_id: act_id, user_id: user_id, is_final_score: true)
+        create(:concept_result, activity_session: activity_session)
       end
     end
 
@@ -97,5 +98,6 @@ RSpec.describe Demo::ReportDemoCreator do
     expect(act_sesh.user_id).to eq(student.id)
     expect(act_sesh.state).to eq('finished')
     expect(act_sesh.percentage).to eq(temp.percentage)
+    expect(act_sesh.concept_results.first.metadata).to eq(temp.concept_results.first.metadata)
   end
 end


### PR DESCRIPTION
## WHAT
Give the demo teacher account access to Evidence activities upon account creation. Add some new Evidence activity session templates to the demo account.

## WHY
So teachers and staff using the Demo Account can test out Evidence activities and see sample Evidence activity data.

## HOW
-add some new Evidence activity sessions to the demo account
-give the demo account `flags: ["beta"]` when the account is created
-add the newly created account's ID to the allow list for Evidence users

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-Quill-Evidence-assigning-access-to-quill-org-quill_staff_demo-account-865290f857ab48ba89b2a234c96944bc
https://www.notion.so/quill/Add-student-Quill-Evidence-data-to-quill-org-quill_staff_demo-account-a4bec64e16f34bf8b7db013172371c2f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
