### PR TITLE
lms/add-concept-result-activity-session-index

### DIFF
--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -23,6 +23,7 @@
 #
 # Indexes
 #
+#  index_concept_results_on_activity_session_id    (activity_session_id)
 #  index_concept_results_on_old_concept_result_id  (old_concept_result_id) UNIQUE
 #
 class ConceptResult < ApplicationRecord

--- a/services/QuillLMS/db/migrate/20220721183005_add_concept_result_activity_session_index.rb
+++ b/services/QuillLMS/db/migrate/20220721183005_add_concept_result_activity_session_index.rb
@@ -1,0 +1,5 @@
+class AddConceptResultActivitySessionIndex < ActiveRecord::Migration[6.0]
+  def change
+    add_index :concept_results, :activity_session_id
+  end
+end

--- a/services/QuillLMS/db/migrate/20220721183005_add_concept_result_activity_session_index.rb
+++ b/services/QuillLMS/db/migrate/20220721183005_add_concept_result_activity_session_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConceptResultActivitySessionIndex < ActiveRecord::Migration[6.0]
   def change
     add_index :concept_results, :activity_session_id

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1239,7 +1239,8 @@ CREATE TABLE public.comprehension_activities (
     scored_level character varying(100),
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    notes character varying
+    notes character varying,
+    version smallint DEFAULT 0 NOT NULL
 );
 
 
@@ -2333,7 +2334,8 @@ CREATE TABLE public.feedback_histories (
     metadata jsonb,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    rule_uid character varying
+    rule_uid character varying,
+    activity_version smallint DEFAULT 0 NOT NULL
 );
 
 
@@ -6784,6 +6786,13 @@ CREATE UNIQUE INDEX index_concept_result_question_types_on_text ON public.concep
 
 
 --
+-- Name: index_concept_results_on_activity_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_concept_results_on_activity_session_id ON public.concept_results USING btree (activity_session_id);
+
+
+--
 -- Name: index_concept_results_on_old_concept_result_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8619,6 +8628,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220608144739'),
 ('20220609173524'),
 ('20220614152118'),
+('20220623214342'),
 ('20220628174900'),
 ('20220705143703'),
 ('20220707154724'),
@@ -8626,6 +8636,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220707155013'),
 ('20220707155014'),
 ('20220707155015'),
-('20220707155016');
+('20220707155016'),
+('20220708201219'),
+('20220721183005');
 
 

--- a/services/QuillLMS/spec/models/concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_spec.rb
@@ -23,6 +23,7 @@
 #
 # Indexes
 #
+#  index_concept_results_on_activity_session_id    (activity_session_id)
 #  index_concept_results_on_old_concept_result_id  (old_concept_result_id) UNIQUE
 #
 require 'rails_helper'


### PR DESCRIPTION
## WHAT
Add an index on concept_results.activity_session_id
## WHY
We excluded this index during the migration to speed up writes during the process, but we almost always reference ConceptResult records from the related ActivitySession, so we need this index for actual performance.
## HOW
Add a migration to create the necessary index

### Notion Card Links
https://www.notion.so/quill/Add-activity_session_id-index-to-concept_results-table-ee26fbcf3d3a4f8f822cfe1cc0dbd698

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior changes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
