### PR TITLE
Make district admin school assignment less restrictive

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -25,7 +25,6 @@ class Cron
 
     # subscriptions
     RenewExpiringRecurringSubscriptionsWorker.perform_async
-    UpdateExpiringSchoolSubscriptionsWorker.perform_async
     AlertSoonToExpireSubscriptionsWorker.perform_async
 
     # demo

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -29,16 +29,16 @@ class District < ApplicationRecord
   validates :name, presence: true
 
   has_many :schools
-  has_many :district_admins, class_name: 'DistrictAdmin', dependent: :destroy
+  has_many :district_admins, dependent: :destroy
   has_many :admins, through: :district_admins, source: :user
   has_many :district_subscriptions
   has_many :subscriptions, through: :district_subscriptions
 
-  scope :by_name, ->(name) { where('lower(name) LIKE ?', "%#{name.downcase}%") }
-  scope :by_city, ->(city) { where('lower(city) LIKE ?', "%#{city.downcase}%") }
-  scope :by_state, ->(state) { where(:state => state.upcase) }
-  scope :by_zipcode, ->(zipcode) { where(:zipcode => zipcode) }
-  scope :by_nces_id, ->(nces_id) { where(:nces_id => nces_id) }
+  scope :by_name, ->(name) { where('name ILIKE ?', "%#{name}%") }
+  scope :by_city, ->(city) { where('city ILIKE ?', "%#{city}%") }
+  scope :by_state, ->(state) { where(state: state.upcase) }
+  scope :by_zipcode, ->(zipcode) { where(zipcode: zipcode) }
+  scope :by_nces_id, ->(nces_id) { where(nces_id: nces_id) }
 
   def attach_subscription(subscription)
     district_subscriptions.create(subscription: subscription)

--- a/services/QuillLMS/app/models/district_admin.rb
+++ b/services/QuillLMS/app/models/district_admin.rb
@@ -20,31 +20,31 @@ class DistrictAdmin < ApplicationRecord
   belongs_to :user
   validates :user_id, uniqueness: { scope: :district_id }
 
-  after_create :attach_to_subscribed_schools
-  after_destroy :detach_from_schools
+  after_create :attach_schools
+  after_destroy :detach_schools
 
   def admin
     user
   end
 
-  def attach_to_subscribed_schools
-    current_schools = admin.administered_schools
-
-    schools_with_subscriptions.each do |school|
-      NewAdminEmailWorker.perform_async(admin.id, school.id) if !current_schools.include?(school)
-    end
-
-    admin.administered_schools += schools_with_subscriptions
-    admin.save
+  def attach_schools
+    admin
+      .schools_admins
+      .create!(unattached_district_schools.map { |school| { school_id: school.id } } )
   end
 
-  def detach_from_schools
-    schools_with_subscriptions.each do |school|
-      SchoolsAdmins.where(school: school, user: admin).destroy_all
-    end
+  def detach_schools
+    admin
+      .schools_admins
+      .where(school: district_schools)
+      .destroy_all
   end
 
-  def schools_with_subscriptions
-    district.schools.filter { |school| school.subscription.present? }
+  private def unattached_district_schools
+    district_schools - admin.reload.administered_schools
+  end
+
+  private def district_schools
+    district.reload.schools
   end
 end

--- a/services/QuillLMS/app/models/school_subscription.rb
+++ b/services/QuillLMS/app/models/school_subscription.rb
@@ -20,7 +20,6 @@ class SchoolSubscription < ApplicationRecord
   belongs_to :school
   belongs_to :subscription
   after_commit :update_schools_users
-  after_commit :attach_district_admins
   after_create :send_premium_emails
 
   def update_schools_users
@@ -46,10 +45,4 @@ class SchoolSubscription < ApplicationRecord
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
-
-  def attach_district_admins
-    school&.district&.district_admins&.each do |district_admin|
-      district_admin.attach_to_subscribed_schools
-    end
-  end
 end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -204,13 +204,6 @@ class Subscription < ApplicationRecord
       .recurring
   end
 
-  def self.expired_today_or_previously_and_not_recurring
-    Subscription
-      .expired
-      .not_de_activated
-      .not_recurring
-  end
-
   def self.redemption_start_date(subscriber)
     subscriber&.subscriptions&.active&.first&.expiration || Date.current
   end
