### PR TITLE
fix mobile view for review activities and assign page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
@@ -64,6 +64,11 @@
       }
     }
   }
+  @media (max-width: 991px) {
+    .links {
+      display: none;
+    }
+  }
 }
 
 .assignment-flow-container {

--- a/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
@@ -243,7 +243,32 @@
         }
       }
     }
+
+    @media (max-width: 991px) {
+      .review-activities-section {
+        display: none;
+      }
+      .import-or-create-classroom-buttons {
+        display: none !important;
+      }
+      .assignment-section-number {
+        display: none !important;
+      }
+      .classroom {
+        flex-direction: column;
+        align-items: flex-start !important;
+        justify-content: flex-start;
+        .checkbox-and-name-container {
+          width: 100%;
+          align-items: flex-start !important;
+        }
+        .dropdown-container {
+          margin-left: 32px;
+        }
+      }
+    }
   }
+
   .select-students-header {
     display: flex;
     justify-content: space-between;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/review_activities.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/review_activities.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ReviewActivities component should render 1`] = `
 <div
-  className="assignment-section"
+  className="assignment-section review-activities-section"
 >
   <div
     className="assignment-section-header"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/review_activities.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/review_activities.jsx
@@ -119,7 +119,7 @@ export default class ReviewActivities extends React.Component {
 
   render() {
     return (
-      <div className="assignment-section">
+      <div className="assignment-section review-activities-section">
         <div className="assignment-section-header">
           <span className="assignment-section-number">2</span>
           <span className="assignment-section-name">Review activities and pick due dates</span>


### PR DESCRIPTION
## WHAT
Fix mobile view for Review Activities and Assign stage of assignment flow.

## WHY
This page was really janky (as you can see in the Notion doc). @happythenewsad brought this card to my attention - I had thought it was previously set up to be responsive for mobile but I can't find any actual trace of that in the Zeplins or in the code, so I may have been wrong. In any case, it seemed like something that warranted immediate attention.

## HOW
Mostly just setting elements to `display: none` on mobile as a quick fix - nothing mission-critical.

### Screenshots
<img width="372" alt="Screen Shot 2022-05-16 at 1 42 30 PM" src="https://user-images.githubusercontent.com/18669014/168654512-02b6526d-cbc8-4292-8a96-61b599ab5f36.png">
<img width="198" alt="Screen Shot 2022-05-16 at 1 37 22 PM" src="https://user-images.githubusercontent.com/18669014/168654513-0a527549-2b71-4bb9-9ce1-a9b3819590ab.png">

### Notion Card Links
https://www.notion.so/quill/Unable-to-assign-activities-on-mobile-browser-10a00923e65f4c41b48a25fcde4f53d3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A