### PR TITLE
fix bug with creating new evidence activities

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -33,11 +33,12 @@ module Evidence
     accepts_nested_attributes_for :prompts
 
     validates :parent_activity_id, uniqueness: {allow_nil: true}
-    validates :target_level, presence: true,
+    validates :target_level,
       numericality: {
         only_integer: true,
         less_than_or_equal_to: MAX_TARGET_LEVEL,
-        greater_than_or_equal_to: MIN_TARGET_LEVEL
+        greater_than_or_equal_to: MIN_TARGET_LEVEL,
+        allow_nil: true
       }
     validates :title, presence: true, length: {in: MIN_TITLE_LENGTH..MAX_TITLE_LENGTH}
     validates :notes, presence: true

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -22,8 +22,6 @@ module Evidence
 
     context 'should validations' do
 
-      it { should validate_presence_of(:target_level) }
-
       it { should validate_numericality_of(:target_level).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(12) }
 
       it { should validate_presence_of(:title) }


### PR DESCRIPTION
## WHAT
Remove presence validation from `target_level` so that curriculum team members can create new Evidence activities.

## WHY
We removed this attribute from the frontend in [this PR](https://github.com/empirical-org/Empirical-Core/pull/8925) per the curriculum team's request [here](https://www.notion.so/quill/Activity-Settings-Organized-by-Toggle-5cafb2bb73a24b61b92e14efc70817cb), but the backend validation remained, so they can't save new activities.

## HOW
Just remove the `presence: true` part of the validation and add `allow_nil` to the numericality validation.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-add-new-Evidence-activities-to-the-CMS-e20478f0390549be91b0ecf55d57449a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
