### PR TITLE
Update secure-headers-spec

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -121,7 +121,7 @@ class ApplicationController < ActionController::Base
   end
 
   protected def set_default_cache_security_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'no-cache, no-store'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end

--- a/services/QuillLMS/spec/requests/secure_headers_spec.rb
+++ b/services/QuillLMS/spec/requests/secure_headers_spec.rb
@@ -27,7 +27,7 @@ describe DummyController, type: :request do
 
   it 'should set cache control headers' do
     get '/dummy'
-    expect(response.header['Cache-Control']).to match('no-cache, no-store, max-age=0, must-revalidate')
+    expect(response.header['Cache-Control']).to match('no-cache, no-store')
     expect(response.header['Pragma']).to match('no-cache')
   end
 


### PR DESCRIPTION
## WHAT
Update a spec in anticipation of Rails 5.2 upgrade.

## WHY
In [Rails 5.2](https://github.com/rails/rails/issues/32557#issuecomment-382864622) the headers for 'Cache-Control' the will be changed.

## HOW
Remove a couple of keys from the spec.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YS
