### PR TITLE
Evidence/record automl confidence levels

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -146,8 +146,10 @@ class FeedbackHistory < ApplicationRecord
       hint: feedback_hash['hint']
     }.reject {|_,v| v.blank? }
 
+    puts "full metadata: #{metadata}"
+
     # NB, there is a before_create that swaps activity_session_uid for a feedback_session.uid
-    create(
+    puts create(
       feedback_session_uid: activity_session_uid,
       prompt_id: prompt_id,
       attempt: attempt,

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -135,6 +135,8 @@ class FeedbackHistory < ApplicationRecord
 
   # TODO: consider making this a background job.
   def self.save_feedback(feedback_hash_raw, entry, prompt_id, activity_session_uid, attempt, api_metadata=nil)
+    puts "api_metadata: #{api_metadata}"
+
     feedback_hash = feedback_hash_raw.deep_stringify_keys
 
     # Remove blank values from metadata

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -134,11 +134,12 @@ class FeedbackHistory < ApplicationRecord
   end
 
   # TODO: consider making this a background job.
-  def self.save_feedback(feedback_hash_raw, entry, prompt_id, activity_session_uid, attempt)
+  def self.save_feedback(feedback_hash_raw, entry, prompt_id, activity_session_uid, attempt, api_metadata=nil)
     feedback_hash = feedback_hash_raw.deep_stringify_keys
 
     # Remove blank values from metadata
     metadata = {
+      api: api_metadata,
       highlight: feedback_hash['highlight'],
       hint: feedback_hash['hint']
     }.reject {|_,v| v.blank? }

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -135,8 +135,6 @@ class FeedbackHistory < ApplicationRecord
 
   # TODO: consider making this a background job.
   def self.save_feedback(feedback_hash_raw, entry, prompt_id, activity_session_uid, attempt, api_metadata=nil)
-    puts "api_metadata: #{api_metadata}"
-
     feedback_hash = feedback_hash_raw.deep_stringify_keys
 
     # Remove blank values from metadata
@@ -146,10 +144,8 @@ class FeedbackHistory < ApplicationRecord
       hint: feedback_hash['hint']
     }.reject {|_,v| v.blank? }
 
-    puts "full metadata: #{metadata}"
-
     # NB, there is a before_create that swaps activity_session_uid for a feedback_session.uid
-    puts create(
+    create(
       feedback_session_uid: activity_session_uid,
       prompt_id: prompt_id,
       attempt: attempt,

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -11,7 +11,8 @@ module Evidence
 
       save_feedback_history(feedback)
 
-      render json: feedback
+      # api-specific data doesn't need to be sent to the client
+      render json: feedback.except(:api)
     end
 
     def grammar
@@ -96,9 +97,11 @@ module Evidence
     private def save_feedback_history(feedback)
       return unless feedback
 
+      api_metadata = feedback[:api]
+      feedback = feedback.except(:api)
       attempt = params[:attempt] || 0
 
-      Evidence.feedback_history_class.save_feedback(feedback, @entry, @prompt.id, @session_id, attempt)
+      Evidence.feedback_history_class.save_feedback(feedback, @entry, @prompt.id, @session_id, attempt, api_metadata)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -77,7 +77,7 @@ module Evidence
       }
       results = automl_prediction_client.predict(name: automl_prediction_model_path, payload: automl_payload)
       sorted_results = results.payload.sort_by { |i| i.classification.score }.reverse
-      sorted_results[0].display_name
+      [sorted_results[0].display_name, sorted_results[0].classification.score]
     end
 
     def older_models

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/automl_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/automl_check.rb
@@ -32,7 +32,10 @@ module Evidence
         concept_uid: matched_rule&.concept_uid || '',
         rule_uid: matched_rule&.uid || '',
         hint: matched_rule&.hint,
-        highlight: highlight
+        highlight: highlight,
+        api: {
+          confidence: @confidence_score
+        }
       }
     end
     # rubocop:enable Metrics/CyclomaticComplexity
@@ -44,7 +47,7 @@ module Evidence
     private def fetch_matched_rule
       return unless @automl_model
 
-      google_automl_label = @automl_model.fetch_automl_label(@entry)
+      google_automl_label, @confidence_score = @automl_model.fetch_automl_label(@entry)
       @prompt.rules.joins(:label).find_by(comprehension_labels: {name: google_automl_label})
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -27,13 +27,13 @@ module Evidence
 
     describe '#create' do
 
-      let(:feedback) { double('feedback', response: {key1: 'some value'} ) }
+      let(:feedback) { double('feedback', response: {key1: 'some value', api: {api_key: 'api_value'}} ) }
       let(:session_id) { 99 }
       let(:attempt) { 3 }
 
       it "should call Check.run_all, save history, and return feedback.response" do
         expect(Check).to receive(:get_feedback).with(entry, prompt, []).and_return(feedback.response)
-        expect(Evidence.feedback_history_class).to receive(:save_feedback).with(feedback.response, entry, prompt.id, session_id, attempt)
+        expect(Evidence.feedback_history_class).to receive(:save_feedback).with(feedback.response.except(:api), entry, prompt.id, session_id, attempt, feedback.response[:api])
 
         post :create, params: {entry: entry, prompt_id: prompt.id, session_id: session_id, previous_feedback: ([]), attempt: attempt }, as: :json
 
@@ -609,6 +609,7 @@ module Evidence
             post("automl", :params => ({ :entry => entry, :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json)
             parsed_response = JSON.parse(response.body)
             expect({
+              :api => {:confidence => nil},
               :feedback => first_feedback.text,
               :feedback_type => "autoML",
               :optimal => rule.optimal,
@@ -617,7 +618,7 @@ module Evidence
               :rule_uid => rule.uid,
               :highlight => ([]),
               :hint => rule.hint.serializable_hash
-            }.stringify_keys).to(eq(parsed_response))
+            }.deep_stringify_keys).to(eq(parsed_response))
           end
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/dummy/app/models/feedback_history.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/app/models/feedback_history.rb
@@ -1,6 +1,6 @@
 class FeedbackHistory
 
-  def self.save_feedback(feedback_hash_raw, entry, prompt_id, session_uid, attempt)
+  def self.save_feedback(feedback_hash_raw, entry, prompt_id, session_uid, attempt, api_metadata=nil)
     feedback_hash = feedback_hash_raw.deep_stringify_keys
 
     {
@@ -19,8 +19,9 @@ class FeedbackHistory
         highlight: feedback_hash['highlight'],
         labels: feedback_hash['labels'],
         hint: feedback_hash['hint']
-      }
-    }
+      },
+      api: api_metadata
+    }.reject {|_,v| v.blank? }
   end
 
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/automl_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/automl_check_spec.rb
@@ -9,6 +9,7 @@ module Evidence
     let!(:label) { create(:evidence_label, :rule => (rule)) }
     let!(:feedback) { create(:evidence_feedback, :rule => (rule)) }
     let!(:automl_model) { create(:evidence_automl_model, :prompt => (prompt), :labels => ([label.name]), :state => (Evidence::AutomlModel::STATE_ACTIVE)) }
