### PR TITLE
Redirect editing of stripe subscriptions in CMS to stripe dashboard

### DIFF
--- a/services/QuillLMS/.env-sample
+++ b/services/QuillLMS/.env-sample
@@ -38,5 +38,8 @@ AUTOML_GOOGLE_PROJECT_ID=
 AUTOML_GOOGLE_LOCATION=
 OPINION_API_DOMAIN=https://opinion-api.quill.org
 GRAMMAR_API_DOMAIN=https://quill.spell.services/Quill/grammar/predict
+
+# STRIPE
+STRIPE_DASHBOARD_URL=https://dashboard.stripe.com/test
 STRIPE_TEACHER_PLAN_PRICE_ID=price_c6db530b0679007c64776a7d28faf1af
 STRIPE_SCHOOL_PLAN_PRICE_ID=price_2fe54c83fca05311a84a7ef5ab365e65

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -4,13 +4,8 @@ class Cms::SchoolsController < Cms::CmsController
   before_action :signed_in!
 
   before_action :text_search_inputs, only: [:index, :search]
-  before_action :set_school, only: [
-    :new_subscription,
-    :edit_subscription,
-    :show,
-    :complete_sales_stage,
-  ]
-  before_action :subscription_data, only: [:new_subscription, :edit_subscription]
+  before_action :set_school, only: [:new_subscription, :show, :complete_sales_stage]
+  before_action :subscription_data, only: [:new_subscription]
 
   SCHOOLS_PER_PAGE = 30.0
 
@@ -75,10 +70,6 @@ class Cms::SchoolsController < Cms::CmsController
     else
       render :edit
     end
-  end
-
-  def edit_subscription
-    @subscription = @school&.subscription
   end
 
   def new_subscription

--- a/services/QuillLMS/app/controllers/cms/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/subscriptions_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class Cms::SubscriptionsController < Cms::CmsController
-  before_action :set_subscription, except: [:index, :create]
+  before_action :set_subscription, only: %i[show edit update destroy]
   before_action :subscription_data, only: [:edit]
-
 
   def show
   end
@@ -19,11 +18,10 @@ class Cms::SubscriptionsController < Cms::CmsController
   end
 
   def edit
-    # everything set in erb file
+    @subscription.stripe? ? redirect_to(@subscription.stripe_subscription_url) : render(:edit)
   end
 
   def update
-    @subscription = Subscription.find(params[:id])
     @subscription.update(subscription_params)
     render json: @subscription.reload
   end

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -3,9 +3,9 @@
 class Cms::UsersController < Cms::CmsController
   before_action :signed_in!
   before_action :set_flags
-  before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :edit_subscription, :new_subscription, :complete_sales_stage]
+  before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :new_subscription, :complete_sales_stage]
   before_action :set_search_inputs, only: [:index, :search]
-  before_action :subscription_data, only: [:new_subscription, :edit_subscription]
+  before_action :subscription_data, only: [:new_subscription]
   before_action :filter_zeroes_from_checkboxes, only: [:update, :create, :create_with_school]
   before_action :log_non_user_action, only: [:index]
   before_action :log_user_action, only: [:show, :edit, :sign_in]
@@ -89,10 +89,6 @@ class Cms::UsersController < Cms::CmsController
   end
 
   def edit
-  end
-
-  def edit_subscription
-    @subscription = @user.subscription
   end
 
   def new_subscription

--- a/services/QuillLMS/app/models/stripe_integration/subscription.rb
+++ b/services/QuillLMS/app/models/stripe_integration/subscription.rb
@@ -22,6 +22,10 @@ module StripeIntegration
       stripe_invoice.subscription
     end
 
+    def stripe_subscription_url
+      "#{STRIPE_DASHBOARD_URL}/subscriptions/#{stripe_subscription_id}"
+    end
+
     private def stripe_card
       stripe_payment_method || stripe_source
     end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -112,7 +112,8 @@ class Subscription < ApplicationRecord
 
   validates :stripe_invoice_id, allow_blank: true, stripe_uid: { prefix: :in }
 
-  delegate :stripe_cancel_at_period_end, :last_four, :stripe_subscription_id, to: :stripe_subscription
+  delegate :stripe_cancel_at_period_end, :last_four, :stripe_subscription_id, :stripe_subscription_url,
+    to: :stripe_subscription
 
   scope :active, -> { not_expired.not_de_activated.order(expiration: :asc) }
   scope :expired, -> { where('expiration <= ?', Date.current) }
@@ -396,7 +397,6 @@ class Subscription < ApplicationRecord
     StripeIntegration::Subscription.new(self)
   end
 
-
   def renewal_stripe_price_id
     return STRIPE_TEACHER_PLAN_PRICE_ID if [TEACHER_PAID, TEACHER_TRIAL].include?(account_type)
     return STRIPE_SCHOOL_PLAN_PRICE_ID if stripe? && account_type == SCHOOL_PAID
@@ -404,9 +404,5 @@ class Subscription < ApplicationRecord
 
   def stripe?
     stripe_invoice_id.present?
