### PR TITLE
Send district data through to Segment

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -183,7 +183,8 @@ class SegmentAnalytics
       traits: {
         premium_state: user.premium_state,
         premium_type: user.subscription&.account_type,
-        auditor: user.auditor?
+        auditor: user.auditor?,
+        district: user.school&.district&.name
       },
       integrations: integration_rules(user.id)
     }

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -169,4 +169,18 @@ describe 'SegmentAnalytics' do
       })
     end
   end
+
+  context '#identify' do
+
+    let(:district) { create(:district) }
+    let(:school) { create(:school, district: district) }
+    let(:teacher) { create(:teacher, school: school) }
+
+    it 'sends events to Intercom when the user is a teacher' do
+      analytics.identify(teacher)
+      expect(identify_calls.size).to eq(1)
+      expect(track_calls.size).to eq(0)
+      expect(identify_calls[0][:traits][:district]).to eq(district.name)
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Now that we've enabled districts, we want to send a user's school district through with their Segment data so Partnerships can see this data on Intercom.

## WHY
So Partnerships can use this data when making sales decisions.

## HOW
Just add this field to the Segment payload.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
