### PR TITLE
Revert "Temporarily fix home page metrics (#9332)"

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -33,12 +33,9 @@ class PagesController < ApplicationController
 
     @title = 'Quill.org | Interactive Writing and Grammar'
     @description = 'Quill provides free writing and grammar activities for middle and high school students.'
-    # default numbers are current as of 07/06/22
-    @number_of_sentences = 1090000000
-    @number_of_students = 5700000
-    # @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 1090000000
-    # @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 5700000
-
+    # default numbers are current as of 03/12/19
+    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 252000000
+    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 2100000
 
     if request.env['affiliate.tag']
       name = ReferrerUser.find_by(referral_code: request.env['affiliate.tag'])&.user&.name


### PR DESCRIPTION
## WHAT
This reverts commit e4edc7ebe7b2f00d7a55db437d06ec5d1ce189a2.
## WHY
That fix is no longer necessary now that we've merged and deployed #9326 
## HOW
Just use `git revert` on the temp fix merge

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A