### PR TITLE
Sales form/ show confirmation message

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/salesForm/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/salesForm/index.tsx
@@ -4,7 +4,6 @@ import LowerFormFields from './lowerFormFields';
 import SchoolAndDistrictFields from './schoolAndDistrictFields';
 import UpperFormFields from './upperFormFields';
 
-import { Snackbar, defaultSnackbarTimeout } from '../../../Shared';
 import { getSchoolsAndDistricts, validateSalesForm, submitSalesForm } from '../../helpers/salesForms';
 import { DropdownObjectInterface, InputEvent } from '../../../Staff/interfaces/evidenceInterfaces';
 import {
@@ -32,7 +31,7 @@ export const SalesForm = ({ type }) => {
   const [districtSearchQuery, setDistrictSearchQuery] = React.useState<any>('');
   const [districtNotListed, setDistrictNotListed] = React.useState<boolean>(false);
   const [schoolOrDistrict, setSchoolOrDistrict] = React.useState<any>('');
-  const [showSnackbar, setShowSnackbar] = React.useState(false)
+  const [showSubmissionConfirmation, setShowSubmissionConfirmation] = React.useState(false)
 
   React.useEffect(() => {
     getSchoolsAndDistricts('school', schoolSearchQuery).then((response) => {
@@ -50,12 +49,6 @@ export const SalesForm = ({ type }) => {
     });
   }, [districtSearchQuery]);
 
-  React.useEffect(() => {
-    if (showSnackbar) {
-      setTimeout(() => setShowSnackbar(false), defaultSnackbarTimeout);
-    }
-  }, [showSnackbar]);
-
   const stateSetters = {
     [FIRST_NAME]: setFirstName,
     [LAST_NAME]: setLastName,
@@ -72,6 +65,7 @@ export const SalesForm = ({ type }) => {
   }
   const schoolIsSelected = schoolOrDistrict === SCHOOL;
   const districtIsSelected = schoolOrDistrict === DISTRICT;
+  const buttonClass = "submit-button quill-button contained primary medium focus-on-light";
 
   function handleUpdateField(e: InputEvent | React.ChangeEvent<HTMLTextAreaElement>) {
     const { target } = e;
@@ -139,14 +133,18 @@ export const SalesForm = ({ type }) => {
           const submissionError = { [SUBMISSION_ERROR]: response.error };
           setErrors(submissionError)
         } else {
-          setShowSnackbar(true);
+          setShowSubmissionConfirmation(true);
         }
       });
     }
   }
 
-  return(
-    <div className="sales-form-container">
+  function handleClick() {
+    window.location.href = `${process.env.DEFAULT_URL}/premium`;
+  }
+
+  function renderForm() {
+    return(
       <form className="container">
         <UpperFormFields
           email={email}
@@ -183,9 +181,25 @@ export const SalesForm = ({ type }) => {
           teacherPremiumEstimate={teacherPremiumEstimate}
         />
         {errors[SUBMISSION_ERROR] && <p className="error-text">{errors[SUBMISSION_ERROR]}</p>}
-        <button className="submit-button quill-button contained primary medium focus-on-light" onClick={handleFormSubmission}>Submit</button>
+        <button className={buttonClass} onClick={handleFormSubmission}>Submit</button>
       </form>
-      <Snackbar text="Request successfully submitted!" visible={showSnackbar} />
+    );
+  }
+
+  function renderSuccessMessage() {
+    return(
+      <section className="container success-message-container">
+        <h3>Thanks for contacting us!</h3>
+        <p>A Quill team member will be in touch with you as soon as possible.</p>
+        <button className={buttonClass} onClick={handleClick}>Done</button>
+      </section>
+    )
+  }
+
+  return(
+    <div className="sales-form-container">
+      {!showSubmissionConfirmation && renderForm()}
+      {showSubmissionConfirmation && renderSuccessMessage()}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/styles/sales-form.scss
+++ b/services/QuillLMS/client/app/bundles/Teacher/styles/sales-form.scss
@@ -69,4 +69,11 @@
       }
     }
   }
+  .success-message-container {
+    height: 100%;
+    border-bottom: none;
+    p {
+      padding: 16px 0px 16px 0px;
+    }
+  }
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/salesForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/tests/components/salesForm/__snapshots__/salesForm.test.tsx.snap
@@ -431,16 +431,6 @@ exports[`SalesForm Component should match snapshot 1`] = `
         Submit
       </button>
     </form>
-    <Snackbar
-      text="Request successfully submitted!"
-      visible={false}
-    >
-      <div
-        className="quill-snackbar "
-      >
-        Request successfully submitted!
-      </div>
-    </Snackbar>
   </div>
 </SalesForm>
 `;


### PR DESCRIPTION
## WHAT
remove the confirmation snackbar and show a new confirmation page instead

## WHY
this was requested to better prevent the chance of users submitting the form multiple times

## HOW
remove snackbar and conditionally render message if submission is successful

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1086" alt="Screen Shot 2022-06-20 at 3 52 21 PM" src="https://user-images.githubusercontent.com/25959584/174669831-b6545c77-7602-44e8-b472-2fb33ea73e2d.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Additional-sales-form-changes-e2a96a52b9e740afa53e1d72467d1f0c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
