### PR TITLE
Prevent duplicate subscription charges

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -5,11 +5,13 @@ module StripeIntegration
     SUBSCRIPTION_MODE = 'subscription'
 
     def create
-      subscription_checkout_session = Stripe::Checkout::Session.create(subscription_checkout_session_args)
-      render json: { redirect_url: subscription_checkout_session.url }
+      stripe_checkout_session =
+        StripeCheckoutSession.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, customer.id)
+
+      render json: { redirect_url: stripe_checkout_session.url }
     end
 
-    private def subscription_checkout_session_args
+    private def external_checkout_session_args
       {
         cancel_url: cancel_url,
         line_items: [{
@@ -17,7 +19,7 @@ module StripeIntegration
           quantity: 1
         }],
         mode: SUBSCRIPTION_MODE,
-        subscription_data: subscription_data,
+        subscription_data: subscription_data.merge(trial_period_days_arg),
         success_url: success_url
       }.merge(customer_arg)
     end

--- a/services/QuillLMS/app/models/stripe_checkout_session.rb
+++ b/services/QuillLMS/app/models/stripe_checkout_session.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stripe_checkout_sessions
+#
+#  id                           :bigint           not null, primary key
+#  expiration                   :datetime         not null
+#  url                          :string           not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  external_checkout_session_id :string           not null
+#  stripe_price_id              :string           not null
+#  user_id                      :bigint
+#
+# Indexes
+#
+#  index_stripe_checkout_sessions_on_external_checkout_session_id  (external_checkout_session_id)
+#  index_stripe_checkout_sessions_on_user_id                       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class StripeCheckoutSession < ApplicationRecord
   belongs_to :user
 

--- a/services/QuillLMS/app/models/stripe_checkout_session.rb
+++ b/services/QuillLMS/app/models/stripe_checkout_session.rb
@@ -5,7 +5,6 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
-#  expiration                   :datetime         not null
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -25,16 +24,13 @@
 class StripeCheckoutSession < ApplicationRecord
   belongs_to :user
 
-  scope :not_expired, -> { where('expiration > ?', DateTime.now.utc) }
-
   def self.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, user_id)
-    stripe_checkout_session = StripeCheckoutSession.not_expired.find_by(stripe_price_id: stripe_price_id, user_id: user_id)
+    stripe_checkout_session = StripeCheckoutSession.find_by(stripe_price_id: stripe_price_id, user_id: user_id)
     return stripe_checkout_session if stripe_checkout_session.present?
 
     external_checkout_session = Stripe::Checkout::Session.create(external_checkout_session_args)
 
     StripeCheckoutSession.create!(
-      expiration: Time.at(external_checkout_session.expires_at).utc.to_datetime,
       external_checkout_session_id: external_checkout_session.id,
       stripe_price_id: stripe_price_id,
       url: external_checkout_session.url,

--- a/services/QuillLMS/app/models/stripe_checkout_session.rb
+++ b/services/QuillLMS/app/models/stripe_checkout_session.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class StripeCheckoutSession < ApplicationRecord
+  belongs_to :user
+
+  scope :not_expired, -> { where('expiration > ?', DateTime.now.utc) }
+
+  def self.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, user_id)
+    stripe_checkout_session = StripeCheckoutSession.not_expired.find_by(stripe_price_id: stripe_price_id, user_id: user_id)
+    return stripe_checkout_session if stripe_checkout_session.present?
+
+    external_checkout_session = Stripe::Checkout::Session.create(external_checkout_session_args)
+
+    StripeCheckoutSession.create!(
+      expiration: Time.at(external_checkout_session.expires_at).utc.to_datetime,
+      external_checkout_session_id: external_checkout_session.id,
+      stripe_price_id: stripe_price_id,
+      url: external_checkout_session.url,
+      user_id: user_id
+    )
+  end
+end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -113,6 +113,7 @@ class User < ApplicationRecord
   has_many :blog_post_user_ratings
 
   has_many :change_logs
+  has_many :stripe_checkout_sessions, dependent: :destroy
 
   accepts_nested_attributes_for :auth_credential
 

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_completed_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_completed_event_handler.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  module Webhooks
+    class CheckoutSessionCompletedEventHandler < EventHandler
+      def run
+        stripe_checkout_session&.update!(expiration: DateTime.now.utc)
+        stripe_webhook_event.processed!
+      rescue => e
+        stripe_webhook_event.log_error(e)
+      end
+
+      private def stripe_checkout_session
+        StripeCheckoutSession.find_by(external_checkout_session_id: external_checkout_session_id)
+      end
+
+      private def external_checkout_session_id
+        stripe_event.data.object.id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_completed_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_completed_event_handler.rb
@@ -4,7 +4,7 @@ module StripeIntegration
   module Webhooks
     class CheckoutSessionCompletedEventHandler < EventHandler
       def run
-        stripe_checkout_session&.update!(expiration: DateTime.now.utc)
+        stripe_checkout_session&.destroy!
         stripe_webhook_event.processed!
       rescue => e
         stripe_webhook_event.log_error(e)

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_expired_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_expired_event_handler.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  module Webhooks
+    class CheckoutSessionExpiredEventHandler < EventHandler
+      def run
+        stripe_checkout_session&.update!(expiration: DateTime.now.utc)
+        stripe_webhook_event.processed!
+      rescue => e
+        stripe_webhook_event.log_error(e)
+      end
+
+      private def stripe_checkout_session
+        StripeCheckoutSession.find_by(external_checkout_session_id: external_checkout_session_id)
+      end
+
+      private def external_checkout_session_id
+        stripe_event.data.object.id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_expired_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/checkout_session_expired_event_handler.rb
@@ -4,7 +4,7 @@ module StripeIntegration
   module Webhooks
     class CheckoutSessionExpiredEventHandler < EventHandler
       def run
