### PR TITLE
Send a Segment event when a school or user subscription is 30 days from expiring

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -26,6 +26,7 @@ class Cron
     # subscriptions
     RenewExpiringRecurringSubscriptionsWorker.perform_async
     UpdateExpiringSchoolSubscriptionsWorker.perform_async
+    AlertSoonToExpireSubscriptionsWorker.perform_async
 
     # demo
     ResetDemoAccountWorker.perform_async

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -19,16 +19,24 @@ class Cron
     # pass yesterday's date for stats email queries and labels
     date = Time.current.getlocal('-05:00').yesterday
 
+    # internal analytics and security
     DailyStatsEmailJob.perform_async(date)
     QuillStaffAccountsChangedWorker.perform_async
+
+    # subscriptions
     RenewExpiringRecurringSubscriptionsWorker.perform_async
     UpdateExpiringSchoolSubscriptionsWorker.perform_async
+
+    # demo
     ResetDemoAccountWorker.perform_async
+
+    # third party analytics
     SyncVitallyWorker.perform_async
+
+    # caching
     MaterializedViewRefreshWorker.perform_async
     RematchUpdatedQuestionsWorker.perform_async(date.beginning_of_day, date.end_of_day)
     PreCacheAdminDashboardsWorker.perform_async
-
     Question::TYPES.each { |type| RefreshQuestionCacheWorker.perform_async(type) }
   end
 

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -118,6 +118,7 @@ class Subscription < ApplicationRecord
   scope :not_recurring, -> { where(recurring: false) }
   scope :not_stripe, -> { where(stripe_invoice_id: nil) }
   scope :started, -> { where("start_date <= ?", Date.current) }
+  scope :paid_with_card, -> { where.not(stripe_invoice_id: nil).or(where(payment_method: 'Credit Card')) }
 
   def is_trial?
     account_type && TRIAL_TYPES.include?(account_type)

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -148,24 +148,22 @@ class SegmentAnalytics
 
   end
 
-  def trigger_teacher_subscription_will_expire(subscription_id)
+  def track_teacher_subscription(subscription_id, event)
     subscription = Subscription.find(subscription_id)
     teacher_id = subscription.users.first.id
-    event = subscription.recurring ? SegmentIo::BackgroundEvents::RECURRING_TEACHER_SUB_WILL_EXPIRE : SegmentIo::BackgroundEvents::NON_RECURRING_TEACHER_SUB_WILL_EXPIRE
 
     track({
       user_id: teacher_id,
       event: event,
       properties: {
-        subscription_id: subscription.id
+        subscription_id: subscription_id
       }
     })
   end
 
-  def trigger_school_subscription_will_expire(subscription_id)
+  def track_school_subscription(subscription_id, event)
     subscription = Subscription.find(subscription_id)
     school_id = subscription.schools.first.id
