### PR TITLE
Evidence internal tool/ fix rule analysis bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -376,7 +376,7 @@ const RuleAnalysis = ({ match }) => {
         className="responses-table"
         columns={responseHeaders}
         data={responses}
-        defaultPageSize={responses.length < 100 ? responses.length : 100}
+        defaultPageSize={responses.length < 100 && responses.length > 0 ? responses.length : 100}
         manualSortBy
         onSortedChange={handleDataUpdate}
       />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -376,7 +376,7 @@ const RuleAnalysis = ({ match }) => {
         className="responses-table"
         columns={responseHeaders}
         data={responses}
-        defaultPageSize={responses.length < 100 && responses.length > 0 ? responses.length : 100}
+        defaultPageSize={Math.min(responses.length, 100) || 100}
         manualSortBy
         onSortedChange={handleDataUpdate}
       />


### PR DESCRIPTION
## WHAT
fix issue where page filters were causing Evidence rule analysis page to crash

## WHY
this page shouldn't crash when updating filters

## HOW
make sure that we pass a `defaultPageSize` prop to the `ReactTable` instance that is greater than 0

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Evidence-Rules-Analysis-Page-sometimes-crashing-out-16346bcfddc04196979f0010ccf804a4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A