### PR TITLE
Add plan id to legacy subscriptions

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -409,8 +409,8 @@ class PagesController < ApplicationController
     @customer_email = current_user&.email
     @associated_schools = current_user&.associated_schools || []
     @eligible_schools = @associated_schools.filter { |s| s.subscription.nil? }
-    @stripe_school_plan = PlanSerializer.new(Plan.stripe_school_plan).as_json
-    @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher_plan).as_json
+    @stripe_school_plan = PlanSerializer.new(Plan.stripe_school).as_json
+    @stripe_teacher_plan = PlanSerializer.new(Plan.stripe_teacher).as_json
 
     @diagnostic_activity_count =
       Activity.where(

--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -31,12 +31,21 @@ class Plan < ApplicationRecord
     DAILY_INTERVAL_TYPE = 'daily'
   ].freeze
 
-  STRIPE_SCHOOL_PLAN = 'School Paid (via Stripe)'
-  STRIPE_TEACHER_PLAN = 'Teacher Paid'
+  NAMES = [
+    COLLEGE_BOARD_LIFETIME = 'College Board Educator Lifetime Premium',
+    INVOICE_SCHOOL = 'School Paid (via invoice)',
+    PREMIUM_CREDIT = 'Premium Credit',
+    SCHOOL_DISTRICT = 'School District Paid',
+    SCHOOL_SPONSORED = 'School Sponsored Free',
+    STRIPE_SCHOOL = 'School Paid (via Stripe)',
+    STRIPE_TEACHER = 'Teacher Paid',
+    TEACHER_TRIAL = 'Teacher Trial',
+    TEACHER_SPONSORED = 'Teacher Sponsored Free'
+  ].freeze
 
   NAME_TO_STRIPE_PRICE_ID = {
-    STRIPE_SCHOOL_PLAN => STRIPE_SCHOOL_PLAN_PRICE_ID,
-    STRIPE_TEACHER_PLAN => STRIPE_TEACHER_PLAN_PRICE_ID
+    STRIPE_SCHOOL => STRIPE_SCHOOL_PLAN_PRICE_ID,
+    STRIPE_TEACHER => STRIPE_TEACHER_PLAN_PRICE_ID
   }.freeze
 
   STRIPE_PRICE_ID_TO_NAME = NAME_TO_STRIPE_PRICE_ID.invert
@@ -55,12 +64,12 @@ class Plan < ApplicationRecord
     find_by!(name: STRIPE_PRICE_ID_TO_NAME[stripe_price_id])
   end
 
-  def self.stripe_school_plan
-    find_by(name: STRIPE_SCHOOL_PLAN)
+  def self.stripe_school
+    find_by(name: STRIPE_SCHOOL)
   end
 
-  def self.stripe_teacher_plan
-    find_by(name: STRIPE_TEACHER_PLAN)
+  def self.stripe_teacher
+    find_by(name: STRIPE_TEACHER)
   end
 
   def stripe_price_id

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -248,7 +248,7 @@ class Subscription < ApplicationRecord
     Stripe::Subscription.create(
       customer: purchaser.stripe_customer_id,
       items: [
-        price: Plan.stripe_teacher_plan.stripe_price_id
+        price: Plan.stripe_teacher.stripe_price_id
       ]
     )
   rescue Stripe::InvalidRequestError, RenewalNilStripeCustomer => e
@@ -348,10 +348,8 @@ class Subscription < ApplicationRecord
   end
 
   def renewal_stripe_price_id
-    return STRIPE_TEACHER_PLAN_PRICE_ID if [TEACHER_PAID, TEACHER_TRIAL].include?(account_type)
-    # TODO: can get cleaned up when we unify account types vs plan names, this covers the existing bases
-    return STRIPE_SCHOOL_PLAN_PRICE_ID if account_type == SCHOOL_PAID
-    return STRIPE_SCHOOL_PLAN_PRICE_ID if account_type == Plan::STRIPE_SCHOOL_PLAN
+    return STRIPE_TEACHER_PLAN_PRICE_ID if plan.teacher?
+    return STRIPE_SCHOOL_PLAN_PRICE_ID if plan.school?
   end
 
   def stripe?

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -35,9 +35,9 @@ module StripeIntegration
 
       private def duplicate_subscription?
         case plan
-        when Plan.stripe_teacher_plan
+        when Plan.stripe_teacher
           purchaser.subscription&.plan == plan
-        when Plan.stripe_school_plan
+        when Plan.stripe_school
           purchaser.associated_schools.any? do |school|
             school.subscriptions.active.any?  do |subscription|
               subscription.schools.pluck(:id).sort == school_ids
@@ -72,10 +72,10 @@ module StripeIntegration
 
       private def run_plan_custom_tasks
         case plan
-        when Plan.stripe_teacher_plan
+        when Plan.stripe_teacher
           UserSubscription.create!(user: purchaser, subscription: subscription)
           UpdateSalesContactWorker.perform_async(purchaser.id, SalesStageType::TEACHER_PREMIUM)
