### PR TITLE
lms/clean-up-duplicate-schools

### DIFF
--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -172,7 +172,7 @@ namespace :schools do
     ActiveRecord::Base.connection.execute(schools_with_duplicates).each do |row|
       ActiveRecord::Base.transaction do
         duplicate = School.find(row['duplicate_school_id'])
-        update_hash = duplicate.as_json.except('id', 'nces_id').select { |_,v| v.present? }
+        update_hash = duplicate.as_json.except('id', 'nces_id', 'created_at').select { |_,v| v.present? }
         School.update(row['original_school_id'], update_hash)
 
         duplicate.destroy!

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -175,6 +175,7 @@ namespace :schools do
         update_hash = duplicate.as_json.except('id', 'nces_id', 'created_at').select { |_,v| v.present? }
         School.update(row['original_school_id'], update_hash)
 
+        puts duplicate.as_json
         duplicate.destroy!
         duplicate_schools_deleted += 1
       end

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -159,7 +159,7 @@ namespace :schools do
   desc 'Clean up duplicate schools based on 0-left-padded NCES ID'
   task :clean_up_duplicates => :environment do
 
-    teachers_assigned_to_duplicates = <<-SQL
+    schools_with_duplicates = <<-SQL
       SELECT original.id AS original_school_id,
             duplicate.id AS duplicate_school_id
           FROM schools AS original
@@ -169,7 +169,7 @@ namespace :schools do
     SQL
 
     duplicate_schools_deleted = 0
-    ActiveRecord::Base.connection.execute(teachers_assigned_to_duplicates).each do |row|
+    ActiveRecord::Base.connection.execute(schools_with_duplicates).each do |row|
       ActiveRecord::Base.transaction do
         duplicate = School.find(row['duplicate_school_id'])
         update_hash = duplicate.as_json.except('id', 'nces_id').select { |_,v| v.present? }

--- a/services/QuillLMS/lib/tasks/schools.rake
+++ b/services/QuillLMS/lib/tasks/schools.rake
@@ -107,4 +107,71 @@ namespace :schools do
       end
     end
   end
+
+  # A bit more detail here: when we did our original population of school
+  # data from federal NCES data sources, NCES ID values included left-
+  # padding "0"s to make them all the same length.  When we updated our
+  # data in 2022 from the same federal sources, the NCES IDs were no longer
+  # left-padded in the data set, so we ended up creating duplicate schools.
+  # One set with leading "0"s and one without.  This task is intended to
+  # move any users from the duplicates to the original schools, and then to
+  # remove the duplicates from our database.
+  desc 'Clean up duplicate schools based on 0-left-padded NCES ID'
+  task :clean_up_duplicates => :environment do
+
+    # First we want to retrieve a list of all `schools_users` and
+    # `schools_admins` records where someone is assigned to a duplicate
+    # school and re-assign them to the correct school
+    teachers_assigned_to_duplicates = <<-SQL
+      SELECT original.id AS original_school_id,
+            schools_users.id AS schools_users_id,
+            schools_admins.id AS schools_admins_id
+          FROM schools AS original
+          JOIN schools AS duplicate
+              ON CONCAT('0', original.nces_id) = duplicate.nces_id
+                  OR CONCAT('00', original.nces_id) = duplicate.nces_id
+          LEFT OUTER JOIN schools_admins
+              ON duplicate.id = schools_admins.school_id
+          LEFT OUTER JOIN schools_users
+              ON duplicate.id = schools_users.school_id
+    SQL
+
+    users_updated = 0
+    admins_updated = 0
+    ActiveRecord::Base.connection.execute(teachers_assigned_to_duplicates).each do |row|
+      if row['schools_users_id']
+        update_me = SchoolsUsers.find(row['schools_users_id'])
+        update_me.update(school_id: row['original_school_id'])
+        users_updated += 1
+      end
+
+      if row['schools_admins_id']
+        update_me = SchoolsAdmins.find(row['schools_admins_id'])
+        update_me.update(school_id: row['original_school_id'])
+        admins_updated += 1
+      end
+    end
+
+    puts "Moved #{users_updated} users to the correct school."
+    puts "Moved #{admins_updated} admins to the correct school."
+
+    # Now we want to remove any schools that are duplicates
+    duplicate_schools = <<-SQL
+      SELECT duplicate.id AS duplicate_id
+          FROM schools AS original
+          JOIN schools AS duplicate
+              ON CONCAT('0', original.nces_id) = duplicate.nces_id
+                  OR CONCAT('00', original.nces_id) = duplicate.nces_id
+    SQL
+
+    duplicate_schools_deleted = 0
+    ActiveRecord::Base.connection.execute(duplicate_schools).each do |row|
+      next unless row['duplicate_id']
+
+      School.find(row['duplicate_id']).destroy!
+      duplicate_schools_deleted += 1
+    end
+
+    puts "Deleted #{duplicate_schools_deleted} duplicate schools."
+  end
 end

--- a/services/QuillLMS/spec/tasks/schools_spec.rb
+++ b/services/QuillLMS/spec/tasks/schools_spec.rb
@@ -7,13 +7,15 @@ Rails.application.load_tasks
 describe "schools.rake", type: :task do
   context "clean_up_duplicates" do
     let(:nces_id) { 123456789 }
