### PR TITLE
Sync subscription recurring updates on Quill with Stripe subscriptions

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
@@ -6,7 +6,7 @@ module StripeIntegration
       Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end: cancel_at_period_end)
       render json: {}, status: 200
     rescue Stripe::InvalidRequestError => e
-      ErrorNotifier.report(e, subscription_id: subscription_id, cancel_at_period_end: cancel_at_period_end)
+      ErrorNotifier.report(e, stripe_subscription_id: stripe_subscription_id)
       render json: {}, status: 500
     end
 

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  class SubscriptionRenewalsController < ApplicationController
+    def create
+      Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end: cancel_at_period_end)
+      render json: {}, status: 200
+    rescue Stripe::InvalidRequestError => e
+      ErrorNotifier.report(e, subscription_id: subscription_id, cancel_at_period_end: cancel_at_period_end)
+      render json: {}, status: 500
+    end
+
+    private def cancel_at_period_end
+      params[:cancel_at_period_end]
+    end
+
+    private def stripe_subscription_id
+      params[:stripe_subscription_id]
+    end
+  end
+end

--- a/services/QuillLMS/app/models/validators/stripe_uid_validator.rb
+++ b/services/QuillLMS/app/models/validators/stripe_uid_validator.rb
@@ -12,6 +12,7 @@ class StripeUidValidator < ActiveModel::EachValidator
     PRICE = 'price',
     PROD = 'prod',
     SETI = 'seti',
+    SI = 'si',
     SUB = 'sub'
   ].freeze
 
@@ -26,6 +27,7 @@ class StripeUidValidator < ActiveModel::EachValidator
     PRICE => 'Price',
     PROD => 'Product',
     SETI => 'Setup Intent',
+    SI => 'Subscription Item',
     SUB => 'Subscription',
   }.freeze
 

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  module Webhooks
+    class CustomerSubscriptionUpdatedEventHandler < EventHandler
+      EVENT_TYPE = 'customer.subscription.updated'
+      PUSHER_EVENT = 'stripe-customer-subscription-updated'
+
+      def self.handles?(event_type)
+        event_type == EVENT_TYPE
+      end
+
+      def run
+        SubscriptionUpdater.run(stripe_subscription)
+        stripe_webhook_event.processed!
+      rescue => e
+        stripe_webhook_event.log_error(e)
+      end
+
+      private def stripe_subscription
+        stripe_event.data.object
+      end
+    end
+  end
+end
+

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
@@ -4,6 +4,7 @@ module StripeIntegration
   module Webhooks
     class EventHandlerFactory
       SINGLE_EVENT_HANDLERS = [
+        CustomerSubscriptionUpdatedEventHandler,
         InvoicePaidEventHandler,
         SetupIntentSucceededEventHandler
       ]

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -12,7 +12,6 @@ module StripeIntegration
         'customer.source.created',
         'customer.source.updated',
         'customer.subscription.created',
-        'customer.subscription.updated',
         'customer.updated',
         'file.created',
         'invoice.updated',

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
@@ -31,9 +31,9 @@ module StripeIntegration
       end
 
       private def subscription
-        ::Subscription.find_by(stripe_invoice_id: stripe_invoice_id)
+        ::Subscription.find_by!(stripe_invoice_id: stripe_invoice_id)
       rescue ActiveRecord::RecordNotFound
-        raise SubscriptionFoundError
+        raise SubscriptionNotFoundError
       end
     end
   end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  module Webhooks
+    class SubscriptionUpdater < ApplicationService
+      class SubscriptionNotFoundError < StandardError; end
+      class NilCancelAtPeriodEndError < StandardError; end
+
+      attr_reader :stripe_subscription
+
+      def initialize(stripe_subscription)
+        @stripe_subscription = stripe_subscription
+      end
+
+      def run
+        subscription.update!(recurring: recurring)
+      end
+
+      private def cancel_at_period_end
+        stripe_subscription.cancel_at_period_end
+      end
+
+      private def recurring
+        raise NilCancelAtPeriodEndError if cancel_at_period_end.nil?
+
+        !cancel_at_period_end
+      end
+
+      private def stripe_invoice_id
+        stripe_subscription.latest_invoice
+      end
+
+      private def subscription
+        ::Subscription.find_by(stripe_invoice_id: stripe_invoice_id)
+      rescue ActiveRecord::RecordNotFound
+        raise SubscriptionFoundError
+      end
+    end
+  end
+end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/change_plan.jsx
@@ -12,10 +12,22 @@ export default class ChangePlan extends React.Component {
       <div className="change-plan">
         <div className="radio-group">
           <label className="radio-option">
-            <input checked={recurring} name="recurring" onChange={this.handleChange} type="radio" value={true} /> {this.props.subscriptionType} - ${this.props.price} Annual Subscription
+            <input
+              checked={recurring}
+              name="recurring"
+              onChange={this.handleChange}
+              type="radio"
+              value={true}
+            /> {this.props.subscriptionType} - ${this.props.price} Annual Subscription
           </label>
           <label className="radio-option">
-            <input checked={!recurring} name="recurring" onChange={this.handleChange} type="radio" value={false} /> Quill Basic - Free
+            <input
+              checked={!recurring}
+              name="recurring"
+              onChange={this.handleChange}
+              type="radio"
+              value={false}
+            /> Quill Basic - Free
           </label>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -13,7 +13,7 @@ export default class CurrentSubscription extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      changePlanVisible: false,
+      showChangePlan: false,
       recurring: _.get(props.subscriptionStatus, 'recurring'),
     };
   }
@@ -56,10 +56,10 @@ export default class CurrentSubscription extends React.Component {
   }
 
   changePlan() {
-    const { changePlanVisible, recurring, } = this.state
+    const { showChangePlan, recurring, } = this.state
     const { subscriptionType, } = this.props
 
-    if (changePlanVisible) {
+    if (showChangePlan) {
       return (
         <ChangePlan
           changeRecurringStatus={this.changeRecurringStatus}
@@ -73,17 +73,17 @@ export default class CurrentSubscription extends React.Component {
 
   changePlanInline() {
     const { authorityLevel, subscriptionStatus, } = this.props
-    const { changePlanVisible, } = this.state
+    const { showChangePlan, } = this.state
 
     if (authorityLevel && subscriptionStatus.payment_method === 'Credit Card') {
       return (
-        <span key={`change-plan${changePlanVisible}`}>
+        <span key={`change-plan${showChangePlan}`}>
           <button
             className="green-link interactive-wrapper focus-on-light"
-            onClick={changePlanVisible ? this.updateRecurring : this.showChangePlan}
+            onClick={showChangePlan ? this.updateRecurring : this.showChangePlan}
             type="button"
           >
-            {changePlanVisible ? 'Save Change' : 'Change Plan'}
+            {showChangePlan ? 'Save Change' : 'Change Plan'}
           </button>
           {this.changePlan()}
         </span>
@@ -334,7 +334,7 @@ export default class CurrentSubscription extends React.Component {
     );
   }
 
-  showChangePlan = () => { this.setState({ changePlanVisible: true, }) }
+  showChangePlan = () => { this.setState({ showChangePlan: true, }) }
 
   updateRecurring = () => {
     const { subscriptionStatus, updateSubscription } = this.props
@@ -346,6 +346,7 @@ export default class CurrentSubscription extends React.Component {
       const cancel_at_period_end = !recurring
       const data = { stripe_subscription_id, cancel_at_period_end }
       const success = () => { updateSubscription({ recurring }, _.get(subscriptionStatus, 'id')) }
+
       const error = () => { alert('An error occurred updating the subscription. Please contact hello@quill.org.') }
 
       requestPost(path, data, success, error)

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
@@ -172,8 +172,7 @@ export default class Subscriptions extends React.Component {
 
   updateSubscriptionStatus = subscription => {
     this.setState({
-      subscriptionStatus: subscription,
-      showPremiumConfirmationModal: true,
+      subscriptionStatus: subscription
     })
   }
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -68,10 +68,10 @@ EmpiricalGrammar::Application.routes.draw do
 
   resources :student_feedback_responses, only: [:create]
 
-  # for Stripe
   namespace :stripe_integration do
     post '/subscription_checkout_sessions', to: 'subscription_checkout_sessions#create'
     post '/subscription_payment_methods', to: 'subscription_payment_methods#create'
+    post '/subscription_renewals', to: 'subscription_renewals#create'
     post '/webhooks', to: 'webhooks#create'
   end
 
@@ -89,7 +89,6 @@ EmpiricalGrammar::Application.routes.draw do
     member do
       get :purchaser_name
     end
-
   end
 
   resources :assessments

--- a/services/QuillLMS/spec/factories/subscriptions.rb
+++ b/services/QuillLMS/spec/factories/subscriptions.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
     stripe_invoice_id { nil }
 
     trait(:recurring) { recurring true }
-    trait(:non_recurring) { recurring true }
+    trait(:non_recurring) { recurring false }
     trait(:stripe) { stripe_invoice_id { "in_#{SecureRandom.hex}"} }
   end
 end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: :controller do
+RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: :request do
   include_context 'Stripe Price'
   include_context 'Stripe Customer'
 
@@ -10,11 +10,12 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
     let(:redirect_url) { '/some_redirect_url' }
     let(:stripe_checkout_session) { double(:stripe_checkout_session, url: redirect_url) }
     let(:params) { { customer_email: customer_email, price_id: stripe_price_id } }
+    let(:url) { '/stripe_integration/subscription_checkout_sessions' }
 
     before { allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_checkout_session) }
 
     it 'creates a stripe checkout session and provides a redirect' do
-      post :create, params: params
+      post url, params: params, as: :json
       expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
     end
 
@@ -22,7 +23,7 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
       before { customer.update(stripe_customer_id: stripe_customer_id) }
 
       it 'creates a stripe checkout session and provides a redirect' do
-        post :create, params: params
+        post url, params: params, as: :json
         expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
       end
     end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::SubscriptionPaymentMethodsController, type: :request do
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
+  let(:cancel_at_period_end) { true }
+  let(:args) { [stripe_subscription_id, cancel_at_period_end: cancel_at_period_end] }
+  let(:update_stripe_subscription) { allow(Stripe::Subscription).to receive(:update).with(*args) }
+  let(:url) { '/stripe_integration/subscription_renewals' }
+  let(:params) { { stripe_subscription_id: stripe_subscription_id, cancel_at_period_end: cancel_at_period_end } }
+
+  context 'Stripe Subscription exists' do
+    before { update_stripe_subscription.and_return({}) }
+
+    it 'returns 200 if the request to Stripe is successful' do
+      post url, params: params, as: :json
+
+      expect(response.content_type).to eq 'application/json'
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  context 'Stripe Subscription does not exist' do
+    let(:error_msg) { "No such subscription: '#{stripe_subscription_id}'" }
+
+    before { update_stripe_subscription.and_raise(Stripe::InvalidRequestError.new(error_msg, :id)) }
+
+    it 'returns 500 if there are errors with the request to Stripe' do
+      post url, params: params, as: :json
+
+      expect(response.content_type).to eq 'application/json'
+      expect(response).to have_http_status :internal_server_error
+    end
+  end
+end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request do
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
+  let(:cancel_at_period_end) { true }
+  let(:args) { [stripe_subscription_id, cancel_at_period_end: cancel_at_period_end] }
+  let(:update_stripe_subscription) { allow(Stripe::Subscription).to receive(:update).with(*args) }
+  let(:url) { '/stripe_integration/subscription_renewals' }
+  let(:params) { { stripe_subscription_id: stripe_subscription_id, cancel_at_period_end: cancel_at_period_end } }
+
+  context 'Stripe Subscription exists' do
+    before { update_stripe_subscription.and_return({}) }
+
+    it 'returns 200 if the request to Stripe is successful' do
+      post url, params: params, as: :json
+
+      expect(response.content_type).to eq 'application/json'
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  context 'Stripe Subscription does not exist' do
+    let(:error_msg) { "No such subscription: '#{stripe_subscription_id}'" }
+
+    before { update_stripe_subscription.and_raise(Stripe::InvalidRequestError.new(error_msg, :id)) }
+
+    it 'returns 500 if there are errors with the request to Stripe' do
+      post url, params: params, as: :json
+
+      expect(response.content_type).to eq 'application/json'
+      expect(response).to have_http_status :internal_server_error
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_updater_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_updater_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::Webhooks::SubscriptionUpdater do
+  include_context 'Stripe Invoice'
+
+  before { allow(stripe_subscription).to receive(:latest_invoice).and_return(stripe_invoice_id) }
+
+  subject { described_class.run(stripe_subscription) }
+
+  context 'turn renew off' do
+    let!(:subscription) { create(:subscription, :recurring, stripe_invoice_id: stripe_invoice_id) }
+
+    before { allow(stripe_subscription).to receive(:cancel_at_period_end).and_return(true) }
+
+    it { expect { subject }.to change { subscription.reload.recurring }.from(true).to(false) }
+  end
+
+  context 'turn renew on' do
+    let!(:subscription) { create(:subscription, :non_recurring, stripe_invoice_id: stripe_invoice_id) }
+
+    before { allow(stripe_subscription).to receive(:cancel_at_period_end).and_return(false) }
+
+    it { expect { subject }.to change { subscription.reload.recurring }.from(false).to(true) }
+  end
+
+  context 'cancel_at_period_end is nil on stripe' do
+    let!(:subscription) { create(:subscription, stripe_invoice_id: stripe_invoice_id) }
+
+    before { allow(stripe_subscription).to receive(:cancel_at_period_end).and_return(nil) }
+
+    it { expect { subject }.to raise_error described_class::NilCancelAtPeriodEndError }
+  end
+
+  context 'no subscription exists in the db' do
+    it { expect { subject }.to raise_error described_class::SubscriptionNotFoundError }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_customer_subscription_updated_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_customer_subscription_updated_event.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Stripe Customer Subscription Updated Event' do
+  include_context 'Stripe Subscription'
+  include_context 'Stripe Payment Method'
+
+  let(:stripe_event_id) { "evt_#{SecureRandom.hex}"}
+  let(:stripe_event_type) { StripeIntegration::Webhooks::CustomerSubscriptionUpdatedEventHandler::EVENT_TYPE }
+
+  let(:stripe_event) do
+    Stripe::Event.construct_from(
+      id: stripe_event_id,
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1650057070,
+      data: stripe_subscription,
+      livemode: false,
+      pending_webhooks: 0,
+      request: {
+        id: 'req_1BajQOOl77CRJO',
+        idempotency_key: '954fc35e-fbff-40c5-954f-d34918ed2280'
+      },
+      type: stripe_event_type
+    )
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_plan.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_plan.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_context 'Stripe Plan' do
+  include_context 'Stripe Price'
+
+  let(:stripe_plan) do
+    Stripe::Plan.construct_from(
+      plan: {
+        id: stripe_price_id,
+        object: 'plan',
+        active: true,
+        aggregate_usage: nil,
+        amount: 8000,
+        amount_decimal: '8000',
+        billing_scheme: 'per_unit',
+        created: 1647349612,
+        currency: 'usd',
+        interval: 'year',
+        interval_count: 1,
+        livemode: false,
+        metadata: {},
+        nickname: nil,
+        product: stripe_product_id,
+        tiers_mode: nil,
+        transform_usage: nil,
+        trial_period_days: nil,
+        usage_type: 'licensed'
+      }
+    )
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'Stripe Subscription' do
+  include_context 'Stripe Subscription Item'
   include_context 'Stripe Payment Method'
-  include_context 'Stripe Price'
   include_context 'Stripe Customer'
 
   let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
@@ -36,17 +36,7 @@ RSpec.shared_context 'Stripe Subscription' do
       items: {
         object: 'list',
         data: [
-          {
-            id: 'si_LMYJmB1ZVMsHkV',
-            object: 'subscription_item',
-            billing_thresholds: nil,
-            created: 1647884416,
-            metadata: {},
-            price: stripe_price,
-            quantity: 1,
-            subscription: stripe_subscription_id,
-            tax_rates: []
-          }
+          stripe_subscription_item
         ],
         has_more: false,
         url: "/v1/subscription_items?subscription=#{stripe_subscription_id}"

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription_item.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription_item.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_context 'Stripe Subscription Item' do
+  include_context 'Stripe Plan'
+
+  let(:stripe_subscription_item_id) { "si_#{SecureRandom.hex}" }
+
+  let(:stripe_subscription_item) do
+    Stripe::SubscriptionItem.construct_from(
+      id: stripe_subscription_item_id,
+      object: 'subscription_item',
+      billing_thresholds: nil,
+      created: 1647884416,
+      metadata: {},
+      plan: stripe_plan,
+      price: stripe_price,
+      quantity: 1,
+      subscription: stripe_subscription_id,
+      tax_rates: []
+    )
+  end
+end
+


### PR DESCRIPTION
## WHAT
Keep subscription's `recurring` information in sync with relevant Stripe subscriptions objects

## WHY
When a user toggles between paid and non-paid subscription, those changes must be sent to Stripe so that when the subscription ends, the subscription is appropriately renewed or not.

`recurring` in our database is the negation of the configuration `cancel_at_period_end` on Stripe.

## HOW
1. Add an [endpoint](https://github.com/empirical-org/Empirical-Core/blob/d4b9dbb7dc721b562999da32739dc8e58d30af22/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx#L345) that the CurrentSubscription component will communicate `recurring` state with Stripe. 
2.  Any changes to `recurring` in our UI will trigger an API call to stripe using the configuration boolean `cancel_at_period_end`.
3. When the subscription is updated on Stripe, the `customer.subscription.updated` webhook event is triggered and our system then handles it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