-        stripe_checkout_session&.update!(expiration: DateTime.now.utc)
+        stripe_checkout_session&.destroy!
         stripe_webhook_event.processed!
       rescue => e
         stripe_webhook_event.log_error(e)

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
@@ -4,6 +4,7 @@ module StripeIntegration
   module Webhooks
     class EventHandlerFactory
       SINGLE_EVENT_HANDLER_LOOKUP = {
+        'checkout.session.completed' => CheckoutSessionCompletedEventHandler,
         'checkout.session.expired' => CheckoutSessionExpiredEventHandler,
         'customer.subscription.deleted' => CustomerSubscriptionDeletedEventHandler,
         'customer.subscription.updated' => CustomerSubscriptionUpdatedEventHandler,

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/event_handler_factory.rb
@@ -4,6 +4,7 @@ module StripeIntegration
   module Webhooks
     class EventHandlerFactory
       SINGLE_EVENT_HANDLER_LOOKUP = {
+        'checkout.session.expired' => CheckoutSessionExpiredEventHandler,
         'customer.subscription.deleted' => CustomerSubscriptionDeletedEventHandler,
         'customer.subscription.updated' => CustomerSubscriptionUpdatedEventHandler,
         'invoice.paid' => InvoicePaidEventHandler,

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -9,8 +9,6 @@ module StripeIntegration
         'charge.failed',
         'charge.refunded',
         'charge.succeeded',
-        'checkout.session.completed',
-        'checkout.session.expired',
         'customer.created',
         'customer.source.created',
         'customer.source.expiring',

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -4,6 +4,7 @@ module StripeIntegration
   module Webhooks
     class SubscriptionCreator < ApplicationService
       class Error < StandardError; end
+      class DuplicateSubscriptionError < Error; end
       class NilSchoolError < Error; end
       class NilStripeCustomerIdError < Error; end
       class NilStripeInvoiceIdError < Error; end
@@ -23,6 +24,7 @@ module StripeIntegration
         raise NilPurchaserEmailError if purchaser_email.nil?
         raise NilStripePriceIdError if stripe_price_id.nil?
         raise NilStripeInvoiceIdError if stripe_invoice.id.nil?
+        raise DuplicateSubscriptionError if purchaser.subscription.present?
 
         subscription
         save_stripe_customer_id
@@ -44,7 +46,6 @@ module StripeIntegration
       rescue ActiveRecord::RecordNotFound
         raise PurchaserNotFoundError
       end
-
 
       private def purchaser_email
         stripe_invoice.customer_email

--- a/services/QuillLMS/db/migrate/20220607120432_create_stripe_checkout_sessions.rb
+++ b/services/QuillLMS/db/migrate/20220607120432_create_stripe_checkout_sessions.rb
@@ -3,7 +3,6 @@
 class CreateStripeCheckoutSessions < ActiveRecord::Migration[5.1]
   def change
     create_table :stripe_checkout_sessions do |t|
-      t.datetime :expiration, null: false
       t.string :external_checkout_session_id, null: false, index: true
       t.string :stripe_price_id, null: false
       t.string :url, null: false

--- a/services/QuillLMS/db/migrate/20220607120432_create_stripe_checkout_sessions.rb
+++ b/services/QuillLMS/db/migrate/20220607120432_create_stripe_checkout_sessions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateStripeCheckoutSessions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :stripe_checkout_sessions do |t|
+      t.datetime :expiration, null: false
+      t.string :external_checkout_session_id, null: false, index: true
+      t.string :stripe_price_id, null: false
+      t.string :url, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/plans.rb
+++ b/services/QuillLMS/spec/factories/plans.rb
@@ -21,7 +21,7 @@
 require 'rails_helper'
 
 FactoryBot.define do
-  factory :plan, aliases: [:teacher_paid_plan] do
+  factory :plan, aliases: [:teacher_premium_plan] do
     name { Plan::STRIPE_TEACHER_PLAN }
     display_name { 'Teacher Premium' }
     price { 9000 }
@@ -29,7 +29,7 @@ FactoryBot.define do
     interval { Plan::YEARLY_INTERVAL_TYPE }
     interval_count { 1 }
 
-    factory :school_paid_plan do
+    factory :school_premium_plan do
       name { Plan::STRIPE_SCHOOL_PLAN }
       display_name { 'School Premium' }
       price { 180000 }

--- a/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
+++ b/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
@@ -5,7 +5,6 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
-#  expiration                   :datetime         not null
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -24,7 +23,6 @@
 #
 FactoryBot.define do
   factory :stripe_checkout_session do
-    expiration { 24.hours.from_now }
     external_checkout_session_id { "cs_#{SecureRandom.hex}" }
     stripe_price_id { "price_#{SecureRandom.hex}" }
     url { "https://www.checkout.stripe/pay/cs_#{SecureRandom.hex}" }

--- a/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
+++ b/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :stripe_checkout_session do
+    expiration { 24.hours.from_now }
+    external_checkout_session_id { "cs_#{SecureRandom.hex}" }
+    stripe_price_id { "price_#{SecureRandom.hex}" }
+    url { "https://www.checkout.stripe/pay/cs_#{SecureRandom.hex}" }
+    user
+  end
+end

--- a/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
+++ b/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stripe_checkout_sessions
+#
+#  id                           :bigint           not null, primary key
+#  expiration                   :datetime         not null
+#  url                          :string           not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  external_checkout_session_id :string           not null
+#  stripe_price_id              :string           not null
+#  user_id                      :bigint
+#
+# Indexes
+#
+#  index_stripe_checkout_sessions_on_external_checkout_session_id  (external_checkout_session_id)
+#  index_stripe_checkout_sessions_on_user_id                       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :stripe_checkout_session do
     expiration { 24.hours.from_now }

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe Plan, type: :model do
   end
 
   context '.stripe_teacher_plan' do
-    let!(:plan) { create(:teacher_paid_plan) }
+    let!(:plan) { create(:teacher_premium_plan) }
 
     it { expect(Plan.stripe_teacher_plan).to eq plan }
   end
 
   context 'teacher?' do
-    let(:plan) { create(:teacher_paid_plan) }
+    let(:plan) { create(:teacher_premium_plan) }
 
     it { expect(plan.teacher?).to be true }
   end

--- a/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeCheckoutSession, type: :model do
+
+  describe '.not_expired' do
+    let!(:stripe_checkout_session) { create(:stripe_checkout_session) }
+    let!(:expired_stripe_checkout_session) { create(:stripe_checkout_session, expiration: DateTime.now.utc) }
+
+    it { expect(described_class.not_expired).to eq [stripe_checkout_session] }
+  end
+
+  describe '.custom_find_or_create_by!' do
+    let(:external_checkout_session_args) { {} }
+
+    subject { described_class.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, user_id) }
+
+    context 'stripe_checkout_session exists' do
+      let!(:stripe_checkout_session) { create(:stripe_checkout_session) }
+
+      let(:stripe_price_id) { stripe_checkout_session.stripe_price_id }
+      let(:user_id) { stripe_checkout_session.user_id }
+
+      it { expect(subject).to eq stripe_checkout_session }
+      it { expect { subject }.not_to change(StripeCheckoutSession, :count) }
+    end
+
+    context 'stripe_checkout_session does not exist' do
+      let(:external_checkout_session_id) { "cs_#{SecureRandom.hex}" }
+      let(:stripe_price_id) { "price_#{SecureRandom.hex}" }
+      let(:user_id) { create(:user).id }
+      let(:url) { 'https;//example.com' }
+
+      let(:external_checkout_session) { double(id: external_checkout_session_id, url: url, expires_at: DateTime.now.utc) }
+
+      before { allow(Stripe::Checkout::Session).to receive(:create).and_return(external_checkout_session) }
+
+      it { expect { subject }.to change(StripeCheckoutSession, :count).from(0).to(1) }
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
@@ -5,7 +5,6 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
-#  expiration                   :datetime         not null
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -25,13 +24,6 @@
 require 'rails_helper'
 
 RSpec.describe StripeCheckoutSession, type: :model do
-
-  describe '.not_expired' do
-    let!(:stripe_checkout_session) { create(:stripe_checkout_session) }
-    let!(:expired_stripe_checkout_session) { create(:stripe_checkout_session, expiration: DateTime.now.utc) }
-
-    it { expect(described_class.not_expired).to eq [stripe_checkout_session] }
-  end
 
   describe '.custom_find_or_create_by!' do
     let(:external_checkout_session_args) { {} }

--- a/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stripe_checkout_sessions
+#
+#  id                           :bigint           not null, primary key
+#  expiration                   :datetime         not null
+#  url                          :string           not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  external_checkout_session_id :string           not null
+#  stripe_price_id              :string           not null
+#  user_id                      :bigint
+#
+# Indexes
+#
+#  index_stripe_checkout_sessions_on_external_checkout_session_id  (external_checkout_session_id)
+#  index_stripe_checkout_sessions_on_user_id                       (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 RSpec.describe StripeCheckoutSession, type: :model do

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
   include_context 'Stripe Customer'
 
   describe '#create' do
-    let(:redirect_url) { '/some_redirect_url' }
-    let(:stripe_checkout_session) { double(:stripe_checkout_session, url: redirect_url) }
-    let(:params) { { customer_email: customer_email, price_id: stripe_price_id } }
+    let(:stripe_checkout_session) { create(:stripe_checkout_session) }
+    let(:redirect_url) { stripe_checkout_session.url }
+    let(:params) { { customer_email: customer_email, stripe_price_id: stripe_price_id } }
     let(:url) { '/stripe_integration/subscription_checkout_sessions' }
 
-    before { allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_checkout_session) }
+    before { allow(StripeCheckoutSession).to receive(:custom_find_or_create_by!).and_return(stripe_checkout_session) }
 
     it 'creates a stripe checkout session and provides a redirect' do
       post url, params: params, as: :json

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionCompletedEventHandler
     create(:stripe_checkout_session, external_checkout_session_id: external_checkout_session_id)
   end
 
