### PR TITLE
Segment/ add school to identify segment params

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -222,6 +222,7 @@ class SegmentAnalytics
         premium_state: user.premium_state,
         premium_type: user.subscription&.account_type,
         auditor: user.auditor?,
+        is_admin: user.admin?,
         school_name: user.school&.name,
         school_id: user.school&.id,
         district: user.school&.district&.name

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -222,6 +222,7 @@ class SegmentAnalytics
         premium_state: user.premium_state,
         premium_type: user.subscription&.account_type,
         auditor: user.auditor?,
+        school: user.school&.name,
         district: user.school&.district&.name
       },
       integrations: integration_rules(user.id)

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -223,6 +223,7 @@ class SegmentAnalytics
         premium_type: user.subscription&.account_type,
         auditor: user.auditor?,
         is_admin: user.admin?,
+        email: user.email,
         school_name: user.school&.name,
         school_id: user.school&.id,
         district: user.school&.district&.name

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -222,7 +222,8 @@ class SegmentAnalytics
         premium_state: user.premium_state,
         premium_type: user.subscription&.account_type,
         auditor: user.auditor?,
-        school: user.school&.name,
+        school_name: user.school&.name,
+        school_id: user.school&.id,
         district: user.school&.district&.name
       },
       integrations: integration_rules(user.id)

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -230,26 +230,27 @@ describe 'SegmentAnalytics' do
 
     let(:district) { create(:district) }
     let(:school) { create(:school, district: district) }
-    let(:teacher) { create(:teacher, school: school) }
-    let(:admin) { create(:admin) }
-    let!(:schools_admins) { create(:schools_admins, school: school, user: admin) }
+    let(:teacher1) { create(:teacher, school: school) }
+    let(:teacher2) { create(:teacher, school: school) }
+    let!(:schools_admins) { create(:schools_admins, school: school, user: teacher2) }
 
     it 'sends events to Intercom when the user is a teacher' do
-      analytics.identify(teacher)
+      analytics.identify(teacher1)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
       expect(identify_calls[0][:traits][:is_admin]).to eq(false)
-      expect(identify_calls[0][:traits][:email]).to eq(teacher.email)
+      expect(identify_calls[0][:traits][:email]).to eq(teacher1.email)
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
     end
 
     it 'sends events to Intercom when the user is an admin' do
-      analytics.identify(admin)
+      analytics.identify(teacher2)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
       expect(identify_calls[0][:traits][:is_admin]).to eq(true)
+      expect(identify_calls[0][:traits][:email]).to eq(teacher2.email)
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -236,7 +236,8 @@ describe 'SegmentAnalytics' do
       analytics.identify(teacher)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
-      expect(identify_calls[0][:traits][:school]).to eq(school.name)
+      expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
+      expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
     end
   end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -236,6 +236,7 @@ describe 'SegmentAnalytics' do
       analytics.identify(teacher)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
+      expect(identify_calls[0][:traits][:school]).to eq(school.name)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
     end
   end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -231,17 +231,20 @@ describe 'SegmentAnalytics' do
     let(:district) { create(:district) }
     let(:school) { create(:school, district: district) }
     let(:teacher) { create(:teacher, school: school) }
-    let(:admin) { create(:admin, school: school) }
+    let(:admin) { create(:admin) }
+    let!(:schools_admins) { create(:schools_admins, school: school, user: admin) }
 
     it 'sends events to Intercom when the user is a teacher' do
       analytics.identify(teacher)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
       expect(identify_calls[0][:traits][:is_admin]).to eq(false)
+      expect(identify_calls[0][:traits][:email]).to eq(teacher.email)
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
     end
+
     it 'sends events to Intercom when the user is an admin' do
       analytics.identify(admin)
       expect(identify_calls.size).to eq(1)

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -231,11 +231,22 @@ describe 'SegmentAnalytics' do
     let(:district) { create(:district) }
     let(:school) { create(:school, district: district) }
     let(:teacher) { create(:teacher, school: school) }
+    let(:admin) { create(:admin, school: school) }
 
     it 'sends events to Intercom when the user is a teacher' do
       analytics.identify(teacher)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
+      expect(identify_calls[0][:traits][:is_admin]).to eq(false)
+      expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
+      expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
+      expect(identify_calls[0][:traits][:district]).to eq(district.name)
+    end
+    it 'sends events to Intercom when the user is an admin' do
+      analytics.identify(admin)
+      expect(identify_calls.size).to eq(1)
+      expect(track_calls.size).to eq(0)
+      expect(identify_calls[0][:traits][:is_admin]).to eq(true)
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)


### PR DESCRIPTION
## WHAT
add school value to the Segment identify params

## WHY
we want to track a teacher's school in these identify calls

## HOW
just add a `school` property to the list of params (tested in the Segment debugger console)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-school-to-Segment-Identify-call-08e66be5f62b4b2baab94170f92f344f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
