### PR TITLE
make sure to actually grab most recently updated classroom unit for caches

### DIFF
--- a/services/QuillLMS/app/models/concerns/user_cacheable.rb
+++ b/services/QuillLMS/app/models/concerns/user_cacheable.rb
@@ -74,6 +74,7 @@ module UserCacheable
       .where(classroom_id: classroom_id)
       .joins(:unit_activities)
       .where(unit: {unit_activities: {activity_id: activity_id}})
+      .order("classroom_units.updated_at DESC")
       .group("classroom_units.id")
       .first
   end

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -182,8 +182,11 @@ RSpec.describe UserCacheable, type: :model do
     let(:classroom_unit1) {create(:classroom_unit, classroom: classroom, unit: unit_activity1.unit) }
     let(:unit_activity2) { create(:unit_activity, activity: activity)}
     let(:classroom_unit2) {create(:classroom_unit, classroom: classroom, unit: unit_activity2.unit) }
+    let(:unit_activity3) { create(:unit_activity, activity: activity)}
+    let(:classroom_unit3) {create(:classroom_unit, classroom: classroom, unit: unit_activity3.unit) }
 
     it 'should call model_cache with last updated unit if no unit_id' do
+      classroom_unit2.touch
       expect(teacher).to receive(:model_cache).with(classroom_unit2, key: 'test.key', groups: {page: 1}, expires_in: subject::DEFAULT_EXPIRATION)
 
       teacher.classroom_unit_by_ids_cache(classroom_id: classroom.id, unit_id: nil, activity_id: activity.id, key: 'test.key', groups: {page: 1})


### PR DESCRIPTION
## WHAT
Update the query that locates the classroom unit that caches are keyed off of to always pull the most recently updated one.

## WHY
I had a bug report come in that appeared to be due to the cache not getting invalidated. After some digging, I realized that it was because this query was consistently pulling a classroom unit that was not the most recently updated one.

## HOW
Just add an `order` call to the query.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES - I added a third classroom unit to the existing test and then updated the second to try to more conclusively test that the returned classroom unit is the last updated and not the last created
Have you deployed to Staging? | No, but tested locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
