### PR TITLE
Add bonus days to new school subscriptions on stripe

### DIFF
--- a/services/QuillLMS/app/models/bonus_days_calculator.rb
+++ b/services/QuillLMS/app/models/bonus_days_calculator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class BonusDaysCalculator < ApplicationService
+  JUNE = 6
+  JULY = 7
+  DECEMBER = 12
+
+  attr_reader :user
+
+  delegate :school, to: :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def run
+    return 0 if user.nil? || school.nil? || school_has_paid_before?
+
+    (plan_ends - today).to_i
+  end
+
+  private def plan_ends
+    today.month < JULY ? today.change(month: JUNE, day: 30) : today.change(month: DECEMBER, day: 31)
+  end
+
+  private def school_has_paid_before?
+    ::Subscription.school_or_user_has_ever_paid?(school)
+  end
+
+  private def today
+    @today ||= Date.current
+  end
+end
+

--- a/services/QuillLMS/app/models/bonus_days_calculator.rb
+++ b/services/QuillLMS/app/models/bonus_days_calculator.rb
@@ -5,30 +5,27 @@ class BonusDaysCalculator < ApplicationService
   JULY = 7
   DECEMBER = 12
 
-  attr_reader :user
+  attr_reader :user, :start
 
   delegate :school, to: :user
 
-  def initialize(user)
+  def initialize(user, start: Date.current)
     @user = user
+    @start = start
   end
 
   def run
     return 0 if user.nil? || school.nil? || school_has_paid_before?
 
-    (plan_ends - today).to_i
+    (plan_ends - start).to_i
   end
 
   private def plan_ends
-    today.month < JULY ? today.change(month: JUNE, day: 30) : today.change(month: DECEMBER, day: 31)
+    start.month < JULY ? start.change(month: JUNE, day: 30) : start.change(month: DECEMBER, day: 31)
   end
 
   private def school_has_paid_before?
     ::Subscription.school_or_user_has_ever_paid?(school)
-  end
-
-  private def today
-    @today ||= Date.current
   end
 end
 

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -193,9 +193,7 @@ class Subscription < ApplicationRecord
   end
 
   def self.school_or_user_has_ever_paid?(school_or_user)
-    # TODO: 'subscription type spot'
-    paid_accounts = school_or_user.subscriptions.pluck(:account_type) & OFFICIAL_PAID_TYPES
-    paid_accounts.any?
+    (OFFICIAL_PAID_TYPES & school_or_user.subscriptions.pluck(:account_type)).present?
   end
 
   def self.new_school_premium_sub(school, user)
@@ -216,9 +214,7 @@ class Subscription < ApplicationRecord
   end
 
   def self.redemption_start_date(school_or_user)
-    last_subscription = school_or_user.subscriptions.active.first
-
-    last_subscription.present? ? last_subscription.expiration : Date.current
+    school_or_user&.subscriptions&.active&.first&.expiration || Date.current
   end
 
   def self.default_expiration_date(school_or_user)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -179,6 +179,12 @@ class User < ApplicationRecord
     )
   end
 
+  def self.find_by_stripe_customer_id_or_email(stripe_customer_id, email)
+    return User.find_by(stripe_customer_id: stripe_customer_id) if stripe_customer_id.present?
+
+    User.find_by(email: email)
+  end
+
   def self.valid_email?(email)
     ValidatesEmailFormatOf.validate_email_format(email).nil?
   end

--- a/services/QuillLMS/lib/tasks/temporary/plans.rake
+++ b/services/QuillLMS/lib/tasks/temporary/plans.rake
@@ -11,16 +11,16 @@ namespace :plans do
           audience: 'teacher',
           interval: 'yearly',
           interval_count: 1,
