### PR TITLE
Fix sorting method on Activity Scores report to match new ReactTable

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
@@ -11,7 +11,7 @@ import { PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, } from './progress_report_const
 
 import ItemDropdown from '../general_components/dropdown_selectors/item_dropdown'
 import LoadingSpinner from '../shared/loading_indicator.jsx'
-import {sortByLastName, sortFromSQLTimeStamp} from '../../../../modules/sortingMethods.js'
+import {sortTableByLastName, sortFromSQLTimeStamp} from '../../../../modules/sortingMethods.js'
 import { getTimeSpent } from '../../helpers/studentReports';
 import { ReactTable, } from '../../../Shared/index'
 
@@ -60,7 +60,7 @@ export class ActivitiesScoresByClassroomProgressReport extends React.Component {
         Header: 'Student',
         accessor: 'name',
         resizable: false,
-        sortMethod: sortByLastName,
+        sortMethod: sortTableByLastName,
         Cell: ({row}) => (<a className='row-link-disguise underlined' href={`/teachers/progress_reports/student_overview?classroom_id=${row.original.classroom_id}&student_id=${row.original.student_id}`}>
           {row.original.name}
         </a>),

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
@@ -60,7 +60,7 @@ export class ActivitiesScoresByClassroomProgressReport extends React.Component {
         Header: 'Student',
         accessor: 'name',
         resizable: false,
-        sortMethod: sortTableByLastName,
+        sortType: sortTableByLastName,
         Cell: ({row}) => (<a className='row-link-disguise underlined' href={`/teachers/progress_reports/student_overview?classroom_id=${row.original.classroom_id}&student_id=${row.original.student_id}`}>
           {row.original.name}
         </a>),
@@ -108,7 +108,7 @@ export class ActivitiesScoresByClassroomProgressReport extends React.Component {
         Cell: ({row}) => (<a className='row-link-disguise' href={`/teachers/progress_reports/student_overview?classroom_id=${row.original.classroom_id}&student_id=${row.original.student_id}`}>
           {row.original.last_active ? moment(row.original.last_active).format("MM/DD/YYYY") : <span />}
         </a>),
-        sortMethod: sortFromSQLTimeStamp,
+        sortType: sortFromSQLTimeStamp,
       },
       {
         Header: "Class",


### PR DESCRIPTION
## WHAT
When pushing out this last round of updates to `ReactTable`, we missed this one file. I'm updating the `sortMethod` (outdated) to `sortType` on this file so the table sorts as expected, and changing the sort method to last name which is the expected sorting method.

## WHY
The sorting on this table broke when we updated to `react-table-7` because we forgot to tweak the sort syntax on this file.

## HOW
Change `sortMethod` to `sortType` (react table 7 syntax).
Use the `sortTableByLastName` method because we use this method on all of the other teacher facing reports.

### Screenshots
![Screen Shot 2022-04-21 at 2 08 36 PM](https://user-images.githubusercontent.com/57366100/164524958-7f825e18-f18f-4ca2-9d6f-2a732b34bc93.png)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Activity-Scores-report-Student-heading-sorting-by-first-name-94af671850924f44a761ed6493b1612b)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, no tests for ReactTable (it's a third party library)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
