### PR TITLE
add screenreader instructions to all activity types

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
@@ -6,7 +6,7 @@ import { NavBar } from './navbar/navbar';
 
 import { routes } from "../routes";
 import { getParameterByName } from '../libs/getParameterByName';
-import { TeacherPreviewMenu, TeacherPreviewMenuButton } from '../../Shared/index';
+import { TeacherPreviewMenu, ScreenreaderInstructions, } from '../../Shared/index';
 import { fetchUserRole } from '../../Shared/utils/userAPIs';
 import { addKeyDownListener } from '../../Shared/hooks/addKeyDownListener';
 
@@ -84,6 +84,7 @@ export const Home = () => {
           />
         </aside>}
         <main style={{ height: '100vh', overflow: 'auto' }}>
+          <ScreenreaderInstructions />
           <button className="skip-main" onClick={handleSkipToMainContentClick} type="button">Skip to main content</button>
           {header}
           <div id="main-content" tabIndex={-1}>{renderRoutes(routes, {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/home.tsx
@@ -7,7 +7,7 @@ import TeacherNavbar from './navbar/teacherNavbar';
 
 import { routes } from "../routes";
 import { getParameterByName } from '../libs/getParameterByName';
-import { TeacherPreviewMenu } from '../../Shared/components/shared/teacherPreviewMenu';
+import { TeacherPreviewMenu, ScreenreaderInstructions, } from '../../Shared/index';
 import { fetchUserRole } from '../../Shared/utils/userAPIs';
 import { addKeyDownListener } from '../../Shared/hooks/addKeyDownListener';
 
@@ -79,7 +79,8 @@ export const Home = () => {
           />
         </aside>}
         <main style={{ height: '100vh', overflow: 'auto' }}>
-          {isPlaying && !isTeacherOrAdmin && <button className="skip-main" onClick={handleSkipToMainContentClick} type="button">Skip to main content</button>}
+          <ScreenreaderInstructions />
+          <button className="skip-main" onClick={handleSkipToMainContentClick} type="button">Skip to main content</button>
           {isPlaying && !isTeacherOrAdmin && <StudentNavBar />}
           {isPlaying && isTeacherOrAdmin && <TeacherNavbar isOnMobile={isOnMobile} onTogglePreview={handleTogglePreviewMenu} previewShowing={previewShowing} />}
           <div id="main-content" tabIndex={-1}>{renderRoutes(routes, {

--- a/services/QuillLMS/client/app/bundles/Evidence/components/PageLayout.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/PageLayout.tsx
@@ -4,6 +4,7 @@ import {renderRoutes} from "react-router-config";
 import Header from "./Header";
 
 import { routes } from "../routes";
+import { ScreenreaderInstructions, } from '../../Shared/index'
 
 const PageLayout: React.StatelessComponent<{}> = (props: any) => {
   const { user } = props;
@@ -17,6 +18,7 @@ const PageLayout: React.StatelessComponent<{}> = (props: any) => {
 
   return (
     <div aria-live="polite" className="app-container">
+      <ScreenreaderInstructions />
       <button className="skip-main" onClick={handleSkipToMainContentClick} type="button">Skip to main content</button>
       <Header />
       <div id="main-content" tabIndex={-1}>{renderRoutes(routes, { user })}</div>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/PageLayout.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/PageLayout.tsx
@@ -7,7 +7,7 @@ import { Header } from "./Header";
 import { routes } from "../routes";
 import { fetchUserRole } from '../../Shared/utils/userAPIs';
 import getParameterByName from '../helpers/getParameterByName';
-import { TeacherPreviewMenu } from '../../Shared/index';
+import { TeacherPreviewMenu, ScreenreaderInstructions, } from '../../Shared/index';
 import { addKeyDownListener } from '../../Shared/hooks/addKeyDownListener';
 import { setCurrentQuestion } from '../actions/session';
 
@@ -63,6 +63,7 @@ export const PageLayout = () => {
   function renderContent (header: JSX.Element, showPreview: boolean, isOnMobile: boolean) {
     return(
       <main style={{ height: '100vh', overflow: 'auto' }}>
+        <ScreenreaderInstructions />
         <button className="skip-main" onClick={handleSkipToMainContentClick} type="button">Skip to main content</button>
         {header}
         <div id="main-content" tabIndex={-1}>{renderRoutes(routes, {

--- a/services/QuillLMS/client/app/bundles/Lessons/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/home.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { renderRoutes } from "react-router-config";
 import { routes } from "../routes";
 
+import { ScreenreaderInstructions, } from '../../Shared/index'
+
 export default class Home extends React.Component<any, any> {
   constructor(props) {
     super(props)
@@ -42,6 +44,7 @@ export default class Home extends React.Component<any, any> {
       <div className={className}>
         <div>
           <main>
+            <ScreenreaderInstructions />
             {skipToMainContentButton}
             {renderRoutes(routes)}
           </main>

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/PageLayout.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/PageLayout.tsx
@@ -3,6 +3,8 @@ import Header from "./Header";
 import {renderRoutes} from "react-router-config";
 import { routes } from "../routes";
 
+import { ScreenreaderInstructions, } from '../../Shared/index'
+
 export default class PageLayout extends React.Component<any, { showFocusState: boolean }> {
   constructor(props: any) {
     super(props)
@@ -50,6 +52,7 @@ export default class PageLayout extends React.Component<any, { showFocusState: b
     return (
       <div className={className}>
         <div className="page-content">
+          <ScreenreaderInstructions />
           <button className="skip-main" onClick={this.handleSkipToMainContentClick} type="button">Skip to main content</button>
           <button className="skip-main" onClick={this.handleSkipToPassageButtonsClick} type="button">Skip to passage buttons</button>
           {header}

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/index.tsx
@@ -51,6 +51,10 @@ export {
 } from './resumeOrBeginButton'
 
 export {
+  ScreenreaderInstructions
+} from './screenreaderInstructions'
+
+export {
   SmartSpinner
 } from './smartSpinner'
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/screenreaderInstructions.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/screenreaderInstructions.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 // disabling the tabIndex rule because setting a tabIndex seemed like the best way to ensure this line would always be read first, and I couldn't find a more appropriate aria-role.
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 export const ScreenreaderInstructions = () => (
-  <div className="screenreader-instructions" tabIndex={0}>
+  <p className="screenreader-instructions" tabIndex={0}>
     Screenreader users, please use your reading keys to navigate this activity.
-  </div>
+  </p>
 )

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/screenreaderInstructions.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/screenreaderInstructions.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+// disabling the tabIndex rule because setting a tabIndex seemed like the best way to ensure this line would always be read first, and I couldn't find a more appropriate aria-role.
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+export const ScreenreaderInstructions = () => (
+  <div className="screenreader-instructions" tabIndex={0}>
+    Screenreader users, please use your reading keys to navigate this activity.
+  </div>
+)

--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -33,6 +33,7 @@ export {
   Input,
   Passthrough,
   ResumeOrBeginButton,
+  ScreenreaderInstructions,
   SmartSpinner,
   Snackbar,
   defaultSnackbarTimeout,

--- a/services/QuillLMS/client/app/bundles/Shared/styles/screenreader_instructions.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/screenreader_instructions.scss
@@ -1,0 +1,27 @@
+.screenreader-instructions {
+  left:-999px;
+  position:absolute;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+  z-index:-999;
+}
+
+.screenreader-instructions:focus, .screenreader-instructions:active {
+  border-radius: 4px;
+  border: solid 1px #bdbdbd;
+  font-size: 15px;
+  line-height: 1;
+  background-color: white;
+  text-decoration: none;
+  outline: none;
+  padding: 13px 16px 12px;
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  overflow: auto;
+  z-index: 999;
+  color: #000000;
+}

--- a/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
@@ -18,6 +18,7 @@
 @import './toggle_component_section';
 @import './text_editor';
 @import './react_table';
+@import './screenreader_instructions';
 @import "~react-select-search/style.css";
 
 #main-content {


### PR DESCRIPTION
## WHAT
Add instructions that are only visible to tab-navigators and screenreader users to tell screenreader users to use their reading keys.

## WHY
This was highlighted by our accessibility auditor as a nice-to-have that would help make sure students weren't confused by missing informational content when tab-navigating.

## HOW
Just add a new element that is only visible on focus (but can still be read by screenreaders if already using reading keys) that tells screenreader users to use reading keys so they don't skip past important content.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-screenreader-legible-command-at-top-of-activity-pages-to-tell-students-to-use-their-reading-keys-497c53db2e56455c8212cdaddaa93162

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
