### PR TITLE
Remove self.formats calls

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -23,7 +23,6 @@ class PagesController < ApplicationController
 
     @body_class = 'home-page'
     @activity = Activity.with_classification.find_by_uid(ENVr.fetch('HOMEPAGE_ACTIVITY_UID', ''))
-    self.formats = ['html']
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -41,10 +40,8 @@ class PagesController < ApplicationController
       name = ReferrerUser.find_by(referral_code: request.env['affiliate.tag'])&.user&.name
       flash.now[:info] = "<strong>#{name}</strong> invited you to help your students become better writers with Quill!" if name
     end
-    if check_should_clear_segment_identity
-      set_just_logged_out_flag
-    end
-    self.formats = ['html']
+
+    set_just_logged_out_flag if check_should_clear_segment_identity
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -28,16 +28,6 @@ describe PagesController do
       end
     end
 
-    context 'when user is not signed in, weird format' do
-      it 'should render page' do
-        headers = { Accept: "RandomGobbledyguck"}
-        request.headers.merge! headers
-        get :home_new
-
-        expect(response).to render_template 'pages/home_new'
-      end
-    end
-
     context 'when a user has just signed out' do
       before do
         allow(controller).to receive(:check_should_clear_segment_identity) { true }


### PR DESCRIPTION
## WHAT
In the PagesController, remove attempts to force content headers to html for `home` and `home_new` actions.

## WHY
The `self.formats` calls were a [mechanism](https://github.com/empirical-org/Empirical-Core/pull/5390) for handling exceptions for invalid accept headers.  In Rails 6, this functionality is broken due to this [PR](https://github.com/rails/rails/pull/40353).  Basically, an accept header with invalid mime type like the spec below (i.e.         `headers = { Accept: "RandomGobbledyguck"}` will now trigger a `ActionDispatch::Http::MimeNegotiation::InvalidType` exception further upstream preventing it from reaching the controller method altogether.  This [thread](https://github.com/rails/rails/issues/37620#issuecomment-598221401) discusses ways of handling he error, but most of the discussion leads to updates in the various third-party libraries that log the exception reporting (e.g. honeybadger, sentry).

While, the long-term solution is to upgrade `sentry-raven` to the newer `sentry-ruby` since it will [ignore](https://github.com/getsentry/sentry-ruby/pull/1215) these exceptions,  such an upgrade will require [migration](    https://docs.sentry.io/platforms/ruby/migration) to sentry-ruby entailing more investigation.

## HOW
Remove the self.formats calls and the spec which handled the invalid accept headers.  This might result in new exceptions on sentry until we upgrade the gem.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
