### PR TITLE
Fix intermittent spec failure involving scorebook query spec

### DIFF
--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -71,9 +71,9 @@ describe 'ScorebookQuery' do
 
         results = Scorebook::Query.run(classroom.id, 1, nil, nil, nil, offset)
 
-        # Use ljust to ensure that trailing 0s are not discarded
-        in_user_time = (activity_session1.updated_at + offset.seconds).strftime('%Y-%m-%d %H:%M:%S.%6N').ljust(26, '0')
-        expect(results.find{|res| res['id'] == activity_session1.id}['updated_at']).to eq(in_user_time)
+        in_user_time = (activity_session1.updated_at + offset.seconds).to_i
+        updated_at = results.find { |res| res['id'] == activity_session1.id }['updated_at'].to_datetime.to_i
+        expect(updated_at).to eq in_user_time
       end
 
       it "factors in offset to return activities where the teacher is in a different timezone than the database" do


### PR DESCRIPTION
## WHAT
There's an [intermittent](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/16072/workflows/76e15c47-4667-444c-8490-09b9982ea337/jobs/221097) spec failure involving comparison of two date times

## WHY
Intermittent specs should be resolved so that we don't get false positives in circleci.

## HOW
This [article](https://tddium.wordpress.com/2011/08/07/rails-time-comparisons-devil-details-etc/) describes some of the underlying issues involving comparison of Ruby datetimes.  The article suggests a potential workaround of converting both datetimes to integers before comparing.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