@@ -223,12 +216,6 @@ class Subscription < ApplicationRecord
       promotional_dates[:expiration]
     else
       Date.current + 1.year
-    end
-  end
-
-  def detach_district_admins
-    schools.each do |school|
-      school.detach_from_existing_district_admins(school.district)
     end
   end
 
@@ -253,12 +240,6 @@ class Subscription < ApplicationRecord
       next unless subscription.users.first.subscriptions.active.empty?
 
       subscription.renew_via_stripe
-    end
-  end
-
-  def self.update_todays_expired_school_subscriptions
-    expired_today_or_previously_and_not_recurring.where(account_type: OFFICIAL_SCHOOL_TYPES).each do |subscription|
-      subscription.detach_district_admins
     end
   end
 

--- a/services/QuillLMS/app/workers/update_expiring_school_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/update_expiring_school_subscriptions_worker.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class UpdateExpiringSchoolSubscriptionsWorker
-  include Sidekiq::Worker
-
-  def perform
-    Subscription.update_todays_expired_school_subscriptions
-  end
-end

--- a/services/QuillLMS/spec/factories/district_admins.rb
+++ b/services/QuillLMS/spec/factories/district_admins.rb
@@ -17,7 +17,7 @@
 #
 FactoryBot.define do
   factory :district_admin do
-    district { create(:district) }
-    user { create(:user) }
+    district
+    user
   end
 end

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -261,7 +261,6 @@ describe Classroom, type: :model do
       expect(classroom).to receive(:find_or_create_checkbox)
       classroom.classrooms_teachers.build(user_id: teacher.id, role: 'owner')
       classroom.save
-      classroom.run_callbacks(:commit)
     end
   end
 

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -62,7 +62,7 @@ describe School, type: :model do
   let!(:bk_teacher_colleague) { create(:teacher, school: bk_school) }
   let!(:queens_teacher) { create(:teacher, school: queens_school) }
 
-  describe('#subscription') do
+  describe '#subscription' do
     let!(:subscription) { create(:subscription, expiration: Date.tomorrow) }
     let!(:school_subscription) {create(:school_subscription, school: bk_school, subscription: subscription)}
 
@@ -82,7 +82,7 @@ describe School, type: :model do
     end
   end
 
-  describe('#present_and_future_subscriptions') do
+  describe '#present_and_future_subscriptions' do
     let!(:subscription) { create(:subscription, expiration: Date.tomorrow) }
     let!(:next_subscription) { create(:subscription, expiration: Date.tomorrow + 1.year, start_date: Date.tomorrow) }
     let!(:school_subscription) {create(:school_subscription, school: bk_school, subscription: subscription)}
@@ -104,56 +104,53 @@ describe School, type: :model do
     end
   end
 
-
   describe 'validations' do
-    before do
-      @school = School.new
-    end
+    let(:school) { School.new }
 
     it 'lower grade is within bounds' do
-      @school.lower_grade = 5
+      school.lower_grade = 5
 
-      expect(@school.valid?).to eq(true)
+      expect(school).to be_valid
     end
 
     it 'lower grade is out of bounds' do
-      @school.lower_grade = -1
+      school.lower_grade = -1
 
-      expect(@school.valid?).to eq(false)
-      expect(@school.errors[:lower_grade]).to eq(['must be between 0 and 12'])
+      expect(school).not_to be_valid
+      expect(school.errors[:lower_grade]).to eq(['must be between 0 and 12'])
     end
 
     it 'upper grade is within bounds' do
-      @school.upper_grade = 8
+      school.upper_grade = 8
 
-      expect(@school.valid?).to eq(true)
+      expect(school).to be_valid
     end
 
     it 'upper grade is out of bounds' do
-      @school.upper_grade = 14
+      school.upper_grade = 14
 
-      expect(@school.valid?).to eq(false)
-      expect(@school.errors[:upper_grade]).to eq(['must be between 0 and 12'])
+      expect(school).not_to be_valid
+      expect(school.errors[:upper_grade]).to eq(['must be between 0 and 12'])
     end
 
     it 'lower grade is below upper grade' do
-      @school.lower_grade = 2
-      @school.upper_grade = 8
+      school.lower_grade = 2
+      school.upper_grade = 8
 
-      expect(@school.valid?).to eq(true)
+      expect(school).to be_valid
     end
 
     it 'lower grade is above upper grade' do
-      @school.lower_grade = 6
-      @school.upper_grade = 3
+      school.lower_grade = 6
+      school.upper_grade = 3
 
-      expect(@school.valid?).to eq(false)
-      expect(@school.errors[:lower_grade]).to eq(['must be less than or equal to upper grade'])
+      expect(school).not_to be_valid
+      expect(school.errors[:lower_grade]).to eq(['must be less than or equal to upper grade'])
     end
 
   end
 
-  describe('school_year_start method') do
+  describe 'school_year_start method' do
     it 'fetches 07-01 of this year if the date is after 07-01' do
       time = Date.parse('2020-07-01')
       expect(School.school_year_start(time)).to eq(time.beginning_of_day)
@@ -165,33 +162,48 @@ describe School, type: :model do
     end
   end
 
-  describe('district admin behavior') do
+  describe 'district admin behavior' do
     let(:school) { create(:school) }
     let(:district) { create(:district) }
+    let(:another_district) { create(:district) }
     let(:admin) { create(:user)}
 
-    it 'creates new school admin record if a school is attached to a new district' do
-      create(:district_admin, user: admin, district: district)
-      expect(SchoolsAdmins.find_by(school: school, user: admin)).not_to be
-      school.update(district_id: district.id)
-      expect(SchoolsAdmins.find_by(school: school, user: admin)).to be
+    before { create(:district_admin, user: admin, district: district) }
+
+    describe '#attach_new_district_school_admins' do
+      it { expect { school }.to not_change(SchoolsAdmins, :count) }
+
+      it 'creates school admin if a school is attached to a new district' do
+        expect(SchoolsAdmins.find_by(school: school, user: admin)).not_to be
+        school.update(district: district)
+        expect(SchoolsAdmins.find_by(school: school, user: admin)).to be
+      end
+
+      context 'district admin is already admin for school' do
+        before { create(:schools_admins, user: admin, school: school) }
+
+        it {  expect { school.update(district: district) }.to not_change(SchoolsAdmins, :count) }
+      end
     end
 
-    it 'does not create new school admin record if a school is attached to a new district and the district admin is already admin for the school' do
-      create(:schools_admins, user: admin, school: school)
-      expect(SchoolsAdmins.where(school: school, user: admin).count).to eq 1
+    describe '#detach_old_district_school_admins' do
+      context 'school has no district' do
+        before { school }
 
-      school.update(district_id: district.id)
-      expect(SchoolsAdmins.where(school: school, user: admin).count).to eq 1
-    end
+        it { expect { school.update(district: nil) }.to not_change(SchoolsAdmins, :count) }
+      end
 
-    it 'destroys school admin record if a school is detached from a district' do
-      create(:district_admin, user: admin, district: district)
-      school.update(district_id: district.id)
-      expect(SchoolsAdmins.find_by(school: school, user: admin)).to be
+      context 'school is attached to district' do
+        before { school.update(district: district) }
 
-      school.update(district_id: nil)
-      expect(SchoolsAdmins.find_by(school: school, user: admin)).not_to be
+        it { expect { school.update(district: nil) }.to change(SchoolsAdmins, :count).from(1).to(0) }
+      end
+
+      context 'school is attached to another district' do
+        before { school.update(district: another_district) }
+
+        it { expect { school.update(district: nil) }.to not_change(SchoolsAdmins, :count) }
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -34,6 +34,10 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+# Define any negatated matchers we need
+# https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/define-negated-matcher
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each {|f| require f}


### PR DESCRIPTION
## WHAT
Remove coupling between `DistrictAdmin` callbacks and `SchoolSubscription`

## WHY
`DistrictAdmin` has callbacks that create or remove records based on the existence of an active `SchoolSubscription`.  This coupling is too restrictive since the UI should be able to show `DistrictAdmin` that exist that are lacking a subscription (which would be consistent with how `SchoolsAdmins` see schools that do not have subscriptions.

## HOW
1.  Update `DistrictAdmin` after_create | after_destroy callbacks to attach / detach schools 
2. Update `School` before_save callbacks that update SchoolAdmins when the associated district is changed

Also, remove the cron job `UpdateExpiringSchoolSubscriptionsWorker` whose job was to remove district_admins on expired school subscriptions.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
