### PR TITLE
Remove legacy district columns on Schools table

### DIFF
--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -11,7 +11,6 @@
 #  free_lunches          :integer
 #  fte_classroom_teacher :integer
 #  latitude              :decimal(9, 6)
-#  leanm                 :string
 #  longitude             :decimal(9, 6)
 #  lower_grade           :integer
 #  magnet                :string
@@ -37,7 +36,6 @@
 #  clever_id             :string
 #  coordinator_id        :integer
 #  district_id           :bigint
-#  lea_id                :string
 #  nces_id               :string
 #
 # Indexes

--- a/services/QuillLMS/db/migrate/20220503155835_remove_district_columns_from_schools.rb
+++ b/services/QuillLMS/db/migrate/20220503155835_remove_district_columns_from_schools.rb
@@ -1,0 +1,6 @@
+class RemoveDistrictColumnsFromSchools < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :schools, :leanm
+    remove_column :schools, :lea_id
+  end
+end

--- a/services/QuillLMS/db/migrate/20220503155835_remove_district_columns_from_schools.rb
+++ b/services/QuillLMS/db/migrate/20220503155835_remove_district_columns_from_schools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveDistrictColumnsFromSchools < ActiveRecord::Migration[5.1]
   def change
     remove_column :schools, :leanm

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -33,8 +33,6 @@ namespace :schools do
     ) do |row|
       school_hash = row.to_hash
       school = School.where(nces_id: school_hash['NCESSCH']).first_or_initialize
-      school.lea_id = school_hash['LEAID']
-      school.leanm = school_hash['LEA_NAME'].titleize
       school.name = school_hash['SCH_NAME'].titleize
       school.phone = school_hash['PHONE']
       school.mail_street = school_hash['MSTREET1'].titleize
@@ -73,7 +71,6 @@ namespace :schools do
   desc 'Titleize all school name, address and other relevant data points'
   task :titleize => :environment do
     School.all.each do |school|
-      school.leanm = school.leanm&.titleize
       school.name = school.name&.titleize
       school.mail_street = school.mail_street&.titleize
       school.mail_city = school.mail_city&.titleize

--- a/services/QuillLMS/spec/factories/schools.rb
+++ b/services/QuillLMS/spec/factories/schools.rb
@@ -11,7 +11,6 @@
 #  free_lunches          :integer
 #  fte_classroom_teacher :integer
 #  latitude              :decimal(9, 6)
-#  leanm                 :string
 #  longitude             :decimal(9, 6)
 #  lower_grade           :integer
 #  magnet                :string
@@ -37,7 +36,6 @@
 #  clever_id             :string
 #  coordinator_id        :integer
 #  district_id           :bigint
-#  lea_id                :string
 #  nces_id               :string
 #
 # Indexes
@@ -63,7 +61,6 @@ FactoryBot.define do
     city { mail_city }
     state { mail_state }
     zipcode { mail_zipcode }
-    leanm { "#{mail_city} School District" }
     name { "#{mail_city} School" }
     phone { "1-800-555-1234" }
     longitude { "-74.044500" }
@@ -76,8 +73,6 @@ FactoryBot.define do
 
     trait :private_school do
       nces_id { nil }
-      lea_id { nil }
-      leanm { nil }
       nces_type_code { nil }
       nces_status_code { nil }
       free_lunches { nil }

--- a/services/QuillLMS/spec/factories/schools.rb
+++ b/services/QuillLMS/spec/factories/schools.rb
@@ -52,7 +52,6 @@
 FactoryBot.define do
   factory :school do
     sequence(:nces_id, 100000000000)
-    lea_id { "1234567" }
     mail_street { "123 Broadway" }
     mail_city { "New York City" }
     mail_state { "NY" }

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -11,7 +11,6 @@
 #  free_lunches          :integer
 #  fte_classroom_teacher :integer
 #  latitude              :decimal(9, 6)
-#  leanm                 :string
 #  longitude             :decimal(9, 6)
 #  lower_grade           :integer
 #  magnet                :string
@@ -37,7 +36,6 @@
 #  clever_id             :string
 #  coordinator_id        :integer
 #  district_id           :bigint
-#  lea_id                :string
 #  nces_id               :string
 #
 # Indexes


### PR DESCRIPTION
## WHAT
Now that we're totally done with the District import and new District modeling, we want to get rid of the old district name and district ID columns on the `Schools` table. We're not using these anymore and it will be confusing to have them there, because the data there might conflict with the data we're actually using on the `Districts` table.

## WHY
So as not to confuse anyone in the future about where district data should live re: schools.

## HOW
Remove these two columns, and any references.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes