### PR TITLE
bump typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,7 +452,7 @@
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
     },
     "astral-regex": {
@@ -1411,7 +1411,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
@@ -1453,7 +1453,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -1851,7 +1851,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -2171,7 +2171,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json-stringify-safe": {
@@ -2393,7 +2393,7 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -2520,7 +2520,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "nice-try": {
@@ -2876,7 +2876,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -2894,7 +2894,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "parent-module": {
@@ -2918,7 +2918,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
@@ -3522,9 +3522,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "request": "^2.81.0",
-    "typescript": "^3.6.4",
+    "typescript": "^3.9.5",
     "glob-parent": ">=5.1.2"
   },
   "devDependencies": {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/getting_started_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/getting_started_mini.jsx
@@ -7,13 +7,13 @@ import LoadingIndicator from '../shared/loading_indicator'
 
 export default class GettingStartedMini extends React.Component {
   checklistSection() {
-    const props = this.props
-    if (props.checkboxData.loading) {
+    const { checkboxData} = this.props
+    if (checkboxData.loading) {
       return <LoadingIndicator />;
     }
     return (
       <CheckboxSection
-        checkboxes={props.checkboxData}
+        checkboxes={checkboxData}
         dashboard
       />
     )
@@ -21,8 +21,8 @@ export default class GettingStartedMini extends React.Component {
 
   graphSection() {
     let content;
-    const props = this.props
-    if (props.checkboxData.loading) {
+    const { checkboxData} = this.props
+    if (checkboxData.loading) {
       content = <LoadingIndicator />;
     } else {
       content =
@@ -36,8 +36,8 @@ export default class GettingStartedMini extends React.Component {
   }
 
   percentageCompleted = () => {
-    const props = this.props
-    const boxes = props.checkboxData
+    const { checkboxData} = this.props
+    const boxes = checkboxData
     const ratio = boxes.filter(obj => obj.completed).length / boxes.length
     return Math.floor(ratio * 100)
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/getting_started_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/teacher_guide/getting_started_mini.jsx
@@ -1,16 +1,19 @@
 import React from 'react'
+
 import PercentageGraph from './percentage_graph'
 import CheckboxSection from './checkbox_sections'
+
 import LoadingIndicator from '../shared/loading_indicator'
 
 export default class GettingStartedMini extends React.Component {
   checklistSection() {
-    if (this.props.checkboxData.loading) {
+    const props = this.props
+    if (props.checkboxData.loading) {
       return <LoadingIndicator />;
     }
     return (
       <CheckboxSection
-        checkboxes={this.props.checkboxData}
+        checkboxes={props.checkboxData}
         dashboard
       />
     )
@@ -18,21 +21,23 @@ export default class GettingStartedMini extends React.Component {
 
   graphSection() {
     let content;
-    if (this.props.checkboxData.loading) {
+    const props = this.props
+    if (props.checkboxData.loading) {
       content = <LoadingIndicator />;
     } else {
       content =
       [
         <h3 key='h3-tag'>Getting Started</h3>,
         <PercentageGraph key='percentage-graph' percentage={this.percentageCompleted()} />,
-        <a className='green-link' href='/teachers/teacher_guide' key='all-tasks'>View All Tasks ></a>
+        <a className='green-link' href='/teachers/teacher_guide' key='all-tasks'>View All Tasks</a>
       ]
     }
     return <div id='graph-section'>{content}</div>
   }
 
   percentageCompleted = () => {
-    const boxes = this.props.checkboxData
+    const props = this.props
+    const boxes = props.checkboxData
     const ratio = boxes.filter(obj => obj.completed).length / boxes.length
     return Math.floor(ratio * 100)
   }


### PR DESCRIPTION
## WHAT
- Bumps top-level typescript package by a minor version 
- fixes eslint errors that resulted from this version bump

## WHY
So that our commit hook can parse es2021 syntax. Notably: [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), among other things.
## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - third party lib only.
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | n/a
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
