### PR TITLE
lms/tweak-evidence-directions-copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
@@ -4,7 +4,7 @@ import { DEFAULT_HIGHLIGHT_PROMPT, } from '../../../Shared/utils/constants'
 import { informationIcon } from '../../../Shared/index'
 
 const READ_PASSAGE_STEP = 1
-const promptDirections = [<li>Use information from the text to finish the sentence.</li>, <li>Put the information in your own words.</li>]
+const promptDirections = [<li>Use information <b>from the text</b> to finish the sentence.</li>, <li>Put the information in your own words.</li>]
 const highlightDirections = [<li>First, read the highlighting task below.</li>, <li>Then, read the text and highlight sentences to complete the task.</li>, <li className="sr-only">Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.</li>]
 
 const renderDirections = (directionElementsArray: JSX.Element[]) => (

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
@@ -96,7 +96,11 @@ exports[`DirectionsSection component when the student is past the read passage s
     </h3>
     <ul>
       <li>
-        Use information from the text to finish the sentence.
+        Use information 
+        <b>
+          from the text
+        </b>
+         to finish the sentence.
       </li>
       <li>
         Put the information in your own words.


### PR DESCRIPTION
## WHAT
Add bolding to directions per Curriculum request
## WHY
Curriculum is requesting that we do this to add emphasis about using evidence from the text for the next round of content testing
## HOW
Just add `b` tags to the appropriate text

### Notion Card Links
https://www.notion.so/quill/Copy-request-Bold-copy-in-instructions-for-gamma-flag-activities-6f7011db00224c8dbe90bfceca82f5e8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This is exclusively a copy change.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A