-  let!(:expiration) { stripe_checkout_session.expiration }
   let(:stripe_webhook_event) { create(:stripe_webhook_event, event_type: stripe_event_type) }
   let(:external_id) { stripe_webhook_event.external_id }
   let(:stripe_checkout_session_status) { 'expired' }
@@ -18,5 +17,10 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionCompletedEventHandler
 
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
-  it { expect { subject }.to change { stripe_checkout_session.reload.expiration }.from(expiration) }
+  it 'updates the expiration of stripe checkout session' do
+    expect do
+      subject
+      stripe_checkout_session.reload
+    end.to change(stripe_checkout_session, :expiration)
+  end
 end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe StripeIntegration::Webhooks::CheckoutSessionExpiredEventHandler do
-  include_context 'Stripe Checkout Session Expired Event'
+RSpec.describe StripeIntegration::Webhooks::CheckoutSessionCompletedEventHandler do
+  include_context 'Stripe Checkout Session Completed Event'
 
   let!(:stripe_checkout_session) do
     create(:stripe_checkout_session, external_checkout_session_id: external_checkout_session_id)

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_completed_event_handler_spec.rb
@@ -17,10 +17,5 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionCompletedEventHandler
 
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
-  it 'updates the expiration of stripe checkout session' do
-    expect do
-      subject
-      stripe_checkout_session.reload
-    end.to change(stripe_checkout_session, :expiration)
-  end
+  it { expect { subject }.to change(StripeCheckoutSession, :count).from(1).to(0) }
 end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
