### PR TITLE
subscriptions page button standardizations

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/subscriptions.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/subscriptions.scss
@@ -79,16 +79,14 @@
     }
   }
 
-  .renew-subscription.cta-button {
-    height: 40px;
-    padding: 8px 9px;
-  }
-
   .subscription-status {
     background-color: #fff;
-    padding-top: 15px;
+    padding-top: 16px;
     color: #3b3b3b;
     padding-bottom: 0px;
+    .quill-button {
+      margin-right: 16px;
+    }
     strong {
       padding-right: 4px;
       a {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -14,6 +14,8 @@ import {
 
 import StripeSubscriptionCheckoutSessionButton from '../shared/StripeSubscriptionCheckoutSessionButton';
 
+const CTA_BUTTON_CLASSNAME = "quill-button medium contained primary focus-on-light"
+
 const quillBasicCopy = (
   <span>
     Quill Basic provides access to all of Quill&apos;s content. To access Quill Premium, you can purchase an individual teacher subscription or a school subscription.
@@ -103,7 +105,7 @@ const SubscriptionStatus = ({
       image = 'basic_icon.png';
       content.premiumCopy = quillBasicCopy;
       content.boxColor = '#00c2a2';
-      content.buttonOrDate = <a className="q-button cta-button bg-orange text-white" href="/premium">Learn More About Quill Premium</a>;
+      content.buttonOrDate = <a className={CTA_BUTTON_CLASSNAME} href="/premium">Learn More About Quill Premium</a>;
       subscriptionTypeText = 'Quill Basic';
       content.status = <h2>{`You have a ${subscriptionType} subscription`}<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
       break;
@@ -116,7 +118,7 @@ const SubscriptionStatus = ({
       content.status = <h2>You have a {teacherSubDisplayName} subscription<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>
       content.boxColor = '#348fdf'
       if (remainingDays < 0) {
-        content.buttonOrDate = <a className="renew-subscription q-button bg-orange text-white cta-button focus-on-light" href="/premium">Subscribe to Premium</a>
+        content.buttonOrDate = <a className={CTA_BUTTON_CLASSNAME} href="/premium">Subscribe to Premium</a>
       }
       break;
     case TEACHER_PREMIUM:
@@ -127,7 +129,7 @@ const SubscriptionStatus = ({
       if (remainingDays < 0) {
         content.buttonOrDate = (
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName={CTA_BUTTON_CLASSNAME}
             buttonText='Renew Subscription'
             cancelPath='subscriptions'
             customerEmail={subscriptionStatus.customer_email}
@@ -146,7 +148,7 @@ const SubscriptionStatus = ({
       if (remainingDays < 0) {
         content.buttonOrDate = (
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName={CTA_BUTTON_CLASSNAME}
             buttonText='Renew Subscription'
             cancelPath='subscriptions'
             customerEmail={subscriptionStatus.customer_email}
@@ -165,7 +167,7 @@ const SubscriptionStatus = ({
       if (remainingDays < 0) {
         content.buttonOrDate = (
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className={CTA_BUTTON_CLASSNAME}
             href="mailto:sales@quill.org"
           >
             Contact Us to Renew
@@ -179,7 +181,7 @@ const SubscriptionStatus = ({
       content.status = <h2>You have a {SCHOOL_PREMIUM} subscription<img alt={`${subscriptionType}`} src={`https://assets.quill.org/images/shared/${image}`} /></h2>;
       content.boxColor = '#9c2bde';
       if (remainingDays < 0) {
-        content.buttonOrDate = <a className="renew-subscription q-button bg-orange text-white cta-button focus-on-light" href="/premium">Subscribe to Premium</a>
+        content.buttonOrDate = <a className={CTA_BUTTON_CLASSNAME} href="/premium">Subscribe to Premium</a>
       }
       break;
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/SubscriptionStatus.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/SubscriptionStatus.test.jsx.snap
@@ -51,14 +51,14 @@ exports[`SubscriptionStatus container should render when the subscription is exp
         </h2>
       </div>
       <StripeSubscriptionCheckoutSessionButton
-        buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+        buttonClassName="quill-button medium contained primary focus-on-light"
         buttonText="Renew Subscription"
         cancelPath="subscriptions"
         userIsEligibleForNewSubscription={true}
         userIsSignedIn={true}
       >
         <button
-          className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+          className="quill-button medium contained primary focus-on-light"
           onClick={[Function]}
           type="button"
         >
@@ -118,7 +118,7 @@ exports[`SubscriptionStatus container should render when there is no subscriptio
         </h2>
       </div>
       <a
-        className="q-button cta-button bg-orange text-white"
+        className="quill-button medium contained primary focus-on-light"
         href="/premium"
       >
         Learn More About Quill Premium

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/available_credits.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/available_credits.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`AvailableCredits container should render when there are no premium cred
        of Teacher Premium Credit available.
     </div>
     <a
-      className="q-button button cta-button bg-orange"
+      className="quill-button medium primary outlined focus-on-light"
       href="/referrals"
     >
       Earn Premium Credits
@@ -47,7 +47,7 @@ exports[`AvailableCredits container should render when there are premium credits
        of Teacher Premium Credit available.
     </div>
     <button
-      className="q-button cta-button bg-orange has-credit"
+      className="quill-button medium primary outlined focus-on-light"
       onClick={[Function]}
       type="button"
     >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/available_credits.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/available_credits.jsx
@@ -13,9 +13,9 @@ const AvailableCredits = ({ userHasValidSub, redeemPremiumCredits, availableCred
 
   let button;
   if (availableCredits > 0) {
-    button = <button className="q-button cta-button bg-orange has-credit" onClick={redeemIfNoCurrentSub} type="button">Redeem Premium Credits</button>;
+    button = <button className="quill-button medium primary outlined focus-on-light" onClick={redeemIfNoCurrentSub} type="button">Redeem Premium Credits</button>;
   } else {
-    button = <a className="q-button button cta-button bg-orange" href="/referrals">Earn Premium Credits</a>;
+    button = <a className="quill-button medium primary outlined focus-on-light" href="/referrals">Earn Premium Credits</a>;
   }
   const weeksOfCredit = Math.round(availableCredits / 7)
   const whiteIfNoCredit = weeksOfCredit === 0 ? 'no-credits' : null;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -30,7 +30,7 @@ export default class CurrentSubscription extends React.Component {
     const baseText = `Once your current ${subscriptionType} subscription expires, you will be downgraded to Quill Basic.`;
 
     if ([TEACHER_PREMIUM_TRIAL, TEACHER_PREMIUM_CREDIT, TEACHER_PREMIUM_SCHOLARSHIP].includes(subscriptionType)) { return baseText }
-    
+
     if (subscriptionType === SCHOOL_PREMIUM_SCHOLARSHIP && !authorityLevel) { return baseText }
 
     if (payment_method === CREDIT_CARD && authorityLevel) {
@@ -180,22 +180,6 @@ export default class CurrentSubscription extends React.Component {
     );
   }
 
-  renewPremium() {
-    const { showPurchaseModal, } = this.props
-
-    return (
-      <div>
-        <button
-          className="renew-subscription q-button bg-orange text-white cta-button"
-          onClick={showPurchaseModal}
-          type="button"
-        >
-          Renew Subscription
-        </button>
-      </div>
-    );
-  }
-
   nextPlan() {
     const { subscriptionStatus, } = this.props
 
@@ -308,7 +292,7 @@ export default class CurrentSubscription extends React.Component {
     if (authorityLevel && subscriptionStatus.payment_method === CREDIT_CARD) {
       return (
         <button
-          className="q-button bg-orange text-white focus-on-light"
+          className="quill-button medium primary contained focus-on-light"
           onClick={this.handleClickShowAutomaticRenewalModal}
           type="button"
         >

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
               }
             />
             <h2>
-              You have a
+              You have a 
               District Premium
                subscription
               <img
@@ -112,30 +112,30 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             District Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             District Premium
              features.
           </span>
@@ -386,13 +386,13 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                     />
                     <span>
                       Once your current District Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact the purchaser at
+                       To renew your subscription for next year, contact the purchaser at 
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
                         emilia+3@quill.org
                       </a>
-                       or
+                       or 
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -562,9 +562,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -619,7 +619,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -772,7 +772,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="mailto:sales@quill.org"
           >
             Contact Us to Renew
@@ -781,11 +781,11 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <p>
           <span>
             <strong>
-              Your
+              Your 
               District Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -794,7 +794,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -986,9 +986,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -1043,7 +1043,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -1189,7 +1189,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
               }
             />
             <h2>
-              You have a
+              You have a 
               District Premium
                subscription
               <img
@@ -1204,30 +1204,30 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             District Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             District Premium
              features.
           </span>
@@ -1539,7 +1539,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                     />
                     <span>
                       Once your current District Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact us at
+                       To renew your subscription for next year, contact us at 
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -1709,9 +1709,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -1766,7 +1766,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -1919,7 +1919,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="mailto:sales@quill.org"
           >
             Contact Us to Renew
@@ -1928,11 +1928,11 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <p>
           <span>
             <strong>
-              Your
+              Your 
               District Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -2122,9 +2122,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -2179,7 +2179,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -2325,7 +2325,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
               }
             />
             <h2>
-              You have a
+              You have a 
               Teacher Premium Credit
                subscription
               <img
@@ -2340,21 +2340,21 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             Teacher Premium Credit
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -2363,7 +2363,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             >
                Here’s more information
             </a>
-             about your
+             about your 
             Teacher Premium Credit
              features.
           </span>
@@ -2775,9 +2775,9 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -2832,7 +2832,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -2994,11 +2994,11 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <p>
           <span>
             <strong>
-              Your
+              Your 
               Teacher Premium Credit
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -3007,7 +3007,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -3199,9 +3199,9 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -3256,7 +3256,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -3402,7 +3402,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -3417,30 +3417,30 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium (Scholarship)
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium (Scholarship)
              features.
           </span>
@@ -3852,9 +3852,9 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -3909,7 +3909,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -4071,11 +4071,11 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <p>
           <span>
             <strong>
-              Your
+              Your 
               School Premium (Scholarship)
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -4084,7 +4084,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -4276,9 +4276,9 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -4333,7 +4333,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -4479,7 +4479,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -4494,30 +4494,30 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -4768,13 +4768,13 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact the purchaser at
+                       To renew your subscription for next year, contact the purchaser at 
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
                         emilia+3@quill.org
                       </a>
-                       or
+                       or 
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -4944,9 +4944,9 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -5001,7 +5001,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -5172,11 +5172,11 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <p>
           <span>
             <strong>
-              Your
+              Your 
               School Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -5185,7 +5185,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -5377,9 +5377,9 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -5434,7 +5434,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -5580,7 +5580,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -5595,30 +5595,30 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -5930,7 +5930,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact us at
+                       To renew your subscription for next year, contact us at 
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -6100,9 +6100,9 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -6157,7 +6157,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -6328,11 +6328,11 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <p>
           <span>
             <strong>
-              Your
+              Your 
               School Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -6522,9 +6522,9 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -6579,7 +6579,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -6725,7 +6725,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -6740,30 +6740,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -7014,7 +7014,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To prevent your subscription from expiring, contact the purchaser at
+                       To prevent your subscription from expiring, contact the purchaser at 
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
@@ -7184,9 +7184,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -7241,7 +7241,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -7387,7 +7387,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -7402,30 +7402,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -7858,9 +7858,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -7915,7 +7915,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -8086,11 +8086,11 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <p>
           <span>
             <strong>
-              Your
+              Your 
               School Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -8099,7 +8099,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -8291,9 +8291,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -8348,7 +8348,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -8494,7 +8494,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -8509,30 +8509,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -8966,9 +8966,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -9023,7 +9023,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -9169,7 +9169,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a
+              You have a 
               School Premium
                subscription
               <img
@@ -9184,30 +9184,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your
+             about your 
             School Premium
              features.
           </span>
@@ -9662,9 +9662,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -9719,7 +9719,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -9890,11 +9890,11 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <p>
           <span>
             <strong>
-              Your
+              Your 
               School Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -10084,9 +10084,9 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -10141,7 +10141,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -10287,7 +10287,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
               }
             />
             <h2>
-              You have a
+              You have a 
               Teacher Premium
                subscription
               <img
@@ -10302,21 +10302,21 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             Teacher Premium (Scholarship)
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -10325,7 +10325,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             >
                Here’s more information
             </a>
-             about your
+             about your 
             Teacher Premium (Scholarship)
              features.
           </span>
@@ -10737,9 +10737,9 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -10794,7 +10794,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -10956,11 +10956,11 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <p>
           <span>
             <strong>
-              Your
+              Your 
               Teacher Premium (Scholarship)
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -10969,7 +10969,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -11161,9 +11161,9 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -11218,7 +11218,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -11364,7 +11364,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
               }
             />
             <h2>
-              You have a
+              You have a 
               Teacher Premium
                subscription
               <img
@@ -11379,21 +11379,21 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             Teacher Premium
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -11402,7 +11402,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             >
                Here’s more information
             </a>
-             about your
+             about your 
             Teacher Premium
              features.
           </span>
@@ -11836,9 +11836,9 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -11893,7 +11893,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -12039,7 +12039,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
               }
             />
             <h2>
-              You have a
+              You have a 
               Teacher Premium
                subscription
               <img
@@ -12054,21 +12054,21 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             Teacher Premium
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -12077,7 +12077,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             >
                Here’s more information
             </a>
-             about your
+             about your 
             Teacher Premium
              features.
           </span>
@@ -12532,9 +12532,9 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -12589,7 +12589,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -12760,11 +12760,11 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <p>
           <span>
             <strong>
-              Your
+              Your 
               Teacher Premium
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -12773,7 +12773,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -12965,9 +12965,9 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -13022,7 +13022,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -13168,7 +13168,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
               }
             />
             <h2>
-              You have a
+              You have a 
               Teacher Premium Trial
                subscription
               <img
@@ -13183,21 +13183,21 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
             <span>
               Valid Until:
             </span>
-
+             
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               |
+               | 
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With
+            With 
             Teacher Premium Trial
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -13206,7 +13206,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
             >
                Here’s more information
             </a>
-             about your
+             about your 
             Teacher Premium Trial
              features.
           </span>
@@ -13618,9 +13618,9 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -13675,7 +13675,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>
@@ -13837,11 +13837,11 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
         <p>
           <span>
             <strong>
-              Your
+              Your 
               Teacher Premium Trial
                subscription (
               02/16/22
-               -
+               - 
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -13850,7 +13850,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
             </span>
             <br />
             <br />
-            The billing contact for your subscription is
+            The billing contact for your subscription is 
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -14042,9 +14042,9 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
         <div
           className="credit-quantity"
         >
-          You have
+          You have 
           <span>
-            0 weeks
+            0 weeks 
           </span>
            of Teacher Premium Credit available.
         </div>
@@ -14099,7 +14099,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
           >
             Total Premium Credits Earned:
           </span>
-
+           
           0 weeks
         </span>
       </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
               }
             />
             <h2>
-              You have a 
+              You have a
               District Premium
                subscription
               <img
@@ -112,30 +112,30 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             District Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             District Premium
              features.
           </span>
@@ -386,13 +386,13 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                     />
                     <span>
                       Once your current District Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact the purchaser at 
+                       To renew your subscription for next year, contact the purchaser at
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
                         emilia+3@quill.org
                       </a>
-                       or 
+                       or
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -562,14 +562,14 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -619,7 +619,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -781,11 +781,11 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <p>
           <span>
             <strong>
-              Your 
+              Your
               District Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -794,7 +794,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -986,14 +986,14 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -1043,7 +1043,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -1189,7 +1189,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
               }
             />
             <h2>
-              You have a 
+              You have a
               District Premium
                subscription
               <img
@@ -1204,30 +1204,30 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             District Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             District Premium
              features.
           </span>
@@ -1539,7 +1539,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                     />
                     <span>
                       Once your current District Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact us at 
+                       To renew your subscription for next year, contact us at
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -1709,14 +1709,14 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -1766,7 +1766,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -1928,11 +1928,11 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <p>
           <span>
             <strong>
-              Your 
+              Your
               District Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -2122,14 +2122,14 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -2179,7 +2179,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -2325,7 +2325,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
               }
             />
             <h2>
-              You have a 
+              You have a
               Teacher Premium Credit
                subscription
               <img
@@ -2340,21 +2340,21 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             Teacher Premium Credit
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -2363,7 +2363,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             >
                Here’s more information
             </a>
-             about your 
+             about your
             Teacher Premium Credit
              features.
           </span>
@@ -2775,14 +2775,14 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -2832,7 +2832,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -2985,7 +2985,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="/premium"
           >
             Subscribe to Premium
@@ -2994,11 +2994,11 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <p>
           <span>
             <strong>
-              Your 
+              Your
               Teacher Premium Credit
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -3007,7 +3007,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -3199,14 +3199,14 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -3256,7 +3256,7 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -3402,7 +3402,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -3417,30 +3417,30 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium (Scholarship)
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium (Scholarship)
              features.
           </span>
@@ -3852,14 +3852,14 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -3909,7 +3909,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -4062,7 +4062,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="/premium"
           >
             Subscribe to Premium
@@ -4071,11 +4071,11 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <p>
           <span>
             <strong>
-              Your 
+              Your
               School Premium (Scholarship)
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -4084,7 +4084,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -4276,14 +4276,14 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -4333,7 +4333,7 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -4479,7 +4479,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -4494,30 +4494,30 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -4768,13 +4768,13 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact the purchaser at 
+                       To renew your subscription for next year, contact the purchaser at
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
                         emilia+3@quill.org
                       </a>
-                       or 
+                       or
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -4944,14 +4944,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -5001,7 +5001,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -5154,14 +5154,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             </h2>
           </div>
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName="quill-button medium contained primary focus-on-light"
             buttonText="Renew Subscription"
             cancelPath="subscriptions"
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}
           >
             <button
-              className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+              className="quill-button medium contained primary focus-on-light"
               onClick={[Function]}
               type="button"
             >
@@ -5172,11 +5172,11 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <p>
           <span>
             <strong>
-              Your 
+              Your
               School Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -5185,7 +5185,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -5377,14 +5377,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -5434,7 +5434,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -5580,7 +5580,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -5595,30 +5595,30 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -5930,7 +5930,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To renew your subscription for next year, contact us at 
+                       To renew your subscription for next year, contact us at
                       <a
                         href="mailto:sales@quill.org"
                       >
@@ -6100,14 +6100,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -6157,7 +6157,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -6310,14 +6310,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
             </h2>
           </div>
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName="quill-button medium contained primary focus-on-light"
             buttonText="Renew Subscription"
             cancelPath="subscriptions"
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}
           >
             <button
-              className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+              className="quill-button medium contained primary focus-on-light"
               onClick={[Function]}
               type="button"
             >
@@ -6328,11 +6328,11 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <p>
           <span>
             <strong>
-              Your 
+              Your
               School Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -6522,14 +6522,14 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -6579,7 +6579,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -6725,7 +6725,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -6740,30 +6740,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -7014,7 +7014,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                     />
                     <span>
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
-                       To prevent your subscription from expiring, contact the purchaser at 
+                       To prevent your subscription from expiring, contact the purchaser at
                       <a
                         href="mailto:emilia+3@quill.org"
                       >
@@ -7184,14 +7184,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -7241,7 +7241,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -7387,7 +7387,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -7402,30 +7402,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -7858,14 +7858,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -7915,7 +7915,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -8068,14 +8068,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             </h2>
           </div>
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName="quill-button medium contained primary focus-on-light"
             buttonText="Renew Subscription"
             cancelPath="subscriptions"
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}
           >
             <button
-              className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+              className="quill-button medium contained primary focus-on-light"
               onClick={[Function]}
               type="button"
             >
@@ -8086,11 +8086,11 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <p>
           <span>
             <strong>
-              Your 
+              Your
               School Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -8099,7 +8099,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -8291,14 +8291,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -8348,7 +8348,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -8494,7 +8494,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -8509,30 +8509,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -8699,7 +8699,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       </div>
                     </_default>
                     <button
-                      className="q-button bg-orange text-white focus-on-light"
+                      className="quill-button medium primary contained focus-on-light"
                       onClick={[Function]}
                       type="button"
                     >
@@ -8966,14 +8966,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -9023,7 +9023,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -9169,7 +9169,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
               }
             />
             <h2>
-              You have a 
+              You have a
               School Premium
                subscription
               <img
@@ -9184,30 +9184,30 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             School Premium
-            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis. 
+            , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
               className="green-link"
               href="https://support.quill.org/quill-premium"
             >
               Here’s more information
             </a>
-             about your 
+             about your
             School Premium
              features.
           </span>
@@ -9374,7 +9374,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       </div>
                     </_default>
                     <button
-                      className="q-button bg-orange text-white focus-on-light"
+                      className="quill-button medium primary contained focus-on-light"
                       onClick={[Function]}
                       type="button"
                     >
@@ -9662,14 +9662,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -9719,7 +9719,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -9872,14 +9872,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
             </h2>
           </div>
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName="quill-button medium contained primary focus-on-light"
             buttonText="Renew Subscription"
             cancelPath="subscriptions"
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}
           >
             <button
-              className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+              className="quill-button medium contained primary focus-on-light"
               onClick={[Function]}
               type="button"
             >
@@ -9890,11 +9890,11 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <p>
           <span>
             <strong>
-              Your 
+              Your
               School Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -10084,14 +10084,14 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -10141,7 +10141,7 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -10287,7 +10287,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
               }
             />
             <h2>
-              You have a 
+              You have a
               Teacher Premium
                subscription
               <img
@@ -10302,21 +10302,21 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             Teacher Premium (Scholarship)
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -10325,7 +10325,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             >
                Here’s more information
             </a>
-             about your 
+             about your
             Teacher Premium (Scholarship)
              features.
           </span>
@@ -10737,14 +10737,14 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -10794,7 +10794,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -10947,7 +10947,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="/premium"
           >
             Subscribe to Premium
@@ -10956,11 +10956,11 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <p>
           <span>
             <strong>
-              Your 
+              Your
               Teacher Premium (Scholarship)
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -10969,7 +10969,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -11161,14 +11161,14 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -11218,7 +11218,7 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -11364,7 +11364,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
               }
             />
             <h2>
-              You have a 
+              You have a
               Teacher Premium
                subscription
               <img
@@ -11379,21 +11379,21 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             Teacher Premium
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -11402,7 +11402,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             >
                Here’s more information
             </a>
-             about your 
+             about your
             Teacher Premium
              features.
           </span>
@@ -11569,7 +11569,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                       </div>
                     </_default>
                     <button
-                      className="q-button bg-orange text-white focus-on-light"
+                      className="quill-button medium primary contained focus-on-light"
                       onClick={[Function]}
                       type="button"
                     >
@@ -11836,14 +11836,14 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -11893,7 +11893,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -12039,7 +12039,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
               }
             />
             <h2>
-              You have a 
+              You have a
               Teacher Premium
                subscription
               <img
@@ -12054,21 +12054,21 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             Teacher Premium
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -12077,7 +12077,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             >
                Here’s more information
             </a>
-             about your 
+             about your
             Teacher Premium
              features.
           </span>
@@ -12244,7 +12244,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                       </div>
                     </_default>
                     <button
-                      className="q-button bg-orange text-white focus-on-light"
+                      className="quill-button medium primary contained focus-on-light"
                       onClick={[Function]}
                       type="button"
                     >
@@ -12532,14 +12532,14 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -12589,7 +12589,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -12742,14 +12742,14 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             </h2>
           </div>
           <StripeSubscriptionCheckoutSessionButton
-            buttonClassName="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            buttonClassName="quill-button medium contained primary focus-on-light"
             buttonText="Renew Subscription"
             cancelPath="subscriptions"
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}
           >
             <button
-              className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+              className="quill-button medium contained primary focus-on-light"
               onClick={[Function]}
               type="button"
             >
@@ -12760,11 +12760,11 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <p>
           <span>
             <strong>
-              Your 
+              Your
               Teacher Premium
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -12773,7 +12773,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -12965,14 +12965,14 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -13022,7 +13022,7 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -13168,7 +13168,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
               }
             />
             <h2>
-              You have a 
+              You have a
               Teacher Premium Trial
                subscription
               <img
@@ -13183,21 +13183,21 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
             <span>
               Valid Until:
             </span>
-             
+
             <span>
               January 1st, 2070
             </span>
             <span
               className="time-left-in-days"
             >
-               | 
+               |
               17400 days
             </span>
           </span>
         </div>
         <p>
           <span>
-            With 
+            With
             Teacher Premium Trial
             , you will have access to all of Quill’s free reports as well as additional advanced reporting. You will also be able to view and print reports of your students’ progress. Our advanced reports support concept, Common Core, and overall progress analysis.
             <a
@@ -13206,7 +13206,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
             >
                Here’s more information
             </a>
-             about your 
+             about your
             Teacher Premium Trial
              features.
           </span>
@@ -13618,14 +13618,14 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -13675,7 +13675,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>
@@ -13828,7 +13828,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
             </h2>
           </div>
           <a
-            className="renew-subscription q-button bg-orange text-white cta-button focus-on-light"
+            className="quill-button medium contained primary focus-on-light"
             href="/premium"
           >
             Subscribe to Premium
@@ -13837,11 +13837,11 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
         <p>
           <span>
             <strong>
-              Your 
+              Your
               Teacher Premium Trial
                subscription (
               02/16/22
-               - 
+               -
               01/01/22
               ) has expired and you are back to Quill Basic.
             </strong>
@@ -13850,7 +13850,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
             </span>
             <br />
             <br />
-            The billing contact for your subscription is 
+            The billing contact for your subscription is
             <strong>
               <a
                 href="mailto:emilia+3@quill.org"
@@ -14042,14 +14042,14 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
         <div
           className="credit-quantity"
         >
-          You have 
+          You have
           <span>
-            0 weeks 
+            0 weeks
           </span>
            of Teacher Premium Credit available.
         </div>
         <a
-          className="q-button button cta-button bg-orange"
+          className="quill-button medium primary outlined focus-on-light"
           href="/referrals"
         >
           Earn Premium Credits
@@ -14099,7 +14099,7 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
           >
             Total Premium Credits Earned:
           </span>
-           
+
           0 weeks
         </span>
       </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/lowerFormFields.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/lowerFormFields.test.tsx.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LowerFormFields Component should match snapshot 1`] = `
+<LowerFormFields
+  comments=""
+  errors={Object {}}
+  handleUpdateField={[MockFunction]}
+  schoolPremiumEstimate={1}
+  studentPremiumEstimate={400}
+  teacherPremiumEstimate={20}
+>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of schools that will receive Quill Premium"
+    label="Estimated number of schools that will receive Quill Premium"
+    placeholder=""
+    value={1}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of schools that will receive Quill Premium"
+      >
+        Estimated number of schools that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of schools that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={1}
+      />
+    </div>
+  </Input>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of teachers that will receive Quill Premium"
+    label="Estimated number of teachers that will receive Quill Premium"
+    placeholder=""
+    value={20}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of teachers that will receive Quill Premium"
+      >
+        Estimated number of teachers that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of teachers that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={20}
+      />
+    </div>
+  </Input>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of students that will receive Quill Premium"
+    label="Estimated number of students that will receive Quill Premium"
+    placeholder=""
+    value={400}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of students that will receive Quill Premium"
+      >
+        Estimated number of students that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of students that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={400}
+      />
+    </div>
+  </Input>
+  <TextArea
+    aria-labelledby="comments-label"
+    className="form-input"
+    handleChange={[MockFunction]}
+    id="Comments"
+    label="Comments (optional)"
+    timesSubmitted={0}
+    value=""
+  >
+    <div>
+      <div
+        className="input-container textfield-container  inactive form-input"
+        onClick={[Function]}
+      >
+        <label>
+          Comments (optional)
+        </label>
+        <textarea
+          id="Comments"
+          maxLength={10000}
+          onFocus={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+  </TextArea>
+</LowerFormFields>
+`;


### PR DESCRIPTION
## WHAT
Update all the buttons on the subscriptions page to use our Backpack buttons.

## WHY
So they have a style that is more in sync with the rest of the website.

## HOW
Just identify all the buttons and change their class names, with a small CSS adjustment to make sure everything still looks good. There are only functionally three buttons now (the CTA button, the turn on/off automatic renewal button, and the redeem premium credits button), so this is pretty straightforward.

### Screenshots
<img width="505" alt="Screen Shot 2022-05-12 at 8 44 18 AM" src="https://user-images.githubusercontent.com/18669014/168108763-ebf56b43-9914-47d1-ac3c-bbad2ff7007f.png">
<img width="506" alt="Screen Shot 2022-05-12 at 8 43 15 AM" src="https://user-images.githubusercontent.com/18669014/168108765-5f087671-c83e-4d2d-ae3d-d35635b85986.png">

### Notion Card Links
https://www.notion.so/quill/Improve-button-styling-on-the-My-Subscriptions-page-4e0daf712fe641ee8031fe1c5184b10a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES