### PR TITLE
Wrap query methods in Arel.sql

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -93,7 +93,7 @@ class Teachers::ClassroomManagerController < ApplicationController
   def students_list
     @classroom = current_user.classrooms_i_teach.find {|classroom| classroom.id == params[:id]&.to_i}
     last_name = "substring(users.name, '(?=\s).*')"
-    render json: {students: @classroom&.students&.order("#{last_name} asc, users.name asc")}
+    render json: { students: @classroom&.students&.order(Arel.sql("#{last_name} asc, users.name asc")) }
   end
 
   def premium

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -349,7 +349,8 @@ class Teachers::UnitsController < ApplicationController
     .joins("JOIN unit_activities ON unit_activities.unit_id = classroom_units.unit_id AND unit_activities.activity_id IN (#{diagnostic_activity_ids.join(',')}) AND unit_activities.visible")
     .joins("JOIN activities ON unit_activities.activity_id = activities.id")
     .group("classrooms.name, activities.name, activities.id, classroom_units.unit_id, classroom_units.id, units.name, classrooms.id, classroom_units.assigned_student_ids, unit_activities.created_at, classroom_units.created_at")
-    .order("classrooms.name, greatest(classroom_units.created_at, unit_activities.created_at) DESC")
+    .order(Arel.sql("classrooms.name, greatest(classroom_units.created_at, unit_activities.created_at) DESC"))
+
     records.map do |r|
       {
         "assigned_student_ids" => r['assigned_student_ids'] || [],

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -139,7 +139,7 @@ class TeachersController < ApplicationController
         .joins("JOIN activities ON unit_activities.activity_id = activities.id")
         .joins("JOIN classroom_unit_activity_states ON classroom_unit_activity_states.classroom_unit_id = classroom_units.id AND classroom_unit_activity_states.unit_activity_id = unit_activities.id AND completed = FALSE")
         .group("classrooms.name, activities.name, activities.id, activities.supporting_info, classroom_units.unit_id, classroom_units.id, classrooms.id, classroom_units.assigned_student_ids, classroom_units.created_at, unit_activities.created_at")
-        .order("greatest(classroom_units.created_at, unit_activities.created_at) DESC")
+        .order(Arel.sql("greatest(classroom_units.created_at, unit_activities.created_at) DESC"))
 
     units = records.map do |r|
       {
@@ -166,7 +166,7 @@ class TeachersController < ApplicationController
       .joins("LEFT JOIN activities AS pre_test ON pre_test.follow_up_activity_id = activities.id")
       .joins("LEFT JOIN activity_sessions ON activity_sessions.activity_id = unit_activities.activity_id AND activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.visible AND activity_sessions.is_final_score")
       .group("classrooms.name, activities.name, activities.id, activities.follow_up_activity_id, pre_test.id, classroom_units.unit_id, classrooms.id, classroom_units.assigned_student_ids, classroom_units.created_at, unit_activities.created_at")
-      .order("greatest(classroom_units.created_at, unit_activities.created_at) DESC")
+      .order(Arel.sql("greatest(classroom_units.created_at, unit_activities.created_at) DESC"))
       units = records.map do |r|
         {
           assigned_count: r['assigned_count'] || 0,

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -561,9 +561,9 @@ class ActivitySession < ApplicationRecord
 
     case sort[:field]
     when 'activity_classification_name'
-      "activity_classifications.name #{order}, #{last_name} #{order}"
+      Arel.sql("activity_classifications.name #{order}, #{last_name} #{order}")
     when 'student_name'
-      "#{last_name} #{order}, users.name #{order}"
+      Arel.sql("#{last_name} #{order}, users.name #{order}")
     when 'completed_at'
       "activity_sessions.completed_at #{order}"
     when 'activity_name'

--- a/services/QuillLMS/app/queries/progress_reports/activity_session.rb
+++ b/services/QuillLMS/app/queries/progress_reports/activity_session.rb
@@ -12,6 +12,7 @@ class ProgressReports::ActivitySession
       .completed
       .by_teacher(@teacher)
       .order(ActivitySession.search_sort_sql(filters[:sort]))
+
     ActivitySession.with_filters(query, filters)
   end
 end

--- a/services/QuillLMS/app/queries/progress_reports/concepts/user.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/user.rb
@@ -18,6 +18,6 @@ class ProgressReports::Concepts::User
       )
       .joins("JOIN #{filtered_correct_results} ON users.id = filtered_correct_results.user_id")
       .group('users.id')
-      .order("#{last_name} ASC, users.name ASC")
+      .order(Arel.sql("#{last_name} ASC, users.name ASC"))
   end
 end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -445,7 +445,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
       get :students_list, params: { id: classroom.id }, as: :json
       expect(assigns(:classroom)).to eq classroom
       expect(response.body).to eq({
-        students: classroom.students.order("substring(users.name, '(?=\s).*') asc, users.name asc"),
+        students: classroom.students.order(Arel.sql("substring(users.name, '(?=\s).*') asc, users.name asc"))
       }.to_json)
     end
   end


### PR DESCRIPTION
## WHAT
For some `order` queries that use raw sql with values that aren't attributes on the model, wrap in Arel.sql.

## WHY
Methods that use raw sql for certain methods will be disallowed in [Rails 6](https://github.com/rails/rails/pull/27947)

## HOW
Locate offending queries and wrap in `Arel.sql`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | Not yet! Deploying now. 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
