### PR TITLE
lms/fix-concept-result-migration-job

### DIFF
--- a/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
@@ -7,6 +7,7 @@ class CopySingleConceptResultWorker
   # rubocop:disable Metrics/CyclomaticComplexity
   def perform(old_concept_result_id)
     old_concept_result = OldConceptResult.find(old_concept_result_id)
+    return if old_concept_result.concept_result.present?
 
     directions = old_concept_result.metadata['directions']
     instructions = old_concept_result.metadata['instructions']

--- a/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
@@ -41,5 +41,12 @@ describe CopySingleConceptResultWorker, type: :worker do
       expect(concept_result.concept_result_prompt.text).to eq(metadata[:prompt])
       expect(concept_result.concept_result_question_type.text).to eq(old_concept_result.question_type)
     end
+
+    it 'should return early if the old_concept_result_id has already been migrated' do
+      create(:concept_result, old_concept_result_id: old_concept_result.id)
+      expect do
+        subject.perform(old_concept_result.id)
+      end.to change(ConceptResult, :count).by(0)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Early return if an OldConceptResult got double-queued for migration
## WHY
Somehow some of our individual OldConceptResult records got added to the migration queue multiple times, and we need to process those records out of the queue to empty it.
## HOW
Just check if we've already created a new `ConceptResult` for a given `OldConceptResult` before trying to migrate them again.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
