### PR TITLE
Update success? predicate to successful?

### DIFF
--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
 
       get :index, as: :json
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expected_keys = Set["first", "second", "third"]
       expect(Set[*JSON.parse(response.body).keys]).to eq expected_keys
     end
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
 
       get :admin_show, params: { name: 'lorem' }, as: :json
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com c@d.com))
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
 
       get :admin_show, params: { name: 'lorem' }, as: :json
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
 
       get :admin_show, params: { name: 'lorem' }, as: :json
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
       expect(JSON.parse(response.body)['users_without_emails']).to eq([user2.name])
     end
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
 
       get :show, params: { name: 'lorem' }, as: :json
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(JSON.parse(response.body)).to eq({ "lorem" => false })
     end
   end

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -182,7 +182,7 @@ describe PagesController do
   describe 'careers page' do
     it 'should load page' do
       get :careers
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -97,14 +97,14 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       2.times do
         get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
     it 'should return empty arrays when there are no activity_sessions' do
       get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-      expect(response).to be_success
+      expect(response).to be_successful
 
       json = JSON.parse(response.body)
 
@@ -125,7 +125,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       it 'should return report data for students and not_completed_name' do
         get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         json = JSON.parse(response.body)
 
@@ -150,7 +150,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         it 'should return report data for students and missing_name' do
           get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-          expect(response).to be_success
+          expect(response).to be_successful
 
           json = JSON.parse(response.body)
 
@@ -179,7 +179,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         it 'should return all 3 records and average score' do
           get :students_by_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-          expect(response).to be_success
+          expect(response).to be_successful
 
           json = JSON.parse(response.body)
 
@@ -222,7 +222,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         Rails.logger.info "\n\n\nStart"
         get :classrooms_with_students, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         json = JSON.parse(response.body)
 
@@ -236,7 +236,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         2.times do
           get :classrooms_with_students, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-          expect(response).to be_success
+          expect(response).to be_successful
 
           json = JSON.parse(response.body)
 
@@ -257,14 +257,14 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     it 'should not error with no activity_sessions' do
       get :lesson_recommendations_for_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should not error with activity_sessions' do
       create(:activity_session, classroom_unit: @classroom_unit, activity: activity)
       get :lesson_recommendations_for_classroom, params: ({activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id})
 
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -322,7 +322,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     it 'should return the total number of acquired skills' do
       get :skills_growth, params: ({classroom_id: classroom.id, post_test_activity_id: post_test_unit_activity.activity_id, pre_test_activity_id: pre_test_unit_activity.activity_id})
 
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['skills_growth']).to eq 1
     end

--- a/services/QuillLMS/spec/support/shared/api_request.rb
+++ b/services/QuillLMS/spec/support/shared/api_request.rb
@@ -22,7 +22,7 @@ shared_examples "a simple api request" do
   end
 
   it 'sends a list' do
-    expect(response).to be_success
+    expect(response).to be_successful
     json = JSON.parse(response.body)
     expect(json[lwc_model_name.pluralize].length).to eq(3)
   end


### PR DESCRIPTION
## WHAT
Update some specs to use a newer predicate matcher

## WHY
Rails 6 will [deprecate](https://github.com/rspec/rspec-rails/issues/1857) the predicate matcher `success?`.

## HOW
Replace `be_success` instances with `be_successful`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
