### PR TITLE
Lms/concept result migration feedback

### DIFF
--- a/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
@@ -4,55 +4,9 @@ class CopyOldConceptResultsToConceptResultsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::MIGRATION
 
-  class ConceptResultMigrationDeadlocked < StandardError; end
-
-  BATCH_SIZE = 1_000
-
-  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(start, finish)
-    directions_cache = {}
-    instructions_cache = {}
-    previous_feedbacks_cache = {}
-    prompts_cache = {}
-    question_types_cache = {}
-
-    ConceptResult.bulk_insert(ignore: true) do |bulk_inserter|
-      OldConceptResult.where(id: start..finish).find_each(batch_size: BATCH_SIZE) do |old_concept_result|
-
-        directions = old_concept_result.metadata['directions']
-        instructions = old_concept_result.metadata['instructions']
-        previous_feedback = old_concept_result.metadata['lastFeedback']
-        prompt = old_concept_result.metadata['prompt']
-        question_type = old_concept_result.question_type
-
-        directions_cache[directions] ||= ConceptResultDirections.find_or_create_by(text: directions)&.id if directions
-        instructions_cache[instructions] ||= ConceptResultInstructions.find_or_create_by(text: instructions)&.id if instructions
-        previous_feedbacks_cache[previous_feedback] ||= ConceptResultPreviousFeedback.find_or_create_by(text: previous_feedback)&.id if previous_feedback
-        prompts_cache[prompt] ||= ConceptResultPrompt.find_or_create_by(text: prompt)&.id if prompt
-        question_types_cache[question_type] ||= ConceptResultQuestionType.find_or_create_by(text: question_type)&.id if question_type
-
-        extra_metadata = ConceptResult.parse_extra_metadata(old_concept_result.metadata)
-
-        bulk_inserter.add({
-          answer: old_concept_result.metadata['answer'],
-          attempt_number: old_concept_result.metadata['attemptNumber'],
-          concept_id: old_concept_result.concept_id,
-          correct: old_concept_result.metadata['correct'] == 1,
-          extra_metadata: extra_metadata,
-          question_number: old_concept_result.metadata['questionNumber'],
-          question_score: old_concept_result.metadata['questionScore'],
-          activity_session_id: old_concept_result.activity_session_id,
-          old_concept_result_id: old_concept_result.id,
-          concept_result_directions_id: directions_cache[directions],
-          concept_result_instructions_id: instructions_cache[instructions],
-          concept_result_previous_feedback_id: previous_feedbacks_cache[previous_feedback],
-          concept_result_prompt_id: prompts_cache[prompt],
-          concept_result_question_type_id: question_types_cache[question_type]
-        })
-      end
+    (start..finish).each do |old_concept_result_id|
+      CopySingleConceptResultWorker.perform_async(old_concept_result_id)
     end
-  rescue ActiveRecord::Deadlocked => e
-    raise(ConceptResultMigrationDeadlocked.new, e.message)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CopySingleConceptResultWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::MIGRATION
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def perform(old_concept_result_id)
+    old_concept_result = OldConceptResult.find(old_concept_result_id)
+
+    directions = old_concept_result.metadata['directions']
+    instructions = old_concept_result.metadata['instructions']
+    previous_feedback = old_concept_result.metadata['lastFeedback']
+    prompt = old_concept_result.metadata['prompt']
+    question_type = old_concept_result.question_type
+
+    ActiveRecord::Base.transaction do
+      directions = ConceptResultDirections.find_or_create_by(text: directions)&.id if directions
+      instructions ConceptResultInstructions.find_or_create_by(text: instructions)&.id if instructions
+      previous_feedbacks = ConceptResultPreviousFeedback.find_or_create_by(text: previous_feedback)&.id if previous_feedback
+      prompts = ConceptResultPrompt.find_or_create_by(text: prompt)&.id if prompt
+      question_types = ConceptResultQuestionType.find_or_create_by(text: question_type)&.id if question_type
+
+      extra_metadata = ConceptResult.parse_extra_metadata(old_concept_result.metadata)
+
+      ConceptResult.create!({
+        answer: old_concept_result.metadata['answer'],
+        attempt_number: old_concept_result.metadata['attemptNumber'],
+        concept_id: old_concept_result.concept_id,
+        correct: old_concept_result.metadata['correct'] == 1,
+        extra_metadata: extra_metadata,
+        question_number: old_concept_result.metadata['questionNumber'],
+        question_score: old_concept_result.metadata['questionScore'],
+        activity_session_id: old_concept_result.activity_session_id,
+        old_concept_result_id: old_concept_result.id,
+        concept_result_directions_id: directions,
+        concept_result_instructions_id: instructions,
+        concept_result_previous_feedback_id: previous_feedbacks,
+        concept_result_prompt_id: prompts,
+        concept_result_question_type_id: question_types
+      })
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+end

