### PR TITLE
improve speed generate_rulewise_report

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -56,9 +56,11 @@ class RuleFeedbackHistory
     start_filter = start_date ? ["feedback_histories.created_at >= ?", start_date] : []
     end_filter = end_date ? ["feedback_histories.created_at <= ?", end_date] : []
 
-    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true).where(*start_filter).where(*end_filter)
-    # feedback_histories = feedback_histories.where("feedback_histories.created_at >= ?", start_date) if start_date
-    # feedback_histories = feedback_histories.where("feedback_histories.created_at <= ?", end_date) if end_date
+    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true).tap do |query|
+      query.where("feedback_histories.created_at >= ?", start_date) if start_date
+      query.where("feedback_histories.created_at <= ?", end_date) if start_date
+    end
+
     if turk_session_id
       feedback_histories = feedback_histories.joins('LEFT JOIN feedback_sessions ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
       feedback_histories = feedback_histories.joins('LEFT JOIN comprehension_turking_round_activity_sessions ON feedback_sessions.activity_session_uid = comprehension_turking_round_activity_sessions.activity_session_uid')

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -53,9 +53,12 @@ class RuleFeedbackHistory
   end
 
   def self.generate_rulewise_report(rule_uid:, prompt_id:, start_date: nil, end_date: nil, turk_session_id: nil)
-    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true)
-    feedback_histories = feedback_histories.where("feedback_histories.created_at >= ?", start_date) if start_date
-    feedback_histories = feedback_histories.where("feedback_histories.created_at <= ?", end_date) if end_date
+    start_filter = start_date ? ["feedback_histories.created_at >= ?", start_date] : []
+    end_filter = end_date ? ["feedback_histories.created_at <= ?", end_date] : []
+
+    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true).where(*start_filter).where(*end_filter)
+    # feedback_histories = feedback_histories.where("feedback_histories.created_at >= ?", start_date) if start_date
+    # feedback_histories = feedback_histories.where("feedback_histories.created_at <= ?", end_date) if end_date
     if turk_session_id
       feedback_histories = feedback_histories.joins('LEFT JOIN feedback_sessions ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
       feedback_histories = feedback_histories.joins('LEFT JOIN comprehension_turking_round_activity_sessions ON feedback_sessions.activity_session_uid = comprehension_turking_round_activity_sessions.activity_session_uid')

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -48,7 +48,7 @@ class RuleFeedbackHistory
         entry: f_h.entry,
         highlight: f_h.metadata.instance_of?(Hash) ? f_h.metadata['highlight'] : '',
         session_uid: f_h.feedback_session_uid,
-        strength: f_h.feedback_history_ratings.sort_by(&:updated_at).last&.rating
+        strength: f_h.feedback_history_ratings.max_by(&:updated_at)&.rating
     }
   end
 

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -56,16 +56,18 @@ class RuleFeedbackHistory
     start_filter = start_date ? ["feedback_histories.created_at >= ?", start_date] : []
     end_filter = end_date ? ["feedback_histories.created_at <= ?", end_date] : []
 
-    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true).tap do |query|
-      query.where("feedback_histories.created_at >= ?", start_date) if start_date
-      query.where("feedback_histories.created_at <= ?", end_date) if start_date
-    end
+    feedback_histories = FeedbackHistory.where(rule_uid: rule_uid, prompt_id: prompt_id, used: true)
+    .where(start_filter)
+    .where(end_filter)
+
+    #binding.pry
 
     if turk_session_id
       feedback_histories = feedback_histories.joins('LEFT JOIN feedback_sessions ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
       feedback_histories = feedback_histories.joins('LEFT JOIN comprehension_turking_round_activity_sessions ON feedback_sessions.activity_session_uid = comprehension_turking_round_activity_sessions.activity_session_uid')
       feedback_histories = feedback_histories.where("comprehension_turking_round_activity_sessions.turking_round_id = ?", turk_session_id)
     end
+
     response_jsons = []
     feedback_histories.each do |f_h|
       response_jsons.append(feedback_history_to_json(f_h))

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -235,6 +235,7 @@ RSpec.describe RuleFeedbackHistory, type: :model do
       responses = result[so_rule1.uid.to_sym][:responses]
 
       response_ids = responses.map {|r| r[:response_id]}
+
       expect(
         Set[*response_ids] == Set[f_h5.id]
       ).to be true


### PR DESCRIPTION
## WHAT
Increases transaction time of 'strong/weak' grading by evidence admins. 

## WHY
Admins are batch grading many responses in a row, and each response can take ~5s.

## HOW
Address n+1 query when loading FeedbackHistoryRatings associated with a FeedbackHistory. 

The below benchmark takes 48 seconds at baseline, and 3.8 seconds with this patch on staging (both times are much faster in production). 
```
Benchmark.realtime {
RuleFeedbackHistory.generate_rulewise_report(rule_uid: 'c5110479-3350-46ce-a508-5b7947b8ab20', prompt_id: 133, start_date: '2022-04-20T06:00:00.000Z'  ) }

```


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
