### PR TITLE
fix bug with activity table score sorting

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
@@ -11,7 +11,7 @@ import { PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, } from './progress_report_const
 
 import ItemDropdown from '../general_components/dropdown_selectors/item_dropdown'
 import LoadingSpinner from '../shared/loading_indicator.jsx'
-import {sortTableByLastName, sortFromSQLTimeStamp} from '../../../../modules/sortingMethods.js'
+import {sortTableByLastName, sortTableFromSQLTimeStamp} from '../../../../modules/sortingMethods.js'
 import { getTimeSpent } from '../../helpers/studentReports';
 import { ReactTable, } from '../../../Shared/index'
 
@@ -108,7 +108,7 @@ export class ActivitiesScoresByClassroomProgressReport extends React.Component {
         Cell: ({row}) => (<a className='row-link-disguise' href={`/teachers/progress_reports/student_overview?classroom_id=${row.original.classroom_id}&student_id=${row.original.student_id}`}>
           {row.original.last_active ? moment(row.original.last_active).format("MM/DD/YYYY") : <span />}
         </a>),
-        sortType: sortFromSQLTimeStamp,
+        sortType: sortTableFromSQLTimeStamp,
       },
       {
         Header: "Class",


### PR DESCRIPTION
## WHAT
Fix bug with activity scores table sorting by last active date.

## WHY
We want this table to sort correctly.

## HOW
Replace the old function, which I had missed, with the new one.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Last-Active-heading-on-Activity-Scores-report-does-not-sort-correctly-72755735e9d6497d974504f80cca621b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES