### PR TITLE
Fix bug with setup_intent.succeeded

### DIFF
--- a/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
@@ -7,7 +7,7 @@ module StripeIntegration
         'customer.subscription.deleted' => CustomerSubscriptionDeletedEventHandler,
         'customer.subscription.updated' => CustomerSubscriptionUpdatedEventHandler,
         'invoice.paid' => InvoicePaidEventHandler,
-        'setup_intent.suceeded' => SetupIntentSucceededEventHandler
+        'setup_intent.succeeded' => SetupIntentSucceededEventHandler
       }
 
       EVENT_HANDLER_LOOKUP = SINGLE_EVENT_HANDLER_LOOKUP.merge(IgnoredEventHandler::EVENT_HANDLER_LOOKUP)

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -36,8 +36,7 @@ module StripeIntegration
         'payout.created',
         'payout.paid',
         'product.updated',
-        'setup_intent.created',
-        'setup_intent.succeeded'
+        'setup_intent.created'
       ]
 
       EVENT_HANDLER_LOOKUP = IGNORED_EVENT_NAMES.to_h { |event_name| [event_name, self] }

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler.rb
@@ -6,9 +6,8 @@ module StripeIntegration
       PUSHER_EVENT = 'stripe-subscription-payment-method-updated'
 
       def run
-        Stripe::Subscription.update(stripe_subscription_id, default_payment_method: stripe_payment_method_id)
+        update_default_payment_method
         stripe_webhook_event.processed!
-        PusherTrigger.run(stripe_subscription_id, PUSHER_EVENT, PUSHER_EVENT.titleize)
       rescue => e
         stripe_webhook_event.log_error(e)
       end
@@ -23,6 +22,13 @@ module StripeIntegration
 
       private def stripe_subscription_id
         stripe_setup_intent&.metadata&.subscription_id
+      end
+
+      private def update_default_payment_method
+        return if stripe_subscription_id.nil?
+
+        Stripe::Subscription.update(stripe_subscription_id, default_payment_method: stripe_payment_method_id)
+        PusherTrigger.run(stripe_subscription_id, PUSHER_EVENT, PUSHER_EVENT.titleize)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3213814254/?project=11238&referrer=slack) with the handling of the Stripe webhook event `setup_intent.succeeded`

## WHY
We would like webhook events to be handled properly.

## HOW
In some cases, the metadata value for the `setup_intent.succeeded` has no `stripe_subscription_id`.  In these cases, we should not try to attempt updating the payment method on a subscription.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
