### PR TITLE
fix bug with find admin users

### DIFF
--- a/services/QuillLMS/app/queries/teachers_data.rb
+++ b/services/QuillLMS/app/queries/teachers_data.rb
@@ -25,11 +25,9 @@ module TeachersData
         COUNT(DISTINCT students_classrooms.id) AS number_of_students
       FROM users
       LEFT OUTER JOIN classrooms_teachers ON users.id = classrooms_teachers.user_id
-      LEFT OUTER JOIN classrooms ON classrooms_teachers.classroom_id = classrooms.id
-      LEFT OUTER JOIN students_classrooms ON classrooms.id = students_classrooms.classroom_id
+      LEFT OUTER JOIN classrooms ON classrooms_teachers.classroom_id = classrooms.id AND classrooms.visible = true
+      LEFT OUTER JOIN students_classrooms ON classrooms.id = students_classrooms.classroom_id AND students_classrooms.visible = true
       WHERE users.id IN (#{teacher_ids_str})
-      AND classrooms.visible
-      AND students_classrooms.visible
       GROUP BY users.id"
     )
 
@@ -70,7 +68,9 @@ module TeachersData
     end
 
     activities_count_query.each do |row|
-      combiner[row.id][:number_of_activities_completed] = row.number_of_activities_completed
+      if combiner[row.id]
+        combiner[row.id][:number_of_activities_completed] = row.number_of_activities_completed
+      end
     end
 
     time_spent_query.each do |row|


### PR DESCRIPTION
## WHAT
Fix bug where `FindAdminUsersWorker` was failing because I'd inadvertently made the scope of a query too narrow, causing a call later to fail because the query was missing rows.

## WHY
We want this to work so admins can load their dashboard.

## HOW
Use the query limiter in the left join instead of the `where` clause, making sure that teacher rows will populate even if they don't have active classrooms. That way the later function should always be able to find the right key in the hash, but just in case, I also added a nil guard there.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
