### PR TITLE
Backend code for Enable 'Renew Subscription' 

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -409,6 +409,7 @@ class PagesController < ApplicationController
     @user_has_school = !!current_user&.school && ['home school', 'us higher ed', 'international', 'other', 'not listed'].exclude?(current_user&.school&.name)
     @user_belongs_to_school_that_has_paid = current_user&.school ? Subscription.school_or_user_has_ever_paid?(current_user&.school) : false
     @customer_email = current_user&.email
+    @school_id = current_user&.school.id
     @stripe_school_plan = PlanSerializer.new(Plan.stripe_school_plan).as_json
     @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher_plan).as_json
     @show_school_buy_now = AppSetting.enabled?(name: SHOW_SCHOOL_BUY_NOW_BUTTON_APP_SETTING, user: current_user)

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -409,7 +409,7 @@ class PagesController < ApplicationController
     @user_has_school = !!current_user&.school && ['home school', 'us higher ed', 'international', 'other', 'not listed'].exclude?(current_user&.school&.name)
     @user_belongs_to_school_that_has_paid = current_user&.school ? Subscription.school_or_user_has_ever_paid?(current_user&.school) : false
     @customer_email = current_user&.email
-    @school_id = current_user&.school.id
+    @school_ids = [current_user&.school&.id].to_json
     @stripe_school_plan = PlanSerializer.new(Plan.stripe_school_plan).as_json
     @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher_plan).as_json
     @show_school_buy_now = AppSetting.enabled?(name: SHOW_SCHOOL_BUY_NOW_BUTTON_APP_SETTING, user: current_user)

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -11,13 +11,14 @@ module StripeIntegration
 
     private def subscription_checkout_session_args
       {
-        success_url: success_url,
         cancel_url: cancel_url,
-        mode: SUBSCRIPTION_MODE,
         line_items: [{
-          quantity: 1,
-          price: stripe_price_id
-        }]
+          price: stripe_price_id,
+          quantity: 1
+        }],
+        mode: SUBSCRIPTION_MODE,
+        subscription_data: subscription_data,
+        success_url: success_url
       }.merge(customer_arg)
     end
 
@@ -37,6 +38,10 @@ module StripeIntegration
       params[:customer_email]
     end
 
+    private def school_ids
+      params[:school_id]
+    end
+
     private def stripe_price_id
       params[:stripe_price_id]
     end
@@ -47,6 +52,12 @@ module StripeIntegration
 
     private def success_url
       "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
+    end
+
+    private def subscription_data
+      return {} unless School.exists?(id: school_ids)
+
+      { metadata: { school_ids: school_ids } }
     end
   end
 end

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -65,9 +65,11 @@ module StripeIntegration
     end
 
     private def success_url
-      return "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}" if schools.empty?
-
-      "#{teacher_admin_subscriptions_url(school_id: school_ids.first)}&checkout_session_id={CHECKOUT_SESSION_ID}"
+      if schools.empty? || !customer.admin?
+        "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
+      else
+        "#{teacher_admin_subscriptions_url(school_id: school_ids.first)}&checkout_session_id={CHECKOUT_SESSION_ID}"
+      end
     end
 
     private def subscription_data

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -11,14 +11,14 @@ module StripeIntegration
 
     private def subscription_checkout_session_args
       {
-        success_url: success_url,
         cancel_url: cancel_url,
-        mode: SUBSCRIPTION_MODE,
-        subscription_data: trial_period_days_arg,
         line_items: [{
           price: stripe_price_id,
           quantity: 1
-        }]
+        }],
+        mode: SUBSCRIPTION_MODE,
+        subscription_data: subscription_data,
+        success_url: success_url
       }.merge(customer_arg)
     end
 
@@ -42,6 +42,10 @@ module StripeIntegration
       params[:customer_email]
     end
 
+    private def school_ids
+      params[:school_id]
+    end
+
     private def school_plan?
       stripe_price_id == STRIPE_SCHOOL_PLAN_PRICE_ID
     end
@@ -56,6 +60,12 @@ module StripeIntegration
 
     private def success_url
       "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
+    end
+
+    private def subscription_data
+      return {} unless School.exists?(id: school_ids)
+
+      { metadata: { school_ids: school_ids } }
     end
 
     private def teacher_plan?

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -42,8 +42,14 @@ module StripeIntegration
       params[:customer_email]
     end
 
