### PR TITLE
Have overnight pre_cache use the DEFAULT Sidekiq queue. (#9073)

### DIFF
--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -8,7 +8,7 @@ class PreCacheAdminDashboardsWorker
     active_admin_ids = User.where('last_sign_in >= ?', School.school_year_start(Time.now)).joins(:schools_admins).pluck(:id)
 
     active_admin_ids.each do |id|
-      FindAdminUsersWorker.perform_async(id)
+      FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -8,26 +8,29 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
   let!(:current_admin1) { create(:user, last_sign_in: Time.now) }
   let!(:current_admin2) { create(:user, last_sign_in: Time.now) }
   let!(:not_admin) { create(:user, last_sign_in: Time.now) }
+  let(:mock_worker) {double(:perform_async)}
 
   before do
     create(:schools_admins, user: old_admin)
     create(:schools_admins, user: current_admin1)
     create(:schools_admins, user: current_admin2)
+
+    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_worker)
   end
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
-    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin1.id).once
-    expect(FindAdminUsersWorker).to receive(:perform_async).with(current_admin2.id).once
+    expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-admins' do
-    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(not_admin.id)
+    expect(mock_worker).not_to receive(:perform_async).with(not_admin.id)
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-active admins' do
-    expect(FindAdminUsersWorker).not_to receive(:perform_async).with(old_admin.id)
+    expect(mock_worker).not_to receive(:perform_async).with(old_admin.id)
     worker.perform
   end
 end


### PR DESCRIPTION
* Have overnight pre_cache use the default queue.

* Make mock more specific.

* Lint.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
