### PR TITLE
update vitally teacher stats for evidence

### DIFF
--- a/services/QuillLMS/app/models/concerns/vitally_teacher_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_teacher_stats.rb
@@ -69,4 +69,29 @@ module VitallyTeacherStats
     ActivityClassification.diagnostic.id
   end
 
+  def filter_evidence(activities)
+    evidence_ids = Activity.where(activity_classification_id: evidence_id).pluck(:id)
+    activities.select {|r| evidence_ids.include?(r.id) }
+  end
+
+  def evidence_id
+    ActivityClassification.evidence.id
+  end
+
+  def evidence_assigned_in_year_count(user, school_year_start, school_year_end)
+    sum_students(filter_evidence(in_school_year(activities_assigned_query(user), school_year_start, school_year_end)))
+  end
+
+  private def evidence_assigned_count(user)
+    sum_students(filter_evidence(activities_assigned_query(user)))
+  end
+
+  private def evidence_finished(user)
+    activities_finished_query(user).where("activities.activity_classification_id=?", evidence_id)
+  end
+
+  private def evidence_completed_in_year_count(user, school_year_start, school_year_end)
+    evidence_finished(@user).where("activity_sessions.completed_at >=? AND activity_sessions.completed_at < ?", school_year_start, school_year_end).count
+  end
+
 end

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
@@ -18,6 +18,9 @@ class PreviousYearTeacherDatum
     activities_finished = activities_finished_query(@user).where("activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?", school_year_start, school_year_end).count
     diagnostics_assigned_this_year = diagnostics_assigned_in_year_count(@user, school_year_start, school_year_end)
     diagnostics_finished_this_year = diagnostics_finished(@user).where("activity_sessions.completed_at >=? and activity_sessions.completed_at < ?", school_year_start, school_year_end).count
+    evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
+    evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
+    completed_evidence_activities_per_student_this_year = activities_per_student(active_students, evidence_activities_completed_this_year)
     {
       total_students: total_students_in_year(@user, school_year_start, school_year_end),
       active_students: active_students,
@@ -27,6 +30,9 @@ class PreviousYearTeacherDatum
       percent_completed_activities: activities_assigned > 0 ? (activities_finished.to_f / activities_assigned).round(2) : 'N/A',
       diagnostics_assigned: diagnostics_assigned_this_year,
       diagnostics_finished: diagnostics_finished_this_year,
+      evidence_activities_assigned: evidence_activities_assigned_this_year,
+      evidence_activities_completed: evidence_activities_completed_this_year,
+      completed_evidence_activities_per_student: completed_evidence_activities_per_student_this_year,
       percent_completed_diagnostics: diagnostics_assigned_this_year > 0 ? (diagnostics_finished_this_year.to_f / diagnostics_assigned_this_year).round(2) : 'N/A'
     }
   end

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
@@ -30,9 +30,9 @@ class PreviousYearTeacherDatum
       percent_completed_activities: activities_assigned > 0 ? (activities_finished.to_f / activities_assigned).round(2) : 'N/A',
       diagnostics_assigned: diagnostics_assigned_this_year,
       diagnostics_finished: diagnostics_finished_this_year,
-      evidence_activities_assigned: evidence_activities_assigned_this_year || 0,
-      evidence_activities_completed: evidence_activities_completed_this_year || 0,
-      completed_evidence_activities_per_student: completed_evidence_activities_per_student_this_year || 0,
+      evidence_activities_assigned: evidence_activities_assigned_this_year,
+      evidence_activities_completed: evidence_activities_completed_this_year,
+      completed_evidence_activities_per_student: completed_evidence_activities_per_student_this_year,
       percent_completed_diagnostics: diagnostics_assigned_this_year > 0 ? (diagnostics_finished_this_year.to_f / diagnostics_assigned_this_year).round(2) : 'N/A'
     }
   end

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
@@ -30,9 +30,9 @@ class PreviousYearTeacherDatum
       percent_completed_activities: activities_assigned > 0 ? (activities_finished.to_f / activities_assigned).round(2) : 'N/A',
       diagnostics_assigned: diagnostics_assigned_this_year,
       diagnostics_finished: diagnostics_finished_this_year,