--- a/services/QuillLMS/spec/workers/copy_old_concept_results_to_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/copy_old_concept_results_to_concept_results_worker_spec.rb
@@ -5,92 +5,14 @@ require 'rails_helper'
 describe CopyOldConceptResultsToConceptResultsWorker, type: :worker do
 
   context '#perform' do
-    let(:question) { create(:question) }
-    let(:activity) { create(:activity, data: {questions: [{key: question.uid}]}) }
-    let(:activity_session) { create(:activity_session_without_concept_results, activity: activity) }
-    let(:metadata) do
-      {
-        "correct": 1,
-        "directions": "Combine the sentences. (And)",
-        "lastFeedback": "Proofread your work. Check your spelling.",
-        "prompt": "Deserts are very dry. Years go by without rain.",
-        "attemptNumber": 2,
-        "answer": "Deserts are very dry, and years go by without rain.",
-        "questionNumber": 1,
-        "questionScore": 0.8
-      }
-    end
-    let(:old_concept_result) { create(:sentence_combining, metadata: metadata, activity_session: activity_session) }
+    it 'should enqueue CopySingleConceptResultWorker job for each id passed in' do
+      min_id = 1
+      max_id = 5
+      (min_id..max_id).each do |id|
+        expect(CopySingleConceptResultWorker).to receive(:perform_async).once.with(id)
+      end
 
