### PR TITLE
Oapi client timeout

### DIFF
--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -30,13 +30,27 @@ module Evidence
       it 'should raise error on timeout' do
         stub_request(:post, mock_endpoint).to_timeout
 
-        expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError, "request took longer than 5 seconds")
+        expect { client.post }.to raise_error(
+          Evidence::Opinion::Client::APITimeoutError, "request took longer than #{Evidence::Opinion::Client::API_TIMEOUT} seconds"
+        )
+      end
+
+      it 'should process successfully on retry' do
+        mock_response = double
+        allow(mock_response).to receive(:success?).and_return true
+        allow(mock_response).to receive(:filter).and_return []
+        allow(client).to receive(:api_request).and_raise(Net::ReadTimeout)
+        allow(client).to receive(:api_request).and_return(mock_response)
+
+        expect { client.post }.to_not raise_error
       end
 
       it 'should raise error on Net::ReadTimeout timeout' do
         stub_request(:post, mock_endpoint).to_raise(Net::ReadTimeout)
 
-        expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError, "request took longer than 5 seconds")
+        expect { client.post }.to raise_error(
+          Evidence::Opinion::Client::APITimeoutError, "request took longer than #{Evidence::Opinion::Client::API_TIMEOUT} seconds"
+        )
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/opinion/client_spec.rb
@@ -27,31 +27,22 @@ module Evidence
         expect { client.post}.to raise_error(Evidence::Opinion::Client::APIError)
       end
 
-      it 'should raise error on timeout' do
-        stub_request(:post, mock_endpoint).to_timeout
-
-        expect { client.post }.to raise_error(
-          Evidence::Opinion::Client::APITimeoutError, "request took longer than #{Evidence::Opinion::Client::API_TIMEOUT} seconds"
-        )
+      it 'should raise error if the retry fails' do
+        allow(client).to receive(:api_request).and_raise(Net::ReadTimeout).twice
+        expect { client.post }.to raise_error(Evidence::Opinion::Client::APITimeoutError)
       end
 
       it 'should process successfully on retry' do
         mock_response = double
         allow(mock_response).to receive(:success?).and_return true
         allow(mock_response).to receive(:filter).and_return []
-        allow(client).to receive(:api_request).and_raise(Net::ReadTimeout)
-        allow(client).to receive(:api_request).and_return(mock_response)
+
+        allow(client).to receive(:api_request).and_raise(Net::ReadTimeout).once
+        allow(client).to receive(:api_request).and_return(mock_response).once
 
         expect { client.post }.to_not raise_error
       end
 
-      it 'should raise error on Net::ReadTimeout timeout' do
-        stub_request(:post, mock_endpoint).to_raise(Net::ReadTimeout)
-
-        expect { client.post }.to raise_error(
-          Evidence::Opinion::Client::APITimeoutError, "request took longer than #{Evidence::Opinion::Client::API_TIMEOUT} seconds"
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
1. Reduces client timeout to 1s
2. Adds a 1x retry to the opinion api client

## WHY
So users get a best-effort response, with minimal latency. 

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=ba0ab40255734234880c4628d91b271c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
