### PR TITLE
lms/fix-concept-result-migration-type

### DIFF
--- a/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
@@ -16,7 +16,7 @@ class CopySingleConceptResultWorker
 
     ActiveRecord::Base.transaction do
       directions = ConceptResultDirections.find_or_create_by(text: directions)&.id if directions
-      instructions ConceptResultInstructions.find_or_create_by(text: instructions)&.id if instructions
+      instructions = ConceptResultInstructions.find_or_create_by(text: instructions)&.id if instructions
       previous_feedbacks = ConceptResultPreviousFeedback.find_or_create_by(text: previous_feedback)&.id if previous_feedback
       prompts = ConceptResultPrompt.find_or_create_by(text: prompt)&.id if prompt
       question_types = ConceptResultQuestionType.find_or_create_by(text: question_type)&.id if question_type

--- a/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
@@ -14,6 +14,7 @@ describe CopySingleConceptResultWorker, type: :worker do
         "directions": "Combine the sentences. (And)",
         "lastFeedback": "Proofread your work. Check your spelling.",
         "prompt": "Deserts are very dry. Years go by without rain.",
+        "instructions": "Instructions go here.",
         "attemptNumber": 2,
         "answer": "Deserts are very dry, and years go by without rain.",
         "questionNumber": 1,
@@ -35,7 +36,7 @@ describe CopySingleConceptResultWorker, type: :worker do
       expect(concept_result.question_score).to eq(metadata[:questionScore])
       expect(concept_result.answer).to eq(metadata[:answer])
       expect(concept_result.concept_result_directions.text).to eq(metadata[:directions])
-      expect(concept_result.concept_result_instructions).to be(nil)
+      expect(concept_result.concept_result_instructions.text).to eq(metadata[:instructions])
       expect(concept_result.concept_result_previous_feedback.text).to eq(metadata[:lastFeedback])
       expect(concept_result.concept_result_prompt.text).to eq(metadata[:prompt])
       expect(concept_result.concept_result_question_type.text).to eq(old_concept_result.question_type)


### PR DESCRIPTION
## WHAT
Fix a typo bug and update tests to make sure it doesn't happen again
## WHY
So that these jobs will complete
## HOW
Add an `=` where it should be, and also make sure that our tests cover setting the value (the tests failed because input data bypassed this line due to its guard statement).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
