### PR TITLE
Add back in edit_subscription endpoints

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -4,8 +4,8 @@ class Cms::SchoolsController < Cms::CmsController
   before_action :signed_in!
 
   before_action :text_search_inputs, only: [:index, :search]
-  before_action :set_school, only: [:new_subscription, :show, :complete_sales_stage]
-  before_action :subscription_data, only: [:new_subscription]
+  before_action :set_school, only: [:new_subscription, :edit_subscription, :show, :complete_sales_stage]
+  before_action :subscription_data, only: [:new_subscription, :edit_subscription]
 
   SCHOOLS_PER_PAGE = 30.0
 
@@ -74,6 +74,10 @@ class Cms::SchoolsController < Cms::CmsController
 
   def new_subscription
     @subscription = Subscription.new(start_date: Subscription.redemption_start_date(@school), expiration: Subscription.default_expiration_date(@school))
+  end
+
+  def edit_subscription
+    @subscription = @school&.subscription
   end
 
   # This allows staff members to create a new school.

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -3,9 +3,9 @@
 class Cms::UsersController < Cms::CmsController
   before_action :signed_in!
   before_action :set_flags
-  before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :new_subscription, :complete_sales_stage]
+  before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :new_subscription, :edit_subscription, :complete_sales_stage]
   before_action :set_search_inputs, only: [:index, :search]
-  before_action :subscription_data, only: [:new_subscription]
+  before_action :subscription_data, only: [:new_subscription, :edit_subscription]
   before_action :filter_zeroes_from_checkboxes, only: [:update, :create, :create_with_school]
   before_action :log_non_user_action, only: [:index]
   before_action :log_user_action, only: [:show, :edit, :sign_in]
@@ -89,6 +89,10 @@ class Cms::UsersController < Cms::CmsController
   end
 
   def edit
+  end
+
+  def edit_subscription
+    @subscription = @user.subscription
   end
 
   def new_subscription

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -589,6 +589,7 @@ EmpiricalGrammar::Application.routes.draw do
         put :clear_data
         get :sign_in
         get :new_subscription
+        get :edit_subscription
         post :complete_sales_stage
       end
       put 'make_admin/:school_id', to: 'users#make_admin', as: :make_admin
@@ -602,6 +603,7 @@ EmpiricalGrammar::Application.routes.draw do
       end
       member do
         get :new_subscription
+        get :edit_subscription
         get :new_admin
         get :add_existing_user
         post :add_admin_by_email

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -124,6 +124,15 @@ describe Cms::SchoolsController do
     end
   end
 
+  describe '#edit_subscription' do
+    let!(:school) { create(:school) }
+
+    it 'should assing the subscription' do
+      get :edit_subscription, params: { id: school.id }
+      expect(assigns(:subscription)).to eq school.subscription
+    end
+  end
+
   describe '#new_subscription' do
     let!(:school) { create(:school) }
     let!(:school_with_no_subscription) { create(:school) }

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -193,6 +193,15 @@ describe Cms::UsersController do
     end
   end
 
+  describe '#edit_subscription' do
+    let!(:another_user) { create(:user) }
+
+    it 'should assign the subscription' do
+      get :edit_subscription, params: { id: another_user.id }
+      expect(assigns(:subscription)).to eq another_user.subscription
+    end
+  end
+
   describe '#new_subscription' do
     let!(:another_user) { create(:user) }
     let!(:user_with_no_subscription) { create(:user) }


### PR DESCRIPTION
## WHAT
Add back in `edit_subscription` endpoints for `Cms::UsersController` and 'Cms::SchoolsController`

## WHY
They are actually still being used.

## HOW
These endpoints were removed in this [PR](https://github.com/empirical-org/Empirical-Core/pull/9208/files).  Add the code back in.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Saving-new-subscription-leads-to-error-page-4eee7dd8700142e9ae89270022973aa6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A