### PR TITLE
evidence/nil-check-plagiarism

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/plagiarism.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/plagiarism.rb
@@ -7,7 +7,7 @@ module Evidence
       rule = prompt.rules&.find_by(rule_type: Evidence::Rule::TYPE_PLAGIARISM)
       feedback = get_plagiarism_feedback_from_previous_feedback(previous_feedback, rule)
 
-      if rule.plagiarism_texts.none?
+      if rule.nil? || rule.plagiarism_texts&.none?
         @response = Evidence::PlagiarismCheck.new(entry, '', feedback, rule).feedback_object
       else
         plagiarism_check = nil


### PR DESCRIPTION
## WHAT
Add a nil check for plagiarism rules
## WHY
Sometimes a prompt doesn't have any Plagiarism rules, and the old code would crash instead of identifying that you hadn't violated the non-existent rules.
## HOW
Add a nil-check for the presence of a rule when checking to see if there are plagiarism texts

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  No tests on this sub-module.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A