### PR TITLE
add ortto into head embed codes

### DIFF
--- a/services/QuillLMS/app/helpers/application_helper.rb
+++ b/services/QuillLMS/app/helpers/application_helper.rb
@@ -65,7 +65,7 @@ module ApplicationHelper
     current_path.include?('sign-up')
   end
 
-  def load_intercom?
+  def user_is_trackable_teacher?
     current_user&.teacher? && !staff_member? && !demo_account? && !on_sign_up?
   end
 

--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -7,11 +7,11 @@
         integrations: {
           all: true
 
-          <%#= We're using load_intercom? as a proxy for Vitally
+          <%#= We're using user_is_trackable_teacher? as a proxy for Vitally
                since the conditions are basically the same (teachers only).
                If we shouldn't load Intercom, then we shouldn't send any
                events to Vitally, either. %>
-          <% unless load_intercom? %>
+          <% unless user_is_trackable_teacher? %>
           , Intercom: false
           , Vitally: false
           , Heap: false
@@ -24,7 +24,7 @@
       #   2) the user literally just logged out, and the controller let us know
       #   3) this is an anonymous user, in which case we don't do anything special at all
     %>
-    <% if load_intercom? %>
+    <% if user_is_trackable_teacher? %>
       analytics.identify(<%= raw(generate_segment_identify_arguments(current_user)) %>);
       <% if current_user.school %>
         analytics.group("<%= raw(current_user.school.id) %>", {
@@ -39,7 +39,7 @@
       analytics.page();
     <% end %>
 
-    <% if load_intercom? %>
+    <% if user_is_trackable_teacher? %>
 
       setInterval(function() {
         if (typeof Intercom !== 'undefined') {
@@ -47,7 +47,7 @@
         }
       }, 30000)
 
-      // In addition to loading Intercom, we're using "load_intercom?" as a proxy for
+      // In addition to loading Intercom, we're using "user_is_trackable_teacher?" as a proxy for
       // "this is a teacher user". Our integration with Vitally suppresses .page()
       // calls.  This means that we need to track pageviews for Vitally with explicit
       // calls to `analytics.track()`.  But we only need to send this data to Vitally.
@@ -71,6 +71,6 @@
   }}();
   </script>
   <!-- end Segment.io -->
-  <%= render partial: 'application/coview' if load_intercom? %>
-  <%= render partial: 'application/ortto' if load_intercom? %>
+  <%= render partial: 'application/coview' if user_is_trackable_teacher? %>
+  <%= render partial: 'application/ortto' if user_is_trackable_teacher? %>
 <% end %>

--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -72,4 +72,5 @@
   </script>
   <!-- end Segment.io -->
   <%= render partial: 'application/coview' if load_intercom? %>
+  <%= render partial: 'application/ortto' %>
 <% end %>

--- a/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
+++ b/services/QuillLMS/app/views/application/_head_embed_codes.html.erb
@@ -72,5 +72,5 @@
   </script>
   <!-- end Segment.io -->
   <%= render partial: 'application/coview' if load_intercom? %>
-  <%= render partial: 'application/ortto' %>
+  <%= render partial: 'application/ortto' if load_intercom? %>
 <% end %>

--- a/services/QuillLMS/app/views/application/_ortto.html.erb
+++ b/services/QuillLMS/app/views/application/_ortto.html.erb
@@ -5,7 +5,7 @@
     ap3c.cmd = ap3c.cmd || [];
 
     ap3c.cmd.push(function() {
-        ap3c.init("<%= ENV["ORTTO_KEY"] %>", 'https://capture-api.autopilotapp.com/');
+        ap3c.init('<%= ENV["ORTTO_KEY"] %>', 'https://capture-api.autopilotapp.com/');
         ap3c.track({"v":0,"ei":"<%= raw(current_user&.id) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
     });
     ap3c.activity = function(act) { ap3c.act = (ap3c.act || []); ap3c.act.push(act); };

--- a/services/QuillLMS/app/views/application/_ortto.html.erb
+++ b/services/QuillLMS/app/views/application/_ortto.html.erb
@@ -1,0 +1,18 @@
+<!-- Ortto quillorg capture code -->
+<script>
+    window.ap3c = window.ap3c || {};
+    var ap3c = window.ap3c;
+    ap3c.cmd = ap3c.cmd || [];
+
+    ap3c.cmd.push(function() {
+        ap3c.init("<%= ENV["ORTTO_KEY"] %>", 'https://capture-api.autopilotapp.com/');
+        <% if current_user %>
+          ap3c.track({"v":0,"ei":"<%= raw(current_user&.id) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
+        <% else %>
+          ap3c.track({"v":0});
+        <% end %>
+    });
+    ap3c.activity = function(act) { ap3c.act = (ap3c.act || []); ap3c.act.push(act); };
+    var s, t; s = document.createElement('script'); s.type = 'text/javascript'; s.src = "https://cdn3l.ink/app.js";
+    t = document.getElementsByTagName('script')[0]; t.parentNode.insertBefore(s, t);
+</script>

--- a/services/QuillLMS/app/views/application/_ortto.html.erb
+++ b/services/QuillLMS/app/views/application/_ortto.html.erb
@@ -6,11 +6,7 @@
 
     ap3c.cmd.push(function() {
         ap3c.init("<%= ENV["ORTTO_KEY"] %>", 'https://capture-api.autopilotapp.com/');
-        <% if current_user %>
-          ap3c.track({"v":0,"ei":"<%= raw(current_user&.id) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
-        <% else %>
-          ap3c.track({"v":0});
-        <% end %>
+        ap3c.track({"v":0,"ei":"<%= raw(current_user&.id) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
     });
     ap3c.activity = function(act) { ap3c.act = (ap3c.act || []); ap3c.act.push(act); };
     var s, t; s = document.createElement('script'); s.type = 'text/javascript'; s.src = "https://cdn3l.ink/app.js";

--- a/services/QuillLMS/app/views/application/_ortto.html.erb
+++ b/services/QuillLMS/app/views/application/_ortto.html.erb
@@ -6,7 +6,7 @@
 
     ap3c.cmd.push(function() {
         ap3c.init('<%= ENV["ORTTO_KEY"] %>', 'https://capture-api.autopilotapp.com/');
-        ap3c.track({"v":0,"ei":"<%= raw(current_user&.id) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
+        ap3c.track({"v":0,"email":"<%= raw(current_user&.email) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
     });
     ap3c.activity = function(act) { ap3c.act = (ap3c.act || []); ap3c.act.push(act); };
     var s, t; s = document.createElement('script'); s.type = 'text/javascript'; s.src = "https://cdn3l.ink/app.js";

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -53,7 +53,9 @@ SecureHeaders::Configuration.default do |config|
       "https://*.intercomcdn.com",
       "https://*.coview.com",
       "https://*.sentry.io",
-      "https://*.heapanalytics.com"
+      "https://*.heapanalytics.com",
+      "https://cdn3l.ink/app.js",
+      "https://capture-api.ap3prod.com"
     ],
 
     font_src: [
@@ -117,7 +119,8 @@ SecureHeaders::Configuration.default do |config|
       "http://localhost:8080/",
       "http://localhost:3200",
       "ws://localhost:3200",
-      "https://checkout.stripe.com"
+      "https://checkout.stripe.com",
+      "https://capture-api.ap3prod.com"
     ]
   }
 


### PR DESCRIPTION
## WHAT
Add Ortto tracking into head embed codes.

## WHY
We are moving to use Ortto instead of Intercom + Heap for product messaging and metrics.

## HOW
Just embed Ortto's code into our `head_embed_codes` partial, using the same logic we do for our other tracking platforms (ie the same rules as the load_intercom? method).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-Ortto-tracking-code-to-all-pages-website-and-application-b680c292587e45a8a03392bd39822415

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? |Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A