### PR TITLE
re-run responseRows function when activity data loads

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -76,7 +76,7 @@ const RuleAnalysis = ({ match }) => {
       const rows = responseRows(ruleFeedbackHistoryData.responses);
       setResponses(rows)
     }
-  }, [ruleFeedbackHistoryData])
+  }, [ruleFeedbackHistoryData, activityData])
 
   React.useEffect(() => {
     if(ruleFeedbackHistoryData) {


### PR DESCRIPTION
## WHAT
Update saved `responses` value when `activityData` loads.

## WHY
Rachel reported a bug where data wasn't showing on the `ruleAnalysis` page when there were fewer than 100 responses on the page. This turned out to be because of a race condition, where the `ruleFeedbackHistories` API call returned prior to the `activityData` API call, and then in line 234 of the file `responseRows` would be set to `[]`, never to be called again. This change will update the page regardless of which call returns first.

## HOW
Just add `activityData` to the list of keys that should force a regeneration of the `responses` data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Some-rules-analysis-pages-won-t-load-a30286335c8e46ceb844c482a8c1a253

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
