### PR TITLE
Improvements to CMS District Manager

### DIFF
--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -28,6 +28,22 @@ class Cms::DistrictsController < Cms::CmsController
     @admins = DistrictAdmin.includes(:user).where(district_id: params[:id].to_i)
   end
 
+  def new
+    @district = District.new
+    @editable_attributes = editable_district_attributes
+  end
+
+  def create
+    new_district = District.new(edit_or_add_district_params)
+    begin
+      new_district.save!
+      redirect_to cms_district_path(new_district.id)
+    rescue => e
+      flash[:error] = e.message
+      redirect_to cms_districts_path
+    end
+  end
+
   def new_admin
     @district = District.find(params[:id])
   end
@@ -38,10 +54,12 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   def update
-    if District.find(edit_or_add_district_params[:id]).update(edit_or_add_district_params)
+    begin
+      District.find(edit_or_add_district_params[:id]).update!(edit_or_add_district_params)
       redirect_to cms_district_path(edit_or_add_district_params[:id])
-    else
-      render :edit
+    rescue => e
+      flash[:error] = e.message
+      redirect_to cms_district_path(edit_or_add_district_params[:id])
     end
   end
 
@@ -63,7 +81,7 @@ class Cms::DistrictsController < Cms::CmsController
 
   private def district_query(params)
     page = [district_query_params[:page].to_i - 1, 0].max
-    result = District.distinct.limit(DISTRICTS_PER_PAGE).offset(DISTRICTS_PER_PAGE * page)
+    result = District.distinct.offset(DISTRICTS_PER_PAGE * page)
 
     sort = district_query_params[:sort]
     sort_direction = district_query_params[:sort_direction]
@@ -105,11 +123,10 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   private def school_query
-    @district.schools.select('schools.name, schools.id, subscriptions.account_type, count(schools_users.id) as number_teachers, count(schools_admins.id) as number_admins')
-      .joins(:schools_users)
-      .joins(:schools_admins)
-      .joins(school_subscription: :subscription)
-      .where('subscriptions.expiration > ? AND subscriptions.start_date <= ?', Date.current, Date.current)
+    @district.schools.select('schools.name, schools.id, schools.city, schools.state, schools.free_lunches, subscriptions.account_type, count(schools_users.id) as number_teachers, count(schools_admins.id) as number_admins')
+      .left_joins(:schools_users)
+      .left_joins(:schools_admins)
+      .left_joins(school_subscription: :subscription)
       .group('schools.name, schools.id, subscriptions.account_type')
   end
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -123,7 +123,7 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   private def school_query
-    @district.schools.select('schools.name, schools.id, schools.city, schools.state, schools.free_lunches, subscriptions.account_type, count(schools_users.id) as number_teachers, count(schools_admins.id) as number_admins')
+    @district.schools.select('schools.name, schools.id, schools.city, schools.state, schools.free_lunches, subscriptions.account_type, count(distinct schools_users.id) as number_teachers, count(distinct schools_admins.id) as number_admins')
       .left_joins(:schools_users)
       .left_joins(:schools_admins)
       .left_joins(school_subscription: :subscription)

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -34,13 +34,11 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   def create
-    new_district = District.new(edit_or_add_district_params)
-    begin
-      new_district.save!
-      redirect_to cms_district_path(new_district.id)
-    rescue => e
-      flash[:error] = e.message
-      redirect_to cms_districts_path
+    new_district = District.new(district_params)
+    if new_district.save
+      redirect_to cms_district_path(new_district)
+    else
+      redirect_to cms_districts_path, error: new_district.errors, flash: { error: new_district.errors }
     end
   end
 
@@ -54,12 +52,11 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   def update
-    begin
-      District.find(edit_or_add_district_params[:id]).update!(edit_or_add_district_params)
-      redirect_to cms_district_path(edit_or_add_district_params[:id])
-    rescue => e
-      flash[:error] = e.message
-      redirect_to cms_district_path(edit_or_add_district_params[:id])
+    district = District.find(district_params[:id])
+    if district.update(district_params)
+      redirect_to cms_district_path(params[:id])
+    else
+      redirect_to cms_district_path(district_params[:id]), error: district.errors
     end
   end
 
@@ -118,7 +115,7 @@ class Cms::DistrictsController < Cms::CmsController
     }
   end
 
-  private def edit_or_add_district_params
+  private def district_params
     params.require(:district).permit(:id, editable_district_attributes.values)
   end
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -310,6 +310,8 @@ class Cms::SchoolsController < Cms::CmsController
             ON school_subscriptions.school_id = schools.id
           LEFT JOIN subscriptions
             ON subscriptions.id = school_subscriptions.subscription_id
+          LEFT JOIN districts
+            ON districts.id = schools.district_id
           #{where_query_string_builder}
           GROUP BY schools.id
           #{having_string}

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -45,7 +45,7 @@ class Cms::SchoolsController < Cms::CmsController
       'City' => @school.city || @school.mail_city,
       'State' => @school.state || @school.mail_state,
       'ZIP' => @school.zipcode || @school.mail_zipcode,
-      'District' => @school.leanm,
+      'District' => @school.district&.name,
       'Free and Reduced Price Lunch' => "#{@school.free_lunches}%",
       'NCES ID' => @school.nces_id,
       'PPIN' => @school.ppin,
@@ -198,7 +198,7 @@ class Cms::SchoolsController < Cms::CmsController
       <<-SQL
         SELECT
           schools.name AS school_name,
-          schools.leanm AS district_name,
+          districts.name AS district_name,
           COALESCE(schools.city, schools.mail_city) AS school_city,
           COALESCE(schools.state, schools.mail_state) AS school_state,
           COALESCE(schools.zipcode, schools.mail_zipcode) AS school_zip,
@@ -216,16 +216,18 @@ class Cms::SchoolsController < Cms::CmsController
           ON school_subscriptions.school_id = schools.id
         LEFT JOIN subscriptions
           ON subscriptions.id = school_subscriptions.subscription_id
+        LEFT JOIN districts
+          ON districts.id = schools.district_id
         #{where_query_string_builder}
         GROUP BY
           schools.name,
-          schools.leanm,
           schools.city,
           schools.state,
           schools.zipcode,
           schools.free_lunches,
           subscriptions.account_type,
-          schools.id
+          schools.id,
+          districts.name
         #{having_string}
         #{order_by_query_string}
         #{pagination_query_string}
@@ -265,7 +267,7 @@ class Cms::SchoolsController < Cms::CmsController
     # School city: schools.city or schools.mail_city
     # School state: schools.state or schools.mail_state
     # School zip: schools.zipcode or schools.mail_zipcode
-    # District name: schools.leanm
+    # District name: districts.name
     # Premium status: subscriptions.account_type
     sanitized_fuzzy_param_value = ActiveRecord::Base.connection.quote("%#{param_value}%")
     sanitized_param_value = ActiveRecord::Base.connection.quote(param_value)
@@ -280,7 +282,7 @@ class Cms::SchoolsController < Cms::CmsController
     when 'school_zip'
       "(schools.zipcode = #{sanitized_param_value} OR schools.mail_zipcode = #{sanitized_param_value})"
     when 'district_name'
-      "schools.leanm ILIKE #{sanitized_fuzzy_param_value}"
+      "districts.name ILIKE #{sanitized_fuzzy_param_value}"
     when 'premium_status'
       "subscriptions.account_type IN (#{sanitized_param_value})"
     else
@@ -338,7 +340,6 @@ class Cms::SchoolsController < Cms::CmsController
       'School City' => :city,
       'School State' => :state,
       'School ZIP' => :zipcode,
-      'District Name' => :leanm,
       'FRP Lunch' => :free_lunches,
       'NCES ID' => :nces_id,
       'Clever ID' => :clever_id

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -7,7 +7,7 @@
 #  id             :integer          not null, primary key
 #  city           :string
 #  grade_range    :string
