### PR TITLE
evidence/stop-spell-checking-then

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -22,6 +22,7 @@ module Evidence
       'españa',
       'cafebabel',
       'cafébabel',
+      'then',
       'sanchez',
       'sánchez',
       'kanaka',


### PR DESCRIPTION
## WHAT
Add 'then' to the spelling exclusions list
## WHY
Bing seems to be flagging the term "then" as a spelling error in ambiguous "then"/"than" confusion situations.  We have Grammar API to solve those problems, though, so we don't need Bing to do it for us
## HOW
Just add `then` to the `EXCLUSIONS` array in the spell checker

### Notion Card Links
https://www.notion.so/quill/Turn-off-then-than-and-plural-possessive-rules-for-APHG-study-48ed69f86a76431fb6c6b83242c05cf1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage for excluded words
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
