### PR TITLE
Address Rails 6.1 deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
             go test
   evidence_rails_build:
     working_directory: ~/Empirical-Core
-    parallelism: 4
+    parallelism: 1
     docker:
       - image: cimg/ruby:2.7.6
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,11 @@ jobs:
       - run:
           name: Run tests
           command: |
-            SUPPRESS_PUTS="true"
             cd services/QuillLMS
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | grep -v "spec/system/" | grep -v "/skip_ci/" | circleci tests split)
             bundle exec rspec -- ${TESTFILES}
+          environment:
+            SUPPRESS_PUTS: "true"
   lms_integration_build:
     working_directory: ~/Empirical-Core
     parallelism: 1

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       rack
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
-    docile (1.3.2)
+    docile (1.4.0)
     doorkeeper (5.0.3)
       railties (>= 4.2)
     dotenv (2.7.6)
@@ -683,13 +683,15 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simplecov (0.19.0)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
     simplecov-json (0.2)
       json
       simplecov
+    simplecov_json_formatter (0.1.4)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -736,7 +736,7 @@ GEM
       activesupport
     timecop (0.9.1)
     ttfunk (1.5.1)
-    turbolinks (5.2.0)
+    turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
     typhoeus (1.3.1)

--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -59,7 +59,7 @@ class AccountsController < ApplicationController
     end
 
     user_params.merge! validate_username: validate_username
-    if @user.update_attributes user_params
+    if @user.update(user_params)
       redirect_to updated_account_path
     else
       render 'accounts/edit'

--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -29,7 +29,7 @@ module Auth
 
     private def user_success(user, redirect=nil)
       CompleteAccountCreation.new(user, request.remote_ip).call if user.previous_changes["id"]
-      user.update_attributes(ip_address: request.remote_ip)
+      user.update(ip_address: request.remote_ip)
       if session[ApplicationController::CLEVER_REDIRECT]
         redirect_route = session[ApplicationController::CLEVER_REDIRECT]
         session[ApplicationController::CLEVER_REDIRECT] = nil

--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -35,7 +35,7 @@ class Cms::ActivitiesController < Cms::CmsController
   end
 
   def update
-    if @activity.update_attributes!(activity_params)
+    if @activity.update!(activity_params)
       render json: { activity: @activity }
     else
       render json: { }

--- a/services/QuillLMS/app/controllers/cms/activity_classifications_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activity_classifications_controller.rb
@@ -25,7 +25,7 @@ class Cms::ActivityClassificationsController < Cms::CmsController
 
   def update
     activity_classification = ActivityClassification.find(params[:id])
-    if activity_classification.update_attributes(filtered_activity_classification_params)
+    if activity_classification.update(filtered_activity_classification_params)
       render json: activity_classification
     else
       render json: {errors: activity_classification.errors}, status: 422

--- a/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
@@ -26,7 +26,7 @@ class Cms::UnitTemplateCategoriesController < Cms::CmsController
   end
 
   def update
-    if @unit_template_category.update_attributes(unit_template_category_params)
+    if @unit_template_category.update(unit_template_category_params)
       render json: @unit_template_category
     else
       render json: {errors: @unit_template_category.errors}, status: 422

--- a/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
@@ -40,7 +40,7 @@ class Cms::UnitTemplatesController < Cms::CmsController
     params = unit_template_params
     @unit_template.activities = []
     @unit_template.save
-    if @unit_template.update_attributes(params)
+    if @unit_template.update(params)
       @unit_template.activities_unit_templates.each do |aut|
         order_number = params["activity_ids"].index(aut.activity_id)
         aut.update(order_number: order_number)

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -100,7 +100,7 @@ class Cms::UsersController < Cms::CmsController
   end
 
   def update
-    if @user.update_attributes(user_params)
+    if @user.update(user_params)
       redirect_to cms_users_path, notice: 'User was successfully updated.'
     else
       flash[:error] = 'Did not save.'

--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -39,8 +39,8 @@ class PasswordResetController < ApplicationController
 
   def update
     @user = User.find_by_token!(params[:id])