-        when Plan.stripe_school_plan
+        when Plan.stripe_school
           schools = School.where(id: school_ids)
           raise NilSchoolError if schools.empty?
 

--- a/services/QuillLMS/lib/tasks/temporary/plans.rake
+++ b/services/QuillLMS/lib/tasks/temporary/plans.rake
@@ -85,4 +85,22 @@ namespace :plans do
       puts "\nBase plans were added to the database"
     end
   end
+
+  task update_legacy_subscriptions_plan: :environment do
+    {
+      'School Paid' => Plan::INVOICE_SCHOOL,
+      'School District Paid' => Plan::SCHOOL_DISTRICT,
+      'Premium Credit' => Plan::PREMIUM_CREDIT,
+      'College Board Educator Lifetime Premium' => Plan::COLLEGE_BOARD_LIFETIME,
+      'School Sponsored Free' => Plan::SCHOOL_SPONSORED,
+      'Teacher Sponsored Free' => Plan::TEACHER_SPONSORED,
+      'Teacher Paid' => Plan::STRIPE_TEACHER,
+      'Teacher Trial' => Plan::TEACHER_TRIAL
+    }.each_pair do |account_type, plan_name|
+      Subscription
+        .where(account_type: account_type, plan_id: nil)
+        .update_all(plan_id: Plan.find_by(name: plan_name).id)
+    end
+  end
 end
+

--- a/services/QuillLMS/spec/factories/plans.rb
+++ b/services/QuillLMS/spec/factories/plans.rb
@@ -22,7 +22,7 @@ require 'rails_helper'
 
 FactoryBot.define do
   factory :plan, aliases: [:teacher_premium_plan] do
-    name { Plan::STRIPE_TEACHER_PLAN }
+    name { Plan::STRIPE_TEACHER }
     display_name { 'Teacher Premium' }
     price { 9000 }
     audience { Plan::TEACHER_AUDIENCE_TYPE }
@@ -30,7 +30,7 @@ FactoryBot.define do
     interval_count { 1 }
 
     factory :school_premium_plan do
-      name { Plan::STRIPE_SCHOOL_PLAN }
+      name { Plan::STRIPE_SCHOOL }
       display_name { 'School Premium' }
       price { 180000 }
       audience { Plan::SCHOOL_AUDIENCE_TYPE }

--- a/services/QuillLMS/spec/models/plan_spec.rb
+++ b/services/QuillLMS/spec/models/plan_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe Plan, type: :model do
     it { should have_readonly_attribute(:price) }
   end
 
-  context '.stripe_teacher_plan' do
+  context '.stripe_teacher' do
     let!(:plan) { create(:teacher_premium_plan) }
 
-    it { expect(Plan.stripe_teacher_plan).to eq plan }
+    it { expect(Plan.stripe_teacher).to eq plan }
   end
 
   context 'teacher?' do

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -389,7 +389,7 @@ describe Subscription, type: :model do
       end
 
       context 'paid via stripe' do
-        let(:account_type) { Plan::STRIPE_SCHOOL_PLAN }
+        let(:account_type) { Plan::STRIPE_SCHOOL }
 
         it { expect(subject).to be STRIPE_SCHOOL_PLAN_PRICE_ID }
       end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
 
   let!(:customer) { create(:user, email: customer_email, stripe_customer_id: stripe_customer_id) }
   let!(:school_plan) { create(:school_premium_plan) }
-  let!(:school_plan_price) { Plan.stripe_school_plan.price }
-  let!(:teacher_plan_price) { Plan.stripe_teacher_plan.price }
+  let!(:school_plan_price) { Plan.stripe_school.price }
+  let!(:teacher_plan_price) { Plan.stripe_teacher.price }
 
   context 'teacher subscription' do
     let(:stripe_invoice_amount_paid) { teacher_plan_price }
@@ -25,7 +25,7 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
       end
 
       context 'active teacher subscription already exists' do
-        let!(:subscription) { create(:subscription, plan: Plan.stripe_teacher_plan) }
+        let!(:subscription) { create(:subscription, plan: Plan.stripe_teacher) }
 
         before { create(:user_subscription, user: customer, subscription: subscription) }
 

--- a/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_invoice.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/stripe_integration/stripe_invoice.rb
@@ -4,7 +4,7 @@ RSpec.shared_context 'Stripe Invoice' do
   include_context 'Stripe Subscription'
 
   let(:stripe_invoice_id) { "in_#{SecureRandom.hex}" }
-  let(:stripe_invoice_amount_paid) { Plan.stripe_teacher_plan.price }
+  let(:stripe_invoice_amount_paid) { Plan.stripe_teacher.price }
 
   let(:stripe_invoice) do
     Stripe::Invoice.construct_from(


### PR DESCRIPTION
## WHAT
Add a rake task that will update legacy subscription's `plan_id` with the appropriate values.

There's also some refactoring of Plan methods and constants that end in `_plan` or `_PLAN`.  I'm removing them since they are redundant.

## WHY
We'd like to transition the account_type value on subscription to a more normalized solution via the plan objects.

## HOW
Iterate through existing subscriptions that have a `plan_id: nil` and assign them the appropriate id.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
