### PR TITLE
fix padding around data table headers

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -12,13 +12,12 @@
 }
 
 .data-table-headers, .data-table-row {
-  height: 48px;
+  min-height: 48px;
   padding: 0px 16px;
   border-bottom: 1px solid #e0e0e0;
   display: flex;
   align-items: center;
   min-width: min-content;
-
 }
 
 .data-table-row-section {


### PR DESCRIPTION
## WHAT
Some change I made caused the data table headers to use the minimum possible height rather than the assigned `48px`. This fixes that.

## WHY
We want them to look how they're supposed to.

## HOW
Change `height` to `min-height`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