+    let(:automl_confidence) { 1 }
 
     context 'should #initialize' do
 
@@ -22,7 +23,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return nil if there is no matched rule' do
-        AutomlModel.stub_any_instance(:fetch_automl_label, "NOT#{label.name}") do
+        AutomlModel.stub_any_instance(:fetch_automl_label, ["NOT#{label.name}", automl_confidence]) do
           automl_check = Evidence::AutomlCheck.new("entry", prompt)
           expect(automl_check.feedback_object).to(eq(nil))
         end
@@ -35,15 +36,15 @@ module Evidence
       end
 
       it 'should return the feedback payload when there is a label match' do
-        AutomlModel.stub_any_instance(:fetch_automl_label, label.name) do
+        AutomlModel.stub_any_instance(:fetch_automl_label, [label.name, automl_confidence]) do
           entry = "entry"
           automl_check = Evidence::AutomlCheck.new(entry, prompt)
-          expect(:feedback => feedback.text, :feedback_type => "autoML", :optimal => rule.optimal,  :entry => entry, :concept_uid => ((rule&.concept_uid or "")), :rule_uid => (rule&.uid), :highlight => ([]), :hint => nil).to(eq(automl_check.feedback_object))
+          expect(:feedback => feedback.text, :feedback_type => "autoML", :optimal => rule.optimal,  :entry => entry, :concept_uid => ((rule&.concept_uid or "")), :rule_uid => (rule&.uid), :highlight => ([]), :hint => nil, :api => {:confidence => automl_confidence}).to(eq(automl_check.feedback_object))
         end
       end
 
       it 'should include highlight data when the feedback object has highlights' do
