### PR TITLE
Fix various stripe integration bugs

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
@@ -2,10 +2,14 @@
 
 module StripeIntegration
   class SubscriptionRenewalsController < ApplicationController
+    class UpdatingCanceledSubscriptionError < StandardError; end
+
     def create
+      raise UpdatingCanceledSubscriptionError if stripe_subscription_canceled?
+
       Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end: cancel_at_period_end)
       render json: {}, status: 200
-    rescue Stripe::InvalidRequestError => e
+    rescue UpdatingCanceledSubscriptionError, Stripe::InvalidRequestError => e
       ErrorNotifier.report(e, stripe_subscription_id: stripe_subscription_id)
       render json: {}, status: 500
     end
@@ -16,6 +20,10 @@ module StripeIntegration
 
     private def stripe_subscription_id
       params[:stripe_subscription_id]
+    end
+
+    private def stripe_subscription_canceled?
+      Stripe::Subscription.retrieve(stripe_subscription_id).canceled_at.present?
     end
   end
 end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_deleted_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_deleted_event_handler.rb
@@ -4,10 +4,14 @@ module StripeIntegration
   module Webhooks
     class CustomerSubscriptionDeletedEventHandler < EventHandler
       def run
-        SubscriptionCanceler.run(stripe_event)
+        SubscriptionCanceler.run(stripe_subscription)
         stripe_webhook_event.processed!
       rescue => e
         stripe_webhook_event.log_error(e)
+      end
+
+      private def stripe_subscription
+        stripe_event.data.object
       end
     end
   end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_updater.rb
@@ -26,7 +26,7 @@ module StripeIntegration
       end
 
       private def previously_incomplete?
-        previous_attributes&.status == INCOMPLETE
+        previous_attributes.respond_to?(:status) && previous_attributes.status == INCOMPLETE
       end
 
       private def recurring

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
@@ -4,33 +4,20 @@ require 'rails_helper'
 
 RSpec.describe StripeIntegration::SubscriptionPaymentMethodsController, type: :request do
   let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
-  let(:cancel_at_period_end) { true }
-  let(:args) { [stripe_subscription_id, cancel_at_period_end: cancel_at_period_end] }
-  let(:update_stripe_subscription) { allow(Stripe::Subscription).to receive(:update).with(*args) }
-  let(:url) { '/stripe_integration/subscription_renewals' }
-  let(:params) { { stripe_subscription_id: stripe_subscription_id, cancel_at_period_end: cancel_at_period_end } }
+  let(:stripe_customer_id) { "cus_#{SecureRandom.hex}"}
+  let(:update_payment_method) { allow(Stripe::Checkout::Session).to receive(:create) }
+  let(:url) { '/stripe_integration/subscription_payment_methods' }
+  let(:params) { { stripe_subscription_id: stripe_subscription_id, stripe_customer_id: stripe_customer_id} }
+  let(:payment_method_session) { double(:payment_method_session, url: redirect_url) }
+  let(:redirect_url) { '/subscriptions?stripe_payment_method_updated=true' }
 
-  context 'Stripe Subscription exists' do
-    before { update_stripe_subscription.and_return({}) }
+  before { update_payment_method.and_return(payment_method_session) }
 
-    it 'returns 200 if the request to Stripe is successful' do
-      post url, params: params, as: :json
+  it 'returns payload with redirect_url' do
+    post url, params: params, as: :json
 
-      expect(response.content_type).to eq 'application/json'
-      expect(response).to have_http_status :ok
-    end
-  end
-
-  context 'Stripe Subscription does not exist' do
-    let(:error_msg) { "No such subscription: '#{stripe_subscription_id}'" }
-
-    before { update_stripe_subscription.and_raise(Stripe::InvalidRequestError.new(error_msg, :id)) }
-
-    it 'returns 500 if there are errors with the request to Stripe' do
-      post url, params: params, as: :json
-
-      expect(response.content_type).to eq 'application/json'
-      expect(response).to have_http_status :internal_server_error
-    end
+    expect(response.content_type).to eq 'application/json'
+    expect(response).to have_http_status :ok
+    expect(JSON.parse(response.body).symbolize_keys).to eq(redirect_url: redirect_url)
   end
 end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request do
+  include_context 'Stripe Subscription'
+
   let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
   let(:cancel_at_period_end) { true }
   let(:args) { [stripe_subscription_id, cancel_at_period_end: cancel_at_period_end] }
   let(:update_stripe_subscription) { allow(Stripe::Subscription).to receive(:update).with(*args) }
   let(:url) { '/stripe_integration/subscription_renewals' }
   let(:params) { { stripe_subscription_id: stripe_subscription_id, cancel_at_period_end: cancel_at_period_end } }
+
+  before { allow(Stripe::Subscription).to receive(:retrieve).with(stripe_subscription_id).and_return(stripe_subscription) }
 
   context 'Stripe Subscription exists' do
     before { update_stripe_subscription.and_return({}) }
@@ -21,12 +25,31 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
     end
   end
 
+  context 'Stripe Subscription exists but was canceled' do
+    let(:stripe_subscription_canceled_at) { Time.current.to_i }
+
+    it 'returns 500 since updates are not allowed on canceled subscriptions' do
+      expect(ErrorNotifier)
+        .to receive(:report)
+        .with(described_class::UpdatingCanceledSubscriptionError, stripe_subscription_id: stripe_subscription_id)
+
+      post url, params: params, as: :json
+
+      expect(response.content_type).to eq 'application/json'
+      expect(response).to have_http_status :internal_server_error
+    end
+  end
+
   context 'Stripe Subscription does not exist' do
     let(:error_msg) { "No such subscription: '#{stripe_subscription_id}'" }
 
     before { update_stripe_subscription.and_raise(Stripe::InvalidRequestError.new(error_msg, :id)) }
 
     it 'returns 500 if there are errors with the request to Stripe' do
+      expect(ErrorNotifier)
+        .to receive(:report)
+        .with(Stripe::InvalidRequestError, stripe_subscription_id: stripe_subscription_id)
+
       post url, params: params, as: :json
 
       expect(response.content_type).to eq 'application/json'

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_deleted_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_deleted_event_handler_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe StripeIntegration::Webhooks::CustomerSubscriptionDeletedEventHand
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
   context 'happy path' do
-    before { allow(subscription_canceler_class).to receive(:run).with(stripe_event) }
+    before { allow(subscription_canceler_class).to receive(:run).with(stripe_subscription) }
 
     it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
   end
@@ -22,7 +22,7 @@ RSpec.describe StripeIntegration::Webhooks::CustomerSubscriptionDeletedEventHand
   context 'error raised' do
     let(:error_class) { subscription_canceler_class::SubscriptionNotFoundError }
 
-    before { allow(subscription_canceler_class).to receive(:run).and_raise(error_class) }
+    before { allow(subscription_canceler_class).to receive(:run).with(stripe_subscription).and_raise(error_class) }
 
     it do
       expect(stripe_webhook_event).to receive(:log_error)

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_updater_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_updater_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionUpdater do
     it { expect { subject }.to change { subscription.reload.recurring }.from(false).to(true) }
   end
 
+  context 'current_period_end is set but there is no status key' do
+    let!(:subscription) { create(:subscription, :non_recurring, stripe_invoice_id: stripe_invoice_id) }
+
+    let(:previous_attributes) { Stripe::StripeObject.construct_from(current_period_end: Time.current.to_i) }
+
+    it { expect { subject }.not_to raise_error }
+  end
+
   context 'cancel_at_period_end is nil on stripe' do
     let!(:subscription) { create(:subscription, stripe_invoice_id: stripe_invoice_id) }
 
@@ -45,3 +53,5 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionUpdater do
     end
   end
 end
+
+

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
@@ -6,8 +6,10 @@ RSpec.shared_context 'Stripe Subscription' do
   include_context 'Stripe Customer'
 
   let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
-  let(:current_period_end) { 1.year.from_now.to_i }
-  let(:current_period_start) { Date.current.to_time.to_i }
+  let(:stripe_subscription_cancel_at_period_end) { false }
+  let(:stripe_subscription_current_period_end) { 1.year.from_now.to_i }
+  let(:stripe_subscription_current_period_start) { Date.current.to_time.to_i }
+  let(:stripe_subscription_canceled_at) { nil }
   let(:stripe_subscription_metadata) { {} }
 
   let(:stripe_subscription) do
@@ -21,12 +23,12 @@ RSpec.shared_context 'Stripe Subscription' do
       billing_cycle_anchor: 1647884415,
       billing_thresholds: nil,
       cancel_at: nil,
-      cancel_at_period_end: false,
-      canceled_at: nil,
+      cancel_at_period_end: stripe_subscription_cancel_at_period_end,
+      canceled_at: stripe_subscription_canceled_at,
       collection_method: 'charge_automatically',
       created: 1647884415,
-      current_period_end: current_period_end,
-      current_period_start: current_period_start,
+      current_period_end: stripe_subscription_current_period_end,
+      current_period_start: stripe_subscription_current_period_start,
       customer: stripe_customer_id,
       days_until_due: nil,
       default_payment_method: stripe_payment_method_id,
@@ -35,7 +37,7 @@ RSpec.shared_context 'Stripe Subscription' do
       discount: nil,
       ended_at: nil,
       items: {
-        object: 'list',
+        object: 'lisk',
         data: [
           stripe_subscription_item
         ],


### PR DESCRIPTION
## WHAT
Address a few bugs from stripe integration
https://sentry.io/organizations/quillorg-5s/issues/3321246859/?referrer=slack
https://sentry.io/organizations/quillorg-5s/issues/3321252188/?referrer=slack
https://sentry.io/organizations/quillorg-5s/issues/3321260200/?referrer=slack

Also, fix `/subscription_payment_methods_controller_spec.rb`, which was a copy-paste error of a different spec.  I've updated it with the actual spec.

## WHY
We want our webhooks from stripe to be processed properly.

## HOW
1.  Fix Stripe::Object access of a `status`.  Sometimes this object does not have a `status` method so we need to check for it first before accessing it.
2. Fix the interface for CustomerSubscriptionDeletedEventHandler.  It should be taking a Stripe::Subscription object but i was wrongly passing it the Stripe::Event wrapper
3. Check to make sure that a Stripe Subscription isn't canceled before trying to update it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A