### PR TITLE
Convert SELECTed DateTime data into user's timezone offset if provided

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -7,6 +7,7 @@ class Scorebook::Query
   def self.run(classroom_id, current_page=1, unit_id=nil, begin_date=nil, end_date=nil, offset=0)
     first_unit = units(unit_id) ? units(unit_id).first : nil
     last_unit = units(unit_id) ? units(unit_id).last : nil
+    user_timezone_offset = "+ INTERVAL '#{offset}' SECOND"
     RawSqlRunner.execute(
       <<-SQL
         SELECT
@@ -18,8 +19,8 @@ class Scorebook::Query
           activity.name AS activity_name,
           activity.id AS activity_id,
           activity.description AS activity_description,
-          MAX(acts.updated_at) AS updated_at,
-          MIN(acts.started_at) AS started_at,
+          MAX(acts.updated_at) #{user_timezone_offset} AS updated_at,
+          MIN(acts.started_at) #{user_timezone_offset} AS started_at,
           MAX(acts.percentage) AS percentage,
           SUM(acts.timespent) AS timespent,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) AS completed_attempts,

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -65,6 +65,16 @@ describe 'ScorebookQuery' do
         new_completed_at
       end
 
+      it "converts timestamps in the SELECT clause to the current user's timezone if one is provided" do
+        tz = TZInfo::Timezone.get('Australia/Perth')
+        offset = tz.period_for_utc(Time.new.utc).utc_total_offset
+
+        results = Scorebook::Query.run(classroom.id, 1, nil, nil, nil, offset)
+
+        in_user_time = (activity_session1.updated_at + offset.seconds).strftime('%Y-%m-%d %H:%M:%S.%6N')
+        expect(results.find{|res| res['id'] == activity_session1.id}['updated_at']).to eq(in_user_time)
+      end
+
       it "factors in offset to return activities where the teacher is in a different timezone than the database" do
         tz = TZInfo::Timezone.get('Australia/Perth')
         offset = tz.period_for_utc(Time.new.utc).utc_total_offset


### PR DESCRIPTION
## WHAT
Apply timezone offsets to `DateTime` data that we pull out of the database for reports via `SELECT`
## WHY
Our current code uses the `current_user`'s configured timezone when filtering by dates, but then shows the data in raw UTC.  This means that a user can see that the user "completed an activity" on one date, but it may disappear when filtering for that date if the completion time was close enough to the midnight rollover that UTC is on one day, and user timezone is on another.  In order to avoid confusion, we should us timezone offset in both input (filter conditions) and output (select options).
## HOW
Add extra code to modify dates in the query's `SELECT` segment by any provided timezone offset (and doing nothing if the offset is the default `0`).

### Notion Card Links
https://www.notion.so/quill/Discrepancy-between-date-completed-date-filters-on-Activity-Summary-4e90c7273b7a4d7f99beca7b6c7f6711

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes, new test added for this edge case
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
