### PR TITLE
add aria labels to buttons on student dashboards

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/pinned_activity_bar.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/pinned_activity_bar.test.jsx.snap
@@ -9,9 +9,11 @@ exports[`PinnedActivityBar component should render if it is being previewed 1`] 
 >
   <div
     className="pinned-activity"
+    role="status"
   >
     <span />
     <button
+      aria-label="Join undefined"
       className="quill-button medium primary contained focus-on-dark"
       onClick={[Function]}
       type="button"
@@ -31,9 +33,11 @@ exports[`PinnedActivityBar component should render if it is not being previewed 
 >
   <div
     className="pinned-activity"
+    role="status"
   >
     <span />
     <a
+      aria-label="Join undefined"
       className="quill-button medium primary contained focus-on-dark"
       href="/activity_sessions/classroom_units/2/activities/1"
     >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -962,6 +962,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Start The Travels of Marco Polo"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/608"
                   >
@@ -974,6 +975,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Christopher Columbus"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/607"
                   >
@@ -986,6 +988,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start A, An, The"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/140"
                   >
@@ -998,6 +1001,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Magellan"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/605"
                   >
@@ -1010,6 +1014,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Jamestown"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/606"
                   >
@@ -1022,6 +1027,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Sailing with the Stars"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/503"
                   >
@@ -1034,6 +1040,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: The Cape of Good Hope"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/504"
                   >
@@ -1046,6 +1053,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Roanoke"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/517"
                   >
@@ -1176,6 +1184,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start The Travels of Marco Polo"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/608"
                     >
@@ -1239,6 +1248,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Christopher Columbus"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/607"
                     >
@@ -1302,6 +1312,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start A, An, The"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/140"
                     >
@@ -1365,6 +1376,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Magellan"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/605"
                     >
@@ -1428,6 +1440,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Jamestown"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/606"
                     >
@@ -1491,6 +1504,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Sailing with the Stars"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/503"
                     >
@@ -1554,6 +1568,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: The Cape of Good Hope"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/504"
                     >
@@ -1617,6 +1632,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Roanoke"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/517"
                     >
@@ -2599,6 +2615,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Start The Travels of Marco Polo"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/608"
                   >
@@ -2611,6 +2628,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Christopher Columbus"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/607"
                   >
@@ -2623,6 +2641,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start A, An, The"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/140"
                   >
@@ -2635,6 +2654,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Magellan"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/605"
                   >
@@ -2647,6 +2667,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Jamestown"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/606"
                   >
@@ -2659,6 +2680,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Sailing with the Stars"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/503"
                   >
@@ -2671,6 +2693,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: The Cape of Good Hope"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/504"
                   >
@@ -2683,6 +2706,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Roanoke"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/517"
                   >
@@ -2813,6 +2837,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start The Travels of Marco Polo"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/608"
                     >
@@ -2876,6 +2901,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Christopher Columbus"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/607"
                     >
@@ -2939,6 +2965,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start A, An, The"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/140"
                     >
@@ -3002,6 +3029,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Magellan"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/605"
                     >
@@ -3065,6 +3093,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Jamestown"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/606"
                     >
@@ -3128,6 +3157,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Sailing with the Stars"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/503"
                     >
@@ -3191,6 +3221,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: The Cape of Good Hope"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/504"
                     >
@@ -3254,6 +3285,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Roanoke"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/517"
                     >
@@ -3602,11 +3634,13 @@ exports[`StudentProfileUnits component should render only completed activities i
     >
       <div
         className="pinned-activity"
+        role="status"
       >
         <span>
           Lesson 1: Missing Subject or Verb Fragments
         </span>
         <a
+          aria-label="Join Lesson 1: Missing Subject or Verb Fragments"
           className="quill-button medium primary contained focus-on-dark"
           href="/activity_sessions/classroom_units/10/activities/560"
         >
@@ -3786,6 +3820,7 @@ exports[`StudentProfileUnits component should render only completed activities i
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Replay A, An"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/138"
                   >
@@ -3808,6 +3843,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Replay Age of Exploration: Spices"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/516"
                   >
@@ -3984,6 +4020,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     }
                   >
                     <a
+                      aria-label="Replay A, An"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/138"
                     >
@@ -4069,6 +4106,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     }
                   >
                     <a
+                      aria-label="Replay Age of Exploration: Spices"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/516"
                     >
@@ -4417,11 +4455,13 @@ exports[`StudentProfileUnits component should render only incomplete activities 
     >
       <div
         className="pinned-activity"
+        role="status"
       >
         <span>
           Lesson 1: Missing Subject or Verb Fragments
         </span>
         <a
+          aria-label="Join Lesson 1: Missing Subject or Verb Fragments"
           className="quill-button medium primary contained focus-on-dark"
           href="/activity_sessions/classroom_units/10/activities/560"
         >
@@ -4638,6 +4678,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/10/activities/560"
                   >
@@ -4799,6 +4840,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/10/activities/560"
                     >
@@ -5240,6 +5282,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Start The Travels of Marco Polo"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/608"
                   >
@@ -5252,6 +5295,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Christopher Columbus"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/607"
                   >
@@ -5264,6 +5308,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start A, An, The"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/140"
                   >
@@ -5276,6 +5321,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Magellan"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/605"
                   >
@@ -5288,6 +5334,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Jamestown"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/606"
                   >
@@ -5300,6 +5347,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Sailing with the Stars"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/503"
                   >
@@ -5312,6 +5360,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: The Cape of Good Hope"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/504"
                   >
@@ -5324,6 +5373,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Roanoke"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/517"
                   >
@@ -5454,6 +5504,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start The Travels of Marco Polo"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/608"
                     >
@@ -5517,6 +5568,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Christopher Columbus"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/607"
                     >
@@ -5580,6 +5632,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start A, An, The"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/140"
                     >
@@ -5643,6 +5696,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Magellan"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/605"
                     >
@@ -5706,6 +5760,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Jamestown"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/606"
                     >
@@ -5769,6 +5824,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Sailing with the Stars"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/503"
                     >
@@ -5832,6 +5888,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: The Cape of Good Hope"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/504"
                     >
@@ -5895,6 +5952,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Roanoke"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/517"
                     >
@@ -6243,11 +6301,13 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
     >
       <div
         className="pinned-activity"
+        role="status"
       >
         <span>
           Lesson 1: Missing Subject or Verb Fragments
         </span>
         <a
+          aria-label="Join Lesson 1: Missing Subject or Verb Fragments"
           className="quill-button medium primary contained focus-on-dark"
           href="/activity_sessions/classroom_units/10/activities/560"
         >
@@ -6464,6 +6524,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/10/activities/560"
                   >
@@ -6625,6 +6686,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/10/activities/560"
                     >
@@ -7066,6 +7128,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Start The Travels of Marco Polo"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/608"
                   >
@@ -7078,6 +7141,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Christopher Columbus"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/607"
                   >
@@ -7090,6 +7154,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start A, An, The"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/140"
                   >
@@ -7102,6 +7167,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Magellan"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/605"
                   >
@@ -7114,6 +7180,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Jamestown"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/606"
                   >
@@ -7126,6 +7193,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Sailing with the Stars"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/503"
                   >
@@ -7138,6 +7206,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: The Cape of Good Hope"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/504"
                   >
@@ -7150,6 +7219,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Roanoke"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/517"
                   >
@@ -7280,6 +7350,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start The Travels of Marco Polo"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/608"
                     >
@@ -7343,6 +7414,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Christopher Columbus"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/607"
                     >
@@ -7406,6 +7478,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start A, An, The"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/140"
                     >
@@ -7469,6 +7542,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Magellan"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/605"
                     >
@@ -7532,6 +7606,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Jamestown"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/606"
                     >
@@ -7595,6 +7670,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Sailing with the Stars"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/503"
                     >
@@ -7658,6 +7734,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: The Cape of Good Hope"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/504"
                     >
@@ -7721,6 +7798,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Roanoke"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/517"
                     >
@@ -8069,11 +8147,13 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
     >
       <div
         className="pinned-activity"
+        role="status"
       >
         <span>
           Lesson 1: Missing Subject or Verb Fragments
         </span>
         <a
+          aria-label="Join Lesson 1: Missing Subject or Verb Fragments"
           className="quill-button medium primary contained focus-on-dark"
           href="/activity_sessions/classroom_units/10/activities/560"
         >
@@ -8290,6 +8370,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/10/activities/560"
                   >
@@ -8451,6 +8532,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Resume Lesson 1: Missing Subject or Verb Fragments"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/10/activities/560"
                     >
@@ -8892,6 +8974,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
               Array [
                 Object {
                   "actionButton": <a
+                    aria-label="Start The Travels of Marco Polo"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/608"
                   >
@@ -8904,6 +8987,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Christopher Columbus"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/607"
                   >
@@ -8916,6 +9000,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start A, An, The"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/140"
                   >
@@ -8928,6 +9013,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Magellan"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/605"
                   >
@@ -8940,6 +9026,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Jamestown"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/606"
                   >
@@ -8952,6 +9039,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Sailing with the Stars"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/503"
                   >
@@ -8964,6 +9052,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: The Cape of Good Hope"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/504"
                   >
@@ -8976,6 +9065,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                 },
                 Object {
                   "actionButton": <a
+                    aria-label="Start Age of Exploration: Roanoke"
                     className="quill-button medium focus-on-light secondary outlined"
                     href="/activity_sessions/classroom_units/1/activities/517"
                   >
@@ -9106,6 +9196,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start The Travels of Marco Polo"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/608"
                     >
@@ -9169,6 +9260,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Christopher Columbus"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/607"
                     >
@@ -9232,6 +9324,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start A, An, The"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/140"
                     >
@@ -9295,6 +9388,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Magellan"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/605"
                     >
@@ -9358,6 +9452,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Jamestown"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/606"
                     >
@@ -9421,6 +9516,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Sailing with the Stars"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/503"
                     >
@@ -9484,6 +9580,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: The Cape of Good Hope"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/504"
                     >
@@ -9547,6 +9644,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     }
                   >
                     <a
+                      aria-label="Start Age of Exploration: Roanoke"
                       className="quill-button medium focus-on-light secondary outlined"
                       href="/activity_sessions/classroom_units/1/activities/517"
                     >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/pinned_activity_bar.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/pinned_activity_bar.tsx
@@ -17,14 +17,14 @@ export default class PinnedActivityBar extends React.Component<PinnedActivityBar
 
   render() {
     const { isBeingPreviewed, classroomUnitId, activityId, name, } = this.props
-    let link = <a className="quill-button medium primary contained focus-on-dark" href={activityLaunchLink(classroomUnitId, activityId)}>Join</a>
+    let link = <a aria-label={`Join ${name}`} className="quill-button medium primary contained focus-on-dark" href={activityLaunchLink(classroomUnitId, activityId)}>Join</a>
 
     if (isBeingPreviewed) {
-      link = <button className="quill-button medium primary contained focus-on-dark" onClick={this.handleClickDuringPreview} type="button">Join</button>
+      link = <button aria-label={`Join ${name}`} className="quill-button medium primary contained focus-on-dark" onClick={this.handleClickDuringPreview} type="button">Join</button>
     }
 
     return (
-      <div className="pinned-activity">
+      <div className="pinned-activity" role="status">
         <span>{name}</span>
         {link}
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/pinned_activity_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/pinned_activity_modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import activityLaunchLink from '../modules/generate_activity_launch_link.js';
 
 interface PinnedActivityModalProps {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -94,7 +94,7 @@ const completeHeaders = [
 export default class StudentProfileUnit extends React.Component {
   actionButton = (act, nextActivitySession) => {
     const { isBeingPreviewed, onShowPreviewModal, } = this.props
-    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, activity_classification_key, } = act
+    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, activity_classification_key, name, } = act
     let linkText = 'Start'
 
     if (activity_classification_key === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY && pre_activity_id && !completed_pre_activity_session) { return <span className="complete-baseline">Complete Baseline first</span>}
@@ -106,9 +106,9 @@ export default class StudentProfileUnit extends React.Component {
     if (locked) { return <span className="needs-teacher">Needs teacher</span> }
 
     if (finished) {
-      linkText = 'Replay';
+      linkText = `Replay`;
     } else if (resume_link === 1) {
-      linkText = 'Resume';
+      linkText = `Resume`;
     }
 
     const isNextActivity = nextActivitySession && classroom_unit_id === nextActivitySession.classroom_unit_id && activity_id === nextActivitySession.activity_id
@@ -119,6 +119,7 @@ export default class StudentProfileUnit extends React.Component {
 
       return (
         <button
+          aria-label={`${linkText} ${name}`}
           className={`quill-button medium focus-on-light ${buttonStyle}`}
           onClick={onClick}
           type="button"
@@ -130,6 +131,7 @@ export default class StudentProfileUnit extends React.Component {
 
     return (
       <a
+        aria-label={`${linkText} ${name}`}
         className={`quill-button medium focus-on-light ${buttonStyle}`}
         href={activityLaunchLink(classroom_unit_id, activity_id)}
       >


### PR DESCRIPTION
## WHAT
Add aria-labels to buttons on student dashboards.

## WHY
So users tab navigating don't have to switch into their reading keys for context.

## HOW
Just add `aria-label`s to all the buttons with the name of the activity, and also add an `aria-role` to the pinned activity bar so focus shifts if a teacher launches a lesson.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Give-context-to-Start-buttons-on-student-dashboard-5a93cac8e49a4f22956f4baf4d34c3bf

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
