### PR TITLE
Remove redundant scope

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -86,7 +86,6 @@ class Activity < ApplicationRecord
   scope :gamma_user, -> { where("'#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
   scope :beta_user, -> { where("'#{BETA}' = ANY(activities.flags) OR '#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
   scope :alpha_user, -> { where("'#{ALPHA}' = ANY(activities.flags) OR '#{BETA}' = ANY(activities.flags) OR '#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
-  scope :not_archived, -> {where("'#{ARCHIVED}' != ANY(activities.flags)")}
 
   scope :with_classification, -> { includes(:classification).joins(:classification) }
 


### PR DESCRIPTION
## WHAT
Fix a warning: "Creating scope :not_archived. Overwriting existing method Activity.not_archived.”

## WHY
The scope already exists in the `Flags` module.

## HOW
Remove the scope in `activity.rb`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
