### PR TITLE
add correct fallback value for react table page size

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
@@ -3,6 +3,8 @@ import { useTable, useSortBy, usePagination, useFilters, useExpanded, useGroupBy
 
 import ReactTablePagination from './reactTablePagination'
 
+const DEFAULT_PAGE_SIZE = 100
+
 function columnClassName(isSorted, isSortedDesc) {
   const defaultClassName = 'rt-th -cursor-pointer'
   if (!isSorted) { return defaultClassName }
@@ -102,7 +104,12 @@ export const ReactTable = ({
       columns,
       autoResetSortBy: false,
       pageCount: manualPageCount,
-      initialState: { pageIndex: currentPage || 0, pageSize: defaultPageSize || data.length || 0, sortBy: defaultSorted || [], groupBy: defaultGroupBy || [], }
+      initialState: {
+        pageIndex: currentPage || 0,
+        pageSize: defaultPageSize || data.length || DEFAULT_PAGE_SIZE,
+        sortBy: defaultSorted || [],
+        groupBy: defaultGroupBy || [],
+      }
     },
     useFilters,
     useGroupBy,


### PR DESCRIPTION
## WHAT
Use a workable default for ReactTable defaultPageSize. 

## WHY
This has arisen on multiple occasions, because we pass a value of `0` by default, which ReactTable chokes on (it uses this value to create an array, resulting in a RangeError). Time to add a generalized solution. 

- https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=9128aa61bbe44b3a9ce339c606269792
- https://github.com/empirical-org/Empirical-Core/pull/9307
## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=9128aa61bbe44b3a9ce339c606269792

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
