### PR TITLE
Pre-rails 6 spec updates

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/standards/activity_session.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/activity_session.rb
@@ -5,15 +5,14 @@ class ProgressReports::Standards::ActivitySession
     @teacher = teacher
   end
 
-  def results(filters)
-    # for some reason indicating the root namespace is necessary in this first assignment
-    query = ::ActivitySession.select(<<-SELECT
-      activity_sessions.*,
-      activities.standard_id as standard_id
-    SELECT
-    ).completed
-      .with_best_scores
-      .by_teacher(@teacher)
+  def results(filters = {})
+    query =
+      ::ActivitySession
+        .select('activity_sessions.*, activities.standard_id as standard_id')
+        .completed
+        .with_best_scores
+        .by_teacher(@teacher)
+
     ActivitySession.with_filters(query, filters)
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -188,12 +188,9 @@ module Evidence
     end
 
     private def assign_to_all_prompts
-      Prompt.all.each do |prompt|
-        unless prompts.include?(prompt)
-          prompts.append(prompt)
-        end
-      end
-      save!
+      unassigned_prompts = Prompt.all - prompts
+
+      prompts_rules.create!(unassigned_prompts.map { |prompt| { prompt: prompt } })
     end
 
     private def one_plagiarism_per_prompt

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
@@ -236,22 +236,22 @@ module Evidence
         it 'should assign newly created rule to all prompts if the rule is universal' do
           prompt = create(:evidence_prompt)
           rule = create(:evidence_rule, :universal => true)
-          expect(prompt.rules.length).to(eq(1))
-          expect(rule.prompts.include?(prompt)).to(eq(true))
+          expect(prompt.reload.rules.length).to eq 1
+          expect(rule.reload.prompts).to include prompt
         end
 
         it 'should not assign newly created rule to all prompts if the rule is not universal' do
           prompt = create(:evidence_prompt)
           rule = create(:evidence_rule, :universal => false)
-          expect(prompt.rules.length).to(eq(0))
-          expect(rule.prompts.include?(prompt)).to(eq(false))
+          expect(prompt.reload.rules.length).to eq 0
+          expect(rule.reload.prompts).not_to include prompt
         end
 
         it 'should not assign newly created rules to prompts that somehow already have them assigned' do
           prompt = create(:evidence_prompt)
           rule = create(:evidence_rule, :universal => true, :prompts => ([prompt]))
-          expect(prompt.rules.length).to(eq(1))
-          expect(rule.prompts.include?(prompt)).to(eq(true))
+          expect(prompt.reload.rules.length).to eq 1
+          expect(rule.reload.prompts).to include prompt
         end
       end
     end


### PR DESCRIPTION
## WHAT
Update some test files.

## WHY
These specs fail in Rails 6, but we can update them now and keep the actual Rails 6 upgrade diff smaller.

## HOW
1. Fix activity_session order by params:  If none is supplied, Rails appends an order by clause after a group by (see [here](     https://stackoverflow.com/a/27738549)).  While a blank `.order('')` call is currently used, Rails 6 will require an explicit select column, otherwise the error `column "activity_sessions.id" must appear in the GROUP BY clause or be used in an aggregate function` will be triggered.
2. Remove redundant save:  In Rails 6, the `prompts.append(prompt)` actually creates the corresponding PromptsRule record.  The subsequent save! attempts to create those same PromptsRule records which raises an error due to uniqueness constraint.  Instead, just create the PromptsRule in one create! call by passing an array of args.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A