-      evidence_activities_assigned: evidence_activities_assigned_this_year,
-      evidence_activities_completed: evidence_activities_completed_this_year,
-      completed_evidence_activities_per_student: completed_evidence_activities_per_student_this_year,
+      evidence_activities_assigned: evidence_activities_assigned_this_year || 0,
+      evidence_activities_completed: evidence_activities_completed_this_year || 0,
+      completed_evidence_activities_per_student: completed_evidence_activities_per_student_this_year || 0,
       percent_completed_diagnostics: diagnostics_assigned_this_year > 0 ? (diagnostics_finished_this_year.to_f / diagnostics_assigned_this_year).round(2) : 'N/A'
     }
   end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -10,6 +10,7 @@ class SerializeVitallySalesUser
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/AbcSize
   def data
     current_time = Time.current
     school_year_start = School.school_year_start(current_time)
@@ -94,6 +95,7 @@ class SerializeVitallySalesUser
     }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/AbcSize
 
   def account_data
     return if account_uid.blank? || account_data_params.blank?

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -24,8 +24,8 @@ class SerializeVitallySalesUser
     diagnostics_assigned_this_year = diagnostics_assigned_in_year_count(@user, school_year_start, school_year_end)
     diagnostics_finished = diagnostics_finished(@user).count
     diagnostics_finished_this_year = diagnostics_finished(@user).where("activity_sessions.completed_at >=?", school_year_start).count
-    evidence_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
-    evidence_finished_this_year = evidence_finished(@user).where("activity_sessions.completed_at >=?", school_year_start).count
+    evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
+    evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
     date_of_last_completed_evidence_activity = evidence_finished(@user).order("activity_sessions.completed_at DESC").select("activity_sessions.completed_at").first&.completed_at&.strftime("%F") || 'N/A'
     {
       accountId: @user.school&.id&.to_s,
@@ -81,8 +81,12 @@ class SerializeVitallySalesUser
         diagnostics_finished_last_year: get_from_cache("diagnostics_finished"),
         percent_completed_diagnostics_this_year: diagnostics_assigned_this_year > 0 ? (diagnostics_finished_this_year.to_f / diagnostics_assigned_this_year).round(2) : 'N/A',
         percent_completed_diagnostics_last_year: get_from_cache("percent_completed_diagnostics"),
-        evidence_activities_assigned_this_year: evidence_assigned_this_year,
-        evidence_activities_completed_this_year: evidence_finished_this_year,
+        evidence_activities_assigned_this_year: evidence_activities_assigned_this_year,
+        evidence_activities_completed_this_year: evidence_activities_completed_this_year,
+        evidence_activities_assigned_last_year: get_from_cache('evidence_activities_assigned'),
+        evidence_activities_completed_last_year: get_from_cache('evidence_activities_completed'),
+        completed_evidence_activities_per_student_this_year: activities_per_student(active_students_this_year, evidence_activities_completed_this_year),
+        completed_evidence_activities_per_student_last_year: get_from_cache("completed_evidence_activities_per_student"),
         date_of_last_completed_evidence_activity: date_of_last_completed_evidence_activity,
         premium_state: @user.premium_state,
         premium_type: @user.subscription&.account_type
@@ -90,10 +94,6 @@ class SerializeVitallySalesUser
     }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
-
-  def evidence_id
-    ActivityClassification.evidence.id
-  end
 
   def account_data
     return if account_uid.blank? || account_data_params.blank?
@@ -151,23 +151,6 @@ class SerializeVitallySalesUser
 
   private def diagnostics_assigned_count(user)
     sum_students(filter_diagnostics(activities_assigned_query(user)))
-  end
-
-  def filter_evidence(activities)
-    evidence_ids = Activity.where(activity_classification_id: evidence_id).pluck(:id)
-    activities.select {|r| evidence_ids.include?(r.id) }
-  end
-
-  def evidence_assigned_in_year_count(user, school_year_start, school_year_end)
-    sum_students(filter_evidence(in_school_year(activities_assigned_query(user), school_year_start, school_year_end)))
-  end
-
-  private def evidence_assigned_count(user)
-    sum_students(filter_evidence(activities_assigned_query(user)))
-  end
-
-  private def evidence_finished(user)
-    activities_finished_query(user).where("activities.activity_classification_id=?", evidence_id)
   end
 
   private def premium_status

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -95,7 +95,7 @@ class SerializeVitallySalesUser
     }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
 
   def account_data
     return if account_uid.blank? || account_data_params.blank?

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
     let!(:unit_activity) { create(:unit_activity, unit: unit, activity: diagnostic, created_at: Date.new(year, 10, 1)) }
     let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: diagnostic, created_at: Date.new(2021, 10, 1)) }
     let!(:unit_activity3) { create(:unit_activity, unit: unit3, activity: connect, created_at: Date.new(year, 10, 1)) }
