### PR TITLE
Prevent duplicate stripe school subscriptions

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -5,8 +5,12 @@ module StripeIntegration
     SUBSCRIPTION_MODE = 'subscription'
 
     def create
-      stripe_checkout_session =
-        StripeCheckoutSession.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, customer.id)
+      stripe_checkout_session = StripeCheckoutSession.custom_find_or_create_by!(
+        external_checkout_session_args: external_checkout_session_args,
+        school_ids: school_ids,
+        stripe_price_id: stripe_price_id,
+        user_id: customer.id
+      )
 
       render json: { redirect_url: stripe_checkout_session.url }
     end
@@ -51,7 +55,7 @@ module StripeIntegration
     private def school_ids
       return [] if params[:school_ids].nil?
 
-      JSON.parse(params[:school_ids])
+      JSON.parse(params[:school_ids]).sort
     end
 
     private def school_plan?

--- a/services/QuillLMS/app/models/stripe_checkout_session.rb
+++ b/services/QuillLMS/app/models/stripe_checkout_session.rb
@@ -5,6 +5,7 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
+#  school_ids                   :integer          default([]), is an Array
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -24,14 +25,20 @@
 class StripeCheckoutSession < ApplicationRecord
   belongs_to :user
 
-  def self.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, user_id)
-    stripe_checkout_session = StripeCheckoutSession.find_by(stripe_price_id: stripe_price_id, user_id: user_id)
+  def self.custom_find_or_create_by!(external_checkout_session_args:, school_ids:, stripe_price_id:, user_id:)
+    stripe_checkout_session = StripeCheckoutSession.find_by(
+      school_ids: school_ids,
+      stripe_price_id: stripe_price_id,
+      user_id: user_id
+    )
+
     return stripe_checkout_session if stripe_checkout_session.present?
 
     external_checkout_session = Stripe::Checkout::Session.create(external_checkout_session_args)
 
     StripeCheckoutSession.create!(
       external_checkout_session_id: external_checkout_session.id,
+      school_ids: school_ids,
       stripe_price_id: stripe_price_id,
       url: external_checkout_session.url,
       user_id: user_id

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -36,7 +36,11 @@ module StripeIntegration
         when Plan.stripe_teacher_plan
           purchaser.subscription&.plan == plan
         when Plan.stripe_school_plan
-          purchaser.subscriptions.active.any? { |subscription| subscription.schools.pluck(:id).sort == school_ids }
+          purchaser.associated_schools.any? do |school|
+            school.subscriptions.active.any?  do |subscription|
+              subscription.schools.pluck(:id).sort == school_ids
+            end
+          end
         end
       end
 

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -24,11 +24,20 @@ module StripeIntegration
         raise NilPurchaserEmailError if purchaser_email.nil?
         raise NilStripePriceIdError if stripe_price_id.nil?
         raise NilStripeInvoiceIdError if stripe_invoice.id.nil?
-        raise DuplicateSubscriptionError if purchaser.subscription.present?
+        raise DuplicateSubscriptionError if duplicate_subscription?
 
         subscription
         save_stripe_customer_id
         run_plan_custom_tasks
+      end
+
+      private def duplicate_subscription?
+        case plan
+        when Plan.stripe_teacher_plan
+          purchaser.subscription&.plan == plan
+        when Plan.stripe_school_plan
+          purchaser.subscriptions.active.any? { |subscription| subscription.schools.pluck(:id).sort == school_ids }
+        end
       end
 
       private def expiration
@@ -74,7 +83,7 @@ module StripeIntegration
       private def school_ids
         return [] if stripe_subscription.metadata[:school_ids].nil?
 
-        JSON.parse(stripe_subscription.metadata[:school_ids])
+        JSON.parse(stripe_subscription.metadata[:school_ids]).sort
       end
 
       private def start_date

--- a/services/QuillLMS/db/migrate/20220609173524_add_school_ids_to_stripe_checkout_session.rb
+++ b/services/QuillLMS/db/migrate/20220609173524_add_school_ids_to_stripe_checkout_session.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSchoolIdsToStripeCheckoutSession < ActiveRecord::Migration[5.1]
+  def change
+    add_column :stripe_checkout_sessions, :school_ids, :integer, array: true, default: []
+  end
+end

--- a/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
+++ b/services/QuillLMS/spec/factories/stripe_checkout_sessions.rb
@@ -5,6 +5,7 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
+#  school_ids                   :integer          default([]), is an Array
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -24,6 +25,7 @@
 FactoryBot.define do
   factory :stripe_checkout_session do
     external_checkout_session_id { "cs_#{SecureRandom.hex}" }
+    school_ids { [] }
     stripe_price_id { "price_#{SecureRandom.hex}" }
     url { "https://www.checkout.stripe/pay/cs_#{SecureRandom.hex}" }
     user

--- a/services/QuillLMS/spec/factories/subscriptions.rb
+++ b/services/QuillLMS/spec/factories/subscriptions.rb
@@ -36,9 +36,14 @@ FactoryBot.define do
     purchaser_id { nil }
     payment_method { '' }
     stripe_invoice_id { nil }
+    plan { nil }
 
     trait(:recurring) { recurring true }
     trait(:non_recurring) { recurring false }
     trait(:stripe) { stripe_invoice_id { "in_#{SecureRandom.hex}"} }
+
+    after(:create) do |subscription|
+      subscription.update(account_type: subscription.plan.name) if subscription.plan.present?
+    end
   end
 end

--- a/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_checkout_session_spec.rb
@@ -5,6 +5,7 @@
 # Table name: stripe_checkout_sessions
 #
 #  id                           :bigint           not null, primary key
+#  school_ids                   :integer          default([]), is an Array
 #  url                          :string           not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -26,9 +27,16 @@ require 'rails_helper'
 RSpec.describe StripeCheckoutSession, type: :model do
 
   describe '.custom_find_or_create_by!' do
-    let(:external_checkout_session_args) { {} }
+    let(:stripe_checkout_session_args) do
+      {
+        external_checkout_session_args: {},
+        school_ids: [],
+        stripe_price_id: stripe_price_id,
+        user_id: user_id
+      }
+    end
 
-    subject { described_class.custom_find_or_create_by!(external_checkout_session_args, stripe_price_id, user_id) }
+    subject { described_class.custom_find_or_create_by!(stripe_checkout_session_args) }
 
     context 'stripe_checkout_session exists' do
       let!(:stripe_checkout_session) { create(:stripe_checkout_session) }
@@ -46,7 +54,7 @@ RSpec.describe StripeCheckoutSession, type: :model do
       let(:user_id) { create(:user).id }
       let(:url) { 'https;//example.com' }
 
-      let(:external_checkout_session) { double(id: external_checkout_session_id, url: url, expires_at: DateTime.now.utc) }
+      let(:external_checkout_session) { double(id: external_checkout_session_id, url: url) }
 
       before { allow(Stripe::Checkout::Session).to receive(:create).and_return(external_checkout_session) }
 

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -18,17 +18,27 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
         expect(UpdateSalesContactWorker).to receive(:perform_async).with(customer.id, SalesStageType::TEACHER_PREMIUM)
         subject
       end
+
+      context 'active teacher subscription already exists' do
+        let!(:subscription) { create(:subscription, plan: Plan.stripe_teacher_plan) }
+
+        before { create(:user_subscription, user: customer, subscription: subscription) }
+
+        it { expect { subject }.to raise_error described_class::DuplicateSubscriptionError }
+      end
     end
   end
 
   context 'school subscription' do
-    context 'happy path' do
-      let!(:teacher) { create(:teacher) }
-      let!(:other_teacher) { create(:teacher) }
-      let!(:school) { create :school, users: [customer, teacher]}
-      let!(:school_plan) { create(:school_premium_plan) }
-      let!(:stripe_subscription_metadata) { { school_ids: [school.id].to_json } }
+    let!(:teacher) { create(:teacher) }
+    let!(:other_teacher) { create(:teacher) }
+    let!(:school) { create(:school, users: [customer, teacher]) }
+    let!(:school_plan) { create(:school_premium_plan) }
+    let!(:stripe_subscription_metadata) { { school_ids: [school.id].to_json } }
+    let!(:other_school) { create(:school) }
+    let(:stripe_price_id) { STRIPE_SCHOOL_PLAN_PRICE_ID }
 
+    context 'happy path' do
       before { allow(Plan).to receive(:find_stripe_plan!).with(stripe_price_id).and_return(school_plan) }
 
       it { expect { subject }.to change(Subscription, :count).from(0).to(1) }
@@ -38,6 +48,24 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
       it 'calls sales contact background job' do
         expect(UpdateSalesContactWorker).to receive(:perform_async).with(customer.id, SalesStageType::SCHOOL_PREMIUM)
         subject
+      end
+    end
+
+    context 'active school subscription exists' do
+      let!(:subscription) { create(:subscription, plan: school_plan) }
+
+      before { create(:user_subscription, user: customer, subscription: subscription) }
+
+      context 'for the same school' do
+        before { create(:school_subscription, school: school, subscription: subscription) }
+
+        it { expect { subject }.to raise_error described_class::DuplicateSubscriptionError }
+      end
+
+      context 'for a different school' do
+        before { create(:school_subscription, school: other_school, subscription: subscription) }
+
+        it { expect { subject }.not_to raise_error }
       end
     end
   end
@@ -64,14 +92,6 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
     before { allow(Plan).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound) }
 
     it { expect { subject }.to raise_error described_class::PlanNotFoundError }
-  end
-
-  context 'active subscription already exists' do
-    let!(:subscription) { create(:subscription) }
-
-    before { create(:user_subscription, user: customer, subscription: subscription) }
-
-    it { expect { subject }.to raise_error described_class::DuplicateSubscriptionError }
   end
 
   context 'purchaser does not exist' do


### PR DESCRIPTION
## WHAT
Add checks in subscription creation to prevent duplicate stripe school subscriptions.

## WHY
We would like to have the same duplicate prevention with school subscriptions that we have with teacher subscriptions.

## HOW
Add an array of integers attribute `school_ids` to the `StripeCheckoutSession` object.  This will ensure that the session is unique to the school[s] a user is attempting to purchase subscriptions for.

Add logic in the duplicate_subscription check with `SubscriptionCreator` that evaluates duplicate subscriptions based on the type of plan.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
