### PR TITLE
Update pry gems

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -166,7 +166,7 @@ gem 'awesome_print'
 
 group :test, :development do
   gem 'parallel_tests'
-  gem 'pry', '~> 0.12.2'
+  gem 'pry', '~> 0.13.1'
   gem 'pry-rails'
   gem 'pry-remote'
   gem 'pry-stack_explorer'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
+    binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
@@ -169,7 +169,7 @@ GEM
       addressable
     cypress-on-rails (1.2.1)
       rack
-    debug_inspector (0.0.3)
+    debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.3.2)
     doorkeeper (5.0.3)
@@ -377,7 +377,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     memoist (0.16.2)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0704)
@@ -459,14 +459,15 @@ GEM
     premailer-rails (1.10.2)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.8.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
-    pry-coolline (0.2.5)
+      pry (~> 0.13.0)
+    pry-coolline (0.2.6)
       coolline (~> 0.5)
+      pry (~> 0.13)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     pry-remote (0.1.8)
@@ -475,9 +476,9 @@ GEM
     pry-rescue (1.5.0)
       interception (>= 0.5)
       pry (>= 0.12.0)
-    pry-stack_explorer (0.4.9.3)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
+    pry-stack_explorer (0.6.1)
+      binding_of_caller (~> 1.0)
+      pry (~> 0.13)
     public_suffix (4.0.6)
     puma (4.3.11)
       nio4r (~> 2.0)
@@ -832,7 +833,7 @@ DEPENDENCIES
   prawn
   prawn-table
   premailer-rails
-  pry (~> 0.12.2)
+  pry (~> 0.13.1)
   pry-byebug
   pry-coolline
   pry-rails


### PR DESCRIPTION
## WHAT
Update `pry`, `pry-byebug`, `pry-coolline`, and `pry-stack_explorer` gems.

## WHY
There's a [warning](https://github.com/pry/pry/issues/2097) associated with a recent Ruby 2.7 upgrade.

## HOW
Bump pry from 0.12.2 to 0.13.1

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
