### PR TITLE
Evidence - Add ‘wilmut’ to spelling exceptions.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -26,7 +26,8 @@ module Evidence
       'sánchez',
       'kanaka',
       'kānaka',
-      'worldwatch'
+      'worldwatch',
+      'wilmut'
     ]
 
     attr_reader :entry


### PR DESCRIPTION
## WHAT
Another spelling exception from a passage, "Wilmut"
## WHY
We don't want false positive spelling errors for passage proper nouns
## HOW
Update exception list.


### Notion Card Links
https://www.notion.so/quill/Add-Wilmut-to-spelling-exceptions-d4c438e91d434628a80db78dd88ada88

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', tiny config change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