-          stripe_price_id: ENV.fetch('STRIPE_TEACHER_PREMIUM_PRICE_ID', '')
+          stripe_price_id: ENV.fetch('STRIPE_TEACHER_PLAN_PRICE_ID', '')
         },
         {
           name: 'School Paid (via Stripe)',
           display_name: 'School Premium',
-          price: 8000,
+          price: 180000,
           audience: 'school',
           interval: 'yearly',
           interval_count: 1,
-          stripe_price_id: ENV.fetch('STRIPE_SCHOOL_PREMIUM_PRICE_ID', '')
+          stripe_price_id: ENV.fetch('STRIPE_SCHOOL_PLAN_PRICE_ID', '')
         },
         {
           name: 'School Paid (via invoice)',

--- a/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
+++ b/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BonusDaysCalculator do
+  let(:user) { create(:user) }
+  let(:school) { create(:school) }
+
+  before { allow(user).to receive(:school).and_return(school) }
+
+  subject { described_class.run(user) }
+
+  context 'nil user' do
+    before { allow(user).to receive(:nil?).and_return(true) }
+
+    it { expect(subject).to eq 0 }
+  end
+
+  context 'nil school' do
+    before { allow(school).to receive(:nil?).and_return(true) }
+
+    it { expect(subject).to eq 0 }
+  end
+
+  context 'school has paid before' do
+    before { allow(Subscription).to receive(:school_or_user_has_ever_paid?).with(school).and_return(true) }
+
+    it { expect(subject).to eq 0 }
+  end
+
+  context 'school has not paid before', :travel_back do
+    context 'day is before JULY' do
+      before { travel_to Date.current.change(month: described_class::JUNE, day: 1) }
+
+      it { expect(subject).to eq 29 }
+    end
+
+    context 'day is after JULY' do
+      before { travel_to Date.current.change(month: described_class::DECEMBER, day: 1) }
+
+      it { expect(subject).to eq 30 }
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
+++ b/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
@@ -8,35 +8,43 @@ RSpec.describe BonusDaysCalculator do
 
   before { allow(user).to receive(:school).and_return(school) }
 
-  subject { described_class.run(user) }
+  subject { described_class.run(*args) }
 
   context 'nil user' do
+    let(:args) { [user] }
+
     before { allow(user).to receive(:nil?).and_return(true) }
 
     it { expect(subject).to eq 0 }
   end
 
   context 'nil school' do
+    let(:args) { [user] }
+
     before { allow(school).to receive(:nil?).and_return(true) }
 
     it { expect(subject).to eq 0 }
   end
 
   context 'school has paid before' do
+    let(:args) { [user] }
+
     before { allow(Subscription).to receive(:school_or_user_has_ever_paid?).with(school).and_return(true) }
 
     it { expect(subject).to eq 0 }
   end
 
-  context 'school has not paid before', :travel_back do
+  context 'school has not paid before' do
+    let(:args) { [user, start: start] }
+
     context 'day is before JULY' do
-      before { travel_to Date.current.change(month: described_class::JUNE, day: 1) }
+      let(:start) { Date.current.change(month: described_class::JUNE, day: 1) }
 
       it { expect(subject).to eq 29 }
     end
 
     context 'day is after JULY' do
-      before { travel_to Date.current.change(month: described_class::DECEMBER, day: 1) }
+      let(:start) { Date.current.change(month: described_class::DECEMBER, day: 1) }
 
       it { expect(subject).to eq 30 }
     end

--- a/services/QuillLMS/spec/support/helpers/time_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/time_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+
+  config.around(:each, :freeze_time) { |example| freeze_time { example.run } }
+
+  config.after(:each, :travel_back) { |example| travel_back { example.run } }
+end


### PR DESCRIPTION
## WHAT
Add parameter bonus days to new School Premium Subscriptions provisioned through Stripe.

## WHY
We'd like to get Schools on the same renewal cycle either June 30 or Dec 31 while also providing a bonus to new School subscribers.

It would also make the school manual plans' bonus days consistent with those purchased on stripe.

## HOW
Stripe [provides](https://stripe.com/docs/billing/subscriptions/trials) a `trial_period_days` parameter that can be [merged](https://github.com/empirical-org/Empirical-Core/pull/9159/commits/3ac63b26da3b994721b80a3dc784671480fe07db#diff-aaa793cd1f752bdf6b145438ed06ad642f56786d928238e2977c3c9f564c9592R21) with the existing parameters sent to the `Stripe:Checkout:Session.create`.

### Screenshots
(If applicable. Also, please censor any sensitive data)
![Screen Shot 2022-05-11 at 9 45 56 AM](https://user-images.githubusercontent.com/2057805/167918386-fab6fa72-1856-43f1-94f6-ecdb6e47ffa3.png)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Implement-a-new-direct-subscription-process-that-utilizes-Stripe-subscriptions-229f2cba7d5e4dbf8bf95388f1ab4209)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
