### PR TITLE
fix poorly labelled elements in log in flow

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -115,13 +115,14 @@ class LoginFormApp extends React.Component {
 
   renderKeepMeSignedIn = () => {
     const { keepMeSignedIn, } = this.state
+    const keepMeSignedInId = "keep-me-signed-in"
     let checkbox
     if (keepMeSignedIn) {
-      checkbox = <button aria-checked={true} className="quill-checkbox selected focus-on-light" onClick={this.handleToggleKeepMeSignedIn} onKeyDown={this.handleKeyDownOnToggleNewsletter} role="checkbox" type="button"><img alt="check" src={smallWhiteCheckSrc} /></button>
+      checkbox = <button aria-checked={true} aria-labelledby={keepMeSignedInId} className="quill-checkbox selected focus-on-light" onClick={this.handleToggleKeepMeSignedIn} onKeyDown={this.handleKeyDownOnToggleNewsletter} role="checkbox" type="button"><img alt="check" src={smallWhiteCheckSrc} /></button>
     } else {
-      checkbox = <button aria-checked={false} aria-label="Unchecked" className="quill-checkbox unselected focus-on-light" onClick={this.handleToggleKeepMeSignedIn} role="checkbox" type="button" />
+      checkbox = <button aria-checked={false} aria-labelledby={keepMeSignedInId} className="quill-checkbox unselected focus-on-light" onClick={this.handleToggleKeepMeSignedIn} role="checkbox" type="button" />
     }
-    return <div className="keep-me-signed-in-row">{checkbox} <p>Keep me signed in</p></div>
+    return <div className="keep-me-signed-in-row" id={keepMeSignedInId}>{checkbox} <p>Keep me signed in</p></div>
   }
 
   render() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/shared/__tests__/__snapshots__/password_wrapper.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/shared/__tests__/__snapshots__/password_wrapper.test.jsx.snap
@@ -50,12 +50,13 @@ exports[`PasswordWrapper component should render 1`] = `
       </div>
     </Input>
     <button
+      aria-label="Show password"
       className="interactive-wrapper focus-on-light"
       onClick={[Function]}
       type="button"
     >
       <img
-        alt="Eye icon"
+        alt=""
         src="undefined/images/icons/icons-visibility-on.svg"
       />
     </button>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/shared/password_wrapper.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/shared/password_wrapper.tsx
@@ -4,8 +4,6 @@ import { Input, } from '../../../../Shared/index'
 
 const passwordVisibleSrc = `${process.env.CDN_URL}/images/icons/icons-visibility-on.svg`
 const passwordNotVisibleSrc = `${process.env.CDN_URL}/images/icons/icons-visibility-off.svg`
-const passwordVisibleAltText = 'Eye icon'
-const passwordNotVisibleAltText = 'Eye with slash icon'
 
 const PasswordWrapper = ({ autoComplete, className, error, onChange, id, label, timesSubmitted, value, }) => {
   const [showPassword, setShowPassword] = React.useState(false)
@@ -25,7 +23,7 @@ const PasswordWrapper = ({ autoComplete, className, error, onChange, id, label, 
         type={showPassword ? 'text' : 'password'}
         value={value}
       />
-      <button className="interactive-wrapper focus-on-light" onClick={toggleShowPassword} type="button"><img alt={showPassword ? passwordNotVisibleAltText : passwordVisibleAltText} src={showPassword ? passwordNotVisibleSrc : passwordVisibleSrc} /></button>
+      <button aria-label={showPassword ? 'Hide password' : 'Show password'} className="interactive-wrapper focus-on-light" onClick={toggleShowPassword} type="button"><img alt="" src={showPassword ? passwordNotVisibleSrc : passwordVisibleSrc} /></button>
     </div>
   )
 }


### PR DESCRIPTION
## WHAT
Make it clearer what the "show password" button and "keep me signed in" checkbox are doing.

## WHY
So these items are accessible for SR users.

## HOW
Just update items to use `aria-label` and `aria-labelledby`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Address-accessibility-issues-with-login-signup-page-e6e2d69ffa374f4d84bd15f9658e6dd4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
