### PR TITLE
Quill Locker/ fix locker variable

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
@@ -115,7 +115,7 @@ export const OrganizeLocker = ({ history, personalLocker, userId }) => {
   }
 
   function handleAddSection() {
-    let updatedLockerPreferences = _.cloneDeep(lockerPreferences);
+    let updatedLockerPreferences = _.cloneDeep(lockerPreferences) || {};
     updatedLockerPreferences[uuid()] = { label: '', lockers: {} };
     setLockerPreferences(updatedLockerPreferences);
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
@@ -115,7 +115,7 @@ export const OrganizeLocker = ({ history, personalLocker, userId }) => {
   }
 
   function handleAddSection() {
-    let updatedLockerPreferences = _.cloneDeep(lockerPreferences) || {};
+    const updatedLockerPreferences = _.cloneDeep(lockerPreferences) || {};
     updatedLockerPreferences[uuid()] = { label: '', lockers: {} };
     setLockerPreferences(updatedLockerPreferences);
   }


### PR DESCRIPTION
## WHAT
small bug fix for initial Locker creation

## WHY
we want staff to be able to create lockers with sections on initial creation (staff can still initially create a locker without sections and add sections after creation)

## HOW
conditionally return empty hash if new locker is being created

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A