### PR TITLE
lms/clear-concept-result-migration-queue

### DIFF
--- a/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/app/workers/copy_single_concept_result_worker.rb
@@ -6,7 +6,8 @@ class CopySingleConceptResultWorker
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def perform(old_concept_result_id)
-    old_concept_result = OldConceptResult.find(old_concept_result_id)
+    old_concept_result = OldConceptResult.find_by(id: old_concept_result_id)
+    return unless old_concept_result
     return if old_concept_result.concept_result.present?
 
     directions = old_concept_result.metadata['directions']

--- a/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
+++ b/services/QuillLMS/spec/workers/copy_single_concept_result_worker.rb
@@ -48,5 +48,9 @@ describe CopySingleConceptResultWorker, type: :worker do
         subject.perform(old_concept_result.id)
       end.to change(ConceptResult, :count).by(0)
     end
+
+    it 'should return early if the specified OldConceptResult id does not reference a real object' do
+      expect(subject.perform(old_concept_result.id + 1000)).to be(nil)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Have the job fail gracefully when the id to migrate doesn't exist
## WHY
We were pretty naive in how we enqueued `OldConceptResult` records to migrate, and this has resulted in a handful of calls to migrate records that don't exist.  We want to handle these cases gracefully so that we can clear the migration queue.
## HOW
Allow the job to exit early if given a non-existent ID so that the queue can clear itself

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
