### PR TITLE
Lms/rename concept results table

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
-    ConceptResult.bulk_insert(values: concept_results_to_save)
+    ConceptResultOld.bulk_insert(values: concept_results_to_save)
   end
 
   private def concept_results_hash(concept_result)

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
-    ConceptResultOld.bulk_insert(values: concept_results_to_save)
+    OldConceptResult.bulk_insert(values: concept_results_to_save)
   end
 
   private def concept_results_hash(concept_result)

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -45,14 +45,14 @@ module DiagnosticReports
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:concept_results, activity: {skills: :concepts})
+        .includes(:old_concept_results, activity: {skills: :concepts})
         .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids, activity_id: activity_id)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:concept_results, activity: {skills: :concepts})
+        .includes(:old_concept_results, activity: {skills: :concepts})
         .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true, user_id: assigned_student_ids)
         .order(completed_at: :desc)
         .uniq { |activity_session| activity_session.user_id }
@@ -69,7 +69,7 @@ module DiagnosticReports
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession
-      .includes(:concept_results, activity: {skills: :concepts})
+      .includes(:old_concept_results, activity: {skills: :concepts})
       .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }
@@ -84,7 +84,7 @@ module DiagnosticReports
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @post_test_activity_sessions = ActivitySession
-      .includes(:concept_results, activity: :skills)
+      .includes(:old_concept_results, activity: :skills)
       .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -57,8 +57,8 @@ module GrowthResultsSummary
     skill_groups.map do |skill_group|
       skills = skill_group.skills.map do |skill|
         {
-          pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
-          post: data_for_skill_by_activity_session(post_test_activity_session.concept_results, skill)
+          pre: data_for_skill_by_activity_session(pre_test_activity_session.old_concept_results, skill),
+          post: data_for_skill_by_activity_session(post_test_activity_session.old_concept_results, skill)
         }
       end
       pre_correct_skills = skills.select { |skill| skill[:pre][:summary] == FULLY_CORRECT }

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -48,7 +48,7 @@ module ResultsSummary
   # rubocop:disable Metrics/CyclomaticComplexity
   private def skill_groups_for_session(skill_groups, activity_session, student_name)
     skill_groups.map do |skill_group|
-      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }
+      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.old_concept_results, skill) }
       present_skill_number = skills.reduce(0) { |sum, skill| sum += skill[:summary] == NOT_PRESENT ? 0 : 1 }
       correct_skills = skills.select { |skill| skill[:summary] == FULLY_CORRECT }
       correct_skill_ids = correct_skills.map { |s| s[:id] }

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -23,16 +23,16 @@ class GradesController < ApplicationController
     RawSqlRunner.execute(
       <<-SQL
         SELECT
-          concept_results.metadata,
+          old_concept_results.metadata,
           activities.description,
           concepts.name,
           activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS completed_at,
           unit_activities.due_date
         FROM activity_sessions
-        LEFT JOIN concept_results
-          ON concept_results.activity_session_id = activity_sessions.id
+        LEFT JOIN old_concept_results
+          ON old_concept_results.activity_session_id = activity_sessions.id
         LEFT JOIN concepts
-          ON concept_results.concept_id = concepts.id
+          ON old_concept_results.concept_id = concepts.id
         JOIN classroom_units
           ON classroom_units.id = activity_sessions.classroom_unit_id
         JOIN activities

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -91,19 +91,19 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
 
       if pre_test && pre_test_activity_session
         concept_results = {
-          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.concept_results.order("(metadata->>'questionNumber')::int")) },
-          post: { questions: format_concept_results(activity_session, activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
+          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) },
+          post: { questions: format_concept_results(activity_session, activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) }
         }
         formatted_skills = skills.map do |skill|
           {
-            pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
-            post: data_for_skill_by_activity_session(activity_session.concept_results, skill)
+            pre: data_for_skill_by_activity_session(pre_test_activity_session.old_concept_results, skill),
+            post: data_for_skill_by_activity_session(activity_session.old_concept_results, skill)
           }
         end
         skill_results = { skills: formatted_skills.uniq { |formatted_skill| formatted_skill[:pre][:skill] } }
       else
-        concept_results = { questions: format_concept_results(activity_session, activity_session.concept_results.order("(metadata->>'questionNumber')::int")) }
-        skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
+        concept_results = { questions: format_concept_results(activity_session, activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) }
+        skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.old_concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
       end
       { concept_results: concept_results, skill_results: skill_results, name: student.name }
     end
@@ -353,7 +353,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       activity_session = @activity_sessions[student.id]
 
       if activity_session
-        formatted_concept_results = format_concept_results(activity_session, activity_session.concept_results)
+        formatted_concept_results = format_concept_results(activity_session, activity_session.old_concept_results)
         score = get_average_score(formatted_concept_results)
         if score >= (ProficiencyEvaluator.proficiency_cutoff * 100)
           proficiency = ActivitySession::PROFICIENT

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -380,7 +380,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     @post_test_activity_sessions.reduce(0) do |sum, as|
       post_correct_skill_ids = as&.correct_skill_ids
       pre_correct_skill_ids = ActivitySession
-        .includes(:concept_results, activity: {skills: :concepts})
+        .includes(:old_concept_results, activity: {skills: :concepts})
         .where(user_id: as.user_id, activity_id: pre_test_activity_id)
         .order(completed_at: :desc)
         .first

--- a/services/QuillLMS/app/graphql/types/user_type.rb
+++ b/services/QuillLMS/app/graphql/types/user_type.rb
@@ -77,7 +77,7 @@ class Types::UserType < Types::BaseObject
 
   private def concept_results_by_count activity_session
     hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
-    activity_session.concept_results.each do |concept_result|
+    activity_session.old_concept_results.each do |concept_result|
       hash[concept_result.concept.uid]["correct"] += concept_result["metadata"]["correct"]
       hash[concept_result.concept.uid]["total"] += 1
     end

--- a/services/QuillLMS/app/helpers/concept_helper.rb
+++ b/services/QuillLMS/app/helpers/concept_helper.rb
@@ -5,7 +5,7 @@ module ConceptHelper
     return '' unless activity_session.present?
 
     # Generate a header for each applicable concept class (activity session has concept tag results for that class)
-    concept_results = activity_session.concept_results
+    concept_results = activity_session.old_concept_results
     concepts = activity_session.concepts
     concepts.reduce "" do |html, concept|
       html += stats_for_concept(concept, concept_results)

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -27,7 +27,7 @@ class ActivityClassification < ApplicationRecord
   include Uid
 
   has_many :activities, dependent: :destroy
-  has_many :concept_results
+  has_many :old_concept_results
   has_many :user_activity_classifications, dependent: :destroy
 
   validates :key, presence: true

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -66,9 +66,9 @@ class ActivitySession < ApplicationRecord
   has_many :user_activity_classifications, through: :classification
   has_one :classroom, through: :classroom_unit
   has_one :unit, through: :classroom_unit
-  has_many :concept_results_old
+  has_many :old_concept_results
   has_many :teachers, through: :classroom
-  has_many :concepts, -> { distinct }, through: :concept_results_old
+  has_many :concepts, -> { distinct }, through: :old_concept_results
   has_one :active_activity_session, foreign_key: :uid, primary_key: :uid
   has_one :activity_survey_response
 
