### PR TITLE
Update evidence circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,8 +290,8 @@ jobs:
           name: Set up DB
           command: |
             cd services/QuillLMS/engines/evidence
-            bundle exec rake db:create
-            bundle exec rake db:migrate
+            bundle exec rake db:create RAILS_ENV=test
+            bundle exec rake db:schema:load RAILS_ENV=test
           environment:
             DATABASE_URL: "postgres://ubuntu@localhost:5432/quill_evidence_test_db"
       - run:


### PR DESCRIPTION
## WHAT
Update the evidence's database build configuration on circleci

## WHY
Current build for Rails 6, including variants like this:

```
cd services/QuillLMS/engines/evidence
bundle exec rake db:drop RAILS_ENV=test
bundle exec rake db:create RAILS_ENV=test
bundle exec rake db:migrate RAILS_ENV=test
bundle exec rake db:migrate:status RAILS_ENV=test
bundle exec rspec
```
[error](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/16644/workflows/9b871650-1c1c-4792-9bdc-08be742bbc1b/jobs/226310) with:

```
Migrations are pending. To resolve this issue, run:

        rails db:migrate RAILS_ENV=test
```

even though no migrations are pending.

## HOW
Change `rake db:migrate` to a `rake db:schema:load RAILS_ENV=test`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
