### PR TITLE
Allow purchase of school premium directly through stripe

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -275,6 +275,10 @@ Metrics/AbcSize:
 Metrics/BlockNesting:
   Max: 4
 
+Metrics/ClassLength:
+  Exclude:
+    - QuillLMS/app/controllers/pages_controller.rb
+
 Metrics/CyclomaticComplexity:
   Max: 7
 

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -15,6 +15,7 @@ class PagesController < ApplicationController
   NUMBER_OF_SCHOOLS = "NUMBER_OF_SCHOOLS"
   NUMBER_OF_LOW_INCOME_SCHOOLS = "NUMBER_OF_LOW_INCOME_SCHOOLS"
   OPEN_POSITIONS = Configs[:careers][:open_positions]
+  SHOW_SCHOOL_BUY_NOW_BUTTON_APP_SETTING = 'show_school_buy_now_button'
 
   def home
     if signed_in?
@@ -408,7 +409,9 @@ class PagesController < ApplicationController
     @user_has_school = !!current_user&.school && ['home school', 'us higher ed', 'international', 'other', 'not listed'].exclude?(current_user&.school&.name)
     @user_belongs_to_school_that_has_paid = current_user&.school ? Subscription.school_or_user_has_ever_paid?(current_user&.school) : false
     @customer_email = current_user&.email
+    @stripe_school_plan = PlanSerializer.new(Plan.stripe_school_plan).as_json
     @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher_plan).as_json
+    @show_school_buy_now = AppSetting.enabled?(name: SHOW_SCHOOL_BUY_NOW_BUTTON_APP_SETTING, user: current_user)
 
     @diagnostic_activity_count =
       Activity.where(

--- a/services/QuillLMS/app/controllers/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/subscriptions_controller.rb
@@ -68,7 +68,6 @@ class SubscriptionsController < ApplicationController
     @subscription_status = current_user.subscription_status
     @school_subscription_types = Subscription::OFFICIAL_SCHOOL_TYPES
     @trial_types = Subscription::TRIAL_TYPES
-    @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher_plan).as_json
 
     if @subscription_status&.key?('id')
       @user_authority_level = current_user.subscription_authority_level(@subscription_status['id'])

--- a/services/QuillLMS/app/models/sales_stage_type.rb
+++ b/services/QuillLMS/app/models/sales_stage_type.rb
@@ -21,7 +21,8 @@ class SalesStageType < ApplicationRecord
   validates :order, uniqueness: true
 
   ORDER_TYPES = [
-    TEACHER_PREMIUM = '2'
+    TEACHER_PREMIUM = '2',
+    SCHOOL_PREMIUM = '6.1'
   ]
 
   enum trigger: { auto: 0, user: 1 }

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -4,11 +4,11 @@ module StripeIntegration
   module Webhooks
     class SubscriptionCreator < ApplicationService
       class Error < StandardError; end
-      class NilSchoolError < Error; end
       class NilStripeCustomerIdError < Error; end
       class NilStripeInvoiceIdError < Error; end
       class NilStripePriceIdError < Error; end
       class PlanNotFoundError < Error; end
+      class PurchaserNilSchoolError < Error; end
       class PurchaserNotFoundError < Error; end
       class StripeInvoiceIdNotUniqueError < Error; end
 
@@ -56,7 +56,7 @@ module StripeIntegration
           UserSubscription.create!(user: purchaser, subscription: subscription)
           UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::TEACHER_PREMIUM)
         when Plan.stripe_school_plan
-          raise NilSchoolError if purchaser.school.nil?
+          raise PurchaserNilSchoolError if purchaser.school.nil?
 
           SchoolSubscription.create!(school: purchaser.school, subscription: subscription)
           UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::SCHOOL_PREMIUM)

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -4,6 +4,7 @@ module StripeIntegration
   module Webhooks
     class SubscriptionCreator < ApplicationService
       class Error < StandardError; end
+      class NilSchoolError < Error; end
       class NilStripeCustomerIdError < Error; end
       class NilStripeInvoiceIdError < Error; end
       class NilStripePriceIdError < Error; end
@@ -50,10 +51,22 @@ module StripeIntegration
       end
 
       private def run_plan_custom_tasks
-        return unless plan.teacher?
+        case plan
+        when Plan.stripe_teacher_plan
+          UserSubscription.create!(user: purchaser, subscription: subscription)
+          UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::TEACHER_PREMIUM)
+        when Plan.stripe_school_plan
+          raise NilSchoolError if purchaser.school.nil?
 
