### PR TITLE
Lms/more caching

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -23,7 +23,15 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def students_by_classroom
-    render json: results_for_classroom(params[:unit_id], params[:activity_id], params[:classroom_id])
+    classroom = Classroom.find(params[:classroom_id])
+    cache_groups = {
+      activity_id: params[:activity_id],
+      unit_id: params[:unit_id]
+    }
+    response = current_user.classroom_cache(classroom, key: 'teachers.progress_reports.diagnostic_reports.student_by_classroom', groups: cache_groups) do
+      results_for_classroom(params[:unit_id], params[:activity_id], params[:classroom_id])
+    end
+    render json: response
   end
 
   def diagnostic_student_responses_index

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
@@ -9,17 +9,26 @@ class Teachers::ProgressReports::Standards::ClassroomsController < Teachers::Pro
 
       format.json do
         classroom_id = params[:classroom_id]
-        student_id = nil
-        data = ::ProgressReports::Standards::AllClassroomsStandard.new(current_user).results(classroom_id, student_id)
-        render json: {
-          data: data,
-          teacher: UserWithEmailSerializer.new(current_user).as_json(root: false),
-          classrooms: current_user.classrooms_i_teach,
-          students: student_names_and_ids(classroom_id)
+        cache_groups = {
+          classroom_id: classroom_id
         }
+        response = current_user.all_classrooms_cache(key: 'teachers.progress_reports.standards.classroom.index', groups: cache_groups) do
+          data = ::ProgressReports::Standards::AllClassroomsStandard.new(current_user).results(classroom_id, nil)
+          {
+            data: data,
+            teacher: UserWithEmailSerializer.new(current_user).as_json(root: false),
+            classrooms: current_user.classrooms_i_teach,
+            students: student_names_and_ids(classroom_id)
+          }
+        end
+        render json: response
       end
     end
   end
+end
+
+private def fetch_index_json_cache
+
 end
 
 private def student_names_and_ids(classroom_id)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/classrooms_controller.rb
@@ -27,10 +27,6 @@ class Teachers::ProgressReports::Standards::ClassroomsController < Teachers::Pro
   end
 end
 
-private def fetch_index_json_cache
-
-end
-
 private def student_names_and_ids(classroom_id)
   classroom_conditional = "AND classrooms.id = #{classroom_id}" if classroom_id
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/standard_students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/standard_students_controller.rb
@@ -6,30 +6,37 @@ class Teachers::ProgressReports::Standards::StandardStudentsController < Teacher
     respond_to do |format|
       format.html
       format.json do
-        students = ::ProgressReports::Standards::NewStudent.new(current_user).results(params)
-        students_json = students.map do |student|
-          serializer = ::ProgressReports::Standards::StudentSerializer.new(student)
-          # Doing this because can't figure out how to get custom params into serializers
-          serializer.classroom_id = classroom_id
-          serializer.as_json(root: false)
-        end
-        standards = ::ProgressReports::Standards::NewStandard.new(current_user).results(params)
-        standards_json = standards.map do |standard|
-          serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
-          # Doing this because can't figure out how to get custom params into serializers
-          serializer.classroom_id = classroom_id
-          serializer.as_json(root: false)
-        end
-        classrooms_i_teach = current_user.classrooms_i_teach
-        selected_classroom = classroom_id == 0 ? 'All Classrooms' : classrooms_i_teach.find{|c| c.id == classroom_id}
-        render json: {
-          selected_classroom: selected_classroom,
-          classrooms: classrooms_i_teach,
-          students: students_json,
-          standards: standards_json,
-          units: ProgressReports::Standards::Unit.new(current_user).results({}),
-          teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
+        cache_groups = {
+          classroom_id: params["classroom_id"],
+          standard_id: params["standard_id"]
         }
+        response = current_user.all_classrooms_cache(key: 'teachers.progress_reports.standards_standard_students.index', groups: cache_groups) do
+          students = ::ProgressReports::Standards::NewStudent.new(current_user).results(params)
+          students_json = students.map do |student|
+            serializer = ::ProgressReports::Standards::StudentSerializer.new(student)
+            # Doing this because can't figure out how to get custom params into serializers
+            serializer.classroom_id = classroom_id
+            serializer.as_json(root: false)
+          end
+          standards = ::ProgressReports::Standards::NewStandard.new(current_user).results(params)
+          standards_json = standards.map do |standard|
+            serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
+            # Doing this because can't figure out how to get custom params into serializers
+            serializer.classroom_id = classroom_id
+            serializer.as_json(root: false)
+          end
+          classrooms_i_teach = current_user.classrooms_i_teach
+          selected_classroom = classroom_id == 0 ? 'All Classrooms' : classrooms_i_teach.find{|c| c.id == classroom_id}
+          {
+            selected_classroom: selected_classroom,
+            classrooms: classrooms_i_teach,
+            students: students_json,
+            standards: standards_json,
+            units: ProgressReports::Standards::Unit.new(current_user).results({}),
+            teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
+          }
+        end
+        render json: response
       end
     end
   end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
@@ -5,21 +5,28 @@ class Teachers::ProgressReports::Standards::StudentStandardsController < Teacher
     respond_to do |format|
       format.html
       format.json do
-        standards = ::ProgressReports::Standards::NewStandard.new(current_user).results(params)
-        standards_json = standards.map do |standard|
-          serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
-          # Doing this because can't figure out how to get custom params into serializers
-          serializer.classroom_id = params[:classroom_id]
-          serializer.as_json(root: false)
-        end
-        student = User.find(params[:student_id])
-        student = nil unless current_user.teaches_student?(student.id)
-        render json: {
-          standards: standards_json,
-          student: student,
-          units: ProgressReports::Standards::Unit.new(current_user).results({}),
-          teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
+        cache_groups = {
+          standard_id: params["standard_id"],
+          student_id: params["student_id"]
         }
+        response = current_user.all_classrooms_cache(key: 'teachers.progress_reports.standards.student_standards.index', groups: cache_groups) do
+          standards = ::ProgressReports::Standards::NewStandard.new(current_user).results(params)
+          standards_json = standards.map do |standard|
+            serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
+            # Doing this because can't figure out how to get custom params into serializers
+            serializer.classroom_id = params[:classroom_id]
+            serializer.as_json(root: false)
+          end
+          student = User.find(params[:student_id])
+          student = nil unless current_user.teaches_student?(student.id)
+          {
+            standards: standards_json,
+            student: student,
+            units: ProgressReports::Standards::Unit.new(current_user).results({}),
+            teacher: UserWithEmailSerializer.new(current_user).as_json(root: false)
+          }
+        end
+        render json: response
       end
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -92,6 +92,15 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:cu) { create(:classroom_unit, classroom: classroom, unit: unit, assigned_student_ids: [student1.id, student2.id, student3.id])}
     let!(:ua) { create(:unit_activity, unit: unit, activity: activity)}
 
+    it 'should cache results so that they are only calculated once' do
+      expect_any_instance_of(Teachers::ProgressReports::DiagnosticReportsController).to receive(:results_for_classroom).with(unit.id.to_s, activity.id.to_s, classroom.id.to_s).once.and_call_original
+      2.times do
+        get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
+
+        expect(response).to be_success
+      end
+    end
+
     it 'should return empty arrays when there are no activity_sessions' do
       get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 


### PR DESCRIPTION
## WHAT
Add caching for additional reporting endpoints so that, as far as I know, all of our report-related APIs for teachers are cached
## WHY
We want to reduce load on the database when we can in order to improve teacher experience
## HOW
Just wrap payload generating code in cache blocks

### Notion Card Links
https://www.notion.so/quill/Turn-Caching-Back-On-4bf7669d517443909640387fbafdc958

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes in cases where there was already a testing framework for testing the endpoint
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
