### PR TITLE
add css rules for forced-colors for mark tags in Evidence

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -361,3 +361,20 @@
     }
   }
 }
+
+@media (forced-colors: active) {
+  .read-passage-container .passage {
+    mark {
+      color: CanvasText;
+      background-color: Canvas;
+      &:focus, &:hover {
+        color: MarkText;
+        background-color: Mark;
+      }
+      &.highlighted {
+        color: HighlightText;
+        background-color: Highlight;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## WHAT
Add CSS rules for `forced-colors` for mark tags in Evidence.

## WHY
We noticed in the last accessibility audit that the text of highlightable elements weren't showing up with Colleen's display settings. I wasn't able to replicate this precisely, because Macs have different accessibility display options than Windows computers, but I found information about how to render colors in that context which will hopefully mitigate the issue.

## HOW
Apply explicit system colors to the different iterations of the highlight elements (unhighlighted and unfocused, which should appear like regular text, focused, which should appear called out in some way, and highlighted, which should appear called out in a different way) in the `forced-colors` media query, which is now supported on all major browsers except Safari, which Windows users are unlikely to be using (`forced-colors` is specific to the Windows settings, but the same issue doesn't appear to happen on Macs anyway).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-contrast-for-highlighting-section-in-Evidence-55563de7e00f4de4ab189ccc537dd4f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
