### PR TITLE
Remove select2-rails dependency

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -96,7 +96,6 @@ gem 'actionpack-action_caching'
 # JS/APP/UI
 gem 'turbolinks'
 gem 'jquery-turbolinks'
-gem 'select2-rails'
 gem 'jbuilder'
 gem 'active_link_to'
 

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -659,8 +659,6 @@ GEM
       tilt
     scout_apm (2.4.21)
     secure_headers (6.3.2)
-    select2-rails (4.0.3)
-      thor (~> 0.14)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -881,7 +879,6 @@ DEPENDENCIES
   sass-rails
   scout_apm
   secure_headers (= 6.3.2)
-  select2-rails
   selenium-webdriver
   sentry-raven (>= 0.12.2)
   shoulda-callback-matchers (~> 1.1.1)

--- a/services/QuillLMS/app/assets/javascripts/application_non_webpack.js
+++ b/services/QuillLMS/app/assets/javascripts/application_non_webpack.js
@@ -6,7 +6,6 @@
 
 //= require es5-shim/es5-shim
 
-//= require select2
 //= require custom
 
 //= require tabslet.js

--- a/services/QuillLMS/app/assets/stylesheets/application.scss
+++ b/services/QuillLMS/app/assets/stylesheets/application.scss
@@ -3,7 +3,6 @@
 
 @import "bootstrap-sprockets";
 @import "bootstrap";
-@import "select2";
 @import "variables";
 @import "mixins";
 @import "custom";

--- a/services/QuillLMS/app/assets/stylesheets/pages/new_account_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/new_account_page.scss
@@ -27,25 +27,6 @@
     font-weight: bold;
   }
 
-  .form-school-select {
-    #zip {
-      // width: 150px;
-    }
-    .school_ids {
-      margin-left: 0; width: 400px; float: left; clear: right;
-      .controls {margin-left: 0;}
-      .select2-container .select2-choice {
-        height: 42px;
-        .select2-chosen {line-height: 42px;}
-        .select2-arrow b {position: absolute; top: 7px;}
-        abbr {top: 14px;}
-      }
-    }
-    .school_select {
-      height: 50px;
-    }
-  }
-
   .form-explanation-text {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
## WHAT
1.  Remove the Gem `select2-rails` from the LMS gemfile
2. Also, remove a test.log file in `services/QuillLMS/engines/comprehension/spec/dummy/log/test.log`

## WHY
1.  The gem doesn't appear to be in use anymore and removing it will simplify Rails 6.1 upgrade.
2. If possible, references to comprehension should be removed.

## HOW
1. `bundle remove select2-rails`.  Then remove a dead css classes referencing select2 along with some imports.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A