-        UserSubscription.create!(user: purchaser, subscription: subscription)
-        UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::TEACHER_PREMIUM)
+          SchoolSubscription.create!(school: purchaser.school, subscription: subscription)
+          UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::SCHOOL_PREMIUM)
+        end
+      end
+
+      private def save_stripe_customer_id
+        raise NilStripeCustomerIdError if stripe_customer_id.nil?
+
+        purchaser.update!(stripe_customer_id: stripe_customer_id)
       end
 
       private def start_date
@@ -82,12 +95,6 @@ module StripeIntegration
         )
       rescue ActiveRecord::RecordNotUnique
         raise StripeInvoiceIdNotUniqueError
-      end
-
-      private def save_stripe_customer_id
-        raise NilStripeCustomerIdError if stripe_customer_id.nil?
-
-        purchaser.update!(stripe_customer_id: stripe_customer_id)
       end
     end
   end

--- a/services/QuillLMS/app/views/pages/premium_access.html.slim
+++ b/services/QuillLMS/app/views/pages/premium_access.html.slim
@@ -1,3 +1,0 @@
-= render 'teachers/shared/scorebook_tabs'
-= render 'pages/shared/premium_subtabs'
-= render 'pages/shared/premium_main'

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
@@ -15,6 +15,8 @@ document.addEventListener('click', function(e) {
   diagnosticActivityCount: @diagnostic_activity_count,
   independentPracticeActivityCount: @independent_practice_activity_count,
   lessonsActivityCount: @lessons_activity_count,
+  showSchoolBuyNow: @show_school_buy_now,
+  stripeSchoolPlan: @stripe_school_plan,
   stripeTeacherPlan: @stripe_teacher_plan,
   userBelongsToSchoolThatHasPaid: @user_belongs_to_school_that_has_paid,
   userHasSchool: @user_has_school,

--- a/services/QuillLMS/app/views/subscriptions/index.html.erb
+++ b/services/QuillLMS/app/views/subscriptions/index.html.erb
@@ -6,6 +6,7 @@
       schoolSubscriptionTypes: @school_subscription_types,
       stripeInvoiceId: @stripe_invoice_id,
       stripePaymentMethodUpdated: @stripe_payment_method_updated,
+      stripeSchoolPlan: @stripe_school_plan,
       stripeTeacherPlan: @stripe_teacher_plan,
       subscriptions: @subscriptions,
       subscriptionStatus: @subscription_status,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -4,16 +4,24 @@ import IndividualFeaturesTable from './individual_features_table'
 
 const greenCheckSrc = `${process.env.CDN_URL}/images/icons/icons-check-green.svg`
 
-const SchoolPricingMini = ({ premiumFeatureData, showBadges }) => (
+const SchoolPricingMini = ({ buyNowButton, plan, premiumFeatureData, showBadges, showSchoolBuyNow }) => (
+
   <div className="pricing-mini">
     <section className="pricing-info">
       <h2>School and District Premium</h2>
       <div className="premium-rates">
-        <h3>$1,800</h3>
+        <h3>${plan.price_in_dollars}</h3>
         <p>Per school, per year</p>
       </div>
       <div className="premium-button-container">
-        <a className="quill-button contained medium primary focus-on-light" href="https://quillpremium.wufoo.com/forms/quill-premium-quote/">Contact us</a>
+        { showSchoolBuyNow && buyNowButton() }
+
+        <a
+          className="quill-button contained medium primary focus-on-light"
+          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+        >
+          Contact us
+        </a>
       </div>
       {showBadges && <div className="school-premium-badge-container">
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> 2 PD sessions</div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/teacher_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/teacher_pricing_mini.jsx
@@ -4,8 +4,7 @@ import IndividualFeaturesTable from './individual_features_table'
 
 export default class TeacherPricingMini extends React.Component {
   render() {
-    const { buyNowButton, premiumFeatureData, stripeTeacherPlan } = this.props
-    const { plan } = stripeTeacherPlan
+    const { buyNowButton, plan, premiumFeatureData} = this.props
 
     return (
       <div className="pricing-mini">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -27,7 +27,17 @@ export default class PremiumPricingMinisRow extends React.Component {
   }
 
   render() {
-    const { diagnosticActivityCount, lessonsActivityCount, independentPracticeActivityCount, } = this.props
+    const {
+      diagnosticActivityCount,
+      lessonsActivityCount,
+      independentPracticeActivityCount,
+      schoolBuyNowButton,
+      showSchoolBuyNow,
+      stripeSchoolPlan,
+      stripeTeacherPlan,
+      teacherBuyNowButton,
+    } = this.props
+
     const { userIsSignedIn, isScrolled, } = this.state
 
     const premiumFeatureData = premiumFeatures({
@@ -49,12 +59,16 @@ export default class PremiumPricingMinisRow extends React.Component {
               userIsSignedIn={userIsSignedIn}
             />
             <TeacherPricingMini
-              {...this.props}
+              buyNowButton={teacherBuyNowButton}
+              plan={stripeTeacherPlan.plan}
               premiumFeatureData={premiumFeatureData}
             />
             <SchoolPricingMini
+              buyNowButton={schoolBuyNowButton}
+              plan={stripeSchoolPlan.plan}
               premiumFeatureData={premiumFeatureData}
               showBadges={!isScrolled}
+              showSchoolBuyNow={showSchoolBuyNow}
             />
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
@@ -7,14 +7,12 @@ export const StripeSubscriptionCheckoutSessionButton = ({
   buttonText,
   cancelPath,
   customerEmail,
-  stripePlan,
+  stripePriceId,
   userIsEligibleForNewSubscription,
   userIsSignedIn
 }) => {
 
   const handleClick = () => {
-    const { plan } = stripePlan
-
     if (!userIsSignedIn) {
       alert('You must be logged in to activate Premium.')
     } else if (!userIsEligibleForNewSubscription) {
@@ -28,7 +26,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
       const data = {
         cancel_path: cancelPath,
         customer_email: customerEmail,
-        stripe_price_id: plan.stripe_price_id
+        stripe_price_id: stripePriceId
       }
 
       requestPost(path, data, body => { window.location.replace(body.redirect_url) })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -42,11 +42,13 @@ function teacherPremiumCopy(subscriptionType) {
 };
 
 const SubscriptionStatus = ({
-  stripeTeacherPlan,
   subscriptionStatus,
   subscriptionType,
   userIsContact,
 }) => {
+
+
+  const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
 
   const content = {};
   let image
@@ -119,7 +121,7 @@ const SubscriptionStatus = ({
         buttonText='Renew Subscription'
         cancelPath='subscriptions'
         customerEmail={subscriptionStatus.customer_email}
-        stripePlan={stripeTeacherPlan}
+        stripePriceId={renewalStripePriceId}
         userIsEligibleForNewSubscription={true}
         userIsSignedIn={true}
       />
@@ -128,7 +130,7 @@ const SubscriptionStatus = ({
 
   content.buttonOrDate = content.buttonOrDate || (<span className="expiration-date">
     <span>Valid Until:</span> <span>{`${expiration.format('MMMM Do, YYYY')}`}</span><span className="time-left-in-days"> | {`${remainingDays} ${pluralize('days', remainingDays)}`}</span>
-  </span>);
+  </span>)
   content.status = content.status || <h2>{`You have a ${subscriptionTypeText} subscription`}<img alt={`${subscriptionTypeText}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
 
   return (

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -32,6 +32,8 @@ export const PremiumPricingGuide = ({
   diagnosticActivityCount,
   independentPracticeActivityCount,
   lessonsActivityCount,
+  showSchoolBuyNow,
+  stripeSchoolPlan,
   stripeTeacherPlan,
   userIsEligibleForNewSubscription,
 }) => {
@@ -40,7 +42,7 @@ export const PremiumPricingGuide = ({
     return !!Number(document.getElementById('current-user-id').getAttribute('content'))
   }
 
-  const buyNowButton = () => {
+  const teacherBuyNowButton = () => {
     return (
       <StripeSubscriptionCheckoutSessionButton
         buttonClassName="quill-button contained medium primary focus-on-light"
@@ -48,7 +50,22 @@ export const PremiumPricingGuide = ({
         buttonText='Buy Now'
         cancelPath='premium'
         customerEmail={customerEmail}
-        stripePlan={stripeTeacherPlan}
+        stripePriceId={stripeTeacherPlan.plan.stripe_price_id}
+        userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
+        userIsSignedIn={userIsSignedIn()}
+      />
+    )
+  }
+
+  const schoolBuyNowButton = () => {
+    return (
+      <StripeSubscriptionCheckoutSessionButton
+        buttonClassName="quill-button contained medium primary focus-on-light"
+        buttonId="purchase-btn"
+        buttonText='Buy Now'
+        cancelPath='premium'
+        customerEmail={customerEmail}
+        stripePriceId={stripeSchoolPlan.plan.stripe_price_id}
         userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
         userIsSignedIn={userIsSignedIn()}
       />
@@ -62,7 +79,7 @@ export const PremiumPricingGuide = ({
         buttonText='Upgrade to Premium Now'
         cancelPath='premium'
         customerEmail={customerEmail}
-        stripePlan={stripeTeacherPlan}
+        stripePriceId={stripeTeacherPlan.plan.stripe_price_id}
         userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
         userIsSignedIn={userIsSignedIn()}
       />
@@ -75,11 +92,14 @@ export const PremiumPricingGuide = ({
         {userIsSignedIn() && <PremiumBannerBuilder originPage="premium" upgradeToPremiumNowButton={upgradeToPremiumNowButton} />}
         <div className="overview text-center">
           <PremiumPricingMinisRow
-            buyNowButton={buyNowButton}
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}
             lessonsActivityCount={lessonsActivityCount}
+            schoolBuyNowButton={schoolBuyNowButton}
+            showSchoolBuyNow={showSchoolBuyNow}
+            stripeSchoolPlan={stripeSchoolPlan}
             stripeTeacherPlan={stripeTeacherPlan}
+            teacherBuyNowButton={teacherBuyNowButton}
             userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
           />
 

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
@@ -186,7 +186,7 @@ export default class Subscriptions extends React.Component {
   }
 
   render() {
-    const { premiumCredits, stripeTeacherPlan } = this.props
+    const { premiumCredits } = this.props
 
     const {
       authorityLevel,
@@ -204,7 +204,6 @@ export default class Subscriptions extends React.Component {
       <div>
         <SubscriptionStatus
           key={subId}
-          stripeTeacherPlan={stripeTeacherPlan}
           subscriptionStatus={subscriptionStatus}
           subscriptionType={this.subscriptionType()}
           userIsContact={this.userIsContact()}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/PremiumPricingGuide.test.jsx.snap
@@ -9,10 +9,11 @@ exports[`PremiumPricingGuide container should render 1`] = `
       className="overview text-center"
     >
       <PremiumPricingMinisRow
-        buyNowButton={[Function]}
         diagnosticActivityCount={9}
         independentPracticeActivityCount={400}
         lessonsActivityCount={50}
+        schoolBuyNowButton={[Function]}
+        teacherBuyNowButton={[Function]}
       />
       <PremiumFeaturesTable
         diagnosticActivityCount={9}

--- a/services/QuillLMS/spec/factories/plans.rb
+++ b/services/QuillLMS/spec/factories/plans.rb
@@ -28,5 +28,12 @@ FactoryBot.define do
     audience { Plan::TEACHER_AUDIENCE_TYPE }
     interval { Plan::YEARLY_INTERVAL_TYPE }
     interval_count { 1 }
+
+    factory :school_paid_plan do
+      name { Plan::STRIPE_SCHOOL_PLAN }
+      display_name { 'School Premium' }
+      price { 180000 }
+      audience { Plan::SCHOOL_AUDIENCE_TYPE }
+    end
   end
 end

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -447,4 +447,78 @@ describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#renewal_stripe_price_id' do
+    let(:subscription) { create(:subscription, account_type: account_type) }
+
+    subject { subscription.renewal_stripe_price_id }
+
+    context 'teachers' do
+      context 'paid' do
+        let(:account_type) { described_class::TEACHER_PAID }
+
+        it { expect(subject).to eq STRIPE_TEACHER_PLAN_PRICE_ID }
+      end
+
+      context 'trial' do
+        let(:account_type) { described_class::TEACHER_TRIAL }
+
+        it { expect(subject).to be nil }
+      end
+
+      context 'premium credit' do
+        let(:account_type) { described_class::PREMIUM_CREDIT }
+
+        it { expect(subject).to be nil }
+      end
+
+      context 'sponsored' do
+        let(:account_type) { described_class::TEACHER_SPONSORED_FREE }
+
+        it { expect(subject).to be nil }
+      end
+    end
+
+    context 'schools' do
+      context 'paid' do
+        let(:account_type) { described_class::SCHOOL_PAID }
+
+        it { expect(subject).to be nil }
+
+        context 'via stripe' do
+          before { allow(subscription).to receive(:stripe?).and_return(true) }
+
+          it { expect(subject).to be STRIPE_SCHOOL_PLAN_PRICE_ID }
+        end
+      end
+
+      context 'sponsored' do
+        let(:account_type) { described_class::SCHOOL_SPONSORED_FREE }
+
+        it { expect(subject).to be nil }
+
+      end
+    end
+
+    context 'districts' do
+      let(:account_type) { described_class::SCHOOL_DISTRICT_PAID }
+
+      it { expect(subject).to be nil }
+
+      context 'via stripe' do
+        before { allow(subscription).to receive(:stripe?).and_return(true) }
+
+        it { expect(subject).to be STRIPE_SCHOOL_PLAN_PRICE_ID }
+      end
+    end
+
+    context 'other' do
+      context 'CB lifetime premium' do
+        let(:account_type) { described_class::CB_LIFETIME_DURATION }
+
+        it { expect(subject).to be nil }
+      end
+    end
+  end
 end
+

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -504,12 +504,6 @@ describe Subscription, type: :model do
       let(:account_type) { described_class::SCHOOL_DISTRICT_PAID }
 
       it { expect(subject).to be nil }
-
-      context 'via stripe' do
-        before { allow(subscription).to receive(:stripe?).and_return(true) }
-
-        it { expect(subject).to be STRIPE_SCHOOL_PLAN_PRICE_ID }
-      end
     end
 
     context 'other' do

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -71,4 +71,13 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
 
     it { expect { subject }.to raise_error described_class::PurchaserNotFoundError }
   end
+
+  context 'purchaser has no school' do
+    let!(:school_plan) { create(:school_paid_plan) }
+
+    before { allow(Plan).to receive(:find_stripe_plan!).with(stripe_price_id).and_return(school_plan) }
+
+    it { expect { subject }.to raise_error described_class::PurchaserNilSchoolError }
+  end
 end
+

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -9,13 +9,36 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
 
   let!(:customer) { create(:user, email: customer_email, stripe_customer_id: stripe_customer_id) }
 
-  context 'happy path' do
-    it { expect { subject }.to change(Subscription, :count).from(0).to(1) }
-    it { expect { subject }.to change(UserSubscription, :count).from(0).to(1) }
+  context 'teacher subscription' do
+    context 'happy path' do
+      it { expect { subject }.to change(Subscription, :count).from(0).to(1) }
+      it { expect { subject }.to change(UserSubscription, :count).from(0).to(1) }
 
-    it 'calls sales contact background job' do
-      expect(UpdateSalesContactWorker).to receive(:perform_async).with(customer.id, SalesStageType::TEACHER_PREMIUM)
-      subject
+      it 'calls sales contact background job' do
+        expect(UpdateSalesContactWorker).to receive(:perform_async).with(customer.id, SalesStageType::TEACHER_PREMIUM)
+        subject
+      end
+    end
+  end
+
+  context 'school subscription' do
+    context 'happy path' do
+      let(:user) { create(:user) }
+      let!(:teacher) { create(:teacher) }
+      let!(:other_teacher) { create(:teacher) }
+      let!(:school) { create :school, users: [customer, teacher]}
+      let!(:school_plan) { create(:school_paid_plan) }
+
+      before { allow(Plan).to receive(:find_stripe_plan!).with(stripe_price_id).and_return(school_plan) }
+
+      it { expect { subject }.to change(Subscription, :count).from(0).to(1) }
+      it { expect { subject }.to change(SchoolSubscription, :count).from(0).to(1) }
+      it { expect { subject }.to change(UserSubscription, :count).from(0).to(2) }
+
+      it 'calls sales contact background job' do
+        expect(UpdateSalesContactWorker).to receive(:perform_async).with(customer.id, SalesStageType::SCHOOL_PREMIUM)
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
## WHAT
Allow direct purchase of school subscriptions through Stripe.  Initially, the button allowing for this will be hidden to staff users only until we have an approved design for the `/premium` page.

## WHY
We'd like to give users the ability to purchase subscriptions directly rather than contacting Quill first.

## HOW
1.  Add a buy now button to `/premium` page for the 'School and Districts Premium' column
1.  Create an AppSetting for staff only: `rake app_settings:create[show_school_buy_now_button,true,true,0,[]]` which will make the button only visible to staff.
1. Add a `renewal_stripe_price_id` to the SubscriptionStatus object which, when applicable, stores the appropriate stripe plan renewal.
1. Update the InvoicePaidEventHandler to handle invoices paid for school subscriptions.

### Screenshots
Non-staff will see the page as it currently is:
![non-staff](https://user-images.githubusercontent.com/2057805/167420972-8d57ef61-3e73-4d93-8d39-03fb4783e67b.png)

Staff view shows the 'buy now' button:
![staff](https://user-images.githubusercontent.com/2057805/167420995-f78f8c56-f452-461a-9f64-a468713946be.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES