### PR TITLE
Fix renew subscription bug involving Teacher Trial

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -388,7 +388,7 @@ class Subscription < ApplicationRecord
   end
 
   def renewal_stripe_price_id
-    return STRIPE_TEACHER_PLAN_PRICE_ID if account_type == TEACHER_PAID
+    return STRIPE_TEACHER_PLAN_PRICE_ID if [TEACHER_PAID, TEACHER_TRIAL].include?(account_type)
     return STRIPE_SCHOOL_PLAN_PRICE_ID if stripe? && account_type == SCHOOL_PAID
   end
 

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -463,7 +463,7 @@ describe Subscription, type: :model do
       context 'trial' do
         let(:account_type) { described_class::TEACHER_TRIAL }
 
-        it { expect(subject).to be nil }
+        it { expect(subject).to eq STRIPE_TEACHER_PLAN_PRICE_ID }
       end
 
       context 'premium credit' do


### PR DESCRIPTION
## WHAT
When a teacher trial subscription expires, the 'Renew Subscription' does not work.  This PR addresses the bug.

## WHY
We want trial users to be able to use the 'Renew Subscription' button after their trial expires.

## HOW
The check for `TEACHER_TRIAL` account types when calculating of `stripe_renewal_price_id`.  

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