-  end
-
-  private def stripe_subscription_id
-    stripe_subscription.stripe_subscription_id
   end
 end

--- a/services/QuillLMS/app/views/cms/schools/show.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/show.html.erb
@@ -51,9 +51,13 @@
     <br /><br />
     <h2>School Subscription</h2>
     <br />
-    <%if @subscription%>
-      <%= link_to 'Edit Subscription', edit_subscription_cms_school_path(params[:id]), class: 'btn button-green' %>
-    <%end%>
+    <% if @subscription %>
+      <% if @subscription.stripe? %>
+        <%= link_to 'Edit Subscription', edit_cms_subscription_path(@subscription), class: 'btn button-green' %>
+      <% else %>
+        <%= link_to 'View in Stripe', edit_cms_subscription_path(@subscription), class: 'btn button-green', target: '_blank' %>
+      <% end %>
+    <% end %>
     <%= link_to 'New Subscription', new_subscription_cms_school_path(params[:id]), class: 'btn button-green' %>
     <br />
     <% @school_subscription_info.each do |k,v| %>

--- a/services/QuillLMS/app/views/cms/subscriptions/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/subscriptions/edit.html.erb
@@ -1,4 +1,9 @@
 <div class='container'>
-  <%= react_component('SubscriptionApp', props: {view: 'edit', school: @school || nil, subscription: @subscription, premiumTypes: @premium_types,
-  subscriptionPaymentMethods: @subscription_payment_methods })%>
+  <%= react_component('SubscriptionApp', props: {
+    view: 'edit',
+    school: @school || nil,
+    subscription: @subscription,
+    premiumTypes: @premium_types,
+    subscriptionPaymentMethods: @subscription_payment_methods }
+  )%>
 </div>

--- a/services/QuillLMS/app/views/cms/users/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/users/edit.html.erb
@@ -4,15 +4,17 @@
     <br /><br />
     <h2>Edit: <%= @user.name %></h2>
     <br />
-    <% if @subscription %>
-      <%= link_to 'Edit Subscription', edit_subscription_cms_user_path(params[:id]), class: 'btn button-green' %>
-    <% end %>
     <%= link_to 'Create Subscription', "/cms/users/#{params[:id]}/new_subscription", class: 'btn button-green' %>
     <br /><br />
     <% if @user.subscriptions.any? %>
-           <% puts @user.credit_transactions.map {|x| x.serializable_hash(methods: :action)}.compact %>
-      <%= react_component('SubscriptionApp', props: {view: 'subscriptionHistory', subscriptions: @user.subscriptions,
-                           premiumCredits: @user.credit_transactions, authorityLevel: 'purchaser' }) %>
+      <%= react_component('SubscriptionApp', props: {
+            view: 'subscriptionHistory',
+            subscriptions: @user.subscriptions,
+            premiumCredits: @user.credit_transactions,
+            authorityLevel: 'purchaser'
+          }
+        )
+      %>
     <% end %>
     <%= render "form" %>
   </article>

--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -94,7 +94,6 @@
 
     <% if @user.role == 'teacher' %>
     <% if @user.subscriptions.any? %>
-      <% puts @user.credit_transactions.map {|x|     x.serializable_hash(methods: :action)}.compact %>
       <%= react_component('SubscriptionApp', props: {view: 'subscriptionHistory', subscriptions: @user.subscriptions, premiumCredits: @user.credit_transactions, authorityLevel: 'purchaser' }) %>
     <% end %>
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
@@ -73,21 +73,28 @@ export default class SubscriptionHistory extends React.Component {
             tooltipTriggerText={<span><img alt={helpIcon.alt} className="subscription-tooltip" src={helpIcon.src} /></span>}
           />
         </span>
-      );
+      )
+
       const tds = [
         <td key={`${sub.id}-1-row`}>{moment(sub.created_at).format('MMMM Do, YYYY')}</td>,
         <td key={`${sub.id}-2-row`}>{subscriptionTypeContent}</td>,
         <td key={`${sub.id}-3-row`}>{this.paymentContent(sub)}</td>,
         <td key={`${sub.id}-4-row`}>{`${duration} ${pluralize('month', duration)}`}</td>,
         <td key={`${sub.id}-5-row`}>{`${startD.format('MM/DD/YY')} - ${endD.format('MM/DD/YY')}`}</td>
-      ];
+      ]
+
       if (view === 'subscriptionHistory') {
-        tds.push(<td key={`${sub.id}-6-row`}><a href={`${process.env.DEFAULT_URL}/cms/subscriptions/${sub.id}/edit`}>Edit Subscription</a></td>);
+        const href = `${process.env.DEFAULT_URL}/cms/subscriptions/${sub.id}/edit`
+        const key = `${sub.id}-6-row`
+
+        if (sub.stripe_invoice_id) {
+          tds.push(<td key={key}><a href={href} rel='noopener noreferrer' target='_blank'>View in Stripe</a></td>)
+        } else {
+          tds.push(<td key={key}><a href={href}>Edit Subscription</a></td>)
+        }
       }
