### PR TITLE
css fixes for data tables

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/my_activities.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_activities.scss
@@ -150,6 +150,9 @@
       .due-date-picker .DateInput_input::placeholder {
         color: #000;
       }
+      .data-table-headers {
+        max-width: min-content;
+      }
       .list-item {
         display: flex;
         align-items: baseline;

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -153,11 +153,11 @@
 }
 
 @media (min-width: 930px) {
-  .hide-on-desktop { display: none; }
+  .hide-on-desktop { display: none !important; }
 }
 
 @media (max-width: 930px) {
-  .hide-on-mobile { display: none; }
+  .hide-on-mobile { display: none !important; }
 
   .discover-tabs .full-screen:not(.mobile) {
     display: none;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -89,7 +89,7 @@ table.data-table {
     top: 0;
     background-color: white;
     z-index: 1;
-    width: min-content;
+    min-width: min-content;
   }
 
   .data-table-row {


### PR DESCRIPTION
## WHAT
Fix issue where `.hide-on-desktop` class was not applying for data tables.

## WHY
We don't want items with that class to show on desktop.

## HOW
Just adjust some CSS.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Duplicate-results-showing-on-Student-Responses-report-3ebe5962ab43482fa141431feb596c22

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - no CSS tests
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
