### PR TITLE
Update customer.subscription.updated webhook handling

### DIFF
--- a/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
@@ -4,17 +4,22 @@ module StripeIntegration
   module Webhooks
     class CustomerSubscriptionUpdatedEventHandler < EventHandler
       EVENT_TYPE = 'customer.subscription.updated'
-      PUSHER_EVENT = 'stripe-customer-subscription-updated'
 
       def self.handles?(event_type)
         event_type == EVENT_TYPE
       end
 
       def run
-        SubscriptionUpdater.run(stripe_subscription)
+        SubscriptionUpdater.run(stripe_event, previous_attributes)
         stripe_webhook_event.processed!
       rescue => e
         stripe_webhook_event.log_error(e)
+      end
+
+      private def previous_attributes
+        return nil unless stripe_event.data.respond_to?(:previous_attributes)
+
+        stripe_event.data.previous_attributes
       end
 
       private def stripe_subscription

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -5,11 +5,14 @@ module StripeIntegration
     class IgnoredEventHandler < EventHandler
       IGNORED_EVENTS = [
         'balance.available',
+        'charge.failed',
+        'charge.refunded',
         'charge.succeeded',
         'checkout.session.expired',
         'checkout.session.completed',
         'customer.created',
         'customer.source.created',
+        'customer.source.expiring',
         'customer.source.updated',
         'customer.subscription.created',
         'customer.updated',
@@ -17,19 +20,24 @@ module StripeIntegration
         'invoice.updated',
         'invoice.created',
         'invoice.finalized',
+        'invoice.payment_failed',
         'invoice.payment_succeeded',
         'invoice.sent',
         'invoice.updated',
+        'invoice.voided',
         'invoiceitem.created',
         'invoiceitem.updated',
         'payment_intent.cancelled',
         'payment_intent.created',
+        'payment_intent.payment_failed',
         'payment_intent.succeeded',
         'payment_method.attached',
         'payment_method.automatically_updated',
         'payout.created',
         'payout.paid',
-        'setup_intent.created'
+        'product.updated',
+        'setup_intent.created',
+        'setup_intent.succeeded'
       ]
 
       def self.handles?(event_type)
@@ -42,5 +50,3 @@ module StripeIntegration
     end
   end
 end
-
-

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
@@ -6,18 +6,27 @@ module StripeIntegration
       class SubscriptionNotFoundError < StandardError; end
       class NilCancelAtPeriodEndError < StandardError; end
 
-      attr_reader :stripe_subscription
+      INCOMPLETE = 'incomplete'
 
-      def initialize(stripe_subscription)
+      attr_reader :stripe_subscription, :previous_attributes
+
+      def initialize(stripe_subscription, previous_attributes)
         @stripe_subscription = stripe_subscription
+        @previous_attributes = previous_attributes
       end
 
       def run
+        return if previously_incomplete?
+
         subscription.update!(recurring: recurring)
       end
 
       private def cancel_at_period_end
         stripe_subscription.cancel_at_period_end
+      end
+
+      private def previously_incomplete?
+        previous_attributes&.status == INCOMPLETE
       end
 
       private def recurring

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_updated_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_updated_event_handler_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::Webhooks::CustomerSubscriptionUpdatedEventHandler do
+  include_context 'Stripe Customer Subscription Updated Event'
+
+  let(:stripe_webhook_event) { create(:stripe_webhook_event, event_type: described_class::EVENT_TYPE) }
+  let(:subscription_updater_class) { StripeIntegration::Webhooks::SubscriptionUpdater }
+  let(:external_id) { stripe_webhook_event.external_id }
+  let(:previous_attributes) { nil }
+
+  subject { described_class.run(stripe_webhook_event) }
+
+  before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
+
+  context 'happy path' do
+    before { allow(subscription_updater_class).to receive(:run).with(stripe_event, previous_attributes) }
+
+    it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
+  end
+
+  context 'error raised' do
+    let(:error_class) { subscription_updater_class::SubscriptionNotFoundError }
+
+    before { allow(subscription_updater_class).to receive(:run).and_raise(error_class) }
+
+    it do
+      expect(stripe_webhook_event).to receive(:log_error)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Fix webhook event handling that is reporting failure

## WHY
The `customer.subscription.updated` handler was originally written to handle events where users toggle the recurring status of the subscription.  However, this same webhook is triggered when users purchase a subscription for the first time.  When the handler attempts to find the subscription it raises a `SubscriptionNotFound` exception since our db does not yet have the subscription (a separate webhook event/handler handles the creation of the subscription in our db). 

## HOW
Add a check to the handler to see if the subscription was previously incomplete.  If so, don't bother trying to update the subscription in our database since it doesn't exist yet.

In this case we can inspect the previous attributes value and check for `status: complete`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