-#  name           :string
+#  name           :string           not null
 #  phone          :string
 #  state          :string
 #  token          :string
@@ -19,7 +19,13 @@
 #  clever_id      :string
 #  nces_id        :integer
 #
+# Indexes
+#
+#  index_districts_on_nces_id  (nces_id) UNIQUE
+#
 class District < ApplicationRecord
+
+  validate :validate_name_not_blank
 
   has_many :schools
   has_many :district_admins, class_name: 'DistrictAdmin', dependent: :destroy
@@ -33,6 +39,10 @@ class District < ApplicationRecord
 
   def total_invoice
     schools.sum { |s| s&.subscription&.payment_amount || 0 } / 100.0
+  end
+
+  def validate_name_not_blank
+    errors.add(:base, "Name cannot be empty") if name.blank?
   end
 
 end

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -25,7 +25,7 @@
 #
 class District < ApplicationRecord
 
-  validate :validate_name_not_blank
+  validates :name, presence: true
 
   has_many :schools
   has_many :district_admins, class_name: 'DistrictAdmin', dependent: :destroy
@@ -39,10 +39,6 @@ class District < ApplicationRecord
 
   def total_invoice
     schools.sum { |s| s&.subscription&.payment_amount || 0 } / 100.0
-  end
-
-  def validate_name_not_blank
-    errors.add(:base, "Name cannot be empty") if name.blank?
   end
 
 end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -26,7 +26,7 @@ class SerializeVitallySalesAccount
         city: @school.city,
         state: @school.state,
         zipcode: @school.zipcode,
-        district: @school.leanm,
+        district: @school.district&.name,
         phone: @school.phone,
         charter: @school.charter,
         frl: @school.free_lunches,

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -213,7 +213,7 @@ class SerializeVitallySalesUser
   end
 
   private def district
-    @user.school.leanm if @user.school.present?
+    @user.school.district&.name if @user.school.present?
   end
 
 end

--- a/services/QuillLMS/app/views/cms/districts/index.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/index.html.erb
@@ -3,6 +3,7 @@
     <div style="margin-bottom:20px">
       <h1 style="margin-bottom:20px">
         District Search
+        <%= link_to 'Add New District', new_cms_district_path, class: 'btn button-green float-right'  %>
       </h1>
     </div>
     <div class='cms-container-meta'>

--- a/services/QuillLMS/app/views/cms/districts/new.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/new.html.erb
@@ -1,20 +1,18 @@
 <div class='container'>
   <article class='simple-rounded-box cms-container'>
-    <%= link_to 'School Directory', cms_schools_path %> > New School
+    <%= link_to 'District Directory', cms_districts_path %> > New District
     <br /><br />
-    <h2>New School</h2>
+    <h2>New District</h2>
     <br />
-    <p><strong>Warning: Before you add a school, be sure to search for it via zipcode. Only add a school if you're certain it doesn't already exist.</strong></p>
+    <p><strong>Warning: Before you add a district, be sure to search for it via zipcode. Only add a district if you're certain it doesn't already exist.</strong></p>
     <br /><strong>Notes:
     <ul>
       <li>State is just initials (e.g. NY)</li>
-      <li>Private schools don't have a district.</li>
       <li>Charter schools should have the charter network name as district.</li>
-      <li>Free and Reduced Price lunch is just a number (e.g. 75 &mdash; not 75%).</li>
     </strong></ul>
     <br />
     <div class='cms-form'>
-      <%= form_for @school, url: cms_schools_path(@school) do |f| %>
+      <%= form_for @district, url: cms_districts_path(@district) do |f| %>
         <% @editable_attributes.each do |attribute_name, attribute_field| %>
           <div class='cms-form-row'>
             <%= f.label attribute_field, attribute_name %>
@@ -23,7 +21,7 @@
         <% end %>
 
         <div class='cms-submit-row'>
-          <%= f.button "Add School", class: 'button-green' %>
+          <%= f.button "Add District", class: 'button-green' %>
         </div>
       <% end %>
     </div>

