### PR TITLE
make sure to include activity id in the key for diagnostic results summary

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -272,7 +272,20 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def diagnostic_results_summary
-    render json: ResultsSummary.results_summary(results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
+    render json: fetch_diagnostic_results_summary_cache
+  end
+
+  private def fetch_diagnostic_results_summary_cache
+    groups = { activity_id: params[:activity_id] }
+    current_user.classroom_unit_by_ids_cache(
+      classroom_id: params[:classroom_id],
+      unit_id: params[:unit_id],
+      activity_id: params[:activity_id],
+      key: 'teachers.progress_reports.diagnostic_reports.diagnostic_results_summary',
+      groups: groups
+    ) do
+      ResultsSummary.results_summary(results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
+    end
   end
 
   def diagnostic_growth_results_summary

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -272,18 +272,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def diagnostic_results_summary
-    render json: fetch_diagnostic_results_summary_cache
-  end
-
-  private def fetch_diagnostic_results_summary_cache
-    current_user.classroom_unit_by_ids_cache(
-      classroom_id: params[:classroom_id],
-      unit_id: params[:unit_id],
-      activity_id: params[:activity_id],
-      key: 'teachers.progress_reports.diagnostic_reports.diagnostic_results_summary'
-    ) do
-      ResultsSummary.results_summary(results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
-    end
+    render json: ResultsSummary.results_summary(results_summary_params[:activity_id], results_summary_params[:classroom_id], results_summary_params[:unit_id])
   end
 
   def diagnostic_growth_results_summary


### PR DESCRIPTION
## WHAT
Remove caching for the results_summary for the diagnostic pages.

## WHY
This cache doesn't care about the activity itself, so in cases where multiple diagnostics were assigned but have the same classroom_unit, teachers can only ever see the data for the most recently completed diagnostic. We don't want that to happen.

## HOW
Just remove the caching wrapper (we already weren't caching the `growth_results_summary`, maybe for the same reason).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Incorrect-results-showing-up-for-ELL-Intermediate-and-Advanced-Pre-test-Diagnostics-5768fecfa3a547239edd813dccd8cf0f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
