### PR TITLE
Add Demo Account option to Welcome Modal for 30% of new teachers

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1,4 +1,3 @@
-.clever-classroom-modal,
 .google-classroom-modal {
   text-align: center;
 
@@ -172,7 +171,7 @@
   font-size: 16px;
   text-align: center;
   color: #333;
-  button:not(.q-button):not(.interactive-wrapper) {
+  button:not(.q-button) {
     display: block;
     margin: auto;
     border-radius: 3px;
@@ -185,7 +184,7 @@
     &.enter-credit-card {
       margin-top: 40%;
     }
-    &.existing-card {
+    &.extant-card {
       box-shadow: 0 1px 2px 0 #e9e9e9;
       border: solid 1px #e9e9e9;
       color: #027360;
@@ -223,10 +222,12 @@
 }
 
 .school-premium-modal {
-  .close-modal-button {
-    position: absolute;
-    right: 0px;
-    top: 0px;
+  .modal-content {
+    .modal-button-close {
+      height: 15px;
+      width: 15px;
+      margin-right: 15px;
+    }
   }
 }
 
@@ -484,22 +485,17 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
-.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal,
-.link-clever-account-modal,
-.link-google-account-modal,
-.share-activity-pack-modal,
+.google-classroom-email-modal,
 .leave-class-modal,
-.clever-classrooms-empty-modal,
 .google-classrooms-empty-modal,
-.reauthorize-clever-modal,
 .welcome-modal {
-  width: 560px;
+  width: 680px;
   overflow: visible;
   top: 50%;
   transform: translate(-50%, -50%);
   position: fixed !important;
-  text-align: left;
+  text-align: center;
   p {
     line-height: 1.57;
     color: #646464;
@@ -515,135 +511,47 @@
       }
     }
   }
-}
-
-.share-activity-pack-modal {
-  bottom: 0;
-  margin-bottom: 0;
-  height: min-content;
-  width: 560px;
-  .title-row {
-    display: flex;
-    justify-content: space-between;
-    .close-button {
-      display: flex;
+  .welcome-modal-image-box {
+    background-color: #eef8f7;
+    height: 302px;
+    width: 600px;
+    display: inline-block;
+    padding-top: 24px;
+    border-radius: 6px;
+  }
+  .welcome-modal-card {
+    width: 300px;
+    text-align: center;
+    border: 1px solid lightgray;
+    border-radius: 5px;
+    padding: 20px;
+    margin: 20px;
+    button {
+      display: inline-block;
+    }
+  }
+  .welcome-modal-demo {
+    float: left;
+  }
+  .welcome-modal-go {
+    float: right;
+  }
+  .welcome-modal-buttons {
+    width: 300px;
+    display: inline-block;
+    button {
+      display: inline-block;
+    }
+    .welcome-modal-demo {
+      color: black;
       background-color: white;
-      padding: 0;
-      align-self: flex-start;
+      border: 1px solid #bdbdbd;
     }
-  }
-  .disclaimer-text {
-    margin-top: 24px;
-  }
-  .activity-pack-data-container {
-    .link-label {
-      margin: 0px 0px 4px 0px;
-      font-size: 12px;
-      font-weight: 600;
-    }
-    .activity-pack-link {
-      font-size: 16px;
-      color: #000000;
-      word-break: break-word;
-    }
-    &.hide-modal-element {
-      visibility: hidden;
-    }
-  }
-  .class-and-activity-data-container {
-    .first-step-container, .second-step-container {
-      display: flex;
-      .left-container {
-        margin-right: 16px;
-        min-height: 32px;
-        .step-number-circle {
-          width: 32px;
-          height: 32px;
-          text-align: center;
-          border: 1px solid #9e9e9e;
-          border-radius: 20px;
-          font-size: 16px;
-          p {
-            font-size: 16px;
-            margin: 1.5px 0px 0px 0px;
-          }
-        }
-      }
-      .right-container {
-        .header {
-          margin-bottom: 4px;
-          font-size: 16px;
-          font-weight: 600;
-          line-height: 1.38;
-          color: #262626;
-        }
-        .secondary-text {
-          margin: 0px 0px 16px 0px;
-          font-size: 14px;
-          line-height: 1.43;
-        }
-      }
-    }
-    .second-step-container {
-      margin-top: 32px;
-    }
-  }
-  .form-buttons {
-    .quill-button {
-      .button-text-container {
-        display: flex;
-        align-items: flex-start;
-        .button-text {
-          margin: 0px 0px 0px 8px;
-          color: #000000;
-        }
-      }
-    }
-    &.hide-modal-element {
-      visibility: hidden;
+    .welcome-modal-skip {
+      float: right;
     }
   }
 }
-
-.override-warning-modal,
-.skip-recommendations-warning-modal {
-  overflow: visible;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  position: fixed !important;
-  text-align: left;
-  width: 560px;
-  padding: 32px;
-  border-radius: 6px;
-  background-color: #fff;
-  min-height: min-content;
-  .title {
-    font-size: 24px;
-    font-weight: bold;
-    line-height: 1.33;
-    color: #000;
-  }
-  .modal-body {
-    padding: 0px;
-    margin-top: 24px;
-    margin-bottom: 48px;
-    p {
-      line-height: 1.57;
-      color: #646464;
-      .quill-tooltip-trigger span:first-of-type {
-        border-bottom: 1px dotted #646464;
-      }
-    }
-  }
-  .buttons {
-    display: flex;
-    justify-content: flex-end;
-    .quill-button {
-      margin-left: 16px;
-    }
-  }
-}
-
 
 .rename-class-modal, .rename-activity-pack-modal {
   min-height: 273px;
@@ -683,15 +591,16 @@
 }
 
 .welcome-modal {
-  max-width: 760px;
+  max-width: 648px;
   width: 100%;
-  height: 440px;
-  padding: 72px 0 72px 32px;
+  height: 543px;
+  padding: 72px 0 72px 0px;
   display: flex;
   align-items: center;
   .modal-body {
     padding: 0px;
     margin-bottom: 0px;
+    width: 100%;
   }
   h1 {
     font-size: 30px;
@@ -699,15 +608,23 @@
     line-height: 1.27;
     color: #000000;
   }
+  h4 {
+    font-weight: bold;
+    margin: 10px;
+  }
   .welcome-modal-text {
-    margin-top: 16px;
-    margin-bottom: 40px;
-    p {
-      color: #5c5c5c;
+    width: 300px;
+    display: inline-block;
+    margin-top: 48px;
+    .welcome-modal-header {
+      font-weight: 600;
+      margin: 5px;
     }
   }
   img {
-    margin-left: 24px;
+    height: 215px;
+    width: 325px;
+    margin-top: 24px;
   }
   button {
     width: min-content !important;
@@ -768,8 +685,6 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
-.reauthorize-clever-modal,
-.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal {
   .input-container {
     margin-bottom: 32px;
@@ -803,11 +718,8 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
-.reauthorize-clever-modal,
-.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal,
-.link-clever-account-modal,
-.link-google-account-modal {
+.google-classroom-email-modal {
   .checkboxes {
     margin-bottom: 48px;
   }
@@ -824,14 +736,6 @@
   }
 }
 
-.reauthorize-clever-modal {
-  height: 256px;
-  .title {
-    margin-bottom: 24px;
-  }
-}
-
-.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal {
   height: 306px;
   .title {
@@ -839,15 +743,13 @@
   }
 }
 
-.link-clever-account-modal,
-.link-google-account-modal {
+.google-classroom-email-modal {
   height: 328px;
   .title {
     margin-bottom: 24px;
   }
 }
 
-.clever-classrooms-empty-modal,
 .google-classrooms-empty-modal {
   height: 449px;
   text-align: center;
@@ -884,7 +786,6 @@
 
 }
 
-.import-clever-classrooms-modal-header,
 .import-google-classrooms-modal-header,
 .bulk-archive-classes-modal-header,
 .invite-coteachers-modal-header {
@@ -896,7 +797,6 @@
   }
 }
 
-.import-clever-classrooms-modal-footer,
 .import-google-classrooms-modal-footer,
 .bulk-archive-classes-modal-footer,
 .invite-coteachers-modal-footer {
@@ -916,15 +816,11 @@
   }
 }
 
-.import-clever-classrooms-modal,
-.import-google-classrooms-modal,
-.bulk-archive-classes-modal {
+.import-google-classrooms-modal, .bulk-archive-classes-modal {
   width: 950px;
   position: fixed !important;
   overflow: hidden;
-  .import-clever-classrooms-modal-footer,
-  .import-google-classrooms-modal-footer,
-  .bulk-archive-classes-modal-footer {
+  .import-google-classrooms-modal-footer, .bulk-archive-classes-modal-footer {
     justify-content: space-between;
     .buttons {
       display: flex;

--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1,3 +1,4 @@
+.clever-classroom-modal,
 .google-classroom-modal {
   text-align: center;
 
@@ -171,7 +172,7 @@
   font-size: 16px;
   text-align: center;
   color: #333;
-  button:not(.q-button) {
+  button:not(.q-button):not(.interactive-wrapper) {
     display: block;
     margin: auto;
     border-radius: 3px;
@@ -184,7 +185,7 @@
     &.enter-credit-card {
       margin-top: 40%;
     }
-    &.extant-card {
+    &.existing-card {
       box-shadow: 0 1px 2px 0 #e9e9e9;
       border: solid 1px #e9e9e9;
       color: #027360;
@@ -222,12 +223,10 @@
 }
 
 .school-premium-modal {
-  .modal-content {
-    .modal-button-close {
-      height: 15px;
-      width: 15px;
-      margin-right: 15px;
-    }
+  .close-modal-button {
+    position: absolute;
+    right: 0px;
+    top: 0px;
   }
 }
 
@@ -485,17 +484,193 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
+.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal,
-.google-classroom-email-modal,
+.link-clever-account-modal,
+.link-google-account-modal,
+.share-activity-pack-modal,
 .leave-class-modal,
+.clever-classrooms-empty-modal,
 .google-classrooms-empty-modal,
-.welcome-modal {
-  width: 680px;
+.reauthorize-clever-modal,
+
+.share-activity-pack-modal {
+  bottom: 0;
+  margin-bottom: 0;
+  height: min-content;
+  width: 560px;
+  .title-row {
+    display: flex;
+    justify-content: space-between;
+    .close-button {
+      display: flex;
+      background-color: white;
+      padding: 0;
+      align-self: flex-start;
+    }
+  }
+  .disclaimer-text {
+    margin-top: 24px;
+  }
+  .activity-pack-data-container {
+    .link-label {
+      margin: 0px 0px 4px 0px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .activity-pack-link {
+      font-size: 16px;
+      color: #000000;
+      word-break: break-word;
+    }
+    &.hide-modal-element {
+      visibility: hidden;
+    }
+  }
+  .class-and-activity-data-container {
+    .first-step-container, .second-step-container {
+      display: flex;
+      .left-container {
+        margin-right: 16px;
+        min-height: 32px;
+        .step-number-circle {
+          width: 32px;
+          height: 32px;
+          text-align: center;
+          border: 1px solid #9e9e9e;
+          border-radius: 20px;
+          font-size: 16px;
+          p {
+            font-size: 16px;
+            margin: 1.5px 0px 0px 0px;
+          }
+        }
+      }
+      .right-container {
+        .header {
+          margin-bottom: 4px;
+          font-size: 16px;
+          font-weight: 600;
+          line-height: 1.38;
+          color: #262626;
+        }
+        .secondary-text {
+          margin: 0px 0px 16px 0px;
+          font-size: 14px;
+          line-height: 1.43;
+        }
+      }
+    }
+    .second-step-container {
+      margin-top: 32px;
+    }
+  }
+  .form-buttons {
+    .quill-button {
+      .button-text-container {
+        display: flex;
+        align-items: flex-start;
+        .button-text {
+          margin: 0px 0px 0px 8px;
+          color: #000000;
+        }
+      }
+    }
+    &.hide-modal-element {
+      visibility: hidden;
+    }
+  }
+}
+
+.override-warning-modal,
+.skip-recommendations-warning-modal {
   overflow: visible;
   top: 50%;
   transform: translate(-50%, -50%);
   position: fixed !important;
-  text-align: center;
+  text-align: left;
+  width: 560px;
+  padding: 32px;
+  border-radius: 6px;
+  background-color: #fff;
+  min-height: min-content;
+  .title {
+    font-size: 24px;
+    font-weight: bold;
+    line-height: 1.33;
+    color: #000;
+  }
+  .modal-body {
+    padding: 0px;
+    margin-top: 24px;
+    margin-bottom: 48px;
+    p {
+      line-height: 1.57;
+      color: #646464;
+      .quill-tooltip-trigger span:first-of-type {
+        border-bottom: 1px dotted #646464;
+      }
+    }
+  }
+  .buttons {
+    display: flex;
+    justify-content: flex-end;
+    .quill-button {
+      margin-left: 16px;
+    }
+  }
+}
+
+
+.rename-class-modal, .rename-activity-pack-modal {
+  min-height: 273px;
+  height: min-content;
+  .title {
+    margin-bottom: 24px;
+  }
+  .input-container {
+    margin-bottom: 48px;
+    &.error.unacknowledged {
+      margin-bottom: 33px;
+    }
+  }
+}
+
+.change-grade-modal {
+  height: 327px;
+  p {
+    margin-top: 24px;
+  }
+  .input-container {
+    margin-bottom: 48px;
+  }
+}
+
+.archive-class-modal {
+  height: 316px;
+}
+
+.archive-activity-pack-modal {
+  min-height: 274px;
+  height: min-content;
+}
+
+.unarchive-class-modal, .leave-class-modal {
+  height: 250px;
+}
+
+.welcome-modal-without-demo {
+  max-width: 760px;
+  width: 100%;
+  height: 440px;
+  padding: 72px 0 72px 32px;
+  display: flex;
+  align-items: center;
+  overflow: visible;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  position: fixed !important;
+  text-align: left;
   p {
     line-height: 1.57;
     color: #646464;
@@ -510,6 +685,92 @@
         margin-top: 5px;
       }
     }
+  }
+  .modal-body {
+    padding: 0px;
+    margin-bottom: 0px;
+  }
+  h1 {
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 1.27;
+    color: #000000;
+  }
+  .welcome-modal-text {
+    margin-top: 16px;
+    margin-bottom: 40px;
+    p {
+      color: #5c5c5c;
+    }
+  }
+  img {
+    margin-left: 24px;
+  }
+  button {
+    width: min-content !important;
+  }
+  @media (max-width: 780px) {
+    width: calc(100vw - 20px);
+  }
+  @media (max-width: 600px) {
+    min-width: 300px;
+    width: 70%;
+    padding: 32px 16px;
+    height: min-content;
+    img {
+      display: none;
+    }
+  }
+}
+
+.welcome-modal-with-demo {
+  width: 680px;
+  overflow: visible;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  position: fixed !important;
+  text-align: center;
+  max-width: 648px;
+  width: 100%;
+  height: 573px;
+  padding: 5px 0 20px 0px;
+  align-items: center;
+  .modal-body {
+    padding: 0px;
+    margin-bottom: 0px;
+    width: 100%;
+  }
+  h1 {
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 1.27;
+    color: #000000;
+  }
+  h4 {
+    font-weight: bold;
+    margin: 10px;
+  }
+  .welcome-modal-text {
+    width: 300px;
+    display: inline-block;
+    margin-top: 48px;
+    margin-bottom: 36px;
+    .welcome-modal-header {
+      font-weight: 600;
+      margin: 5px;
+    }
+  }
+  img {
+    height: 215px;
+    width: 325px;
+    margin-top: 24px;
+  }
+  button {
+    width: min-content !important;
+  }
+  p {
+    line-height: 1.57;
+    color: #646464;
   }
   .welcome-modal-image-box {
     background-color: #eef8f7;
@@ -551,83 +812,25 @@
       float: right;
     }
   }
-}
-
-.rename-class-modal, .rename-activity-pack-modal {
-  min-height: 273px;
-  height: min-content;
-  .title {
-    margin-bottom: 24px;
-  }
-  .input-container {
-    margin-bottom: 48px;
-    &.error.unacknowledged {
-      margin-bottom: 33px;
-    }
-  }
-}
-
-.change-grade-modal {
-  height: 327px;
-  p {
-    margin-top: 24px;
-  }
-  .input-container {
-    margin-bottom: 48px;
-  }
-}
-
-.archive-class-modal {
-  height: 316px;
-}
-
-.archive-activity-pack-modal {
-  min-height: 274px;
-  height: min-content;
-}
-
-.unarchive-class-modal, .leave-class-modal {
-  height: 250px;
-}
-
-.welcome-modal {
-  max-width: 648px;
-  width: 100%;
-  height: 543px;
-  padding: 72px 0 72px 0px;
-  display: flex;
-  align-items: center;
-  .modal-body {
-    padding: 0px;
-    margin-bottom: 0px;
-    width: 100%;
-  }
-  h1 {
-    font-size: 30px;
-    font-weight: bold;
-    line-height: 1.27;
-    color: #000000;
-  }
-  h4 {
-    font-weight: bold;
-    margin: 10px;
-  }
-  .welcome-modal-text {
-    width: 300px;
+  .modal-head {
     display: inline-block;
-    margin-top: 48px;
-    .welcome-modal-header {
-      font-weight: 600;
-      margin: 5px;
+    width: 648px;
+  }
+  .close-welcome-modal {
+    margin: 0 auto;
+    height: 40px;
+    float: right;
+    width: 40px;
+    overflow: hidden;
+    background-color: white;
+    img {
+      height: 40px;
+      width: 40px;
+      margin: 0 auto;
     }
   }
-  img {
-    height: 215px;
-    width: 325px;
-    margin-top: 24px;
-  }
-  button {
-    width: min-content !important;
+  .close-welcome-modal:hover {
+    cursor: pointer;
   }
   @media (max-width: 780px) {
     width: calc(100vw - 20px);
@@ -639,6 +842,11 @@
     height: min-content;
     img {
       display: none;
+    }
+    .welcome-modal-image-box {
+      width: auto;
+      height: auto;
+      background-color: white;
     }
   }
 }
@@ -685,6 +893,8 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
+.reauthorize-clever-modal,
+.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal {
   .input-container {
     margin-bottom: 32px;
@@ -718,8 +928,11 @@
 .remove-students-modal,
 .remove-coteacher-modal,
 .transfer-ownership-modal,
+.reauthorize-clever-modal,
+.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal,
-.google-classroom-email-modal {
+.link-clever-account-modal,
+.link-google-account-modal {
   .checkboxes {
     margin-bottom: 48px;
   }
@@ -736,6 +949,14 @@
   }
 }
 
+.reauthorize-clever-modal {
+  height: 256px;
+  .title {
+    margin-bottom: 24px;
+  }
+}
+
+.import-clever-classroom-students-modal,
 .import-google-classroom-students-modal {
   height: 306px;
   .title {
@@ -743,13 +964,15 @@
   }
 }
 
-.google-classroom-email-modal {
+.link-clever-account-modal,
+.link-google-account-modal {
   height: 328px;
   .title {
     margin-bottom: 24px;
   }
 }
 
+.clever-classrooms-empty-modal,
 .google-classrooms-empty-modal {
   height: 449px;
   text-align: center;
@@ -786,6 +1009,7 @@
 
 }
 
+.import-clever-classrooms-modal-header,
 .import-google-classrooms-modal-header,
 .bulk-archive-classes-modal-header,
 .invite-coteachers-modal-header {
@@ -797,6 +1021,7 @@
   }
 }
 
+.import-clever-classrooms-modal-footer,
 .import-google-classrooms-modal-footer,
 .bulk-archive-classes-modal-footer,
 .invite-coteachers-modal-footer {
@@ -816,11 +1041,15 @@
   }
 }
 
-.import-google-classrooms-modal, .bulk-archive-classes-modal {
+.import-clever-classrooms-modal,
+.import-google-classrooms-modal,
+.bulk-archive-classes-modal {
   width: 950px;
   position: fixed !important;
   overflow: hidden;
-  .import-google-classrooms-modal-footer, .bulk-archive-classes-modal-footer {
+  .import-clever-classrooms-modal-footer,
+  .import-google-classrooms-modal-footer,
+  .bulk-archive-classes-modal-footer {
     justify-content: space-between;
     .buttons {
       display: flex;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/welcome_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/welcome_modal.test.jsx.snap
@@ -13,33 +13,6 @@ exports[`WelcomeModal component should render WelcomeModal 1`] = `
     recycle={false}
     width={600}
   />
-  <div
-    className="welcome-modal quill-modal"
-  >
-    <div
-      className="modal-body"
-    >
-      <h1>
-        Welcome to Quill!
-      </h1>
-      <div
-        className="welcome-modal-text"
-      >
-        <p>
-          Our mission as a non-profit is to help students become strong writers, so all our content is completely free to use with an unlimited number of students.
-        </p>
-      </div>
-      <button
-        className="quill-button contained primary medium"
-        type="button"
-      >
-        Let's go!
-      </button>
-    </div>
-    <img
-      alt="Teacher at projector in classroom"
-      src="undefined/images/pages/dashboard/illustrations-classroom-activities.svg"
-    />
-  </div>
+  <WelcomeModalWithoutDemo />
 </div>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
@@ -1,12 +1,59 @@
 import * as React from 'react'
 import Confetti from 'react-confetti'
 
+import { handleHasAppSetting } from "../../../Shared/utils/appSettingAPIs";
+
 const classroomActivitiesSrc = `${process.env.CDN_URL}/images/pages/dashboard/illustrations-classroom-activities-2.svg`
 
 const exploreDemoLink = `${process.env.DEFAULT_URL}/teachers/view_demo`
 
+const WelcomeModalWithoutDemo = ({close}) => (
+  <div className="welcome-modal-without-demo quill-modal">
+    <div className="modal-body">
+      <h1>Welcome to Quill!</h1>
+      <div className="welcome-modal-text">
+        <p>Our mission as a non-profit is to help students become strong writers, so all our content is completely free to use with an unlimited number of students.</p>
+      </div>
+      <button className="quill-button contained primary medium" onClick={close} type="button">Let&apos;s go!</button>
+    </div>
+    <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
+  </div>
+)
+
+const WelcomeModalWithDemo = ({close}) => (
+  <div className="welcome-modal-with-demo quill-modal">
+    <div className="modal-head">
+      <button className="close-welcome-modal" onClick={close} type="button"><img alt="Close the modal" src={`${process.env.CDN_URL}/images/shared/close_x.svg`} /></button>
+    </div>
+
+    <div className="modal-body">
+
+      <div className="welcome-modal-image-box">
+        <h1>Welcome to Quill!</h1>
+        <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
+      </div>
+      <div>
+        <div className="welcome-modal-text">
+          <p className="welcome-modal-header">Want to see Quill&apos;s full potential?</p>
+          <p>Play around with a demo account to see sample student data and reports.</p>
+        </div>
+        <br />
+        <div className="welcome-modal-buttons">
+          <a className="quill-button contained secondary medium outlined welcome-modal-demo" href={exploreDemoLink}>Explore demo</a>
+          <button className="quill-button contained primary medium welcome-modal-skip" onClick={close} type="button">Maybe later, skip</button>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
 const WelcomeModal = ({ close, size }) => {
   const { width, height } = size;
+  const [errors, setErrors] = React.useState<string[]>([])
+  const [hasAppSetting, setHasAppSetting] = React.useState<boolean>(false);
+  React.useEffect(() => {
+    handleHasAppSetting({appSettingSetter: setHasAppSetting, errorSetter: setErrors, key: 'demo-welcome-modal', })
+  }, []);
 
   return (
     <div className="modal-container welcome-modal-container">
@@ -17,25 +64,7 @@ const WelcomeModal = ({ close, size }) => {
         recycle={false}
         width={width}
       />
-      <div className="welcome-modal quill-modal">
-        <div className="modal-body">
-          <div className="welcome-modal-image-box">
-            <h1>Welcome to Quill!</h1>
-            <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
-          </div>
-          <div>
-            <div className="welcome-modal-text">
-              <p className="welcome-modal-header">Want to see Quill&apos;s full potential?</p>
-              <p>Play around with a demo account to see sample student data and reports.</p>
-            </div>
-            <br />
-            <div className="welcome-modal-buttons">
-              <a className="quill-button contained secondary medium outlined welcome-modal-demo" href={exploreDemoLink}>Explore demo</a>
-              <button className="quill-button contained primary medium welcome-modal-skip" onClick={close} type="button">Maybe later, skip</button>
-            </div>
-          </div>
-        </div>
-      </div>
+      {hasAppSetting ? <WelcomeModalWithDemo close={close} /> : <WelcomeModalWithoutDemo close={close} />}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
@@ -14,7 +14,7 @@ const WelcomeModalWithoutDemo = ({close}) => (
       <div className="welcome-modal-text">
         <p>Our mission as a non-profit is to help students become strong writers, so all our content is completely free to use with an unlimited number of students.</p>
       </div>
-      <button className="quill-button contained primary medium" onClick={close} type="button">Let&apos;s go!</button>
+      <button className="quill-button contained focus-on-light primary medium" onClick={close} type="button">Let&apos;s go!</button>
     </div>
     <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
   </div>
@@ -39,8 +39,8 @@ const WelcomeModalWithDemo = ({close}) => (
         </div>
         <br />
         <div className="welcome-modal-buttons">
-          <a className="quill-button contained secondary medium outlined welcome-modal-demo" href={exploreDemoLink}>Explore demo</a>
-          <button className="quill-button contained primary medium welcome-modal-skip" onClick={close} type="button">Maybe later, skip</button>
+          <a className="quill-button contained focus-on-light secondary medium outlined welcome-modal-demo" href={exploreDemoLink}>Explore demo</a>
+          <button className="quill-button contained focus-on-light primary medium welcome-modal-skip" onClick={close} type="button">Maybe later, skip</button>
         </div>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/welcome_modal.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import Confetti from 'react-confetti'
 
-const classroomActivitiesSrc = `${process.env.CDN_URL}/images/pages/dashboard/illustrations-classroom-activities.svg`
+const classroomActivitiesSrc = `${process.env.CDN_URL}/images/pages/dashboard/illustrations-classroom-activities-2.svg`
+
+const exploreDemoLink = `${process.env.DEFAULT_URL}/teachers/view_demo`
 
 const WelcomeModal = ({ close, size }) => {
   const { width, height } = size;
@@ -17,13 +19,22 @@ const WelcomeModal = ({ close, size }) => {
       />
       <div className="welcome-modal quill-modal">
         <div className="modal-body">
-          <h1>Welcome to Quill!</h1>
-          <div className="welcome-modal-text">
-            <p>Our mission as a non-profit is to help students become strong writers, so all our content is completely free to use with an unlimited number of students.</p>
+          <div className="welcome-modal-image-box">
+            <h1>Welcome to Quill!</h1>
+            <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
           </div>
-          <button className="quill-button contained primary medium" onClick={close} type="button">Let&apos;s go!</button>
+          <div>
+            <div className="welcome-modal-text">
+              <p className="welcome-modal-header">Want to see Quill&apos;s full potential?</p>
+              <p>Play around with a demo account to see sample student data and reports.</p>
+            </div>
+            <br />
+            <div className="welcome-modal-buttons">
+              <a className="quill-button contained secondary medium outlined welcome-modal-demo" href={exploreDemoLink}>Explore demo</a>
+              <button className="quill-button contained primary medium welcome-modal-skip" onClick={close} type="button">Maybe later, skip</button>
+            </div>
+          </div>
         </div>
-        <img alt="Teacher at projector in classroom" src={classroomActivitiesSrc} />
       </div>
     </div>
   )


### PR DESCRIPTION
## WHAT
Add a new Welcome Modal that encourages new teachers to explore the demo account. I'll add an AppSetting that triggers this modal so that only 30% of teachers see it for now.

## WHY
To test the outcome of letting teachers explore the demo account when they first sign up.

## HOW
Add this welcome modal component and styling, and have it conditionally appear only when the AppSetting is applied.

### Screenshots
<img width="979" alt="Screen Shot 2022-05-17 at 2 15 19 PM" src="https://user-images.githubusercontent.com/57366100/168887044-dcb9ffe4-6cb6-4a1e-b013-03a27baa82c8.png">

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=d4b49293112b4b378666e1ed470c167f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
