### PR TITLE
Add new activity details field most recent attempt

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
@@ -1,48 +1,62 @@
-import React from 'react';
-import moment from 'moment';
+import React from 'react'
+import moment from 'moment'
 
 export const ActivityDetails = ({ data }) => {
 
   if (!Object.keys(data).length) { return <span /> }
 
-  const { concept_results, started_at, updated, scores, activity_description } = data;
+  const { concept_results, started_at, completed_at, updated, scores, activity_description } = data
 
   function getClassName() {
     if (concept_results && concept_results.length) {
-      return 'activity-details';
+      return 'activity-details'
     }
-    return 'activity-details no-concept-results';
-  };
+    return 'activity-details no-concept-results'
+  }
 
   function detailOrNot() {
-    let dateTitle, dateBody;
+    let dateTitle, dateBody, completedTitle, completedBody
+
     if (!concept_results || !concept_results.length) {
       if (started_at) {
         dateTitle = 'Started'
         dateBody = started_at
       }
     } else {
-      const scoresExist = scores && scores.length;
-      const firstCr = concept_results[0];
-      // check if scores exist and use updated for most recent activity completion date
-      if (scoresExist && updated) {
-        dateTitle = 'Completed';
-        dateBody = updated;
+      const scoresExist = scores && scores.length
+      const firstCr = concept_results[0]
+
+      if (scoresExist) {
+        const completedAt = scores[0].completed_at
+
+        if (completedAt) {
+          completedTitle = 'Completed'
+          completedBody = completedAt
+        }
+
+        if (updated) {
+          dateTitle = 'Most Recent Attempt'
+          dateBody = updated
+        }
+
       } else {
-        dateTitle = 'Due';
-        dateBody = firstCr.due_date;
+        dateTitle = 'Due'
+        dateBody = firstCr.due_date
       }
     }
+
     const objectiveSection = activity_description ? <p><strong>Objectives:</strong>{` ${activity_description}`}</p> : <span />
     const dateSection = dateTitle ? <p><strong>{`${dateTitle}: `}</strong>{`${moment(dateBody).format('MMMM D, YYYY')}`}</p> : <span />
+    const completedSection = completedTitle ? <p><strong>{`${completedTitle}: `}</strong>{`${moment(completedBody).format('MMMM D, YYYY')}`}</p> : <span />
 
     return (
       <div className="activity-detail">
         {objectiveSection}
         {dateSection}
+        {completedSection}
       </div>
-    );
-  };
+    )
+  }
 
   return (
     <div className={getClassName()}>
@@ -52,7 +66,7 @@ export const ActivityDetails = ({ data }) => {
         </div>
       </div>
     </div>
-  );
+  )
 }
 
 export default ActivityDetails

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/activity_details.jsx
@@ -5,7 +5,7 @@ export const ActivityDetails = ({ data }) => {
 
   if (!Object.keys(data).length) { return <span /> }
 
-  const { concept_results, started_at, completed_at, updated, scores, activity_description } = data
+  const { concept_results, started_at, updated, scores, activity_description } = data
 
   function getClassName() {
     if (concept_results && concept_results.length) {


### PR DESCRIPTION
## WHAT
Fix an issue with activity details tooltip in student reports. 

## WHY
When using the date picker to filter a subset of activities, there's an ambiguity concerning the word 'Completed'.

## HOW
Add a new field 'Most Recent Attempt' tied to `updated` and then keep 'Completed' for the first score with a  `completed_at` value.

### Screenshots
![Screen Shot 2022-06-01 at 2 49 35 PM](https://user-images.githubusercontent.com/2057805/171480757-cbcbc613-8005-47b5-b1eb-f7d77d2774b6.png)



### Notion Card Links
https://www.notion.so/quill/Date-filter-on-Activity-Summary-not-showing-activities-w-replay-attempts-correctly-8d3854de46994d07ba1047aa93db0b70

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
