### PR TITLE
Numeric lib should handle strings more gracefully

### DIFF
--- a/services/QuillLMS/app/lib/utils/numeric.rb
+++ b/services/QuillLMS/app/lib/utils/numeric.rb
@@ -2,7 +2,7 @@
 
 module Utils::Numeric
   def self.to_human_string(numeric)
-    raise ArgumentError, "Not a numeric" unless numeric.is_a?(Numeric)
+    return numeric.to_s unless numeric.is_a?(Numeric)
 
     millions = ->(x) { x >= 1_000_000 && x < 1_000_000_000 }
     billions = ->(x) { x >= 1_000_000_000 }

--- a/services/QuillLMS/app/lib/utils/numeric.rb
+++ b/services/QuillLMS/app/lib/utils/numeric.rb
@@ -2,16 +2,16 @@
 
 module Utils::Numeric
   def self.to_human_string(numeric)
-    return numeric.to_s unless numeric.is_a?(Numeric)
+    numeric = numeric.to_f
 
     millions = ->(x) { x >= 1_000_000 && x < 1_000_000_000 }
     billions = ->(x) { x >= 1_000_000_000 }
 
     case numeric
     when millions
-      "#{(numeric.to_f / 1_000_000).round} Million"
+      "#{(numeric / 1_000_000).round} Million"
     when billions
-      "#{(numeric.to_f / 1_000_000_000).round} Billion"
+      "#{(numeric / 1_000_000_000).round} Billion"
     else
       numeric.to_s
     end

--- a/services/QuillLMS/spec/lib/utils/numeric_spec.rb
+++ b/services/QuillLMS/spec/lib/utils/numeric_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Utils::Numeric do
         "18 Billion"
       )
     end
+
+    it 'should handle string input gracefully' do
+      expect(Utils::Numeric.to_human_string("5700000")).to eq "5700000"
+    end
   end
 
 end

--- a/services/QuillLMS/spec/lib/utils/numeric_spec.rb
+++ b/services/QuillLMS/spec/lib/utils/numeric_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Utils::Numeric do
     end
 
     it 'should handle string input gracefully' do
-      expect(Utils::Numeric.to_human_string("5700000")).to eq "5700000"
+      expect(Utils::Numeric.to_human_string("100")).to eq "100.0"
+      expect(Utils::Numeric.to_human_string("5700000")).to eq "6 Million"
     end
   end
 


### PR DESCRIPTION
## WHAT
Numeric lib should handle string input more gracefully.

## WHY
Redis values are string by default.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? | na
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
