### PR TITLE
Standard report na masking

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
@@ -15,7 +15,7 @@ class Teachers::ProgressReports::Standards::StudentStandardsController < Teacher
             serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
             # Doing this because can't figure out how to get custom params into serializers
             serializer.classroom_id = params[:classroom_id]
-            serializer.as_json(root: false)
+            serializer.as_json(root: false).merge(is_evidence: standard_category_id == Constants::EVIDENCE_STANDARD_CATEGORY)
           end
           student = User.find(params[:student_id])
           student = nil unless current_user.teaches_student?(student.id)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/standards/student_standards_controller.rb
@@ -15,7 +15,7 @@ class Teachers::ProgressReports::Standards::StudentStandardsController < Teacher
             serializer = ::ProgressReports::Standards::StandardSerializer.new(standard)
             # Doing this because can't figure out how to get custom params into serializers
             serializer.classroom_id = params[:classroom_id]
-            serializer.as_json(root: false).merge(is_evidence: standard_category_id == Constants::EVIDENCE_STANDARD_CATEGORY)
+            serializer.as_json(root: false)
           end
           student = User.find(params[:student_id])
           student = nil unless current_user.teaches_student?(student.id)

--- a/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
@@ -36,7 +36,7 @@ class ProgressReports::Standards::AllClassroomsStandard
           COUNT(DISTINCT(final_activity_sessions.user_id)) AS total_student_count,
           COUNT(DISTINCT(avg_score_for_standard_by_user.user_id)) AS proficient_count,
           SUM(final_activity_sessions.timespent) AS timespent,