-    event = subscription.recurring ? SegmentIo::BackgroundEvents::RECURRING_SCHOOL_SUB_WILL_EXPIRE : SegmentIo::BackgroundEvents::NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE
 
     if subscription.purchaser_id.present?
       track({

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -151,10 +151,11 @@ class SegmentAnalytics
   def trigger_teacher_subscription_will_expire(subscription_id)
     subscription = Subscription.find(subscription_id)
     teacher_id = subscription.users.first.id
+    event = subscription.recurring ? SegmentIo::BackgroundEvents::RECURRING_TEACHER_SUB_WILL_EXPIRE : SegmentIo::BackgroundEvents::NON_RECURRING_TEACHER_SUB_WILL_EXPIRE
 
     track({
       user_id: teacher_id,
-      event: SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE,
+      event: event,
       properties: {
         subscription_id: subscription.id
       }
@@ -164,12 +165,14 @@ class SegmentAnalytics
   def trigger_school_subscription_will_expire(subscription_id)
     subscription = Subscription.find(subscription_id)
     school_id = subscription.schools.first.id
+    event = subscription.recurring ? SegmentIo::BackgroundEvents::RECURRING_SCHOOL_SUB_WILL_EXPIRE : SegmentIo::BackgroundEvents::NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE
 
     track({
       # Segment requires us to send a unique User ID or Anonymous ID for every event
       # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
       anonymous_id: SecureRandom.uuid,
-      event: SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE,
+      user_id: subscription.purchaser_id,
+      event: event,
       properties: {
         subscription_id: subscription.id,
         school_id: school_id

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -148,6 +148,35 @@ class SegmentAnalytics
 
   end
 
+  def trigger_teacher_subscription_will_expire(subscription_id)
+    subscription = Subscription.find(subscription_id)
+    teacher = subscription.users.first.id
+
+    track({
+      user_id: teacher.id,
+      event: SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE,
+      properties: {
+        subscription_id: subscription.id
+      }
+    })
+  end
+
+  def trigger_school_subscription_will_expire(subscription_id)
+    subscription = Subscription.find(subscription_id)
+    school = subscription.schools.first
+
+    track({
+      # Segment requires us to send a unique User ID or Anonymous ID for every event
+      # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
+      anonymous_id: SecureRandom.uuid,
+      event: SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE,
+      properties: {
+        subscription_id: subscription.id,
+        school_id: school.id
+      }
+    })
+  end
+
   def track(options)
     return unless backend.present?
 

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -148,21 +148,19 @@ class SegmentAnalytics
 
   end
 
-  def track_teacher_subscription(subscription_id, event)
-    subscription = Subscription.find(subscription_id)
+  def track_teacher_subscription(subscription, event)
     teacher_id = subscription.users.first.id
 
     track({
       user_id: teacher_id,
       event: event,
       properties: {
-        subscription_id: subscription_id
+        subscription_id: subscription.id
       }
     })
   end
 
-  def track_school_subscription(subscription_id, event)
-    subscription = Subscription.find(subscription_id)
+  def track_school_subscription(subscription, event)
     school_id = subscription.schools.first.id
 
     if subscription.purchaser_id.present?

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -167,17 +167,27 @@ class SegmentAnalytics
     school_id = subscription.schools.first.id
     event = subscription.recurring ? SegmentIo::BackgroundEvents::RECURRING_SCHOOL_SUB_WILL_EXPIRE : SegmentIo::BackgroundEvents::NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE
 
-    track({
-      # Segment requires us to send a unique User ID or Anonymous ID for every event
-      # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
-      anonymous_id: SecureRandom.uuid,
-      user_id: subscription.purchaser_id,
-      event: event,
-      properties: {
-        subscription_id: subscription.id,
-        school_id: school_id
-      }
-    })
+    if subscription.purchaser_id.present?
+      track({
+        user_id: subscription.purchaser_id,
+        event: event,
+        properties: {
+          subscription_id: subscription.id,
+          school_id: school_id
+        }
+      })
+    else
+      track({
+        # Segment requires us to send a unique User ID or Anonymous ID for every event
+        # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
+        anonymous_id: SecureRandom.uuid,
+        event: event,
+        properties: {
+          subscription_id: subscription.id,
+          school_id: school_id
+        }
+      })
+    end
   end
 
   def track(options)

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -150,10 +150,10 @@ class SegmentAnalytics
 
   def trigger_teacher_subscription_will_expire(subscription_id)
     subscription = Subscription.find(subscription_id)
-    teacher = subscription.users.first.id
+    teacher_id = subscription.users.first.id
 
     track({
-      user_id: teacher.id,
+      user_id: teacher_id,
       event: SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE,
       properties: {
         subscription_id: subscription.id
@@ -163,7 +163,7 @@ class SegmentAnalytics
 
   def trigger_school_subscription_will_expire(subscription_id)
     subscription = Subscription.find(subscription_id)
-    school = subscription.schools.first
+    school_id = subscription.schools.first.id
 
     track({
       # Segment requires us to send a unique User ID or Anonymous ID for every event
@@ -172,7 +172,7 @@ class SegmentAnalytics
       event: SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE,
       properties: {
         subscription_id: subscription.id,
-        school_id: school.id
+        school_id: school_id
       }
     })
   end

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -47,6 +47,8 @@ module SegmentIo
     VIEWED_DEMO = 'User logged into Demo account'
     PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
     TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
+    TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
+    SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal On'
   end
 
   module Events

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -47,8 +47,10 @@ module SegmentIo
     VIEWED_DEMO = 'User logged into Demo account'
     PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
     TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
-    TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
-    SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    RECURRING_TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
+    RECURRING_SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    NON_RECURRING_TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal Off'
+    NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal Off'
   end
 
   module Events

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -47,10 +47,12 @@ module SegmentIo
     VIEWED_DEMO = 'User logged into Demo account'
     PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
     TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
-    RECURRING_TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
-    RECURRING_SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal On'
-    NON_RECURRING_TEACHER_SUB_WILL_EXPIRE = 'Teacher Premium Renews in 30 Days | Automatic Renewal Off'
-    NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE = 'School Premium Renews in 30 Days | Automatic Renewal Off'
+    TEACHER_SUB_WILL_RENEW = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
+    SCHOOL_SUB_WILL_RENEW = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    TEACHER_SUB_WILL_EXPIRE_IN_30 = 'Teacher Premium Expires in 30 Days | Automatic Renewal Off'
+    SCHOOL_SUB_WILL_EXPIRE_IN_30 = 'School Premium Expires in 30 Days | Automatic Renewal Off'
+    TEACHER_SUB_WILL_EXPIRE_IN_14 = 'Teacher Premium Expires in 14 Days | Automatic Renewal Off'
+    SCHOOL_SUB_WILL_EXPIRE_IN_14 = 'School Premium Expires in 14 Days | Automatic Renewal Off'
   end
 
   module Events

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AlertSoonToExpireSubscriptions
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+
+  def perform
+    current_time = Time.current
+
+    expiring_teacher_subs = Subscription.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, recurring: true, expiration: current_time + 30.days)
+    expiring_school_subs = Subscription.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, recurring: true, expiration: current_time + 30.days)
+
+    analytics = SegmentAnalytics.new
+    expiring_teacher_subs.each { |sub| analytics.trigger_teacher_subscription_will_expire(sub.id) }
+    expiring_school_subs.each { |sub| analytics.trigger_school_subscription_will_expire(sub.id) }
+end

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlertSoonToExpireSubscriptions
+class AlertSoonToExpireSubscriptionsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
@@ -13,4 +13,5 @@ class AlertSoonToExpireSubscriptions
     analytics = SegmentAnalytics.new
     expiring_teacher_subs.each { |sub| analytics.trigger_teacher_subscription_will_expire(sub.id) }
     expiring_school_subs.each { |sub| analytics.trigger_school_subscription_will_expire(sub.id) }
+  end
 end

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -16,11 +16,11 @@ class AlertSoonToExpireSubscriptionsWorker
     school_subs_expiring_in_fourteen = Subscription.paid_with_card.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, expiration: current_time + 14.days, recurring: false)
 
     analytics = SegmentAnalytics.new
-    teacher_subs_renewing_in_thirty.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW) }
-    school_subs_renewing_in_thirty.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW) }
-    teacher_subs_expiring_in_thirty.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30) }
-    school_subs_expiring_in_thirty.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30) }
-    teacher_subs_expiring_in_fourteen.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14) }
-    school_subs_expiring_in_fourteen.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14) }
+    teacher_subs_renewing_in_thirty.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW) }
+    school_subs_renewing_in_thirty.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW) }
+    teacher_subs_expiring_in_thirty.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30) }
+    school_subs_expiring_in_thirty.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30) }
+    teacher_subs_expiring_in_fourteen.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14) }
+    school_subs_expiring_in_fourteen.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14) }
   end
 end

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -7,8 +7,8 @@ class AlertSoonToExpireSubscriptionsWorker
   def perform
     current_time = Time.current
 
-    expiring_teacher_subs = Subscription.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, recurring: true, expiration: current_time + 30.days)
-    expiring_school_subs = Subscription.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, recurring: true, expiration: current_time + 30.days)
+    expiring_teacher_subs = Subscription.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, expiration: current_time + 30.days)
+    expiring_school_subs = Subscription.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, expiration: current_time + 30.days)
 
     analytics = SegmentAnalytics.new
     expiring_teacher_subs.each { |sub| analytics.trigger_teacher_subscription_will_expire(sub.id) }

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -7,11 +7,20 @@ class AlertSoonToExpireSubscriptionsWorker
   def perform
     current_time = Time.current
 
-    expiring_teacher_subs = Subscription.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, expiration: current_time + 30.days)
-    expiring_school_subs = Subscription.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, expiration: current_time + 30.days)
+    subs_expiring_in_thirty = Subscription.paid_with_card.where(expiration: current_time + 30.days)
+    teacher_subs_renewing_in_thirty = subs_expiring_in_thirty.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, recurring: true)
+    school_subs_renewing_in_thirty = subs_expiring_in_thirty.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, recurring: true)
+    teacher_subs_expiring_in_thirty = subs_expiring_in_thirty.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, recurring: false)
+    school_subs_expiring_in_thirty = subs_expiring_in_thirty.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, recurring: false)
+    teacher_subs_expiring_in_fourteen = Subscription.paid_with_card.where(account_type: Subscription::OFFICIAL_TEACHER_TYPES, expiration: current_time + 14.days, recurring: false)
+    school_subs_expiring_in_fourteen = Subscription.paid_with_card.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, expiration: current_time + 14.days, recurring: false)
 
     analytics = SegmentAnalytics.new
-    expiring_teacher_subs.each { |sub| analytics.trigger_teacher_subscription_will_expire(sub.id) }
-    expiring_school_subs.each { |sub| analytics.trigger_school_subscription_will_expire(sub.id) }
+    teacher_subs_renewing_in_thirty.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW) }
+    school_subs_renewing_in_thirty.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW) }
+    teacher_subs_expiring_in_thirty.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30) }
+    school_subs_expiring_in_thirty.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30) }
+    teacher_subs_expiring_in_fourteen.each { |sub| analytics.track_teacher_subscription(sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14) }
+    school_subs_expiring_in_fourteen.each { |sub| analytics.track_school_subscription(sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14) }
   end
 end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -73,6 +73,11 @@ describe "Cron", type: :model do
       expect(PreCacheAdminDashboardsWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
+
+    it "enqueues AlertSoonToExpireSubscriptionsWorker" do
+      expect(AlertSoonToExpireSubscriptionsWorker).to receive(:perform_async)
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_saturday" do

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -135,7 +135,7 @@ describe 'SegmentAnalytics' do
 
   end
 
-  context 'trigger teacher subscription will expire' do
+  context 'track teacher subscription' do
     let(:teacher) { create(:teacher) }
     let(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
     let(:other_subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 30.days)}
@@ -143,23 +143,23 @@ describe 'SegmentAnalytics' do
     let!(:other_user_subscription) { create(:user_subscription, user: teacher, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.trigger_teacher_subscription_will_expire(subscription.id)
+      analytics.track_teacher_subscription(subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::RECURRING_TEACHER_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end
 
     it 'sends an event with information about the subscription for non-recurring subscriptions' do
-      analytics.trigger_teacher_subscription_will_expire(other_subscription.id)
+      analytics.track_teacher_subscription(other_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::NON_RECURRING_TEACHER_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(other_subscription.id)
     end
   end
 
-  context 'trigger school subscription will expire' do
+  context 'track school subscription' do
     let(:school) { create(:school) }
     let(:subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
     let(:other_subscription) { create(:subscription, account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 30.days, purchaser_id: 'test')}
@@ -167,24 +167,24 @@ describe 'SegmentAnalytics' do
     let!(:other_school_subscription) { create(:school_subscription, school: school, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.trigger_school_subscription_will_expire(subscription.id)
+      analytics.track_school_subscription(subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::RECURRING_SCHOOL_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end
 
     it 'sends an event with information about the subscription for nonrecurring subscriptions' do
-      analytics.trigger_school_subscription_will_expire(other_subscription.id)
+      analytics.track_school_subscription(other_subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::NON_RECURRING_SCHOOL_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(other_subscription.id)
       expect(track_calls[0][:user_id]).to eq(other_subscription.purchaser_id)
     end
 
     it 'sends an event with anonymous ID if there is no purchaser id' do
-      analytics.trigger_school_subscription_will_expire(subscription.id)
+      analytics.track_school_subscription(subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:user_id]).to eq(nil)
       expect(track_calls[0][:anonymous_id]).to be

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -135,6 +135,34 @@ describe 'SegmentAnalytics' do
 
   end
 
+  context 'trigger teacher subscription will expire' do
+    let(:teacher) { create(:teacher) }
+    let(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 30.days)}
+    let!(:user_subscription) { create(:user_subscription, user: teacher, subscription: subscription)}
+
+    it 'sends an event with information about the subscription' do
+      analytics.trigger_teacher_subscription_will_expire(subscription.id)
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:user_id]).to eq(teacher.id)
+      expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
+    end
+  end
+
+  context 'trigger school subscription will expire' do
+    let(:school) { create(:school) }
+    let(:subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Date.today + 30.days)}
+    let!(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
+
+    it 'sends an event with information about the subscription' do
+      analytics.trigger_school_subscription_will_expire(subscription.id)
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE)
+      expect(track_calls[0][:properties][:school_id]).to eq(school.id)
+      expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
+    end
+  end
+
   context '#track' do
     let(:teacher) { create(:teacher) }
     let(:student) { create(:student) }

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -143,7 +143,7 @@ describe 'SegmentAnalytics' do
     let!(:other_user_subscription) { create(:user_subscription, user: teacher, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_teacher_subscription(subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      analytics.track_teacher_subscription(subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
@@ -151,7 +151,7 @@ describe 'SegmentAnalytics' do
     end
 
     it 'sends an event with information about the subscription for non-recurring subscriptions' do
-      analytics.track_teacher_subscription(other_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      analytics.track_teacher_subscription(other_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
@@ -167,7 +167,7 @@ describe 'SegmentAnalytics' do
     let!(:other_school_subscription) { create(:school_subscription, school: school, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_school_subscription(subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
@@ -175,7 +175,7 @@ describe 'SegmentAnalytics' do
     end
 
     it 'sends an event with information about the subscription for nonrecurring subscriptions' do
-      analytics.track_school_subscription(other_subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      analytics.track_school_subscription(other_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
@@ -184,7 +184,7 @@ describe 'SegmentAnalytics' do
     end
 
     it 'sends an event with anonymous ID if there is no purchaser id' do
-      analytics.track_school_subscription(subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:user_id]).to eq(nil)
       expect(track_calls[0][:anonymous_id]).to be

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -182,6 +182,13 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:subscription_id]).to eq(other_subscription.id)
       expect(track_calls[0][:user_id]).to eq(other_subscription.purchaser_id)
     end
+
+    it 'sends an event with anonymous ID if there is no purchaser id' do
+      analytics.trigger_school_subscription_will_expire(subscription.id)
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:user_id]).to eq(nil)
+      expect(track_calls[0][:anonymous_id]).to be
+    end
   end
 
   context '#track' do

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -137,7 +137,7 @@ describe 'SegmentAnalytics' do
 
   context 'trigger teacher subscription will expire' do
     let(:teacher) { create(:teacher) }
-    let(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 30.days)}
+    let(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
     let!(:user_subscription) { create(:user_subscription, user: teacher, subscription: subscription)}
 
     it 'sends an event with information about the subscription' do
@@ -151,7 +151,7 @@ describe 'SegmentAnalytics' do
 
   context 'trigger school subscription will expire' do
     let(:school) { create(:school) }
-    let(:subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Date.today + 30.days)}
+    let(:subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
     let!(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
 
     it 'sends an event with information about the subscription' do

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -9,8 +9,8 @@ describe AlertSoonToExpireSubscriptionsWorker do
     let(:analytics) { double(:analytics) }
     let!(:user) { create(:user) }
     let(:school) { create(:school)}
-    let!(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 30.days)}
-    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Date.today + 30.days)}
+    let!(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
     let(:user_subscription) { create(:user_subscription, user: user, subscription: subscription)}
     let(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
 
@@ -26,7 +26,7 @@ describe AlertSoonToExpireSubscriptionsWorker do
 
     it 'should not trigger the event for subscriptions that are not recurring' do
       user = create(:user)
-      non_recurring_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: false, expiration: Date.today + 30.days)
+      non_recurring_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 30.days)
       create(:user_subscription, user: user, subscription: non_recurring_subscription)
 
       expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_recurring_subscription.id)
@@ -37,7 +37,7 @@ describe AlertSoonToExpireSubscriptionsWorker do
 
     it 'should not trigger the event for subscriptions that are not expiring in 30 days' do
       user = create(:user)
-      non_expired_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 90.days)
+      non_expired_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 90.days)
       create(:user_subscription, user: user, subscription: non_expired_subscription)
 
       expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_expired_subscription.id)

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AlertSoonToExpireSubscriptionsWorker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:analytics) { double(:analytics) }
+    let!(:user) { create(:user) }
+    let(:school) { create(:school)}
+    let!(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 30.days)}
+    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Date.today + 30.days)}
+    let(:user_subscription) { create(:user_subscription, user: user, subscription: subscription)}
+    let(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
+
+    before do
+      allow(SegmentAnalytics).to receive(:new) { analytics }
+    end
+
+    it 'should trigger the teacher subscription will expire event in segment' do
+      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
+      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
+      subject.perform
+    end
+
+    it 'should not trigger the event for subscriptions that are not recurring' do
+      user = create(:user)
+      non_recurring_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: false, expiration: Date.today + 30.days)
+      create(:user_subscription, user: user, subscription: non_recurring_subscription)
+
+      expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_recurring_subscription.id)
+      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
+      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
+      subject.perform
+    end
+
+    it 'should not trigger the event for subscriptions that are not expiring in 30 days' do
+      user = create(:user)
+      non_expired_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Date.today + 90.days)
+      create(:user_subscription, user: user, subscription: non_expired_subscription)
+
+      expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_expired_subscription.id)
+      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
+      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
+      subject.perform
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -27,12 +27,12 @@ describe AlertSoonToExpireSubscriptionsWorker do
     end
 
     it 'should trigger the teacher subscription will renew event in segment' do
-      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
-      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
-      expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
-      expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
-      expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
-      expect(analytics).to receive(:track_school_subscription).with(expiring_14_school_sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_14_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14)
       subject.perform
     end
 
@@ -41,14 +41,14 @@ describe AlertSoonToExpireSubscriptionsWorker do
       non_expired_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 90.days)
       create(:user_subscription, user: user, subscription: non_expired_subscription)
 
-      expect(analytics).not_to receive(:track_teacher_subscription).with(non_expired_subscription.id)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(non_expired_subscription)
       subject.perform
     end
 
     it 'should not trigger the event for subscriptions that are not paid for with credit card' do
       renewing_teacher_subscription.update(payment_method: 'Invoice')
 
-      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       subject.perform
     end
   end

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -10,7 +10,7 @@ describe AlertSoonToExpireSubscriptionsWorker do
     let!(:user) { create(:user) }
     let(:school) { create(:school)}
     let!(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
-    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 30.days)}
     let(:user_subscription) { create(:user_subscription, user: user, subscription: subscription)}
     let(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
 
@@ -19,17 +19,6 @@ describe AlertSoonToExpireSubscriptionsWorker do
     end
 
     it 'should trigger the teacher subscription will expire event in segment' do
-      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
-      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
-      subject.perform
-    end
-
-    it 'should not trigger the event for subscriptions that are not recurring' do
-      user = create(:user)
-      non_recurring_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 30.days)
-      create(:user_subscription, user: user, subscription: non_recurring_subscription)
-
-      expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_recurring_subscription.id)
       expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
       expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
       subject.perform

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -6,21 +6,33 @@ describe AlertSoonToExpireSubscriptionsWorker do
   subject { described_class.new }
 
   describe '#perform' do
-    let(:analytics) { double(:analytics) }
+    let(:analytics) { double(:analytics).as_null_object }
     let!(:user) { create(:user) }
     let(:school) { create(:school)}
-    let!(:subscription) { create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
-    let!(:another_subscription) { create(:subscription, account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 30.days)}
-    let(:user_subscription) { create(:user_subscription, user: user, subscription: subscription)}
-    let(:school_subscription) { create(:school_subscription, school: school, subscription: subscription)}
+    let!(:renewing_teacher_subscription) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:renewing_school_subscription) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:expiring_30_teacher_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 30.days)}
+    let!(:expiring_30_school_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 30.days)}
+    let!(:expiring_14_teacher_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 14.days)}
+    let!(:expiring_14_school_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 14.days)}
+    let(:user_subscription) { create(:user_subscription, user: user, subscription: renewing_teacher_subscription)}
+    let(:school_subscription) { create(:school_subscription, school: school, subscription: renewing_school_subscription)}
+    let(:user_subscription_2) { create(:user_subscription, user: user, subscription: expiring_30_teacher_subscription)}
+    let(:school_subscription_2) { create(:school_subscription, school: school, subscription: expiring_30_school_subscription)}
+    let(:user_subscription_3) { create(:user_subscription, user: user, subscription: expiring_14_teacher_subscription)}
+    let(:school_subscription_3) { create(:school_subscription, school: school, subscription: expiring_14_school_subscription)}
 
     before do
       allow(SegmentAnalytics).to receive(:new) { analytics }
     end
 