-    it 'should create a Student ConceptResult record with Normalized Texts' do
-      expect { subject.perform(old_concept_result.id, old_concept_result.id) }.to change(ConceptResult, :count).by(1)
-
-      concept_result = old_concept_result.concept_result
-
-      expect(concept_result.activity_session).to eq(old_concept_result.activity_session)
-      expect(concept_result.concept).to eq(old_concept_result.concept)
-      expect(concept_result.correct).to be(true)
-      expect(concept_result.attempt_number).to eq(metadata[:attemptNumber])
-      expect(concept_result.question_number).to eq(metadata[:questionNumber])
-      expect(concept_result.question_score).to eq(metadata[:questionScore])
-      expect(concept_result.answer).to eq(metadata[:answer])
-      expect(concept_result.concept_result_directions.text).to eq(metadata[:directions])
-      expect(concept_result.concept_result_instructions).to be(nil)
-      expect(concept_result.concept_result_previous_feedback.text).to eq(metadata[:lastFeedback])
-      expect(concept_result.concept_result_prompt.text).to eq(metadata[:prompt])
-      expect(concept_result.concept_result_question_type.text).to eq(old_concept_result.question_type)
-    end
-
-    it 'should normalize empty string values as nil references to normalized tables' do
-      new_metadata = metadata.merge({'instructions': ''})
-      old_concept_result.update(metadata: new_metadata)
-
-      expect { subject.perform(old_concept_result.id, old_concept_result.id) }.to change(ConceptResult, :count).by(1)
-
-      concept_result = old_concept_result.concept_result
-
-      expect(concept_result.concept_result_instructions).to eq(nil)
-    end
-
-    it 'should be idempotent so that if the same ID is present twice, only one new record is created' do
-      expect do
-        subject.perform(old_concept_result.id, old_concept_result.id)
-        subject.perform(old_concept_result.id, old_concept_result.id)
-      end.to change(ConceptResult, :count).by(1)
-    end
-
-    it 'should skip items with IDs lower than start' do
-      old_concept_result
-      activity_session2 = create(:activity_session_without_concept_results, activity: activity)
-      used_old_concept_result = create(:sentence_combining, metadata: metadata, activity_session: activity_session2)
-
-      bulk_insert_worker_stub = double
-      expect(ConceptResult).to receive(:bulk_insert).and_yield(bulk_insert_worker_stub)
-
-      expect(bulk_insert_worker_stub).to receive(:add).with(hash_including(old_concept_result_id: used_old_concept_result.id))
-      expect(bulk_insert_worker_stub).not_to receive(:add).with(hash_including(old_concept_result_id: old_concept_result.id))
-
-      subject.perform(used_old_concept_result.id, used_old_concept_result.id)
-    end
-
-    it 'should not process items with IDs higher than finish' do
-      old_concept_result
-      activity_session2 = create(:activity_session_without_concept_results, activity: activity)
-      unused_old_concept_result = create(:sentence_combining, metadata: metadata, activity_session: activity_session2)
-
-      bulk_insert_worker_stub = double
-      expect(ConceptResult).to receive(:bulk_insert).and_yield(bulk_insert_worker_stub)
-
-      expect(bulk_insert_worker_stub).to receive(:add).with(hash_including(old_concept_result_id: old_concept_result.id))
-      expect(bulk_insert_worker_stub).not_to receive(:add).with(hash_including(old_concept_result_id: unused_old_concept_result.id))
-
-      subject.perform(old_concept_result.id, old_concept_result.id)
-    end
-
-    it 'should raise custom ConceptResultMigrationDeadlocked error when it triggers and ActiveRecord::Deadlocked error' do
-      expect(ConceptResult).to receive(:bulk_insert).and_raise(ActiveRecord::Deadlocked)
-
-      expect { subject.perform(1,1) }.to raise_error(CopyOldConceptResultsToConceptResultsWorker::ConceptResultMigrationDeadlocked)
+      subject.perform(min_id, max_id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CopySingleConceptResultWorker, type: :worker do
+
+  context '#perform' do
+    let(:question) { create(:question) }
+    let(:activity) { create(:activity, data: {questions: [{key: question.uid}]}) }
+    let(:activity_session) { create(:activity_session_without_concept_results, activity: activity) }
+    let(:metadata) do
+      {
+        "correct": 1,
+        "directions": "Combine the sentences. (And)",
+        "lastFeedback": "Proofread your work. Check your spelling.",
+        "prompt": "Deserts are very dry. Years go by without rain.",
+        "attemptNumber": 2,
+        "answer": "Deserts are very dry, and years go by without rain.",
+        "questionNumber": 1,
+        "questionScore": 0.8
+      }
+    end
+    let(:old_concept_result) { create(:sentence_combining, metadata: metadata, activity_session: activity_session) }
+
+    it 'should create a Student ConceptResult record with Normalized Texts' do
+      expect { subject.perform(old_concept_result.id) }.to change(ConceptResult, :count).by(1)
+
+      concept_result = old_concept_result.concept_result
+
+      expect(concept_result.activity_session).to eq(old_concept_result.activity_session)
+      expect(concept_result.concept).to eq(old_concept_result.concept)
+      expect(concept_result.correct).to be(true)
+      expect(concept_result.attempt_number).to eq(metadata[:attemptNumber])
+      expect(concept_result.question_number).to eq(metadata[:questionNumber])
+      expect(concept_result.question_score).to eq(metadata[:questionScore])
+      expect(concept_result.answer).to eq(metadata[:answer])
+      expect(concept_result.concept_result_directions.text).to eq(metadata[:directions])
+      expect(concept_result.concept_result_instructions).to be(nil)
+      expect(concept_result.concept_result_previous_feedback.text).to eq(metadata[:lastFeedback])
+      expect(concept_result.concept_result_prompt.text).to eq(metadata[:prompt])
+      expect(concept_result.concept_result_question_type.text).to eq(old_concept_result.question_type)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Refactor the batch migration job for `ConceptResult` records so that failing batches fan out into individual migration jobs
## WHY
These batches are failing because specific rows have problematic data in them.  By un-batching the migrations, we can work our way down to the specific failing rows and address those issues on an individual basis without worrying about the surrounding records.
## HOW
- Create a new worker that migrates individual `OldConceptResult` rows to `ConceptResult` records
- Refactor the batch-migrator to enqueue its records into this new worker

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | There's no locked-up data on Staging, so I'm deploying now to make sure it still works, but can't easily test this in staging
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
