### PR TITLE
fix bug with individual student reports

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -87,7 +87,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       student = User.find_by_id(student_id)
       skills = Activity.find(activity_id).skills.distinct
       pre_test = Activity.find_by_follow_up_activity_id(activity_id)
-      pre_test_activity_session = pre_test && find_activity_session_for_student_activity_and_classroom(student_id, pre_test.id, classroom_id, unit_id)
+      pre_test_activity_session = pre_test && find_activity_session_for_student_activity_and_classroom(student_id, pre_test.id, classroom_id, nil)
 
       if pre_test && pre_test_activity_session
         concept_results = {


### PR DESCRIPTION
## WHAT
Fix bug with individual student diagnostic response reports.

## WHY
When the activity is a post-test, and the controller action gets called with a unit id, that unit id was being passed to the `find` function for the pre-test activity session, which doesn't necessarily (and in fact rarely) has the same unit id as the post test, resulting in funky data. This always passes nil, which will just find the most recently completed session for the pre-test.

## HOW
Just pass `nil` instead of `unit_id`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Intermediate-Growth-Diagnostic-results-showing-wrong-of-skills-correct-dc02fc75acf74aad8af617390c61344e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
