### PR TITLE
Evidence - Take “sex” out of profanity words.

### DIFF
--- a/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
+++ b/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
@@ -197,7 +197,6 @@
     "schlong",
     "screwing",
     "semen",
-    "sex",
     "sexy",
     "Sh!t",
     "sh1t",


### PR DESCRIPTION
## WHAT
Take “sex” out of profanity words.
## WHY
The Genetic Testing passage references "Critics worry that PGD could lead parents to select embryos based on characteristics like **sex**, hair color, athleticism, and even musical ability", so this will appear in answers and cause false positives with the profanity filter.
## HOW
Remove the word from the list.


### Notion Card Links
https://www.notion.so/quill/Remove-the-word-sex-from-the-profanity-filter-b1a77746146b4386acaab0f87a8a7d68

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', tiny config change
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes, amazing.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
