### PR TITLE
Remove max-height constraint on evidence image hints

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -344,27 +344,3 @@
     }
   }
 }
-
-@media (min-width: 992px) {
-  .hint {
-    height: 344px;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .hint {
-    height: 304px;
-  }
-}
-
-@media (min-width: 660px) and (max-width: 767px) {
-  .hint {
-    height: 256px;
-  }
-}
-
-@media (min-width: 320px) and (max-width: 659px) {
-  .hint {
-    height: 228px;
-  }
-}


### PR DESCRIPTION
## WHAT
Revert a change to max-height property for evidence tooltip images

## WHY
Images are being cropped

## HOW
Remove the offending CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Annotated-examples-cut-off-in-Evidence-tool-23a7cf7f48fb4718b031756ca64aa372)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  CSS change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
