### PR TITLE
Add event handling for manual invoicing

### DIFF
--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -5,11 +5,12 @@ module StripeIntegration
     class IgnoredEventHandler < EventHandler
       IGNORED_EVENT_NAMES = [
         'balance.available',
+        'charge.captured',
         'charge.failed',
         'charge.refunded',
         'charge.succeeded',
-        'checkout.session.expired',
         'checkout.session.completed',
+        'checkout.session.expired',
         'customer.created',
         'customer.source.created',
         'customer.source.expiring',
@@ -17,7 +18,6 @@ module StripeIntegration
         'customer.subscription.created',
         'customer.updated',
         'file.created',
-        'invoice.updated',
         'invoice.created',
         'invoice.finalized',
         'invoice.payment_failed',
@@ -27,7 +27,8 @@ module StripeIntegration
         'invoice.voided',
         'invoiceitem.created',
         'invoiceitem.updated',
-        'payment_intent.cancelled',
+        'payment_intent.amount_capturable_updated',
+        'payment_intent.canceled',
         'payment_intent.created',
         'payment_intent.payment_failed',
         'payment_intent.succeeded',
@@ -36,6 +37,9 @@ module StripeIntegration
         'payout.created',
         'payout.paid',
         'product.updated',
+        'quote.canceled',
+        'quote.created',
+        'quote.finalized',
         'setup_intent.created'
       ]
 

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/invoice_paid_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/invoice_paid_event_handler.rb
@@ -6,11 +6,19 @@ module StripeIntegration
       PUSHER_EVENT = 'stripe-subscription-created'
 
       def run
-        SubscriptionCreator.run(stripe_invoice, stripe_subscription)
+        create_subscription unless manual_invoice?
         stripe_webhook_event.processed!
-        PusherTrigger.run(stripe_invoice.id, PUSHER_EVENT, PUSHER_EVENT.titleize)
       rescue => e
         stripe_webhook_event.log_error(e)
+      end
+
+      private def create_subscription
+        SubscriptionCreator.run(stripe_invoice, stripe_subscription)
+        PusherTrigger.run(stripe_invoice.id, PUSHER_EVENT, PUSHER_EVENT.titleize)
+      end
+
+      private def manual_invoice?
+        stripe_invoice.subscription.nil?
       end
 
       private def stripe_invoice

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/invoice_paid_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/invoice_paid_event_handler_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe StripeIntegration::Webhooks::InvoicePaidEventHandler do
     it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
   end
 
+  context 'manual invoice' do
+    let(:stripe_subscription_id) { nil }
+
+    it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
+  end
+
   context 'raised errors' do
     let(:error_class) { StripeIntegration::Webhooks::SubscriptionCreator::Error.subclasses.sample }
 


### PR DESCRIPTION
## WHAT
Update the InvoicePaidEventHandler for manual invoicing.

Also, add some event_types to the `IGNORED_EVENT_NAMES`  which are associated with the manual invoicing process.

## WHY
When a manual invoice is paid for that is not a Stripe Subscription, we don't want to create a subscription for it on Quill.

## HOW
Update the EventHandler to check for a manual invoice.  If there isn't an associated subscription, skip running `SubscriptionCreator`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Implement-a-new-manual-subscription-process-that-utilizes-Stripe-invoices-81cd1b6892b44b16a1a89268c8144e06

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
