### PR TITLE
Remove ransack gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -14,7 +14,6 @@ gem 'dotenv-rails'
 # DB/MODEL
 gem 'pg', '0.18.4'
 gem 'ancestry'
-gem 'ransack'
 gem 'ranked-model'
 gem 'rails_admin', '~> 1.4.3'
 gem 'bulk_insert'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -576,11 +576,6 @@ GEM
     rake (13.0.6)
     ranked-model (0.4.3)
       activerecord (>= 4.1.16)
-    ransack (1.8.10)
-      actionpack (>= 3.0, < 5.2)
-      activerecord (>= 3.0, < 5.2)
-      activesupport (>= 3.0, < 5.2)
-      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -884,7 +879,6 @@ DEPENDENCIES
   rails_admin (~> 1.4.3)
   rails_autoscale_agent
   ranked-model
-  ransack
   rb-readline
   react_on_rails (= 11.3.0)
   redcarpet (~> 3.5.1)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -528,10 +528,6 @@ class User < ApplicationRecord
     UnsubscribeFromNewsletterWorker.perform_async(id)
   end
 
-  ransacker :created_at_date, type: :date do |parent|
-    Arel::Nodes::SqlLiteral.new "date(items.created_at)"
-  end
-
   # Create the user from a Clever info hash
   def self.create_from_clever(hash, role_override = nil)
     user = User.where(email: hash[:info][:email]).first_or_initialize


### PR DESCRIPTION
## WHAT
Remove the gem ransack gem from LMS Gemfile

## WHY
It doesn't appear we are using the Gem anymore.  Normally, ransack is utilized via: `search_form_for`, which it was in this old [commit](https://github.com/empirical-org/Empirical-Core/commit/3832bcf5f762018bedfd3704c21da23fbc9d49fe#diff-982a93f46a47e4b3a34725c965a14b3cadaa7486129dcc2fc19ebf81369aa731R3)

This will help streamline Rails 5.2. upgrade.

## HOW
Remove item from the Gemfile and `bundle update`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
