### PR TITLE
add nil guard

### DIFF
--- a/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
@@ -18,7 +18,7 @@ class ProgressReports::Standards::StudentSerializer < ActiveModel::Serializer
              :mastery_status
 
   def average_score
-    object.average_score.round(2)
+    object.average_score&.round(2) || 0
   end
 
   def student_standards_href

--- a/services/QuillLMS/spec/serializers/progress_reports/standards/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/standards/student_serializer_spec.rb
@@ -61,11 +61,8 @@ describe ProgressReports::Standards::StudentSerializer, type: :serializer do
     end
 
     it 'should not raise error when average_score is nil' do
-      mock_object = double.tap { |mock| allow(mock).to receive(:average_score).and_return(nil) }
-      serializer = described_class.new(mock_object)
-      expect do
-        serializer.average_score
-      end.to_not raise_error
+      serializer = described_class.new(double(average_score: nil))
+      expect { serializer.average_score }.to_not raise_error
       expect(serializer.average_score).to eq 0
     end
 

--- a/services/QuillLMS/spec/serializers/progress_reports/standards/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/standards/student_serializer_spec.rb
@@ -16,26 +16,27 @@ describe ProgressReports::Standards::StudentSerializer, type: :serializer do
   let(:student_for_report) do
     ProgressReports::Standards::Student.new(teacher).results({}).first
   end
+
   let(:serializer) do
     serializer = described_class.new(student_for_report)
     serializer.classroom_id = 123
     serializer
   end
 
-  before do
-    student.activity_sessions.create!(
-      percentage: 0.7547,
-      state: 'finished',
-      completed_at: 5.minutes.ago,
-      classroom_unit: classroom_unit,
-      activity: activity
-    )
-  end
-
   describe '#to_json output' do
     let(:json)   { serializer.to_json }
     let(:parsed) { JSON.parse(json) }
     let(:parsed_student) { parsed['student'] }
+
+    before do
+      student.activity_sessions.create!(
+        percentage: 0.7547,
+        state: 'finished',
+        completed_at: 5.minutes.ago,
+        classroom_unit: classroom_unit,
+        activity: activity
+      )
+    end
 
     it 'includes the right keys' do
       expect(parsed_student.keys).to match_array(
@@ -58,5 +59,15 @@ describe ProgressReports::Standards::StudentSerializer, type: :serializer do
     it 'includes properly rounded scores' do
       expect(parsed_student['average_score']).to eq(0.75)
     end
+
+    it 'should not raise error when average_score is nil' do
+      mock_object = double.tap { |mock| allow(mock).to receive(:average_score).and_return(nil) }
+      serializer = described_class.new(mock_object)
+      expect do
+        serializer.average_score
+      end.to_not raise_error
+      expect(serializer.average_score).to eq 0
+    end
+
   end
 end


### PR DESCRIPTION
## WHAT
Add a nil guard so that a serializer in Standards Report does not raise an exception.

## WHY
So the Standards Report page can load correctly when `average_score` is nil. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=d0394e4bc7784d559757ce366f4e8594

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
