### PR TITLE
Suppress puts statements in rspec on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            SUPPRESS_PUTS="true"
             cd services/QuillLMS
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | grep -v "spec/system/" | grep -v "/skip_ci/" | circleci tests split)
             bundle exec rspec -- ${TESTFILES}

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -92,6 +92,11 @@ RSpec.configure do |config|
     example.run
     ActionController::Base.perform_caching = caching
   end
+
+  config.before do
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:write)
+  end
 end
 
 if defined?(Coveralls)

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -93,9 +93,11 @@ RSpec.configure do |config|
     ActionController::Base.perform_caching = caching
   end
 
-  config.before do
-    allow($stdout).to receive(:puts)
-    allow($stdout).to receive(:write)
+  if ENV.fetch('SUPPRESS_PUTS', false) == 'true'
+    config.before do
+      allow($stdout).to receive(:puts)
+      allow($stdout).to receive(:write)
+    end
   end
 end
 


### PR DESCRIPTION
## WHAT
Prevent specs from printing to stdout.

## WHY
While puts statements are helpful when running rake tasks in development or production, while running tests on circleci they add unnecessary information which should be reserved for errors, warnings and deprecations.

## HOW
Add a configuration that stubs out these calls.
Various versions where proposed in this [thread](https://stackoverflow.com/a/57538689)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