-    let!(:unit_activity_4) { create(:unit_activity, unit: unit4, activity: evidence, created_at: Date.new(year, 10, 1)) }
+    let!(:unit_activity4) { create(:unit_activity, unit: unit4, activity: evidence, created_at: Date.new(year, 10, 1)) }
 
     before do
       create(:classrooms_teacher, user: teacher, classroom: active_classroom)

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
@@ -86,15 +86,15 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
       expected_data = {
         total_students: 3,
         active_students: 2,
-        activities_assigned: 3,
-        completed_activities: 3,
-        completed_activities_per_student: 1.5,
+        activities_assigned: 4,
+        completed_activities: 4,
+        completed_activities_per_student: 2.0,
+        completed_evidence_activities_per_student: 0.5,
         percent_completed_activities: 1.0,
         diagnostics_assigned: 2,
         diagnostics_finished: 2,
-        evidence_activities_assigned: 4,
+        evidence_activities_assigned: 1,
         evidence_activities_completed: 1,
-        completed_evidence_activities_per_student: 0.25,
         percent_completed_diagnostics: 1.0
       }
       teacher_data = PreviousYearTeacherDatum.new(teacher, year).calculate_data

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
@@ -17,14 +17,18 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
     let!(:unit) { create(:unit, user_id: teacher.id) }
     let!(:unit3) { create(:unit, user_id: teacher.id)}
     let!(:unit2) { create(:unit, user_id: teacher.id) }
+    let!(:unit4) { create(:unit, user_id: teacher.id)}
     let!(:classroom_unit1) { create(:classroom_unit, classroom: active_classroom, unit: unit, created_at: Date.new(year, 10, 1), assigned_student_ids: [student1.id, student2.id])}
     let!(:classroom_unit2) { create(:classroom_unit, classroom: archived_classroom, unit: unit3, created_at: Date.new(year, 10, 1), assigned_student_ids: [student4.id])}
     let!(:classroom_unit3) { create(:classroom_unit, classroom: current_classroom, unit: unit2, created_at: Date.new(2021, 10, 1), assigned_student_ids: [student3.id])}
+    let!(:classroom_unit4) { create(:classroom_unit, classroom: current_classroom, unit: unit4, created_at: Date.new(year, 10, 1), assigned_student_ids: [student4.id])}
     let!(:diagnostic) { create(:diagnostic_activity)}
     let!(:connect) { create(:connect_activity)}
+    let!(:evidence) { create(:evidence_activity)}
     let!(:unit_activity) { create(:unit_activity, unit: unit, activity: diagnostic, created_at: Date.new(year, 10, 1)) }
-    let!(:unit_activity3) { create(:unit_activity, unit: unit3, activity: connect, created_at: Date.new(year, 10, 1)) }
     let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: diagnostic, created_at: Date.new(2021, 10, 1)) }
+    let!(:unit_activity3) { create(:unit_activity, unit: unit3, activity: connect, created_at: Date.new(year, 10, 1)) }
+    let!(:unit_activity_4) { create(:unit_activity, unit: unit4, activity: evidence, created_at: Date.new(year, 10, 1)) }
 
     before do
       create(:classrooms_teacher, user: teacher, classroom: active_classroom)