-    @user.update_attributes params[:user].permit(:password)
-    @user.save validate: false
+    @user.update(params[:user].permit(:password))
+    @user.save(validate: false)
     @user.update!(token: nil)
     sign_in @user
     flash[:notice] = 'Your password has been updated.'

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -46,7 +46,7 @@ class StudentsController < ApplicationController
   end
 
   def update_account
-    if current_user.update_attributes(student_params.slice(:email, :name, :username))
+    if current_user.update(student_params.slice(:email, :name, :username))
       render json: current_user, serializer: UserSerializer
     else
       render json: {errors: current_user.errors.messages}, status: 422

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -69,7 +69,7 @@ class Teachers::ClassroomsController < ApplicationController
 
   def update
     @classroom = Classroom.find(params[:id])
-    @classroom.update_attributes(classroom_params)
+    @classroom.update(classroom_params)
     # this is updated from the students tab of the scorebook, so will make sure we keep user there
     respond_to do |format|
       format.html { redirect_to teachers_classroom_students_path(@classroom.id) }

--- a/services/QuillLMS/app/controllers/teachers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/students_controller.rb
@@ -36,7 +36,7 @@ class Teachers::StudentsController < ApplicationController
           validate_username = true
         end
         user_params.merge!(validate_username: validate_username)
-        if @student.update_attributes(user_params)
+        if @student.update(user_params)
           #head :ok
           redirect_to teachers_classroom_students_path(@classroom)
         else

--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -10,7 +10,7 @@ class Teachers::UnitActivitiesController < ApplicationController
   before_action :set_activity_session, only: :hide
 
   def update
-    @unit_activities.each{ |unit_activity| unit_activity.try(:update_attributes, unit_activity_params)}
+    @unit_activities.each { |unit_activity| unit_activity&.update(unit_activity_params) }
     render json: @unit_activities.to_json
   end
 

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -44,7 +44,7 @@ class Teachers::UnitsController < ApplicationController
       render json: {errors: { name: 'Unit must have a name'} }, status: 422
     elsif unit_template_names.include?(unit_params[:name].downcase)
       render json: {errors: { name: "Each activity pack needs a unique name. You're already using that name for another activity pack. Please choose a different name."} }, status: 422
-    elsif Unit.find(params[:id]).try(:update_attributes, unit_params)
+    elsif Unit.find(params[:id])&.update(unit_params)
       render json: {}
     else
       render json: {errors: { name: "Each activity pack needs a unique name. You're already using that name for another activity pack. Please choose a different name."} }, status: 422

--- a/services/QuillLMS/app/models/classroom_unit_activity_state.rb
+++ b/services/QuillLMS/app/models/classroom_unit_activity_state.rb
@@ -32,10 +32,11 @@ class ClassroomUnitActivityState < ApplicationRecord
   belongs_to :classroom_unit, touch: true
   belongs_to :unit_activity
 
+  before_validation :handle_pinning
+
+  after_create :lock_if_lesson
   after_save :update_lessons_cache_with_data
 
-  before_validation :handle_pinning
-  after_create :lock_if_lesson
   validate :not_duplicate, :only_one_pinned
 
   def visible
@@ -54,10 +55,11 @@ class ClassroomUnitActivityState < ApplicationRecord
   end
 
   private def not_duplicate