@@ -335,7 +335,7 @@ class ActivitySession < ApplicationRecord
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def parse_for_results
-    concept_results_by_concept = concept_results_old.group_by { |c| c.concept_id }
+    concept_results_by_concept = old_concept_results.group_by { |c| c.concept_id }
 
     results = {
       PROFICIENT => [],
@@ -396,7 +396,7 @@ class ActivitySession < ApplicationRecord
       concept_result[:activity_session_id] = activity_session_id
       concept_result.delete(:activity_session_uid)
 
-      ConceptResultOld.create(
+      OldConceptResult.create(
         concept_id: concept_result[:concept_id],
         question_type: concept_result[:question_type],
         activity_session_id: concept_result[:activity_session_id],
@@ -408,7 +408,7 @@ class ActivitySession < ApplicationRecord
   def self.delete_activity_sessions_with_no_concept_results(activity_sessions)
     incomplete_activity_session_ids = []
     activity_sessions.each do |as|
-      if as.concept_result_ids.empty?
+      if as.old_concept_result_ids.empty?
         incomplete_activity_session_ids.push(as.id)
       end
     end
@@ -440,7 +440,7 @@ class ActivitySession < ApplicationRecord
 
   def self.activity_session_metadata(activity_sessions)
     activity_sessions.map do |activity_session|
-      activity_session.concept_results_old.map do |concept_result|
+      activity_session.old_concept_results.map do |concept_result|
         concept_result.metadata
       end
     end.flatten
@@ -516,11 +516,11 @@ class ActivitySession < ApplicationRecord
   end
 
   # when using this method, you should eager load ass
-  # e.g. .includes(:concept_results_old, activity: {skills: :concepts})
+  # e.g. .includes(:old_concept_results, activity: {skills: :concepts})
   def correct_skills
     @correct_skills ||= begin
       skills.select do |skill|
-        results = concept_results_old.select {|cr| cr.concept_id.in?(skill.concept_ids)}
+        results = old_concept_results.select {|cr| cr.concept_id.in?(skill.concept_ids)}
 
         results.length && results.all?(&:correct?)
       end

--- a/services/QuillLMS/app/models/announcement.rb
+++ b/services/QuillLMS/app/models/announcement.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_announcements_on_start_and_end  (start,end)
+#  index_announcements_on_start_and_end  (start,end DESC)
 #
 class Announcement < ApplicationRecord
   TYPES = {

--- a/services/QuillLMS/app/models/concept_result_old.rb
+++ b/services/QuillLMS/app/models/concept_result_old.rb
@@ -20,7 +20,7 @@
 #
 #  fk_rails_...  (activity_classification_id => activity_classifications.id)
 #
-class ConceptResult < ApplicationRecord
+class ConceptResultOld < ApplicationRecord
 
   belongs_to :concept
   belongs_to :activity_session

--- a/services/QuillLMS/app/models/concerns/concepts.rb
+++ b/services/QuillLMS/app/models/concerns/concepts.rb
@@ -8,7 +8,7 @@ module Concepts
     return '' unless activity_session.present?
 
     @concepts = activity_session.concepts
-    @concept_results_by_question_type = activity_session.concept_results.group_by{|c| c.question_type}.values
+    @concept_results_by_question_type = activity_session.old_concept_results.group_by{|c| c.question_type}.values
     organize_by_type
   end
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -142,7 +142,7 @@ module PublicProgressReports
     # Use DISTINCT ON to only pull one session per user
     final_sessions_by_user = ActivitySession
       .select("DISTINCT ON (activity_sessions.user_id) user_id, activity_sessions.*")
-      .includes(concept_results: :concept)
+      .includes(old_concept_results: :concept)
       .where(
         user_id: students.map(&:id),
         is_final_score: true,

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -179,7 +179,7 @@ module PublicProgressReports
   end
 
   def formatted_score_obj(final_activity_session, classification_key, student, average_score_on_quill)
-    formatted_concept_results = format_concept_results(final_activity_session, final_activity_session.concept_results)
+    formatted_concept_results = format_concept_results(final_activity_session, final_activity_session.old_concept_results)
     if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification_key)
       score = get_average_score(formatted_concept_results)
     elsif [ActivityClassification::EVIDENCE_KEY].include?(classification_key)
@@ -358,7 +358,7 @@ module PublicProgressReports
 
   def concept_results_by_count(activity_session)
     hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
-    activity_session.concept_results.each do |concept_result|
+    activity_session.old_concept_results.each do |concept_result|
       hash[concept_result.concept.uid]["correct"] += concept_result["metadata"]["correct"]
       hash[concept_result.concept.uid]["total"] += 1
     end

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: concept_results
+# Table name: old_concept_results
 #
 #  id                         :integer          not null, primary key
 #  metadata                   :json
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_concept_results_on_activity_session_id  (activity_session_id)
-#  index_concept_results_on_concept_id           (concept_id)
+#  index_old_concept_results_on_activity_session_id  (activity_session_id)
+#  index_old_concept_results_on_concept_id           (concept_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -20,8 +20,7 @@
 #
 #  fk_rails_...  (activity_classification_id => activity_classifications.id)
 #
-class ConceptResultOld < ApplicationRecord
-
+class OldConceptResult < ApplicationRecord
   belongs_to :concept
   belongs_to :activity_session
   belongs_to :activity_classification

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -45,7 +45,7 @@ class QuestionHealthDashboard
       SELECT
       cr.metadata::json->>'questionScore' AS score,
       cr.activity_session_id
-      FROM concept_results cr
+      FROM old_concept_results cr
       INNER JOIN (
         SELECT *
         FROM activity_sessions

--- a/services/QuillLMS/app/models/student_problem_report.rb
+++ b/services/QuillLMS/app/models/student_problem_report.rb
@@ -5,6 +5,7 @@
 # Table name: student_problem_reports
 #
 #  id                  :bigint           not null, primary key
+#  optimal             :boolean          default(FALSE), not null
 #  report              :string           not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -30,7 +30,7 @@
 #
 # Indexes
 #
-#  email_idx                          (email gin_trgm_ops) USING gin
+#  email_idx                          (email) USING gin
 #  index_users_on_active              (active)
 #  index_users_on_classcode           (classcode)
 #  index_users_on_clever_id           (clever_id)
@@ -41,12 +41,12 @@
 #  index_users_on_time_zone           (time_zone)
 #  index_users_on_token               (token)
 #  index_users_on_username            (username)
-#  name_idx                           (name gin_trgm_ops) USING gin
+#  name_idx                           (name) USING gin
 #  unique_index_users_on_clever_id    (clever_id) UNIQUE WHERE ((clever_id IS NOT NULL) AND ((clever_id)::text <> ''::text) AND ((id > 5593155) OR ((role)::text = 'student'::text)))
 #  unique_index_users_on_email        (email) UNIQUE WHERE ((id > 1641954) AND (email IS NOT NULL) AND ((email)::text <> ''::text))
 #  unique_index_users_on_google_id    (google_id) UNIQUE WHERE ((id > 1641954) AND (google_id IS NOT NULL) AND ((google_id)::text <> ''::text))
 #  unique_index_users_on_username     (username) UNIQUE WHERE ((id > 1641954) AND (username IS NOT NULL) AND ((username)::text <> ''::text))
-#  username_idx                       (username gin_trgm_ops) USING gin
+#  username_idx                       (username) USING gin
 #  users_to_tsvector_idx              (to_tsvector('english'::regconfig, (name)::text)) USING gin
 #  users_to_tsvector_idx1             (to_tsvector('english'::regconfig, (email)::text)) USING gin
 #  users_to_tsvector_idx2             (to_tsvector('english'::regconfig, (role)::text)) USING gin

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -13,7 +13,7 @@
 #
 #  index_user_activity_classifications_on_classifications  (activity_classification_id)
 #  index_user_activity_classifications_on_user_id          (user_id)
-#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#  user_activity_classification_unique_index               (user_id,activity_classification_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
@@ -3,10 +3,10 @@
 class ProgressReports::Concepts::ConceptResult
 
   def self.results(teacher, filters)
-    query = ::ConceptResult.select(<<-SELECT
-      cast(concept_results.metadata->>'correct' as int) as is_correct,
+    query = ::OldConceptResult.select(<<-SELECT
+      cast(old_concept_results.metadata->>'correct' as int) as is_correct,
       activity_sessions.user_id,
-      concept_results.concept_id
+      old_concept_results.concept_id
     SELECT
   ).joins({activity_session: {classroom_unit: :classroom}})
      .joins("INNER JOIN classrooms_teachers ON classrooms.id = classrooms_teachers.classroom_id")

--- a/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
@@ -23,8 +23,8 @@ class ProgressReports::DistrictConceptReports
           classrooms.name AS classroom_name,
           students.name AS student_name,
           students.id AS student_id,
-          SUM(CAST(concept_results.metadata->>'correct' as INT)) AS correct,
-          COUNT(concept_results) AS concept_results_count
+          SUM(CAST(old_concept_results.metadata->>'correct' as INT)) AS correct,
+          COUNT(old_concept_results) AS old_concept_results_count
         FROM schools_admins
         JOIN schools
           ON schools.id = schools_admins.school_id
@@ -43,8 +43,8 @@ class ProgressReports::DistrictConceptReports
           ON activity_sessions.classroom_unit_id = classroom_units.id
         JOIN users AS students
           ON students.id = activity_sessions.user_id
-        JOIN concept_results
-          ON concept_results.activity_session_id = activity_sessions.id
+        JOIN old_concept_results
+          ON old_concept_results.activity_session_id = activity_sessions.id
         WHERE schools_admins.user_id = #{@admin_id}
         GROUP BY
           student_id,
@@ -59,8 +59,8 @@ class ProgressReports::DistrictConceptReports
         classroom_name,
         student_name,
         correct,
-        (concept_results_count - correct) as incorrect,
-        FLOOR(( correct/concept_results_count::float ) * 100 ) as percentage
+        (old_concept_results_count - correct) as incorrect,
+        FLOOR(( correct/old_concept_results_count::float ) * 100 ) as percentage
       FROM results;
     SQL
   end

--- a/services/QuillLMS/app/serializers/user_serializer.rb
+++ b/services/QuillLMS/app/serializers/user_serializer.rb
@@ -30,7 +30,7 @@
 #
 # Indexes
 #
-#  email_idx                          (email gin_trgm_ops) USING gin
+#  email_idx                          (email) USING gin
 #  index_users_on_active              (active)
 #  index_users_on_classcode           (classcode)
 #  index_users_on_clever_id           (clever_id)
@@ -41,12 +41,12 @@
 #  index_users_on_time_zone           (time_zone)
 #  index_users_on_token               (token)
 #  index_users_on_username            (username)
-#  name_idx                           (name gin_trgm_ops) USING gin
+#  name_idx                           (name) USING gin
 #  unique_index_users_on_clever_id    (clever_id) UNIQUE WHERE ((clever_id IS NOT NULL) AND ((clever_id)::text <> ''::text) AND ((id > 5593155) OR ((role)::text = 'student'::text)))
 #  unique_index_users_on_email        (email) UNIQUE WHERE ((id > 1641954) AND (email IS NOT NULL) AND ((email)::text <> ''::text))
 #  unique_index_users_on_google_id    (google_id) UNIQUE WHERE ((id > 1641954) AND (google_id IS NOT NULL) AND ((google_id)::text <> ''::text))
 #  unique_index_users_on_username     (username) UNIQUE WHERE ((id > 1641954) AND (username IS NOT NULL) AND ((username)::text <> ''::text))
-#  username_idx                       (username gin_trgm_ops) USING gin
+#  username_idx                       (username) USING gin
 #  users_to_tsvector_idx              (to_tsvector('english'::regconfig, (name)::text)) USING gin
 #  users_to_tsvector_idx1             (to_tsvector('english'::regconfig, (email)::text)) USING gin
 #  users_to_tsvector_idx2             (to_tsvector('english'::regconfig, (role)::text)) USING gin

--- a/services/QuillLMS/app/services/demo/concept_results.rb
+++ b/services/QuillLMS/app/services/demo/concept_results.rb
@@ -29,7 +29,7 @@ module Demo::OldConceptResults
   end
 
   def self.handle_scores(activity_session)
-    crs = activity_session.reload.concept_results
+    crs = activity_session.reload.old_concept_results
     percentage = activity_session.percentage
     num_correct = (percentage*crs.count).ceil
     shuffled = crs.shuffle

--- a/services/QuillLMS/app/services/demo/concept_results.rb
+++ b/services/QuillLMS/app/services/demo/concept_results.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Demo::ConceptResults
+module Demo::OldConceptResults
 
   def self.create_from_classrooms(classrooms)
     activity_sessions = classrooms
@@ -54,7 +54,7 @@ module Demo::ConceptResults
     concept = Concept.find_or_create_by(name: concept_name)
     crs = []
     number_of_concept_results.to_i.times do |i|
-      cr = ConceptResultOld.find_or_create_by(concept: concept, activity_session: activity_session)
+      cr = OldConceptResult.find_or_create_by(concept: concept, activity_session: activity_session)
       cr.update(metadata: {})
       crs.push(cr)
     end

--- a/services/QuillLMS/app/services/demo/concept_results.rb
+++ b/services/QuillLMS/app/services/demo/concept_results.rb
@@ -54,7 +54,7 @@ module Demo::ConceptResults
     concept = Concept.find_or_create_by(name: concept_name)
     crs = []
     number_of_concept_results.to_i.times do |i|
-      cr = ConceptResult.find_or_create_by(concept: concept, activity_session: activity_session)
+      cr = ConceptResultOld.find_or_create_by(concept: concept, activity_session: activity_session)
       cr.update(metadata: {})
       crs.push(cr)
     end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -169,7 +169,7 @@ class Demo::CreateAdminReport
               state: the_activity_session_should_be_marked_as_in_progress ? 'started' : 'finished',
               percentage: exemplar_activity_session.percentage,
             )
-            exemplar_activity_session.concept_results.each do |cr|
+            exemplar_activity_session.old_concept_results.each do |cr|
               OldConceptResult.create!(
                 activity_session_id: activity_session.id,
                 concept_id: cr.concept_id,

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -170,7 +170,7 @@ class Demo::CreateAdminReport
               percentage: exemplar_activity_session.percentage,
             )
             exemplar_activity_session.concept_results.each do |cr|
-              ConceptResult.create!(
+              ConceptResultOld.create!(
                 activity_session_id: activity_session.id,
                 concept_id: cr.concept_id,
                 metadata: cr.metadata,

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -170,7 +170,7 @@ class Demo::CreateAdminReport
               percentage: exemplar_activity_session.percentage,
             )
             exemplar_activity_session.concept_results.each do |cr|
-              ConceptResultOld.create!(
+              OldConceptResult.create!(
                 activity_session_id: activity_session.id,
                 concept_id: cr.concept_id,
                 metadata: cr.metadata,

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -209,7 +209,7 @@ module Demo::ReportDemoAPCreator
 
         cu = ClassroomUnit.where("#{student.id} = ANY (assigned_student_ids) AND classroom_id=#{classroom.id}").first
         act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
-        temp.concept_results.each do |cr|
+        temp.old_concept_results.each do |cr|
           values = {
             activity_session_id: act_session.id,
             concept_id: cr.concept_id,

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -216,7 +216,7 @@ module Demo::ReportDemoAPCreator
             metadata: cr.metadata,
             question_type: cr.question_type
           }
-          ConceptResult.create(values)
+          ConceptResultOld.create(values)
         end
       end
     end

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -216,7 +216,7 @@ module Demo::ReportDemoAPCreator
             metadata: cr.metadata,
             question_type: cr.question_type
           }
-          ConceptResultOld.create(values)
+          OldConceptResult.create(values)
         end
       end
     end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -385,7 +385,7 @@ module Demo::ReportDemoCreator
         metadata: cr.metadata,
         question_type: cr.question_type
       }
-      ConceptResult.create(values)
+      ConceptResultOld.create(values)
     end
   end
 
@@ -409,7 +409,7 @@ module Demo::ReportDemoCreator
               metadata: cr.metadata,
               question_type: cr.question_type
             }
-            ConceptResult.create(values)
+            ConceptResultOld.create(values)
           end
         end
       end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -378,7 +378,7 @@ module Demo::ReportDemoCreator
     replayed_session = ActivitySession.unscoped.where({activity_id: REPLAYED_ACTIVITY_ID, user_id: REPLAYED_SAMPLE_USER_ID, is_final_score: true}).first
     student_id = student.id
     act_session = ActivitySession.create({activity_id: REPLAYED_ACTIVITY_ID, classroom_unit_id: classroom_unit.id, user_id: student.id, state: "finished", percentage: replayed_session&.percentage})
-    replayed_session&.concept_results&.each do |cr|
+    replayed_session&.old_concept_results&.each do |cr|
       values = {
         activity_session_id: act_session.id,
         concept_id: cr.concept_id,
@@ -402,7 +402,7 @@ module Demo::ReportDemoCreator
           cu = ClassroomUnit.find_by(classroom_id: classroom.id, unit_id: unit.id)
           act_session = ActivitySession.create({activity_id: act_id, classroom_unit_id: cu.id, user_id: student.id, state: "finished", percentage: temp.percentage})
 
-          temp.concept_results.each do |cr|
+          temp.old_concept_results.each do |cr|
             values = {
               activity_session_id: act_session.id,
               concept_id: cr.concept_id,

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -385,7 +385,7 @@ module Demo::ReportDemoCreator
         metadata: cr.metadata,
         question_type: cr.question_type
       }
-      ConceptResultOld.create(values)
+      OldConceptResult.create(values)
     end
   end
 
@@ -409,7 +409,7 @@ module Demo::ReportDemoCreator
               metadata: cr.metadata,
               question_type: cr.question_type
             }
-            ConceptResultOld.create(values)
+            OldConceptResult.create(values)
           end
         end
       end

--- a/services/QuillLMS/app/workers/concept_replacement_lms_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_lms_worker.rb
@@ -5,7 +5,7 @@ class ConceptReplacementLMSWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(original_concept_id, new_concept_id)
-    ConceptResult.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
+    ConceptResultOld.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
     Criterion.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
     Concept.unscoped.find(original_concept_id).update(visible: false, replacement_id: new_concept_id)
   end

--- a/services/QuillLMS/app/workers/concept_replacement_lms_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_lms_worker.rb
@@ -5,7 +5,7 @@ class ConceptReplacementLMSWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(original_concept_id, new_concept_id)
-    ConceptResultOld.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
+    OldConceptResult.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
     Criterion.where(concept_id: original_concept_id).update_all(concept_id: new_concept_id)
     Concept.unscoped.find(original_concept_id).update(visible: false, replacement_id: new_concept_id)
   end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -91,10 +91,10 @@ class GetConceptsInUseIndividualConceptWorker
             ON concepts.parent_id = parent_concepts.id
           LEFT JOIN concepts AS grandparent_concepts
             ON parent_concepts.parent_id = grandparent_concepts.id
-          LEFT JOIN concept_results
-            ON concept_results.concept_id = concepts.id
+          LEFT JOIN old_concept_results
+            ON old_concept_results.concept_id = concepts.id
           LEFT JOIN activity_sessions
-            ON concept_results.activity_session_id = activity_sessions.id
+            ON old_concept_results.activity_session_id = activity_sessions.id
           LEFT JOIN activities
             ON activity_sessions.activity_id = activities.id
           LEFT JOIN activity_classifications

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -171,7 +171,7 @@ RailsAdmin.config do |config|
   # Exclude the models with huge datasets (~10M+) because they are performance hits
   MODELS_TO_EXCLUDE = [
     'ActivitySession',
-    'ConceptResult',
+    'OldConceptResult',
     'Notification',
     'OauthAccessToken',
     'OldActivitySession',

--- a/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
+++ b/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
@@ -1,5 +1,5 @@
 class RenameConceptResultsTable < ActiveRecord::Migration[5.2]
   def change
-    rename_table :concept_results, :concept_results_old
+    rename_table :concept_results, :old_concept_results
   end
 end

--- a/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
+++ b/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
@@ -1,0 +1,5 @@
+class RenameConceptResultsTable < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :concept_results, :concept_results_old
+  end
+end

--- a/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
+++ b/services/QuillLMS/db/migrate/20220628174900_rename_concept_results_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameConceptResultsTable < ActiveRecord::Migration[5.2]
   def change
     rename_table :concept_results, :old_concept_results

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -124,7 +124,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-
+          
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -139,11 +139,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-
+                
                 RETURN COALESCE(time_spent,0);
           END IF;
-
-
+          
+          
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -167,11 +167,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-
+          
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-
+          
           RETURN time_spent;
         END;
       $$;
@@ -186,7 +186,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student
+          WHERE activity_sessions.user_id = student 
           GROUP BY id) as as_ids;
 
       $$;
@@ -226,6 +226,8 @@ CREATE FUNCTION public.timespent_teacher(teacher integer) RETURNS bigint
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: active_activity_sessions; Type: TABLE; Schema: public; Owner: -
@@ -310,7 +312,7 @@ ALTER SEQUENCE public.activities_id_seq OWNED BY public.activities.id;
 CREATE TABLE public.activities_unit_templates (
     unit_template_id integer NOT NULL,
     activity_id integer NOT NULL,
-    id bigint NOT NULL,
+    id integer NOT NULL,
     order_number integer
 );
 
@@ -320,6 +322,7 @@ CREATE TABLE public.activities_unit_templates (
 --
 
 CREATE SEQUENCE public.activities_unit_templates_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -967,8 +970,8 @@ CREATE TABLE public.change_logs (
     id integer NOT NULL,
     explanation text,
     action character varying NOT NULL,
-    changed_record_type character varying NOT NULL,
     changed_record_id integer,
+    changed_record_type character varying NOT NULL,
     user_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1198,7 +1201,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
-    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
+    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
 );
 
 
@@ -1547,8 +1550,8 @@ ALTER SEQUENCE public.comprehension_prompts_rules_id_seq OWNED BY public.compreh
 
 CREATE TABLE public.comprehension_regex_rules (
     id integer NOT NULL,
-    regex_text character varying(200) NOT NULL,
-    case_sensitive boolean NOT NULL,
+    regex_text character varying(200),
+    case_sensitive boolean,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rule_id integer,
@@ -1590,10 +1593,9 @@ CREATE TABLE public.comprehension_rules (
     rule_type character varying NOT NULL,
     optimal boolean NOT NULL,
     suborder integer,
-    concept_uid character varying NOT NULL,
+    concept_uid character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    sequence_type character varying,
     state character varying NOT NULL
 );
 
@@ -1720,10 +1722,10 @@ ALTER SEQUENCE public.concept_feedbacks_id_seq OWNED BY public.concept_feedbacks
 
 
 --
--- Name: concept_results; Type: TABLE; Schema: public; Owner: -
+-- Name: concept_results_old; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.concept_results (
+CREATE TABLE public.concept_results_old (
     id integer NOT NULL,
     activity_session_id integer,
     concept_id integer NOT NULL,
@@ -1734,10 +1736,10 @@ CREATE TABLE public.concept_results (
 
 
 --
--- Name: concept_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: concept_results_old_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.concept_results_id_seq
+CREATE SEQUENCE public.concept_results_old_id_seq
     AS integer
     START WITH 1
     INCREMENT BY 1
@@ -1747,10 +1749,10 @@ CREATE SEQUENCE public.concept_results_id_seq
 
 
 --
--- Name: concept_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+-- Name: concept_results_old_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.concept_results_id_seq OWNED BY public.concept_results.id;
+ALTER SEQUENCE public.concept_results_old_id_seq OWNED BY public.concept_results_old.id;
 
 
 --
@@ -1899,8 +1901,8 @@ CREATE TABLE public.credit_transactions (
     id integer NOT NULL,
     amount integer NOT NULL,
     user_id integer NOT NULL,
-    source_type character varying,
     source_id integer,
+    source_type character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -2028,13 +2030,45 @@ ALTER SEQUENCE public.district_admins_id_seq OWNED BY public.district_admins.id;
 
 
 --
+-- Name: district_subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.district_subscriptions (
+    id bigint NOT NULL,
+    district_id bigint,
+    subscription_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: district_subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.district_subscriptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: district_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.district_subscriptions_id_seq OWNED BY public.district_subscriptions.id;
+
+
+--
 -- Name: districts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.districts (
     id integer NOT NULL,
     clever_id character varying,
-    name character varying,
+    name character varying NOT NULL,
     token character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -2067,42 +2101,6 @@ CREATE SEQUENCE public.districts_id_seq
 --
 
 ALTER SEQUENCE public.districts_id_seq OWNED BY public.districts.id;
-
-
---
--- Name: districts_tables; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.districts_tables (
-    id bigint NOT NULL,
-    name character varying NOT NULL,
-    nces_id character varying NOT NULL,
-    city character varying NOT NULL,
-    state character varying NOT NULL,
-    zipcode integer,
-    phone character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: districts_tables_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.districts_tables_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: districts_tables_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.districts_tables_id_seq OWNED BY public.districts_tables.id;
 
 
 --
@@ -2156,8 +2154,8 @@ ALTER SEQUENCE public.evidence_hints_id_seq OWNED BY public.evidence_hints.id;
 CREATE TABLE public.feedback_histories (
     id integer NOT NULL,
     feedback_session_uid text,
-    prompt_type character varying,
     prompt_id integer,
+    prompt_type character varying,
     concept_uid text,
     attempt integer NOT NULL,
     entry text NOT NULL,
@@ -2766,7 +2764,6 @@ CREATE TABLE public.plans (
     audience character varying NOT NULL,
     "interval" character varying,
     interval_count integer,
-    stripe_price_id character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -3033,6 +3030,204 @@ ALTER SEQUENCE public.referrer_users_id_seq OWNED BY public.referrer_users.id;
 
 
 --
+-- Name: response_directions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.response_directions (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: response_directions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.response_directions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: response_directions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.response_directions_id_seq OWNED BY public.response_directions.id;
+
+
+--
+-- Name: response_instructions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.response_instructions (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: response_instructions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.response_instructions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: response_instructions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.response_instructions_id_seq OWNED BY public.response_instructions.id;
+
+
+--
+-- Name: response_previous_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.response_previous_feedbacks (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: response_previous_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.response_previous_feedbacks_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: response_previous_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.response_previous_feedbacks_id_seq OWNED BY public.response_previous_feedbacks.id;
+
+
+--
+-- Name: response_prompts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.response_prompts (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: response_prompts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.response_prompts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: response_prompts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.response_prompts_id_seq OWNED BY public.response_prompts.id;
+
+
+--
+-- Name: response_question_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.response_question_types (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: response_question_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.response_question_types_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: response_question_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.response_question_types_id_seq OWNED BY public.response_question_types.id;
+
+
+--
+-- Name: responses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.responses (
+    id bigint NOT NULL,
+    activity_session_id integer NOT NULL,
+    answer jsonb,
+    attempt_number integer,
+    concept_id integer,
+    concept_result_id integer,
+    correct boolean NOT NULL,
+    extra_metadata jsonb,
+    question_number integer,
+    question_score double precision,
+    response_directions_id integer,
+    response_instructions_id integer,
+    response_previous_feedback_id integer,
+    response_prompt_id integer,
+    response_question_type_id integer,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.responses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.responses_id_seq OWNED BY public.responses.id;
+
+
+--
 -- Name: sales_contacts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3062,6 +3257,49 @@ CREATE SEQUENCE public.sales_contacts_id_seq
 --
 
 ALTER SEQUENCE public.sales_contacts_id_seq OWNED BY public.sales_contacts.id;
+
+
+--
+-- Name: sales_form_submissions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sales_form_submissions (
+    id bigint NOT NULL,
+    first_name character varying NOT NULL,
+    last_name character varying NOT NULL,
+    email character varying NOT NULL,
+    phone_number character varying NOT NULL,
+    zipcode character varying NOT NULL,
+    collection_type character varying NOT NULL,
+    school_name character varying,
+    district_name character varying,
+    school_premium_count_estimate integer DEFAULT 0 NOT NULL,
+    teacher_premium_count_estimate integer DEFAULT 0 NOT NULL,
+    student_premium_count_estimate integer DEFAULT 0 NOT NULL,
+    submission_type character varying NOT NULL,
+    comment text DEFAULT ''::text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sales_form_submissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sales_form_submissions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sales_form_submissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sales_form_submissions_id_seq OWNED BY public.sales_form_submissions.id;
 
 
 --
@@ -3183,8 +3421,6 @@ ALTER SEQUENCE public.school_subscriptions_id_seq OWNED BY public.school_subscri
 CREATE TABLE public.schools (
     id integer NOT NULL,
     nces_id character varying,
-    lea_id character varying,
-    leanm character varying,
     name character varying,
     phone character varying,
     mail_street character varying,
@@ -3279,7 +3515,7 @@ ALTER SEQUENCE public.schools_id_seq OWNED BY public.schools.id;
 CREATE TABLE public.schools_users (
     school_id integer,
     user_id integer,
-    id bigint NOT NULL
+    id integer NOT NULL
 );
 
 
@@ -3288,6 +3524,7 @@ CREATE TABLE public.schools_users (
 --
 
 CREATE SEQUENCE public.schools_users_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3533,6 +3770,75 @@ ALTER SEQUENCE public.standards_id_seq OWNED BY public.standards.id;
 
 
 --
+-- Name: stripe_checkout_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.stripe_checkout_sessions (
+    id bigint NOT NULL,
+    external_checkout_session_id character varying NOT NULL,
+    stripe_price_id character varying NOT NULL,
+    url character varying NOT NULL,
+    user_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    school_ids integer[] DEFAULT '{}'::integer[]
+);
+
+
+--
+-- Name: stripe_checkout_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.stripe_checkout_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: stripe_checkout_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.stripe_checkout_sessions_id_seq OWNED BY public.stripe_checkout_sessions.id;
+
+
+--
+-- Name: stripe_webhook_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.stripe_webhook_events (
+    id bigint NOT NULL,
+    event_type character varying NOT NULL,
+    status character varying DEFAULT 'pending'::character varying,
+    external_id character varying NOT NULL,
+    processing_errors character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: stripe_webhook_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.stripe_webhook_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: stripe_webhook_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.stripe_webhook_events_id_seq OWNED BY public.stripe_webhook_events.id;
+
+
+--
 -- Name: student_feedback_responses; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3634,40 +3940,6 @@ ALTER SEQUENCE public.students_classrooms_id_seq OWNED BY public.students_classr
 
 
 --
--- Name: subscription_types; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.subscription_types (
-    id integer NOT NULL,
-    name character varying NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    price integer,
-    teacher_alias character varying
-);
-
-
---
--- Name: subscription_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.subscription_types_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: subscription_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.subscription_types_id_seq OWNED BY public.subscription_types.id;
-
-
---
 -- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3679,12 +3951,13 @@ CREATE TABLE public.subscriptions (
     account_type character varying,
     purchaser_email character varying,
     start_date date,
-    subscription_type_id integer,
+    plan_id integer,
     purchaser_id integer,
     recurring boolean DEFAULT false,
     de_activated_date date,
     payment_method character varying,
-    payment_amount integer
+    payment_amount integer,
+    stripe_invoice_id character varying
 );
 
 
@@ -4465,10 +4738,10 @@ ALTER TABLE ONLY public.concept_feedbacks ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
--- Name: concept_results id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: concept_results_old id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concept_results ALTER COLUMN id SET DEFAULT nextval('public.concept_results_id_seq'::regclass);
+ALTER TABLE ONLY public.concept_results_old ALTER COLUMN id SET DEFAULT nextval('public.concept_results_old_id_seq'::regclass);
 
 
 --
@@ -4528,17 +4801,17 @@ ALTER TABLE ONLY public.district_admins ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: district_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.district_subscriptions ALTER COLUMN id SET DEFAULT nextval('public.district_subscriptions_id_seq'::regclass);
+
+
+--
 -- Name: districts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.districts ALTER COLUMN id SET DEFAULT nextval('public.districts_id_seq'::regclass);
-
-
---
--- Name: districts_tables id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.districts_tables ALTER COLUMN id SET DEFAULT nextval('public.districts_tables_id_seq'::regclass);
 
 
 --
@@ -4724,10 +4997,59 @@ ALTER TABLE ONLY public.referrer_users ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: response_directions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_directions ALTER COLUMN id SET DEFAULT nextval('public.response_directions_id_seq'::regclass);
+
+
+--
+-- Name: response_instructions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_instructions ALTER COLUMN id SET DEFAULT nextval('public.response_instructions_id_seq'::regclass);
+
+
+--
+-- Name: response_previous_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_previous_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.response_previous_feedbacks_id_seq'::regclass);
+
+
+--
+-- Name: response_prompts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_prompts ALTER COLUMN id SET DEFAULT nextval('public.response_prompts_id_seq'::regclass);
+
+
+--
+-- Name: response_question_types id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_question_types ALTER COLUMN id SET DEFAULT nextval('public.response_question_types_id_seq'::regclass);
+
+
+--
+-- Name: responses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.responses ALTER COLUMN id SET DEFAULT nextval('public.responses_id_seq'::regclass);
+
+
+--
 -- Name: sales_contacts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.sales_contacts ALTER COLUMN id SET DEFAULT nextval('public.sales_contacts_id_seq'::regclass);
+
+
+--
+-- Name: sales_form_submissions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sales_form_submissions ALTER COLUMN id SET DEFAULT nextval('public.sales_form_submissions_id_seq'::regclass);
 
 
 --
@@ -4822,6 +5144,20 @@ ALTER TABLE ONLY public.standards ALTER COLUMN id SET DEFAULT nextval('public.st
 
 
 --
+-- Name: stripe_checkout_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_checkout_sessions ALTER COLUMN id SET DEFAULT nextval('public.stripe_checkout_sessions_id_seq'::regclass);
+
+
+--
+-- Name: stripe_webhook_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_webhook_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_webhook_events_id_seq'::regclass);
+
+
+--
 -- Name: student_feedback_responses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4840,13 +5176,6 @@ ALTER TABLE ONLY public.student_problem_reports ALTER COLUMN id SET DEFAULT next
 --
 
 ALTER TABLE ONLY public.students_classrooms ALTER COLUMN id SET DEFAULT nextval('public.students_classrooms_id_seq'::regclass);
-
-
---
--- Name: subscription_types id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.subscription_types ALTER COLUMN id SET DEFAULT nextval('public.subscription_types_id_seq'::regclass);
 
 
 --
@@ -5284,11 +5613,11 @@ ALTER TABLE ONLY public.concept_feedbacks
 
 
 --
--- Name: concept_results concept_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: concept_results_old concept_results_old_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concept_results
-    ADD CONSTRAINT concept_results_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.concept_results_old
+    ADD CONSTRAINT concept_results_old_pkey PRIMARY KEY (id);
 
 
 --
@@ -5356,19 +5685,19 @@ ALTER TABLE ONLY public.district_admins
 
 
 --
+-- Name: district_subscriptions district_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.district_subscriptions
+    ADD CONSTRAINT district_subscriptions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: districts districts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.districts
     ADD CONSTRAINT districts_pkey PRIMARY KEY (id);
-
-
---
--- Name: districts_tables districts_tables_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.districts_tables
-    ADD CONSTRAINT districts_tables_pkey PRIMARY KEY (id);
 
 
 --
@@ -5580,11 +5909,67 @@ ALTER TABLE ONLY public.referrer_users
 
 
 --
+-- Name: response_directions response_directions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_directions
+    ADD CONSTRAINT response_directions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: response_instructions response_instructions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_instructions
+    ADD CONSTRAINT response_instructions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: response_previous_feedbacks response_previous_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_previous_feedbacks
+    ADD CONSTRAINT response_previous_feedbacks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: response_prompts response_prompts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_prompts
+    ADD CONSTRAINT response_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: response_question_types response_question_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.response_question_types
+    ADD CONSTRAINT response_question_types_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: responses responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.responses
+    ADD CONSTRAINT responses_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: sales_contacts sales_contacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.sales_contacts
     ADD CONSTRAINT sales_contacts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sales_form_submissions sales_form_submissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sales_form_submissions
+    ADD CONSTRAINT sales_form_submissions_pkey PRIMARY KEY (id);
 
 
 --
@@ -5601,14 +5986,6 @@ ALTER TABLE ONLY public.sales_stage_types
 
 ALTER TABLE ONLY public.sales_stages
     ADD CONSTRAINT sales_stages_pkey PRIMARY KEY (id);
-
-
---
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
@@ -5700,6 +6077,22 @@ ALTER TABLE ONLY public.standards
 
 
 --
+-- Name: stripe_checkout_sessions stripe_checkout_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_checkout_sessions
+    ADD CONSTRAINT stripe_checkout_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: stripe_webhook_events stripe_webhook_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_webhook_events
+    ADD CONSTRAINT stripe_webhook_events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: student_feedback_responses student_feedback_responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5721,14 +6114,6 @@ ALTER TABLE ONLY public.student_problem_reports
 
 ALTER TABLE ONLY public.students_classrooms
     ADD CONSTRAINT students_classrooms_pkey PRIMARY KEY (id);
-
-
---
--- Name: subscription_types subscription_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.subscription_types
-    ADD CONSTRAINT subscription_types_pkey PRIMARY KEY (id);
 
 
 --
@@ -6362,17 +6747,17 @@ CREATE UNIQUE INDEX index_concept_feedbacks_on_uid_and_activity_type ON public.c
 
 
 --
--- Name: index_concept_results_on_activity_session_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_concept_results_old_on_activity_session_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_concept_results_on_activity_session_id ON public.concept_results USING btree (activity_session_id);
+CREATE INDEX index_concept_results_old_on_activity_session_id ON public.concept_results_old USING btree (activity_session_id);
 
 
 --
--- Name: index_concept_results_on_concept_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_concept_results_old_on_concept_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_concept_results_on_concept_id ON public.concept_results USING btree (concept_id);
+CREATE INDEX index_concept_results_old_on_concept_id ON public.concept_results_old USING btree (concept_id);
 
 
 --
@@ -6443,6 +6828,27 @@ CREATE INDEX index_district_admins_on_district_id ON public.district_admins USIN
 --
 
 CREATE INDEX index_district_admins_on_user_id ON public.district_admins USING btree (user_id);
+
+
+--
+-- Name: index_district_subscriptions_on_district_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_district_subscriptions_on_district_id ON public.district_subscriptions USING btree (district_id);
+
+
+--
+-- Name: index_district_subscriptions_on_subscription_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_district_subscriptions_on_subscription_id ON public.district_subscriptions USING btree (subscription_id);
+
+
+--
+-- Name: index_districts_on_nces_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_districts_on_nces_id ON public.districts USING btree (nces_id);
 
 
 --
@@ -6684,6 +7090,48 @@ CREATE UNIQUE INDEX index_referrer_users_on_user_id ON public.referrer_users USI
 
 
 --
+-- Name: index_response_directions_on_text; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_response_directions_on_text ON public.response_directions USING btree (text);
+
+
+--
+-- Name: index_response_instructions_on_text; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_response_instructions_on_text ON public.response_instructions USING btree (text);
+
+
+--
+-- Name: index_response_previous_feedbacks_on_text; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_response_previous_feedbacks_on_text ON public.response_previous_feedbacks USING btree (text);
+
+
+--
+-- Name: index_response_prompts_on_text; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_response_prompts_on_text ON public.response_prompts USING btree (text);
+
+
+--
+-- Name: index_response_question_types_on_text; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_response_question_types_on_text ON public.response_question_types USING btree (text);
+
+
+--
+-- Name: index_responses_on_concept_result_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_responses_on_concept_result_id ON public.responses USING btree (concept_result_id);
+
+
+--
 -- Name: index_sales_contacts_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6852,6 +7300,27 @@ CREATE INDEX index_skills_on_skill_group_id ON public.skills USING btree (skill_
 
 
 --
+-- Name: index_stripe_checkout_sessions_on_external_checkout_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_stripe_checkout_sessions_on_external_checkout_session_id ON public.stripe_checkout_sessions USING btree (external_checkout_session_id);
+
+
+--
+-- Name: index_stripe_checkout_sessions_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_stripe_checkout_sessions_on_user_id ON public.stripe_checkout_sessions USING btree (user_id);
+
+
+--
+-- Name: index_stripe_webhook_events_on_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_stripe_webhook_events_on_external_id ON public.stripe_webhook_events USING btree (external_id);
+
+
+--
 -- Name: index_student_problem_reports_on_feedback_history_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6877,13 +7346,6 @@ CREATE INDEX index_students_classrooms_on_student_id ON public.students_classroo
 --
 
 CREATE UNIQUE INDEX index_students_classrooms_on_student_id_and_classroom_id ON public.students_classrooms USING btree (student_id, classroom_id);
-
-
---
--- Name: index_subscription_types_on_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_subscription_types_on_name ON public.subscription_types USING btree (name);
 
 
 --
@@ -6919,6 +7381,13 @@ CREATE INDEX index_subscriptions_on_recurring ON public.subscriptions USING btre
 --
 
 CREATE INDEX index_subscriptions_on_start_date ON public.subscriptions USING btree (start_date);
+
+
+--
+-- Name: index_subscriptions_on_stripe_invoice_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_subscriptions_on_stripe_invoice_id ON public.subscriptions USING btree (stripe_invoice_id);
 
 
 --
@@ -7216,10 +7685,17 @@ CREATE UNIQUE INDEX unique_index_users_on_username ON public.users USING btree (
 
 
 --
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
+
+
+--
 -- Name: user_activity_classification_unique_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX user_activity_classification_unique_index ON public.user_activity_classifications USING btree (user_id, activity_classification_id);
+CREATE INDEX user_activity_classification_unique_index ON public.user_activity_classifications USING btree (user_id, activity_classification_id);
 
 
 --
@@ -7294,6 +7770,14 @@ ALTER TABLE ONLY public.skills
 
 
 --
+-- Name: district_subscriptions fk_rails_0494854b11; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.district_subscriptions
+    ADD CONSTRAINT fk_rails_0494854b11 FOREIGN KEY (district_id) REFERENCES public.districts(id);
+
+
+--
 -- Name: teacher_saved_activities fk_rails_08453fa16b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7342,6 +7826,14 @@ ALTER TABLE ONLY public.comprehension_automl_models
 
 
 --
+-- Name: district_subscriptions fk_rails_38a73665c2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.district_subscriptions
+    ADD CONSTRAINT fk_rails_38a73665c2 FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
 -- Name: classroom_units fk_rails_3e1ff09783; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7363,6 +7855,14 @@ ALTER TABLE ONLY public.user_activity_classifications
 
 ALTER TABLE ONLY public.sales_stages
     ADD CONSTRAINT fk_rails_41082adef9 FOREIGN KEY (sales_contact_id) REFERENCES public.sales_contacts(id);
+
+
+--
+-- Name: stripe_checkout_sessions fk_rails_428a7d5f1b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.stripe_checkout_sessions
+    ADD CONSTRAINT fk_rails_428a7d5f1b FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -7550,10 +8050,10 @@ ALTER TABLE ONLY public.standards
 
 
 --
--- Name: concept_results fk_rails_cebe4a6023; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: concept_results_old fk_rails_cebe4a6023; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concept_results
+ALTER TABLE ONLY public.concept_results_old
     ADD CONSTRAINT fk_rails_cebe4a6023 FOREIGN KEY (activity_classification_id) REFERENCES public.activity_classifications(id);
 
 
@@ -8093,17 +8593,36 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211019143514'),
 ('20211026160939'),
 ('20211108171529'),
+('20211202235402'),
 ('20220105145446'),
 ('20220106193721'),
 ('20220128175405'),
 ('20220201132114'),
 ('20220201161514'),
 ('20220315131616'),
-('20220315172237'),
 ('20220317153356'),
+('20220321170433'),
 ('20220321215816'),
+('20220322164718'),
+('20220323145502'),
+('20220323145803'),
 ('20220328165932'),
 ('20220328170304'),
-('20220404180807');
+('20220404180807'),
+('20220418234207'),
+('20220428171629'),
+('20220503133521'),
+('20220503155835'),
+('20220505154724'),
+('20220505154951'),
+('20220505155013'),
+('20220505155014'),
+('20220505155015'),
+('20220505155016'),
+('20220607120432'),
+('20220608144739'),
+('20220609173524'),
+('20220614152118'),
+('20220628174900');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1722,40 +1722,6 @@ ALTER SEQUENCE public.concept_feedbacks_id_seq OWNED BY public.concept_feedbacks
 
 
 --
--- Name: concept_results_old; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.concept_results_old (
-    id integer NOT NULL,
-    activity_session_id integer,
-    concept_id integer NOT NULL,
-    metadata json,
-    activity_classification_id integer,
-    question_type character varying
-);
-
-
---
--- Name: concept_results_old_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.concept_results_old_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: concept_results_old_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.concept_results_old_id_seq OWNED BY public.concept_results_old.id;
-
-
---
 -- Name: concepts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2681,6 +2647,40 @@ CREATE SEQUENCE public.objectives_id_seq
 --
 
 ALTER SEQUENCE public.objectives_id_seq OWNED BY public.objectives.id;
+
+
+--
+-- Name: old_concept_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.old_concept_results (
+    id integer NOT NULL,
+    activity_session_id integer,
+    concept_id integer NOT NULL,
+    metadata json,
+    activity_classification_id integer,
+    question_type character varying
+);
+
+
+--
+-- Name: old_concept_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.old_concept_results_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: old_concept_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.old_concept_results_id_seq OWNED BY public.old_concept_results.id;
 
 
 --
@@ -4738,13 +4738,6 @@ ALTER TABLE ONLY public.concept_feedbacks ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
--- Name: concept_results_old id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.concept_results_old ALTER COLUMN id SET DEFAULT nextval('public.concept_results_old_id_seq'::regclass);
-
-
---
 -- Name: concepts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4924,6 +4917,13 @@ ALTER TABLE ONLY public.oauth_applications ALTER COLUMN id SET DEFAULT nextval('
 --
 
 ALTER TABLE ONLY public.objectives ALTER COLUMN id SET DEFAULT nextval('public.objectives_id_seq'::regclass);
+
+
+--
+-- Name: old_concept_results id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.old_concept_results ALTER COLUMN id SET DEFAULT nextval('public.old_concept_results_id_seq'::regclass);
 
 
 --
@@ -5613,14 +5613,6 @@ ALTER TABLE ONLY public.concept_feedbacks
 
 
 --
--- Name: concept_results_old concept_results_old_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.concept_results_old
-    ADD CONSTRAINT concept_results_old_pkey PRIMARY KEY (id);
-
-
---
 -- Name: concepts concepts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5826,6 +5818,14 @@ ALTER TABLE ONLY public.oauth_applications
 
 ALTER TABLE ONLY public.objectives
     ADD CONSTRAINT objectives_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: old_concept_results old_concept_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.old_concept_results
+    ADD CONSTRAINT old_concept_results_pkey PRIMARY KEY (id);
 
 
 --
@@ -6747,20 +6747,6 @@ CREATE UNIQUE INDEX index_concept_feedbacks_on_uid_and_activity_type ON public.c
 
 
 --
--- Name: index_concept_results_old_on_activity_session_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_concept_results_old_on_activity_session_id ON public.concept_results_old USING btree (activity_session_id);
-
-
---
--- Name: index_concept_results_old_on_concept_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_concept_results_old_on_concept_id ON public.concept_results_old USING btree (concept_id);
-
-
---
 -- Name: index_content_partner_activities_on_activity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6996,6 +6982,20 @@ CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON public.oauth_access_to
 --
 
 CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications USING btree (uid);
+
+
+--
+-- Name: index_old_concept_results_on_activity_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_old_concept_results_on_activity_session_id ON public.old_concept_results USING btree (activity_session_id);
+
+
+--
+-- Name: index_old_concept_results_on_concept_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_old_concept_results_on_concept_id ON public.old_concept_results USING btree (concept_id);
 
 
 --
@@ -8050,10 +8050,10 @@ ALTER TABLE ONLY public.standards
 
 
 --
--- Name: concept_results_old fk_rails_cebe4a6023; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: old_concept_results fk_rails_cebe4a6023; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.concept_results_old
+ALTER TABLE ONLY public.old_concept_results
     ADD CONSTRAINT fk_rails_cebe4a6023 FOREIGN KEY (activity_classification_id) REFERENCES public.activity_classifications(id);
 
 

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -217,15 +217,15 @@ describe Api::V1::ActivitiesController, type: :controller do
     let!(:activity_session2) { create(:activity_session, activity: activity) }
     let!(:activity_session3) { create(:activity_session, activity: activity) }
     let!(:concept_result1) do
-      create(:concept_result, activity_session: activity_session1, metadata: {questionNumber: 1, questionScore: 1})
+      create(:old_concept_result, activity_session: activity_session1, metadata: {questionNumber: 1, questionScore: 1})
     end
 
     let!(:concept_result2) do
-      create(:concept_result, activity_session: activity_session2, metadata: {questionNumber: 1, questionScore: 0.75})
+      create(:old_concept_result, activity_session: activity_session2, metadata: {questionNumber: 1, questionScore: 0.75})
     end
 
     let!(:concept_result3) do
-      create(:concept_result, activity_session: activity_session3, metadata: {questionNumber: 1, questionScore: 0})
+      create(:old_concept_result, activity_session: activity_session3, metadata: {questionNumber: 1, questionScore: 0})
     end
 
     before do

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -44,7 +44,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       let(:writing_concept) { create(:concept, name: 'Creative Writing') }
 
       let(:concept_result1) do
-        create(:concept_result,
+        create(:old_concept_result,
           activity_session_id: activity_session.id,
           concept: writing_concept,
           metadata: { foo: 'bar' }
@@ -52,14 +52,14 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       end
 
       let(:concept_result2) do
-        create(:concept_result,
+        create(:old_concept_result,
           activity_session_id: activity_session.id,
           metadata: { baz: 'foo' }
         )
       end
 
       let(:concept_result3) do
-        create(:concept_result,
+        create(:old_concept_result,
           activity_session_id: activity_session.id
         )
       end
@@ -82,16 +82,16 @@ describe Api::V1::ActivitySessionsController, type: :controller do
 
       it 'stores the concept results' do
         activity_session.reload
-        expect(activity_session.concept_results.size).to eq 7
+        expect(activity_session.old_concept_results.size).to eq 7
       end
 
       it 'saves the arbitrary metadata for the results' do
         activity_session.reload
-        expect(activity_session.concept_results.find{|x| x.metadata == {"foo"=>"bar"}}).to be
+        expect(activity_session.old_concept_results.find{|x| x.metadata == {"foo"=>"bar"}}).to be
       end
 
       it 'saves the concept tag relationship (ID) in the result' do
-        expect(ConceptResultOld.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
+        expect(OldConceptResult.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
       end
     end
 
@@ -110,9 +110,9 @@ describe Api::V1::ActivitySessionsController, type: :controller do
 
       # this is no longer the case, as results should not be saved with nonexistent concept tag
       it 'does not save the concept result' do
-        activity_session.concept_results.destroy_all
+        activity_session.old_concept_results.destroy_all
         response = subject
-        expect(activity_session.concept_results).to eq([])
+        expect(activity_session.old_concept_results).to eq([])
       end
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -91,7 +91,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       end
 
       it 'saves the concept tag relationship (ID) in the result' do
-        expect(ConceptResult.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
+        expect(ConceptResultOld.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
       end
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -92,7 +92,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
 
     it 'authenticates a teacher who does own the classroom activity' do
       session[:user_id] = teacher.id
-      concept_result = create(:concept_result)
+      concept_result = create(:old_concept_result)
 
       put :finish_lesson,
         params: {

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -9,8 +9,8 @@ describe DiagnosticReports do
     let!(:activity_session) { create(:activity_session) }
     let!(:concept) { create(:concept) }
     let!(:skill_concept) { create(:skill_concept, concept: concept) }
-    let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-    let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+    let!(:correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
+    let!(:incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
     it 'should return data with the name of the skill, number of correct concept results, number of incorrect concept results, and a summary' do
       expect(data_for_skill_by_activity_session(activity_session.concept_results, skill_concept.skill)).to eq({

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -13,7 +13,7 @@ describe DiagnosticReports do
     let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
     it 'should return data with the name of the skill, number of correct concept results, number of incorrect concept results, and a summary' do
-      expect(data_for_skill_by_activity_session(activity_session.concept_results, skill_concept.skill)).to eq({
+      expect(data_for_skill_by_activity_session(activity_session.old_concept_results, skill_concept.skill)).to eq({
         id: skill_concept.skill.id,
         skill: skill_concept.skill.name,
         number_correct: 1,

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -9,8 +9,8 @@ describe DiagnosticReports do
     let!(:activity_session) { create(:activity_session) }
     let!(:concept) { create(:concept) }
     let!(:skill_concept) { create(:skill_concept, concept: concept) }
-    let!(:correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-    let!(:incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+    let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
+    let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
     it 'should return data with the name of the skill, number of correct concept results, number of incorrect concept results, and a summary' do
       expect(data_for_skill_by_activity_session(activity_session.concept_results, skill_concept.skill)).to eq({

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -24,9 +24,9 @@ describe GrowthResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-  let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-  let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+  let!(:pre_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
+  let!(:post_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
+  let!(:pre_test_incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
 
   describe '#growth_results_summary' do
     it 'should return data with the student results and skill group summaries' do

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -24,9 +24,9 @@ describe GrowthResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:pre_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-  let!(:post_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-  let!(:pre_test_incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+  let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
+  let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
+  let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
 
   describe '#growth_results_summary' do
     it 'should return data with the student results and skill group summaries' do

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -18,8 +18,8 @@ describe ResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-  let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+  let!(:correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
+  let!(:incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
   describe '#results_summary' do
     it 'should return data with the student results and skill group summaries' do

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -18,8 +18,8 @@ describe ResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-  let!(:incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+  let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
+  let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
 
   describe '#results_summary' do
     it 'should return data with the student results and skill group summaries' do

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
@@ -18,13 +18,13 @@ describe Teachers::ProgressReports::Concepts::StudentsController, type: :control
       before { session[:user_id] = teacher.id }
 
       it 'includes a list of students in the JSON' do
-        crs = alice.activity_sessions.map(&:concept_results).flatten.map(&:metadata)
+        crs = alice.activity_sessions.map(&:old_concept_results).flatten.map(&:metadata)
         crs_correct = 0
         crs.each{|cr| crs_correct += cr["correct"]}
         subject
         alice_json = json['students'][0]
         expect(alice_json['name']).to eq(alice.name)
-        expect(alice_json['total_result_count'].to_i).to eq(alice_session.concept_results.size)
+        expect(alice_json['total_result_count'].to_i).to eq(alice_session.old_concept_results.size)
         expect(alice_json['correct_result_count'].to_i).to eq(crs_correct)
         expect(alice_json['incorrect_result_count'].to_i).to eq(crs.length - crs_correct)
       end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -315,9 +315,9 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:concept) { create(:concept) }
     let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
     let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-    let!(:pre_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-    let!(:post_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-    let!(:pre_test_incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+    let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
+    let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
+    let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
 
     it 'should return the total number of acquired skills' do
       get :skills_growth, params: ({classroom_id: classroom.id, post_test_activity_id: post_test_unit_activity.activity_id, pre_test_activity_id: pre_test_unit_activity.activity_id})

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -315,9 +315,9 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:concept) { create(:concept) }
     let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
     let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-    let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-    let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-    let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+    let!(:pre_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
+    let!(:post_test_correct_concept_result) { create(:old_concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
+    let!(:pre_test_incorrect_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
 
     it 'should return the total number of acquired skills' do
       get :skills_growth, params: ({classroom_id: classroom.id, post_test_activity_id: post_test_unit_activity.activity_id, pre_test_activity_id: pre_test_unit_activity.activity_id})

--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
       classroom_unit = activity_session.classroom_unit
       UnitActivity.find_or_create_by(activity: activity_session.activity, unit_id: classroom_unit.unit_id)
       StudentsClassrooms.find_or_create_by(student_id: activity_session.user_id, classroom_id: classroom_unit.classroom_id )
-      create(:concept_result, activity_session: activity_session)
+      create(:old_concept_result, activity_session: activity_session)
     end
 
     trait :retry do
@@ -126,7 +126,7 @@ FactoryBot.define do
 
     factory :activity_session_without_concept_results do
       after(:create) do |activity_session|
-        ConceptResultOld.where(activity_session: activity_session).destroy_all
+        OldConceptResult.where(activity_session: activity_session).destroy_all
       end
     end
   end

--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -126,7 +126,7 @@ FactoryBot.define do
 
     factory :activity_session_without_concept_results do
       after(:create) do |activity_session|
-        ConceptResult.where(activity_session: activity_session).destroy_all
+        ConceptResultOld.where(activity_session: activity_session).destroy_all
       end
     end
   end

--- a/services/QuillLMS/spec/factories/announcements.rb
+++ b/services/QuillLMS/spec/factories/announcements.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id                :integer          not null, primary key
+#  announcement_type :string
+#  end               :datetime
+#  link              :text
+#  start             :datetime
+#  text              :text
+#
+# Indexes
+#
+#  index_announcements_on_start_and_end  (start,end DESC)
+#
 FactoryBot.define do
   factory :announcement do
     announcement_type   Announcement::TYPES[:webinar]

--- a/services/QuillLMS/spec/factories/concept_result_old.rb
+++ b/services/QuillLMS/spec/factories/concept_result_old.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :concept_result do
+  factory :concept_result_old do
     concept
     activity_session
     metadata { { "answer": 'Arbitrary sample correct answer.', "correct": 1 } }

--- a/services/QuillLMS/spec/factories/old_concept_result.rb
+++ b/services/QuillLMS/spec/factories/old_concept_result.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :concept_result_old do
+  factory :old_concept_result do
     concept
     activity_session
     metadata { { "answer": 'Arbitrary sample correct answer.', "correct": 1 } }

--- a/services/QuillLMS/spec/factories/school_subscriptions.rb
+++ b/services/QuillLMS/spec/factories/school_subscriptions.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: school_subscriptions
+#
+#  id              :integer          not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  school_id       :integer
+#  subscription_id :integer
+#
+# Indexes
+#
+#  index_school_subscriptions_on_school_id        (school_id)
+#  index_school_subscriptions_on_subscription_id  (subscription_id)
+#
 FactoryBot.define do
   factory :school_subscription do
     school

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -30,7 +30,7 @@
 #
 # Indexes
 #
-#  email_idx                          (email gin_trgm_ops) USING gin
+#  email_idx                          (email) USING gin
 #  index_users_on_active              (active)
 #  index_users_on_classcode           (classcode)
 #  index_users_on_clever_id           (clever_id)
@@ -41,12 +41,12 @@
 #  index_users_on_time_zone           (time_zone)
 #  index_users_on_token               (token)
 #  index_users_on_username            (username)
-#  name_idx                           (name gin_trgm_ops) USING gin
+#  name_idx                           (name) USING gin
 #  unique_index_users_on_clever_id    (clever_id) UNIQUE WHERE ((clever_id IS NOT NULL) AND ((clever_id)::text <> ''::text) AND ((id > 5593155) OR ((role)::text = 'student'::text)))
 #  unique_index_users_on_email        (email) UNIQUE WHERE ((id > 1641954) AND (email IS NOT NULL) AND ((email)::text <> ''::text))
 #  unique_index_users_on_google_id    (google_id) UNIQUE WHERE ((id > 1641954) AND (google_id IS NOT NULL) AND ((google_id)::text <> ''::text))
 #  unique_index_users_on_username     (username) UNIQUE WHERE ((id > 1641954) AND (username IS NOT NULL) AND ((username)::text <> ''::text))
-#  username_idx                       (username gin_trgm_ops) USING gin
+#  username_idx                       (username) USING gin
 #  users_to_tsvector_idx              (to_tsvector('english'::regconfig, (name)::text)) USING gin
 #  users_to_tsvector_idx1             (to_tsvector('english'::regconfig, (email)::text)) USING gin
 #  users_to_tsvector_idx2             (to_tsvector('english'::regconfig, (role)::text)) USING gin

--- a/services/QuillLMS/spec/helpers/concept_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/concept_helper_spec.rb
@@ -9,13 +9,13 @@ describe ConceptHelper, type: :helper do
 
   describe "#all_concept_stats" do
     before do
-      activity_session.concept_results.create!(
+      activity_session.old_concept_results.create!(
         concept: punctuation_concept,
         metadata: {
           correct: 0
         }
       )
-      activity_session.concept_results.create!(
+      activity_session.old_concept_results.create!(
         concept: prepositions_concept,
         metadata: {
           correct: 1

--- a/services/QuillLMS/spec/models/activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/activity_classification_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 
 describe ActivityClassification, type: :model, redis: true do
   it { should have_many(:activities) }
-  it { should have_many(:concept_results) }
+  it { should have_many(:old_concept_results) }
   it { should have_many(:user_activity_classifications).dependent(:destroy) }
 
   it_behaves_like "uid"

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -49,7 +49,7 @@ describe ActivitySession, type: :model, redis: true do
   it { should have_many(:feedback_histories).through(:feedback_sessions) }
   it { should have_one(:classroom).through(:classroom_unit) }
   it { should have_one(:unit).through(:classroom_unit) }
-  it { should have_many(:concepts).through(:concept_results) }
+  it { should have_many(:concepts).through(:old_concept_results) }
   it { should have_many(:teachers).through(:classroom) }
   it { should belong_to(:user) }
 
@@ -505,15 +505,15 @@ end
   describe '#parse_for_results' do
     let!(:activity_session) { create(:activity_session) }
     let!(:proficient_concept) { create(:concept)}
-    let!(:proficient_concept_result) { create(:old_concept_result_with_correct_answer, concept: proficient_concept, activity_session: activity_session)}
+    let!(:proficient_concept_result) { create(:concept_result_with_correct_answer, concept: proficient_concept, activity_session: activity_session)}
     let!(:nearly_proficient_concept) { create(:concept)}
-    let!(:nearly_proficient_concept_result_positive1) { create(:old_concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_positive2) { create(:old_concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_negative) { create(:old_concept_result_with_incorrect_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_positive1) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_positive2) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_negative) { create(:concept_result_with_incorrect_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
     let!(:not_yet_proficient_concept) { create(:concept)}
-    let!(:not_yet_proficient_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: not_yet_proficient_concept, activity_session: activity_session)}
+    let!(:not_yet_proficient_concept_result) { create(:concept_result_with_incorrect_answer, concept: not_yet_proficient_concept, activity_session: activity_session)}
     let!(:ignored_concept) { create(:concept, uid: ActivitySession::CONCEPT_UIDS_TO_EXCLUDE_FROM_REPORT[0])}
-    let!(:ignored_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: ignored_concept, activity_session: activity_session)}
+    let!(:ignored_concept_result) { create(:concept_result_with_incorrect_answer, concept: ignored_concept, activity_session: activity_session)}
 
     it 'should return an object with concept results organized by category' do
       expect(activity_session.parse_for_results[ActivitySession::PROFICIENT]).to be_present
@@ -542,7 +542,7 @@ end
     it 'should return the ignored concept result if there are at least four concept results for it' do
       3.times do |i|
         ignored_concept_result.id = nil
-        ConceptResultOld.create(ignored_concept_result.attributes)
+        OldConceptResult.create(ignored_concept_result.attributes)
       end
       expect(activity_session.parse_for_results[ActivitySession::NOT_YET_PROFICIENT]).to include(ignored_concept.name)
     end
@@ -828,7 +828,7 @@ end
     before { activity_session.update_attributes(visible: true) }
 
     it 'should create a concept result with the hash given' do
-      expect(ConceptResultOld).to receive(:create).with({
+      expect(OldConceptResult).to receive(:create).with({
         activity_session_id: activity_session.id,
         concept_id: concept.id,
         metadata: metadata,

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -505,15 +505,15 @@ end
   describe '#parse_for_results' do
     let!(:activity_session) { create(:activity_session) }
     let!(:proficient_concept) { create(:concept)}
-    let!(:proficient_concept_result) { create(:concept_result_with_correct_answer, concept: proficient_concept, activity_session: activity_session)}
+    let!(:proficient_concept_result) { create(:old_concept_result_with_correct_answer, concept: proficient_concept, activity_session: activity_session)}
     let!(:nearly_proficient_concept) { create(:concept)}
-    let!(:nearly_proficient_concept_result_positive1) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_positive2) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_negative) { create(:concept_result_with_incorrect_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_positive1) { create(:old_concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_positive2) { create(:old_concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_negative) { create(:old_concept_result_with_incorrect_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
     let!(:not_yet_proficient_concept) { create(:concept)}
-    let!(:not_yet_proficient_concept_result) { create(:concept_result_with_incorrect_answer, concept: not_yet_proficient_concept, activity_session: activity_session)}
+    let!(:not_yet_proficient_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: not_yet_proficient_concept, activity_session: activity_session)}
     let!(:ignored_concept) { create(:concept, uid: ActivitySession::CONCEPT_UIDS_TO_EXCLUDE_FROM_REPORT[0])}
-    let!(:ignored_concept_result) { create(:concept_result_with_incorrect_answer, concept: ignored_concept, activity_session: activity_session)}
+    let!(:ignored_concept_result) { create(:old_concept_result_with_incorrect_answer, concept: ignored_concept, activity_session: activity_session)}
 
     it 'should return an object with concept results organized by category' do
       expect(activity_session.parse_for_results[ActivitySession::PROFICIENT]).to be_present

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -542,7 +542,7 @@ end
     it 'should return the ignored concept result if there are at least four concept results for it' do
       3.times do |i|
         ignored_concept_result.id = nil
-        ConceptResult.create(ignored_concept_result.attributes)
+        ConceptResultOld.create(ignored_concept_result.attributes)
       end
       expect(activity_session.parse_for_results[ActivitySession::NOT_YET_PROFICIENT]).to include(ignored_concept.name)
     end
@@ -828,7 +828,7 @@ end
     before { activity_session.update_attributes(visible: true) }
 
     it 'should create a concept result with the hash given' do
-      expect(ConceptResult).to receive(:create).with({
+      expect(ConceptResultOld).to receive(:create).with({
         activity_session_id: activity_session.id,
         concept_id: concept.id,
         metadata: metadata,

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -845,7 +845,7 @@ end
     let!(:activity_session1) { create(:activity_session, activity: activity, classroom_unit: classroom_unit) }
 
     it 'should delete the activity sessions without the concept results' do
-      activity_session.concept_results.destroy_all
+      activity_session.old_concept_results.destroy_all
       expect{ ActivitySession.delete_activity_sessions_with_no_concept_results([activity_session, activity_session1]) }.to change(ActivitySession, :count).by(-1)
     end
   end

--- a/services/QuillLMS/spec/models/announcement_spec.rb
+++ b/services/QuillLMS/spec/models/announcement_spec.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_announcements_on_start_and_end  (start,end)
+#  index_announcements_on_start_and_end  (start,end DESC)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/concept_result_old_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_old_spec.rb
@@ -22,7 +22,7 @@
 #
 require 'rails_helper'
 
-describe ConceptResult, type: :model do
+describe ConceptResultOld, type: :model do
 
   let(:concept_result) { build(:concept_result, concept: nil) }
   let!(:concept) { create(:concept) }

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -36,8 +36,8 @@ describe PublicProgressReports, type: :model do
 
       last_feedback = "This is the last feedback the student received."
       directions = "Combine the sentences."
-      create(:concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
-      create(:concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
+      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
+      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
       report = FakeReports.new.results_for_classroom(classroom_unit.unit_id, activity.id, classroom.id)
 
       expect(report[:students].count).to eq 1
@@ -56,8 +56,8 @@ describe PublicProgressReports, type: :model do
 
       last_feedback = "This is the last feedback the student received."
       directions = "Combine the sentences."
-      create(:concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
-      create(:concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
+      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
+      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
       report = FakeReports.new.results_for_classroom(classroom_unit.unit_id, activity.id, classroom.id)
 
       expect(report[:students].count).to eq 1

--- a/services/QuillLMS/spec/models/old_concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/old_concept_result_spec.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: concept_results
+# Table name: old_concept_results
 #
 #  id                         :integer          not null, primary key
 #  metadata                   :json
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_concept_results_on_activity_session_id  (activity_session_id)
-#  index_concept_results_on_concept_id           (concept_id)
+#  index_old_concept_results_on_activity_session_id  (activity_session_id)
+#  index_old_concept_results_on_concept_id           (concept_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/spec/models/old_concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/old_concept_result_spec.rb
@@ -42,27 +42,27 @@ describe OldConceptResult, type: :model do
     end
 
     it "can equal passage-proofreader" do
-      concept_result_with_concept.update(question_type:'passage-proofreader')
+      concept_result_with_concept.update(question_type: 'passage-proofreader')
       expect(concept_result_with_concept).to be_valid
     end
 
     it "can equal sentence-writing" do
-      concept_result_with_concept.update(question_type:'sentence-writing')
+      concept_result_with_concept.update(question_type: 'sentence-writing')
       expect(concept_result_with_concept).to be_valid
     end
 
     it "can equal sentence-fragment-identification" do
-      concept_result_with_concept.update(question_type:'sentence-fragment-identification')
+      concept_result_with_concept.update(question_type: 'sentence-fragment-identification')
       expect(concept_result_with_concept).to be_valid
     end
 
     it "can equal sentence-fragment-expansion" do
-      concept_result_with_concept.update(question_type:'sentence-fragment-expansion')
+      concept_result_with_concept.update(question_type: 'sentence-fragment-expansion')
       expect(concept_result_with_concept).to be_valid
     end
 
     it "can equal sentence-combining" do
-      concept_result_with_concept.update(question_type:'sentence-combining')
+      concept_result_with_concept.update(question_type: 'sentence-combining')
       expect(concept_result_with_concept).to be_valid
     end
 

--- a/services/QuillLMS/spec/models/old_concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/old_concept_result_spec.rb
@@ -22,7 +22,7 @@
 #
 require 'rails_helper'
 
-describe ConceptResultOld, type: :model do
+describe OldConceptResult, type: :model do
 
   let(:concept_result) { build(:concept_result, concept: nil) }
   let!(:concept) { create(:concept) }

--- a/services/QuillLMS/spec/models/old_concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/old_concept_result_spec.rb
@@ -24,9 +24,9 @@ require 'rails_helper'
 
 describe OldConceptResult, type: :model do
 
-  let(:concept_result) { build(:concept_result, concept: nil) }
+  let(:concept_result) { build(:old_concept_result, concept: nil) }
   let!(:concept) { create(:concept) }
-  let(:concept_result_with_concept) { build(:concept_result, concept: concept) }
+  let(:concept_result_with_concept) { build(:old_concept_result, concept: concept) }
 
   describe '#concept_uid=' do
     it 'assigns the concept with that UID' do

--- a/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
+++ b/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
@@ -20,17 +20,17 @@ describe ProgressReports::Concepts::Concept do
     end
 
     it 'retrieves the total result count' do
-      expect(subject.first.total_result_count).to eq(ConceptResultOld.where(concept: subject.first.concept_id).count)
+      expect(subject.first.total_result_count).to eq(OldConceptResult.where(concept: subject.first.concept_id).count)
     end
 
     it 'retrieves the correct result count' do
       cr_count = 0
-      ConceptResultOld.where(concept: subject.first.concept_id).pluck(:metadata).each{|cr| cr_count += cr["correct"]}
+      OldConceptResult.where(concept: subject.first.concept_id).pluck(:metadata).each{|cr| cr_count += cr["correct"]}
       expect(subject.first.correct_result_count).to eq(cr_count)
     end
 
     it 'retrieves the incorrect result count' do
-      results = ConceptResultOld.where(concept: subject.first.concept_id).pluck(:metadata)
+      results = OldConceptResult.where(concept: subject.first.concept_id).pluck(:metadata)
       cr_count = 0
       results.each{|cr| cr_count += cr["correct"]}
       incorrect_count = results.count - cr_count

--- a/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
+++ b/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
@@ -16,7 +16,7 @@ describe ProgressReports::Concepts::Concept do
     let(:filters) { {} }
 
     it 'can retrieve concepts based on no filters' do
-      expect(subject.size).to eq(teacher.classrooms_i_teach.map(&:activity_sessions).flatten.map(&:concept_results).flatten.map(&:concept).uniq.count)
+      expect(subject.size).to eq(teacher.classrooms_i_teach.map(&:activity_sessions).flatten.map(&:old_concept_results).flatten.map(&:concept).uniq.count)
     end
 
     it 'retrieves the total result count' do

--- a/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
+++ b/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
@@ -20,17 +20,17 @@ describe ProgressReports::Concepts::Concept do
     end
 
     it 'retrieves the total result count' do
-      expect(subject.first.total_result_count).to eq(ConceptResult.where(concept: subject.first.concept_id).count)
+      expect(subject.first.total_result_count).to eq(ConceptResultOld.where(concept: subject.first.concept_id).count)
     end
 
     it 'retrieves the correct result count' do
       cr_count = 0
-      ConceptResult.where(concept: subject.first.concept_id).pluck(:metadata).each{|cr| cr_count += cr["correct"]}
+      ConceptResultOld.where(concept: subject.first.concept_id).pluck(:metadata).each{|cr| cr_count += cr["correct"]}
       expect(subject.first.correct_result_count).to eq(cr_count)
     end
 
     it 'retrieves the incorrect result count' do
-      results = ConceptResult.where(concept: subject.first.concept_id).pluck(:metadata)
+      results = ConceptResultOld.where(concept: subject.first.concept_id).pluck(:metadata)
       cr_count = 0
       results.each{|cr| cr_count += cr["correct"]}
       incorrect_count = results.count - cr_count

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -9,7 +9,7 @@ describe QuestionHealthDashboard, type: :model do
   let!(:activity_session3) { create(:activity_session, activity: activity) }
 
   let!(:concept_result1) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session1,
       metadata: {
         questionNumber: 1,
@@ -19,7 +19,7 @@ describe QuestionHealthDashboard, type: :model do
   end
 
   let!(:concept_result2) do
-    create(:concept_result,
+    create(:old_concept_result,
      activity_session: activity_session2,
      metadata: {
        questionNumber: 1,
@@ -29,7 +29,7 @@ describe QuestionHealthDashboard, type: :model do
   end
 
   let!(:concept_result3) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session3,
       metadata: {
         questionNumber: 1,
@@ -39,7 +39,7 @@ describe QuestionHealthDashboard, type: :model do
   end
 
   let!(:concept_result4) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session1,
       metadata: {
         questionNumber: 2,

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe QuestionHealthObj, type: :model do
     let!(:activity_session3) { create(:activity_session, activity: activity) }
 
     let!(:concept_result1) do
-      create(:concept_result,
+      create(:old_concept_result,
        activity_session: activity_session1,
        metadata: {
          questionNumber: 1,
@@ -23,7 +23,7 @@ RSpec.describe QuestionHealthObj, type: :model do
     end
 
     let!(:concept_result2) do
-      create(:concept_result,
+      create(:old_concept_result,
        activity_session: activity_session2,
        metadata: {
          questionNumber: 1,
@@ -33,7 +33,7 @@ RSpec.describe QuestionHealthObj, type: :model do
     end
 
     let!(:concept_result3) do
-      create(:concept_result,
+      create(:old_concept_result,
         activity_session: activity_session3,
         metadata: {
           questionNumber: 1,

--- a/services/QuillLMS/spec/models/student_problem_report_spec.rb
+++ b/services/QuillLMS/spec/models/student_problem_report_spec.rb
@@ -5,6 +5,7 @@
 # Table name: student_problem_reports
 #
 #  id                  :bigint           not null, primary key
+#  optimal             :boolean          default(FALSE), not null
 #  report              :string           not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -13,7 +13,7 @@
 #
 #  index_user_activity_classifications_on_classifications  (activity_classification_id)
 #  index_user_activity_classifications_on_user_id          (user_id)
-#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#  user_activity_classification_unique_index               (user_id,activity_classification_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -30,7 +30,7 @@
 #
 # Indexes
 #
-#  email_idx                          (email gin_trgm_ops) USING gin
+#  email_idx                          (email) USING gin
 #  index_users_on_active              (active)
 #  index_users_on_classcode           (classcode)
 #  index_users_on_clever_id           (clever_id)
@@ -41,12 +41,12 @@
 #  index_users_on_time_zone           (time_zone)
 #  index_users_on_token               (token)
 #  index_users_on_username            (username)
-#  name_idx                           (name gin_trgm_ops) USING gin
+#  name_idx                           (name) USING gin
 #  unique_index_users_on_clever_id    (clever_id) UNIQUE WHERE ((clever_id IS NOT NULL) AND ((clever_id)::text <> ''::text) AND ((id > 5593155) OR ((role)::text = 'student'::text)))
 #  unique_index_users_on_email        (email) UNIQUE WHERE ((id > 1641954) AND (email IS NOT NULL) AND ((email)::text <> ''::text))
 #  unique_index_users_on_google_id    (google_id) UNIQUE WHERE ((id > 1641954) AND (google_id IS NOT NULL) AND ((google_id)::text <> ''::text))
 #  unique_index_users_on_username     (username) UNIQUE WHERE ((id > 1641954) AND (username IS NOT NULL) AND ((username)::text <> ''::text))
-#  username_idx                       (username gin_trgm_ops) USING gin
+#  username_idx                       (username) USING gin
 #  users_to_tsvector_idx              (to_tsvector('english'::regconfig, (name)::text)) USING gin
 #  users_to_tsvector_idx1             (to_tsvector('english'::regconfig, (email)::text)) USING gin
 #  users_to_tsvector_idx2             (to_tsvector('english'::regconfig, (role)::text)) USING gin

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -14,7 +14,7 @@ describe ProgressReports::DistrictConceptReports do
     let!(:classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: "owner", classroom: classroom) }
     let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id]) }
     let!(:activity_session) { create(:activity_session_without_concept_results, classroom_unit: classroom_unit, user_id: student.id) }
-    let!(:concept_result) { create(:concept_result, activity_session: activity_session) }
+    let!(:concept_result) { create(:old_concept_result, activity_session: activity_session) }
 
     subject { described_class.new(admin.id) }
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -20,8 +20,8 @@ describe ProgressReports::DistrictConceptReports do
 
     it 'should return the correct results' do
       correct = concept_result.metadata["correct"]
-      incorrect = ConceptResult.count - correct
-      percentage = (100 * correct.to_f / ConceptResult.count).floor
+      incorrect = ConceptResultOld.count - correct
+      percentage = (100 * correct.to_f / ConceptResultOld.count).floor
 
       expect(subject.results).to eq(
         [{

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -20,8 +20,8 @@ describe ProgressReports::DistrictConceptReports do
 
     it 'should return the correct results' do
       correct = concept_result.metadata["correct"]
-      incorrect = ConceptResultOld.count - correct
-      percentage = (100 * correct.to_f / ConceptResultOld.count).floor
+      incorrect = OldConceptResult.count - correct
+      percentage = (100 * correct.to_f / OldConceptResult.count).floor
 
       expect(subject.results).to eq(
         [{

--- a/services/QuillLMS/spec/queries/teachers_data_spec.rb
+++ b/services/QuillLMS/spec/queries/teachers_data_spec.rb
@@ -40,8 +40,8 @@ describe 'TeachersData' do
 
   let!(:concept1) { create(:concept) }
   let!(:concept2) { create(:concept) }
-  let!(:concept_result1) { create(:concept_result, concept: concept1, activity_session: activity_session1) }
-  let!(:concept_result2) { create(:concept_result, concept: concept2, activity_session: activity_session2) }
+  let!(:concept_result1) { create(:old_concept_result, concept: concept1, activity_session: activity_session1) }
+  let!(:concept_result2) { create(:old_concept_result, concept: concept2, activity_session: activity_session2) }
 
   before do
     @results = teachers_data_module.run(teacher_ids)

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
@@ -28,9 +28,9 @@ describe ProgressReports::Concepts::ConceptSerializer, type: :serializer do
       completed_at: 5.minutes.ago,
       classroom_unit: classroom_unit
     )
-    activity_session.concept_results
+    activity_session.old_concept_results
       .create!(concept: concept, metadata: {'correct' => 1})
-    activity_session.concept_results
+    activity_session.old_concept_results
       .create!(concept: concept, metadata: {'correct' => 0})
   end
 

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
@@ -26,8 +26,8 @@ describe ProgressReports::Concepts::StudentSerializer, type: :serializer do
       state: 'finished',
       completed_at: 5.minutes.ago,
     )
-    activity_session.concept_results.create!(concept: concept, metadata: {'correct' => 1})
-    activity_session.concept_results.create!(concept: concept, metadata: {'correct' => 0})
+    activity_session.old_concept_results.create!(concept: concept, metadata: {'correct' => 1})
+    activity_session.old_concept_results.create!(concept: concept, metadata: {'correct' => 0})
   end
 
   describe '#to_json' do

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -98,6 +98,6 @@ RSpec.describe Demo::ReportDemoCreator do
     expect(act_sesh.user_id).to eq(student.id)
     expect(act_sesh.state).to eq('finished')
     expect(act_sesh.percentage).to eq(temp.percentage)
-    expect(act_sesh.concept_results.first.metadata).to eq(temp.concept_results.first.metadata)
+    expect(act_sesh.old_concept_results.first.metadata).to eq(temp.old_concept_results.first.metadata)
   end
 end

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Demo::ReportDemoCreator do
         user = build(:user, id: user_id)
         user.save
         activity_session = create(:activity_session, state: 'finished', activity_id: act_id, user_id: user_id, is_final_score: true)
-        create(:concept_result, activity_session: activity_session)
+        create(:old_concept_result, activity_session: activity_session)
       end
     end
 

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -47,7 +47,7 @@ describe 'SerializeActivityHealth' do
   let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
 
   let!(:concept_result1) do
-    create(:concept_result,
+    create(:old_concept_result,
      activity_session: activity_session1,
      metadata: {
        questionNumber: 1,
@@ -57,7 +57,7 @@ describe 'SerializeActivityHealth' do
   end
 
   let!(:concept_result2) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session2,
       metadata: {
         questionNumber: 1,
@@ -67,7 +67,7 @@ describe 'SerializeActivityHealth' do
   end
 
   let!(:concept_result3) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session3,
       metadata: {
         questionNumber: 1,
@@ -77,7 +77,7 @@ describe 'SerializeActivityHealth' do
   end
 
   let!(:concept_result4) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session1,
       metadata: {
         questionNumber: 2,

--- a/services/QuillLMS/spec/support/shared/concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/concept_progress_report.rb
@@ -37,7 +37,7 @@ shared_context 'Concept Progress Report' do
 
 
   let!(:correct_writing_result1) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session,
       concept: writing_concept,
       metadata: {
@@ -47,7 +47,7 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:correct_writing_result2) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session,
       concept: writing_concept,
       metadata: {
@@ -57,7 +57,7 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:incorrect_writing_result) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session,
       concept: writing_concept,
       metadata: {
@@ -67,7 +67,7 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:correct_grammar_result) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session,
       concept: grammar_tag,
       metadata: {
@@ -77,7 +77,7 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:incorrect_grammar_result) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: activity_session,
       concept: grammar_tag,
       metadata: {
@@ -115,7 +115,7 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:other_grammar_result) do
-    create(:concept_result,
+    create(:old_concept_result,
       activity_session: other_activity_session,
       concept: writing_concept,
       metadata: {

--- a/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
@@ -55,28 +55,28 @@ shared_context 'Student Concept Progress Report' do
 
   before do
     # Incorrect result for Alice
-    alice_session.concept_results.create!(
+    alice_session.old_concept_results.create!(
       concept: create(:concept_with_grandparent),
       metadata: {
         "correct" => 0
       })
 
     # Correct result for Alice
-    alice_session.concept_results.create!(
+    alice_session.old_concept_results.create!(
       concept: concept,
       metadata: {
         "correct" => 1
       })
 
     # Incorrect result for Fred
-    fred_session.concept_results.create!(
+    fred_session.old_concept_results.create!(
       concept: concept,
       metadata: {
         "correct" => 0
       })
 
     # Correct result for Fred for hidden tag (not displayed)
-    fred_session.concept_results.create!(
+    fred_session.old_concept_results.create!(
       concept: hidden_concept,
       metadata: {
         "correct" => 1

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -54,7 +54,7 @@ describe PopulateActivityHealthWorker do
     let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
 
     let!(:concept_result1) do
-      create(:concept_result,
+      create(:old_concept_result,
         activity_session: activity_session1,
         metadata: {
           questionNumber: 1,
@@ -64,7 +64,7 @@ describe PopulateActivityHealthWorker do
     end
 
     let!(:concept_result2) do
-      create(:concept_result,
+      create(:old_concept_result,
         activity_session: activity_session2,
         metadata: {
           questionNumber: 1,
@@ -74,7 +74,7 @@ describe PopulateActivityHealthWorker do
     end
 
     let!(:concept_result3) do
-      create(:concept_result,
+      create(:old_concept_result,
         activity_session: activity_session3,
         metadata: {
           questionNumber: 1,
@@ -84,7 +84,7 @@ describe PopulateActivityHealthWorker do
     end
 
     let!(:concept_result4) do
-      create(:concept_result,
+      create(:old_concept_result,
         activity_session: activity_session1,
         metadata: {
           questionNumber: 2,


### PR DESCRIPTION
## WHAT
Rename `ConceptResult` model to `OldConceptResult` and the `concept_results` database table to `old_concept_results`

Note: In addition to manual testing on staging, I've run staging Ghost Inspector tests, too.  Everything looks good to me.
## WHY
Given that the new model that we're going to replace the current `ConceptResult` with is going to be a row-for-row replacement, we decided it made sense to call the new model `ConceptResult`.  In preparation for that, we want to rename the old table so that the table name is available when we migrate.
## HOW
- Add a migration to rename `concept_results` to `old_concept_results`
- Change the name of the model from `ConceptResult` to `OldConceptResult`
- Update model associations to point at the renamed model
- Update code to reference the new model name
- Update all raw SQL that references `concept_results` to reference `old_concept_results` instead
- Update all ActiveRecord association references from `concept_results` to the renamed `old_concept_results` association name

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852
https://www.notion.so/quill/Rename-ConceptResult-to-OldConceptResult-in-preparation-for-replacing-it-with-the-new-normalized-f6002e476c0943d7ae2d27ef3e655583

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
