### PR TITLE
Force trailing zeros in time string comparison

### DIFF
--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -71,7 +71,8 @@ describe 'ScorebookQuery' do
 
         results = Scorebook::Query.run(classroom.id, 1, nil, nil, nil, offset)
 
-        in_user_time = (activity_session1.updated_at + offset.seconds).strftime('%Y-%m-%d %H:%M:%S.%6N')
+        # Use ljust to ensure that trailing 0s are not discarded
+        in_user_time = (activity_session1.updated_at + offset.seconds).strftime('%Y-%m-%d %H:%M:%S.%6N').ljust(26, '0')
         expect(results.find{|res| res['id'] == activity_session1.id}['updated_at']).to eq(in_user_time)
       end
 


### PR DESCRIPTION
## WHAT
Fix a test that failed intermittently
## WHY
One side of an expectation kept trailing zeros in timestamps if they existed, while the other side discarded the, resulting in intermittent mismatches.
https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/15985/workflows/4aedf8cb-f218-4813-abfc-75d3d7325f65/jobs/220307
## HOW
Force the code that would discard the trailing zeros to replace them if that happens.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tests only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