-    cua = ClassroomUnitActivityState.find_by(
+    cua = ClassroomUnitActivityState.unscoped.find_by(
       classroom_unit_id: classroom_unit_id,
       unit_activity_id: unit_activity_id
     )
+
     if cua && (cua.id != id)
       begin
         raise 'This classroom unit activity state is a duplicate'

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -373,7 +373,7 @@ module Teacher
       end
     end
     if !are_there_school_related_errors
-      if update_attributes(
+      if update(
         username: params.key?(:username) ? params[:username] : username,
         email: params.key?(:email) ? params[:email] : email,
         name: params.key?(:name) ? params[:name] : name,

--- a/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
@@ -64,7 +64,7 @@ class CoteacherClassroomInvitation < ApplicationRecord
     # In order to avoid letting people use our platform to spam folks,
     # we want to put some limits on the number of invitations a user can issue.
     # One of those limits is a cap on invitations per classroom
-    current_count = CoteacherClassroomInvitation.where(classroom_id: classroom_id).count
+    current_count = CoteacherClassroomInvitation.unscoped.where(classroom_id: classroom_id).count
     return if current_count < MAX_COTEACHER_INVITATIONS_PER_CLASS
 
     errors.add(:base, "The maximum limit of #{MAX_COTEACHER_INVITATIONS_PER_CLASS} coteacher invitations have already been issued for class #{classroom_id}")

--- a/services/QuillLMS/app/models/invitation.rb
+++ b/services/QuillLMS/app/models/invitation.rb
@@ -18,7 +18,6 @@
 #  index_invitations_on_inviter_id     (inviter_id)
 #
 class Invitation < ApplicationRecord
-
   belongs_to :inviter, class_name: 'User', foreign_key: 'inviter_id'
   has_many :coteacher_classroom_invitations, dependent: :destroy
 
@@ -30,8 +29,6 @@ class Invitation < ApplicationRecord
   MAX_COTEACHER_INVITATIONS_PER_TIME = 50
   MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS = 24
 
-
-
   def downcase_fields
     invitee_email.downcase!
   end
@@ -40,7 +37,7 @@ class Invitation < ApplicationRecord
     # In order to avoid letting people use our platform to spam folks,
     # we want to put some limits on the number of invitations a user can issue.
     # One of those limits is a cap on invitations per user per time period
-    recent_invitation_count = Invitation.where(inviter_id: inviter_id, invitation_type: TYPES[:coteacher], created_at: MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS.hours.ago..Time.current).count()
+    recent_invitation_count = Invitation.unscoped.where(inviter_id: inviter_id, invitation_type: TYPES[:coteacher], created_at: MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS.hours.ago..Time.current).count()
     return if recent_invitation_count <= MAX_COTEACHER_INVITATIONS_PER_TIME
 
     errors.add(:base, "User #{inviter_id} has reached the maximum of #{MAX_COTEACHER_INVITATIONS_PER_TIME} coteacher invitations that they can issue in a #{MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS} hour period")

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -420,8 +420,8 @@ class User < ApplicationRecord
   end
 
   def refresh_token!
-    update_attributes token: SecureRandom.urlsafe_base64
-    save validate: false
+    update(token: SecureRandom.urlsafe_base64)
+    save(validate: false)
   end
 
   def serialized
@@ -532,7 +532,7 @@ class User < ApplicationRecord
   def self.create_from_clever(hash, role_override = nil)
     user = User.where(email: hash[:info][:email]).first_or_initialize
     user = User.new if user.email.nil?
-    user.update_attributes(
+    user.update(
       clever_id: hash[:info][:id],
       token: (hash[:credentials] ? hash[:credentials][:token] : nil),
       role: role_override || hash[:info][:user_type],

--- a/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
@@ -25,7 +25,7 @@ module Evidence
     end
 
     def expire!
-      update_attributes(expires_at: Time.current)
+      update(expires_at: Time.current)
     end
 
     private def expires_at_in_future

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
@@ -10,16 +10,12 @@ module Evidence
     end
 
     context 'should validations' do
-
       it { should validate_presence_of(:rule) }
-
       it { should validate_presence_of(:regex_text) }
-
       it { should validate_length_of(:regex_text).is_at_most(200) }
-
-      it { should validate_inclusion_of(:case_sensitive).in_array(RegexRule::CASE_SENSITIVE_ALLOWED_VALUES) }
-
       it { should validate_inclusion_of(:sequence_type).in_array(RegexRule::SEQUENCE_TYPES) }
+
+      it { should allow_value(described_class::CASE_SENSITIVE_ALLOWED_VALUES).for(:case_sensitive) }
     end
 
     context 'should custom validations' do

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
@@ -9,18 +9,14 @@ module Evidence
       subject { FactoryBot.build(:evidence_rule) }
 
       it { should validate_uniqueness_of(:uid) }
-
       it { should validate_presence_of(:name) }
-
       it { should validate_length_of(:name).is_at_most(250) }
-
-      it { should validate_inclusion_of(:universal).in_array(Rule::ALLOWED_BOOLEANS) }
-
       it { should validate_inclusion_of(:rule_type).in_array(Rule::TYPES) }
-
       it { should validate_inclusion_of(:state).in_array(Rule::STATES) }
 
-      it { should validate_inclusion_of(:optimal).in_array(Rule::ALLOWED_BOOLEANS) }
+      it { should allow_value(true).for(:optimal) }
+      it { should allow_value(false).for(:universal) }
+      it { should_not allow_value(nil).for(:universal) }
 
       it { should validate_numericality_of(:suborder).only_integer.is_greater_than_or_equal_to(0).allow_nil }
     end
@@ -28,15 +24,10 @@ module Evidence
     context 'should relationships' do
 
       it { should have_one(:label) }
-
       it { should have_many(:plagiarism_texts) }
-
       it { should have_many(:feedbacks) }
-
       it { should have_many(:prompts_rules) }
-
       it { should have_many(:prompts).through(:prompts_rules) }
-
       it { should have_many(:regex_rules).dependent(:destroy) }
     end
 

--- a/services/QuillLMS/lib/tasks/quill_writer.rake
+++ b/services/QuillLMS/lib/tasks/quill_writer.rake
@@ -7,7 +7,7 @@ namespace :quillwriter do
 
     # classification
     ac = ActivityClassification.where(key: 'writer').first_or_create!
-    ac.update_attributes(name: 'Quill Writer', key: 'writer', app_name: :writer,
+    ac.update(name: 'Quill Writer', key: 'writer', app_name: :writer,
                    module_url: 'http://quill-writer.firebaseapp.com/',
                      form_url: 'http://quill-writer.firebaseapp.com/?form=true')
 

--- a/services/QuillLMS/lib/tasks/test_activities.rake
+++ b/services/QuillLMS/lib/tasks/test_activities.rake
@@ -34,11 +34,10 @@ namespace :test do
 
     a_datas = [a1_data, a2_data, a3_data]
 
-
     a_datas.each do |a_data|
       a = Activity.find_or_create_by uid: a_data[:uid]
-      a.update_attributes(a_data)
-      a.update_attributes flags: ["production"]
+      a.update(a_data)
+      a.update(flags: ["production"])
     end
   end
 end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -718,28 +718,28 @@ end
     let(:student) {create(:student)}
     let(:activity) {create(:activity)}
 
-    let(:classroom_unit)   {create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])}
-    let(:previous_final_score) {create(:activity_session, completed_at: Time.current, percentage: 0.9, is_final_score: true, user: student, classroom_unit: classroom_unit, activity: activity)}
+    let(:classroom_unit)   { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])}
+    let(:previous_final_score) { create(:activity_session, completed_at: Time.current, percentage: 0.9, is_final_score: true, user: student, classroom_unit: classroom_unit, activity: activity)}
 
     it 'updates when new activity session has higher percentage' do
       previous_final_score
-      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
-      new_activity_session.update_attributes completed_at: Time.current, state: 'finished', percentage: 0.95
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: 0.95)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
 
     it 'updates when new activity session has equal percentage' do
       previous_final_score
-      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
-      new_activity_session.update_attributes completed_at: Time.current, state: 'finished', percentage: previous_final_score.percentage
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: previous_final_score.percentage)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
 
     it 'updates when new and old session percentages are nil' do
       previous_final_score
       previous_final_score.update(percentage: nil)
