### PR TITLE
make tooltip component accessible

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/Header.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/Header.tsx
@@ -91,7 +91,6 @@ export class Header extends React.Component<any, any> {
                 <img alt="Quill.org logo" className="hide-on-mobile" src={logoSrc} />
               </a>
               <Tooltip
-                isTabbable={true}
                 tooltipText="Quill Reading for Evidence is in beta, which means that it’s not perfect yet. As you complete activities, you may notice some issues—a button may not work or some feedback could be unhelpful. Please know that we’re actively working on Quill Reading for Evidence and making improvements every day."
                 tooltipTriggerText={tooltipTrigger}
                 tooltipTriggerTextClass="hide-on-mobile beta-tag focus-on-dark"

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/headerImage.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/headerImage.tsx
@@ -57,7 +57,6 @@ export const HeaderImage = ({ headerImage, passage }) => {
         {headerImage}
         <section className="header-image-information">
           {passage.image_caption && <p className="header-image-caption">{stripHtml(passage.image_caption)}</p>}
-          <span className="sr-only">Image credit: {tooltipText}</span>
           {passage.image_attribution && <Tooltip handleClick={handleImageAttributionClick} tooltipText={tooltipText} tooltipTriggerText="Image credit" tooltipTriggerTextClass="image-attribution-tooltip" />}
         </section>
       </section>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/readAndHighlightInstructions.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/readAndHighlightInstructions.tsx
@@ -49,7 +49,6 @@ const ReadAndHighlightInstructions = ({ passage, activeStep, studentHighlights, 
         <div className="highlight-label-section">
           <h3>Highlights</h3>
           <Tooltip
-            isTabbable={true}
             tooltipText={tooltipText}
             tooltipTriggerText={tooltipTrigger}
           />

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
@@ -51,11 +51,17 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
             tooltipTriggerTextClass="hide-on-mobile beta-tag focus-on-dark"
           >
             <span
+              aria-hidden={false}
+              aria-role="button"
               className="quill-tooltip-trigger"
+              role="tooltip"
             >
               <span
                 className="hide-on-mobile beta-tag focus-on-dark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 tabIndex={0}
@@ -77,6 +83,7 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
                 className="quill-tooltip-wrapper"
               >
                 <span
+                  aria-live="polite"
                   className="quill-tooltip"
                 />
               </span>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
           >
             <span
               aria-hidden={false}
-              aria-role="button"
               className="quill-tooltip-trigger"
               role="tooltip"
             >
@@ -64,6 +63,7 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
+                role="button"
                 tabIndex={0}
               >
                 <div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/headerImage.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/headerImage.test.tsx.snap
@@ -14,13 +14,9 @@ exports[`Header Image component should render Header Image 1`] = `
       <p
         className="header-image-caption"
       />
-      <span
-        className="sr-only"
-      >
-        Image credit: 
-      </span>
       <Tooltip
         handleClick={[Function]}
+        isTabbable={true}
         tooltipTriggerText="Image credit"
         tooltipTriggerTextClass="image-attribution-tooltip"
       />

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -84,11 +84,17 @@ exports[`ReadAndHighlightInstructions component when the student has not started
           }
         >
           <span
+            aria-hidden={false}
+            aria-role="button"
             className="quill-tooltip-trigger"
+            role="tooltip"
           >
             <span
               className="undefined"
+              onBlur={[Function]}
               onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
               tabIndex={0}
@@ -102,6 +108,7 @@ exports[`ReadAndHighlightInstructions component when the student has not started
               className="quill-tooltip-wrapper"
             >
               <span
+                aria-live="polite"
                 className="quill-tooltip"
               />
             </span>
@@ -208,11 +215,17 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
           }
         >
           <span
+            aria-hidden={false}
+            aria-role="button"
             className="quill-tooltip-trigger"
+            role="tooltip"
           >
             <span
               className="undefined"
+              onBlur={[Function]}
               onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
               tabIndex={0}
@@ -226,6 +239,7 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
               className="quill-tooltip-wrapper"
             >
               <span
+                aria-live="polite"
                 className="quill-tooltip"
               />
             </span>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`ReadAndHighlightInstructions component when the student has not started
         >
           <span
             aria-hidden={false}
-            aria-role="button"
             className="quill-tooltip-trigger"
             role="tooltip"
           >
@@ -97,6 +96,7 @@ exports[`ReadAndHighlightInstructions component when the student has not started
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              role="button"
               tabIndex={0}
             >
               <img
@@ -216,7 +216,6 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
         >
           <span
             aria-hidden={false}
-            aria-role="button"
             className="quill-tooltip-trigger"
             role="tooltip"
           >
@@ -228,6 +227,7 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              role="button"
               tabIndex={0}
             >
               <img

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -12,7 +12,7 @@ interface TooltipProps {
   tooltipTriggerStyle?: { [key:string]: any }
 }
 
-export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean, tooltipVisible: boolean }> {
+class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean, tooltipVisible: boolean }> {
   private timer: any // eslint-disable-line react/sort-comp
   private tooltip: any // eslint-disable-line react/sort-comp
   private tooltipTrigger: any // eslint-disable-line react/sort-comp
@@ -127,3 +127,9 @@ export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: 
     )
   }
 }
+
+Tooltip.defaultProps = {
+  isTabbable: true
+}
+
+export { Tooltip, }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { onMobile } from '../..'
 
 interface TooltipProps {
@@ -85,21 +86,31 @@ export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: 
     }
   }
 
+  handleTooltipKeyDown = (e) => {
+    if (e.key === 'Escape') { this.hideTooltip() }
+  }
+
   render() {
-    const { tooltipTriggerText, tooltipTriggerTextClass, tooltipTriggerStyle, tooltipTriggerTextStyle, isTabbable } = this.props
+    const { tooltipTriggerText, tooltipTriggerTextClass, tooltipTriggerStyle, tooltipTriggerTextStyle, isTabbable, } = this.props
     const tabIndex = isTabbable ? 0 : null;
 
     return (
       <span
+        aria-hidden={!isTabbable}
         className="quill-tooltip-trigger"
         ref={node => this.tooltipTrigger = node}
+        role="tooltip"
         style={tooltipTriggerStyle}
       >
         <span
           className={`${tooltipTriggerTextClass}`}
+          onBlur={this.hideTooltip}
           onClick={this.handleTooltipClick}
+          onFocus={this.showTooltip}
+          onKeyDown={this.handleTooltipKeyDown}
           onMouseEnter={this.showTooltip}
           onMouseLeave={this.startTimer}
+          role="button"
           style={tooltipTriggerTextStyle}
           tabIndex={tabIndex}
         >
@@ -107,6 +118,7 @@ export class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: 
         </span>
         <span className="quill-tooltip-wrapper">
           <span
+            aria-live="polite"
             className="quill-tooltip"
             ref={node => this.tooltip = node}
           />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1517,7 +1517,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "100px",
@@ -1528,7 +1531,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -1561,6 +1567,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -1601,7 +1608,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "100px",
@@ -1612,7 +1622,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -1645,6 +1658,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -1683,7 +1697,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "100px",
@@ -1694,7 +1711,10 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -1725,6 +1745,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1483,6 +1483,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               December 7th, 2020
             </span>
             <Tooltip
+              isTabbable={true}
               key="copy-17-1"
               tooltipText={
                 <TurkSessionButton
@@ -1517,8 +1518,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -1537,6 +1537,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "100px",
@@ -1544,7 +1545,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                       "width": "100px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   <TurkSessionButton
                     clickHandler={[Function]}
@@ -1574,6 +1575,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               </span>
             </Tooltip>
             <Tooltip
+              isTabbable={true}
               key="edit-17-1"
               tooltipText={
                 <TurkSessionButton
@@ -1608,8 +1610,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -1628,6 +1629,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "100px",
@@ -1635,7 +1637,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                       "width": "100px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   <TurkSessionButton
                     clickHandler={[Function]}
@@ -1665,6 +1667,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               </span>
             </Tooltip>
             <Tooltip
+              isTabbable={true}
               key="delete-17-1"
               tooltipText={
                 <TurkSessionButton
@@ -1697,8 +1700,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -1717,6 +1719,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "100px",
@@ -1724,7 +1727,7 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
                       "width": "100px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   <TurkSessionButton
                     clickHandler={[Function]}

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`Tooltip component should render when it is not searchable 1`] = `
 <Tooltip
+  isTabbable={true}
   tooltipText="I am a tooltip"
   tooltipTriggerText="I have a lot of text"
 >
   <span
-    aria-hidden={true}
-    aria-role="button"
+    aria-hidden={false}
     className="quill-tooltip-trigger"
     role="tooltip"
   >
@@ -19,7 +19,8 @@ exports[`Tooltip component should render when it is not searchable 1`] = `
       onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
-      tabIndex={null}
+      role="button"
+      tabIndex={0}
     >
       I have a lot of text
     </span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -6,11 +6,17 @@ exports[`Tooltip component should render when it is not searchable 1`] = `
   tooltipTriggerText="I have a lot of text"
 >
   <span
+    aria-hidden={true}
+    aria-role="button"
     className="quill-tooltip-trigger"
+    role="tooltip"
   >
     <span
       className="undefined"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       tabIndex={null}
@@ -21,6 +27,7 @@ exports[`Tooltip component should render when it is not searchable 1`] = `
       className="quill-tooltip-wrapper"
     >
       <span
+        aria-live="polite"
         className="quill-tooltip"
       />
     </span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
@@ -16,7 +16,7 @@ class Tooltips extends React.Component<any, any> {
             {
               `<div className="tooltips-container">
   <Tooltip
-    isTabbable={true}
+    isTabbable={false}
     tooltipText="I am a tooltip!"
     tooltipTriggerText="Hover here"
   />
@@ -29,6 +29,7 @@ class Tooltips extends React.Component<any, any> {
           </pre>
           <div className="tooltips-container">
             <Tooltip
+              isTabbable={false}
               tooltipText="I am a tooltip!"
               tooltipTriggerText="Hover here"
             />

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
@@ -16,11 +16,11 @@ class Tooltips extends React.Component<any, any> {
             {
               `<div className="tooltips-container">
   <Tooltip
+    isTabbable={true}
     tooltipText="I am a tooltip!"
     tooltipTriggerText="Hover here"
   />
   <Tooltip
-    isTabbable={true}
     tooltipText="But the wind and water know all the earth’s secrets. They’ve seen and heard all that has ever been said or done. And if you listen, they will tell you all the stories and sing every song. The stories of everyone who has ever lived. Millions and millions of lives. Millions and millions of stories."
     tooltipTriggerText="Or here"
   />

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/tooltips.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+
 import { Tooltip } from '../../../Shared/index'
 
 class Tooltips extends React.Component<any, any> {
@@ -19,6 +20,7 @@ class Tooltips extends React.Component<any, any> {
     tooltipTriggerText="Hover here"
   />
   <Tooltip
+    isTabbable={true}
     tooltipText="But the wind and water know all the earth’s secrets. They’ve seen and heard all that has ever been said or done. And if you listen, they will tell you all the stories and sing every song. The stories of everyone who has ever lived. Millions and millions of lives. Millions and millions of stories."
     tooltipTriggerText="Or here"
   />
@@ -31,8 +33,9 @@ class Tooltips extends React.Component<any, any> {
               tooltipTriggerText="Hover here"
             />
             <Tooltip
+              isTabbable={true}
               tooltipText="But the wind and water know all the earth’s secrets. They’ve seen and heard all that has ever been said or done. And if you listen, they will tell you all the stories and sing every song. The stories of everyone who has ever lived. Millions and millions of lives. Millions and millions of stories."
-              tooltipTriggerText="Or here"
+              tooltipTriggerText="Or here (I'm tabbable)"
             />
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -570,6 +570,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       </span>
                     </a>
                     <Tooltip
+                      isTabbable={true}
                       tooltipText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
                       tooltipTriggerText={
                         <button
@@ -585,8 +586,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       }
                     >
                       <span
-                        aria-hidden={true}
-                        aria-role="button"
+                        aria-hidden={false}
                         className="quill-tooltip-trigger"
                         role="tooltip"
                       >
@@ -598,7 +598,8 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           onKeyDown={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          tabIndex={null}
+                          role="button"
+                          tabIndex={0}
                         >
                           <button
                             className="quill-button small disabled contained"
@@ -850,6 +851,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       </span>
                     </a>
                     <Tooltip
+                      isTabbable={true}
                       tooltipText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
                       tooltipTriggerText={
                         <button
@@ -865,8 +867,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       }
                     >
                       <span
-                        aria-hidden={true}
-                        aria-role="button"
+                        aria-hidden={false}
                         className="quill-tooltip-trigger"
                         role="tooltip"
                       >
@@ -878,7 +879,8 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           onKeyDown={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          tabIndex={null}
+                          role="button"
+                          tabIndex={0}
                         >
                           <button
                             className="quill-button small disabled contained"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -585,11 +585,17 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       }
                     >
                       <span
+                        aria-hidden={true}
+                        aria-role="button"
                         className="quill-tooltip-trigger"
+                        role="tooltip"
                       >
                         <span
                           className="undefined"
+                          onBlur={[Function]}
                           onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           tabIndex={null}
@@ -609,6 +615,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           className="quill-tooltip-wrapper"
                         >
                           <span
+                            aria-live="polite"
                             className="quill-tooltip"
                           />
                         </span>
@@ -858,11 +865,17 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                       }
                     >
                       <span
+                        aria-hidden={true}
+                        aria-role="button"
                         className="quill-tooltip-trigger"
+                        role="tooltip"
                       >
                         <span
                           className="undefined"
+                          onBlur={[Function]}
                           onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           tabIndex={null}
@@ -882,6 +895,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                           className="quill-tooltip-wrapper"
                         >
                           <span
+                            aria-live="polite"
                             className="quill-tooltip"
                           />
                         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
@@ -17810,13 +17810,13 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             type="button"
           />
           <Tooltip
+            isTabbable={true}
             tooltipText="History: Causes of the American Revolution"
             tooltipTriggerText="History: Causes of the American Revolution"
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
-              aria-hidden={true}
-              aria-role="button"
+              aria-hidden={false}
               className="quill-tooltip-trigger"
               role="tooltip"
             >
@@ -17828,7 +17828,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                tabIndex={null}
+                role="button"
+                tabIndex={0}
               >
                 History: Causes of the American Revolution
               </span>
@@ -44641,13 +44642,13 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             type="button"
           />
           <Tooltip
+            isTabbable={true}
             tooltipText="History: Causes of the American Revolution"
             tooltipTriggerText="History: Causes of the American Revolution"
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
-              aria-hidden={true}
-              aria-role="button"
+              aria-hidden={false}
               className="quill-tooltip-trigger"
               role="tooltip"
             >
@@ -44659,7 +44660,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                tabIndex={null}
+                role="button"
+                tabIndex={0}
               >
                 History: Causes of the American Revolution
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
@@ -17815,11 +17815,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
+              aria-hidden={true}
+              aria-role="button"
               className="quill-tooltip-trigger"
+              role="tooltip"
             >
               <span
                 className="tooltip-trigger-text"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 tabIndex={null}
@@ -17830,6 +17836,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 className="quill-tooltip-wrapper"
               >
                 <span
+                  aria-live="polite"
                   className="quill-tooltip"
                 />
               </span>
@@ -44639,11 +44646,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
+              aria-hidden={true}
+              aria-role="button"
               className="quill-tooltip-trigger"
+              role="tooltip"
             >
               <span
                 className="tooltip-trigger-text"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 tabIndex={null}
@@ -44654,6 +44667,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 className="quill-tooltip-wrapper"
               >
                 <span
+                  aria-live="polite"
                   className="quill-tooltip"
                 />
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
@@ -45868,13 +45868,13 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 type="button"
               />
               <Tooltip
+                isTabbable={true}
                 tooltipText="History: Causes of the American Revolution"
                 tooltipTriggerText="History: Causes of the American Revolution"
                 tooltipTriggerTextClass="tooltip-trigger-text"
               >
                 <span
-                  aria-hidden={true}
-                  aria-role="button"
+                  aria-hidden={false}
                   className="quill-tooltip-trigger"
                   role="tooltip"
                 >
@@ -45886,7 +45886,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
-                    tabIndex={null}
+                    role="button"
+                    tabIndex={0}
                   >
                     History: Causes of the American Revolution
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/filter_column.test.tsx.snap
@@ -45873,11 +45873,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 tooltipTriggerTextClass="tooltip-trigger-text"
               >
                 <span
+                  aria-hidden={true}
+                  aria-role="button"
                   className="quill-tooltip-trigger"
+                  role="tooltip"
                 >
                   <span
                     className="tooltip-trigger-text"
+                    onBlur={[Function]}
                     onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex={null}
@@ -45888,6 +45894,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     className="quill-tooltip-wrapper"
                   >
                     <span
+                      aria-live="polite"
                       className="quill-tooltip"
                     />
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -63507,13 +63507,13 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     type="button"
                   />
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="History: Causes of the American Revolution"
                     tooltipTriggerText="History: Causes of the American Revolution"
                     tooltipTriggerTextClass="tooltip-trigger-text"
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -63525,7 +63525,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         History: Causes of the American Revolution
                       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -63512,11 +63512,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     tooltipTriggerTextClass="tooltip-trigger-text"
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="tooltip-trigger-text"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -63527,6 +63533,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
@@ -34,12 +34,12 @@ exports[`OverrideWarningModal component should render 1`] = `
       >
         <p>
           <Tooltip
+            isTabbable={true}
             tooltipText="Student Name"
             tooltipTriggerText="1 student"
           >
             <span
-              aria-hidden={true}
-              aria-role="button"
+              aria-hidden={false}
               className="quill-tooltip-trigger"
               role="tooltip"
             >
@@ -51,7 +51,8 @@ exports[`OverrideWarningModal component should render 1`] = `
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                tabIndex={null}
+                role="button"
+                tabIndex={0}
               >
                 1 student
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
@@ -38,11 +38,17 @@ exports[`OverrideWarningModal component should render 1`] = `
             tooltipTriggerText="1 student"
           >
             <span
+              aria-hidden={true}
+              aria-role="button"
               className="quill-tooltip-trigger"
+              role="tooltip"
             >
               <span
                 className="undefined"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 tabIndex={null}
@@ -53,6 +59,7 @@ exports[`OverrideWarningModal component should render 1`] = `
                 className="quill-tooltip-wrapper"
               >
                 <span
+                  aria-live="polite"
                   className="quill-tooltip"
                 />
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
@@ -38,11 +38,17 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
             tooltipTriggerText="1 student"
           >
             <span
+              aria-hidden={true}
+              aria-role="button"
               className="quill-tooltip-trigger"
+              role="tooltip"
             >
               <span
                 className="undefined"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 tabIndex={null}
@@ -53,6 +59,7 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
                 className="quill-tooltip-wrapper"
               >
                 <span
+                  aria-live="polite"
                   className="quill-tooltip"
                 />
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
@@ -34,12 +34,12 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
       >
         <p>
           <Tooltip
+            isTabbable={true}
             tooltipText="Student Name"
             tooltipTriggerText="1 student"
           >
             <span
-              aria-hidden={true}
-              aria-role="button"
+              aria-hidden={false}
               className="quill-tooltip-trigger"
               role="tooltip"
             >
@@ -51,7 +51,8 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
                 onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                tabIndex={null}
+                role="button"
+                tabIndex={0}
               >
                 1 student
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -409,7 +409,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "245px",
@@ -420,7 +423,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -438,6 +444,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -516,7 +523,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "245px",
@@ -527,7 +537,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -545,6 +558,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -883,7 +897,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "245px",
@@ -894,7 +911,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -912,6 +932,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -389,6 +389,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               Angie Thomas
             </span>
             <Tooltip
+              isTabbable={true}
               key="activityName-33"
               tooltipText="Subject and Object Pronoun Agreement 1"
               tooltipTriggerStyle={
@@ -409,8 +410,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -429,6 +429,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "245px",
@@ -436,7 +437,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                       "width": "245px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Subject and Object Pronoun Agreement 1
                 </span>
@@ -503,6 +504,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               Angie Thomas
             </span>
             <Tooltip
+              isTabbable={true}
               key="activityName-32"
               tooltipText="Capitalize Names of People and the Pronoun \\"I\\""
               tooltipTriggerStyle={
@@ -523,8 +525,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -543,6 +544,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "245px",
@@ -550,7 +552,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                       "width": "245px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Capitalize Names of People and the Pronoun "I"
                 </span>
@@ -877,6 +879,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               Angie Thomas
             </span>
             <Tooltip
+              isTabbable={true}
               key="activityName-25"
               tooltipText="Capitalize Holidays and Geographic Names"
               tooltipTriggerStyle={
@@ -897,8 +900,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -917,6 +919,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "245px",
@@ -924,7 +927,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                       "width": "245px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Capitalize Holidays and Geographic Names
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
@@ -395,6 +395,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               ELL Diagnostic
             </span>
             <Tooltip
+              isTabbable={true}
               key="classroom-447-484134-826269"
               tooltipText="Quill Classroom Extremely Long So Long SUper Duper"
               tooltipTriggerStyle={
@@ -415,8 +416,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -435,6 +435,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "180px",
@@ -442,7 +443,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       "width": "180px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Quill Classroom Extremely Long So Long SUper Duper
                 </span>
@@ -586,6 +587,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               Starter Diagnostic
             </span>
             <Tooltip
+              isTabbable={true}
               key="classroom-849-484134-826268"
               tooltipText="Quill Classroom Extremely Long So Long SUper Duper"
               tooltipTriggerStyle={
@@ -606,8 +608,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -626,6 +627,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "180px",
@@ -633,7 +635,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       "width": "180px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Quill Classroom Extremely Long So Long SUper Duper
                 </span>
@@ -706,6 +708,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               Starter Diagnostic
             </span>
             <Tooltip
+              isTabbable={true}
               key="classroom-849-484134-826269"
               tooltipText="Quill Classroom Extremely Long So Long SUper Duper"
               tooltipTriggerStyle={
@@ -726,8 +729,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -746,6 +748,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "180px",
@@ -753,7 +756,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       "width": "180px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Quill Classroom Extremely Long So Long SUper Duper
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
@@ -415,7 +415,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "180px",
@@ -426,7 +429,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -444,6 +450,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -599,7 +606,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "180px",
@@ -610,7 +620,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -628,6 +641,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -712,7 +726,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "180px",
@@ -723,7 +740,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -741,6 +761,7 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -685,6 +685,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
             key="649-1-undefined"
           >
             <Tooltip
+              isTabbable={true}
               key="lesson-649-1-undefined"
               tooltipText="Advanced Combining: Complex Sentences with Modifiers"
               tooltipTriggerStyle={
@@ -705,8 +706,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -725,6 +725,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "289px",
@@ -732,7 +733,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                       "width": "289px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Advanced Combining: Complex Sentences with Modifiers
                 </span>
@@ -950,6 +951,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
             key="566-6-undefined"
           >
             <Tooltip
+              isTabbable={true}
               key="lesson-566-6-undefined"
               tooltipText="Lesson 1: Conjunctions of Time (After, Until, Before, etc.)"
               tooltipTriggerStyle={
@@ -970,8 +972,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               }
             >
               <span
-                aria-hidden={true}
-                aria-role="button"
+                aria-hidden={false}
                 className="quill-tooltip-trigger"
                 role="tooltip"
                 style={
@@ -990,6 +991,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  role="button"
                   style={
                     Object {
                       "minWidth": "289px",
@@ -997,7 +999,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                       "width": "289px",
                     }
                   }
-                  tabIndex={null}
+                  tabIndex={0}
                 >
                   Lesson 1: Conjunctions of Time (After, Until, Before, etc.)
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -705,7 +705,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "289px",
@@ -716,7 +719,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -734,6 +740,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>
@@ -963,7 +970,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               }
             >
               <span
+                aria-hidden={true}
+                aria-role="button"
                 className="quill-tooltip-trigger"
+                role="tooltip"
                 style={
                   Object {
                     "minWidth": "289px",
@@ -974,7 +984,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
               >
                 <span
                   className="data-table-row-section undefined"
+                  onBlur={[Function]}
                   onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -992,6 +1005,7 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   className="quill-tooltip-wrapper"
                 >
                   <span
+                    aria-live="polite"
                     className="quill-tooltip"
                   />
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
@@ -338,6 +338,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Compound-Complex Sentences
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/320' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -347,8 +348,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -360,7 +360,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -396,6 +397,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Appositive Phrases
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/322' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -405,8 +407,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -418,7 +419,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -454,6 +456,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Relative Clauses
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/324' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -463,8 +466,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -476,7 +478,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -512,6 +515,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Participial Phrases
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/327' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -521,8 +525,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -534,7 +537,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -570,6 +574,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Parallel Structure
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/329' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -579,8 +584,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -592,7 +596,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -628,6 +633,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     Advanced Combining
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/331' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -637,8 +643,7 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -650,7 +655,8 @@ exports[`RecommendationsTable component should render when no students have comp
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -5063,13 +5069,13 @@ exports[`RecommendationsTable component should render when no students have comp
                       name="Gabriel De La Concordia Garcia"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Gabriel De La Concordia Garcia"
                         tooltipTriggerText="Gabriel De La Concordia Garcia"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -5081,7 +5087,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Gabriel De La Concordia Garcia
                           </span>
@@ -7434,13 +7441,13 @@ exports[`RecommendationsTable component should render when no students have comp
                       name="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                         tooltipTriggerText="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -7452,7 +7459,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
                           </span>
@@ -8593,13 +8601,13 @@ exports[`RecommendationsTable component should render when no students have comp
                       name="Dehab Lee Kassis-washington"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Dehab Lee Kassis-washington"
                         tooltipTriggerText="Dehab Lee Kassis-washington"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -8611,7 +8619,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Dehab Lee Kassis-washington
                           </span>
@@ -10721,13 +10730,13 @@ exports[`RecommendationsTable component should render when no students have comp
                       name="Henry Wadsworth Longfellow"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Henry Wadsworth Longfellow"
                         tooltipTriggerText="Henry Wadsworth Longfellow"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -10739,7 +10748,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Henry Wadsworth Longfellow
                           </span>
@@ -11413,6 +11423,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Capitalization
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/308' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11422,8 +11433,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11435,7 +11445,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -11471,6 +11482,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Plural and Possessive Nouns
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/310' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11480,8 +11492,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11493,7 +11504,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -11529,6 +11541,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Adjectives and Adverbs
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/312' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11538,8 +11551,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11551,7 +11563,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -11587,6 +11600,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Prepositional Phrases
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/314' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11596,8 +11610,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11609,7 +11622,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -11645,6 +11659,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Compound Subjects, Objects, and Predicates
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/316' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11654,8 +11669,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11667,7 +11681,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -11703,6 +11718,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     Commonly Confused Words
                   </span>
                   <Tooltip
+                    isTabbable={true}
                     tooltipText="<a href='/activities/packs/318' target=\\"_blank\\">Preview the activity pack</a>"
                     tooltipTriggerText={
                       <img
@@ -11712,8 +11728,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
-                      aria-hidden={true}
-                      aria-role="button"
+                      aria-hidden={false}
                       className="quill-tooltip-trigger"
                       role="tooltip"
                     >
@@ -11725,7 +11740,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
-                        tabIndex={null}
+                        role="button"
+                        tabIndex={0}
                       >
                         <img
                           alt="Question mark icon"
@@ -19360,13 +19376,13 @@ exports[`RecommendationsTable component should render when there are recommendat
                       name="Gabriel De La Concordia Garcia"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Gabriel De La Concordia Garcia"
                         tooltipTriggerText="Gabriel De La Concordia Garcia"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -19378,7 +19394,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Gabriel De La Concordia Garcia
                           </span>
@@ -23441,13 +23458,13 @@ exports[`RecommendationsTable component should render when there are recommendat
                       name="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                         tooltipTriggerText="Judy Heier-hammond Name Keeps Going For A Long Long Tim"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -23459,7 +23476,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
                           </span>
@@ -25389,13 +25407,13 @@ exports[`RecommendationsTable component should render when there are recommendat
                       name="Dehab Lee Kassis-washington"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Dehab Lee Kassis-washington"
                         tooltipTriggerText="Dehab Lee Kassis-washington"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -25407,7 +25425,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Dehab Lee Kassis-washington
                           </span>
@@ -28849,13 +28868,13 @@ exports[`RecommendationsTable component should render when there are recommendat
                       name="Henry Wadsworth Longfellow"
                     >
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="Henry Wadsworth Longfellow"
                         tooltipTriggerText="Henry Wadsworth Longfellow"
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={true}
-                          aria-role="button"
+                          aria-hidden={false}
                           className="quill-tooltip-trigger"
                           role="tooltip"
                         >
@@ -28867,7 +28886,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
-                            tabIndex={null}
+                            role="button"
+                            tabIndex={0}
                           >
                             Henry Wadsworth Longfellow
                           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
@@ -347,11 +347,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -365,6 +371,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -398,11 +405,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -416,6 +429,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -449,11 +463,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -467,6 +487,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -500,11 +521,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -518,6 +545,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -551,11 +579,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -569,6 +603,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -602,11 +637,17 @@ exports[`RecommendationsTable component should render when no students have comp
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -620,6 +661,7 @@ exports[`RecommendationsTable component should render when no students have comp
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -5026,11 +5068,17 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -5041,6 +5089,7 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -7390,11 +7439,17 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -7405,6 +7460,7 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -8542,11 +8598,17 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -8557,6 +8619,7 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -10663,11 +10726,17 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -10678,6 +10747,7 @@ exports[`RecommendationsTable component should render when no students have comp
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -11352,11 +11422,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11370,6 +11446,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -11403,11 +11480,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11421,6 +11504,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -11454,11 +11538,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11472,6 +11562,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -11505,11 +11596,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11523,6 +11620,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -11556,11 +11654,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11574,6 +11678,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -11607,11 +11712,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                     }
                   >
                     <span
+                      aria-hidden={true}
+                      aria-role="button"
                       className="quill-tooltip-trigger"
+                      role="tooltip"
                     >
                       <span
                         className="undefined"
+                        onBlur={[Function]}
                         onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         tabIndex={null}
@@ -11625,6 +11736,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                         className="quill-tooltip-wrapper"
                       >
                         <span
+                          aria-live="polite"
                           className="quill-tooltip"
                         />
                       </span>
@@ -19253,11 +19365,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -19268,6 +19386,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -23327,11 +23446,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -23342,6 +23467,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -25268,11 +25394,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -25283,6 +25415,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>
@@ -28721,11 +28854,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
+                          aria-hidden={true}
+                          aria-role="button"
                           className="quill-tooltip-trigger"
+                          role="tooltip"
                         >
                           <span
                             className="student-name"
+                            onBlur={[Function]}
                             onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
                             onMouseEnter={[Function]}
                             onMouseLeave={[Function]}
                             tabIndex={null}
@@ -28736,6 +28875,7 @@ exports[`RecommendationsTable component should render when there are recommendat
                             className="quill-tooltip-wrapper"
                           >
                             <span
+                              aria-live="polite"
                               className="quill-tooltip"
                             />
                           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
@@ -15,11 +15,17 @@ exports[`SkillGroupTooltip component should render 1`] = `
     }
   >
     <span
+      aria-hidden={true}
+      aria-role="button"
       className="quill-tooltip-trigger"
+      role="tooltip"
     >
       <span
         className="undefined"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         tabIndex={null}
@@ -33,6 +39,7 @@ exports[`SkillGroupTooltip component should render 1`] = `
         className="quill-tooltip-wrapper"
       >
         <span
+          aria-live="polite"
           className="quill-tooltip"
         />
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`SkillGroupTooltip component should render 1`] = `
   name="Capitalization"
 >
   <Tooltip
+    isTabbable={true}
     tooltipText="<p>Capitalization<br/><br/>Students who show proficiency in this skill will use capitalization at the beginning of a sentence and correct capitalization of names, dates, holidays, geographic locations, and the pronoun \\"I.\\"</p>"
     tooltipTriggerText={
       <img
@@ -15,8 +16,7 @@ exports[`SkillGroupTooltip component should render 1`] = `
     }
   >
     <span
-      aria-hidden={true}
-      aria-role="button"
+      aria-hidden={false}
       className="quill-tooltip-trigger"
       role="tooltip"
     >
@@ -28,7 +28,8 @@ exports[`SkillGroupTooltip component should render 1`] = `
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
-        tabIndex={null}
+        role="button"
+        tabIndex={0}
       >
         <img
           alt="Question mark icon"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
@@ -10,11 +10,17 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
     tooltipTriggerTextClass="student-name"
   >
     <span
+      aria-hidden={true}
+      aria-role="button"
       className="quill-tooltip-trigger"
+      role="tooltip"
     >
       <span
         className="student-name"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         tabIndex={null}
@@ -25,6 +31,7 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
         className="quill-tooltip-wrapper"
       >
         <span
+          aria-live="polite"
           className="quill-tooltip"
         />
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
@@ -5,13 +5,13 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
   name="Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia"
 >
   <Tooltip
+    isTabbable={true}
     tooltipText="Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia"
     tooltipTriggerText="Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia"
     tooltipTriggerTextClass="student-name"
   >
     <span
-      aria-hidden={true}
-      aria-role="button"
+      aria-hidden={false}
       className="quill-tooltip-trigger"
       role="tooltip"
     >
@@ -23,7 +23,8 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
         onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
-        tabIndex={null}
+        role="button"
+        tabIndex={0}
       >
         Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -115,6 +115,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Compound-Complex Sentences"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Compound-Complex Sentences<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -124,8 +125,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -137,7 +137,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -174,6 +175,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Appositive Phrases"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Appositive Phrases<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -183,8 +185,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -196,7 +197,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -233,6 +235,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Relative Clauses"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Relative Clauses<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -242,8 +245,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -255,7 +257,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -292,6 +295,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Participal Phrases"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Participal Phrases<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -301,8 +305,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -314,7 +317,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -351,6 +355,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Parallel Structure"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Parallel Structure<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -360,8 +365,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -373,7 +377,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -410,6 +415,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Advanced Combining"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Advanced Combining<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -419,8 +425,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -432,7 +437,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -469,6 +475,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Subject-Verb Agreement"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Subject-Verb Agreement<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -478,8 +485,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -491,7 +497,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -528,6 +535,7 @@ exports[`StudentResultsTable component should render when there is no student da
                 name="Nouns, Pronouns, and Verbs"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Nouns, Pronouns, and Verbs<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -537,8 +545,7 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -550,7 +557,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1610,6 +1618,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Capitalization"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Capitalization<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1619,8 +1628,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1632,7 +1640,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1677,6 +1686,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Plural and Possessive Nouns"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Plural and Possessive Nouns<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1686,8 +1696,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1699,7 +1708,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1745,6 +1755,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Adjectives and Adverbs"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Adjectives and Adverbs<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1754,8 +1765,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1767,7 +1777,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1813,6 +1824,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Prepositional Phrases"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Prepositional Phrases<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1822,8 +1834,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1835,7 +1846,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1881,6 +1893,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Compound Subjects, Objects, and Predicates"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Compound Subjects, Objects, and Predicates<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1890,8 +1903,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1903,7 +1915,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"
@@ -1948,6 +1961,7 @@ exports[`StudentResultsTable component should render when there is student data 
                 name="Commonly Confused Words"
               >
                 <Tooltip
+                  isTabbable={true}
                   tooltipText="<p>Commonly Confused Words<br/><br/>null</p>"
                   tooltipTriggerText={
                     <img
@@ -1957,8 +1971,7 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={true}
-                    aria-role="button"
+                    aria-hidden={false}
                     className="quill-tooltip-trigger"
                     role="tooltip"
                   >
@@ -1970,7 +1983,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
-                      tabIndex={null}
+                      role="button"
+                      tabIndex={0}
                     >
                       <img
                         alt="Question mark icon"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -124,11 +124,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -142,6 +148,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -176,11 +183,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -194,6 +207,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -228,11 +242,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -246,6 +266,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -280,11 +301,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -298,6 +325,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -332,11 +360,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -350,6 +384,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -384,11 +419,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -402,6 +443,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -436,11 +478,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -454,6 +502,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -488,11 +537,17 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -506,6 +561,7 @@ exports[`StudentResultsTable component should render when there is no student da
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1563,11 +1619,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1581,6 +1643,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1623,11 +1686,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1641,6 +1710,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1684,11 +1754,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1702,6 +1778,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1745,11 +1822,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1763,6 +1846,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1806,11 +1890,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1824,6 +1914,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>
@@ -1866,11 +1957,17 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
+                    aria-hidden={true}
+                    aria-role="button"
                     className="quill-tooltip-trigger"
+                    role="tooltip"
                   >
                     <span
                       className="undefined"
+                      onBlur={[Function]}
                       onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       tabIndex={null}
@@ -1884,6 +1981,7 @@ exports[`StudentResultsTable component should render when there is student data 
                       className="quill-tooltip-wrapper"
                     >
                       <span
+                        aria-live="polite"
                         className="quill-tooltip"
                       />
                     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -71,6 +71,7 @@ exports[`ScoreLegend component should render 1`] = `
       </div>
     </div>
     <Tooltip
+      isTabbable={true}
       tooltipText="This type of activity is not graded."
       tooltipTriggerText={
         <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -128,11 +128,17 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
+                            aria-hidden={true}
+                            aria-role="button"
                             className="quill-tooltip-trigger"
+                            role="tooltip"
                           >
                             <span
                               className="undefined"
+                              onBlur={[Function]}
                               onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
                               tabIndex={null}
@@ -149,6 +155,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               className="quill-tooltip-wrapper"
                             >
                               <span
+                                aria-live="polite"
                                 className="quill-tooltip"
                               />
                             </span>
@@ -350,11 +357,17 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
+                            aria-hidden={true}
+                            aria-role="button"
                             className="quill-tooltip-trigger"
+                            role="tooltip"
                           >
                             <span
                               className="undefined"
+                              onBlur={[Function]}
                               onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
                               tabIndex={null}
@@ -371,6 +384,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               className="quill-tooltip-wrapper"
                             >
                               <span
+                                aria-live="polite"
                                 className="quill-tooltip"
                               />
                             </span>
@@ -587,11 +601,17 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
+                            aria-hidden={true}
+                            aria-role="button"
                             className="quill-tooltip-trigger"
+                            role="tooltip"
                           >
                             <span
                               className="undefined"
+                              onBlur={[Function]}
                               onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
                               tabIndex={null}
@@ -608,6 +628,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               className="quill-tooltip-wrapper"
                             >
                               <span
+                                aria-live="polite"
                                 className="quill-tooltip"
                               />
                             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -91,6 +91,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                     <span>
                       School Premium
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="You have a School Paid subscription"
                         tooltipTriggerText={
                           <span>
@@ -116,6 +117,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                       <span>
                         School Premium
                         <Tooltip
+                          isTabbable={true}
                           tooltipText="You have a School Paid subscription"
                           tooltipTriggerText={
                             <span>
@@ -128,8 +130,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={true}
-                            aria-role="button"
+                            aria-hidden={false}
                             className="quill-tooltip-trigger"
                             role="tooltip"
                           >
@@ -141,7 +142,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
-                              tabIndex={null}
+                              role="button"
+                              tabIndex={0}
                             >
                               <span>
                                 <img
@@ -320,6 +322,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                     <span>
                       School Premium
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="You have a School Paid subscription"
                         tooltipTriggerText={
                           <span>
@@ -345,6 +348,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                       <span>
                         School Premium
                         <Tooltip
+                          isTabbable={true}
                           tooltipText="You have a School Paid subscription"
                           tooltipTriggerText={
                             <span>
@@ -357,8 +361,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={true}
-                            aria-role="button"
+                            aria-hidden={false}
                             className="quill-tooltip-trigger"
                             role="tooltip"
                           >
@@ -370,7 +373,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
-                              tabIndex={null}
+                              role="button"
+                              tabIndex={0}
                             >
                               <span>
                                 <img
@@ -564,6 +568,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                     <span>
                       School Premium
                       <Tooltip
+                        isTabbable={true}
                         tooltipText="You have a School Paid subscription"
                         tooltipTriggerText={
                           <span>
@@ -589,6 +594,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                       <span>
                         School Premium
                         <Tooltip
+                          isTabbable={true}
                           tooltipText="You have a School Paid subscription"
                           tooltipTriggerText={
                             <span>
@@ -601,8 +607,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={true}
-                            aria-role="button"
+                            aria-hidden={false}
                             className="quill-tooltip-trigger"
                             role="tooltip"
                           >
@@ -614,7 +619,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
-                              tabIndex={null}
+                              role="button"
+                              tabIndex={0}
                             >
                               <span>
                                 <img

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/lowerFormFields.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/lowerFormFields.test.tsx.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LowerFormFields Component should match snapshot 1`] = `
+<LowerFormFields
+  comments=""
+  errors={Object {}}
+  handleUpdateField={[MockFunction]}
+  schoolPremiumEstimate={1}
+  studentPremiumEstimate={400}
+  teacherPremiumEstimate={20}
+>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of schools that will receive Quill Premium"
+    label="Estimated number of schools that will receive Quill Premium"
+    placeholder=""
+    value={1}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of schools that will receive Quill Premium"
+      >
+        Estimated number of schools that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of schools that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={1}
+      />
+    </div>
+  </Input>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of teachers that will receive Quill Premium"
+    label="Estimated number of teachers that will receive Quill Premium"
+    placeholder=""
+    value={20}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of teachers that will receive Quill Premium"
+      >
+        Estimated number of teachers that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of teachers that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={20}
+      />
+    </div>
+  </Input>
+  <Input
+    autoComplete="on"
+    className="form-input estimate"
+    handleChange={[MockFunction]}
+    id="Estimated number of students that will receive Quill Premium"
+    label="Estimated number of students that will receive Quill Premium"
+    placeholder=""
+    value={400}
+  >
+    <div
+      className="input-container  inactive has-text form-input estimate "
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={-1}
+    >
+      <label
+        htmlFor="Estimated number of students that will receive Quill Premium"
+      >
+        Estimated number of students that will receive Quill Premium
+      </label>
+      <input
+        autoComplete="on"
+        id="Estimated number of students that will receive Quill Premium"
+        maxLength={10000}
+        onChange={[MockFunction]}
+        onFocus={[Function]}
+        placeholder={false}
+        value={400}
+      />
+    </div>
+  </Input>
+  <TextArea
+    aria-labelledby="comments-label"
+    className="form-input"
+    handleChange={[MockFunction]}
+    id="Comments"
+    label="Comments (optional)"
+    timesSubmitted={0}
+    value=""
+  >
+    <div>
+      <div
+        className="input-container textfield-container  inactive form-input"
+        onClick={[Function]}
+      >
+        <label>
+          Comments (optional)
+        </label>
+        <textarea
+          id="Comments"
+          maxLength={10000}
+          onFocus={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+  </TextArea>
+</LowerFormFields>
+`;


### PR DESCRIPTION
## WHAT
Make the tooltip component accessible.

## WHY
Right now, there is no way for keyboard users to access the information inside of the tooltip. We don't want that to be the case.

## HOW
Change `isTabbable` to be true by default - while there are some cases where we might not want to have a tooltip be keyboard-interactable, that shouldn't be the default state. If it isn't keyboard-interactable, then I hid it from screenreaders altogether. Cleaned up the files where we were actively passing `true` for that prop since it's now redundant. Then I followed the WCAG guidance to make sure the content would be accessible, which seemed successful in testing using VoiceOver: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Investigate-accessibility-for-Tooltip-component-in-general-efb8397537df468fb9718cb90f682d08

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