-        AutomlModel.stub_any_instance(:fetch_automl_label, label.name) do
+        AutomlModel.stub_any_instance(:fetch_automl_label, [label.name, automl_confidence]) do
           highlight = create(:evidence_highlight, :feedback => (feedback))
           automl_check = Evidence::AutomlCheck.new("whatever", prompt)
           expect([{ :type => highlight.highlight_type, :text => highlight.text, :category => "" }]).to(eq(automl_check.feedback_object[:highlight]))
@@ -51,7 +52,7 @@ module Evidence
       end
 
       it 'should include hint data when there is an associated hint' do
-        AutomlModel.stub_any_instance(:fetch_automl_label, label.name) do
+        AutomlModel.stub_any_instance(:fetch_automl_label, [label.name, automl_confidence]) do
           hint = create(:evidence_hint, :rule => (rule))
           automl_check = Evidence::AutomlCheck.new("whatever", prompt)
           expect(hint).to(eq(automl_check.feedback_object[:hint]))

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
@@ -217,7 +217,7 @@ module Evidence
         expect(Google::Cloud::AutoML).to receive(:prediction_service).and_return(prediction_client)
         expect(prediction_client).to receive(:model_path).and_return("the_path")
 
-        expect(automl_model.fetch_automl_label('some text')).to eq 'result1'
+        expect(automl_model.fetch_automl_label('some text')).to eq ['result1', 2]
       end
 
       it "should raise if the google api a raises for a timeout" do

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe FeedbackHistory, type: :model do
       expect(feedback.valid?).to be true
       expect(feedback.metadata['highlight'].first).to eq(highlight)
     end
+
+    it 'should save special "api" key to metadata if passed an api_metadata argument' do
+      api_metadata = {'confidence' => 1}
+      feedback = FeedbackHistory.save_feedback(feedback_hash, entry, prompt_id, activity_session_uid, attempt, api_metadata)
+
+      expect(feedback.valid?).to be true
+      expect(feedback.metadata['api']).to eq(api_metadata)
+    end
   end
 
   context 'batch_create' do


### PR DESCRIPTION
## WHAT
- Add a method for storing API-specific logging data in `FeedbackHistory.metadata`, specifically for items we don't want to provide in the payload sent to the user
- Begin recording AutoML label confidence level
## WHY
Generally, we need a way to evaluate some of our "under-the-hood" API performance to see how things like prediction confidence align with good feedback.  Specifically, in this instance, we want to understand the statistics for how confident we are when we provide AutoML-based feedback to students to decide if we should require a minimum confidence level.
## HOW
Allow feedback `Check` generators to attach a key to their payload called `api`.  This key will be stripped from the payload before it is sent to the end user, and using a new param in the `FeedbackHistory.save_feedback` function, attach that arbitrary `api` key payload as `FeedbackHistory.metadata[:api]`.  This allows for any `Check` lib that needs to record API-related data to just attach the `api` key to their payloads and let the rest of the system handle it from there.

With that in place, I modified the flow of data for AutoML checks to retrieve not just the most likely label, but the confidence AutoML has that the label is accurate.  That data is now passed through on the `api` payload key from the AutoML Check lib and ends up in `FeedbackHistory.metadata`.

### Notion Card Links
https://www.notion.so/quill/Record-AutoML-Label-confidence-in-FeedbackHistory-metadata-when-recording-AutoML-feedback-ab1b7e65c264448293239b5852d54252

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