-      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
-      new_activity_session.update_attributes completed_at: Time.current, state: 'finished', percentage: nil
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: nil)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
 
@@ -749,19 +749,19 @@ end
       activity.update(classification: classification)
       previous_final_score
       previous_final_score.update(percentage: nil)
-      new_activity_session =  create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
-      new_activity_session.update_attributes completed_at: Time.current, state: 'finished', percentage: nil
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: nil)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
 
     it 'doesnt update when new activity session has lower percentage' do
       previous_final_score
-      new_activity_session =  create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session = create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
       expect([ActivitySession.find(previous_final_score.id).is_final_score, ActivitySession.find(new_activity_session.id).is_final_score]).to eq([true, false])
     end
 
     it 'mark finished anonymous sessions as final' do
-      new_activity_session =  create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: nil, classroom_unit: nil, activity: activity)
+      new_activity_session = create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: nil, classroom_unit: nil, activity: activity)
       expect(new_activity_session.is_final_score).to eq(true)
     end
   end
@@ -825,7 +825,7 @@ end
       }]
     end
 
-    before { activity_session.update_attributes(visible: true) }
+    before { activity_session.update(visible: true) }
 
     it 'should create a concept result with the hash given' do
       expect(OldConceptResult).to receive(:create).with({

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -246,7 +246,7 @@ describe Classroom, type: :model do
     it "does not generate a code twice" do
       classroom = create(:classroom)
       old_code = classroom.code
-      classroom.update_attributes(name: 'Testy Westy')
+      classroom.update(name: 'Testy Westy')
       expect(classroom.code).to eq(old_code)
     end
   end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_payment_methods_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe StripeIntegration::SubscriptionPaymentMethodsController, type: :r
   it 'returns payload with redirect_url' do
     post url, params: params, as: :json
 
-    expect(response.content_type).to eq 'application/json'
+    expect(response.media_type).to eq 'application/json'
     expect(response).to have_http_status :ok
     expect(JSON.parse(response.body).symbolize_keys).to eq(redirect_url: redirect_url)
   end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
     it 'returns 200 if the request to Stripe is successful' do
       post url, params: params, as: :json
 
-      expect(response.content_type).to eq 'application/json'
+      expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :ok
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
 
       post url, params: params, as: :json
 
-      expect(response.content_type).to eq 'application/json'
+      expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :internal_server_error
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
 
       post url, params: params, as: :json
 
-      expect(response.content_type).to eq 'application/json'
+      expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :internal_server_error
     end
   end

--- a/services/QuillLMS/spec/support/shared/profile/profile.rb
+++ b/services/QuillLMS/spec/support/shared/profile/profile.rb
@@ -117,15 +117,15 @@ shared_context 'profile' do
   let!(:as3_finished) { classroom_activity3.session_for(student) }
 
   before do
-    as1.update_attributes(percentage: 0.8, state: 'finished')
-    as_1a.update_attributes(percentage: 0.5, state: 'finished')
-    as_1aa.update_attributes(percentage: 0.5, state: 'finished')
-    as_1b.update_attributes(percentage: 1, state: 'finished')
+    as1.update(percentage: 0.8, state: 'finished')
+    as_1a.update(percentage: 0.5, state: 'finished')
+    as_1aa.update(percentage: 0.5, state: 'finished')
+    as_1b.update(percentage: 1, state: 'finished')
   end
 
   before do
-    as3_unstarted.update_attributes(state: 'unstarted')
-    as3_started.update_attributes(percentage: 0.5, state: 'started')
-    as3_finished.update_attributes(percentage: 0.5, state: 'finished')
+    as3_unstarted.update(state: 'unstarted')
+    as3_started.update(percentage: 0.5, state: 'started')
+    as3_finished.update(percentage: 0.5, state: 'finished')
   end
 end


### PR DESCRIPTION
## WHAT
Fix some deprecations:

1.  Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. 
2.   Class level methods will no longer inherit [scoping](https://github.com/rails/rails/pull/32380) from `create` in Rails 6.1.
3.   `update_attributes` is deprecated and will be removed in Rails 6.1:  
4.  Shoulda [warns](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb#L56) of` validates_inclusion_of` matching on booleans

Also, Set the parallelism on rails_evidence_build to 1.

## WHY
Deprecation messages pollute the circleci logs.  It's better to clean them up now if possible.

Also, evidence_rails_build has four nodes but they all test the same specs.  Since the suite is already really fast, it probably makes sense to just set parallelism in the config to 1 and save cycles in our quota for other builds.

Here's a screen shot of the four parallel runs running the same [specs](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/16681/workflows/eb6ce1e2-f98e-4972-8730-4d5f8c1ca885/jobs/226645/parallel-runs/1?filterBy=ALL):
![Screen Shot 2022-07-08 at 3 44 58 PM](https://user-images.githubusercontent.com/2057805/178060361-6fc27196-9e58-4345-ab7a-b3b13e51e258.png)

## HOW
1.   In specs, use `media_type` instead of `content_type`.  Also, turbolinks needed to be bumped due to this [bug](https://github.com/rails/rails/issues/36989) 
2.  Add unscoped to the relevant queries except ones where default scope is expected.  For those, add `.default_scope`  
3.  This one is just a simple change from `update_attributes` to `update`
4.  Change the spec to check for appropriate values

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