-    let!(:original_school) { create(:school, nces_id: nces_id) }
-    let!(:duplicate_school) { create(:school, nces_id: "0#{nces_id}") } 
+    let(:left_padded_nces_id) { "0#{nces_id}" }
+    let(:new_name) { 'New School Name' }
+    let!(:original_school) { create(:school, nces_id: left_padded_nces_id) }
+    let!(:duplicate_school) { create(:school, nces_id: nces_id, name: new_name) }
 
     # Originally I tried to do this as three different `it` blocks, but
     # whichever one ran first would pass, and the other two would fail.
     # Not sure what was up with that, but this test at least works?
-    it 'should move users and admins assigned to duplicate schools to their original schools, then remove duplicate schools' do
+    it 'should move users and admins assigned to duplicate schools to their original schools, update old schools with data from the "new" school, then remove duplicate schools' do
       user = create(:user, school: duplicate_school)
       admin = create(:user, administered_schools: [duplicate_school])
 
@@ -22,6 +24,7 @@ describe "schools.rake", type: :task do
 
       expect(user.reload.school).to eq(original_school)
       expect(admin.reload.administered_schools).to eq([original_school])
+      expect(original_school.reload.name).to eq(new_name)
       expect(School.exists?(original_school.id)).to be(true)
       expect(School.exists?(duplicate_school.id)).to be(false)
     end

--- a/services/QuillLMS/spec/tasks/schools_spec.rb
+++ b/services/QuillLMS/spec/tasks/schools_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+Rails.application.load_tasks
+
+describe "schools.rake", type: :task do
+  context "clean_up_duplicates" do
+    let(:nces_id) { 123456789 }
+    let!(:original_school) { create(:school, nces_id: nces_id) }
+    let!(:duplicate_school) { create(:school, nces_id: "0#{nces_id}") } 
+
+    # Originally I tried to do this as three different `it` blocks, but
+    # whichever one ran first would pass, and the other two would fail.
+    # Not sure what was up with that, but this test at least works?
+    it 'should move users and admins assigned to duplicate schools to their original schools, then remove duplicate schools' do
+      user = create(:user, school: duplicate_school)
+      admin = create(:user, administered_schools: [duplicate_school])
+
+
+      Rake::Task["schools:clean_up_duplicates"].invoke
+
+      expect(user.reload.school).to eq(original_school)
+      expect(admin.reload.administered_schools).to eq([original_school])
+      expect(School.exists?(original_school.id)).to be(true)
+      expect(School.exists?(duplicate_school.id)).to be(false)
+    end
+  end
+end

--- a/services/QuillLMS/spec/tasks/schools_spec.rb
+++ b/services/QuillLMS/spec/tasks/schools_spec.rb
@@ -5,25 +5,32 @@ require 'rails_helper'
 Rails.application.load_tasks
 
 describe "schools.rake", type: :task do
-  context "clean_up_duplicates" do
-    let(:nces_id) { 123456789 }
-    let(:left_padded_nces_id) { "0#{nces_id}" }
-    let(:new_name) { 'New School Name' }
-    let!(:original_school) { create(:school, nces_id: left_padded_nces_id) }
-    let!(:duplicate_school) { create(:school, nces_id: nces_id, name: new_name) }
+  let(:nces_id) { 123456789 }
+  let(:left_padded_nces_id) { "0#{nces_id}" }
+  let(:new_name) { 'New School Name' }
+  let!(:original_school) { create(:school, nces_id: left_padded_nces_id) }
+  let!(:duplicate_school) { create(:school, nces_id: nces_id, name: new_name) }
+
+  context "reassign_users_from_duplicates" do
 
     # Originally I tried to do this as three different `it` blocks, but
     # whichever one ran first would pass, and the other two would fail.
     # Not sure what was up with that, but this test at least works?
-    it 'should move users and admins assigned to duplicate schools to their original schools, update old schools with data from the "new" school, then remove duplicate schools' do
+    it 'should move users and admins assigned to duplicate schools to their original schools' do
       user = create(:user, school: duplicate_school)
       admin = create(:user, administered_schools: [duplicate_school])
 
-
-      Rake::Task["schools:clean_up_duplicates"].invoke
+      Rake::Task["schools:reassign_users_from_duplicates"].invoke
 
       expect(user.reload.school).to eq(original_school)
       expect(admin.reload.administered_schools).to eq([original_school])
+    end
+  end
+
+  context "clean_up_duplicates" do
+    it 'should update original school record with data from the new school record, and then delete the old record' do
+      Rake::Task["schools:clean_up_duplicates"].invoke
+
       expect(original_school.reload.name).to eq(new_name)
       expect(School.exists?(original_school.id)).to be(true)
       expect(School.exists?(duplicate_school.id)).to be(false)


### PR DESCRIPTION
## WHAT
Add a rake task to clean up duplicate school entries
## WHY
When we renewed our `School` data from NCES sources this year (the last time we'd updated this data was in 2014) we did not realize that while the NCES IDs for schools in the two datasets were the same, the original 2014 data set left-padded NCES IDs with "0"s while the new 2022 data set did not.  This meant that instead of recognizing that an existing record needed to be updated from the data, a new school was created instead.  We want to correct that mistake.
## HOW
- Identify all School records that have the same NCES ID as an older "original" school except that the older one has left-padded 0s
- For each of those "duplicate" schools, find any Users or Admins attached to them, and move those attachments over to the "original" school
- Update the "original" school columns with data from the "duplicate" school if the "duplicate" school has something set.  (Things like mailing addresses, phone numbers, student population, and FRPL status.)
- Delete the "duplicate" school from the database

### Notion Card Links
https://www.notion.so/quill/Clean-up-accidental-duplicate-records-in-Schools-87d040bfc1894314babd563665771ac1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
