### PR TITLE
test proofreader with screenreader and make necessary changes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -19,7 +19,6 @@ import ProgressBar from './progressBar'
 import WelcomePage from './welcomePage'
 import formatInitialPassage from './formatInitialPassage'
 
-
 import getParameterByName from '../../helpers/getParameterByName';
 import EditCaretPositioning from '../../helpers/EditCaretPositioning'
 import { getActivity } from "../../actions/proofreaderActivities";
@@ -148,6 +147,8 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
 
     constructor(props: any) {
       super(props);
+
+      this.passageContainer = null
 
       const { proofreaderActivities, admin, } = props
 
@@ -467,7 +468,10 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
     }
 
     handleNextClick = () => {
-      this.setState({ showWelcomePage: false }, () => window.scrollTo(0, 0))
+      this.setState({ showWelcomePage: false }, () => {
+        window.scrollTo(0, 0)
+        this.passageContainer && this.passageContainer.focus()
+      })
     }
 
     handleResetClick = () => {
@@ -610,19 +614,19 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const { edits, necessaryEdits, loadingFirebaseSession, showWelcomePage, } = this.state
       const { currentActivity } = proofreaderActivities
 
-      if (loadingFirebaseSession) { return <LoadingSpinner />}
+      if (loadingFirebaseSession) { return <div className="passage-container" ref={this.passageContainer}><LoadingSpinner /></div>}
 
       if (showWelcomePage) { return <WelcomePage onNextClick={this.handleNextClick} /> }
 
-      if (session.error) { return <div>{session.error}</div> }
+      if (session.error) { return <div className="passage-container" ref={this.passageContainer}>{session.error}</div> }
 
-      if (!currentActivity) { return <LoadingSpinner />}
+      if (!currentActivity) { return <div className="passage-container" ref={this.passageContainer}><LoadingSpinner /></div>}
 
       const className = currentActivity.underlineErrorsInProofreader ? 'underline-errors' : ''
       const necessaryEditsLength = necessaryEdits ? necessaryEdits.length : 1
       const meterWidth = edits / necessaryEditsLength * 100
       return (
-        <div className="passage-container">
+        <div className="passage-container" ref={this.passageContainer}>
           <div className="header-section">
             <ProgressBar answeredQuestionCount={edits} percent={meterWidth} questionCount={necessaryEditsLength} />
             <div className="inner-header">
@@ -631,6 +635,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
                 <div>
                   <img alt="Directions icon" src={directionSrc} />
                   <p dangerouslySetInnerHTML={{__html: currentActivity.description || this.defaultInstructions()}} />
+                  <p className="sr-only">Screenreader users: once you have finished reading the passage, use the tab keys to navigate between words and make changes to ones that have errors. {currentActivity.underlineErrorsInProofreader && 'Words that contain errors will be described as underlined.'} Words that you have already changed will be described as bolded. There are {necessaryEditsLength} errors to find and fix. When you are done, navigate to the "Get Feedback" button after the passage and select it.</p>
                 </div>
               </div>
             </div>

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -614,13 +614,11 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       const { edits, necessaryEdits, loadingFirebaseSession, showWelcomePage, } = this.state
       const { currentActivity } = proofreaderActivities
 
-      if (loadingFirebaseSession) { return <div className="passage-container" ref={this.passageContainer}><LoadingSpinner /></div>}
-
       if (showWelcomePage) { return <WelcomePage onNextClick={this.handleNextClick} /> }
 
-      if (session.error) { return <div className="passage-container" ref={this.passageContainer}>{session.error}</div> }
+      if (loadingFirebaseSession || !currentActivity) { return <div className="passage-container" ref={this.passageContainer}><LoadingSpinner /></div>}
 
-      if (!currentActivity) { return <div className="passage-container" ref={this.passageContainer}><LoadingSpinner /></div>}
+      if (session.error) { return <div className="passage-container" ref={this.passageContainer}>{session.error}</div> }
 
       const className = currentActivity.underlineErrorsInProofreader ? 'underline-errors' : ''
       const necessaryEditsLength = necessaryEdits ? necessaryEdits.length : 1

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/earlySubmitModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/earlySubmitModal.tsx
@@ -13,7 +13,7 @@ export default class EarlySubmitModal extends React.Component<EarlySubmitModalPr
   render() {
     const { requiredEditCount, closeModal, } = this.props
     return (
-      <div className="early-submit-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
+      <div aria-live="polite" className="early-submit-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
         <div className="early-submit-modal-background" />
         <div className="early-submit-modal">
           <div className="top-section">

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/edit.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/edit.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Concept } from '../../interfaces/concepts'
+import EditTooltip from './editTooltip'
 
 import {
   UNNECESSARY_SPACE,
@@ -10,10 +10,7 @@ import {
   SINGLE_UNNECESSARY_ADDITION,
   UNNECESSARY_CHANGE
 } from '../../helpers/determineUnnecessaryEditType'
-
-const notNecessaryIconSrc = `${process.env.CDN_URL}/images/icons/review-not-necessary.svg`
-const incorrectIconSrc = `${process.env.CDN_URL}/images/icons/review-incorrect.svg`
-const correctIconSrc = `${process.env.CDN_URL}/images/icons/review-correct.svg`
+import { Concept } from '../../interfaces/concepts'
 
 interface EditProps {
   displayText: string;
@@ -57,114 +54,23 @@ export default class Edit extends React.Component<EditProps, {mounting: boolean,
 
   handleComponentBeingMounted = () => this.setState({ mounting: false, })
 
-  renderConceptExplanation(): JSX.Element {
-    const { concept } = this.props
-    if (!(concept && concept.explanation)) { return <span /> }
-    return (
-      <div className="explanation">
-        <p className="label">Explanation</p>
-        <p dangerouslySetInnerHTML={{ __html: concept.explanation }} />
-      </div>
-    )
-  }
-
-  renderCorrectAnswers() {
-    const { displayText } = this.props
-    if (!displayText) { return }
-
-    const correctAnswerArray = displayText ? displayText.split('~') : []
-    const correctAnswers = correctAnswerArray.map(ca => <span className="correct-answer" key={ca}>{ca}</span>)
-    const correctAnswerHTML = <p>{correctAnswers}</p>
-    return (
-      <div>
-        <p className="label">Correct</p>
-        {correctAnswerHTML}
-      </div>
-    )
-  }
-
-  renderNotNecessaryExplanation() {
-    const { state, } = this.props
-    const unnecessaryArray = [UNNECESSARY_SPACE, MULTIPLE_UNNECESSARY_DELETION, SINGLE_UNNECESSARY_DELETION, MULTIPLE_UNNECESSARY_ADDITION, SINGLE_UNNECESSARY_ADDITION, UNNECESSARY_CHANGE]
-    if (!unnecessaryArray.includes(state)) { return }
-    let explanation
-
-    switch (state) {
-      case UNNECESSARY_SPACE:
-        explanation = 'You added an unnecessary space.'
-        break
-      case MULTIPLE_UNNECESSARY_DELETION:
-        explanation = "You took out words that weren't part of an error."
-        break
-      case SINGLE_UNNECESSARY_DELETION:
-        explanation = "You took out a word that wasn't part of an error."
-        break
-      case MULTIPLE_UNNECESSARY_ADDITION:
-        explanation = "You added unnecessary words."
-        break
-      case SINGLE_UNNECESSARY_ADDITION:
-        explanation = "You added an unnecessary word."
-        break
-      case SINGLE_UNNECESSARY_ADDITION:
-        explanation = "You added an unnecessary word."
-        break
-      case UNNECESSARY_CHANGE:
-        explanation = 'You made an unnecessary change.'
-        break
-    }
-
-    return <p className="unnecessary-explanation">{explanation}</p>
-  }
-
   renderTooltip() {
     const { mounting, tooltipHeight, } = this.state
-    const { activeIndex, index, state, numberOfEdits, next, back, id, } = this.props
+    const { activeIndex, index, state, numberOfEdits, next, back, id, displayText, incorrectText, } = this.props
     if (mounting || activeIndex !== index) { return }
 
-    let src, headerText, altText
-    switch (state) {
-      case 'correct':
-        src = correctIconSrc
-        altText = "Correct icon"
-        headerText = "Correct"
-        break
-      case 'incorrect':
-        src = incorrectIconSrc
-        altText = "Incorrect icon"
-        headerText = "Incorrect"
-        break
-      case UNNECESSARY_SPACE:
-      case MULTIPLE_UNNECESSARY_DELETION:
-      case SINGLE_UNNECESSARY_DELETION:
-      case MULTIPLE_UNNECESSARY_ADDITION:
-      case SINGLE_UNNECESSARY_ADDITION:
-      case UNNECESSARY_CHANGE:
-        src = notNecessaryIconSrc
-        altText = "Not necessary icon"
-        headerText = "Not necessary"
-        break
-    }
-    const parentElement = document.getElementById(id)
-    const style = parentElement ? { top: `${parentElement.offsetTop + 5}px`, height: tooltipHeight } : {}
-    const backButton = back ? <button className="quill-button medium secondary outlined focus-on-light" onClick={back} type="button">Back</button> : <div className="placeholder" />
-    const nextButton = <button className="quill-button medium primary contained focus-on-light" onClick={next} type="button">{index + 1 === numberOfEdits ? 'Done' : 'Next'}</button>
     return (
-      <div className="edit-tooltip" style={style}>
-        <div className="top-section">
-          <img alt={altText} src={src} />
-          <h2>{headerText}</h2>
-        </div>
-        <div className="middle-section">
-          {this.renderNotNecessaryExplanation()}
-          {this.renderCorrectAnswers()}
-          {this.renderConceptExplanation()}
-        </div>
-        <div className="button-section">
-          {backButton}
-          <div className="counter">{index + 1} of {numberOfEdits}</div>
-          {nextButton}
-        </div>
-      </div>
+      <EditTooltip
+        back={back}
+        displayText={displayText}
+        id={id}
+        incorrectText={incorrectText}
+        index={index}
+        next={next}
+        numberOfEdits={numberOfEdits}
+        state={state}
+        tooltipHeight={tooltipHeight}
+      />
     )
   }
 

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
@@ -3,7 +3,7 @@ import ContentEditable from 'react-contenteditable';
 
 import { WordObject } from '../../interfaces/proofreaderActivities'
 
-type EditInputProps = WordObject & { onWordChange: Function, numberOfResets: number, isFollowedByPunctuation: boolean }
+type EditInputProps = WordObject & { onWordChange: Function, numberOfResets: number, isFollowedByPunctuation: boolean, underlineErrors: boolean }
 
 export default class EditInput extends React.Component<EditInputProps, {}> {
   handleWordChange = (e: any) => {
@@ -15,29 +15,39 @@ export default class EditInput extends React.Component<EditInputProps, {}> {
   setEditInputRef = node => this.editInput = node
 
   render() {
-    const { currentText, originalText, underlined, wordIndex, paragraphIndex, numberOfResets, isFollowedByPunctuation, } = this.props
+    const { currentText, originalText, underlined, wordIndex, paragraphIndex, numberOfResets, isFollowedByPunctuation, underlineErrors} = this.props
+    const beforeElements = []
+    const afterElements = []
     let className = 'edit-input'
-    if (underlined ) {
+    if (underlined && underlineErrors) {
       className += ' underlined'
+      beforeElements.push(<span className="sr-only" tabIndex={0}>(underlined text begins here)</span>)
+      afterElements.push(<span className="sr-only" tabIndex={0}>(underlined text ends here)</span>)
     }
     if (isFollowedByPunctuation) {
       className += ' no-right-margin'
     }
     if (currentText.trim() !== originalText) {
       className += ' bolded'
+      beforeElements.push(<span className="sr-only" tabIndex={0}>(bolded text begins here)</span>)
+      afterElements.push(<span className="sr-only" tabIndex={0}>(bolded text ends here)</span>)
     }
     const key = `${paragraphIndex}-${wordIndex}-${numberOfResets}`
     return (
-      <ContentEditable
-        className={className}
-        data-gramm={false}
-        html={currentText}
-        innerRef={this.setEditInputRef}
-        key={key}
-        onChange={this.handleWordChange}
-        spellCheck={false}
-        tagName="span"
-      />
+      <React.Fragment>
+        {beforeElements}
+        <ContentEditable
+          className={className}
+          data-gramm={false}
+          html={currentText}
+          innerRef={this.setEditInputRef}
+          key={key}
+          onChange={this.handleWordChange}
+          spellCheck={false}
+          tagName="span"
+        />
+        {afterElements}
+      </React.Fragment>
     )
   }
 }

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
@@ -21,16 +21,22 @@ export default class EditInput extends React.Component<EditInputProps, {}> {
     let className = 'edit-input'
     if (underlined && underlineErrors) {
       className += ' underlined'
+      // disabling tabIndex rule because this is a non-standard use case - since screenreader users will likely be using tab keys to navigate the passage, it is important that this information is discoverable in that mode
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
       beforeElements.push(<span className="sr-only" tabIndex={0}>(underlined text begins here)</span>)
       afterElements.push(<span className="sr-only" tabIndex={0}>(underlined text ends here)</span>)
+      /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
     }
     if (isFollowedByPunctuation) {
       className += ' no-right-margin'
     }
     if (currentText.trim() !== originalText) {
       className += ' bolded'
+      // disabling tabIndex rule because this is a non-standard use case - since screenreader users will likely be using tab keys to navigate the passage, it is important that this information is discoverable in that mode
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
       beforeElements.push(<span className="sr-only" tabIndex={0}>(bolded text begins here)</span>)
       afterElements.push(<span className="sr-only" tabIndex={0}>(bolded text ends here)</span>)
+      /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
     }
     const key = `${paragraphIndex}-${wordIndex}-${numberOfResets}`
     return (

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+
+import {
+  UNNECESSARY_SPACE,
+  MULTIPLE_UNNECESSARY_DELETION,
+  SINGLE_UNNECESSARY_DELETION,
+  MULTIPLE_UNNECESSARY_ADDITION,
+  SINGLE_UNNECESSARY_ADDITION,
+  UNNECESSARY_CHANGE
+} from '../../helpers/determineUnnecessaryEditType'
+import useFocus from '../../../Shared/hooks/useFocus'
+
+const notNecessaryIconSrc = `${process.env.CDN_URL}/images/icons/review-not-necessary.svg`
+const incorrectIconSrc = `${process.env.CDN_URL}/images/icons/review-incorrect.svg`
+const correctIconSrc = `${process.env.CDN_URL}/images/icons/review-correct.svg`
+
+const renderConceptExplanation = (concept) => {
+  if (!(concept && concept.explanation)) { return <span /> }
+  return (
+    <div className="explanation">
+      <p className="label">Explanation</p>
+      <p dangerouslySetInnerHTML={{ __html: concept.explanation }} />
+    </div>
+  )
+}
+
+const renderCorrectAnswers = (displayText) => {
+  if (!displayText) { return }
+
+  const correctAnswerArray = displayText ? displayText.split('~') : []
+  const correctAnswers = correctAnswerArray.map(ca => <span className="correct-answer" key={ca}>{ca}</span>)
+  const correctAnswerHTML = <p>{correctAnswers}</p>
+  return (
+    <div aria-hidden={true}>
+      <p className="label">Correct</p>
+      {correctAnswerHTML}
+    </div>
+  )
+}
+
+const renderNotNecessaryExplanation = (state) => {
+  const unnecessaryArray = [UNNECESSARY_SPACE, MULTIPLE_UNNECESSARY_DELETION, SINGLE_UNNECESSARY_DELETION, MULTIPLE_UNNECESSARY_ADDITION, SINGLE_UNNECESSARY_ADDITION, UNNECESSARY_CHANGE]
+  if (!unnecessaryArray.includes(state)) { return }
+  let explanation
+
+  switch (state) {
+    case UNNECESSARY_SPACE:
+      explanation = 'You added an unnecessary space.'
+      break
+    case MULTIPLE_UNNECESSARY_DELETION:
+      explanation = "You took out words that weren't part of an error."
+      break
+    case SINGLE_UNNECESSARY_DELETION:
+      explanation = "You took out a word that wasn't part of an error."
+      break
+    case MULTIPLE_UNNECESSARY_ADDITION:
+      explanation = "You added unnecessary words."
+      break
+    case SINGLE_UNNECESSARY_ADDITION:
+      explanation = "You added an unnecessary word."
+      break
+    case SINGLE_UNNECESSARY_ADDITION:
+      explanation = "You added an unnecessary word."
+      break
+    case UNNECESSARY_CHANGE:
+      explanation = 'You made an unnecessary change.'
+      break
+  }
+
+  return <p className="unnecessary-explanation">{explanation}</p>
+}
+
+
+const EditTooltip = ({ state, id, tooltipHeight, back, numberOfEdits, next, index, displayText, concept, incorrectText, }) => {
+  const [containerRef, setContainerFocus] = useFocus()
+
+  React.useEffect(() => {
+    setContainerFocus()
+  }, [])
+
+  let src, headerText, altText
+  switch (state) {
+    case 'correct':
+      src = correctIconSrc
+      headerText = "Correct"
+      break
+    case 'incorrect':
+      src = incorrectIconSrc
+      headerText = "Incorrect"
+      break
+    case UNNECESSARY_SPACE:
+    case MULTIPLE_UNNECESSARY_DELETION:
+    case SINGLE_UNNECESSARY_DELETION:
+    case MULTIPLE_UNNECESSARY_ADDITION:
+    case SINGLE_UNNECESSARY_ADDITION:
+    case UNNECESSARY_CHANGE:
+      src = notNecessaryIconSrc
+      headerText = "Not necessary"
+      break
+  }
+  const parentElement = document.getElementById(id)
+  const style = parentElement ? { top: `${parentElement.offsetTop + 5}px`, height: tooltipHeight } : {}
+  const backButton = back ? <button className="quill-button medium secondary outlined focus-on-light" onClick={back} type="button">Back</button> : <div className="placeholder" />
+  const nextButton = <button className="quill-button medium primary contained focus-on-light" onClick={next} type="button">{index + 1 === numberOfEdits ? 'Done' : 'Next'}</button>
+  return (
+    <div aria-live="polite" className="edit-tooltip" ref={containerRef} style={style} tabIndex={-1}>
+      <div className="top-section">
+        <img alt="" src={src} />
+        <h2>{headerText}</h2>
+      </div>
+      <div className="middle-section">
+        {renderNotNecessaryExplanation(state)}
+        <p className="sr-only">The correct text was {displayText}. {incorrectText && `You submitted ${incorrectText === ' ' ? 'An empty space.' : incorrectText}.`}</p>
+        {renderCorrectAnswers(displayText)}å
+        {renderConceptExplanation(concept)}
+      </div>
+      <div className="button-section">
+        {backButton}
+        <div className="counter">{index + 1} of {numberOfEdits}</div>
+        {nextButton}
+      </div>
+    </div>
+  )
+
+}
+
+export default EditTooltip

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
@@ -78,7 +78,7 @@ const EditTooltip = ({ state, id, tooltipHeight, back, numberOfEdits, next, inde
     setContainerFocus()
   }, [])
 
-  let src, headerText, altText
+  let src, headerText
   switch (state) {
     case 'correct':
       src = correctIconSrc

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/followupModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/followupModal.tsx
@@ -13,7 +13,7 @@ export default class FollowupModal extends React.Component<FollowupModalProps> {
   render() {
     const { goToLMS, goToFollowupPractice, } = this.props
     return (
-      <div className="followup-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
+      <div aria-live="polite" className="followup-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
         <div className="followup-modal-background" />
         <div className="followup-modal">
           <div className="top-section">

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/paragraph.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/paragraph.tsx
@@ -44,6 +44,7 @@ export default class Paragraph extends React.Component<ParagraphProps, {}> {
           isFollowedByPunctuation={!!isFollowedByPunctuation}
           numberOfResets={numberOfResets}
           onWordChange={this.handleWordChange}
+          underlineErrors={underlineErrors}
         />
       )})
     return <div className={className}>{inputs}</div>

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/resetModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/resetModal.tsx
@@ -13,7 +13,7 @@ export default class ResetModal extends React.Component<ResetModalProps> {
   render() {
     const { reset, closeModal, } = this.props
     return (
-      <div className="reset-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
+      <div aria-live="polite" className="reset-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
         <div className="reset-modal-background" />
         <div className="reset-modal">
           <div className="top-section">

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/reviewModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/reviewModal.tsx
@@ -15,7 +15,7 @@ export default class ReviewModal extends React.Component<ReviewModalProps> {
     const { closeModal, numberOfErrors, numberOfCorrectChanges, } = this.props
     const highScoreMessage = numberOfCorrectChanges > numberOfErrors / 2 ? "Good work! " : null
     return (
-      <div className="review-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
+      <div aria-live="polite" className="review-modal-container" ref={(node) => this.modal = node} tabIndex={-1}>
         <div className="review-modal-background" />
         <div className="review-modal">
           <div className="top-section">


### PR DESCRIPTION
## WHAT
Update Proofreader to make it more screenreader-friendly.

## WHY
Now that we've conducted part one of the accessibility audit, I feel better equipped to test screenreaders myself, so I tried to apply that knowledge to taking another pass at Proofreader and seeing what could be improved.

## HOW
- Make sure focus goes where it's supposed to
- Add some sr-only elements to clarify what sighted users can get from visual context

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Take-another-pass-at-using-a-screenreader-to-navigate-Proofreader-0fabcb33dac04977bcfb3cc413c3aa5d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