--- a/services/QuillLMS/app/views/cms/districts/show.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/show.html.erb
@@ -4,33 +4,6 @@
     <br /><br />
     <h2><%= @district.name %></h2>
     <br />
-    <table class='cms-results-table'>
-      <thead>
-        <tr>
-          <% ['Name', 'Teachers', 'Premium?', 'Admins', 'Manage'].each do |td| %>
-            <td><%= td %></td>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @school_data.each do |school| %>
-          <tr>
-            <td><%= school['school_name'] || 'N/A' %></td>
-            <td><%= school['number_teachers'] || '0' %></td>
-            <td><%= school['premium_status'] || '' %></td>
-            <td><%= school['number_admins'] || '0' %></td>
-            <td>
-              <%= link_to 'view', cms_school_path(school['school_id']) %>
-              <br />
-              <% if !school['school_id'].blank? %>
-                <%= link_to 'edit', edit_cms_school_path(school['school_id']) %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <br /><br />
     <h2>District Info</h2>
     <br />
     <%= link_to 'Edit District Info', edit_cms_district_path(params[:id]), class: 'btn button-green' %>
@@ -75,6 +48,37 @@
     <p><strong>Grade Range</strong></p>
     <p><%= @district.grade_range || 'N/A' %></p>
     <br /> <br />
+
+    <table class='cms-results-table'>
+      <thead>
+        <tr>
+          <% ['Name', 'City', 'State', 'FRL', 'Teachers', 'Premium?', 'Admins', 'Manage'].each do |td| %>
+            <td><%= td %></td>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @school_data.each do |school| %>
+          <tr>
+            <td><%= school.name || 'N/A' %></td>
+            <td><%= school.city || 'N/A' %></td>
+            <td><%= school.state || 'N/A' %></td>
+            <td><%= school.free_lunches || 'N/A' %>%</td>
+            <td><%= school.number_teachers || '0' %></td>
+            <td><%= school.account_type || '' %></td>
+            <td><%= school.number_admins || '0' %></td>
+            <td>
+              <%= link_to 'view', cms_school_path(school.id) %>
+              <br />
+              <% if school.id.present? %>
+                <%= link_to 'edit', edit_cms_school_path(school.id) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <br /><br />
 
     <br /><br />
     <h2>All Admins</h2>

--- a/services/QuillLMS/app/views/cms/schools/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/edit.html.erb
@@ -10,7 +10,6 @@
       <li>State is just initials (e.g. NY)</li>
       <li>Private schools don't have a district.</li>
       <li>Charter schools should have the charter network name as district.</li>
-      <li>Before adding a district, search for other schools in the same district so you can copy and paste the exact district name in the database.</li>
       <li>Free and Reduced Price lunch is just a number (e.g. 75 &mdash; not 75%).</li>
     </strong></ul><br />
     <div class='cms-form'>

--- a/services/QuillLMS/db/migrate/20220428171629_add_constraints_to_districts.rb
+++ b/services/QuillLMS/db/migrate/20220428171629_add_constraints_to_districts.rb
@@ -1,0 +1,6 @@
+class AddConstraintsToDistricts < ActiveRecord::Migration[5.1]
+  def change
+    add_index :districts, :nces_id, unique: true
+    change_column_null :districts, :name, false
+  end
+end

--- a/services/QuillLMS/db/migrate/20220428171629_add_constraints_to_districts.rb
+++ b/services/QuillLMS/db/migrate/20220428171629_add_constraints_to_districts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConstraintsToDistricts < ActiveRecord::Migration[5.1]
   def change
     add_index :districts, :nces_id, unique: true

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -43,7 +43,8 @@ describe Cms::SchoolsController do
   end
 
   describe '#show' do
-    let!(:school) { create(:school) }
+    let!(:district) { create(:district) }
+    let!(:school) { create(:school, district: district) }
 
     it 'should assign the correct values' do
       allow_any_instance_of(Cms::TeacherSearchQuery).to receive(:run) { "teacher data" }
