### PR TITLE
Fix bug with stripe_setup_intent

### DIFF
--- a/services/QuillLMS/app/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler.rb
@@ -12,6 +12,10 @@ module StripeIntegration
         stripe_webhook_event.log_error(e)
       end
 
+      private def metadata
+        stripe_setup_intent&.metadata
+      end
+
       private def stripe_setup_intent
         stripe_event.data.object
       end
@@ -21,7 +25,9 @@ module StripeIntegration
       end
 
       private def stripe_subscription_id
-        stripe_setup_intent&.metadata&.subscription_id
+        return nil unless metadata.respond_to?(:subscription_id)
+
+        metadata.subscription_id
       end
 
       private def update_default_payment_method

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/setup_intent_succeeded_event_handler_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe StripeIntegration::Webhooks::SetupIntentSucceededEventHandler do
     it { expect { subject }.to change(stripe_webhook_event, :status).to(StripeWebhookEvent::PROCESSED) }
   end
 
+  context 'metadata does not respond to subscription_id' do
+    let(:metadata) { double(:metadata) }
+
+    before do
+      allow(stripe_setup_intent).to receive(:metadata).and_return(metadata)
+      allow(metadata).to receive(:respond_to?).with(:subscription_id).and_return(false)
+    end
+
+    it 'does not update stripe nor trigger Pusher' do
+      expect(Stripe::Subscription).not_to receive(:update)
+      expect(PusherTrigger).not_to receive(:run)
+
+      subject
+    end
+  end
+
   context 'stripe_subscription_id is nil' do
     let(:stripe_subscription_id) { nil }
 


### PR DESCRIPTION
## WHAT
Fix an [error](https://sentry.io/organizations/quillorg-5s/issues/3360924957/?referrer=slack
) involving the webhook event `setup_intent.succeeded`

## WHY
We would like relevant webhooks to be handled properly.  

The typical use case for this webhook is a user changing their credit card on a subscription.  In this case, the user changed had no underlying stripe subscription, but updated their credit card on stripe.

## HOW
The `event.metadata` call returns a `Stripe::StripeObject` instead of a hash.  Safe navigation with `metadata&.subscription_id` returns an error here, so use `metadata.respond_to?(:subscription_id)` instead.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
