### PR TITLE
UI fix/ scroll to clicked activity pack on back navigation

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
@@ -12,6 +12,7 @@ export const ACTIVITY_IDS_ARRAY = 'activityIdsArray'
 export const CLASSROOMS = 'classrooms'
 export const UNIT_ID = 'unitId'
 export const ASSIGNED_CLASSROOMS = 'assignedClassrooms'
+export const CLICKED_ACTIVITY_PACK_ID = 'clickedActivityPackId'
 
 export const STARTER_DIAGNOSTIC_UNIT_TEMPLATE_ID = 99
 export const STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID = 217

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import AssignmentCard from './assignment_card'
 
 import { requestPost, } from '../../../../../modules/request'
+import { CLICKED_ACTIVITY_PACK_ID } from '../assignmentFlowConstants'
 
 const diagnosticWaveSrc = `${process.env.CDN_URL}/images/illustrations/diagnostic-wave.svg`
 const activityLibrarySrc = `${process.env.CDN_URL}/images/icons/icons-activity-library.svg`
@@ -66,7 +67,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
 
   React.useState(() => {
     // remove any previously stored activityPackId used for back navigation element focus in the event that user assigned pack or navigated back to dashboard before assigning
-    window.sessionStorage.removeItem('clickedActivityPackId');
+    window.sessionStorage.removeItem(CLICKED_ACTIVITY_PACK_ID);
   }, []);
 
   function closeDiagnosticBanner() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
@@ -64,6 +64,11 @@ const minis = (diagnosticBannerShowing) => [
 const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }) => {
   const [diagnosticBannerShowing, setDiagnosticBannerShowing] = React.useState(showDiagnosticBanner)
 
+  React.useState(() => {
+    // remove any previously stored activityPackId used for back navigation element focus in the event that user assigned pack or navigated back to dashboard before assigning
+    window.sessionStorage.setItem('clickedActivityPackId', null);
+  }, []);
+
   function closeDiagnosticBanner() {
     setDiagnosticBannerShowing(false)
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
@@ -66,7 +66,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
 
   React.useState(() => {
     // remove any previously stored activityPackId used for back navigation element focus in the event that user assigned pack or navigated back to dashboard before assigning
-    window.sessionStorage.setItem('clickedActivityPackId', null);
+    window.sessionStorage.removeItem('clickedActivityPackId');
   }, []);
 
   function closeDiagnosticBanner() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
-
+import { Link} from 'react-router-dom'
 import UnitTemplateFirstRow from './unit_template_first_row'
 import UnitTemplateSecondRow from './unit_template_second_row'
 
@@ -11,6 +10,26 @@ export default class UnitTemplateMini extends React.Component {
     super(props)
 
     this.modules = { string: new String() }
+    this.miniRef = React.createRef()
+  }
+
+  componentDidMount() {
+    const clickedActivityPackId = window.sessionStorage.getItem('clickedActivityPack');
+    const miniRefId = this.miniRef.current ? this.miniRef.current.id : null;
+    const isClickedMini = clickedActivityPackId && miniRefId && clickedActivityPackId === miniRefId;
+
+    if(isClickedMini) {
+      const element = document.getElementById(clickedActivityPackId)
+      if (!element) { return }
+      const yOffset = -80;
+      const y = element.getBoundingClientRect().top + window.pageYOffset + yOffset;
+      element.focus()
+      window.scrollTo({top: y});
+    }
+  }
+
+  componentWillUnmount() {
+    window.sessionStorage.setItem('clickedActivityPack', null);
   }
 
   isSignedIn() {
@@ -47,7 +66,8 @@ export default class UnitTemplateMini extends React.Component {
 
   miniSpecificComponents() {
     const { data, } = this.props
-    if (data.id == 'createYourOwn') {
+    const { id } = data;
+    if (id === 'createYourOwn') {
       return (
         <a href={this.getLink()}>
           <div className='text-center create-your-own'>
@@ -62,7 +82,7 @@ export default class UnitTemplateMini extends React.Component {
     }
     // else it is a normal mini
     else {
-      const innerContent = (<div>
+      const innerContent = (<div id={id} ref={this.miniRef}>
         <UnitTemplateFirstRow
           data={data}
           modules={{string: this.modules.string}}
@@ -70,7 +90,7 @@ export default class UnitTemplateMini extends React.Component {
         <UnitTemplateSecondRow data={data} modules={{string: this.modules.string}} />
       </div>)
 
-      return this.renderMini(innerContent)
+      return this.renderMini(innerContent, id)
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Link} from 'react-router-dom'
+import { Link } from 'react-router-dom'
+
 import UnitTemplateFirstRow from './unit_template_first_row'
 import UnitTemplateSecondRow from './unit_template_second_row'
 
@@ -26,10 +27,6 @@ export default class UnitTemplateMini extends React.Component {
       element.focus()
       window.scrollTo({top: y});
     }
-  }
-
-  componentWillUnmount() {
-    window.sessionStorage.setItem('clickedActivityPackId', null);
   }
 
   isSignedIn() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
@@ -5,6 +5,7 @@ import UnitTemplateFirstRow from './unit_template_first_row'
 import UnitTemplateSecondRow from './unit_template_second_row'
 
 import String from '../../modules/string.jsx'
+import { CLICKED_ACTIVITY_PACK_ID } from '../assignmentFlowConstants'
 
 export default class UnitTemplateMini extends React.Component {
   constructor(props) {
@@ -15,7 +16,7 @@ export default class UnitTemplateMini extends React.Component {
   }
 
   componentDidMount() {
-    const clickedActivityPackId = window.sessionStorage.getItem('clickedActivityPackId');
+    const clickedActivityPackId = window.sessionStorage.getItem(CLICKED_ACTIVITY_PACK_ID);
     const miniRefId = this.miniRef.current ? this.miniRef.current.id : null;
     const isClickedMini = clickedActivityPackId && miniRefId && clickedActivityPackId === miniRefId;
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_mini.jsx
@@ -14,7 +14,7 @@ export default class UnitTemplateMini extends React.Component {
   }
 
   componentDidMount() {
-    const clickedActivityPackId = window.sessionStorage.getItem('clickedActivityPack');
+    const clickedActivityPackId = window.sessionStorage.getItem('clickedActivityPackId');
     const miniRefId = this.miniRef.current ? this.miniRef.current.id : null;
     const isClickedMini = clickedActivityPackId && miniRefId && clickedActivityPackId === miniRefId;
 
@@ -29,7 +29,7 @@ export default class UnitTemplateMini extends React.Component {
   }
 
   componentWillUnmount() {
-    window.sessionStorage.setItem('clickedActivityPack', null);
+    window.sessionStorage.setItem('clickedActivityPackId', null);
   }
 
   isSignedIn() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/__tests__/unit_template_profile.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/__tests__/unit_template_profile.test.jsx
@@ -7,6 +7,7 @@ import { UnitTemplateProfile } from '../unit_template_profile.tsx'
 import LoadingIndicator from '../../../../shared/loading_indicator'
 import UnitTemplateProfileDescription from '../unit_template_profile_description'
 import UnitTemplateProfileShareButtons from '../unit_template_profile_share_buttons';
+import { CLICKED_ACTIVITY_PACK_ID } from '../../../assignmentFlowConstants';
 
 const props = {
   history: {
@@ -98,7 +99,7 @@ describe('UnitTemplateProfile component', () => {
     })
     it('should set localStorage item clickedActivityPackId to activityPackId', () => {
       const setItem = jest.spyOn(global.sessionStorage, 'setItem')
-      expect(setItem).toHaveBeenCalledWith('clickedActivityPackId', '34')
+      expect(setItem).toHaveBeenCalledWith(CLICKED_ACTIVITY_PACK_ID, '34')
     })
   })
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/__tests__/unit_template_profile.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/__tests__/unit_template_profile.test.jsx
@@ -96,6 +96,9 @@ describe('UnitTemplateProfile component', () => {
     it('should set state.data to be response.data', () => {
       expect(wrapper.state('data')).toEqual(response.data)
     })
-
+    it('should set localStorage item clickedActivityPackId to activityPackId', () => {
+      const setItem = jest.spyOn(global.sessionStorage, 'setItem')
+      expect(setItem).toHaveBeenCalledWith('clickedActivityPackId', '34')
+    })
   })
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -40,9 +40,7 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     const { match } = this.props;
     const { activityPackId } = match.params;
     this.getProfileInfo(activityPackId);
-    if(!window.sessionStorage.getItem('clickedActivityPackId')) {
-      window.sessionStorage.setItem('clickedActivityPackId', activityPackId);
-    }
+    window.sessionStorage.setItem('clickedActivityPackId', activityPackId);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: RouteComponentProps) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -16,7 +16,8 @@ import {
   ACTIVITY_IDS_ARRAY,
   UNIT_TEMPLATE_ID,
   UNIT_NAME,
-  COLLEGE_BOARD_SLUG
+  COLLEGE_BOARD_SLUG,
+  CLICKED_ACTIVITY_PACK_ID
 } from '../../assignmentFlowConstants'
 import parsedQueryParams from '../../parsedQueryParams'
 import { requestGet } from '../../../../../../modules/request/index.js';
@@ -40,7 +41,7 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     const { match } = this.props;
     const { activityPackId } = match.params;
     this.getProfileInfo(activityPackId);
-    window.sessionStorage.setItem('clickedActivityPackId', activityPackId);
+    window.sessionStorage.setItem(CLICKED_ACTIVITY_PACK_ID, activityPackId);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: RouteComponentProps) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -40,6 +40,7 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     const { match } = this.props;
     const { activityPackId } = match.params;
     this.getProfileInfo(activityPackId);
+    window.sessionStorage.setItem('clickedActivityPack', activityPackId);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: RouteComponentProps) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -40,7 +40,9 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     const { match } = this.props;
     const { activityPackId } = match.params;
     this.getProfileInfo(activityPackId);
-    window.sessionStorage.setItem('clickedActivityPack', activityPackId);
+    if(!window.sessionStorage.getItem('clickedActivityPackId')) {
+      window.sessionStorage.setItem('clickedActivityPackId', activityPackId);
+    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: RouteComponentProps) {


### PR DESCRIPTION
## WHAT
scroll to a selected activity pack when a user navigates back to the activity pack index page

## WHY
we want the user to be taken back to the same place that they were on the page when navigating back from viewing an activity pack

## HOW
store the `activityPackId` in `sessionStorage`, add a ref and id to each of the activity pack elements and then check the stored `activityPackId` against the element `id`-- if there's a match, scroll to the activity pack on load

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Design-Edit-Going-Back-on-Activity-Packs-Page-Returns-to-Previous-Scroll-Height-df4842c0a88644c480da5090e26b6116

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