@@ -58,7 +59,7 @@ describe Cms::SchoolsController do
        'City' => school.city || school.mail_city,
        'State' => school.state || school.mail_state,
        'ZIP' => school.zipcode || school.mail_zipcode,
-       'District' => school.leanm,
+       'District' => school.district.name,
        'Free and Reduced Price Lunch' => "#{school.free_lunches}%",
        'NCES ID' => school.nces_id,
        'PPIN' => school.ppin,
@@ -88,7 +89,6 @@ describe Cms::SchoolsController do
           'School City' => :city,
           'School State' => :state,
           'School ZIP' => :zipcode,
-          'District Name' => :leanm,
           'FRP Lunch' => :free_lunches,
           'NCES ID' => :nces_id,
           'Clever ID' => :clever_id
@@ -122,14 +122,12 @@ describe Cms::SchoolsController do
           city: "test city",
           state: "test state",
           zipcode: "1100",
-          leanm: "lean",
           free_lunches: 2
       } }
       expect(School.last.name).to eq "test"
       expect(School.last.city).to eq "test city"
       expect(School.last.state).to eq "test state"
       expect(School.last.zipcode).to eq "1100"
-      expect(School.last.leanm).to eq "lean"
       expect(School.last.free_lunches).to eq 2
       expect(response).to redirect_to cms_school_path(School.last.id)
     end

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -7,7 +7,7 @@
 #  id             :integer          not null, primary key
 #  city           :string
 #  grade_range    :string
-#  name           :string
+#  name           :string           not null
 #  phone          :string
 #  state          :string
 #  token          :string
@@ -18,6 +18,10 @@
 #  updated_at     :datetime
 #  clever_id      :string
 #  nces_id        :integer
+#
+# Indexes
+#
+#  index_districts_on_nces_id  (nces_id) UNIQUE
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -3,19 +3,21 @@
 require 'rails_helper'
 
 describe 'SerializeVitallySalesAccount' do
+  let!(:district) { create(:district, name: 'Kool District') }
   let(:school) do
     create(:school,
       name: 'Kool School',
       mail_city: 'New York',
       mail_state: 'NY',
       mail_zipcode: '11104',
-      leanm: 'Kool District',
+      district_id: district.id,
       phone: '555-666-3210',
       charter: 'N',
       free_lunches: 0,
       ppin: nil,
       nces_id: '111111111',
-      ulocal: '41'
+      ulocal: '41',
+      district_id: district.id
     )
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -16,8 +16,7 @@ describe 'SerializeVitallySalesAccount' do
       free_lunches: 0,
       ppin: nil,
       nces_id: '111111111',
-      ulocal: '41',
-      district_id: district.id
+      ulocal: '41'
     )
   end
 


### PR DESCRIPTION
## WHAT
A round of improvements to the Staff District Manager page, now that we've finished the big data upload.
-"Add New District" page added.
-Get rid of the `leanm` field on schools and directly display a school's district name through the rails `district` relationship
-Fix the "Schools" query on district to show all schools regardless of whether they have a subscription or not

## WHY
This is the last round of tweaks we need to make to get the Districts UI operational on Quill staff's end, so they can start going in and editing Districts in the CMS.

## HOW
Adding a few new views and boilerplate controller endpoints, and then modifying the code wherever we're fetching a school's district.

### Screenshots
<img width="984" alt="Screen Shot 2022-04-28 at 5 12 43 PM" src="https://user-images.githubusercontent.com/57366100/165846967-d47f3604-c97a-4a0f-bf78-f4357ff5d7e8.png">
<img width="1104" alt="Screen Shot 2022-04-28 at 5 13 50 PM" src="https://user-images.githubusercontent.com/57366100/165846983-0f4d8ca6-f107-4e68-8b88-67a5bc4233f8.png">
<img width="858" alt="Screen Shot 2022-04-28 at 5 13 59 PM" src="https://user-images.githubusercontent.com/57366100/165846996-d36d79db-77fc-4805-861b-f34c8fcf65e5.png">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
