### PR TITLE
Remove Rails 12 Factor from Gemfile.lock

### DIFF
--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -548,9 +548,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_admin (2.2.1)
       activemodel-serializers-xml (>= 1.0)
       builder (~> 3.1)
@@ -564,8 +561,6 @@ GEM
       remotipart (~> 1.3)
       sassc-rails (>= 1.3, < 3)
     rails_autoscale_agent (0.10.2)
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.5)
       actionpack (= 6.0.5)
       activesupport (= 6.0.5)
@@ -863,7 +858,6 @@ DEPENDENCIES
   rack-test (~> 0.6.3)
   rails (= 6.0.5)
   rails-controller-testing
-  rails_12factor
   rails_admin (~> 2.2)
   rails_autoscale_agent
   ranked-model (~> 0.4.3)


### PR DESCRIPTION
## WHAT
Remove Rails 12 Factor from Gemfile.lock

## WHY
It got left out of previous commit.

## HOW
Add file

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Yes.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A