### PR TITLE
Remove haml-rails

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -119,7 +119,6 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
 gem 'slim-rails'
-gem 'haml-rails'
 
 gem 'es5-shim-rails'
 # Use the exact gem version to match npm version of react-on-rails

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -179,7 +179,6 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    erubis (2.7.0)
     es5-shim-rails (4.0.1)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -305,12 +304,6 @@ GEM
     haml (5.1.1)
       temple (>= 0.8.0)
       tilt
-    haml-rails (1.0.0)
-      actionpack (>= 4.0.1)
-      activesupport (>= 4.0.1)
-      haml (>= 4.0.6, < 6.0)
-      html2haml (>= 1.0.1)
-      railties (>= 4.0.1)
     hashdiff (0.3.8)
     hashery (2.1.2)
     hashie (3.6.0)
@@ -319,11 +312,6 @@ GEM
       ffi
       ffi-compiler
       rake
-    html2haml (2.2.0)
-      erubis (~> 2.7.0)
-      haml (>= 4.0, < 6)
-      nokogiri (>= 1.6.0)
-      ruby_parser (~> 3.5)
     htmlentities (4.3.4)
     httparty (0.16.4)
       mime-types (~> 3.0)
@@ -639,8 +627,6 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.11.0)
     ruby-rc4 (0.1.5)
-    ruby_parser (3.12.0)
-      sexp_processor (~> 4.9)
     rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.7.4)
@@ -672,7 +658,6 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
-    sexp_processor (4.11.0)
     shellany (0.0.1)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
@@ -821,7 +806,6 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-shell
-  haml-rails
   haversine
   httparty
   intercom (~> 3.5.23)


### PR DESCRIPTION
## WHAT
Remove the haml-rails library.

## WHY
It doesn't appear that we are using this anymore.  It's also causing a deprecation warning for Rails 6:

```
DEPRECATION WARNING: SourceAnnotationExtractor is deprecated! Use Rails::SourceAnnotationExtractor instead. 
(called from <top (required)> at /Users/brendanshean/Empirical-Core/services/QuillLMS/config/environment.rb:7)
```

## HOW
Remove `haml-rails` from Gemfile.  Then `bundle`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
