### PR TITLE
lms/allow-partnerships-to-edit-school-districts

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -61,8 +61,7 @@ class Cms::SchoolsController < Cms::CmsController
   # This allows staff members to edit certain details about a school.
   def edit
     @school = School.find(params[:id])
-    # Except 'District' because we have special handling in the view
-    @editable_attributes = editable_school_attributes.except('District')
+    @editable_text_attributes = editable_school_text_attributes
   end
 
   def update
@@ -84,8 +83,7 @@ class Cms::SchoolsController < Cms::CmsController
   # This allows staff members to create a new school.
   def new
     @school = School.new
-    # Except 'District' because we have special handling in the view
-    @editable_attributes = editable_school_attributes.except('District')
+    @editable_text_attributes = editable_school_text_attributes
   end
 
   def create
@@ -333,7 +331,7 @@ class Cms::SchoolsController < Cms::CmsController
     params.require(:school).permit(:id, editable_school_attributes.values)
   end
 
-  private def editable_school_attributes
+  private def editable_school_text_attributes
     {
       'School Name' => :name,
       'School City' => :city,
@@ -341,9 +339,14 @@ class Cms::SchoolsController < Cms::CmsController
       'School ZIP' => :zipcode,
       'FRP Lunch' => :free_lunches,
       'NCES ID' => :nces_id,
-      'Clever ID' => :clever_id,
-      'District' => :district_id
+      'Clever ID' => :clever_id
     }
+  end
+
+  private def editable_school_attributes
+    editable_school_text_attributes.merge({
+      'District' => :district_id
+    })
   end
 
   private def subscription_params

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -61,7 +61,8 @@ class Cms::SchoolsController < Cms::CmsController
   # This allows staff members to edit certain details about a school.
   def edit
     @school = School.find(params[:id])
-    @editable_attributes = editable_school_attributes
+    # Except 'District' because we have special handling in the view
+    @editable_attributes = editable_school_attributes.except('District')
   end
 
   def update
@@ -83,7 +84,8 @@ class Cms::SchoolsController < Cms::CmsController
   # This allows staff members to create a new school.
   def new
     @school = School.new
-    @editable_attributes = editable_school_attributes
+    # Except 'District' because we have special handling in the view
+    @editable_attributes = editable_school_attributes.except('District')
   end
 
   def create
@@ -339,7 +341,8 @@ class Cms::SchoolsController < Cms::CmsController
       'School ZIP' => :zipcode,
       'FRP Lunch' => :free_lunches,
       'NCES ID' => :nces_id,
-      'Clever ID' => :clever_id
+      'Clever ID' => :clever_id,
+      'District' => :district_id
     }
   end
 

--- a/services/QuillLMS/app/views/cms/schools/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/edit.html.erb
@@ -14,7 +14,7 @@
     </strong></ul><br />
     <div class='cms-form'>
       <%= form_for @school, url: cms_school_path(@school.id) do |f| %>
-        <% @editable_attributes.each do |attribute_name, attribute_field| %>
+        <% @editable_text_attributes.each do |attribute_name, attribute_field| %>
           <div class='cms-form-row'>
             <%= f.label attribute_field, attribute_name %>
             <%= f.text_field attribute_field, autocomplete: 'off' %>

--- a/services/QuillLMS/app/views/cms/schools/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/edit.html.erb
@@ -20,6 +20,10 @@
             <%= f.text_field attribute_field, autocomplete: 'off' %>
           </div>
         <% end %>
+        <div class='cms-form-row'>
+          <%= f.label :district_id, 'District' %>
+          <%= f.collection_select :district_id, District.order(:name), :id, :name, include_blank: false %>
+        </div>
 
         <%= f.hidden_field :id %>
 

--- a/services/QuillLMS/app/views/cms/schools/new.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/new.html.erb
@@ -21,6 +21,10 @@
             <%= f.text_field attribute_field, autocomplete: 'off' %>
           </div>
         <% end %>
+        <div class='cms-form-row'>
+          <%= f.label :district_id, 'District' %>
+          <%= f.collection_select :district_id, District.order(:name), :id, :name, include_blank: false %>
+        </div>
 
         <div class='cms-submit-row'>
           <%= f.button "Add School", class: 'button-green' %>

--- a/services/QuillLMS/app/views/cms/schools/new.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/new.html.erb
@@ -15,7 +15,7 @@
     <br />
     <div class='cms-form'>
       <%= form_for @school, url: cms_schools_path(@school) do |f| %>
-        <% @editable_attributes.each do |attribute_name, attribute_field| %>
+        <% @editable_text_attributes.each do |attribute_name, attribute_field| %>
           <div class='cms-form-row'>
             <%= f.label attribute_field, attribute_name %>
             <%= f.text_field attribute_field, autocomplete: 'off' %>

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -84,7 +84,7 @@ describe Cms::SchoolsController do
     it 'should assign the school and editable attributes' do
       get :edit, params: { id: school.id }
       expect(assigns(:school)).to eq school
-      expect(assigns(:editable_attributes)).to eq({
+      expect(assigns(:editable_text_attributes)).to eq({
           'School Name' => :name,
           'School City' => :city,
           'School State' => :state,


### PR DESCRIPTION
## WHAT
Add the ability to set Districts on School New and Edit pages
## WHY
This will allow Quill Staff to change the District a school is assigned to without needing help from Engineering.
## HOW
Just add a new `collection_select` element to the new and edit forms for Schools.

### Screenshots
![image](https://user-images.githubusercontent.com/331565/174389655-1049bcb5-9003-401d-9103-5920aa515e3a.png)

### Notion Card Links
https://www.notion.so/quill/Allow-Staff-to-add-District-to-Schools-via-CMS-Schools-Manager-0c44e80d0c974001b58bde26185a14cc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on views
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes