### PR TITLE
make sure feedback is always announced by sr

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -390,6 +390,7 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
             feedbackType="instructions"
           >
             <div
+              aria-live="assertive"
               className="student-feedback-container default"
               role="status"
             >

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/__snapshots__/question.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/__snapshots__/question.test.tsx.snap
@@ -254,6 +254,7 @@ Sentences flow easily when all the actions in a list have the same ending. This 
           feedbackType="instructions"
         >
           <div
+            aria-live="assertive"
             className="student-feedback-container default"
             role="status"
           >

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
@@ -351,6 +351,7 @@ exports[`FillInTheBlank component projector view inactive renders 1`] = `
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -765,6 +766,7 @@ exports[`FillInTheBlank component projector view when an answer is being display
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -1131,6 +1133,7 @@ exports[`FillInTheBlank component student view inactive renders 1`] = `
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -1510,6 +1513,7 @@ exports[`FillInTheBlank component student view when an answer is being displayed
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -1883,6 +1887,7 @@ exports[`FillInTheBlank component student view when the student has submitted an
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/singleAnswer.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/singleAnswer.test.jsx.snap
@@ -130,6 +130,7 @@ exports[`SingleAnswer component projector view inactive renders 1`] = `
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -364,6 +365,7 @@ exports[`SingleAnswer component projector view when an answer is being displayed
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -552,6 +554,7 @@ exports[`SingleAnswer component student view inactive renders 1`] = `
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -747,6 +750,7 @@ exports[`SingleAnswer component student view when an answer is being displayed r
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >
@@ -936,6 +940,7 @@ exports[`SingleAnswer component student view when the student has submitted an a
         feedbackType="default"
       >
         <div
+          aria-live="assertive"
           className="student-feedback-container default"
           role="status"
         >

--- a/services/QuillLMS/client/app/bundles/Shared/components/renderForQuestions/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/renderForQuestions/feedback.tsx
@@ -115,7 +115,7 @@ function getCSSClasses(feedbackType: string): string {
 }
 
 const Feedback = ({ feedbackType, feedback, }: any) => (
-  <div className={getCSSClasses(feedbackType)} role="status">
+  <div aria-live="assertive" className={getCSSClasses(feedbackType)} role="status">
     <div className='feedback-row student-feedback-inner-container'>
       <img alt={getIconAlt(feedbackType)} className={getIconClassName(feedbackType)} src={getFeedbackIcon(feedbackType)}  />
       {feedback}


### PR DESCRIPTION
## WHAT
Add "assertive" live region to feedback to make sure it always gets announced.

## WHY
It seemed like in some circumstances (maybe first load?) the screenreader wasn't consistently announcing changes in this area.

## HOW
Just add the `aria-live` attribute in addition to the `role`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Investigate-feedback-not-being-announced-to-screenreader-on-at-least-one-Connect-question-320e696064a9431bb5a7682e52c5166b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