-      rows.push(
-        <tr key={`${sub.id}-subscription-table`}>{tds}</tr>
-      );
-    });
+      rows.push(<tr key={`${sub.id}-subscription-table`}>{tds}</tr>)
+    })
     return rows;
   }
 
@@ -96,7 +103,7 @@ export default class SubscriptionHistory extends React.Component {
 
     const tableHeaders = ['Purchase Date', 'Subscription', 'Payment', 'Length', 'Start & End Date'];
     if (view === 'subscriptionHistory') {
-      tableHeaders.push('Edit Link');
+      tableHeaders.push('Link');
     }
     return tableHeaders.map((content, i) => <th key={`${i}-table-header`}>{content}</th>);
   }

--- a/services/QuillLMS/config/initializers/stripe.rb
+++ b/services/QuillLMS/config/initializers/stripe.rb
@@ -7,5 +7,6 @@ Rails.configuration.stripe = {
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]
 
+STRIPE_DASHBOARD_URL = ENV.fetch('STRIPE_DASHBOARD_URL', nil)
 STRIPE_SCHOOL_PLAN_PRICE_ID = ENV.fetch('STRIPE_SCHOOL_PLAN_PRICE_ID', nil)
 STRIPE_TEACHER_PLAN_PRICE_ID = ENV.fetch('STRIPE_TEACHER_PLAN_PRICE_ID', nil)

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -584,7 +584,6 @@ EmpiricalGrammar::Application.routes.draw do
         put :sign_in
         put :clear_data
         get :sign_in
-        get :edit_subscription
         get :new_subscription
         post :complete_sales_stage
       end
@@ -598,7 +597,6 @@ EmpiricalGrammar::Application.routes.draw do
         get :search, to: 'schools#index'
       end
       member do
-        get :edit_subscription
         get :new_subscription
         get :new_admin
         get :add_existing_user

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -106,15 +106,6 @@ describe Cms::SchoolsController do
     end
   end
 
-  describe '#edit_subscription' do
-    let!(:school) { create(:school) }
-
-    it 'should assing the subscription' do
-      get :edit_subscription, params: { id: school.id }
-      expect(assigns(:subscription)).to eq school.subscription
-    end
-  end
-
   describe '#create' do
     it 'should create the school with the given params' do
       post :create, params: { school: {

--- a/services/QuillLMS/spec/controllers/cms/subscription_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/subscription_controller_spec.rb
@@ -45,6 +45,34 @@ describe Cms::SubscriptionsController do
     end
   end
 
+  describe '#edit' do
+    context 'stripe' do
+      let(:subscription) { create(:subscription, :stripe) }
+      let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}"}
+      let(:stripe_invoice_id) { subscription.stripe_invoice_id }
+      let(:stripe_invoice) { double(:stripe_invoice, subscription: stripe_subscription_id) }
+
+      before do
+        allow(Stripe::Invoice).to receive(:retrieve).with(stripe_invoice_id).and_return(stripe_invoice)
+        stub_request(:get, %r{https://api.stripe.com/v1/}).to_return(status: :found)
+      end
+
+      it 'redirects to the stripe dashboard' do
+        get :edit, params: { id: subscription.id }
+        expect(response).to have_http_status :found
+      end
+    end
+
+    context 'non stripe' do
+      let(:subscription) { create(:subscription) }
+
+      it 'redirects to the subscription edit view' do
+        get :edit, params: { id: subscription.id }
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+
   describe '#update' do
     let!(:subscription) { create(:subscription) }
 

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -193,15 +193,6 @@ describe Cms::UsersController do
     end
   end
 
-  describe '#edit_subscription' do
-    let!(:another_user) { create(:user) }
-
-    it 'should assign the subscription' do
-      get :edit_subscription, params: { id: another_user.id }
-      expect(assigns(:subscription)).to eq another_user.subscription
-    end
-  end
-
   describe '#new_subscription' do
     let!(:another_user) { create(:user) }
     let!(:user_with_no_subscription) { create(:user) }


### PR DESCRIPTION
## WHAT
When a staff attempts to edit a user's stripe subscription via internal tools, provide a link 'View in Stripe' that redirects to the stripe dashboard UI.

## WHY
Using the cms to edit stripe subscriptions adds unnecessary complexity to our system.

## HOW
Have the route `edit_cms_subscription_path(@subscription)` redirect to the stripe UI if `@subscription` is a stripe one.

Also, I removed some `edit_subscription` routes since they were dead/redundant code.

### Screenshots
![Screen Shot 2022-05-25 at 9 58 52 AM](https://user-images.githubusercontent.com/2057805/170280466-2fbb9223-53ee-4b27-86be-3f2234d5d8be.png)

### Notion Card Links
https://www.notion.so/quill/Improve-and-streamline-how-we-manage-subscriptions-ebce644a45094c2593d6b52e9cebec89#01835b63193e4ac18d7504f7024f6096

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
