### PR TITLE
Datepicker

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -118,8 +118,10 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   });
 
   React.useEffect(() => {
-    onStartDateChange(new Date(getDateFromLatestAutoMLModel(modelsData?.models)))
-    setStartDate(getDateFromLatestAutoMLModel(modelsData?.models))
+    if (modelsData?.models) {
+      onStartDateChange(new Date(getDateFromLatestAutoMLModel(modelsData.models)))
+      setStartDate(getDateFromLatestAutoMLModel(modelsData.models))
+    }
 
   }, [modelsData])
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -60,7 +60,7 @@ const getDateFromLatestAutoMLModel = (models) => {
   if (!models) { return null }
   const latestModel = models.find( model => model.state === 'active')
   if (!latestModel) { return null }
-  return latestModel.created_at
+  return latestModel.updated_at
 }
 
 const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ history, match }) => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -97,7 +97,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const { data: modelsData } = useQuery({
     queryKey: [`models-${selectedPrompt?.id}`, selectedPrompt?.id],
     queryFn: fetchModels,
-    enabled: selectedPrompt !== null
+    enabled: !!selectedPrompt
   });
 
   // cache rules data for updates

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -57,8 +57,8 @@ const MoreInfo = (row) => {
 }
 
 const getDateFromLatestAutoMLModel = (models) => {
-  const latestModel = models?.find( model => model.state === 'active')
-  console.log("getDateFromLatestAutoMLModel called, latest model:", latestModel)
+  if (!models) { return null }
+  const latestModel = models.find( model => model.state === 'active')
   if (!latestModel) { return null }
   return latestModel.created_at
 }
@@ -67,7 +67,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const { params } = match;
   const { activityId, promptConjunction, } = params;
   const today = new Date();
-  const thirtyDaysAgo = new Date().setDate(today.getDate()); // TODO: REVERT
+  const thirtyDaysAgo = new Date().setDate(today.getDate()-30);
 
   const ruleTypeValues = [DEFAULT_RULE_TYPE].concat(Object.keys(apiOrderLookup))
   const ruleTypeOptions = ruleTypeValues.map(val => ({ label: val, value: val, }))
@@ -75,9 +75,8 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const initialStartDateString = window.sessionStorage.getItem(`${RULES_ANALYSIS}startDate`) || '';
   const initialEndDateString = window.sessionStorage.getItem(`${RULES_ANALYSIS}endDate`) || '';
   const initialTurkSessionId = window.sessionStorage.getItem(`${RULES_ANALYSIS}turkSessionId`) || '';
-
+  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : new Date(thirtyDaysAgo);
   const initialEndDate = initialEndDateString ? new Date(initialEndDateString) : null;
-
   const selectedRuleTypeOption = ruleTypeOptions.find(opt => opt.value === ruleTypeFromUrl)
 
   const [showError, setShowError] = React.useState<boolean>(false);
@@ -91,6 +90,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const [turkSessionID, setTurkSessionID] = React.useState<string>(initialTurkSessionId);
   const [turkSessionIDForQuery, setTurkSessionIDForQuery] = React.useState<string>(initialTurkSessionId);
   const [formattedRows, setFormattedRows] = React.useState<any[]>(null);
+  const [startDate, onStartDateChange] = React.useState<Date>(initialStartDate);
 
   const selectedConjunction = selectedPrompt ? selectedPrompt.conjunction : promptConjunction
 
@@ -99,10 +99,6 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
     queryFn: fetchModels,
     enabled: selectedPrompt !== null
   });
-
-  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : new Date(thirtyDaysAgo);
-  const [startDate, onStartDateChange] = React.useState<Date>(initialStartDate);
-
 
   // cache rules data for updates
   const { data: ruleFeedbackHistory } = useQuery({
@@ -447,7 +443,6 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       </div>
     )
   }
-
 
   return(
     <div className={containerClassName}>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -59,7 +59,7 @@ const MoreInfo = (row) => {
 const getDateFromLatestAutoMLModel = (models) => {
   const latestModel = models?.find( model => model.state === 'active')
   console.log("getDateFromLatestAutoMLModel called, latest model:", latestModel)
-  if (!latestModel) { return '' }
+  if (!latestModel) { return null }
   return latestModel.created_at
 }
 
@@ -122,7 +122,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   });
 
   React.useEffect(() => {
-    onStartDateChange(getDateFromLatestAutoMLModel(modelsData?.models))
+    onStartDateChange(new Date(getDateFromLatestAutoMLModel(modelsData?.models)))
     setStartDate(getDateFromLatestAutoMLModel(modelsData?.models))
 
   }, [modelsData])
@@ -474,7 +474,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
         onEndDateChange={onEndDateChange}
         onStartDateChange={onStartDateChange}
         showError={showError}
-        startDate={startDateForQuery}
+        startDate={startDate}
         turkSessionID={turkSessionID}
       />
       {renderDataSection()}

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -34,7 +34,7 @@ module Evidence
       options ||= {}
 
       super(options.reverse_merge(
-        only: [:id, :automl_model_id, :notes, :name, :labels, :state, :prompt_id, :created_at],
+        only: [:id, :automl_model_id, :notes, :name, :labels, :state, :prompt_id, :created_at, :updated_at],
         methods: [:older_models]
       ))
     end


### PR DESCRIPTION
## WHAT
By default, set the 'start time' filter in Rules Analysis to the time the automl model was last updated.

## WHY
Curriculum team request

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=40d447da79b94edf9ac4a9e213b30961

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
