### PR TITLE
Add root key for classrooms_i_teach

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -31,7 +31,7 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   def classrooms_i_teach
-    render json: fetch_classrooms_i_teach_cache, each_serializer: ClassroomSerializer
+    render json: fetch_classrooms_i_teach_cache, root: 'classrooms'
   end
 
   def regenerate_code


### PR DESCRIPTION
## WHAT
Fix [bug](https://sentry.io/organizations/quillorg-5s/issues/3419591769/?project=11238&query=is%3Aunresolved&statsPeriod=14d):

`ActiveModel::Serializer::CollectionSerializer::CannotInferRootKeyError: Cannot infer root key from collection type. Please specify the root or each_serializer option, or render a JSON String`

## WHY
We would like JSON payloads to be properly formatted.   This code change was deployed yesterday but the error didn't manifest until the cache was cleared this morning.

## HOW
Add root key to render json call

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