@@ -17,10 +17,5 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionExpiredEventHandler d
 
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
-  it 'updates the expiration of stripe checkout session' do
-    expect do
-      subject
-      stripe_checkout_session.reload
-    end.to change(stripe_checkout_session, :expiration)
-  end
+  it { expect { subject }.to change(StripeCheckoutSession, :count).from(1).to(0) }
 end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::Webhooks::CheckoutSessionExpiredEventHandler do
+  include_context 'Stripe Checkout Session Expired Event'
+
+  let!(:stripe_checkout_session) do
+    create(:stripe_checkout_session, external_checkout_session_id: external_checkout_session_id)
+  end
+
+  let(:stripe_webhook_event) { create(:stripe_webhook_event, event_type: stripe_event_type) }
+  let(:external_id) { stripe_webhook_event.external_id }
+  let(:stripe_checkout_session_status) { 'expired' }
+
+  subject { described_class.run(stripe_webhook_event) }
+
+  before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
+
+  it { expect { subject }.to change { stripe_checkout_session.reload.expiration } }
+end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/checkout_session_expired_event_handler_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionExpiredEventHandler d
     create(:stripe_checkout_session, external_checkout_session_id: external_checkout_session_id)
   end
 
-  let!(:expiration) { stripe_checkout_session.expiration }
   let(:stripe_webhook_event) { create(:stripe_webhook_event, event_type: stripe_event_type) }
   let(:external_id) { stripe_webhook_event.external_id }
   let(:stripe_checkout_session_status) { 'expired' }
@@ -18,5 +17,10 @@ RSpec.describe StripeIntegration::Webhooks::CheckoutSessionExpiredEventHandler d
 
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
-  it { expect { subject }.to change { stripe_checkout_session.reload.expiration }.from(expiration) }
+  it 'updates the expiration of stripe checkout session' do
+    expect do
+      subject
+      stripe_checkout_session.reload
+    end.to change(stripe_checkout_session, :expiration)
+  end
 end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/external_checkout_session.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/external_checkout_session.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'External Checkout Session' do