-    private def school_id
-      params[:school_id]
+    private def schools
+      @schools ||= School.where(id: school_ids)
+    end
+
+    private def school_ids
+      return [] if params[:school_ids].nil?
+
+      JSON.parse(params[:school_ids])
     end
 
     private def school_plan?
@@ -59,15 +65,15 @@ module StripeIntegration
     end
 
     private def success_url
-      return "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}" unless school_id
+      return "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}" if schools.empty?
 
-      "#{teacher_admin_subscriptions_url(school_id: school_id)}&checkout_session_id={CHECKOUT_SESSION_ID}"
+      "#{teacher_admin_subscriptions_url(school_id: school_ids.first)}&checkout_session_id={CHECKOUT_SESSION_ID}"
     end
 
     private def subscription_data
-      return {} unless School.exists?(id: school_id)
+      return {} if schools.empty?
 
-      { metadata: { school_id: school_id } }
+      { metadata: { school_ids: school_ids.to_json } }
     end
 
     private def teacher_plan?

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -42,7 +42,7 @@ module StripeIntegration
       params[:customer_email]
     end
 
-    private def school_ids
+    private def school_id
       params[:school_id]
     end
 
@@ -59,13 +59,15 @@ module StripeIntegration
     end
 
     private def success_url
-      "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
+      return "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}" unless school_id
+
+      "#{teacher_admin_subscriptions_url(school_id: school_id)}&checkout_session_id={CHECKOUT_SESSION_ID}"
     end
 
     private def subscription_data
-      return {} unless School.exists?(id: school_ids)
+      return {} unless School.exists?(id: school_id)
 
-      { metadata: { school_ids: school_ids } }
+      { metadata: { school_id: school_id } }
     end
 
     private def teacher_plan?

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -38,7 +38,7 @@ module StripeIntegration
       params[:customer_email]
     end
 
-    private def school_ids
+    private def school_id
       params[:school_id]
     end
 
@@ -51,13 +51,15 @@ module StripeIntegration
     end
 
     private def success_url
-      "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
+      return "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}" unless school_id
+
+      "#{teacher_admin_subscriptions_url(school_id: school_id)}&checkout_session_id={CHECKOUT_SESSION_ID}"
     end
 
     private def subscription_data
-      return {} unless School.exists?(id: school_ids)
+      return {} unless School.exists?(id: school_id)
 
-      { metadata: { school_ids: school_ids } }
+      { metadata: { school_id: school_id } }
     end
   end
 end

--- a/services/QuillLMS/app/controllers/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/subscriptions_controller.rb
@@ -28,7 +28,7 @@ class SubscriptionsController < ApplicationController
         id: school.id,
         name: school.name,
         subscriptions: school.subscriptions,
-        subscription_status: school.subscription&.subscription_status || school.last_expired_subscription&.subscription_status
+        subscription_status: school.subscription_status
       }
     end
 

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -157,6 +157,10 @@ class School < ApplicationRecord
     schools_admins.where(user_id: district.admins.map(&:id)).destroy_all
   end
 
+  def subscription_status
+    subscription&.subscription_status || last_expired_subscription&.subscription_status
+  end
+
   private def generate_leap_csv_row(student, teacher, classroom, activity_session)
     [
       student.id,

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -379,6 +379,7 @@ class Subscription < ApplicationRecord
       'purchaser_name' => purchaser&.name,
       'renewal_stripe_price_id' => renewal_stripe_price_id,
       'renewal_price' => plan && PlanSerializer.new(plan).price_in_dollars,
+      'school_ids' =>  schools.pluck(:id),
       'stripe_customer_id' => purchaser&.stripe_customer_id,
       'stripe_subscription_id' => stripe_subscription_id
     )

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -390,6 +390,7 @@ class Subscription < ApplicationRecord
       'purchaser_name' => purchaser&.name,
       'renewal_stripe_price_id' => renewal_stripe_price_id,
       'renewal_price' => plan && PlanSerializer.new(plan).price_in_dollars,
+      'school_ids' =>  schools.pluck(:id),
       'stripe_customer_id' => purchaser&.stripe_customer_id,
       'stripe_subscription_id' => stripe_subscription_id
     )

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -56,9 +56,9 @@ module StripeIntegration
           UserSubscription.create!(user: purchaser, subscription: subscription)
           UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::TEACHER_PREMIUM)
         when Plan.stripe_school_plan
-          raise NilSchoolError unless School.exists?(id: school_ids)
+          raise NilSchoolError unless School.find_by(id: school_id)
 
