### PR TITLE
react-query/ default options

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/app.tsx
@@ -21,6 +21,7 @@ import titleCardActions from './actions/titleCards.ts';
 import quillNormalizer from './libs/quillNormalizer';
 import Home from './components/home.tsx';
 
+import { defaultQueryClientOptions } from '../Shared';
 
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
@@ -28,7 +29,7 @@ if (process.env.NODE_ENV === 'production') {
 
 BackOff();
 const store = createStore();
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 // This is pretty hacky.
 // Ideally we should really be extracting the both UIDs from

--- a/services/QuillLMS/client/app/bundles/Connect/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/app.tsx
@@ -21,7 +21,7 @@ import titleCardActions from './actions/titleCards.ts';
 import quillNormalizer from './libs/quillNormalizer';
 import Home from './components/home.tsx';
 
-import { defaultQueryClientOptions } from '../Shared';
+import { DefaultReactQueryClient } from '../Shared';
 
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV === 'production') {
 
 BackOff();
 const store = createStore();
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 // This is pretty hacky.
 // Ideally we should really be extracting the both UIDs from

--- a/services/QuillLMS/client/app/bundles/Connect/components/__tests__/__snapshots__/home.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Connect/components/__tests__/__snapshots__/home.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Home Component should match snapshot 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Connect/components/__tests__/__snapshots__/home.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Connect/components/__tests__/__snapshots__/home.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`Home Component should match snapshot 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Connect/components/__tests__/home.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/__tests__/home.test.tsx
@@ -4,9 +4,9 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { Home } from '../home';
 
-import { defaultQueryClientOptions } from '../../../Shared';
+import { DefaultReactQueryClient } from '../../../Shared';
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('Home Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Connect/components/__tests__/home.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/__tests__/home.test.tsx
@@ -4,7 +4,9 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { Home } from '../home';
 
-const queryClient = new QueryClient()
+import { defaultQueryClientOptions } from '../../../Shared';
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('Home Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Diagnostic/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/app.tsx
@@ -23,7 +23,7 @@ import quillNormalizer from './libs/quillNormalizer';
 import './i18n';
 import Home from './components/home';
 
-import { defaultQueryClientOptions } from '../Shared';
+import { DefaultReactQueryClient } from '../Shared';
 
 if (process.env.RAILS_ENV === 'production') {
   Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
@@ -31,7 +31,7 @@ if (process.env.RAILS_ENV === 'production') {
 
 BackOff();
 const store = createStore();
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 // This is pretty hacky.
 // Ideally we should really be extracting the both UIDs from

--- a/services/QuillLMS/client/app/bundles/Diagnostic/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/app.tsx
@@ -23,13 +23,15 @@ import quillNormalizer from './libs/quillNormalizer';
 import './i18n';
 import Home from './components/home';
 
+import { defaultQueryClientOptions } from '../Shared';
+
 if (process.env.RAILS_ENV === 'production') {
   Sentry.init({ dsn: 'https://528794315c61463db7d5181ebc1d51b9@o95148.ingest.sentry.io/210579' })
 }
 
 BackOff();
 const store = createStore();
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 // This is pretty hacky.
 // Ideally we should really be extracting the both UIDs from

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/__snapshots__/home.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/__snapshots__/home.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Home Component should match snapshot 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/__snapshots__/home.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/__snapshots__/home.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`Home Component should match snapshot 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/home.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/home.test.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
+import { defaultQueryClientOptions } from '../../../Shared';
+
 import { Home } from '../home';
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('Home Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/home.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/__tests__/home.test.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
-import { defaultQueryClientOptions } from '../../../Shared';
+import { DefaultReactQueryClient } from '../../../Shared';
 
 import { Home } from '../home';
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('Home Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Grammar/App.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/App.tsx
@@ -8,7 +8,7 @@ import { configureStore, initStore } from "./store/configStore";
 
 const store = configureStore();
 store.dispatch(initStore());
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 class App extends React.Component<{}, {}> {
   componentDidMount() {

--- a/services/QuillLMS/client/app/bundles/Grammar/App.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/App.tsx
@@ -6,9 +6,11 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import {route} from "./routes";
 import { configureStore, initStore } from "./store/configStore";
 
+import { DefaultReactQueryClient } from "../Shared";
+
 const store = configureStore();
 store.dispatch(initStore());
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 class App extends React.Component<{}, {}> {
   componentDidMount() {

--- a/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/PageLayout.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/PageLayout.test.tsx
@@ -4,7 +4,9 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { PageLayout } from '../PageLayout';
 
-const queryClient = new QueryClient()
+import { defaultQueryClientOptions } from '../../../Shared';
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('PageLayout Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/PageLayout.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/PageLayout.test.tsx
@@ -4,9 +4,9 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { PageLayout } from '../PageLayout';
 
-import { defaultQueryClientOptions } from '../../../Shared';
+import { DefaultReactQueryClient } from '../../../Shared';
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('PageLayout Component', () => {
   const component = shallow(

--- a/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PageLayout Component should match snapshot 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`PageLayout Component should match snapshot 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -172,3 +172,5 @@ export {
   SUPPORT,
   TEAMS
 } from './utils/constants'
+
+export { defaultQueryClientOptions } from './utils/defaultOptions'

--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -173,4 +173,4 @@ export {
   TEAMS
 } from './utils/constants'
 
-export { defaultQueryClientOptions } from './utils/defaultOptions'
+export { DefaultReactQueryClient } from './utils/defaultReactQueryClient'

--- a/services/QuillLMS/client/app/bundles/Shared/utils/defaultOptions.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/defaultOptions.ts
@@ -1,0 +1,9 @@
+// https://react-query.tanstack.com/reference/QueryClient
+
+export const defaultQueryClientOptions = {
+  queries: {
+    staleTime: Infinity,
+    // all current query instances are manually refetched after data changes so no cache is needed (this option can be overridden in any useQuery instance)
+    cacheTime: Infinity
+  }
+}

--- a/services/QuillLMS/client/app/bundles/Shared/utils/defaultOptions.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/defaultOptions.ts
@@ -1,9 +1,0 @@
-// https://react-query.tanstack.com/reference/QueryClient
-
-export const defaultQueryClientOptions = {
-  queries: {
-    staleTime: Infinity,
-    // all current query instances are manually refetched after data changes so no cache is needed (this option can be overridden in any useQuery instance)
-    cacheTime: Infinity
-  }
-}

--- a/services/QuillLMS/client/app/bundles/Shared/utils/defaultReactQueryClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/defaultReactQueryClient.tsx
@@ -1,0 +1,15 @@
+import { QueryClient } from 'react-query'
+
+export class DefaultReactQueryClient extends QueryClient {
+  constructor() {
+    super({
+      defaultOptions: {
+        queries: {
+          staleTime: Infinity,
+          // all current query instances are manually refetched after data changes so no cache is needed (this option can be overridden in any useQuery instance)
+          cacheTime: Infinity
+        }
+      }
+    })
+  }
+}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityStats.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityStats.test.tsx.snap
@@ -1,121 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActivityStats component should render ActivityStats 1`] = `
-<div
-  className="activity-stats-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="comprehension-page-header-container"
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
+      }
+    }
   >
-    <h2>
-      Activity Stats
-    </h2>
-    <h3>
-      Could Capybaras Create Chaos?
-    </h3>
-    <h4>
-      Could Capybaras Create Chaos? [student testing]
-    </h4>
-  </section>
-  <FilterWidget
-    endDate={null}
-    handleFilterClick={[Function]}
-    handleSetTurkSessionID={[Function]}
-    onEndDateChange={[Function]}
-    onStartDateChange={[Function]}
-    showError={false}
-    startDate={null}
-    turkSessionID=""
-  />
-  <ReactTable
-    className="activity-stats-table"
-    columns={
-      Array [
+    <ActivityStats
+      history={
         Object {
-          "Cell": [Function],
-          "Header": "",
-          "accessor": "promptText",
-          "key": "promptText",
-        },
+          "createHref": [Function],
+          "createKey": [Function],
+          "createLocation": [Function],
+          "createPath": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "listenBefore": [Function],
+          "push": [Function],
+          "pushState": [Function],
+          "registerTransitionHook": [Function],
+          "replace": [Function],
+          "replaceState": [Function],
+          "setState": [Function],
+          "transitionTo": [Function],
+          "unregisterTransitionHook": [Function],
+        }
+      }
+      location={
         Object {
-          "Header": "Total Responses",
-          "accessor": "totalResponses",
-          "key": "totalResponses",
-          "width": 80,
-        },
+          "action": "POP",
+          "hash": "",
+          "key": null,
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        }
+      }
+      match={
         Object {
-          "Header": "Sessions",
-          "accessor": "sessionCount",
-          "key": "sessionCount",
-          "width": 70,
-        },
-        Object {
-          "Header": "Final Attempt: Optimal | Sub-Optimal",
-          "accessor": "finalAttemptData",
-          "key": "finalAttemptData",
-          "width": 160,
-        },
-        Object {
-          "Header": "Average Attempts",
-          "accessor": "averageAttempts",
-          "key": "averageAttempts",
-          "width": 120,
-        },
-        Object {
-          "Header": "Rule Repeated: Consecutive Attempt",
-          "accessor": "ruleRepeatedConsecutiveData",
-          "key": "ruleRepeatedConsecutiveData",
-          "width": 150,
-        },
-        Object {
-          "Header": "Rule Repeated: Non-consecutive Attempt",
-          "accessor": "ruleRepeatedNotConsecutiveData",
-          "key": "ruleRepeatedNotConsecutiveData",
-          "width": 150,
-        },
-        Object {
-          "Header": "First Attempt: Optimal | Sub-Optimal",
-          "accessor": "firstAttemptData",
-          "key": "firstAttemptData",
-          "width": 160,
-        },
-      ]
-    }
-    data={
-      Array [
-        Object {
-          "averageAttempts": 2.73,
-          "finalAttemptData": "100% (224) | 0% (0)",
-          "firstAttemptData": "80.36% (180) | 19.64% (44)",
-          "promptText": "A surge barrier in New York City could harm the local ecosystem because",
-          "ruleRepeatedConsecutiveData": "92.86% (208)",
-          "ruleRepeatedNotConsecutiveData": "98.21% (220)",
-          "sessionCount": 224,
-          "totalResponses": 4720,
-        },
-        Object {
-          "averageAttempts": 2.61,
-          "finalAttemptData": "100% (155) | 0% (0)",
-          "firstAttemptData": "87.1% (135) | 12.9% (20)",
-          "promptText": "A surge barrier in New York City could harm the local ecosystem, but",
-          "ruleRepeatedConsecutiveData": "89.68% (139)",
-          "ruleRepeatedNotConsecutiveData": "96.77% (150)",
-          "sessionCount": 155,
-          "totalResponses": 3176,
-        },
-        Object {
-          "averageAttempts": 2.22,
-          "finalAttemptData": "100% (195) | 0% (0)",
-          "firstAttemptData": "82.56% (161) | 17.44% (34)",
-          "promptText": "A surge barrier in New York City could harm the local ecosystem, so",
-          "ruleRepeatedConsecutiveData": "93.33% (182)",
-          "ruleRepeatedNotConsecutiveData": "97.44% (190)",
-          "sessionCount": 195,
-          "totalResponses": 3291,
-        },
-      ]
-    }
-    defaultPageSize={3}
-  />
-</div>
+          "isExact": true,
+          "params": Object {
+            "activityId": "1",
+          },
+          "path": "",
+          "url": "",
+        }
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/labelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/labelsTable.test.tsx.snap
@@ -1,150 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LabelsTable component should render LabelsTable 1`] = `
-<section
-  className="semantic-labels-container"
+<ContextProvider
+  value={true}
 >
-  <DataTable
-    averageFontWidth={7}
-    className="semantic-labels-table"
-    headers={
-      Array [
-        Object {
-          "attribute": "id",
-          "name": "Rule ID",
-          "width": "70px",
-        },
-        Object {
-          "attribute": "descriptive_label",
-          "name": "Descriptive Label",
-          "width": "400px",
-        },
-        Object {
-          "attribute": "automl_label",
-          "name": "AutoML Label",
-          "width": "150px",
-        },
-        Object {
-          "attribute": "state",
-          "name": "Active?",
-          "width": "150px",
-        },
-        Object {
-          "attribute": "optimal",
-          "name": "Optimal?",
-          "width": "70px",
-        },
-        Object {
-          "attribute": "edit",
-          "name": "",
-          "width": "70px",
-        },
-      ]
-    }
-    rows={
-      Array [
-        Object {
-          "automl_label": "label_1",
-          "descriptive_label": "rule_1",
-          "edit": <Link
-            className="data-link"
-            to={
-              Object {
-                "pathname": "/activities/17/semantic-labels/1/1",
-                "state": Object {
-                  "conjunction": "because",
-                  "rule": Object {
-                    "id": 1,
-                    "label": Object {
-                      "id": 1,
-                      "name": "label_1",
-                    },
-                    "name": "rule_1",
-                    "optimal": false,
-                    "state": "active",
-                  },
-                },
-              }
-            }
-          >
-            View
-          </Link>,
-          "id": 1,
-          "optimal": <img
-            alt="quill-circle-checkmark"
-            src="/images/red_x.svg"
-          />,
-          "state": <img
-            alt="quill-circle-checkmark"
-            src="/images/green_check.svg"
-          />,
-          "state_for_sort": "active",
-        },
-        Object {
-          "automl_label": "label_2",
-          "descriptive_label": "rule_2",
-          "edit": <Link
-            className="data-link"
-            to={
-              Object {
-                "pathname": "/activities/17/semantic-labels/1/2",
-                "state": Object {
-                  "conjunction": "because",
-                  "rule": Object {
-                    "id": 2,
-                    "label": Object {
-                      "id": 2,
-                      "name": "label_2",
-                    },
-                    "name": "rule_2",
-                    "optimal": false,
-                    "state": "active",
-                  },
-                },
-              }
-            }
-          >
-            View
-          </Link>,
-          "id": 2,
-          "optimal": <img
-            alt="quill-circle-checkmark"
-            src="/images/red_x.svg"
-          />,
-          "state": <img
-            alt="quill-circle-checkmark"
-            src="/images/green_check.svg"
-          />,
-          "state_for_sort": "active",
-        },
-      ]
-    }
-  />
-  <div
-    className="button-wrapper"
-  >
-    <Link
-      className="quill-button fun primary contained"
-      id="add-rule-button"
-      to={
-        Object {
-          "pathname": "/activities/17/semantic-labels/1/new",
-          "state": Object {
-            "conjunction": "because",
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
           },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
+      }
+    }
+  >
+    <LabelsTable
+      activityId="17"
+      prompt={
+        Object {
+          "conjunction": "because",
+          "id": 1,
         }
       }
-    >
-      Add Label
-    </Link>
-    <Link
-      className="quill-button fun secondary outlined"
-      rel="noopener noreferrer"
-      target="_blank"
-      to="/activities/17/semantic-labels/1/semantic-rules-cheat-sheet"
-    >
-      Semantic Rules Cheat Sheet
-    </Link>
-  </div>
-</section>
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/modelsTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/modelsTable.test.tsx.snap
@@ -1,84 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LabelsTable component should render ModelsTable 1`] = `
-<section
-  className="models-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="header-container"
-  >
-    <h2>
-       Model (Prompt ID: 1)
-    </h2>
-  </section>
-  <DataTable
-    averageFontWidth={7}
-    className="models-table"
-    defaultSortAttribute="name"
-    headers={
-      Array [
-        Object {
-          "attribute": "created_at",
-          "name": "Created At",
-          "noTooltip": true,
-          "width": "100px",
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
         },
-        Object {
-          "attribute": "version",
-          "name": "Version",
-          "noTooltip": true,
-          "width": "50px",
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
         },
-        Object {
-          "attribute": "name",
-          "name": "Model Name",
-          "width": "150px",
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
         },
-        Object {
-          "attribute": "notes",
-          "name": "Model Notes",
-          "width": "350px",
-        },
-        Object {
-          "attribute": "label_count",
-          "name": "Label Count",
-          "noTooltip": true,
-          "width": "70px",
-        },
-        Object {
-          "attribute": "status",
-          "name": "Status",
-          "noTooltip": true,
-          "width": "70px",
-        },
-        Object {
-          "attribute": "view",
-          "name": "",
-          "noTooltip": true,
-          "width": "50px",
-        },
-        Object {
-          "attribute": "activate",
-          "name": "",
-          "noTooltip": true,
-          "width": "70px",
-        },
-      ]
-    }
-    rows={Array []}
-  />
-  <Link
-    className="quill-button fun primary contained"
-    to={
-      Object {
-        "pathname": "/activities/17/semantic-labels/1/add-model",
-        "state": Object {
-          "conjunction": undefined,
-        },
+        "queryDefaults": Array [],
       }
     }
   >
-    Add Model
-  </Link>
-</section>
+    <ModelsTable
+      activityId="17"
+      prompt={
+        Object {
+          "id": 1,
+        }
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
@@ -1,121 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PlagiarismRulesIndex component should render PlagiarismRulesIndex 1`] = `
-<div
-  className="rules-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="comprehension-page-header-container"
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
+      }
+    }
   >
-    <h2>
-      Plagiarism Rules
-    </h2>
-    <h3>
-      Could Capybaras Create Chaos?
-    </h3>
-    <h4>
-      Could Capybaras Create Chaos? [student testing]
-    </h4>
-  </section>
-  <section
-    className="plagiarism-section"
-    id="first-plagiarism-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button disabled"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/plagiarism-rules/new",
-            "state": Object {
-              "ruleType": "plagiarism",
-            },
-          }
+    <PlagiarismRulesIndex
+      history={
+        Object {
+          "createHref": [Function],
+          "createKey": [Function],
+          "createLocation": [Function],
+          "createPath": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "listenBefore": [Function],
+          "push": [Function],
+          "pushState": [Function],
+          "registerTransitionHook": [Function],
+          "replace": [Function],
+          "replaceState": [Function],
+          "setState": [Function],
+          "transitionTo": [Function],
+          "unregisterTransitionHook": [Function],
         }
-      >
-        Add Plagiarism Rule
-      </Link>
-    </button>
-    <p
-      className="one-rule-warning"
-    >
-      There can only be one plagiarism rule per conjunction. Please click "View" below if you would like to update the plagiarized text.
-    </p>
-    <section
-      className="no-rules-section"
-    >
-      <p>
-        Click the button above to add a plagiarism rule.
-      </p>
-    </section>
-  </section>
-  <section
-    className="plagiarism-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button disabled"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/plagiarism-rules/new",
-            "state": Object {
-              "ruleType": "plagiarism",
-            },
-          }
+      }
+      location={
+        Object {
+          "action": "POP",
+          "hash": "",
+          "key": null,
+          "pathname": "/",
+          "search": "",
+          "state": null,
         }
-      >
-        Add Plagiarism Rule
-      </Link>
-    </button>
-    <p
-      className="one-rule-warning"
-    >
-      There can only be one plagiarism rule per conjunction. Please click "View" below if you would like to update the plagiarized text.
-    </p>
-    <section
-      className="no-rules-section"
-    >
-      <p>
-        Click the button above to add a plagiarism rule.
-      </p>
-    </section>
-  </section>
-  <section
-    className="plagiarism-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button disabled"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/plagiarism-rules/new",
-            "state": Object {
-              "ruleType": "plagiarism",
-            },
-          }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {
+            "activityId": "1",
+          },
+          "path": "",
+          "url": "",
         }
-      >
-        Add Plagiarism Rule
-      </Link>
-    </button>
-    <p
-      className="one-rule-warning"
-    >
-      There can only be one plagiarism rule per conjunction. Please click "View" below if you would like to update the plagiarized text.
-    </p>
-    <section
-      className="no-rules-section"
-    >
-      <p>
-        Click the button above to add a plagiarism rule.
-      </p>
-    </section>
-  </section>
-</div>
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/promptTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/promptTable.test.tsx.snap
@@ -1,114 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PromptTable component should render PromptTable 1`] = `
-<section
-  className="prompt-table-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="attempts-section"
-  >
-    <p
-      className="attempts-label"
-    >
-      Attempts
-    </p>
-    <p
-      className="attempts-value"
-    >
-      1
-    </p>
-  </section>
-  <section
-    className="completed-section"
-  >
-    <p
-      className="completed-label"
-    >
-      Completed
-    </p>
-    <p
-      className="completed-value"
-    >
-      False
-    </p>
-  </section>
-  <DataTable
-    averageFontWidth={7}
-    className="attempts-feedback-table"
-    headers={
-      Array [
-        Object {
-          "attribute": "status",
-          "name": "Status",
-          "width": "100px",
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
         },
-        Object {
-          "attribute": "results",
-          "name": "Results",
-          "width": "600px",
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
         },
-        Object {
-          "attribute": "feedback",
-          "name": "Rule",
-          "width": "300px",
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
         },
-        Object {
-          "attribute": "buttons",
-          "name": "",
-          "width": "120px",
-        },
-      ]
+        "queryDefaults": Array [],
+      }
     }
-    rows={
-      Array [
+  >
+    <PromptTable
+      activity={
         Object {
-          "id": "undefined:0:attempt",
-          "results": <div>
-            <b />
-            <p
-              className="entry"
-            >
-              
-            </p>
-          </div>,
-          "status": "1st Attempt",
-        },
+          "name": "Test Name",
+          "prompts": Array [
+            Object {
+              "conjunction": "because",
+              "id": 1,
+              "max_attempts": 5,
+              "max_attempts_feedback": "good try!",
+              "text": "test",
+            },
+          ],
+          "scored_level": "7",
+          "target_level": 7,
+          "title": "Test Activity",
+        }
+      }
+      prompt={
         Object {
-          "buttons": <div
-            className="strength-buttons"
-          >
-            <button
-              className="strength-button"
-              onClick={[Function]}
-              type="button"
-            >
-              strong
-            </button>
-            <button
-              className="strength-button"
-              onClick={[Function]}
-              type="button"
-            >
-              weak
-            </button>
-          </div>,
-          "className": "sub-optimal",
-          "feedback": <Link
-            className="data-link word-wrap"
-            rel="noopener noreferrer"
-            target="_blank"
-            to="/activities/undefined/rules-analysis/undefined/rule/undefined/prompt/undefined"
-          >
-            : null
-          </Link>,
-          "id": "undefined:0:feedback",
-          "results": <p
-            className="word-wrap"
-          />,
-          "status": "1st Feedback",
-        },
-      ]
-    }
-  />
-</section>
+          "attempts": Object {
+            "1": Array [
+              Object {
+                "entry": "",
+                "feedback_text": "",
+                "feedback_type": "",
+                "optimal": false,
+              },
+            ],
+          },
+          "conjunction": "because",
+          "max_attempts": 5,
+          "max_attempts_feedback": "good try!",
+          "text": "test",
+        }
+      }
+      sessionId="3q7dvhjhas"
+      showHeader={false}
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
@@ -1,358 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RegexRulesIndex component should render RegexRulesIndex 1`] = `
-<div
-  className="rules-container"
+<ContextProvider
+  value={true}
 >
-  <a
-    className="quill-button fun secondary outlined focus-on-light play-activity-button"
-    href="/evidence/#/play?uid=1&skipToPrompts=true"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    Play Test Activity
-  </a>
-  <section
-    className="rules-based-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/regex-rules/new",
-            "state": Object {
-              "ruleType": "rules-based-1",
-            },
-          }
-        }
-      >
-        Add Sentence Structure Regex Rule
-      </Link>
-    </button>
-    <DataTable
-      averageFontWidth={7}
-      className="rules-table regex-index-table"
-      defaultSortAttribute="name"
-      headers={
-        Array [
-          Object {
-            "attribute": "priority",
-            "name": "Priority",
-            "width": "50px",
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
           },
-          Object {
-            "attribute": "name",
-            "name": "Rule Name",
-            "width": "300px",
-          },
-          Object {
-            "attribute": "required_sequence",
-            "name": "Required Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "incorrect_sequence",
-            "name": "Incorrect Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "because_prompt",
-            "name": "Because",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "but_prompt",
-            "name": "But",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "so_prompt",
-            "name": "So",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "view",
-            "name": "",
-            "width": "50px",
-          },
-        ]
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
       }
-      isReorderable={true}
-      reorderCallback={[Function]}
-      rows={
-        Array [
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 1,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_1",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/1"
-            >
-              View
-            </Link>,
+    }
+  >
+    <RegexRulesIndex
+      history={
+        Object {
+          "createHref": [Function],
+          "createKey": [Function],
+          "createLocation": [Function],
+          "createPath": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "listenBefore": [Function],
+          "push": [Function],
+          "pushState": [Function],
+          "registerTransitionHook": [Function],
+          "replace": [Function],
+          "replaceState": [Function],
+          "setState": [Function],
+          "transitionTo": [Function],
+          "unregisterTransitionHook": [Function],
+        }
+      }
+      location={
+        Object {
+          "action": "POP",
+          "hash": "",
+          "key": null,
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {
+            "activityId": "1",
           },
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 2,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_2",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/2"
-            >
-              View
-            </Link>,
-          },
-        ]
+          "path": "",
+          "url": "",
+        }
       }
     />
-  </section>
-  <section
-    className="rules-based-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/regex-rules/new",
-            "state": Object {
-              "ruleType": "rules-based-2",
-            },
-          }
-        }
-      >
-        Add Post-Topic Regex Rule
-      </Link>
-    </button>
-    <DataTable
-      averageFontWidth={7}
-      className="rules-table regex-index-table"
-      defaultSortAttribute="name"
-      headers={
-        Array [
-          Object {
-            "attribute": "priority",
-            "name": "Priority",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "name",
-            "name": "Rule Name",
-            "width": "300px",
-          },
-          Object {
-            "attribute": "required_sequence",
-            "name": "Required Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "incorrect_sequence",
-            "name": "Incorrect Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "because_prompt",
-            "name": "Because",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "but_prompt",
-            "name": "But",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "so_prompt",
-            "name": "So",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "view",
-            "name": "",
-            "width": "50px",
-          },
-        ]
-      }
-      isReorderable={true}
-      reorderCallback={[Function]}
-      rows={
-        Array [
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 1,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_1",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/1"
-            >
-              View
-            </Link>,
-          },
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 2,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_2",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/2"
-            >
-              View
-            </Link>,
-          },
-        ]
-      }
-    />
-  </section>
-  <section
-    className="rules-based-section"
-  >
-    <button
-      className="quill-button fun primary contained add-rule-button"
-      type="submit"
-    >
-      <Link
-        to={
-          Object {
-            "pathname": "/activities/1/regex-rules/new",
-            "state": Object {
-              "ruleType": "rules-based-3",
-            },
-          }
-        }
-      >
-        Add Typo Regex Rule
-      </Link>
-    </button>
-    <DataTable
-      averageFontWidth={7}
-      className="rules-table regex-index-table"
-      defaultSortAttribute="name"
-      headers={
-        Array [
-          Object {
-            "attribute": "priority",
-            "name": "Priority",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "name",
-            "name": "Rule Name",
-            "width": "300px",
-          },
-          Object {
-            "attribute": "required_sequence",
-            "name": "Required Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "incorrect_sequence",
-            "name": "Incorrect Sequence",
-            "width": "250px",
-          },
-          Object {
-            "attribute": "because_prompt",
-            "name": "Because",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "but_prompt",
-            "name": "But",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "so_prompt",
-            "name": "So",
-            "width": "50px",
-          },
-          Object {
-            "attribute": "view",
-            "name": "",
-            "width": "50px",
-          },
-        ]
-      }
-      isReorderable={true}
-      reorderCallback={[Function]}
-      rows={
-        Array [
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 1,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_1",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/1"
-            >
-              View
-            </Link>,
-          },
-          Object {
-            "because_prompt": undefined,
-            "but_prompt": undefined,
-            "id": 2,
-            "incorrect_sequence": <div
-              className="regex-text-container"
-            />,
-            "name": "rule_2",
-            "priority": undefined,
-            "required_sequence": <div
-              className="regex-text-container"
-            />,
-            "so_prompt": undefined,
-            "view": <Link
-              to="/activities/1/regex-rules/2"
-            >
-              View
-            </Link>,
-          },
-        ]
-      }
-    />
-  </section>
-</div>
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rule component should render Rule 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`Rule component should render Rule 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RuleAnalysis component should render RuleAnalysis 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`RuleAnalysis component should render RuleAnalysis 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleForm.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RuleForm component should render RuleForm 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleForm.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`RuleForm component should render RuleForm 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rules component should render Rules 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
@@ -7,7 +7,12 @@ exports[`Rules component should render Rules 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
@@ -7,7 +7,12 @@ exports[`RulesAnalysis component should render RulesAnalysis 1`] = `
   <ContextProvider
     value={
       QueryClient {
-        "defaultOptions": Object {},
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
         "mutationCache": MutationCache {
           "config": Object {},
           "listeners": Array [],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`RulesAnalysis component should render RulesAnalysis 1`] = `
 >
   <ContextProvider
     value={
-      QueryClient {
+      DefaultReactQueryClient {
         "defaultOptions": Object {
           "queries": Object {
             "cacheTime": Infinity,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/semanticRulesCheatSheet.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/semanticRulesCheatSheet.test.tsx.snap
@@ -1,158 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SemanticRulesCheatSheet component should render SemanticRulesCheatSheet 1`] = `
-<section
-  className="semantic-labels-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="comprehension-page-header-container"
-  >
-    <h2>
-      Semantic Rules Cheat Sheet
-    </h2>
-    <h3>
-      Could Capybaras Create Chaos?
-    </h3>
-    <h4 />
-  </section>
-  <h4
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "Prompt: 1",
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
       }
     }
-  />
-  <DataTable
-    averageFontWidth={7}
-    className="semantic-rules-cheat-sheet"
-    headers={
-      Array [
+  >
+    <SemanticRulesCheatSheet
+      match={
         Object {
-          "attribute": "name",
-          "name": "Rule Name",
-          "noTooltip": true,
-          "width": "200px",
-        },
-        Object {
-          "attribute": "note",
-          "name": "Rule Notes",
-          "noTooltip": true,
-          "width": "300px",
-        },
-        Object {
-          "attribute": "firstLayerFeedback",
-          "name": "Rule Feedback - 1st Layer",
-          "noTooltip": true,
-          "width": "300px",
-        },
-        Object {
-          "attribute": "edit",
-          "name": "",
-          "noTooltip": true,
-          "width": "70px",
-        },
-      ]
-    }
-    rows={
-      Array [
-        Object {
-          "edit": <Link
-            className="quill-button fun contained primary"
-            rel="noopener noreferrer"
-            target="_blank"
-            to={
-              Object {
-                "pathname": "/activities/1/semantic-labels/1/1",
-                "state": Object {
-                  "rule": Object {
-                    "feedbacks": Array [
-                      Object {
-                        "text": "Here is some feedback",
-                      },
-                    ],
-                    "id": 1,
-                    "name": "rule_1",
-                    "note": "Here is a note",
-                  },
-                },
-              }
-            }
-          >
-            Edit Rule
-          </Link>,
-          "firstLayerFeedback": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Here is some feedback",
-              }
-            }
-          />,
-          "id": 1,
-          "name": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "rule_1",
-              }
-            }
-          />,
-          "note": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Here is a note",
-              }
-            }
-          />,
-        },
-        Object {
-          "edit": <Link
-            className="quill-button fun contained primary"
-            rel="noopener noreferrer"
-            target="_blank"
-            to={
-              Object {
-                "pathname": "/activities/1/semantic-labels/1/2",
-                "state": Object {
-                  "rule": Object {
-                    "feedbacks": Array [
-                      Object {
-                        "text": "Here is some other feedback",
-                      },
-                    ],
-                    "id": 2,
-                    "name": "rule_2",
-                    "note": "Here is another note",
-                  },
-                },
-              }
-            }
-          >
-            Edit Rule
-          </Link>,
-          "firstLayerFeedback": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Here is some other feedback",
-              }
-            }
-          />,
-          "id": 2,
-          "name": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "rule_2",
-              }
-            }
-          />,
-          "note": <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Here is another note",
-              }
-            }
-          />,
-        },
-      ]
-    }
-  />
-</section>
+          "params": Object {
+            "activityId": "1",
+            "promptId": "1",
+          },
+        }
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
@@ -1,346 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SessionsIndex component should render SessionsIndex 1`] = `
-<div
-  className="sessions-index-container"
+<ContextProvider
+  value={true}
 >
-  <section
-    className="comprehension-page-header-container"
-  >
-    <h2>
-      View Sessions
-    </h2>
-    <h3>
-      merp
-    </h3>
-    <h4 />
-  </section>
-  <section>
-    <p
-      className="link-info-blurb"
-    >
-      Use 
-      <a
-        href="https://data.quill.org/question/615?activity_id=1"
-      >
-        <strong>
-          this Metabase
-        </strong>
-      </a>
-       query to display feedback sessions on a single page.
-    </p>
-    <p
-      className="link-info-blurb"
-    >
-      If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence#/activities/
-      <strong>
-        activityID
-      </strong>
-      /
-      <strong>
-        sessionID
-      </strong>
-    </p>
-    <section
-      className="top-section"
-    >
-      <section
-        className="total-container"
-      >
-        <p
-          className="total-label"
-        >
-          Total
-        </p>
-        <p
-          className="total-value"
-        >
-          2
-        </p>
-      </section>
-      <DropdownInput
-        className="page-number-dropdown"
-        handleChange={[Function]}
-        isSearchable={false}
-        label=""
-        options={null}
-        value={null}
-      />
-    </section>
-    <section
-      className="top-section"
-    >
-      <DropdownInput
-        className="session-filters-dropdown"
-        handleChange={[Function]}
-        isSearchable={false}
-        label=""
-        options={
-          Array [
-            Object {
-              "label": "Show all sessions",
-              "value": "all",
-            },
-            Object {
-              "label": "Show only scored sessions",
-              "value": "scored",
-            },
-            Object {
-              "label": "Show only unscored sessions",
-              "value": "unscored",
-            },
-            Object {
-              "label": "Show sessions with weak responses",
-              "value": "weak",
-            },
-            Object {
-              "label": "Show complete sessions",
-              "value": "complete",
-            },
-            Object {
-              "label": "Show incomplete sessions",
-              "value": "incomplete",
-            },
-          ]
-        }
-        value={
-          Object {
-            "label": "Show all sessions",
-            "value": "all",
-          }
-        }
-      />
-      <p
-        className="date-picker-label"
-      >
-        Start Date:
-      </p>
-      <DateTimePicker
-        ampm={false}
-        calendarIcon={
-          <svg
-            className="react-datetime-picker__calendar-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              fill="none"
-              height="15"
-              width="15"
-              x="2"
-              y="2"
-            />
-            <line
-              x1="6"
-              x2="6"
-              y1="0"
-              y2="4"
-            />
-            <line
-              x1="13"
-              x2="13"
-              y1="0"
-              y2="4"
-            />
-          </svg>
-        }
-        clearIcon={
-          <svg
-            className="react-datetime-picker__clear-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="4"
-              x2="15"
-              y1="4"
-              y2="15"
-            />
-            <line
-              x1="15"
-              x2="4"
-              y1="4"
-              y2="15"
-            />
-          </svg>
-        }
-        closeWidgets={true}
-        format="y-MM-dd HH:mm"
-        isCalendarOpen={null}
-        isClockOpen={null}
-        maxDetail="minute"
-        onChange={[Function]}
-        openWidgetsOnFocus={true}
-        value={null}
-      />
-      <p
-        className="date-picker-label"
-      >
-        End Date (optional):
-      </p>
-      <DateTimePicker
-        ampm={false}
-        calendarIcon={
-          <svg
-            className="react-datetime-picker__calendar-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              fill="none"
-              height="15"
-              width="15"
-              x="2"
-              y="2"
-            />
-            <line
-              x1="6"
-              x2="6"
-              y1="0"
-              y2="4"
-            />
-            <line
-              x1="13"
-              x2="13"
-              y1="0"
-              y2="4"
-            />
-          </svg>
-        }
-        clearIcon={
-          <svg
-            className="react-datetime-picker__clear-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="4"
-              x2="15"
-              y1="4"
-              y2="15"
-            />
-            <line
-              x1="15"
-              x2="4"
-              y1="4"
-              y2="15"
-            />
-          </svg>
-        }
-        closeWidgets={true}
-        format="y-MM-dd HH:mm"
-        isCalendarOpen={null}
-        isClockOpen={null}
-        maxDetail="minute"
-        onChange={[Function]}
-        openWidgetsOnFocus={true}
-        value={null}
-      />
-      <p
-        className="date-picker-label"
-      >
-        Turk Session ID (optional):
-      </p>
-      <Input
-        autoComplete="on"
-        className="turk-session-id-input"
-        handleChange={[Function]}
-        label=""
-        value=""
-      />
-      <button
-        className="quill-button fun primary contained"
-        onClick={[Function]}
-        type="submit"
-      >
-        Filter
-      </button>
-    </section>
-    <div
-      className="error-container"
-    />
-    <ReactTable
-      className="activity-sessions-table"
-      columns={
-        Array [
-          Object {
-            "Header": "Date | Time",
-            "accessor": "datetime",
-            "width": 150,
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
           },
-          Object {
-            "Header": "Session ID",
-            "accessor": "session_uid",
-            "width": 100,
-          },
-          Object {
-            "Header": "Total Responses",
-            "accessor": "total_attempts",
-            "width": 150,
-          },
-          Object {
-            "Header": "Because",
-            "accessor": "because_attempts",
-            "width": 100,
-          },
-          Object {
-            "Header": "But",
-            "accessor": "but_attempts",
-            "width": 100,
-          },
-          Object {
-            "Header": "So",
-            "accessor": "so_attempts",
-            "width": 100,
-          },
-          Object {
-            "Header": "Scored",
-            "accessor": "scored_count",
-            "width": 100,
-          },
-          Object {
-            "Header": "Weak",
-            "accessor": "weak_count",
-            "width": 100,
-          },
-          Object {
-            "Header": "Strong",
-            "accessor": "strong_count",
-            "width": 100,
-          },
-          Object {
-            "Header": "Completed?",
-            "accessor": "completed",
-            "width": 100,
-          },
-          Object {
-            "Header": "",
-            "accessor": "view_link",
-            "width": 100,
-          },
-        ]
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
       }
-      data={Array []}
-      defaultPageSize={0}
-      manualSortBy={true}
-      onSortedChange={[Function]}
+    }
+  >
+    <SessionsIndex
+      history={
+        Object {
+          "createHref": [Function],
+          "createKey": [Function],
+          "createLocation": [Function],
+          "createPath": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "listenBefore": [Function],
+          "push": [Function],
+          "pushState": [Function],
+          "registerTransitionHook": [Function],
+          "replace": [Function],
+          "replaceState": [Function],
+          "setState": [Function],
+          "transitionTo": [Function],
+          "unregisterTransitionHook": [Function],
+        }
+      }
+      location={
+        Object {
+          "action": "POP",
+          "hash": "",
+          "key": null,
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {
+            "activityId": "1",
+          },
+          "path": "",
+          "url": "",
+        }
+      }
     />
-  </section>
-</div>
+  </ContextProvider>
+</ContextProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -1,1784 +1,791 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TurkSessions component should render TurkSessions 1`] = `
-<TurkSessions
-  history={
-    Object {
-      "createHref": [Function],
-      "createKey": [Function],
-      "createLocation": [Function],
-      "createPath": [Function],
-      "go": [Function],
-      "goBack": [Function],
-      "goForward": [Function],
-      "listen": [Function],
-      "listenBefore": [Function],
-      "push": [Function],
-      "pushState": [Function],
-      "registerTransitionHook": [Function],
-      "replace": [Function],
-      "replaceState": [Function],
-      "setState": [Function],
-      "transitionTo": [Function],
-      "unregisterTransitionHook": [Function],
-    }
-  }
-  location={
-    Object {
-      "action": "POP",
-      "hash": "",
-      "key": null,
-      "pathname": "/",
-      "search": "",
-      "state": null,
-    }
-  }
-  match={
-    Object {
-      "isExact": true,
-      "params": Object {
-        "activityId": "1",
+<QueryClientProvider
+  client={
+    DefaultReactQueryClient {
+      "defaultOptions": Object {
+        "queries": Object {
+          "cacheTime": Infinity,
+          "staleTime": Infinity,
+        },
       },
-      "path": "",
-      "url": "",
+      "mutationCache": MutationCache {
+        "config": Object {},
+        "listeners": Array [],
+        "mutationId": 0,
+        "mutations": Array [],
+      },
+      "mutationDefaults": Array [],
+      "queryCache": QueryCache {
+        "config": Object {},
+        "listeners": Array [],
+        "queries": Array [
+          Query {
+            "abortSignalConsumed": false,
+            "cache": [Circular],
+            "cacheTime": Infinity,
+            "defaultOptions": undefined,
+            "gcTimeout": undefined,
+            "hadObservers": true,
+            "initialState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "meta": undefined,
+            "observers": Array [
+              QueryObserver {
+                "client": [Circular],
+                "currentQuery": [Circular],
+                "currentQueryInitialState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": false,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "idle",
+                },
+                "currentRefetchInterval": false,
+                "currentResult": Object {
+                  "data": undefined,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdatedAt": 0,
+                  "failureCount": 0,
+                  "isError": false,
+                  "isFetched": false,
+                  "isFetchedAfterMount": false,
+                  "isFetching": true,
+                  "isIdle": false,
+                  "isLoading": true,
+                  "isLoadingError": false,
+                  "isPlaceholderData": false,
+                  "isPreviousData": false,
+                  "isRefetchError": false,
+                  "isRefetching": false,
+                  "isStale": true,
+                  "isSuccess": false,
+                  "refetch": [Function],
+                  "remove": [Function],
+                  "status": "loading",
+                },
+                "currentResultOptions": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"activity-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "activity-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "currentResultState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": true,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "loading",
+                },
+                "listeners": Array [
+                  [Function],
+                ],
+                "options": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"activity-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "activity-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "previousQueryResult": undefined,
+                "previousSelectError": null,
+                "refetch": [Function],
+                "refetchIntervalId": undefined,
+                "remove": [Function],
+                "staleTimeoutId": undefined,
+                "trackedProps": Array [],
+              },
+            ],
+            "options": Object {
+              "_defaulted": true,
+              "cacheTime": Infinity,
+              "optimisticResults": true,
+              "queryFn": [Function],
+              "queryHash": "[\\"activity-1\\",\\"1\\"]",
+              "queryKey": Array [
+                "activity-1",
+                "1",
+              ],
+              "staleTime": Infinity,
+            },
+            "promise": Promise {},
+            "queryHash": "[\\"activity-1\\",\\"1\\"]",
+            "queryKey": Array [
+              "activity-1",
+              "1",
+            ],
+            "retryer": Retryer {
+              "abort": [Function],
+              "cancel": [Function],
+              "cancelRetry": [Function],
+              "continue": [Function],
+              "continueRetry": [Function],
+              "failureCount": 0,
+              "isPaused": false,
+              "isResolved": false,
+              "isTransportCancelable": false,
+              "promise": Promise {},
+            },
+            "revertState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "state": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": true,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "loading",
+            },
+          },
+          Query {
+            "abortSignalConsumed": false,
+            "cache": [Circular],
+            "cacheTime": Infinity,
+            "defaultOptions": undefined,
+            "gcTimeout": undefined,
+            "hadObservers": true,
+            "initialState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "meta": undefined,
+            "observers": Array [
+              QueryObserver {
+                "client": [Circular],
+                "currentQuery": [Circular],
+                "currentQueryInitialState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": false,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "idle",
+                },
+                "currentRefetchInterval": false,
+                "currentResult": Object {
+                  "data": undefined,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdatedAt": 0,
+                  "failureCount": 0,
+                  "isError": false,
+                  "isFetched": false,
+                  "isFetchedAfterMount": false,
+                  "isFetching": true,
+                  "isIdle": false,
+                  "isLoading": true,
+                  "isLoadingError": false,
+                  "isPlaceholderData": false,
+                  "isPreviousData": false,
+                  "isRefetchError": false,
+                  "isRefetching": false,
+                  "isStale": true,
+                  "isSuccess": false,
+                  "refetch": [Function],
+                  "remove": [Function],
+                  "status": "loading",
+                },
+                "currentResultOptions": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "turk-sessions-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "currentResultState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": true,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "loading",
+                },
+                "listeners": Array [
+                  [Function],
+                ],
+                "options": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "turk-sessions-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "previousQueryResult": undefined,
+                "previousSelectError": null,
+                "refetch": [Function],
+                "refetchIntervalId": undefined,
+                "remove": [Function],
+                "staleTimeoutId": undefined,
+                "trackedProps": Array [],
+              },
+            ],
+            "options": Object {
+              "_defaulted": true,
+              "cacheTime": Infinity,
+              "optimisticResults": true,
+              "queryFn": [Function],
+              "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+              "queryKey": Array [
+                "turk-sessions-1",
+                "1",
+              ],
+              "staleTime": Infinity,
+            },
+            "promise": Promise {},
+            "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+            "queryKey": Array [
+              "turk-sessions-1",
+              "1",
+            ],
+            "retryer": Retryer {
+              "abort": [Function],
+              "cancel": [Function],
+              "cancelRetry": [Function],
+              "continue": [Function],
+              "continueRetry": [Function],
+              "failureCount": 0,
+              "isPaused": false,
+              "isResolved": false,
+              "isTransportCancelable": false,
+              "promise": Promise {},
+            },
+            "revertState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "state": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": true,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "loading",
+            },
+          },
+        ],
+        "queriesMap": Object {
+          "[\\"activity-1\\",\\"1\\"]": Query {
+            "abortSignalConsumed": false,
+            "cache": [Circular],
+            "cacheTime": Infinity,
+            "defaultOptions": undefined,
+            "gcTimeout": undefined,
+            "hadObservers": true,
+            "initialState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "meta": undefined,
+            "observers": Array [
+              QueryObserver {
+                "client": [Circular],
+                "currentQuery": [Circular],
+                "currentQueryInitialState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": false,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "idle",
+                },
+                "currentRefetchInterval": false,
+                "currentResult": Object {
+                  "data": undefined,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdatedAt": 0,
+                  "failureCount": 0,
+                  "isError": false,
+                  "isFetched": false,
+                  "isFetchedAfterMount": false,
+                  "isFetching": true,
+                  "isIdle": false,
+                  "isLoading": true,
+                  "isLoadingError": false,
+                  "isPlaceholderData": false,
+                  "isPreviousData": false,
+                  "isRefetchError": false,
+                  "isRefetching": false,
+                  "isStale": true,
+                  "isSuccess": false,
+                  "refetch": [Function],
+                  "remove": [Function],
+                  "status": "loading",
+                },
+                "currentResultOptions": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"activity-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "activity-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "currentResultState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": true,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "loading",
+                },
+                "listeners": Array [
+                  [Function],
+                ],
+                "options": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"activity-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "activity-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "previousQueryResult": undefined,
+                "previousSelectError": null,
+                "refetch": [Function],
+                "refetchIntervalId": undefined,
+                "remove": [Function],
+                "staleTimeoutId": undefined,
+                "trackedProps": Array [],
+              },
+            ],
+            "options": Object {
+              "_defaulted": true,
+              "cacheTime": Infinity,
+              "optimisticResults": true,
+              "queryFn": [Function],
+              "queryHash": "[\\"activity-1\\",\\"1\\"]",
+              "queryKey": Array [
+                "activity-1",
+                "1",
+              ],
+              "staleTime": Infinity,
+            },
+            "promise": Promise {},
+            "queryHash": "[\\"activity-1\\",\\"1\\"]",
+            "queryKey": Array [
+              "activity-1",
+              "1",
+            ],
+            "retryer": Retryer {
+              "abort": [Function],
+              "cancel": [Function],
+              "cancelRetry": [Function],
+              "continue": [Function],
+              "continueRetry": [Function],
+              "failureCount": 0,
+              "isPaused": false,
+              "isResolved": false,
+              "isTransportCancelable": false,
+              "promise": Promise {},
+            },
+            "revertState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "state": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": true,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "loading",
+            },
+          },
+          "[\\"turk-sessions-1\\",\\"1\\"]": Query {
+            "abortSignalConsumed": false,
+            "cache": [Circular],
+            "cacheTime": Infinity,
+            "defaultOptions": undefined,
+            "gcTimeout": undefined,
+            "hadObservers": true,
+            "initialState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "meta": undefined,
+            "observers": Array [
+              QueryObserver {
+                "client": [Circular],
+                "currentQuery": [Circular],
+                "currentQueryInitialState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": false,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "idle",
+                },
+                "currentRefetchInterval": false,
+                "currentResult": Object {
+                  "data": undefined,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdatedAt": 0,
+                  "failureCount": 0,
+                  "isError": false,
+                  "isFetched": false,
+                  "isFetchedAfterMount": false,
+                  "isFetching": true,
+                  "isIdle": false,
+                  "isLoading": true,
+                  "isLoadingError": false,
+                  "isPlaceholderData": false,
+                  "isPreviousData": false,
+                  "isRefetchError": false,
+                  "isRefetching": false,
+                  "isStale": true,
+                  "isSuccess": false,
+                  "refetch": [Function],
+                  "remove": [Function],
+                  "status": "loading",
+                },
+                "currentResultOptions": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "turk-sessions-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "currentResultState": Object {
+                  "data": undefined,
+                  "dataUpdateCount": 0,
+                  "dataUpdatedAt": 0,
+                  "error": null,
+                  "errorUpdateCount": 0,
+                  "errorUpdatedAt": 0,
+                  "fetchFailureCount": 0,
+                  "fetchMeta": null,
+                  "isFetching": true,
+                  "isInvalidated": false,
+                  "isPaused": false,
+                  "status": "loading",
+                },
+                "listeners": Array [
+                  [Function],
+                ],
+                "options": Object {
+                  "_defaulted": true,
+                  "cacheTime": Infinity,
+                  "optimisticResults": true,
+                  "queryFn": [Function],
+                  "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+                  "queryKey": Array [
+                    "turk-sessions-1",
+                    "1",
+                  ],
+                  "staleTime": Infinity,
+                },
+                "previousQueryResult": undefined,
+                "previousSelectError": null,
+                "refetch": [Function],
+                "refetchIntervalId": undefined,
+                "remove": [Function],
+                "staleTimeoutId": undefined,
+                "trackedProps": Array [],
+              },
+            ],
+            "options": Object {
+              "_defaulted": true,
+              "cacheTime": Infinity,
+              "optimisticResults": true,
+              "queryFn": [Function],
+              "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+              "queryKey": Array [
+                "turk-sessions-1",
+                "1",
+              ],
+              "staleTime": Infinity,
+            },
+            "promise": Promise {},
+            "queryHash": "[\\"turk-sessions-1\\",\\"1\\"]",
+            "queryKey": Array [
+              "turk-sessions-1",
+              "1",
+            ],
+            "retryer": Retryer {
+              "abort": [Function],
+              "cancel": [Function],
+              "cancelRetry": [Function],
+              "continue": [Function],
+              "continueRetry": [Function],
+              "failureCount": 0,
+              "isPaused": false,
+              "isResolved": false,
+              "isTransportCancelable": false,
+              "promise": Promise {},
+            },
+            "revertState": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": false,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "idle",
+            },
+            "state": Object {
+              "data": undefined,
+              "dataUpdateCount": 0,
+              "dataUpdatedAt": 0,
+              "error": null,
+              "errorUpdateCount": 0,
+              "errorUpdatedAt": 0,
+              "fetchFailureCount": 0,
+              "fetchMeta": null,
+              "isFetching": true,
+              "isInvalidated": false,
+              "isPaused": false,
+              "status": "loading",
+            },
+          },
+        },
+      },
+      "queryDefaults": Array [],
+      "unsubscribeFocus": [Function],
+      "unsubscribeOnline": [Function],
     }
   }
+  contextSharing={true}
 >
-  <div
-    className="turk-sessions-container"
+  <TurkSessions
+    history={
+      Object {
+        "createHref": [Function],
+        "createKey": [Function],
+        "createLocation": [Function],
+        "createPath": [Function],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "listen": [Function],
+        "listenBefore": [Function],
+        "push": [Function],
+        "pushState": [Function],
+        "registerTransitionHook": [Function],
+        "replace": [Function],
+        "replaceState": [Function],
+        "setState": [Function],
+        "transitionTo": [Function],
+        "unregisterTransitionHook": [Function],
+      }
+    }
+    location={
+      Object {
+        "action": "POP",
+        "hash": "",
+        "key": null,
+        "pathname": "/",
+        "search": "",
+        "state": null,
+      }
+    }
+    match={
+      Object {
+        "isExact": true,
+        "params": Object {
+          "activityId": "1",
+        },
+        "path": "",
+        "url": "",
+      }
+    }
   >
     <div
-      className="add-session-container"
+      className="loading-spinner-container"
     >
-      <div
-        className="date-picker-container"
-      >
-        <label
-          className="datepicker-label"
-          htmlFor="date-picker"
+      <Spinner>
+        <div
+          className="loading-spinner"
         >
-          Expiration
-        </label>
-        <withStyles(SingleDatePicker)
-          anchorDirection="left"
-          appendToBody={false}
-          block={false}
-          calendarInfoPosition="bottom"
-          customCloseIcon={null}
-          customInputIcon={null}
-          date={null}
-          dayPickerNavigationInlineStyles={null}
-          daySize={39}
-          disableScroll={false}
-          disabled={false}
-          displayFormat={[Function]}
-          enableOutsideDays={false}
-          firstDayOfWeek={null}
-          focused={false}
-          hideKeyboardShortcutsPanel={false}
-          horizontalMargin={0}
-          horizontalMonthPadding={13}
-          id="date-picker"
-          initialVisibleMonth={null}
-          inputIconPosition="after"
-          isDayBlocked={[Function]}
-          isDayHighlighted={[Function]}
-          isOutsideRange={[Function]}
-          isRTL={false}
-          keepFocusOnInput={false}
-          keepOpenOnDateSelect={false}
-          monthFormat="MMMM YYYY"
-          navNext={null}
-          navPosition="navPositionTop"
-          navPrev={null}
-          noBorder={false}
-          numberOfMonths={1}
-          onClose={[Function]}
-          onDateChange={[Function]}
-          onFocusChange={[Function]}
-          onNextMonthClick={[Function]}
-          onPrevMonthClick={[Function]}
-          openDirection="down"
-          orientation="horizontal"
-          phrases={
-            Object {
-              "calendarLabel": "Calendar",
-              "chooseAvailableDate": [Function],
-              "clearDate": "Clear Date",
-              "closeDatePicker": "Close",
-              "dateIsSelected": [Function],
-              "dateIsUnavailable": [Function],
-              "enterKey": "Enter key",
-              "escape": "Escape key",
-              "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-              "homeEnd": "Home and end keys",
-              "jumpToNextMonth": "Move forward to switch to the next month.",
-              "jumpToPrevMonth": "Move backward to switch to the previous month.",
-              "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-              "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-              "keyboardShortcuts": "Keyboard Shortcuts",
-              "leftArrowRightArrow": "Right and left arrow keys",
-              "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-              "moveFocusByOneMonth": "Switch months.",
-              "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-              "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-              "openThisPanel": "Open this panel.",
-              "pageUpPageDown": "page up and page down keys",
-              "questionMark": "Question mark",
-              "returnFocusToInput": "Return to the date input field.",
-              "roleDescription": "datepicker",
-              "selectFocusedDate": "Select the date in focus.",
-              "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-              "upArrowDownArrow": "up and down arrow keys",
-            }
-          }
-          placeholder="Date"
-          readOnly={false}
-          regular={false}
-          renderCalendarInfo={null}
-          renderDayContents={null}
-          renderMonthElement={null}
-          renderMonthText={null}
-          renderNavNextButton={null}
-          renderNavPrevButton={null}
-          renderWeekHeaderElement={null}
-          reopenPickerOnClearDate={false}
-          required={false}
-          screenReaderInputMessage=""
-          showClearDate={false}
-          showDefaultInputIcon={false}
-          small={false}
-          verticalHeight={null}
-          verticalSpacing={22}
-          weekDayFormat="dd"
-          withFullScreenPortal={false}
-          withPortal={false}
-        >
-          <WithStyles
-            anchorDirection="left"
-            appendToBody={false}
-            block={false}
-            calendarInfoPosition="bottom"
-            customCloseIcon={null}
-            customInputIcon={null}
-            date={null}
-            dayPickerNavigationInlineStyles={null}
-            daySize={39}
-            disableScroll={false}
-            disabled={false}
-            displayFormat={[Function]}
-            enableOutsideDays={false}
-            firstDayOfWeek={null}
-            focused={false}
-            forwardedRef={null}
-            hideKeyboardShortcutsPanel={false}
-            horizontalMargin={0}
-            horizontalMonthPadding={13}
-            id="date-picker"
-            initialVisibleMonth={null}
-            inputIconPosition="after"
-            isDayBlocked={[Function]}
-            isDayHighlighted={[Function]}
-            isOutsideRange={[Function]}
-            isRTL={false}
-            keepFocusOnInput={false}
-            keepOpenOnDateSelect={false}
-            monthFormat="MMMM YYYY"
-            navNext={null}
-            navPosition="navPositionTop"
-            navPrev={null}
-            noBorder={false}
-            numberOfMonths={1}
-            onClose={[Function]}
-            onDateChange={[Function]}
-            onFocusChange={[Function]}
-            onNextMonthClick={[Function]}
-            onPrevMonthClick={[Function]}
-            openDirection="down"
-            orientation="horizontal"
-            phrases={
-              Object {
-                "calendarLabel": "Calendar",
-                "chooseAvailableDate": [Function],
-                "clearDate": "Clear Date",
-                "closeDatePicker": "Close",
-                "dateIsSelected": [Function],
-                "dateIsUnavailable": [Function],
-                "enterKey": "Enter key",
-                "escape": "Escape key",
-                "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                "homeEnd": "Home and end keys",
-                "jumpToNextMonth": "Move forward to switch to the next month.",
-                "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                "keyboardShortcuts": "Keyboard Shortcuts",
-                "leftArrowRightArrow": "Right and left arrow keys",
-                "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                "moveFocusByOneMonth": "Switch months.",
-                "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                "openThisPanel": "Open this panel.",
-                "pageUpPageDown": "page up and page down keys",
-                "questionMark": "Question mark",
-                "returnFocusToInput": "Return to the date input field.",
-                "roleDescription": "datepicker",
-                "selectFocusedDate": "Select the date in focus.",
-                "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                "upArrowDownArrow": "up and down arrow keys",
-              }
-            }
-            placeholder="Date"
-            readOnly={false}
-            regular={false}
-            renderCalendarInfo={null}
-            renderDayContents={null}
-            renderMonthElement={null}
-            renderMonthText={null}
-            renderNavNextButton={null}
-            renderNavPrevButton={null}
-            renderWeekHeaderElement={null}
-            reopenPickerOnClearDate={false}
-            required={false}
-            screenReaderInputMessage=""
-            showClearDate={false}
-            showDefaultInputIcon={false}
-            small={false}
-            verticalHeight={null}
-            verticalSpacing={22}
-            weekDayFormat="dd"
-            withFullScreenPortal={false}
-            withPortal={false}
+          <div
+            className="spinner-container"
           >
-            <SingleDatePicker
-              anchorDirection="left"
-              appendToBody={false}
-              block={false}
-              calendarInfoPosition="bottom"
-              css={[Function]}
-              customCloseIcon={null}
-              customInputIcon={null}
-              date={null}
-              dayPickerNavigationInlineStyles={null}
-              daySize={39}
-              disableScroll={false}
-              disabled={false}
-              displayFormat={[Function]}
-              enableOutsideDays={false}
-              firstDayOfWeek={null}
-              focused={false}
-              hideKeyboardShortcutsPanel={false}
-              horizontalMargin={0}
-              horizontalMonthPadding={13}
-              id="date-picker"
-              initialVisibleMonth={null}
-              inputIconPosition="after"
-              isDayBlocked={[Function]}
-              isDayHighlighted={[Function]}
-              isOutsideRange={[Function]}
-              isRTL={false}
-              keepFocusOnInput={false}
-              keepOpenOnDateSelect={false}
-              monthFormat="MMMM YYYY"
-              navNext={null}
-              navPosition="navPositionTop"
-              navPrev={null}
-              noBorder={false}
-              numberOfMonths={1}
-              onClose={[Function]}
-              onDateChange={[Function]}
-              onFocusChange={[Function]}
-              onNextMonthClick={[Function]}
-              onPrevMonthClick={[Function]}
-              openDirection="down"
-              orientation="horizontal"
-              phrases={
-                Object {
-                  "calendarLabel": "Calendar",
-                  "chooseAvailableDate": [Function],
-                  "clearDate": "Clear Date",
-                  "closeDatePicker": "Close",
-                  "dateIsSelected": [Function],
-                  "dateIsUnavailable": [Function],
-                  "enterKey": "Enter key",
-                  "escape": "Escape key",
-                  "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                  "homeEnd": "Home and end keys",
-                  "jumpToNextMonth": "Move forward to switch to the next month.",
-                  "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                  "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                  "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                  "keyboardShortcuts": "Keyboard Shortcuts",
-                  "leftArrowRightArrow": "Right and left arrow keys",
-                  "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                  "moveFocusByOneMonth": "Switch months.",
-                  "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                  "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                  "openThisPanel": "Open this panel.",
-                  "pageUpPageDown": "page up and page down keys",
-                  "questionMark": "Question mark",
-                  "returnFocusToInput": "Return to the date input field.",
-                  "roleDescription": "datepicker",
-                  "selectFocusedDate": "Select the date in focus.",
-                  "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                  "upArrowDownArrow": "up and down arrow keys",
-                }
-              }
-              placeholder="Date"
-              readOnly={false}
-              regular={false}
-              renderCalendarInfo={null}
-              renderDayContents={null}
-              renderMonthElement={null}
-              renderMonthText={null}
-              renderNavNextButton={null}
-              renderNavPrevButton={null}
-              renderWeekHeaderElement={null}
-              reopenPickerOnClearDate={false}
-              required={false}
-              screenReaderInputMessage=""
-              showClearDate={false}
-              showDefaultInputIcon={false}
-              small={false}
-              styles={
-                Object {
-                  "SingleDatePicker": "SingleDatePicker",
-                  "SingleDatePicker__block": "SingleDatePicker__block",
-                  "SingleDatePicker_closeButton": "SingleDatePicker_closeButton",
-                  "SingleDatePicker_closeButton_svg": "SingleDatePicker_closeButton_svg",
-                  "SingleDatePicker_picker": "SingleDatePicker_picker",
-                  "SingleDatePicker_picker__directionLeft": "SingleDatePicker_picker__directionLeft",
-                  "SingleDatePicker_picker__directionRight": "SingleDatePicker_picker__directionRight",
-                  "SingleDatePicker_picker__fullScreenPortal": "SingleDatePicker_picker__fullScreenPortal",
-                  "SingleDatePicker_picker__portal": "SingleDatePicker_picker__portal",
-                  "SingleDatePicker_picker__rtl": "SingleDatePicker_picker__rtl",
-                }
-              }
-              theme={
-                Object {
-                  "reactDates": Object {
-                    "border": Object {
-                      "input": Object {
-                        "border": 0,
-                        "borderBottom": "2px solid transparent",
-                        "borderBottomFocused": "2px solid #008489",
-                        "borderFocused": 0,
-                        "borderLeft": 0,
-                        "borderLeftFocused": 0,
-                        "borderRadius": 0,
-                        "borderRight": 0,
-                        "borderRightFocused": 0,
-                        "borderTop": 0,
-                        "borderTopFocused": 0,
-                        "outlineFocused": 0,
-                      },
-                      "pickerInput": Object {
-                        "borderRadius": 2,
-                        "borderStyle": "solid",
-                        "borderWidth": 1,
-                      },
-                    },
-                    "color": Object {
-                      "background": "#fff",
-                      "backgroundDark": "#f2f2f2",
-                      "backgroundFocused": "#fff",
-                      "blocked_calendar": Object {
-                        "backgroundColor": "#cacccd",
-                        "backgroundColor_active": "#cacccd",
-                        "backgroundColor_hover": "#cacccd",
-                        "borderColor": "#cacccd",
-                        "borderColor_active": "#cacccd",
-                        "borderColor_hover": "#cacccd",
-                        "color": "#82888a",
-                        "color_active": "#82888a",
-                        "color_hover": "#82888a",
-                      },
-                      "blocked_out_of_range": Object {
-                        "backgroundColor": "#fff",
-                        "backgroundColor_active": "#fff",
-                        "backgroundColor_hover": "#fff",
-                        "borderColor": "#e4e7e7",
-                        "borderColor_active": "#e4e7e7",
-                        "borderColor_hover": "#e4e7e7",
-                        "color": "#cacccd",
-                        "color_active": "#cacccd",
-                        "color_hover": "#cacccd",
-                      },
-                      "border": "rgb(219, 219, 219)",
-                      "core": Object {
-                        "border": "#dbdbdb",
-                        "borderBright": "#f4f5f5",
-                        "borderLight": "#e4e7e7",
-                        "borderLighter": "#eceeee",
-                        "borderMedium": "#c4c4c4",
-                        "gray": "#484848",
-                        "grayLight": "#82888a",
-                        "grayLighter": "#cacccd",
-                        "grayLightest": "#f2f2f2",
-                        "primary": "#00a699",
-                        "primaryShade_1": "#33dacd",
-                        "primaryShade_2": "#66e2da",
-                        "primaryShade_3": "#80e8e0",
-                        "primaryShade_4": "#b2f1ec",
-                        "primary_dark": "#008489",
-                        "secondary": "#007a87",
-                        "white": "#fff",
-                        "yellow": "#ffe8bc",
-                        "yellow_dark": "#ffce71",
-                      },
-                      "disabled": "#f2f2f2",
-                      "highlighted": Object {
-                        "backgroundColor": "#ffe8bc",
-                        "backgroundColor_active": "#ffce71",
-                        "backgroundColor_hover": "#ffce71",
-                        "color": "#484848",
-                        "color_active": "#484848",
-                        "color_hover": "#484848",
-                      },
-                      "hoveredSpan": Object {
-                        "backgroundColor": "#b2f1ec",
-                        "backgroundColor_active": "#80e8e0",
-                        "backgroundColor_hover": "#b2f1ec",
-                        "borderColor": "#80e8e0",
-                        "borderColor_active": "#80e8e0",
-                        "borderColor_hover": "#80e8e0",
-                        "color": "#007a87",
-                        "color_active": "#007a87",
-                        "color_hover": "#007a87",
-                      },
-                      "minimumNights": Object {
-                        "backgroundColor": "#fff",
-                        "backgroundColor_active": "#fff",
-                        "backgroundColor_hover": "#fff",
-                        "borderColor": "#eceeee",
-                        "color": "#cacccd",
-                        "color_active": "#cacccd",
-                        "color_hover": "#cacccd",
-                      },
-                      "outside": Object {
-                        "backgroundColor": "#fff",
-                        "backgroundColor_active": "#fff",
-                        "backgroundColor_hover": "#fff",
-                        "color": "#484848",
-                        "color_active": "#484848",
-                        "color_hover": "#484848",
-                      },
-                      "placeholderText": "#757575",
-                      "selected": Object {
-                        "backgroundColor": "#00a699",
-                        "backgroundColor_active": "#00a699",
-                        "backgroundColor_hover": "#00a699",
-                        "borderColor": "#00a699",
-                        "borderColor_active": "#00a699",
-                        "borderColor_hover": "#00a699",
-                        "color": "#fff",
-                        "color_active": "#fff",
-                        "color_hover": "#fff",
-                      },
-                      "selectedSpan": Object {
-                        "backgroundColor": "#66e2da",
-                        "backgroundColor_active": "#33dacd",
-                        "backgroundColor_hover": "#33dacd",
-                        "borderColor": "#33dacd",
-                        "borderColor_active": "#00a699",
-                        "borderColor_hover": "#00a699",
-                        "color": "#fff",
-                        "color_active": "#fff",
-                        "color_hover": "#fff",
-                      },
-                      "text": "#484848",
-                      "textDisabled": "#dbdbdb",
-                      "textFocused": "#007a87",
-                    },
-                    "font": Object {
-                      "captionSize": 18,
-                      "input": Object {
-                        "letterSpacing_small": "0.2px",
-                        "lineHeight": "24px",
-                        "lineHeight_small": "18px",
-                        "size": 19,
-                        "size_small": 15,
-                        "styleDisabled": "italic",
-                        "weight": 200,
-                      },
-                      "size": 14,
-                    },
-                    "noScrollBarOnVerticalScrollable": false,
-                    "sizing": Object {
-                      "arrowWidth": 24,
-                      "inputWidth": 130,
-                      "inputWidth_small": 97,
-                    },
-                    "spacing": Object {
-                      "captionPaddingBottom": 37,
-                      "captionPaddingTop": 22,
-                      "dayPickerHorizontalPadding": 9,
-                      "displayTextPaddingBottom": 9,
-                      "displayTextPaddingBottom_small": 5,
-                      "displayTextPaddingHorizontal": undefined,
-                      "displayTextPaddingHorizontal_small": undefined,
-                      "displayTextPaddingLeft": 11,
-                      "displayTextPaddingLeft_small": 7,
-                      "displayTextPaddingRight": 11,
-                      "displayTextPaddingRight_small": 7,
-                      "displayTextPaddingTop": 11,
-                      "displayTextPaddingTop_small": 7,
-                      "displayTextPaddingVertical": undefined,
-                      "displayTextPaddingVertical_small": undefined,
-                      "inputPadding": 0,
-                    },
-                    "zIndex": 0,
-                  },
-                }
-              }
-              verticalHeight={null}
-              verticalSpacing={22}
-              weekDayFormat="dd"
-              withFullScreenPortal={false}
-              withPortal={false}
-            >
-              <div
-                className="SingleDatePicker SingleDatePicker_1"
-              >
-                <OutsideClickHandler
-                  disabled={false}
-                  display="block"
-                  onOutsideClick={[Function]}
-                  useCapture={true}
-                >
-                  <div>
-                    <SingleDatePickerInputController
-                      block={false}
-                      customCloseIcon={null}
-                      customInputIcon={null}
-                      date={null}
-                      disabled={false}
-                      displayFormat={[Function]}
-                      focused={false}
-                      id="date-picker"
-                      inputIconPosition="after"
-                      isFocused={false}
-                      isOutsideRange={[Function]}
-                      isRTL={false}
-                      keepOpenOnDateSelect={false}
-                      noBorder={false}
-                      onClose={[Function]}
-                      onDateChange={[Function]}
-                      onFocusChange={[Function]}
-                      onKeyDownArrowDown={[Function]}
-                      onKeyDownQuestionMark={[Function]}
-                      openDirection="down"
-                      phrases={
-                        Object {
-                          "calendarLabel": "Calendar",
-                          "chooseAvailableDate": [Function],
-                          "clearDate": "Clear Date",
-                          "closeDatePicker": "Close",
-                          "dateIsSelected": [Function],
-                          "dateIsUnavailable": [Function],
-                          "enterKey": "Enter key",
-                          "escape": "Escape key",
-                          "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                          "homeEnd": "Home and end keys",
-                          "jumpToNextMonth": "Move forward to switch to the next month.",
-                          "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                          "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                          "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                          "keyboardShortcuts": "Keyboard Shortcuts",
-                          "leftArrowRightArrow": "Right and left arrow keys",
-                          "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                          "moveFocusByOneMonth": "Switch months.",
-                          "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                          "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                          "openThisPanel": "Open this panel.",
-                          "pageUpPageDown": "page up and page down keys",
-                          "questionMark": "Question mark",
-                          "returnFocusToInput": "Return to the date input field.",
-                          "roleDescription": "datepicker",
-                          "selectFocusedDate": "Select the date in focus.",
-                          "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                          "upArrowDownArrow": "up and down arrow keys",
-                        }
-                      }
-                      placeholder="Date"
-                      readOnly={false}
-                      regular={false}
-                      reopenPickerOnClearDate={false}
-                      required={false}
-                      screenReaderMessage=""
-                      showCaret={true}
-                      showClearDate={false}
-                      showDefaultInputIcon={false}
-                      small={false}
-                      verticalSpacing={22}
-                    >
-                      <withStyles(SingleDatePickerInput)
-                        block={false}
-                        customCloseIcon={null}
-                        customInputIcon={null}
-                        disabled={false}
-                        displayValue={null}
-                        focused={false}
-                        id="date-picker"
-                        inputIconPosition="after"
-                        isFocused={false}
-                        isRTL={false}
-                        noBorder={false}
-                        onChange={[Function]}
-                        onClearDate={[Function]}
-                        onFocus={[Function]}
-                        onKeyDownArrowDown={[Function]}
-                        onKeyDownQuestionMark={[Function]}
-                        onKeyDownShiftTab={[Function]}
-                        onKeyDownTab={[Function]}
-                        openDirection="down"
-                        phrases={
-                          Object {
-                            "calendarLabel": "Calendar",
-                            "chooseAvailableDate": [Function],
-                            "clearDate": "Clear Date",
-                            "closeDatePicker": "Close",
-                            "dateIsSelected": [Function],
-                            "dateIsUnavailable": [Function],
-                            "enterKey": "Enter key",
-                            "escape": "Escape key",
-                            "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                            "homeEnd": "Home and end keys",
-                            "jumpToNextMonth": "Move forward to switch to the next month.",
-                            "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                            "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                            "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                            "keyboardShortcuts": "Keyboard Shortcuts",
-                            "leftArrowRightArrow": "Right and left arrow keys",
-                            "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                            "moveFocusByOneMonth": "Switch months.",
-                            "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                            "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                            "openThisPanel": "Open this panel.",
-                            "pageUpPageDown": "page up and page down keys",
-                            "questionMark": "Question mark",
-                            "returnFocusToInput": "Return to the date input field.",
-                            "roleDescription": "datepicker",
-                            "selectFocusedDate": "Select the date in focus.",
-                            "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                            "upArrowDownArrow": "up and down arrow keys",
-                          }
-                        }
-                        placeholder="Date"
-                        readOnly={false}
-                        regular={false}
-                        required={false}
-                        screenReaderMessage=""
-                        showCaret={true}
-                        showClearDate={false}
-                        showDefaultInputIcon={false}
-                        small={false}
-                        verticalSpacing={22}
-                      >
-                        <WithStyles
-                          block={false}
-                          customCloseIcon={null}
-                          customInputIcon={null}
-                          disabled={false}
-                          displayValue={null}
-                          focused={false}
-                          forwardedRef={null}
-                          id="date-picker"
-                          inputIconPosition="after"
-                          isFocused={false}
-                          isRTL={false}
-                          noBorder={false}
-                          onChange={[Function]}
-                          onClearDate={[Function]}
-                          onFocus={[Function]}
-                          onKeyDownArrowDown={[Function]}
-                          onKeyDownQuestionMark={[Function]}
-                          onKeyDownShiftTab={[Function]}
-                          onKeyDownTab={[Function]}
-                          openDirection="down"
-                          phrases={
-                            Object {
-                              "calendarLabel": "Calendar",
-                              "chooseAvailableDate": [Function],
-                              "clearDate": "Clear Date",
-                              "closeDatePicker": "Close",
-                              "dateIsSelected": [Function],
-                              "dateIsUnavailable": [Function],
-                              "enterKey": "Enter key",
-                              "escape": "Escape key",
-                              "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                              "homeEnd": "Home and end keys",
-                              "jumpToNextMonth": "Move forward to switch to the next month.",
-                              "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                              "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                              "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                              "keyboardShortcuts": "Keyboard Shortcuts",
-                              "leftArrowRightArrow": "Right and left arrow keys",
-                              "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                              "moveFocusByOneMonth": "Switch months.",
-                              "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                              "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                              "openThisPanel": "Open this panel.",
-                              "pageUpPageDown": "page up and page down keys",
-                              "questionMark": "Question mark",
-                              "returnFocusToInput": "Return to the date input field.",
-                              "roleDescription": "datepicker",
-                              "selectFocusedDate": "Select the date in focus.",
-                              "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                              "upArrowDownArrow": "up and down arrow keys",
-                            }
-                          }
-                          placeholder="Date"
-                          readOnly={false}
-                          regular={false}
-                          required={false}
-                          screenReaderMessage=""
-                          showCaret={true}
-                          showClearDate={false}
-                          showDefaultInputIcon={false}
-                          small={false}
-                          verticalSpacing={22}
-                        >
-                          <SingleDatePickerInput
-                            block={false}
-                            css={[Function]}
-                            customCloseIcon={null}
-                            customInputIcon={null}
-                            disabled={false}
-                            displayValue={null}
-                            focused={false}
-                            id="date-picker"
-                            inputIconPosition="after"
-                            isFocused={false}
-                            isRTL={false}
-                            noBorder={false}
-                            onChange={[Function]}
-                            onClearDate={[Function]}
-                            onFocus={[Function]}
-                            onKeyDownArrowDown={[Function]}
-                            onKeyDownQuestionMark={[Function]}
-                            onKeyDownShiftTab={[Function]}
-                            onKeyDownTab={[Function]}
-                            openDirection="down"
-                            phrases={
-                              Object {
-                                "calendarLabel": "Calendar",
-                                "chooseAvailableDate": [Function],
-                                "clearDate": "Clear Date",
-                                "closeDatePicker": "Close",
-                                "dateIsSelected": [Function],
-                                "dateIsUnavailable": [Function],
-                                "enterKey": "Enter key",
-                                "escape": "Escape key",
-                                "hideKeyboardShortcutsPanel": "Close the shortcuts panel.",
-                                "homeEnd": "Home and end keys",
-                                "jumpToNextMonth": "Move forward to switch to the next month.",
-                                "jumpToPrevMonth": "Move backward to switch to the previous month.",
-                                "keyboardBackwardNavigationInstructions": "Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                                "keyboardForwardNavigationInstructions": "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.",
-                                "keyboardShortcuts": "Keyboard Shortcuts",
-                                "leftArrowRightArrow": "Right and left arrow keys",
-                                "moveFocusByOneDay": "Move backward (left) and forward (right) by one day.",
-                                "moveFocusByOneMonth": "Switch months.",
-                                "moveFocusByOneWeek": "Move backward (up) and forward (down) by one week.",
-                                "moveFocustoStartAndEndOfWeek": "Go to the first or last day of a week.",
-                                "openThisPanel": "Open this panel.",
-                                "pageUpPageDown": "page up and page down keys",
-                                "questionMark": "Question mark",
-                                "returnFocusToInput": "Return to the date input field.",
-                                "roleDescription": "datepicker",
-                                "selectFocusedDate": "Select the date in focus.",
-                                "showKeyboardShortcutsPanel": "Open the keyboard shortcuts panel.",
-                                "upArrowDownArrow": "up and down arrow keys",
-                              }
-                            }
-                            placeholder="Date"
-                            readOnly={false}
-                            regular={false}
-                            required={false}
-                            screenReaderMessage=""
-                            showCaret={true}
-                            showClearDate={false}
-                            showDefaultInputIcon={false}
-                            small={false}
-                            styles={
-                              Object {
-                                "SingleDatePickerInput": "SingleDatePickerInput",
-                                "SingleDatePickerInput__block": "SingleDatePickerInput__block",
-                                "SingleDatePickerInput__disabled": "SingleDatePickerInput__disabled",
-                                "SingleDatePickerInput__rtl": "SingleDatePickerInput__rtl",
-                                "SingleDatePickerInput__showClearDate": "SingleDatePickerInput__showClearDate",
-                                "SingleDatePickerInput__withBorder": "SingleDatePickerInput__withBorder",
-                                "SingleDatePickerInput_calendarIcon": "SingleDatePickerInput_calendarIcon",
-                                "SingleDatePickerInput_calendarIcon_svg": "SingleDatePickerInput_calendarIcon_svg",
-                                "SingleDatePickerInput_clearDate": "SingleDatePickerInput_clearDate",
-                                "SingleDatePickerInput_clearDate__default": "SingleDatePickerInput_clearDate__default",
-                                "SingleDatePickerInput_clearDate__hide": "SingleDatePickerInput_clearDate__hide",
-                                "SingleDatePickerInput_clearDate__small": "SingleDatePickerInput_clearDate__small",
-                                "SingleDatePickerInput_clearDate_svg": "SingleDatePickerInput_clearDate_svg",
-                                "SingleDatePickerInput_clearDate_svg__small": "SingleDatePickerInput_clearDate_svg__small",
-                              }
-                            }
-                            theme={
-                              Object {
-                                "reactDates": Object {
-                                  "border": Object {
-                                    "input": Object {
-                                      "border": 0,
-                                      "borderBottom": "2px solid transparent",
-                                      "borderBottomFocused": "2px solid #008489",
-                                      "borderFocused": 0,
-                                      "borderLeft": 0,
-                                      "borderLeftFocused": 0,
-                                      "borderRadius": 0,
-                                      "borderRight": 0,
-                                      "borderRightFocused": 0,
-                                      "borderTop": 0,
-                                      "borderTopFocused": 0,
-                                      "outlineFocused": 0,
-                                    },
-                                    "pickerInput": Object {
-                                      "borderRadius": 2,
-                                      "borderStyle": "solid",
-                                      "borderWidth": 1,
-                                    },
-                                  },
-                                  "color": Object {
-                                    "background": "#fff",
-                                    "backgroundDark": "#f2f2f2",
-                                    "backgroundFocused": "#fff",
-                                    "blocked_calendar": Object {
-                                      "backgroundColor": "#cacccd",
-                                      "backgroundColor_active": "#cacccd",
-                                      "backgroundColor_hover": "#cacccd",
-                                      "borderColor": "#cacccd",
-                                      "borderColor_active": "#cacccd",
-                                      "borderColor_hover": "#cacccd",
-                                      "color": "#82888a",
-                                      "color_active": "#82888a",
-                                      "color_hover": "#82888a",
-                                    },
-                                    "blocked_out_of_range": Object {
-                                      "backgroundColor": "#fff",
-                                      "backgroundColor_active": "#fff",
-                                      "backgroundColor_hover": "#fff",
-                                      "borderColor": "#e4e7e7",
-                                      "borderColor_active": "#e4e7e7",
-                                      "borderColor_hover": "#e4e7e7",
-                                      "color": "#cacccd",
-                                      "color_active": "#cacccd",
-                                      "color_hover": "#cacccd",
-                                    },
-                                    "border": "rgb(219, 219, 219)",
-                                    "core": Object {
-                                      "border": "#dbdbdb",
-                                      "borderBright": "#f4f5f5",
-                                      "borderLight": "#e4e7e7",
-                                      "borderLighter": "#eceeee",
-                                      "borderMedium": "#c4c4c4",
-                                      "gray": "#484848",
-                                      "grayLight": "#82888a",
-                                      "grayLighter": "#cacccd",
-                                      "grayLightest": "#f2f2f2",
-                                      "primary": "#00a699",
-                                      "primaryShade_1": "#33dacd",
-                                      "primaryShade_2": "#66e2da",
-                                      "primaryShade_3": "#80e8e0",
-                                      "primaryShade_4": "#b2f1ec",
-                                      "primary_dark": "#008489",
-                                      "secondary": "#007a87",
-                                      "white": "#fff",
-                                      "yellow": "#ffe8bc",
-                                      "yellow_dark": "#ffce71",
-                                    },
-                                    "disabled": "#f2f2f2",
-                                    "highlighted": Object {
-                                      "backgroundColor": "#ffe8bc",
-                                      "backgroundColor_active": "#ffce71",
-                                      "backgroundColor_hover": "#ffce71",
-                                      "color": "#484848",
-                                      "color_active": "#484848",
-                                      "color_hover": "#484848",
-                                    },
-                                    "hoveredSpan": Object {
-                                      "backgroundColor": "#b2f1ec",
-                                      "backgroundColor_active": "#80e8e0",
-                                      "backgroundColor_hover": "#b2f1ec",
-                                      "borderColor": "#80e8e0",
-                                      "borderColor_active": "#80e8e0",
-                                      "borderColor_hover": "#80e8e0",
-                                      "color": "#007a87",
-                                      "color_active": "#007a87",
-                                      "color_hover": "#007a87",
-                                    },
-                                    "minimumNights": Object {
-                                      "backgroundColor": "#fff",
-                                      "backgroundColor_active": "#fff",
-                                      "backgroundColor_hover": "#fff",
-                                      "borderColor": "#eceeee",
-                                      "color": "#cacccd",
-                                      "color_active": "#cacccd",
-                                      "color_hover": "#cacccd",
-                                    },
-                                    "outside": Object {
-                                      "backgroundColor": "#fff",
-                                      "backgroundColor_active": "#fff",
-                                      "backgroundColor_hover": "#fff",
-                                      "color": "#484848",
-                                      "color_active": "#484848",
-                                      "color_hover": "#484848",
-                                    },
-                                    "placeholderText": "#757575",
-                                    "selected": Object {
-                                      "backgroundColor": "#00a699",
-                                      "backgroundColor_active": "#00a699",
-                                      "backgroundColor_hover": "#00a699",
-                                      "borderColor": "#00a699",
-                                      "borderColor_active": "#00a699",
-                                      "borderColor_hover": "#00a699",
-                                      "color": "#fff",
-                                      "color_active": "#fff",
-                                      "color_hover": "#fff",
-                                    },
-                                    "selectedSpan": Object {
-                                      "backgroundColor": "#66e2da",
-                                      "backgroundColor_active": "#33dacd",
-                                      "backgroundColor_hover": "#33dacd",
-                                      "borderColor": "#33dacd",
-                                      "borderColor_active": "#00a699",
-                                      "borderColor_hover": "#00a699",
-                                      "color": "#fff",
-                                      "color_active": "#fff",
-                                      "color_hover": "#fff",
-                                    },
-                                    "text": "#484848",
-                                    "textDisabled": "#dbdbdb",
-                                    "textFocused": "#007a87",
-                                  },
-                                  "font": Object {
-                                    "captionSize": 18,
-                                    "input": Object {
-                                      "letterSpacing_small": "0.2px",
-                                      "lineHeight": "24px",
-                                      "lineHeight_small": "18px",
-                                      "size": 19,
-                                      "size_small": 15,
-                                      "styleDisabled": "italic",
-                                      "weight": 200,
-                                    },
-                                    "size": 14,
-                                  },
-                                  "noScrollBarOnVerticalScrollable": false,
-                                  "sizing": Object {
-                                    "arrowWidth": 24,
-                                    "inputWidth": 130,
-                                    "inputWidth_small": 97,
-                                  },
-                                  "spacing": Object {
-                                    "captionPaddingBottom": 37,
-                                    "captionPaddingTop": 22,
-                                    "dayPickerHorizontalPadding": 9,
-                                    "displayTextPaddingBottom": 9,
-                                    "displayTextPaddingBottom_small": 5,
-                                    "displayTextPaddingHorizontal": undefined,
-                                    "displayTextPaddingHorizontal_small": undefined,
-                                    "displayTextPaddingLeft": 11,
-                                    "displayTextPaddingLeft_small": 7,
-                                    "displayTextPaddingRight": 11,
-                                    "displayTextPaddingRight_small": 7,
-                                    "displayTextPaddingTop": 11,
-                                    "displayTextPaddingTop_small": 7,
-                                    "displayTextPaddingVertical": undefined,
-                                    "displayTextPaddingVertical_small": undefined,
-                                    "inputPadding": 0,
-                                  },
-                                  "zIndex": 0,
-                                },
-                              }
-                            }
-                            verticalSpacing={22}
-                          >
-                            <div
-                              className="SingleDatePickerInput SingleDatePickerInput_1 SingleDatePickerInput__withBorder SingleDatePickerInput__withBorder_2"
-                            >
-                              <withStyles(DateInput)
-                                block={false}
-                                disabled={false}
-                                displayValue={null}
-                                focused={false}
-                                id="date-picker"
-                                isFocused={false}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                onKeyDownArrowDown={[Function]}
-                                onKeyDownQuestionMark={[Function]}
-                                onKeyDownShiftTab={[Function]}
-                                onKeyDownTab={[Function]}
-                                openDirection="down"
-                                placeholder="Date"
-                                readOnly={false}
-                                regular={false}
-                                required={false}
-                                screenReaderMessage="Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
-                                showCaret={true}
-                                small={false}
-                                verticalSpacing={22}
-                              >
-                                <WithStyles
-                                  block={false}
-                                  disabled={false}
-                                  displayValue={null}
-                                  focused={false}
-                                  forwardedRef={null}
-                                  id="date-picker"
-                                  isFocused={false}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDownArrowDown={[Function]}
-                                  onKeyDownQuestionMark={[Function]}
-                                  onKeyDownShiftTab={[Function]}
-                                  onKeyDownTab={[Function]}
-                                  openDirection="down"
-                                  placeholder="Date"
-                                  readOnly={false}
-                                  regular={false}
-                                  required={false}
-                                  screenReaderMessage="Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
-                                  showCaret={true}
-                                  small={false}
-                                  verticalSpacing={22}
-                                >
-                                  <DateInput
-                                    block={false}
-                                    css={[Function]}
-                                    disabled={false}
-                                    displayValue={null}
-                                    focused={false}
-                                    id="date-picker"
-                                    isFocused={false}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDownArrowDown={[Function]}
-                                    onKeyDownQuestionMark={[Function]}
-                                    onKeyDownShiftTab={[Function]}
-                                    onKeyDownTab={[Function]}
-                                    openDirection="down"
-                                    placeholder="Date"
-                                    readOnly={false}
-                                    regular={false}
-                                    required={false}
-                                    screenReaderMessage="Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
-                                    showCaret={true}
-                                    small={false}
-                                    styles={
-                                      Object {
-                                        "DateInput": "DateInput",
-                                        "DateInput__block": "DateInput__block",
-                                        "DateInput__disabled": "DateInput__disabled",
-                                        "DateInput__small": "DateInput__small",
-                                        "DateInput_fang": "DateInput_fang",
-                                        "DateInput_fangShape": "DateInput_fangShape",
-                                        "DateInput_fangStroke": "DateInput_fangStroke",
-                                        "DateInput_input": "DateInput_input",
-                                        "DateInput_input__disabled": "DateInput_input__disabled",
-                                        "DateInput_input__focused": "DateInput_input__focused",
-                                        "DateInput_input__readOnly": "DateInput_input__readOnly",
-                                        "DateInput_input__regular": "DateInput_input__regular",
-                                        "DateInput_input__small": "DateInput_input__small",
-                                        "DateInput_screenReaderMessage": "DateInput_screenReaderMessage",
-                                      }
-                                    }
-                                    theme={
-                                      Object {
-                                        "reactDates": Object {
-                                          "border": Object {
-                                            "input": Object {
-                                              "border": 0,
-                                              "borderBottom": "2px solid transparent",
-                                              "borderBottomFocused": "2px solid #008489",
-                                              "borderFocused": 0,
-                                              "borderLeft": 0,
-                                              "borderLeftFocused": 0,
-                                              "borderRadius": 0,
-                                              "borderRight": 0,
-                                              "borderRightFocused": 0,
-                                              "borderTop": 0,
-                                              "borderTopFocused": 0,
-                                              "outlineFocused": 0,
-                                            },
-                                            "pickerInput": Object {
-                                              "borderRadius": 2,
-                                              "borderStyle": "solid",
-                                              "borderWidth": 1,
-                                            },
-                                          },
-                                          "color": Object {
-                                            "background": "#fff",
-                                            "backgroundDark": "#f2f2f2",
-                                            "backgroundFocused": "#fff",
-                                            "blocked_calendar": Object {
-                                              "backgroundColor": "#cacccd",
-                                              "backgroundColor_active": "#cacccd",
-                                              "backgroundColor_hover": "#cacccd",
-                                              "borderColor": "#cacccd",
-                                              "borderColor_active": "#cacccd",
-                                              "borderColor_hover": "#cacccd",
-                                              "color": "#82888a",
-                                              "color_active": "#82888a",
-                                              "color_hover": "#82888a",
-                                            },
-                                            "blocked_out_of_range": Object {
-                                              "backgroundColor": "#fff",
-                                              "backgroundColor_active": "#fff",
-                                              "backgroundColor_hover": "#fff",
-                                              "borderColor": "#e4e7e7",
-                                              "borderColor_active": "#e4e7e7",
-                                              "borderColor_hover": "#e4e7e7",
-                                              "color": "#cacccd",
-                                              "color_active": "#cacccd",
-                                              "color_hover": "#cacccd",
-                                            },
-                                            "border": "rgb(219, 219, 219)",
-                                            "core": Object {
-                                              "border": "#dbdbdb",
-                                              "borderBright": "#f4f5f5",
-                                              "borderLight": "#e4e7e7",
-                                              "borderLighter": "#eceeee",
-                                              "borderMedium": "#c4c4c4",
-                                              "gray": "#484848",
-                                              "grayLight": "#82888a",
-                                              "grayLighter": "#cacccd",
-                                              "grayLightest": "#f2f2f2",
-                                              "primary": "#00a699",
-                                              "primaryShade_1": "#33dacd",
-                                              "primaryShade_2": "#66e2da",
-                                              "primaryShade_3": "#80e8e0",
-                                              "primaryShade_4": "#b2f1ec",
-                                              "primary_dark": "#008489",
-                                              "secondary": "#007a87",
-                                              "white": "#fff",
-                                              "yellow": "#ffe8bc",
-                                              "yellow_dark": "#ffce71",
-                                            },
-                                            "disabled": "#f2f2f2",
-                                            "highlighted": Object {
-                                              "backgroundColor": "#ffe8bc",
-                                              "backgroundColor_active": "#ffce71",
-                                              "backgroundColor_hover": "#ffce71",
-                                              "color": "#484848",
-                                              "color_active": "#484848",
-                                              "color_hover": "#484848",
-                                            },
-                                            "hoveredSpan": Object {
-                                              "backgroundColor": "#b2f1ec",
-                                              "backgroundColor_active": "#80e8e0",
-                                              "backgroundColor_hover": "#b2f1ec",
-                                              "borderColor": "#80e8e0",
-                                              "borderColor_active": "#80e8e0",
-                                              "borderColor_hover": "#80e8e0",
-                                              "color": "#007a87",
-                                              "color_active": "#007a87",
-                                              "color_hover": "#007a87",
-                                            },
-                                            "minimumNights": Object {
-                                              "backgroundColor": "#fff",
-                                              "backgroundColor_active": "#fff",
-                                              "backgroundColor_hover": "#fff",
-                                              "borderColor": "#eceeee",
-                                              "color": "#cacccd",
-                                              "color_active": "#cacccd",
-                                              "color_hover": "#cacccd",
-                                            },
-                                            "outside": Object {
-                                              "backgroundColor": "#fff",
-                                              "backgroundColor_active": "#fff",
-                                              "backgroundColor_hover": "#fff",
-                                              "color": "#484848",
-                                              "color_active": "#484848",
-                                              "color_hover": "#484848",
-                                            },
-                                            "placeholderText": "#757575",
-                                            "selected": Object {
-                                              "backgroundColor": "#00a699",
-                                              "backgroundColor_active": "#00a699",
-                                              "backgroundColor_hover": "#00a699",
-                                              "borderColor": "#00a699",
-                                              "borderColor_active": "#00a699",
-                                              "borderColor_hover": "#00a699",
-                                              "color": "#fff",
-                                              "color_active": "#fff",
-                                              "color_hover": "#fff",
-                                            },
-                                            "selectedSpan": Object {
-                                              "backgroundColor": "#66e2da",
-                                              "backgroundColor_active": "#33dacd",
-                                              "backgroundColor_hover": "#33dacd",
-                                              "borderColor": "#33dacd",
-                                              "borderColor_active": "#00a699",
-                                              "borderColor_hover": "#00a699",
-                                              "color": "#fff",
-                                              "color_active": "#fff",
-                                              "color_hover": "#fff",
-                                            },
-                                            "text": "#484848",
-                                            "textDisabled": "#dbdbdb",
-                                            "textFocused": "#007a87",
-                                          },
-                                          "font": Object {
-                                            "captionSize": 18,
-                                            "input": Object {
-                                              "letterSpacing_small": "0.2px",
-                                              "lineHeight": "24px",
-                                              "lineHeight_small": "18px",
-                                              "size": 19,
-                                              "size_small": 15,
-                                              "styleDisabled": "italic",
-                                              "weight": 200,
-                                            },
-                                            "size": 14,
-                                          },
-                                          "noScrollBarOnVerticalScrollable": false,
-                                          "sizing": Object {
-                                            "arrowWidth": 24,
-                                            "inputWidth": 130,
-                                            "inputWidth_small": 97,
-                                          },
-                                          "spacing": Object {
-                                            "captionPaddingBottom": 37,
-                                            "captionPaddingTop": 22,
-                                            "dayPickerHorizontalPadding": 9,
-                                            "displayTextPaddingBottom": 9,
-                                            "displayTextPaddingBottom_small": 5,
-                                            "displayTextPaddingHorizontal": undefined,
-                                            "displayTextPaddingHorizontal_small": undefined,
-                                            "displayTextPaddingLeft": 11,
-                                            "displayTextPaddingLeft_small": 7,
-                                            "displayTextPaddingRight": 11,
-                                            "displayTextPaddingRight_small": 7,
-                                            "displayTextPaddingTop": 11,
-                                            "displayTextPaddingTop_small": 7,
-                                            "displayTextPaddingVertical": undefined,
-                                            "displayTextPaddingVertical_small": undefined,
-                                            "inputPadding": 0,
-                                          },
-                                          "zIndex": 0,
-                                        },
-                                      }
-                                    }
-                                    verticalSpacing={22}
-                                  >
-                                    <div
-                                      className="DateInput DateInput_1"
-                                    >
-                                      <input
-                                        aria-describedby="DateInput__screen-reader-message-date-picker"
-                                        aria-label="Date"
-                                        autoComplete="off"
-                                        className="DateInput_input DateInput_input_1"
-                                        disabled={false}
-                                        id="date-picker"
-                                        name="date-picker"
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        onKeyDown={[Function]}
-                                        placeholder="Date"
-                                        readOnly={false}
-                                        required={false}
-                                        type="text"
-                                        value=""
-                                      />
-                                      <p
-                                        className="DateInput_screenReaderMessage DateInput_screenReaderMessage_1"
-                                        id="DateInput__screen-reader-message-date-picker"
-                                      >
-                                        Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.
-                                      </p>
-                                    </div>
-                                  </DateInput>
-                                </WithStyles>
-                              </withStyles(DateInput)>
-                            </div>
-                          </SingleDatePickerInput>
-                        </WithStyles>
-                      </withStyles(SingleDatePickerInput)>
-                    </SingleDatePickerInputController>
-                  </div>
-                </OutsideClickHandler>
-              </div>
-            </SingleDatePicker>
-          </WithStyles>
-        </withStyles(SingleDatePicker)>
-      </div>
-      <button
-        className="generate-session-button quill-button fun primary contained"
-        onClick={[Function]}
-        type="submit"
-      >
-        Generate Turk Session
-      </button>
+            <img
+              alt=""
+              className="spinner"
+              src="https://assets.quill.org/images/icons/loader_still.svg"
+            />
+          </div>
+        </div>
+      </Spinner>
     </div>
-    <DataTable
-      averageFontWidth={7}
-      className="turk-sessions-table"
-      headers={
-        Array [
-          Object {
-            "attribute": "turkLink",
-            "name": "Link",
-            "width": "500px",
-          },
-          Object {
-            "attribute": "expiration",
-            "name": "Expiration Date",
-            "width": "200px",
-          },
-          Object {
-            "attribute": "copy",
-            "name": "",
-            "width": "100px",
-          },
-          Object {
-            "attribute": "edit",
-            "name": "",
-            "width": "100px",
-          },
-          Object {
-            "attribute": "delete",
-            "name": "",
-            "width": "100px",
-          },
-        ]
-      }
-      rows={
-        Array [
-          Object {
-            "copy": <TurkSessionButton
-              clickHandler={[Function]}
-              id={1}
-              label="copy"
-              value="undefined/evidence/#/turk?uid=17&id=1"
-            />,
-            "delete": <TurkSessionButton
-              clickHandler={[Function]}
-              id={1}
-              label="delete"
-            />,
-            "edit": <TurkSessionButton
-              clickHandler={[Function]}
-              id={1}
-              label="edit"
-              value="2020-12-07T22:52:41.945Z"
-            />,
-            "expiration": "December 7th, 2020",
-            "id": "17-1",
-            "turkLink": <a
-              href="undefined/evidence/#/turk?uid=17&id=1"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              undefined/evidence/#/turk?uid=17&id=1
-            </a>,
-          },
-        ]
-      }
-    >
-      <table
-        className="data-table turk-sessions-table"
-      >
-        <tr
-          className="data-table-headers"
-        >
-          <th
-            className="data-table-header undefined"
-            scope="col"
-            style={
-              Object {
-                "minWidth": "500px",
-                "textAlign": "left",
-                "width": "500px",
-              }
-            }
-          >
-            Link
-          </th>
-          <th
-            className="data-table-header undefined"
-            scope="col"
-            style={
-              Object {
-                "minWidth": "200px",
-                "textAlign": "left",
-                "width": "200px",
-              }
-            }
-          >
-            Expiration Date
-          </th>
-          <th
-            className="data-table-header undefined"
-            scope="col"
-            style={
-              Object {
-                "minWidth": "100px",
-                "textAlign": "left",
-                "width": "100px",
-              }
-            }
-          />
-          <th
-            className="data-table-header undefined"
-            scope="col"
-            style={
-              Object {
-                "minWidth": "100px",
-                "textAlign": "left",
-                "width": "100px",
-              }
-            }
-          />
-          <th
-            className="data-table-header undefined"
-            scope="col"
-            style={
-              Object {
-                "minWidth": "100px",
-                "textAlign": "left",
-                "width": "100px",
-              }
-            }
-          />
-        </tr>
-        <tbody
-          className="data-table-body"
-        >
-          <tr
-            className="data-table-row  "
-            key="17-1"
-          >
-            <td
-              className="data-table-row-section undefined"
-              key="turkLink-17-1"
-              style={
-                Object {
-                  "minWidth": "500px",
-                  "textAlign": "left",
-                  "width": "500px",
-                }
-              }
-            >
-              <a
-                href="undefined/evidence/#/turk?uid=17&id=1"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                undefined/evidence/#/turk?uid=17&id=1
-              </a>
-            </td>
-            <td
-              className="data-table-row-section undefined"
-              key="expiration-17-1"
-              style={
-                Object {
-                  "minWidth": "200px",
-                  "textAlign": "left",
-                  "width": "200px",
-                }
-              }
-            >
-              December 7th, 2020
-            </td>
-            <td>
-              <Tooltip
-                isTabbable={true}
-                key="copy-17-1"
-                tooltipText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="copy"
-                    value="undefined/evidence/#/turk?uid=17&id=1"
-                  />
-                }
-                tooltipTriggerStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-                tooltipTriggerText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="copy"
-                    value="undefined/evidence/#/turk?uid=17&id=1"
-                  />
-                }
-                tooltipTriggerTextClass="data-table-row-section undefined"
-                tooltipTriggerTextStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <span
-                  aria-hidden={false}
-                  className="quill-tooltip-trigger"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "minWidth": "100px",
-                      "textAlign": "left",
-                      "width": "100px",
-                    }
-                  }
-                >
-                  <span
-                    className="data-table-row-section undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "minWidth": "100px",
-                        "textAlign": "left",
-                        "width": "100px",
-                      }
-                    }
-                    tabIndex={0}
-                  >
-                    <TurkSessionButton
-                      clickHandler={[Function]}
-                      id={1}
-                      label="copy"
-                      value="undefined/evidence/#/turk?uid=17&id=1"
-                    >
-                      <button
-                        className="quill-button fun primary contained"
-                        id="1"
-                        onClick={[Function]}
-                        type="submit"
-                        value="undefined/evidence/#/turk?uid=17&id=1"
-                      >
-                        copy
-                      </button>
-                    </TurkSessionButton>
-                  </span>
-                  <span
-                    className="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      className="quill-tooltip"
-                    />
-                  </span>
-                </span>
-              </Tooltip>
-            </td>
-            <td>
-              <Tooltip
-                isTabbable={true}
-                key="edit-17-1"
-                tooltipText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="edit"
-                    value="2020-12-07T22:52:41.945Z"
-                  />
-                }
-                tooltipTriggerStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-                tooltipTriggerText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="edit"
-                    value="2020-12-07T22:52:41.945Z"
-                  />
-                }
-                tooltipTriggerTextClass="data-table-row-section undefined"
-                tooltipTriggerTextStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <span
-                  aria-hidden={false}
-                  className="quill-tooltip-trigger"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "minWidth": "100px",
-                      "textAlign": "left",
-                      "width": "100px",
-                    }
-                  }
-                >
-                  <span
-                    className="data-table-row-section undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "minWidth": "100px",
-                        "textAlign": "left",
-                        "width": "100px",
-                      }
-                    }
-                    tabIndex={0}
-                  >
-                    <TurkSessionButton
-                      clickHandler={[Function]}
-                      id={1}
-                      label="edit"
-                      value="2020-12-07T22:52:41.945Z"
-                    >
-                      <button
-                        className="quill-button fun primary contained"
-                        id="1"
-                        onClick={[Function]}
-                        type="submit"
-                        value="2020-12-07T22:52:41.945Z"
-                      >
-                        edit
-                      </button>
-                    </TurkSessionButton>
-                  </span>
-                  <span
-                    className="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      className="quill-tooltip"
-                    />
-                  </span>
-                </span>
-              </Tooltip>
-            </td>
-            <td>
-              <Tooltip
-                isTabbable={true}
-                key="delete-17-1"
-                tooltipText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="delete"
-                  />
-                }
-                tooltipTriggerStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-                tooltipTriggerText={
-                  <TurkSessionButton
-                    clickHandler={[Function]}
-                    id={1}
-                    label="delete"
-                  />
-                }
-                tooltipTriggerTextClass="data-table-row-section undefined"
-                tooltipTriggerTextStyle={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <span
-                  aria-hidden={false}
-                  className="quill-tooltip-trigger"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "minWidth": "100px",
-                      "textAlign": "left",
-                      "width": "100px",
-                    }
-                  }
-                >
-                  <span
-                    className="data-table-row-section undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "minWidth": "100px",
-                        "textAlign": "left",
-                        "width": "100px",
-                      }
-                    }
-                    tabIndex={0}
-                  >
-                    <TurkSessionButton
-                      clickHandler={[Function]}
-                      id={1}
-                      label="delete"
-                    >
-                      <button
-                        className="quill-button fun primary contained"
-                        id="1"
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        delete
-                      </button>
-                    </TurkSessionButton>
-                  </span>
-                  <span
-                    className="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      className="quill-tooltip"
-                    />
-                  </span>
-                </span>
-              </Tooltip>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </DataTable>
-    <Snackbar
-      text="Copied!"
-      visible={false}
-    >
-      <div
-        className="quill-snackbar "
-      >
-        Copied!
-      </div>
-    </Snackbar>
-  </div>
-</TurkSessions>
+  </TurkSessions>
+</QueryClientProvider>
 `;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activateModelForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activateModelForm.test.tsx
@@ -1,44 +1,12 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from 'react-query'
 
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 import ActivateModelForm from '../semanticRules/activateModelForm';
-import { DataTable } from '../../../../Shared/index';
 
-const mockModel = { id: 2, automl_model_id: '378jghai', name: 'Test Model', older_models: 0, labels: [{ id: 1, name: "label_1"}] }
-const mockModels = [
-  { id: 1, name: 'model_1', state: 'inactive', created_at: '', older_models: 0, labels: [{ id: 1, name: 'label_1' }] },
-  { id: 2, name: 'model_2', state: 'active', created_at: '', older_models: 1, labels: [{ id: 2, name: 'label_2' }] },
-];
-const mockRules = [
-  { id: 1, name: 'rule_1', state: 'active', optimal: false, label: { id: 1, name: 'label_1' } },
-  { id: 2, name: 'rule_2', state: 'active', optimal: false, label: { id: 2, name: 'label_2' } },
-]
-
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { model: mockModel},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { rules: mockModels},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { rules: mockRules},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -56,13 +24,12 @@ const mockProps = {
 describe('ActivateModelForm component', () => {
   const container = mount(
     <MemoryRouter>
-      <ActivateModelForm {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <ActivateModelForm {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render ActivateModelForm', () => {
     expect(container.find(ActivateModelForm).length).toEqual(1);
-  });
-  it('should render two DataTable components', () => {
-    expect(container.find(DataTable).length).toEqual(2);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
@@ -2,19 +2,12 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
 import 'whatwg-fetch';
+import { QueryClientProvider } from 'react-query'
 
 import Activities from '../activities';
-import { DataTable } from '../../../../Shared/index';
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 
-const mockActivities = [{ id: 1, title: 'First' }, { id: 2, title: 'Second' }]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { activities: mockActivities},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 describe('Activities component', () => {
   const mockProps = {
@@ -28,10 +21,13 @@ describe('Activities component', () => {
     location: createLocation('')
   }
   const container = shallow(
-    <Activities {...mockProps} />
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <Activities {...mockProps} />
+    </QueryClientProvider>
   );
 
-  it('should render a DataTable passing activites', () => {
-    expect(container.find(DataTable).length).toEqual(1)
+  it('should render an Activities component', () => {
+    console.log(container.debug())
+    expect(container.find(Activities).length).toEqual(1)
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
@@ -27,7 +27,6 @@ describe('Activities component', () => {
   );
 
   it('should render an Activities component', () => {
-    console.log(container.debug())
     expect(container.find(Activities).length).toEqual(1)
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettingsWrapper.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettingsWrapper.test.tsx
@@ -2,19 +2,12 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import * as _ from 'lodash'
+import { QueryClientProvider } from 'react-query'
 
 import ActivitySettingsWrapper from '../configureSettings/activitySettingsWrapper';
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 
-const mockActivity = [{ id: 1, title: 'First' }]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { activity: mockActivity},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -30,7 +23,9 @@ const mockProps = {
 describe('ActivitySettingsWrapper component', () => {
   const container = mount(
     <MemoryRouter>
-      <ActivitySettingsWrapper {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <ActivitySettingsWrapper {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render ActivitySettingsWrapper', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activityStats.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activityStats.test.tsx
@@ -1,24 +1,13 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-
-import ActivityStats from '../activityStats/activityStats';
-import { mockActivity } from '../__mocks__/data';
+import { QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
-const mockPrompts = "{\"118\":{\"total_responses\":4720,\"session_count\":224,\"display_name\":\"A surge barrier in New York City could harm the local ecosystem because\",\"num_final_attempt_optimal\":224,\"num_final_attempt_not_optimal\":0,\"avg_attempts\":2.73,\"num_sessions_with_consecutive_repeated_rule\":208,\"num_sessions_with_non_consecutive_repeated_rule\":220,\"num_first_attempt_optimal\":180,\"num_first_attempt_not_optimal\":44},\"119\":{\"total_responses\":3176,\"session_count\":155,\"display_name\":\"A surge barrier in New York City could harm the local ecosystem, but\",\"num_final_attempt_optimal\":155,\"num_final_attempt_not_optimal\":0,\"avg_attempts\":2.6129032258064515,\"num_sessions_with_consecutive_repeated_rule\":139,\"num_sessions_with_non_consecutive_repeated_rule\":150,\"num_first_attempt_optimal\":135,\"num_first_attempt_not_optimal\":20},\"120\":{\"total_responses\":3291,\"session_count\":195,\"display_name\":\"A surge barrier in New York City could harm the local ecosystem, so\",\"num_final_attempt_optimal\":195,\"num_final_attempt_not_optimal\":0,\"avg_attempts\":2.2153846153846155,\"num_sessions_with_consecutive_repeated_rule\":182,\"num_sessions_with_non_consecutive_repeated_rule\":190,\"num_first_attempt_optimal\":161,\"num_first_attempt_not_optimal\":34}}"
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+import ActivityStats from '../activityStats/activityStats';
 
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: {
-      prompts: JSON.parse(mockPrompts),
-      activity: mockActivity
-    },
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -34,7 +23,11 @@ const mockProps = {
 }
 
 describe('ActivityStats component', () => {
-  const container = shallow(<ActivityStats {...mockProps} />);
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <ActivityStats {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render ActivityStats', () => {
     expect(container).toMatchSnapshot();

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/labelsTable.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/labelsTable.test.tsx
@@ -2,20 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import LabelsTable from '../semanticRules/labelsTable';
-import { DataTable } from '../../../../Shared/index';
+import { QueryClientProvider } from 'react-query'
 
-const mockRules = [
-  { id: 1, name: 'rule_1', state: 'active', optimal: false, label: { id: 1, name: 'label_1' } },
-  { id: 2, name: 'rule_2', state: 'active', optimal: false, label: { id: 2, name: 'label_2' } },
-]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { rules: mockRules},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+
+const queryClient = new DefaultReactQueryClient();
 
 describe('LabelsTable component', () => {
   const mockProps = {
@@ -23,13 +14,12 @@ describe('LabelsTable component', () => {
     prompt: { id: 1, conjunction: 'because' }
   }
   const container = shallow(
-    <LabelsTable {...mockProps} />
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <LabelsTable {...mockProps} />
+    </QueryClientProvider>
   );
 
   it('should render LabelsTable', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('should render a DataTable', () => {
-    expect(container.find(DataTable).length).toEqual(1)
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/model.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/model.test.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from 'react-query'
 
 import Model from '../semanticRules/model';
-import { DataTable } from '../../../../Shared/index';
 
-const mockModel = { id: 1, automl_model_id: '378jghai', name: 'Test Model', older_models: 0, labels: [] }
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { model: mockModel},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -31,13 +24,12 @@ const mockProps = {
 describe('Model component', () => {
   const container = mount(
     <MemoryRouter>
-      <Model {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <Model {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render Model', () => {
     expect(container.find(Model).length).toEqual(1);
-  });
-  it('should render two DataTable components', () => {
-    expect(container.find(DataTable).length).toEqual(2);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelForm.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import ModelForm from '../semanticRules/modelForm';
-import { Input, defaultQueryClientOptions } from '../../../../Shared/index';
+import { Input, DefaultReactQueryClient } from '../../../../Shared/index';
 
 const mockProps = {
   match: {
@@ -19,7 +19,7 @@ const mockProps = {
   history: {}
 }
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('ModelForm component', () => {
   const container = mount(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelForm.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import ModelForm from '../semanticRules/modelForm';
-import { Input } from '../../../../Shared/index';
+import { Input, defaultQueryClientOptions } from '../../../../Shared/index';
 
 const mockProps = {
   match: {
@@ -19,7 +19,7 @@ const mockProps = {
   history: {}
 }
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('ModelForm component', () => {
   const container = mount(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelsTable.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/modelsTable.test.tsx
@@ -1,21 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { QueryClientProvider } from 'react-query'
 
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 import ModelsTable from '../semanticRules/modelsTable';
-import { DataTable } from '../../../../Shared/index';
 
-const mockModels = [
-  { id: 1, name: 'model_1', state: 'inactive', created_at: '', older_models: 0, labels: [{ id: 1, name: 'label_1' }] },
-  { id: 2, name: 'model_2', state: 'active', created_at: '', older_models: 1, labels: [{ id: 2, name: 'label_2' }] },
-]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { rules: mockModels},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 jest.mock('../../../helpers/evidence/miscHelpers', () => ({
   titleCase: jest.fn().mockImplementation(() => {
@@ -30,13 +20,12 @@ describe('LabelsTable component', () => {
     prompt: { id: 1 }
   }
   const container = shallow(
-    <ModelsTable {...mockProps} />
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <ModelsTable {...mockProps} />
+    </QueryClientProvider>
   );
 
   it('should render ModelsTable', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('should render a DataTable', () => {
-    expect(container.find(DataTable).length).toEqual(1)
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
@@ -1,27 +1,14 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-
-import PlagiarismRulesIndex from '../plagiarismRules/plagiarismRulesIndex';
-import { mockActivity } from '../__mocks__/data';
+import { QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: {
-      rules: mockRules,
-      activity: mockActivity
-    },
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+import PlagiarismRulesIndex from '../plagiarismRules/plagiarismRulesIndex';
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 
-const mockRules = [
-  { id: 1, name: 'rule_1', state: 'active', plagiarism_texts: [{ text: 'do not plagiarize!' }], label: { id: 1, name: 'label_1' }, prompt_ids: [7] },
-  { id: 2, name: 'rule_2', state: 'active', plagiarism_texts: [{ text: 'seriously!' }], label: { id: 2, name: 'label_2' }, prompt_ids: [9] },
-]
+const queryClient = new DefaultReactQueryClient();
+
 const mockProps = {
   match: {
     params: {
@@ -36,7 +23,11 @@ const mockProps = {
 }
 
 describe('PlagiarismRulesIndex component', () => {
-  const container = shallow(<PlagiarismRulesIndex {...mockProps} />);
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <PlagiarismRulesIndex {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render PlagiarismRulesIndex', () => {
     expect(container).toMatchSnapshot();

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesRouter.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesRouter.test.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from 'react-query'
 
 import PlagiarismRulesRouter from '../plagiarismRules/plagiarismRulesRouter';
+import { DefaultReactQueryClient } from '../../../../Shared';
 
-const mockActivity = [{ id: 1, title: 'First' }]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { activity: mockActivity},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -31,7 +24,9 @@ const mockProps = {
 describe('PlagiarismRulesRouter component', () => {
   const container = mount(
     <MemoryRouter>
-      <PlagiarismRulesRouter {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <PlagiarismRulesRouter {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render PlagiarismRulesRouter', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/promptTable.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/promptTable.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import 'whatwg-fetch';
 import { shallow } from 'enzyme';
+import { QueryClientProvider } from 'react-query'
 
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 import PromptTable from '../activitySessions/promptTable';
 
-jest.mock("react-query", () => ({
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 jest.mock('string-strip-html', () => ({
   default: jest.fn()
@@ -39,14 +39,13 @@ const mockProps = {
 }
 
 describe('PromptTable component', () => {
-  const container = shallow(<PromptTable {...mockProps} />);
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <PromptTable {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render PromptTable', () => {
-    const attributes = ['status', 'results', 'feedback', 'buttons']
     expect(container).toMatchSnapshot();
-    container.find('DataTable').props().headers.forEach((header, i) => {
-      const { attribute } = header;
-      expect(attributes[i]).toEqual(attribute);
-    })
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
@@ -1,27 +1,16 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-import { Link } from 'react-router-dom';
-
-import { DataTable } from '../../../../Shared/index';
-import RegexRulesIndex from '../regexRules/regexRulesIndex';
+import { QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { rules: mockRules },
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+import RegexRulesIndex from '../regexRules/regexRulesIndex';
+
+const queryClient = new DefaultReactQueryClient();
+
 const { firstBy } = jest.requireActual('thenby');
 
-const mockRules = [
-  { id: 1, name: 'rule_1', state: 'active', optimal: false, label: { id: 1, name: 'label_1' }, regex_rules: [{id: 1, regex_text: 'test1'}, {id: 2, regex_text: 'test2'}] },
-  { id: 2, name: 'rule_2', state: 'active', optimal: false, label: { id: 2, name: 'label_2' }, regex_rules: [{id: 1, regex_text: 'test1'}, {id: 2, regex_text: 'test2'}] },
-]
 const mockProps = {
   match: {
     params: {
@@ -36,15 +25,13 @@ const mockProps = {
 }
 
 describe('RegexRulesIndex component', () => {
-  const container = shallow(<RegexRulesIndex {...mockProps} />);
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <RegexRulesIndex {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render RegexRulesIndex', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('should render three separate DataTables and buttons for each regex rule type', () => {
-    expect(container.find(DataTable).length).toEqual(3);
-    expect(container.find(Link).at(0).props().children).toEqual('Add Sentence Structure Regex Rule')
-    expect(container.find(Link).at(1).props().children).toEqual('Add Post-Topic Regex Rule')
-    expect(container.find(Link).at(2).props().children).toEqual('Add Typo Regex Rule')
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesRouter.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesRouter.test.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from 'react-query'
 
 import RegexRulesRouter from '../regexRules/regexRulesRouter';
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 
-const mockActivity = [{ id: 1, title: 'First' }]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { activity: mockActivity},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -31,7 +24,9 @@ const mockProps = {
 describe('RegexRulesRouter component', () => {
   const container = mount(
     <MemoryRouter>
-      <RegexRulesRouter {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <RegexRulesRouter {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render RegexRulesRouter', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import Rule from '../configureRules/rule';
+import { defaultQueryClientOptions } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -28,7 +29,8 @@ const fields = [
   'So'
 ];
 
-const queryClient = new QueryClient()
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('Rule component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
@@ -4,7 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import Rule from '../configureRules/rule';
-import { defaultQueryClientOptions } from '../../../../Shared';
+import { DefaultReactQueryClient } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -30,7 +30,7 @@ const fields = [
 ];
 
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('Rule component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import RuleAnalysis from '../rulesAnalysis/ruleAnalysis';
+import { defaultQueryClientOptions } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -19,7 +20,8 @@ const mockProps = {
   location: createLocation('')
 }
 
-const queryClient = new QueryClient()
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('RuleAnalysis component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
@@ -4,7 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import RuleAnalysis from '../rulesAnalysis/ruleAnalysis';
-import { defaultQueryClientOptions } from '../../../../Shared';
+import { DefaultReactQueryClient } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -21,7 +21,7 @@ const mockProps = {
 }
 
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('RuleAnalysis component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleForm.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClientProvider } from 'react-query'
 
 import { mockRule } from '../__mocks__/data';
 import RuleForm from '../configureRules/ruleForm';
-import { defaultQueryClientOptions } from '../../../../Shared';
+import { DefaultReactQueryClient } from '../../../../Shared';
 
 jest.mock('../../../helpers/evidence/ruleHelpers', () => ({
   // ...jest.requireActual('../../../helpers/evidence/ruleHelpers'),
@@ -45,7 +45,7 @@ jest.mock('../../../helpers/evidence/renderHelpers', () => ({
 }));
 
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   rule: mockRule,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleForm.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleForm.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { mockRule } from '../__mocks__/data';
 import RuleForm from '../configureRules/ruleForm';
+import { defaultQueryClientOptions } from '../../../../Shared';
 
 jest.mock('../../../helpers/evidence/ruleHelpers', () => ({
   // ...jest.requireActual('../../../helpers/evidence/ruleHelpers'),
@@ -43,7 +44,8 @@ jest.mock('../../../helpers/evidence/renderHelpers', () => ({
   }
 }));
 
-const queryClient = new QueryClient()
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 const mockProps = {
   rule: mockRule,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import Rules from '../configureRules/rules';
+import { defaultQueryClientOptions } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -21,7 +22,8 @@ const mockProps = {
   location: createLocation('')
 }
 
-const queryClient = new QueryClient()
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('Rules component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClientProvider } from 'react-query'
 
 import Rules from '../configureRules/rules';
-import { defaultQueryClientOptions } from '../../../../Shared';
+import { DefaultReactQueryClient } from '../../../../Shared';
 import 'whatwg-fetch';
 
 const mockProps = {
@@ -23,7 +23,7 @@ const mockProps = {
 }
 
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('Rules component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
-import { defaultQueryClientOptions } from '../../../../Shared';
+import { DefaultReactQueryClient } from '../../../../Shared';
 import RulesAnalysis from '../rulesAnalysis/rulesAnalysis';
 
 jest.mock('qs', () => ({
@@ -28,7 +28,7 @@ const mockProps = {
 }
 
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 describe('RulesAnalysis component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
@@ -4,6 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
+import { defaultQueryClientOptions } from '../../../Shared';
 import RulesAnalysis from '../rulesAnalysis/rulesAnalysis';
 
 jest.mock('qs', () => ({
@@ -26,7 +27,8 @@ const mockProps = {
   location: createLocation('')
 }
 
-const queryClient = new QueryClient()
+
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 describe('RulesAnalysis component', () => {
   const container = shallow(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
@@ -4,7 +4,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClient, QueryClientProvider } from 'react-query'
 import 'whatwg-fetch';
 
-import { defaultQueryClientOptions } from '../../../Shared';
+import { defaultQueryClientOptions } from '../../../../Shared';
 import RulesAnalysis from '../rulesAnalysis/rulesAnalysis';
 
 jest.mock('qs', () => ({

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticLabelsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticLabelsIndex.test.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from 'react-query'
 
 import SemanticLabelsIndex from '../semanticRules/semanticLabelsIndex';
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 
-const mockActivity = [{ id: 1, title: 'First' }]
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { activity: mockActivity},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
+
 
 const mockProps = {
   match: {
@@ -31,7 +25,9 @@ const mockProps = {
 describe('SemanticLabelsIndex component', () => {
   const container = mount(
     <MemoryRouter>
-      <SemanticLabelsIndex {...mockProps} />
+      <QueryClientProvider client={queryClient} contextSharing={true}>
+        <SemanticLabelsIndex {...mockProps} />
+      </QueryClientProvider>
     </MemoryRouter>
   );
   it('should render SemanticLabelsIndex', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticRulesCheatSheet.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/semanticRulesCheatSheet.test.tsx
@@ -1,54 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { QueryClientProvider } from 'react-query'
 
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 import SemanticRulesCheatSheet from '../semanticRules/semanticRulesCheatSheet';
-import { BUT, BECAUSE, SO }  from '../../../../../constants/evidence';
 
-const FEEDBACK = 'At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.'
-
-const mockRules = [
-  { id: 1, name: 'rule_1', feedbacks: [{ text: "Here is some feedback" }], note: "Here is a note" },
-  { id: 2, name: 'rule_2', feedbacks: [{ text: "Here is some other feedback" }], note: "Here is another note" },
-]
-
-const mockActivity = {
-  title: 'Could Capybaras Create Chaos?',
-  prompts: [
-    {
-      conjunction: BECAUSE,
-      text: '1',
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-      id: 1,
-    },
-    {
-      conjunction: BUT,
-      text: '2',
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-      id: 2,
-    },
-    {
-      conjunction: SO,
-      text: '3',
-      max_attempts: 5,
-      max_attempts_feedback: FEEDBACK,
-      id: 3,
-    }
-  ]
-}
-
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: {
-      rules: mockRules,
-      activity: mockActivity
-    },
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 describe('SemanticRulesCheatSheet component', () => {
   const mockProps = {
@@ -61,7 +18,9 @@ describe('SemanticRulesCheatSheet component', () => {
   }
 
   const container = shallow(
-    <SemanticRulesCheatSheet {...mockProps} />
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <SemanticRulesCheatSheet {...mockProps} />
+    </QueryClientProvider>
   );
 
   it('should render SemanticRulesCheatSheet', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
@@ -31,6 +31,5 @@ describe('SessionsIndex component', () => {
 
   it('should render SessionsIndex', () => {
     expect(container).toMatchSnapshot();
-    console.log(container.debug())
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
@@ -2,34 +2,12 @@ import * as React from 'react';
 import 'whatwg-fetch';
 import { shallow } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
-import * as ReactTable from 'react-table';
+import { QueryClientProvider } from 'react-query'
 
+import { DefaultReactQueryClient } from '../../../../Shared/index';
 import SessionsIndex from '../activitySessions/sessionsIndex';
-import { activitySessionIndexResponseHeaders } from '../../../../../constants/evidence';
 
-const mockActivitySessions = [
-  { id: 1 },
-  { id: 2 },
-]
-
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: {
-      activity:  {
-        title: 'merp'
-      },
-      activitySessions: {
-        current_page: 1,
-        total_pages: 1,
-        total_activity_sessions: 2,
-        activity_sessions: mockActivitySessions
-      }
-    },
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 const mockProps = {
   match: {
@@ -45,19 +23,14 @@ const mockProps = {
 }
 
 describe('SessionsIndex component', () => {
-  const container = shallow(<SessionsIndex {...mockProps} />);
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <SessionsIndex {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render SessionsIndex', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('should render a ReactTable component passing the activity sessions as props', () => {
-    expect(container.find(".activity-sessions-table").length).toEqual(1);
-    container.find(".activity-sessions-table").props().columns.forEach((column, i) => {
-      const { accessor } = column;
-      expect(activitySessionIndexResponseHeaders[i].accessor).toEqual(accessor);
-    })
-  });
-  it('should render two dropdown inputs, one for page change and one for filtering', () => {
-    expect(container.find('DropdownInput').length).toEqual(2);
+    console.log(container.debug())
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { createMemoryHistory, createLocation } from 'history';
+import { QueryClientProvider } from 'react-query';
 
 import TurkSessions from '../gatherResponses/turkSessions';
 import 'whatwg-fetch';
+import { DefaultReactQueryClient } from '../../../../Shared';
 
-jest.mock("react-query", () => ({
-  useQuery: jest.fn(() => ({
-    data: { turkSessions: [{activity_id: 17, expires_at: '2020-12-07T22:52:41.945Z', id: 1 }]},
-    error: null,
-    status: "success",
-    isFetching: true,
-  })),
-  useQueryClient: jest.fn(() => ({})),
-}));
+const queryClient = new DefaultReactQueryClient();
 
 describe('TurkSessions component', () => {
   const mockProps = {
@@ -26,38 +20,13 @@ describe('TurkSessions component', () => {
     history: createMemoryHistory(),
     location: createLocation('')
   }
-  const container = mount(<TurkSessions {...mockProps} />);
-  const handleClick = jest.spyOn(React, "useState");
-  const setEditTurkSessionId = jest.fn();
-  const setEditTurkSessionDate = jest.fn();
-  const setDateError = jest.fn();
-  const setShowEditOrDeleteTurkSessionModal = jest.fn();
-  handleClick.mockImplementation(editTurkSessionId => [editTurkSessionId, setEditTurkSessionId]);
-  handleClick.mockImplementation(editTurkSessionDate => [editTurkSessionDate, setEditTurkSessionDate]);
-  handleClick.mockImplementation(dateError => [dateError, setDateError]);
-  handleClick.mockImplementation(showEditOrDeleteTurkSessionModal => [showEditOrDeleteTurkSessionModal, setShowEditOrDeleteTurkSessionModal]);
+  const container = mount(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <TurkSessions {...mockProps} />
+    </QueryClientProvider>
+  );
 
   it('should render TurkSessions', () => {
     expect(container).toMatchSnapshot();
-  });
-  it('clicking copy should briefly update snackBarVisible to true', () => {
-    const setSnackBarVisible = jest.fn();
-    handleClick.mockImplementation(snackBarVisible => [snackBarVisible, setSnackBarVisible]);
-    container.find("button").at(1).simulate("click");
-    expect(setSnackBarVisible).toBeTruthy();
-  });
-  it('clicking edit should update editTurkSessionId, editTurkSessionDate, dateError & showEditOrDeleteTurkSessionModal', () => {
-    container.find("button").at(2).simulate("click");
-    expect(setEditTurkSessionId).toBeTruthy();
-    expect(setEditTurkSessionDate).toBeTruthy();
-    expect(setDateError).toBeTruthy();
-    expect(setShowEditOrDeleteTurkSessionModal).toBeTruthy();
-  });
-  it('clicking delete should update editTurkSessionId, editTurkSessionDate, dateError & showEditOrDeleteTurkSessionModal', () => {
-    container.find("button").at(3).simulate("click");
-    expect(setEditTurkSessionId).toBeTruthy();
-    expect(setEditTurkSessionDate).toBeTruthy();
-    expect(setDateError).toBeTruthy();
-    expect(setShowEditOrDeleteTurkSessionModal).toBeTruthy();
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/startup/EvidenceIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/startup/EvidenceIndex.tsx
@@ -3,8 +3,9 @@ import { HashRouter, Route,  } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import EvidenceLanding from '../components/evidence/EvidenceLanding';
+import { defaultQueryClientOptions } from '../../Shared';
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 const EvidenceIndex = () => (
   <QueryClientProvider client={queryClient} contextSharing={true}>

--- a/services/QuillLMS/client/app/bundles/Staff/startup/EvidenceIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/startup/EvidenceIndex.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { HashRouter, Route,  } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClientProvider } from 'react-query'
 
 import EvidenceLanding from '../components/evidence/EvidenceLanding';
-import { defaultQueryClientOptions } from '../../Shared';
+import { DefaultReactQueryClient } from '../../Shared';
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 const EvidenceIndex = () => (
   <QueryClientProvider client={queryClient} contextSharing={true}>

--- a/services/QuillLMS/client/app/bundles/Staff/startup/lockerAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/startup/lockerAppClient.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { HashRouter, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClientProvider } from 'react-query';
 
-import { defaultQueryClientOptions} from '../../Shared';
+import { DefaultReactQueryClient } from '../../Shared';
 import LockerApp from '../components/locker/lockerApp';
 
-const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
+const queryClient = new DefaultReactQueryClient();
 
 const LockerAppClient = (props) => (
   <QueryClientProvider client={queryClient} contextSharing={true}>

--- a/services/QuillLMS/client/app/bundles/Staff/startup/lockerAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/startup/lockerAppClient.tsx
@@ -2,20 +2,10 @@ import React from 'react';
 import { HashRouter, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
+import { defaultQueryClientOptions} from '../../Shared';
 import LockerApp from '../components/locker/lockerApp';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      retry: false,
-      // 24 hours in minutes
-      staleTime: 1440,
-    },
-  },
-});
+const queryClient = new QueryClient({ defaultOptions: defaultQueryClientOptions })
 
 const LockerAppClient = (props) => (
   <QueryClientProvider client={queryClient} contextSharing={true}>


### PR DESCRIPTION
## WHAT
add default options for react-query queries

## WHY
we only want these queries to be executed once on load by default (currently, they are being refetched multiple times per minute which is unnecessary)

## HOW
add a shared `defaultQueryClientOptions` passed to each of the `QueryClient` options. Note: these options can be overridden by individual `useQuery` instances if needed

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-options-to-react-query-client-instances-ec644258220d48b087f14368606117e7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
