### PR TITLE
Remove rails_12_factor gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -151,7 +151,6 @@ gem 'awesome_print'
 
 group :production, :staging do
   gem 'rails_autoscale_agent'
-  gem 'rails_12factor'
   gem 'lograge'
   gem 'sqreen'
 end

--- a/services/QuillLMS/config/environments/production.rb
+++ b/services/QuillLMS/config/environments/production.rb
@@ -115,4 +115,14 @@ EmpiricalGrammar::Application.configure do
     'www.quill.org.' => 'www.quill.org',
     'quill.org' => 'www.quill.org'
   }
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new($stdout)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/services/QuillLMS/config/environments/production.rb
+++ b/services/QuillLMS/config/environments/production.rb
@@ -118,9 +118,9 @@ EmpiricalGrammar::Application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', 'false') == 'true'
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV.fetch("RAILS_LOG_TO_STDOUT", 'false') == 'true'
     logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
## WHAT
Remove the rails_12_factor gem from the LMS.

## WHY
The gem is no longer maintained.

There is also a deprecation in Rails 6.1: 
```
DEPRECATION WARNING: Including LoggerSilence is deprecated and will be removed in Rails 6.1. 
Please use `ActiveSupport::LoggerSilence` instead 
(called from <top (required)> at /tmp/build_48c3bc04/config/application.rb:15)
```

## HOW
Follow the [instructions](https://github.com/heroku/rails_12factor#migrating-to-rails-5) for removing  the gem.

Note the setting of ENV variables:
![Screen Shot 2022-07-25 at 10 55 15 AM](https://user-images.githubusercontent.com/2057805/180807213-c76978b3-f919-4406-b58b-f8f1790afff4.png)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
