### PR TITLE
Fix bug with customer subscription updated event handler

### DIFF
--- a/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/customer_subscription_updated_event_handler.rb
@@ -4,7 +4,7 @@ module StripeIntegration
   module Webhooks
     class CustomerSubscriptionUpdatedEventHandler < EventHandler
       def run
-        SubscriptionUpdater.run(stripe_event, previous_attributes)
+        SubscriptionUpdater.run(stripe_subscription, previous_attributes)
         stripe_webhook_event.processed!
       rescue => e
         stripe_webhook_event.log_error(e)

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_updated_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/customer_subscription_updated_event_handler_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe StripeIntegration::Webhooks::CustomerSubscriptionUpdatedEventHandler do
   include_context 'Stripe Customer Subscription Updated Event'
 
+  let!(:subscription) { create(:subscription, stripe_invoice_id: stripe_invoice_id) }
   let(:stripe_webhook_event) { create(:stripe_webhook_event, event_type: stripe_event_type) }
   let(:subscription_updater_class) { StripeIntegration::Webhooks::SubscriptionUpdater }
   let(:external_id) { stripe_webhook_event.external_id }
@@ -15,7 +16,7 @@ RSpec.describe StripeIntegration::Webhooks::CustomerSubscriptionUpdatedEventHand
   before { allow(Stripe::Event).to receive(:retrieve).with(external_id).and_return(stripe_event) }
 
   context 'happy path' do
-    before { allow(subscription_updater_class).to receive(:run).with(stripe_event, previous_attributes) }
+    before { allow(subscription_updater_class).to receive(:run).with(stripe_subscription, previous_attributes) }
 
     it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
   end

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_completed_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_completed_event.rb
@@ -13,7 +13,7 @@ RSpec.shared_context 'Stripe Checkout Session Completed Event' do
       object: 'event',
       api_version: '2020-08-27',
       created: 1654609712,
-      data:  {
+      data: {
         object: external_checkout_session
       },
       livemode: false,

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_expired_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_checkout_session_expired_event.rb
@@ -13,7 +13,7 @@ RSpec.shared_context 'Stripe Checkout Session Expired Event' do
       object: 'event',
       api_version: '2020-08-27',
       created: 1654609712,
-      data:  {
+      data: {
         object: external_checkout_session
       },
       livemode: false,

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_customer_subscription_updated_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_customer_subscription_updated_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'Stripe Customer Subscription Updated Event' do
-  include_context 'Stripe Subscription'
+  include_context 'Stripe Invoice'
   include_context 'Stripe Payment Method'
 
   let(:stripe_event_id) { "evt_#{SecureRandom.hex}"}
@@ -13,7 +13,9 @@ RSpec.shared_context 'Stripe Customer Subscription Updated Event' do
       object: 'event',
       api_version: '2020-08-27',
       created: 1650057070,
-      data: stripe_subscription,
+      data: {
+        object: stripe_subscription
+      },
       livemode: false,
       pending_webhooks: 0,
       request: {

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_subscription.rb
@@ -37,7 +37,7 @@ RSpec.shared_context 'Stripe Subscription' do
       discount: nil,
       ended_at: nil,
       items: {
-        object: 'lisk',
+        object: 'list',
         data: [
           stripe_subscription_item
         ],


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3334839657/?project=11238&referrer=slack) involving a stripe webhook handler.

## WHY
The webhook handler isn't functioning properly

## HOW
Pass the stripe_subscription to the handler instead of stripe_event.

Also fix the corresponding shared_contexts which probably gave the spec a false positive.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A