### PR TITLE
Cancel subscription renewal on deleted users

### DIFF
--- a/services/QuillLMS/app/workers/clear_user_data_worker.rb
+++ b/services/QuillLMS/app/workers/clear_user_data_worker.rb
@@ -21,7 +21,11 @@ class ClearUserDataWorker
       SchoolsUsers.where(user_id: id).destroy_all
       ClassroomUnit.where("? = ANY (assigned_student_ids)", id).each {|cu| cu.update(assigned_student_ids: cu.assigned_student_ids - [id])}
       ActivitySession.where(user_id: id).update_all(user_id: nil, classroom_unit_id: nil)
-    end
 
+      user.subscriptions.each do |subscription|
+        subscription.update!(recurring: false)
+        subscription.stripe_cancel_at_period_end
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe ClearUserDataWorker, type: :worker do
-  subject { described_class.new }
+  subject { described_class.new.perform(user.id) }
 
   let!(:ip_location) { create(:ip_location) }
   let(:user) { create(:student_in_two_classrooms_with_many_activities, google_id: 'sergey_and_larry_were_here', send_newsletter: true, ip_location: ip_location) }
@@ -11,53 +11,25 @@ describe ClearUserDataWorker, type: :worker do
   let!(:activity_sessions) { user.activity_sessions }
   let!(:classroom_units) { ClassroomUnit.where("? = ANY (assigned_student_ids)", user.id) }
 
-  before { subject.perform(user.id) }
+  it { expect { subject }.to change { user.reload.email }.to("deleted_user_#{user.id}@example.com") }
+  it { expect { subject }.to change { user.reload.username }.to("deleted_user_#{user.id}") }
+  it { expect { subject }.to change { user.reload.name }.to("Deleted User_#{user.id}") }
+  it { expect { subject }.to change { user.reload.google_id }.to(nil) }
+  it { expect { subject }.to change { user.reload.auth_credential }.to(nil) }
+  it { expect { subject }.to change { user.reload.ip_address }.to(nil) }
+  it { expect { subject }.to change { user.reload.send_newsletter }.to(false) }
+  it { expect { subject }.to change { user.reload.ip_location }.to(nil) }
+  it { expect { subject }.to change { StudentsClassrooms.where(student_id: user.id).count }.to(0) }
 
-  it "changes the user's email to one that is not personally identiable" do
-    expect(user.reload.email).to eq("deleted_user_#{user.id}@example.com")
-  end
-
-  it "changes the user's username to one that is not personally identiable" do
-    expect(user.reload.username).to eq("deleted_user_#{user.id}")
-  end
-
-  it "changes the user's name to one that is not personally identiable" do
-    expect(user.reload.name).to eq("Deleted User_#{user.id}")
-  end
-
-  it "removes the google id" do
-    expect(user.reload.google_id).to be nil
-  end
-
-  it "destroys associated auth credentials if present" do
-    expect(user.reload.auth_credential).to be nil
-  end
-
-  it "destroys associated schools_users if present" do
-    expect(user.reload.schools_users).to be nil
-  end
-
-  it "destroys associated students_classrooms if present" do
-    expect(StudentsClassrooms.where(student_id: user.id).count).to eq(0)
-  end
-
-  it "removes the ip address" do
-    expect(user.reload.ip_address).to be nil
-  end
-
-  it "sets send_newsletter to be false" do
-    expect(user.reload.send_newsletter).to be false
-  end
-
-  it "removes ip_location" do
-    expect(user.reload.ip_location).to be nil
-  end
 
   it "removes student from related classroom_units" do
+    subject
     classroom_units.each {|cu| expect(cu.assigned_student_ids).not_to include(user.id)}
   end
 
   it "removes student from related activity_sessions" do
+    subject
+
     expect(user.reload.activity_sessions.count).to eq(0)
     activity_sessions.each do |as|
       expect(as.classroom_unit_id).to be nil
@@ -65,4 +37,18 @@ describe ClearUserDataWorker, type: :worker do
     end
   end
 
+  context 'subscriptions' do
+    let!(:subscription) { create(:subscription, :recurring, :stripe) }
+    let!(:user_subscription) { create(:user_subscription, subscription: subscription, user: user) }
+    let(:stripe_subscription) { double(:stripe_subscription, stripe_cancel_at_period_end: nil) }
+
+    before { allow(StripeIntegration::Subscription).to receive(:new).with(subscription).and_return(stripe_subscription) }
+
+    it { expect { subject }.to change { subscription.reload.recurring }.from(true).to(false) }
+
+    it 'updates the stripe subscription' do
+      expect(stripe_subscription).to receive(:stripe_cancel_at_period_end)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
When a user is deleted, set the users subscriptions to `recurring: false` and set any stripe subscriptions' `cancel_at_period_end` to true.

## WHY
We don't want to accidentally charge users that have been deleted.

## HOW
Update the `ClearDataWorker` user.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/If-a-teacher-s-account-is-deleted-and-they-have-an-active-direct-subscription-then-turn-off-automat-19aa7b90b3d34ee7b7433f66684628d0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