-          school_ids.each { |school_id| SchoolSubscription.create!(school_id: school_id, subscription: subscription) }
+          SchoolSubscription.create!(school_id: school_id, subscription: subscription)
           UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::SCHOOL_PREMIUM)
         end
       end
@@ -69,8 +69,8 @@ module StripeIntegration
         purchaser.update!(stripe_customer_id: stripe_customer_id)
       end
 
-      private def school_ids
-        stripe_subscription.metadata[:school_ids]
+      private def school_id
+        stripe_subscription.metadata[:school_id]
       end
 
       private def start_date

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
@@ -17,7 +17,7 @@ document.addEventListener('click', function(e) {
       diagnosticActivityCount: @diagnostic_activity_count,
       independentPracticeActivityCount: @independent_practice_activity_count,
       lessonsActivityCount: @lessons_activity_count,
-      schoolId: @school_id,
+      schoolIds: @school_ids,
       showSchoolBuyNow: @show_school_buy_now,
       stripeSchoolPlan: @stripe_school_plan,
       stripeTeacherPlan: @stripe_teacher_plan,

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
@@ -17,6 +17,7 @@ document.addEventListener('click', function(e) {
       diagnosticActivityCount: @diagnostic_activity_count,
       independentPracticeActivityCount: @independent_practice_activity_count,
       lessonsActivityCount: @lessons_activity_count,
+      schoolId: @school_id,
       showSchoolBuyNow: @show_school_buy_now,
       stripeSchoolPlan: @stripe_school_plan,
       stripeTeacherPlan: @stripe_teacher_plan,

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
@@ -8,19 +8,22 @@ document.addEventListener('click', function(e) {
   $('body').removeClass('show-focus');
 });
 </script>
+
 <span id='user-logged-in' data-signed-in= <%= !!current_user%>>
+
 <div id="first-preview-section">
-<%= react_component('PremiumPricingGuideApp', props: {
-  customerEmail: @customer_email,
-  diagnosticActivityCount: @diagnostic_activity_count,
-  independentPracticeActivityCount: @independent_practice_activity_count,
-  lessonsActivityCount: @lessons_activity_count,
-  showSchoolBuyNow: @show_school_buy_now,
-  stripeSchoolPlan: @stripe_school_plan,
-  stripeTeacherPlan: @stripe_teacher_plan,
-  userBelongsToSchoolThatHasPaid: @user_belongs_to_school_that_has_paid,
-  userHasSchool: @user_has_school,
-  userIsEligibleForNewSubscription: @user_is_eligible_for_new_subscription,
-  userIsEligibleForTrial: @user_is_eligible_for_trial
-}) %>
+  <%= react_component('PremiumPricingGuideApp', props: {
+      customerEmail: @customer_email,
+      diagnosticActivityCount: @diagnostic_activity_count,
+      independentPracticeActivityCount: @independent_practice_activity_count,
+      lessonsActivityCount: @lessons_activity_count,
+      showSchoolBuyNow: @show_school_buy_now,
+      stripeSchoolPlan: @stripe_school_plan,
+      stripeTeacherPlan: @stripe_teacher_plan,
+      userBelongsToSchoolThatHasPaid: @user_belongs_to_school_that_has_paid,
+      userHasSchool: @user_has_school,
+      userIsEligibleForNewSubscription: @user_is_eligible_for_new_subscription,
+      userIsEligibleForTrial: @user_is_eligible_for_trial
+    })
+  %>
 </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
@@ -7,7 +7,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
   buttonText,
   cancelPath,
   customerEmail,
-  schoolId,
+  schoolIds,
   stripePriceId,
   userIsEligibleForNewSubscription,
   userIsSignedIn
@@ -27,7 +27,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
       const data = {
         cancel_path: cancelPath,
         customer_email: customerEmail,
-        ...(schoolId && { school_id: schoolId }),
+        ...(schoolIds && { school_ids: schoolIds }),
         stripe_price_id: stripePriceId
       }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
@@ -7,6 +7,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
   buttonText,
   cancelPath,
   customerEmail,
+  schoolIds,
   stripePriceId,
   userIsEligibleForNewSubscription,
   userIsSignedIn
@@ -26,6 +27,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
       const data = {
         cancel_path: cancelPath,
         customer_email: customerEmail,
+        ...(schoolIds && { school_ids: schoolIds }),
         stripe_price_id: stripePriceId
       }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/StripeSubscriptionCheckoutSessionButton.jsx
@@ -7,7 +7,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
   buttonText,
   cancelPath,
   customerEmail,
-  schoolIds,
+  schoolId,
   stripePriceId,
   userIsEligibleForNewSubscription,
   userIsSignedIn
@@ -27,7 +27,7 @@ export const StripeSubscriptionCheckoutSessionButton = ({
       const data = {
         cancel_path: cancelPath,
         customer_email: customerEmail,
-        ...(schoolIds && { school_ids: schoolIds }),
+        ...(schoolId && { school_id: schoolId }),
         stripe_price_id: stripePriceId
       }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -80,7 +80,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
-  const schoolIds = subscriptionStatus && subscriptionStatus.school_ids
+  const schoolId = subscriptionStatus && subscriptionStatus.school_id
 
   let image
   let expiration
@@ -153,8 +153,8 @@ const SubscriptionStatus = ({
             buttonClassName={CTA_BUTTON_CLASSNAME}
             buttonText='Renew subscription'
             cancelPath='subscriptions'
-            customerEmail={subscriptionStatus.customer_email}
-            schoolIds={schoolIds}
+            customerEmail={customerEmail}
+            schoolId={schoolId}
             stripePriceId={renewalStripePriceId}
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -77,6 +77,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
+  const schoolIds = subscriptionStatus && subscriptionStatus.schoolIds
 
   let image
   let expiration
@@ -150,6 +151,7 @@ const SubscriptionStatus = ({
             buttonText='Renew Subscription'
             cancelPath='subscriptions'
             customerEmail={subscriptionStatus.customer_email}
+            schoolIds={schoolIds}
             stripePriceId={renewalStripePriceId}
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -80,7 +80,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
-  const schoolId = subscriptionStatus && subscriptionStatus.school_id
+  const schoolIds = subscriptionStatus && JSON.stringify(subscriptionStatus.school_ids)
 
   let image
   let expiration
@@ -154,7 +154,7 @@ const SubscriptionStatus = ({
             buttonText='Renew subscription'
             cancelPath='subscriptions'
             customerEmail={customerEmail}
-            schoolId={schoolId}
+            schoolIds={schoolIds}
             stripePriceId={renewalStripePriceId}
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -80,7 +80,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
-  const schoolIds = subscriptionStatus && subscriptionStatus.schoolIds
+  const schoolIds = subscriptionStatus && subscriptionStatus.school_ids
 
   let image
   let expiration

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -80,6 +80,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
+  const schoolIds = subscriptionStatus && subscriptionStatus.schoolIds
 
   let image
   let expiration
@@ -153,6 +154,7 @@ const SubscriptionStatus = ({
             buttonText='Renew subscription'
             cancelPath='subscriptions'
             customerEmail={subscriptionStatus.customer_email}
+            schoolIds={schoolIds}
             stripePriceId={renewalStripePriceId}
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -80,7 +80,7 @@ const SubscriptionStatus = ({
 }) => {
 
   const renewalStripePriceId = subscriptionStatus && subscriptionStatus.renewal_stripe_price_id
-  const schoolIds = subscriptionStatus && subscriptionStatus.school_ids
+  const schoolId = subscriptionStatus && subscriptionStatus.school_id
 
   let image
   let expiration
@@ -154,7 +154,7 @@ const SubscriptionStatus = ({
             buttonText='Renew Subscription'
             cancelPath='subscriptions'
             customerEmail={customerEmail}
-            schoolIds={schoolIds}
+            schoolId={schoolId}
             stripePriceId={renewalStripePriceId}
             userIsEligibleForNewSubscription={true}
             userIsSignedIn={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -32,7 +32,7 @@ export const PremiumPricingGuide = ({
   diagnosticActivityCount,
   independentPracticeActivityCount,
   lessonsActivityCount,
-  schoolId,
+  schoolIds,
   showSchoolBuyNow,
   stripeSchoolPlan,
   stripeTeacherPlan,
@@ -66,7 +66,7 @@ export const PremiumPricingGuide = ({
         buttonText='Buy Now'
         cancelPath='premium'
         customerEmail={customerEmail}
-        schoolId={schoolId}
+        schoolIds={schoolIds}
         stripePriceId={stripeSchoolPlan.plan.stripe_price_id}
         userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
         userIsSignedIn={userIsSignedIn()}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -32,6 +32,7 @@ export const PremiumPricingGuide = ({
   diagnosticActivityCount,
   independentPracticeActivityCount,
   lessonsActivityCount,
+  schoolId,
   showSchoolBuyNow,
   stripeSchoolPlan,
   stripeTeacherPlan,
@@ -65,6 +66,7 @@ export const PremiumPricingGuide = ({
         buttonText='Buy Now'
         cancelPath='premium'
         customerEmail={customerEmail}
+        schoolId={schoolId}
         stripePriceId={stripeSchoolPlan.plan.stripe_price_id}
         userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
         userIsSignedIn={userIsSignedIn()}

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -164,7 +164,7 @@ EmpiricalGrammar::Application.routes.draw do
   put 'students/update_password' => 'students#update_password'
   get 'join/:classcode' => 'students#join_classroom'
   get 'teachers/admin_dashboard' => 'teachers#admin_dashboard'
-  get 'teachers/admin_dashboard/school_subscriptions' => 'teachers#admin_dashboard'
+  get 'teachers/admin_dashboard/school_subscriptions' => 'teachers#admin_dashboard', as: :teacher_admin_subscriptions
   get 'teachers/admin_dashboard/district_activity_scores' => 'teachers#admin_dashboard'
   get 'teachers/admin_dashboard/district_activity_scores/student_overview' => 'teachers#admin_dashboard'
   get 'teachers/admin_dashboard/district_concept_reports' => 'teachers#admin_dashboard'

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -163,7 +163,7 @@ EmpiricalGrammar::Application.routes.draw do
   put 'students/update_password' => 'students#update_password'
   get 'join/:classcode' => 'students#join_classroom'
   get 'teachers/admin_dashboard' => 'teachers#admin_dashboard'
-  get 'teachers/admin_dashboard/school_subscriptions' => 'teachers#admin_dashboard'
+  get 'teachers/admin_dashboard/school_subscriptions' => 'teachers#admin_dashboard', as: :teacher_admin_subscriptions
   get 'teachers/admin_dashboard/district_activity_scores' => 'teachers#admin_dashboard'
   get 'teachers/admin_dashboard/district_activity_scores/student_overview' => 'teachers#admin_dashboard'
   get 'teachers/admin_dashboard/district_concept_reports' => 'teachers#admin_dashboard'

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
 
   context 'school subscription' do
     context 'happy path' do
-      let(:user) { create(:user) }
       let!(:teacher) { create(:teacher) }
       let!(:other_teacher) { create(:teacher) }
       let!(:school) { create :school, users: [customer, teacher]}
       let!(:school_plan) { create(:school_paid_plan) }
+      let!(:stripe_subscription_metadata) { { school_ids: [school.id].to_json } }
 
       before { allow(Plan).to receive(:find_stripe_plan!).with(stripe_price_id).and_return(school_plan) }
 

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
     it { expect { subject }.to raise_error described_class::PurchaserNotFoundError }
   end
 
-  context 'purchaser has no school' do
+  context 'school does not exist' do
     let!(:school_plan) { create(:school_paid_plan) }
 
     before { allow(Plan).to receive(:find_stripe_plan!).with(stripe_price_id).and_return(school_plan) }
 
-    it { expect { subject }.to raise_error described_class::PurchaserNilSchoolError }
+    it { expect { subject }.to raise_error described_class::NilSchoolError }
   end
 end
 

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
@@ -8,6 +8,7 @@ RSpec.shared_context 'Stripe Subscription' do
   let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
   let(:current_period_end) { 1.year.from_now.to_i }
   let(:current_period_start) { Date.current.to_time.to_i }
+  let(:stripe_subscription_metadata) { {} }
 
   let(:stripe_subscription) do
     Stripe::Subscription.construct_from(
@@ -43,7 +44,7 @@ RSpec.shared_context 'Stripe Subscription' do
       },
       latest_invoice: nil,
       livemode: false,
-      metadata: {},
+      metadata: stripe_subscription_metadata,
       next_pending_invoice_item_invoice: nil,
       pause_collection: nil,
       payment_settings: {


### PR DESCRIPTION
## WHAT
When a user attempts to renew a school subscription through stripe associate the relevant schools to that subscription

## WHY
We would like to enable school subscriptions through stripe.

## HOW
When a user attempts to renew a school subscription, add the relevant school_id to the `stripe_subscription.metadata` object under the key `school_ids`.  Upon successful checkout on stripe, the relevant [school_ids](https://github.com/empirical-org/Empirical-Core/pull/9231/files#diff-59492826a34540b6a1a39aaeeae1d87fca0385e29154c3e0d8e4ca3114a79cadR59) can then be pulled from the metadata and saved in our database as new `SchoolSubscription` records.

Note, this code also sends the ground work for new purchases, but those flows will be implemented in another PR

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A