### PR TITLE
Add back in user.last_four for stripe legacy subscriptions

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -112,7 +112,7 @@ class Subscription < ApplicationRecord
 
   validates :stripe_invoice_id, allow_blank: true, stripe_uid: { prefix: :in }
 
-  delegate :stripe_cancel_at_period_end, :last_four, :stripe_subscription_id, :stripe_subscription_url,
+  delegate :stripe_cancel_at_period_end, :stripe_subscription_id, :stripe_subscription_url,
     to: :stripe_subscription
 
   scope :active, -> { not_expired.not_de_activated.order(expiration: :asc) }
@@ -375,6 +375,10 @@ class Subscription < ApplicationRecord
     "#{type}Subscription".constantize.create(h)
 
     subscription
+  end
+
+  def last_four
+    stripe_subscription&.last_four || purchaser&.last_four
   end
 
   def subscription_status

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -270,6 +270,14 @@ class User < ApplicationRecord
       .first
   end
 
+  def last_four
+    return nil unless stripe_customer_id
+
+    Stripe::Customer.retrieve(id: stripe_customer_id, expand: ['sources']).sources.data.first&.last4
+  rescue Stripe::InvalidRequestError
+    nil
+  end
+
   def present_and_future_subscriptions
     subscriptions.active
   end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -151,7 +151,30 @@ describe User, type: :model do
         expect(user.auditor?).to eq(false)
       end
     end
+  end
 
+  describe '#last_four' do
+    it 'returns nil if a user does not have a stripe_customer_id' do
+      expect(user.last_four).to eq(nil)
+    end
+
+    context 'user has a stripe customer_id' do
+      let(:user) { create(:user, stripe_customer_id: stripe_customer_id)}
+      let(:stripe_customer_id) { 'cus_abcdefg' }
+      let(:last4) { 1000 }
+      let(:customer) { double('customer') }
+      let(:customer_with_sources) { double('customer', sources: double(data: double(first: double(last4: last4)))) }
+      let(:retrieve_sources_args) { { id: stripe_customer_id, expand: ['sources'] } }
+
+      before do
+        allow(Stripe::Customer).to receive(:retrieve).with(stripe_customer_id).and_return(customer)
+        allow(Stripe::Customer).to receive(:retrieve).with(retrieve_sources_args).and_return(customer_with_sources)
+      end
+
+      it "calls Stripe::Customer.retrieve with the current user's stripe_customer_id" do
+        expect(user.last_four).to eq last4
+      end
+    end
   end
 
   describe '#stripe_customer?' do


### PR DESCRIPTION
## WHAT
Add back in `last_four` method on the `User` model.

## WHY
Previously, we charged subscriptions through stripe without them actually being subscriptions on stripe, but instead just a purchase.  However, when we display our subscriptions page, we currently pull `last_four` for subscriptions via `stripe_invoice_id`.  Since older subscriptions do not have a `stripe_invoice_id`, we need to pull the `last_four` from the user model itself using `stripe_customer_id`.

## HOW
Revert this [method](https://github.com/empirical-org/Empirical-Core/blob/59566e8958834aecd0d6833219be14f0d1108cb3/services/QuillLMS/app/models/user.rb#L304) 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Credit-card-last-four-showing-null-for-users-on-an-old-style-Stripe-subscription-903fa69f11894fd582f759026d250f63

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