-          (CASE WHEN standards.standard_category_id = #{Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
+          (CASE WHEN standards.standard_category_id = #{::Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
 
         FROM standards
         JOIN standard_levels

--- a/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ProgressReports::Standards::AllClassroomsStandard
+  EVIDENCE_STANDARD_CATEGORY = 27
   def initialize(teacher)
     @teacher = teacher
     @proficiency_cutoff = ProficiencyEvaluator.proficiency_cutoff
@@ -35,7 +36,9 @@ class ProgressReports::Standards::AllClassroomsStandard
           COUNT(DISTINCT(final_activity_sessions.activity_id)) AS total_activity_count,
           COUNT(DISTINCT(final_activity_sessions.user_id)) AS total_student_count,
           COUNT(DISTINCT(avg_score_for_standard_by_user.user_id)) AS proficient_count,
-          SUM(final_activity_sessions.timespent) AS timespent
+          SUM(final_activity_sessions.timespent) AS timespent,
+          (CASE WHEN standards.standard_category_id = #{EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
+
         FROM standards
         JOIN standard_levels
           ON standard_levels.id = standards.standard_level_id

--- a/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ProgressReports::Standards::AllClassroomsStandard
-  EVIDENCE_STANDARD_CATEGORY = 27
   def initialize(teacher)
     @teacher = teacher
     @proficiency_cutoff = ProficiencyEvaluator.proficiency_cutoff
@@ -37,7 +36,7 @@ class ProgressReports::Standards::AllClassroomsStandard
           COUNT(DISTINCT(final_activity_sessions.user_id)) AS total_student_count,
           COUNT(DISTINCT(avg_score_for_standard_by_user.user_id)) AS proficient_count,
           SUM(final_activity_sessions.timespent) AS timespent,
-          (CASE WHEN standards.standard_category_id = #{EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
+          (CASE WHEN standards.standard_category_id = #{Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
 
         FROM standards
         JOIN standard_levels

--- a/services/QuillLMS/app/queries/progress_reports/standards/new_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/new_standard.rb
@@ -22,7 +22,7 @@ class ProgressReports::Standards::NewStandard
           SUM(best_activity_sessions.timespent) AS timespent,
           COALESCE(AVG(proficient_count.user_count), 0)::integer AS proficient_student_count,
           COALESCE(AVG(not_proficient_count.user_count), 0)::integer AS not_proficient_student_count,
-          (CASE WHEN standards.standard_category_id = #{Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
+          (CASE WHEN standards.standard_category_id = #{::Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
         SQL
       )
       .joins('JOIN standard_levels ON standard_levels.id = standards.standard_level_id')

--- a/services/QuillLMS/app/queries/progress_reports/standards/new_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/new_standard.rb
@@ -21,7 +21,8 @@ class ProgressReports::Standards::NewStandard
           COUNT(DISTINCT(best_activity_sessions.user_id)) AS total_student_count,
           SUM(best_activity_sessions.timespent) AS timespent,
           COALESCE(AVG(proficient_count.user_count), 0)::integer AS proficient_student_count,
-          COALESCE(AVG(not_proficient_count.user_count), 0)::integer AS not_proficient_student_count
+          COALESCE(AVG(not_proficient_count.user_count), 0)::integer AS not_proficient_student_count,
+          (CASE WHEN standards.standard_category_id = #{Constants::EVIDENCE_STANDARD_CATEGORY} THEN true ELSE false END) AS is_evidence
         SQL
       )
       .joins('JOIN standard_levels ON standard_levels.id = standards.standard_level_id')

--- a/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
@@ -18,6 +18,10 @@ class ProgressReports::Standards::StandardSerializer < ActiveModel::Serializer
              :mastery_status,
              :is_evidence
 
+  def is_evidence
+    !!object.try(:is_evidence)
+  end
+
   def average_score
     object.average_score&.round(2) || 0
   end

--- a/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
@@ -15,10 +15,11 @@ class ProgressReports::Standards::StandardSerializer < ActiveModel::Serializer
              :timespent,
              :average_score,
              :standard_students_href,
-             :mastery_status
+             :mastery_status,
+             :is_evidence
 
   def average_score
-    object.average_score.round(2)
+    object.average_score&.round(2) || 0
   end
 
   def standard_students_href

--- a/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
@@ -18,9 +18,11 @@ class ProgressReports::Standards::StandardSerializer < ActiveModel::Serializer
              :mastery_status,
              :is_evidence
 
+  # rubocop:disable Naming/PredicateName
   def is_evidence
     !!object.try(:is_evidence)
   end
+  # rubocop:enable Naming/PredicateName
 
   def average_score
     object.average_score&.round(2) || 0

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/constants.js
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/constants.js
@@ -4,3 +4,5 @@ export const DIAGNOSTIC_KEY = 'diagnostic'
 export const CONNECT_KEY = 'connect'
 export const LESSONS_KEY = 'lessons'
 export const EVIDENCE_KEY = 'evidence'
+
+export const NOT_SCORED_DISPLAY_TEXT = 'Not Scored'

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
@@ -7,13 +7,14 @@ import CSVDownloadForProgressReport from './csv_download_for_progress_report.jsx
 import EmptyStateForReport from './empty_state_for_report'
 import { PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, } from './progress_report_constants'
 
+import { NOT_SCORED_DISPLAY_TEXT } from './constants.js'
+
 import ItemDropdown from '../general_components/dropdown_selectors/item_dropdown'
 import LoadingSpinner from '../shared/loading_indicator.jsx'
 import userIsPremium from '../modules/user_is_premium'
 import {sortTableByStandardLevel} from '../../../../modules/sortingMethods.js'
 import { Tooltip, ReactTable, } from '../../../Shared/index'
-import { getTimeSpent } from '../../helpers/studentReports';
-
+import { getTimeSpent } from '../../helpers/studentReports'
 
 interface StandardsAllClassroomsProgressReportProps {
 }
@@ -191,7 +192,7 @@ export default class StandardsAllClassroomsProgressReport extends React.Componen
       row.standard_level = row.standard_level_name
       row.standard_name = row.name
       row.number_of_students = Number(row.total_student_count)
-      row.proficient = row.is_evidence ? 'Not Scored' : `${row.proficient_count} of ${row.total_student_count}`
+      row.proficient = row.is_evidence ? NOT_SCORED_DISPLAY_TEXT : `${row.proficient_count} of ${row.total_student_count}`
       row.activities = Number(row.total_activity_count)
       row.green_arrow = (
         <a className='green-arrow' href={`/teachers/progress_reports/standards/classrooms/${selectedClassroomId || 0}/standards/${row.id}/students`}>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
@@ -191,7 +191,7 @@ export default class StandardsAllClassroomsProgressReport extends React.Componen
       row.standard_level = row.standard_level_name
       row.standard_name = row.name
       row.number_of_students = Number(row.total_student_count)
-      row.proficient = row.is_evidence ? 'N/A' : `${row.proficient_count} of ${row.total_student_count}`
+      row.proficient = row.is_evidence ? 'Not Scored' : `${row.proficient_count} of ${row.total_student_count}`
       row.activities = Number(row.total_activity_count)
       row.green_arrow = (
         <a className='green-arrow' href={`/teachers/progress_reports/standards/classrooms/${selectedClassroomId || 0}/standards/${row.id}/students`}>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
@@ -16,7 +16,6 @@ import { getTimeSpent } from '../../helpers/studentReports';
 
 
 interface StandardsAllClassroomsProgressReportProps {
-
 }
 
 interface StandardsAllClassroomsProgressReportState {
@@ -192,7 +191,7 @@ export default class StandardsAllClassroomsProgressReport extends React.Componen
       row.standard_level = row.standard_level_name
       row.standard_name = row.name
       row.number_of_students = Number(row.total_student_count)
-      row.proficient = `${row.proficient_count} of ${row.total_student_count}`
+      row.proficient = row.is_evidence ? 'N/A' : `${row.proficient_count} of ${row.total_student_count}`
       row.activities = Number(row.total_activity_count)
       row.green_arrow = (
         <a className='green-arrow' href={`/teachers/progress_reports/standards/classrooms/${selectedClassroomId || 0}/standards/${row.id}/students`}>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
@@ -25,6 +25,10 @@ export default class IndividualStandardsReport extends React.Component {
     this.getData()
   }
 
+  decorateAsEvidence(standard) {
+    return !!standard?.is_evidence
+  }
+
   getData() {
     this.setState({loading: true}, () => {
       const { sourceUrl } = this.props;
@@ -36,10 +40,12 @@ export default class IndividualStandardsReport extends React.Component {
         url: url
       }, (e, r, body) => {
         const data = JSON.parse(body)
-        const studentData = this.formattedStudentData(data.students)
+        const decorateAsEvidence = this.decorateAsEvidence(data.standards[0])
+        const studentData = this.formattedStudentData(data.students, decorateAsEvidence)
         const csvData = this.formatDataForCSV(data.students)
         const standard = data.standards[0]
         const classrooms = JSON.parse(body).classrooms
+
         const allClassrooms = {name: showAllClassroomKey}
         const selectedClassroom = data.selected_classroom ? data.selected_classroom : allClassrooms
         classrooms.unshift(allClassrooms)
@@ -78,7 +84,7 @@ export default class IndividualStandardsReport extends React.Component {
         className: blurIfNotPremium,
         resizable: false,
         Cell: ({row}) => (
-          `${row.original['average_score']}%`
+          `${row.original['average_score']}`
         )
       }, {
         Header: 'Proficiency Status',
@@ -104,12 +110,12 @@ export default class IndividualStandardsReport extends React.Component {
     return csvData
   }
 
-  formattedStudentData(data) {
+  formattedStudentData(data, decorateAsEvidence=false) {
     return data.map((row) => {
       row.name = row.name
       row.total_activity_count = Number(row.total_activity_count)
-      row.average_score = Number(row.average_score * 100)
-      row.proficiency_status = row.proficiency_status
+      row.average_score = decorateAsEvidence ? 'Not Scored' : `${Number(row.average_score * 100)}%`
+      row.mastery_status = decorateAsEvidence ? 'Not Scored' : row.mastery_status
       row.green_arrow = (
         <a className='green-arrow' href={row.student_standards_href}>
           <img alt="" src="https://assets.quill.org/images/icons/chevron-dark-green.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
@@ -5,6 +5,8 @@ import request from 'request'
 
 import CSVDownloadForProgressReport from './csv_download_for_progress_report.jsx'
 
+import { NOT_SCORED_DISPLAY_TEXT } from './constants.js'
+
 import {sortTableByLastName} from '../../../../modules/sortingMethods.js'
 import LoadingSpinner from '../shared/loading_indicator.jsx'
 import ItemDropdown from '../general_components/dropdown_selectors/item_dropdown'
@@ -114,8 +116,8 @@ export default class IndividualStandardsReport extends React.Component {
     return data.map((row) => {
       row.name = row.name
       row.total_activity_count = Number(row.total_activity_count)
-      row.average_score = decorateAsEvidence ? 'Not Scored' : `${Number(row.average_score * 100)}%`
-      row.mastery_status = decorateAsEvidence ? 'Not Scored' : row.mastery_status
+      row.average_score = decorateAsEvidence ? NOT_SCORED_DISPLAY_TEXT : `${Number(row.average_score * 100)}%`
+      row.mastery_status = decorateAsEvidence ? NOT_SCORED_DISPLAY_TEXT : row.mastery_status
       row.green_arrow = (
         <a className='green-arrow' href={row.student_standards_href}>
           <img alt="" src="https://assets.quill.org/images/icons/chevron-dark-green.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standards_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standards_progress_report.jsx
@@ -4,6 +4,8 @@ import _ from 'underscore'
 
 import CSVDownloadForProgressReport from './csv_download_for_progress_report.jsx'
 
+import { NOT_SCORED_DISPLAY_TEXT } from './constants.js'
+
 import LoadingSpinner from '../shared/loading_indicator.jsx'
 import userIsPremium from '../modules/user_is_premium'
 import {sortTableByStandardLevel} from '../../../../modules/sortingMethods.js'
@@ -81,7 +83,7 @@ export default class StandardsProgressReport extends React.Component {
         resizable: false,
         width: 100,
         Cell: ({row}) => (
-          `${row.original['average_score']}%`
+          `${row.original['average_score']}`
         )
       }, {
         Header: 'Proficiency Status',
@@ -118,8 +120,8 @@ export default class StandardsProgressReport extends React.Component {
       row.standard_level = row.standard_level_name
       row.standard_name = row.name
       row.activities = Number(row.total_activity_count)
-      row.average_score = Number(row.average_score * 100)
-      row.mastery_status = row.mastery_status
+      row.average_score = row.is_evidence ? NOT_SCORED_DISPLAY_TEXT : `${Number(row.average_score * 100)}%`
+      row.mastery_status = row.is_evidence ? NOT_SCORED_DISPLAY_TEXT : row.mastery_status
       row.green_arrow = (
         <a className='green-arrow' href={`/teachers/progress_reports/standards/classrooms/0/standards/${row.id}/students`}>
           <img alt="" src="https://assets.quill.org/images/icons/chevron-dark-green.svg" />

--- a/services/QuillLMS/lib/constants.rb
+++ b/services/QuillLMS/lib/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Constants
   EVIDENCE_STANDARD_CATEGORY = 27
 end

--- a/services/QuillLMS/lib/constants.rb
+++ b/services/QuillLMS/lib/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  EVIDENCE_STANDARD_CATEGORY = 27
+end

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe ProgressReports::Standards::AllClassroomsStandard do
   describe '#results' do
-    let!(:standard1) { create(:standard) }
+
+    #let!(:standard1) { create(:standard, standard_category: non_evidence_standard_category) }
     let!(:teacher1) { create(:teacher, :with_classrooms_students_and_activities) }
 
     let!(:sample_student_data) do
@@ -15,15 +16,55 @@ describe ProgressReports::Standards::AllClassroomsStandard do
       }
     end
 
-    let!(:activity_session1) do
+    let!(:activity_session_non_evidence) do
       create(:activity_session, user: sample_student_data[:student], classroom_unit: sample_student_data[:classroom_unit])
     end
 
-    it 'should return results' do
-      expected_keys =  ["id", "name", "standard_level_name", "total_activity_count", "total_student_count", "proficient_count", "timespent"]
+    it 'should return the correctly shaped payload' do
+      expected_keys =  [
+        'id',
+        'name',
+        'standard_category_name',
+        'total_activity_count',
+        'total_student_count',
+        'proficient_count',
+        'timespent',
+        'is_evidence'
+      ]
       result = ProgressReports::Standards::AllClassroomsStandard.new(teacher1)
       .results(sample_student_data[:classroom_unit].classroom_id, nil)
       expect(result.first.keys).to eq expected_keys
+    end
+
+    context 'without evidence activity' do
+      it 'should indicate evidence activities via the is_evidence property' do
+        result = ProgressReports::Standards::AllClassroomsStandard.new(teacher1)
+        .results(sample_student_data[:classroom_unit].classroom_id, nil)
+        expect(result.first['is_evidence']).to eq false
+      end
+    end
+
+    context 'with evidence activity' do
+      let(:evidence_standard_category) do
+        create(:standard_category, id: described_class::EVIDENCE_STANDARD_CATEGORY)
+      end
+      let!(:evidence_standard) { create(:standard, standard_category: evidence_standard_category) }
+      let!(:evidence_activity) { create(:activity, standard: evidence_standard)}
+      let!(:activity_session_evidence) do
+        create(
+          :activity_session,
+          user: sample_student_data[:student],
+          classroom_unit: sample_student_data[:classroom_unit],
+          activity: evidence_activity
+        )
+      end
+
+      it 'should indicate evidence activities via the is_evidence property' do
+        results = ProgressReports::Standards::AllClassroomsStandard.new(teacher1)
+        .results(sample_student_data[:classroom_unit].classroom_id, nil)
+        result = results.find {|r| r['id'] == evidence_standard.id}
+        expect(result['is_evidence']).to eq true
+      end
     end
   end
 

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -46,7 +46,7 @@ describe ProgressReports::Standards::AllClassroomsStandard do
 
     context 'with evidence activity' do
       let(:evidence_standard_category) do
-        create(:standard_category, id: described_class::EVIDENCE_STANDARD_CATEGORY)
+        create(:standard_category, id: Constants::EVIDENCE_STANDARD_CATEGORY)
       end
       let!(:evidence_standard) { create(:standard, standard_category: evidence_standard_category) }
       let!(:evidence_activity) { create(:activity, standard: evidence_standard)}

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ProgressReports::Standards::AllClassroomsStandard do
+  describe '#results' do
+    let!(:standard1) { create(:standard) }
+    let!(:teacher1) { create(:teacher, :with_classrooms_students_and_activities) }
+
+    let!(:sample_student_data) do
+      classroom_unit = ClassroomUnit.last
+      {
+        student: User.find(classroom_unit.assigned_student_ids.first),
+        classroom_unit: classroom_unit
+      }
+    end
+
+    let!(:activity_session1) do
+      create(:activity_session, user: sample_student_data[:student], classroom_unit: sample_student_data[:classroom_unit])
+    end
+
+    it 'should return results' do
+      expected_keys =  ["id", "name", "standard_level_name", "total_activity_count", "total_student_count", "proficient_count", "timespent"]
+      result = ProgressReports::Standards::AllClassroomsStandard.new(teacher1)
+      .results(sample_student_data[:classroom_unit].classroom_id, nil)
+      expect(result.first.keys).to eq expected_keys
+    end
+  end
+
+end

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -44,7 +44,7 @@ describe ProgressReports::Standards::AllClassroomsStandard do
 
     context 'with evidence activity' do
       let(:evidence_standard_category) do
-        create(:standard_category, id: Constants::EVIDENCE_STANDARD_CATEGORY)
+        create(:standard_category, id: ::Constants::EVIDENCE_STANDARD_CATEGORY)
       end
       let!(:evidence_standard) { create(:standard, standard_category: evidence_standard_category) }
       let!(:evidence_activity) { create(:activity, standard: evidence_standard)}

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 describe ProgressReports::Standards::AllClassroomsStandard do
   describe '#results' do
-
-    #let!(:standard1) { create(:standard, standard_category: non_evidence_standard_category) }
     let!(:teacher1) { create(:teacher, :with_classrooms_students_and_activities) }
 
     let!(:sample_student_data) do

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -24,7 +24,7 @@ describe ProgressReports::Standards::AllClassroomsStandard do
       expected_keys =  [
         'id',
         'name',
-        'standard_category_name',
+        'standard_level_name',
         'total_activity_count',
         'total_student_count',
         'proficient_count',

--- a/services/QuillLMS/spec/serializers/progress_reports/standards/standard_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/standards/standard_serializer_spec.rb
@@ -50,7 +50,8 @@ describe ProgressReports::Standards::StandardSerializer, type: :serializer do
                            total_activity_count
                            average_score
                            standard_students_href
-                           mastery_status)
+                           mastery_status
+                           is_evidence)
     end
 
     it 'includes properly rounded scores' do


### PR DESCRIPTION
## WHAT
Evidence activities are not scored, by the standards reports coerce scoring to undesired values, like "0%" proficient. We want to display "Not Scored" for various standards reporting table values that relate to evidence activities. Evidence activities are defined as activities with standard category = 27.

## WHY
Better teacher UX.

## HOW
We surface scores on the front end via 3 (!) pathways. One ingests raw SQL from the controller; the other two use a serializer as well.

### Screenshots
An example view after the patch. More screenshots in notion.
<img width="998" alt="Screen Shot 2022-06-08 at 9 03 02 PM" src="https://user-images.githubusercontent.com/90669/172757118-7f8cef82-18e7-4f47-982c-204add359eeb.png">



### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=2d5f2d4bf8874dfd8d854fdb5ef546b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
