### PR TITLE
Update spec to not expect unsorted data to be in a specific order

### DIFF
--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -133,44 +133,42 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
         it 'should be a an array with objects containing the activity id, post test id, and assigned classroom ids' do
           get :assign
-          expect(assigns(:assigned_pre_tests)).to eq ([
-            {
-              id: starter_pre_test.id,
-              post_test_id: starter_post_test.id,
-              assigned_classroom_ids: [user.classrooms_i_teach.last.id],
-              all_classrooms: [
-                {
-                  id: user.classrooms_i_teach.last.id,
-                  completed_pre_test_student_ids: [students_classrooms.student.id],
-                  completed_post_test_student_ids: []
-                }
-              ]
-            },
-            {
-              id: intermediate_pre_test.id,
-              post_test_id: intermediate_post_test.id,
-              assigned_classroom_ids: [],
-              all_classrooms: [
-                {
-                  id: user.classrooms_i_teach.last.id,
-                  completed_pre_test_student_ids: [],
-                  completed_post_test_student_ids: []
-                }
-              ]
-            },
-            {
-              id: advanced_pre_test.id,
-              post_test_id: advanced_post_test.id,
-              assigned_classroom_ids: [],
-              all_classrooms: [
-                {
-                  id: user.classrooms_i_teach.last.id,
-                  completed_pre_test_student_ids: [],
-                  completed_post_test_student_ids: []
-                }
-              ]
-            }
-          ])
+          expect(assigns(:assigned_pre_tests)).to include({
+            id: starter_pre_test.id,
+            post_test_id: starter_post_test.id,
+            assigned_classroom_ids: [user.classrooms_i_teach.last.id],
+            all_classrooms: [
+              {
+                id: user.classrooms_i_teach.last.id,
+                completed_pre_test_student_ids: [students_classrooms.student.id],
+                completed_post_test_student_ids: []
+              }
+            ]
+          },
+          {
+            id: intermediate_pre_test.id,
+            post_test_id: intermediate_post_test.id,
+            assigned_classroom_ids: [],
+            all_classrooms: [
+              {
+                id: user.classrooms_i_teach.last.id,
+                completed_pre_test_student_ids: [],
+                completed_post_test_student_ids: []
+              }
+            ]
+          },
+          {
+            id: advanced_pre_test.id,
+            post_test_id: advanced_post_test.id,
+            assigned_classroom_ids: [],
+            all_classrooms: [
+              {
+                id: user.classrooms_i_teach.last.id,
+                completed_pre_test_student_ids: [],
+                completed_post_test_student_ids: []
+              }
+            ]
+          })
         end
       end
 


### PR DESCRIPTION
## WHAT
Update spec so that we don't expect data to come back in a specific order when we're not actually sorting the data
## WHY
This spec intermittently fails unpredictably:
https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/15953/workflows/28b84c11-161e-4ac0-a391-0a66f606044a/jobs/220014
## HOW
Instead of expecting `eq(ARRAY)` we expect `include(ELEMENT1, ELEMENT2, etc.)`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, test only change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
