### PR TITLE
Lms/updated parallel write responses

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
-    bulk_inserter = OldConceptResult.bulk_insert(values: concept_results_to_save, return_primary_keys: true)
+    bulk_inserter = OldConceptResult.custom_bulk_insert(values: concept_results_to_save, return_primary_keys: true)
     old_concept_result_ids = bulk_inserter.result_sets.first.map { |result| result['id'] }
     # Note that this will need to be overhauled when we stop writing OldConceptResult
     # records, but we have to have this here now because we have to have the id value

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,8 +85,12 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
-    SaveActivitySessionConceptResultsWorker.perform_async(concept_results_to_save)
-    OldConceptResult.bulk_insert(values: concept_results_to_save)
+    bulk_inserter = OldConceptResult.bulk_insert(values: concept_results_to_save, return_primary_keys: true)
+    old_concept_result_ids = bulk_inserter.result_sets.first.map { |result| result['id'] }
+    # Note that this will need to be overhauled when we stop writing OldConceptResult
+    # records, but we have to have this here now because we have to have the id value
+    # from the OldConceptResult to record the new ConceptResult
+    SaveActivitySessionConceptResultsWorker.perform_async(old_concept_result_ids)
   end
 
   private def concept_results_hash(concept_result)

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,6 +85,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
+    SaveActivitySessionConceptResultsWorker.perform_async(concept_results_to_save)
     OldConceptResult.bulk_insert(values: concept_results_to_save)
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -66,6 +66,7 @@ class ActivitySession < ApplicationRecord
   has_many :user_activity_classifications, through: :classification
   has_one :classroom, through: :classroom_unit
   has_one :unit, through: :classroom_unit
+  has_many :concept_results
   has_many :old_concept_results
   has_many :teachers, through: :classroom
   has_many :concepts, -> { distinct }, through: :old_concept_results

--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -55,6 +55,7 @@ class ConceptResult < ApplicationRecord
 
   def self.create_from_json(data_hash)
     response = init_from_json(data_hash)
+    puts response.as_json
     response.save!
     response
   end
@@ -81,13 +82,16 @@ class ConceptResult < ApplicationRecord
   end
 
   def self.bulk_create_from_json(data_hash_array)
-    data_hash_array.map { |data_hash| create_from_json(data_hash) }
+    data_hash_array.map { |data_hash| create_from_json(data_hash.clone) }
   end
 
   def self.find_or_create_from_old_concept_result(old_concept_result)
     return old_concept_result.concept_result if old_concept_result.concept_result
 
-    create_from_json(old_concept_result.as_json)
+    json = old_concept_result.as_json
+    json['old_concept_result_id'] = old_concept_result.id
+
+    create_from_json(json)
   end
 
   def self.parse_extra_metadata(metadata)

--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -82,7 +82,7 @@ class ConceptResult < ApplicationRecord
   end
 
   def self.bulk_create_from_json(data_hash_array)
-    data_hash_array.map { |data_hash| create_from_json(data_hash.clone) }
+    data_hash_array.map { |data_hash| create_from_json(data_hash) }
   end
 
   def self.find_or_create_from_old_concept_result(old_concept_result)

--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -88,10 +88,10 @@ class ConceptResult < ApplicationRecord
   def self.find_or_create_from_old_concept_result(old_concept_result)
     return old_concept_result.concept_result if old_concept_result.concept_result
 
-    json = old_concept_result.as_json
-    json['old_concept_result_id'] = old_concept_result.id
+    data_hash = old_concept_result.as_json
+    data_hash['old_concept_result_id'] = old_concept_result.id
 
-    create_from_json(json)
+    create_from_json(data_hash)
   end
 
   def self.parse_extra_metadata(metadata)

--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -55,7 +55,6 @@ class ConceptResult < ApplicationRecord
 
   def self.create_from_json(data_hash)
     response = init_from_json(data_hash)
-    puts response.as_json
     response.save!
     response
   end
@@ -71,6 +70,7 @@ class ConceptResult < ApplicationRecord
       concept_id: data_hash[:concept_id],
       attempt_number: metadata[:attemptNumber],
       correct: ActiveModel::Type::Boolean.new.cast(metadata[:correct]),
+      old_concept_result_id: data_hash[:old_concept_result_id],
       question_number: metadata[:questionNumber],
       question_score: metadata[:questionScore]
     )

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -46,7 +46,7 @@ class OldConceptResult < ApplicationRecord
   # as documented when passed `return_primary_keys: true`.  Minimal modifications from
   # the original code found here, specifically around return values in if blocks:
   # https://github.com/jamis/bulk_insert/blob/master/lib/bulk_insert.rb
-  def self.bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false, return_primary_keys: false)
+  def self.bulk_insert(*columns, values: nil, set_size: 500, ignore: false, update_duplicates: false, return_primary_keys: false)
     columns = default_bulk_columns if columns.empty?
     worker = BulkInsert::Worker.new(connection, table_name, primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)
 
@@ -55,15 +55,12 @@ class OldConceptResult < ApplicationRecord
         worker.add_all(values)
         worker.save!
       end
-      worker
     elsif block_given?
       transaction do
         yield worker
         worker.save!
       end
-      worker
-    else
-      worker
     end
+    worker
   end
 end

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -44,7 +44,7 @@ class OldConceptResult < ApplicationRecord
   # Over-riding the `bulk_insert` classmethod from the bulk_insert gem because the
   # behavior documented in the gem doesn't actually work.  This change makes it behave
   # as documented when passed `return_primary_keys: true`.  Minimal modifications from
-  # the original code found here:
+  # the original code found here, specifically around return values in if blocks:
   # https://github.com/jamis/bulk_insert/blob/master/lib/bulk_insert.rb
   def self.bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false, return_primary_keys: false)
     columns = default_bulk_columns if columns.empty?

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -46,6 +46,8 @@ class OldConceptResult < ApplicationRecord
   # as documented when passed `return_primary_keys: true`.  Minimal modifications from
   # the original code found here, specifically around return values in if blocks:
   # https://github.com/jamis/bulk_insert/blob/master/lib/bulk_insert.rb
+  # There's an open issue on the Github project for the gem:
+  # https://github.com/jamis/bulk_insert/issues/66
   def self.bulk_insert(*columns, values: nil, set_size: 500, ignore: false, update_duplicates: false, return_primary_keys: false)
     columns = default_bulk_columns if columns.empty?
     worker = BulkInsert::Worker.new(connection, table_name, primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)

--- a/services/QuillLMS/app/models/old_concept_result.rb
+++ b/services/QuillLMS/app/models/old_concept_result.rb
@@ -48,7 +48,7 @@ class OldConceptResult < ApplicationRecord
   # https://github.com/jamis/bulk_insert/blob/master/lib/bulk_insert.rb
   # There's an open issue on the Github project for the gem:
   # https://github.com/jamis/bulk_insert/issues/66
-  def self.bulk_insert(*columns, values: nil, set_size: 500, ignore: false, update_duplicates: false, return_primary_keys: false)
+  def self.custom_bulk_insert(*columns, values: nil, set_size: 500, ignore: false, update_duplicates: false, return_primary_keys: false)
     columns = default_bulk_columns if columns.empty?
     worker = BulkInsert::Worker.new(connection, table_name, primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)
 

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -2,7 +2,6 @@
 
 class SaveActivitySessionConceptResultsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::MIGRATION
 
   def perform(old_concept_result_ids)
     OldConceptResult.where(id: old_concept_result_ids).each do |old_concept_result|

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -4,7 +4,9 @@ class SaveActivitySessionConceptResultsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::MIGRATION
 
-  def perform(concept_results_hashes)
-    ConceptResult.bulk_create_from_json(concept_results_hashes)
+  def perform(old_concept_result_ids)
+    OldConceptResult.where(id: old_concept_result_ids).each do |old_concept_result|
+      ConceptResult.find_or_create_from_old_concept_result(old_concept_result)
+    end
   end
 end

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SaveActivitySessionConceptResultsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::MIGRATION
+
+  def perform(concept_results_hashes)
+    ConceptResult.bulk_create_from_json(concept_results_hashes)
+  end
+end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -47,24 +47,25 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         create(:old_concept_result,
           activity_session_id: activity_session.id,
           concept: writing_concept,
-          metadata: { foo: 'bar' }
+          metadata: { foo: 'bar', correct: true }
         )
       end
 
       let(:concept_result2) do
         create(:old_concept_result,
           activity_session_id: activity_session.id,
-          metadata: { baz: 'foo' }
+          metadata: { baz: 'foo', correct: true }
         )
       end
 
       let(:concept_result3) do
         create(:old_concept_result,
-          activity_session_id: activity_session.id
+          activity_session_id: activity_session.id,
+          metadata: { correct: true }
         )
       end
 
-      let(:concept_results) do
+      let!(:concept_results) do
         results = JSON.parse([concept_result1, concept_result2, concept_result3].to_json)
 
         results[0] = results[0].merge('concept_uid' => concept_result1.concept.uid)
@@ -74,29 +75,29 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         results
       end
 
