### PR TITLE
Upgrade puma to 5.6.4

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -6,10 +6,10 @@ ruby '2.7.6'
 
 # CORE DEPS
 gem 'rails', '6.0.5'
-gem 'puma', '>= 4.3.11'
+gem 'puma', '~> 5.6.4'
 
 # EARLY TO APPLY TO OTHER GEMS
-gem 'dotenv-rails', '~>2.6'
+gem 'dotenv-rails', '~> 2.6'
 
 # DB/MODEL
 gem 'pg', '0.18.4'
@@ -140,7 +140,7 @@ gem 'rack-heartbeat'
 gem 'clever-ruby', '~> 2.0.1'
 
 # Memory profiling
-gem 'puma_worker_killer', '~> 0.1.0'
+gem 'puma_worker_killer'
 
 # temp for migrations
 gem 'paperclip'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -493,11 +493,11 @@ GEM
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
     public_suffix (4.0.6)
-    puma (4.3.11)
+    puma (5.6.4)
       nio4r (~> 2.0)
-    puma_worker_killer (0.1.1)
+    puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
-      puma (>= 2.7, < 5)
+      puma (>= 2.7)
     pusher (1.3.2)
       httpclient (~> 2.7)
       multi_json (~> 1.0)
@@ -846,8 +846,8 @@ DEPENDENCIES
   pry-remote
   pry-rescue
   pry-stack_explorer
-  puma (>= 4.3.11)
-  puma_worker_killer (~> 0.1.0)
+  puma (~> 5.6.4)
+  puma_worker_killer
   pusher (~> 1.3)
   rack-affiliates (= 0.4.0)
   rack-attack (~> 6.3)

--- a/services/QuillLMS/config/puma.rb
+++ b/services/QuillLMS/config/puma.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 workers Integer(ENV['PUMA_WORKERS'] || 3)
-threads Integer(ENV['MIN_THREADS']  || 1), Integer(ENV['MAX_THREADS'] || 10)
+threads Integer(ENV['PUMA_MIN_THREADS']  || 1), Integer(ENV['PUMA_MAX_THREADS'] || 10)
 
 preload_app!
 
@@ -14,7 +14,7 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     config = ActiveRecord::Base.configurations[Rails.env] ||
                 Rails.application.config.database_configuration[Rails.env]
-    config['pool'] = ENV['MAX_THREADS'] || 16
+    config['pool'] = ENV['PUMA_MAX_THREADS'] || 16
     ActiveRecord::Base.establish_connection(config)
   end
 end

--- a/services/QuillLMS/config/puma.rb
+++ b/services/QuillLMS/config/puma.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 workers Integer(ENV['WEB_CONCURRENCY'] || 3)
-threads Integer(ENV['PUMA_MIN_THREADS']  || 1), Integer(ENV['PUMA_MAX_THREADS'] || 10)
+threads Integer(ENV['MIN_THREADS'] || 1), Integer(ENV['MAX_THREADS'] || 10)
 
 preload_app!
 
@@ -14,7 +14,7 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     config = ActiveRecord::Base.configurations[Rails.env] ||
                 Rails.application.config.database_configuration[Rails.env]
-    config['pool'] = ENV['PUMA_MAX_THREADS'] || 16
+    config['pool'] = ENV['MAX_THREADS'] || 16
     ActiveRecord::Base.establish_connection(config)
   end
 end

--- a/services/QuillLMS/config/puma.rb
+++ b/services/QuillLMS/config/puma.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-workers Integer(ENV['PUMA_WORKERS'] || 3)
+workers Integer(ENV['WEB_CONCURRENCY'] || 3)
 threads Integer(ENV['PUMA_MIN_THREADS']  || 1), Integer(ENV['PUMA_MAX_THREADS'] || 10)
 
 preload_app!


### PR DESCRIPTION
## WHAT
Upgrade puma library to latest version

## WHY
This is in preparation for Rails 6.1 ugprade.
Using the current version of puma yields:

![Screen Shot 2022-07-25 at 1 53 55 PM](https://user-images.githubusercontent.com/2057805/180850599-43bbc281-4ba4-40e4-9abc-21917b6b31c6.png)

## HOW
Update version in Gemfile and run `bundle update`
Rename a `PUMA_WORKERS` ENV variable  to `WEB_CONCURRENCY` per the upgrade [doc](https://github.com/puma/puma/blob/master/5.0-Upgrade.md#upgrade)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
