### PR TITLE
simplify and fix database.yml

### DIFF
--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -1,17 +1,17 @@
 default: &default
   pool: <%= ENV.fetch("MAX_THREADS") { 5 } %>
   prepared_statements: false
+  adapter: postgresql
   timeout: 5000
 
-development_env: &development_env
-  adapter: postgresql
+development_shared: &development_shared
   encoding: unicode
   database: emp_gr_development
   host:     localhost
   port: 5432
 
 test_env: &test_env
-  <<: *development_env
+  <<: *development_shared
   database: emp_gr_test
 
 # While we don't actually connect to any follower DBs, they
@@ -24,7 +24,7 @@ leader_db_env: &leader_db_env
 
 development: &development
   <<: *default
-  adapter: postgresql
+  <<: *development_shared
   <<: *leader_db_env
 
 # Warning: The database defined as "test" will be erased and
@@ -32,12 +32,10 @@ development: &development
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  adapter: postgresql
   <<: *test_env
 
 staging: &staging
   <<: *default
-  adapter: postgresql
   <<: *leader_db_env
 
 sprint:
@@ -45,5 +43,4 @@ sprint:
 
 production:
   <<: *default
-  adapter: postgresql
   <<: *leader_db_env

--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -6,7 +6,6 @@ default: &default
 
 development_shared: &development_shared
   encoding: unicode
-  database: emp_gr_development
   host:     localhost
   port: 5432
 
@@ -26,6 +25,7 @@ development: &development
   <<: *default
   <<: *development_shared
   <<: *leader_db_env
+  database: emp_gr_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
## WHAT
1. Makes the `development` database config inherit from `development_shared`, thereby including the `database` yaml property. Without the `database` yaml property, this line of active_record will throw an unhandled exception, preventing local schema dumps: `activerecord-5.2.8/lib/active_record/tasks/postgresql_database_tasks.rb:116`

Here's the output of the error:
```
rake aborted!
TypeError: no implicit conversion of nil into String
/Users/pk/.rbenv/versions/2.6.6/bin/bundle:23:in `load'
/Users/pk/.rbenv/versions/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => db:structure:dump
```

2. I also made database.yml a bit more DRY and readable.

## WHY
So that all developer environments can make schema dumps. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config change only
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