-      before do
-        # Run Sidekiq jobs immediately instead of queuing them
-        Sidekiq::Testing.inline! do
-          put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
-        end
-      end
-
       it 'succeeds' do
+        put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
         expect(response.status).to eq(200)
       end
 
       it 'stores the concept results' do
-        activity_session.reload
-        expect(activity_session.old_concept_results.size).to eq 7
-        expect(activity_session.concept_results.size).to eq(7)
+        # Run Sidekiq jobs immediately instead of queuing them
+        Sidekiq::Testing.inline! do
+          expect do
+            put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
+          end.to change { activity_session.reload.old_concept_results.size }.by(3)
+             .and change { activity_session.reload.concept_results.size }.by(3)
+        end
       end
 
       it 'saves the arbitrary metadata for the results' do
+        put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
         activity_session.reload
-        expect(activity_session.old_concept_results.find{|x| x.metadata == {"foo"=>"bar"}}).to be
+        expect(activity_session.old_concept_results.find{|x| x.metadata['foo'] == "bar"}).to be
       end
 
       it 'saves the concept tag relationship (ID) in the result' do
+        put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
         expect(OldConceptResult.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
       end
     end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -49,6 +49,7 @@ describe ActivitySession, type: :model, redis: true do
   it { should have_many(:feedback_histories).through(:feedback_sessions) }
   it { should have_one(:classroom).through(:classroom_unit) }
   it { should have_one(:unit).through(:classroom_unit) }
+  it { should have_many(:concept_results) }
   it { should have_many(:concepts).through(:old_concept_results) }
   it { should have_many(:teachers).through(:classroom) }
   it { should belong_to(:user) }

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -10,7 +10,7 @@ describe SaveActivitySessionConceptResultsWorker, type: :worker do
     it 'should save new ConceptResult records based on an array of OldConceptResult ids' do
       expect { subject.perform(old_concept_result.id) }
         .to change(ConceptResult, :count).by(1)
-      expect(old_concept_result.reload.concept_result).to be
+      expect(old_concept_result.concept_result).to be
     end
 
     it 'should create new ConceptResults that are related to the same ActivitySession as the original OldConceptResult' do

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -5,8 +5,14 @@ require 'rails_helper'
 describe SaveActivitySessionConceptResultsWorker, type: :worker do
 
   context '#perform' do
-    it 'should save new ConceptResult records based on an array of hashes' do
-      raise NotImplementedError
+    let(:old_concept_result) { create(:old_concept_result) }
+
+    it 'should save new ConceptResult records based on an array of OldConceptResult ids' do
+      expect { subject.perform(old_concept_result.id) }
+        .to change(ConceptResult, :count).by(1)
+      puts old_concept_result.reload.as_json
+      puts ConceptResult.all.as_json
+      expect(old_concept_result.reload.concept_result).to be
     end
   end
 end

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -10,8 +10,6 @@ describe SaveActivitySessionConceptResultsWorker, type: :worker do
     it 'should save new ConceptResult records based on an array of OldConceptResult ids' do
       expect { subject.perform(old_concept_result.id) }
         .to change(ConceptResult, :count).by(1)
-      puts old_concept_result.reload.as_json
-      puts ConceptResult.all.as_json
       expect(old_concept_result.reload.concept_result).to be
     end
   end

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -12,5 +12,11 @@ describe SaveActivitySessionConceptResultsWorker, type: :worker do
         .to change(ConceptResult, :count).by(1)
       expect(old_concept_result.reload.concept_result).to be
     end
+
+    it 'should create new ConceptResults that are related to the same ActivitySession as the original OldConceptResult' do
+      subject.perform(old_concept_result.id)
+
+      expect(old_concept_result.concept_result.activity_session).to eq(old_concept_result.activity_session)
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SaveActivitySessionConceptResultsWorker, type: :worker do
+
+  context '#perform' do
+    it 'should save new ConceptResult records based on an array of hashes' do
+      raise NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Begin writing `ConceptResult` records whenever we write `OldConceptResult` records so that both tables keep up to date with any new data from student activities
## WHY
We eventually want to replace `OldConceptResult` with `ConceptResult`, so we need to make sure we can write to both at the same time.  Once we're doing that, we can confirm that the data being written is complete in both places to build confidence for a full switch-over
## HOW
Add a worker that writes `ConceptResult` records, and enqueue that job during the `ActivitySessionController`'s `handle_concept_results` function which is the place where that data gets written.

### Notion Card Links
https://www.notion.so/quill/Write-Response-records-in-parallel-with-ConceptResults-977206a533da442c9c3cd9fa9ad97be7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
