### PR TITLE
Evidence/ add constraint for Hint image height

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -304,9 +304,6 @@
       }
     }
   }
-  .hint {
-    height: 344px;
-  }
 
   &:not(.active) {
     .step-content {
@@ -348,11 +345,18 @@
   }
 }
 
+@media (min-width: 992px) {
+  .hint {
+    height: 344px;
+  }
+}
+
 @media (min-width: 768px) and (max-width: 991px) {
   .hint {
     height: 304px;
   }
 }
+
 @media (min-width: 660px) and (max-width: 767px) {
   .hint {
     height: 256px;

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -304,6 +304,9 @@
       }
     }
   }
+  .hint {
+    height: 344px;
+  }
 
   &:not(.active) {
     .step-content {
@@ -342,14 +345,22 @@
         display: none;
       }
     }
-    .hint {
-      height: 304px;
-    }
   }
 }
 
-@media (max-width: 660px) {
+@media (min-width: 768px) and (max-width: 991px) {
   .hint {
-    height: 248px;
+    height: 304px;
+  }
+}
+@media (min-width: 660px) and (max-width: 767px) {
+  .hint {
+    height: 256px;
+  }
+}
+
+@media (min-width: 320px) and (max-width: 659px) {
+  .hint {
+    height: 228px;
   }
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -342,5 +342,14 @@
         display: none;
       }
     }
+    .hint {
+      height: 304px;
+    }
+  }
+}
+
+@media (max-width: 660px) {
+  .hint {
+    height: 248px;
   }
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
@@ -63,7 +63,7 @@ const RuleHint = ({
           text={hint.explanation}
         />
         <p className="form-subsection-label">Hint Annotated Example</p>
-        <i>Click the square below or drag a file into it to upload. Please make sure to upload an .svg image.</i>
+        <i>Click the square below or drag a file into it to upload. Please make sure to upload an .svg image and ensure that any extra whitespace below the image is cropped.</i>
         <Dropzone onDrop={handleDrop} />
         {hint.image_link && hint.image_link.length ? <img alt={hint.image_alt_text} src={hint.image_link} /> : null}
         <p className="form-subsection-label">Hint Image Alt Text</p>


### PR DESCRIPTION
## WHAT
add constraints for Hint image height

## WHY
Hint images that weren't cropped are displaying a lot of extra whitespace on smaller screen sizes

## HOW
add a few media queries to set height

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/QE-on-iPad-Large-amount-of-whitespace-between-feedback-and-passage-a9a0efe265704929bd975d66d76478be

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
