### PR TITLE
Bump NewRelic version to 6.15

### DIFF
--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nested_form (0.3.2)
-    newrelic_rpm (6.0.0.351)
+    newrelic_rpm (6.15.0)
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)


### PR DESCRIPTION
## WHAT
Upgrade the newrelic_rpm to v 6.15.0

## WHY
After upgrading the LMS to Rails 6.0, New relic is reporting large chunks of "middleware":

<img width="617" alt="Screen Shot 2022-07-12 at 10 46 54 AM" src="https://user-images.githubusercontent.com/2057805/178521834-219f0ed0-cad0-4cf1-a370-f047055b2739.png">


We'd like to get more refined analysis of response time.  Rails 6 support is added in [v6.3](https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v630
)

## HOW
`bundle update newrelic_rpm`

## Related links
https://github.com/newrelic/newrelic-ruby-agent/blob/7bb753161cf0215a09fd609f39b5a859a9860f49/lib/new_relic/agent/instrumentation/rails_notifications/action_controller.rb#L30
https://discuss.newrelic.com/t/significant-time-spent-in-actiondispatch-routeset-call/74549
https://discuss.newrelic.com/t/ruby-web-transactions-are-rolled-up-into-a-single-call/78957

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A