@@ -60,6 +64,13 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
         completed_at: Date.new(year, 10, 2)
       )
       create(:activity_session,
+        user: student4,
+        classroom_unit: classroom_unit4,
+        state: 'finished',
+        activity: evidence,
+        completed_at: Date.new(year, 10, 2)
+      )
+      create(:activity_session,
         user: student3,
         classroom_unit: classroom_unit3,
         state: 'finished',
@@ -81,6 +92,9 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
         percent_completed_activities: 1.0,
         diagnostics_assigned: 2,
         diagnostics_finished: 2,
+        evidence_activities_assigned: 4,
+        evidence_activities_completed: 1,
+        completed_evidence_activities_per_student: 0.25,
         percent_completed_diagnostics: 1.0
       }
       teacher_data = PreviousYearTeacherDatum.new(teacher, year).calculate_data

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -341,7 +341,7 @@ describe 'SerializeVitallySalesUser' do
     expect(teacher_data[:traits]).to include(
       total_students_last_year: 3,
       active_students_last_year: 2,
-      activities_assigned_last_year: 3,
+      activities_assigned_last_year: 4,
       completed_activities_last_year: 3,
       completed_activities_per_student_last_year: 1.5,
       percent_completed_activities_last_year: 1.0,

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -312,7 +312,7 @@ describe 'SerializeVitallySalesUser' do
     expect(teacher_data[:traits]).to include(
       evidence_activities_assigned_this_year: 2,
       evidence_activities_completed_this_year: 2,
-      completed_evidence_activities_per_student_this_year: 1,
+      completed_evidence_activities_per_student_this_year: 2.0,
       date_of_last_completed_evidence_activity: (middle_of_school_year - 3.days).strftime("%F")
     )
   end
@@ -344,9 +344,9 @@ describe 'SerializeVitallySalesUser' do
       percent_completed_activities_last_year: 1.0,
       diagnostics_assigned_last_year: 2,
       diagnostics_finished_last_year: 2,
-      evidence_activities_assigned: 0,
-      evidence_activities_completed: 0,
-      completed_evidence_activities_per_student: 0,
+      evidence_activities_assigned_last_year: 0,
+      evidence_activities_completed_last_year: 0,
+      completed_evidence_activities_per_student_last_year: 0,
       percent_completed_diagnostics_last_year: 1.0
     )
   end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -29,13 +29,16 @@ describe 'SerializeVitallySalesUser' do
     previous_year_data = {
       total_students: 3,
       active_students: 2,
-      activities_assigned: 3,
+      activities_assigned: 4,
       completed_activities: 3,
       completed_activities_per_student: 1.5,
       percent_completed_activities: 1.0,
       diagnostics_assigned: 2,
       diagnostics_finished: 2,
-      percent_completed_diagnostics: 1.0
+      percent_completed_diagnostics: 1.0,
+      evidence_activities_assigned: 2,
+      evidence_activities_completed: 1,
+      completed_evidence_activities_per_student: 0.5,
     }
     year = School.school_year_start(1.year.ago).year
     CacheVitallyTeacherData.set(teacher.id, year, previous_year_data.to_json)
@@ -344,9 +347,9 @@ describe 'SerializeVitallySalesUser' do
       percent_completed_activities_last_year: 1.0,
       diagnostics_assigned_last_year: 2,
       diagnostics_finished_last_year: 2,
-      evidence_activities_assigned_last_year: 0,
-      evidence_activities_completed_last_year: 0,
-      completed_evidence_activities_per_student_last_year: 0,
+      evidence_activities_assigned_last_year: 2,
+      evidence_activities_completed_last_year: 1,
+      completed_evidence_activities_per_student_last_year: 0.5,
       percent_completed_diagnostics_last_year: 1.0
     )
   end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -312,6 +312,7 @@ describe 'SerializeVitallySalesUser' do
     expect(teacher_data[:traits]).to include(
       evidence_activities_assigned_this_year: 2,
       evidence_activities_completed_this_year: 2,
+      completed_evidence_activities_per_student_this_year: 1,
       date_of_last_completed_evidence_activity: (middle_of_school_year - 3.days).strftime("%F")
     )
   end
@@ -343,6 +344,9 @@ describe 'SerializeVitallySalesUser' do
       percent_completed_activities_last_year: 1.0,
       diagnostics_assigned_last_year: 2,
       diagnostics_finished_last_year: 2,
+      evidence_activities_assigned: 0,
+      evidence_activities_completed: 0,
+      completed_evidence_activities_per_student: 0,
       percent_completed_diagnostics_last_year: 1.0
     )
   end


### PR DESCRIPTION
## WHAT
Update Vitally teacher stats to include Evidence stats for last year, as well as a new stat on Evidence activities completed per student.

## WHY
Sherry requested this data.

## HOW
Minor updates to how we calculate this data, mostly moving things into the shared module so we can store them in the caching function as well as the primary stats file. We'll have to wipe the existing caches with the following method once this is live:

```
keys_to_delete = $redis.keys.select { |k| k.include?('vitally_stats') }
keys_to_delete.each { |key| $redis.del(key) }
```

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Request-for-addition-revision-to-Vitally-Analytics-API-re-Evidence-034337e666db449798b9fb2e4e988907

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | NO - non-app change, NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