-    it 'should trigger the teacher subscription will expire event in segment' do
-      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
-      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
+    it 'should trigger the teacher subscription will renew event in segment' do
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_14_school_sub.id, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14)
       subject.perform
     end
 
@@ -29,9 +41,14 @@ describe AlertSoonToExpireSubscriptionsWorker do
       non_expired_subscription = create(:subscription, account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 90.days)
       create(:user_subscription, user: user, subscription: non_expired_subscription)
 
-      expect(analytics).not_to receive(:trigger_teacher_subscription_will_expire).with(non_expired_subscription.id)
-      expect(analytics).to receive(:trigger_teacher_subscription_will_expire).with(subscription.id)
-      expect(analytics).to receive(:trigger_school_subscription_will_expire).with(another_subscription.id)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(non_expired_subscription.id)
+      subject.perform
+    end
+
+    it 'should not trigger the event for subscriptions that are not paid for with credit card' do
+      renewing_teacher_subscription.update(payment_method: 'Invoice')
+
+      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription.id, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
       subject.perform
     end
   end

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -17,10 +17,10 @@ describe AlertSoonToExpireSubscriptionsWorker do
     let!(:expiring_14_school_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 14.days)}
     let(:user_subscription) { create(:user_subscription, user: user, subscription: renewing_teacher_subscription)}
     let(:school_subscription) { create(:school_subscription, school: school, subscription: renewing_school_subscription)}
-    let(:user_subscription_2) { create(:user_subscription, user: user, subscription: expiring_30_teacher_subscription)}
-    let(:school_subscription_2) { create(:school_subscription, school: school, subscription: expiring_30_school_subscription)}
-    let(:user_subscription_3) { create(:user_subscription, user: user, subscription: expiring_14_teacher_subscription)}
-    let(:school_subscription_3) { create(:school_subscription, school: school, subscription: expiring_14_school_subscription)}
+    let(:user_subscription_two) { create(:user_subscription, user: user, subscription: expiring_30_teacher_subscription)}
+    let(:school_subscription_two) { create(:school_subscription, school: school, subscription: expiring_30_school_subscription)}
+    let(:user_subscription_three) { create(:user_subscription, user: user, subscription: expiring_14_teacher_subscription)}
+    let(:school_subscription_three) { create(:school_subscription, school: school, subscription: expiring_14_school_subscription)}
 
     before do
       allow(SegmentAnalytics).to receive(:new) { analytics }


### PR DESCRIPTION
## WHAT
Run a nightly worker that checks to find all subscriptions that are 30 days away from expiring and marked as `recurring: true` and send an event to Sentry that alerts the subscription is going to expire. 

## WHY
This is part of the Subscriptions workflow we're trying to set up in Sentry to allow Peter Sharkey to hook up automated emails to our users with upcoming subscription renewals.

## HOW
Create a worker that fetches all subscriptions that will expire in 30 days and triggers Sentry tracking events.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Send-renewal-reminders-to-users-with-a-direct-subscription-automatic-renewal-off-1-9158f5cd10bd44e58bf37bf066e71f20
https://www.notion.so/quill/Send-renewal-reminders-to-users-with-a-direct-subscription-automatic-renewal-on-1-cb39bb9cbd80482b968d3e58cccd920e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
