### PR TITLE
add rake task, update flags validation

### DIFF
--- a/services/QuillLMS/app/models/concerns/flags.rb
+++ b/services/QuillLMS/app/models/concerns/flags.rb
@@ -2,7 +2,7 @@
 
 module Flags
   extend ActiveSupport::Concern
-  FLAGS = %w(production archive alpha beta gamma private)
+  FLAGS = %w(production archived alpha beta gamma private)
 
   module ClassMethods
     def flag_all(flag)

--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -17,6 +17,12 @@ namespace :activities do
     end
   end
 
+  desc "replace 'archive' flag with 'archived'"
+  task :replace_archive_flag_with_archived => :environment do
+    activities = Activity.where(flags: ['archive'])
+    activities.update_all(flags: ['archived'])
+  end
+
   desc 'Take pipe of CSV with activity names to be set to "private"'
   task set_to_private_by_name: :environment do
     pipe_data = $stdin.read unless $stdin.tty?

--- a/services/QuillLMS/spec/controllers/api/v1/activity_flags_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_flags_controller_spec.rb
@@ -7,8 +7,7 @@ describe Api::V1::ActivityFlagsController, type: :controller do
     it 'returns appropriate flags' do
       get :index, as: :json
 
-      expect(JSON.parse(response.body)['activity_flags']).to match_array(
-        ['production', 'archive', 'alpha', 'beta', 'gamma', 'private'])
+      expect(JSON.parse(response.body)['activity_flags']).to match_array(Flags::FLAGS)
     end
   end
 end


### PR DESCRIPTION
## WHAT
- rake task for getting existing data to conform to desired Activity.flags schema
- update the Activity.flags schema validation, via flags.rb 

## WHY
Pre-work for https://github.com/empirical-org/Empirical-Core/pull/9118 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually on staging. No change in logic.
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
