### PR TITLE
indicate to screenreader when words are bolded

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/renderForQuestions/sentenceFragments.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/renderForQuestions/sentenceFragments.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
-const SentenceFragments = (props: any) => <div className="draft-js sentence-fragments" dangerouslySetInnerHTML={{ __html: props.prompt, }} />
+const beginBold = '<span class="sr-only">(begin bold) </span>'
+const endBold = '<span class="sr-only"> (end bold)</span>'
+
+const SentenceFragments = ({ prompt, }) => {
+  const promptAnnotatedForScreenreader = prompt.replace(/<strong>/g, `${beginBold}<strong>`).replace(/<\/strong>/g, `</strong>${endBold}`)
+  return <div className="draft-js sentence-fragments" dangerouslySetInnerHTML={{ __html: promptAnnotatedForScreenreader, }} />
+}
 
 export { SentenceFragments }


### PR DESCRIPTION
## WHAT
Add screenreader-only text that indicates to users when prompt text is bolded.

## WHY
There are questions in the starter diagnostic, and possibly elsewhere, that have instructions like "Correct the bolded words", but not all screenreaders will announce which words are wrapped in `<strong>` tags, making those unhelpful. This fixes that issue.  

## HOW
Parse strings for strong tags and replace them with text that also reads out "start bold" and "end bold" to make it clear for screenreaders (solution from here: https://universaldesign.ie/technology-ict/web-accessibility-techniques1/content-provider-s-introduction-and-index/cp-1-write-accessible-text/cp-1-5-%E2%80%93-style-to-maximise-readability/).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Figure-out-how-to-make-it-clear-to-screenreader-users-which-words-are-bolded-on-questions-that-note--40cb4cde4e21427583280b38fb758b29

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? |  YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