+  include_context 'Stripe Customer'
+
+  let(:external_checkout_session_id) { "cs_#{SecureRandom.hex}" }
+
+  let(:external_checkout_session) do
+    Stripe::Invoice.construct_from(
+      id: external_checkout_session_id,
+      object: 'checkout.session',
+      after_expiration: nil,
+      allow_promotion_codes: nil,
+      amount_subtotal: 8000,
+      amount_total: 8000,
+      automatic_tax: {
+        enabled: false,
+        status: nil
+      },
+      billing_address_collection: nil,
+      cancel_url: 'http://localhost:3000/premium',
+      client_reference_id: nil,
+      consent: nil,
+      consent_collection: nil,
+      currency: 'usd',
+      customer: stripe_customer_id,
+      customer_creation: nil,
+      customer_details: {
+        address: nil,
+        email: customer_email,
+        name: nil,
+        phone: nil,
+        tax_exempt: nil,
+        tax_ids: nil
+      },
+      customer_email: nil,
+      expires_at: 1654609711,
+      livemode: false,
+      locale: nil,
+      metadata: {},
+      mode: 'subscription',
+      payment_intent: nil,
+      payment_link: nil,
+      payment_method_options: nil,
+      payment_method_types: ['card'],
+      payment_status: 'unpaid',
+      phone_number_collection: {
+        enabled: false
+      },
+      recovered_from: nil,
+      setup_intent: nil,
+      shipping: nil,
+      shipping_address_collection: nil,
+      shipping_options: [],
+      shipping_rate: nil,
+      status: stripe_checkout_session_status,
+      submit_type: nil,
+      subscription: nil,
+      success_url: "http://localhost:3000/subscriptions?checkout_session_id={CHECKOUT_SESSION_ID}",
+      total_details: {
+        amount_discount: 0,
+        amount_shipping: 0,
+        amount_tax: 0
+      },
+      url: nil
+    )
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_completed_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_completed_event.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Stripe Checkout Session Completed Event' do
+  include_context 'External Checkout Session'
+
+  let(:stripe_event_id) { "evt_#{SecureRandom.hex}"}
+  let(:stripe_event_type) { 'checkout.session.completed' }
+  let(:stripe_checkout_session_status) { 'complete' }
+
+  let(:stripe_event) do
+    Stripe::Event.construct_from(
+      id: stripe_event_id,
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1654609712,
+      data:  {
+        object: external_checkout_session
+      },
+      livemode: false,
+      pending_webhooks: 3,
+      request: {
+        id: 'req_ji2VMrCOabDEc7',
+        idempotency_key: '14e52478-1935-43a8-ac5e-96bbc039706f'
+      },
+      type: stripe_event_type
+    )
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_expired_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_expired_event.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Stripe Checkout Session Expired Event' do
+  include_context 'External Checkout Session'
+
+  let(:stripe_event_id) { "evt_#{SecureRandom.hex}"}
+  let(:stripe_event_type) { 'checkout.session.expired' }
+  let(:stripe_checkout_session_status) { 'expired' }
+
+  let(:stripe_event) do
+    Stripe::Event.construct_from(
+      id: stripe_event_id,
+      object: 'event',
+      api_version: '2020-08-27',
+      created: 1654609712,
+      data:  {
+        object: external_checkout_session
+      },
+      livemode: false,
+      pending_webhooks: 3,
+      request: {
+        id: 'req_ji2VMrCOabDEc7',
+        idempotency_key: '14e52478-1935-43a8-ac5e-96bbc039706f'
+      },
+      type: stripe_event_type
+    )
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_price.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_price.rb
@@ -4,7 +4,7 @@ RSpec.shared_context "Stripe Price" do
   let(:stripe_price_id) { STRIPE_TEACHER_PLAN_PRICE_ID }
   let(:stripe_product_id) { "prod_#{SecureRandom.hex}" }
 
-  before { create(:teacher_paid_plan) }
+  before { create(:teacher_premium_plan) }
 
   let(:stripe_price) do
     Stripe::Price.construct_from(


### PR DESCRIPTION
## WHAT
Clean up some edge cases involving users purchasing duplicate subscriptions.

## WHY
The presence of duplicate subscriptions causes a headache for support as well as our backend.

## HOW
In the original design, `Stripe::Checkout::Session` objects were [created](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb#L8) with each request to the controller.  However, this leads to an edge cases where a user opens multiple tabs and attempts to purchase two subscriptions at separate times.  

To fix this, I'm introducing a new database model, `StripeCheckoutSession` that will store a few pieces of information that will point each user to a sole url for purchase of a particular subscription.
1. `external_checkout_session_id` is the id used for the checkout session on stripe.  This value is used with the webhooks `checkout.sesssion.completed` and `checkout.session.expired`.
2. `stripe_price_id` identifies the type of subscription being purchased
3. `url` is the redirect_url that stripe produces that will direct users to the purchasing page.
4.  `user_id`

With this change, if a user clicks 'Buy Now / Renew Subscription' for the same product in different tabs, they will redirected to the the same URL which refers to the same `StripeCheckoutSession` (i.e (NB Stripe will block duplicate purchases from the same session).

Upon completion of purchase (i.e. webhook 'checkout.session.completed'), or expiration of the checkout session (i.e. webhook 'checkout.session.expired'), the `StripeCheckoutSession` will be deleted.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Handle-duplicate-charges-336f63d940da4988aeb1d761b9755302

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
