### PR TITLE
lms/create-concept-result-analyzer

### DIFF
--- a/services/QuillLMS/app/mailers/application_mailer.rb
+++ b/services/QuillLMS/app/mailers/application_mailer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationMailer < ActionMailer::Base
+
+end

--- a/services/QuillLMS/app/mailers/send_attachment_mailer.rb
+++ b/services/QuillLMS/app/mailers/send_attachment_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SendAttachmentMailer < ActionMailer::Base
+class SendAttachmentMailer < ApplicationMailer
   default from: 'hello@quill.org'
 
   def send_attached_file(recipient, subject, file_name, file_stream)

--- a/services/QuillLMS/app/mailers/send_attachment_mailer.rb
+++ b/services/QuillLMS/app/mailers/send_attachment_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SendAttachmentMailer < ActionMailer::Base
+  default from: 'hello@quill.org'
+
+  def send_attached_file(recipient, subject, file_name, file_stream)
+    attachments[file_name] = file_stream
+    mail(to: recipient, subject: subject) do |format|
+      format.text { render(plain: "'#{file_name}' attached.") }
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
@@ -45,5 +45,6 @@ class IdentifyUnmigratedOldConceptResultsWorker
       .left_outer_joins(:concept_result)
       .where(concept_results: {id: nil})
       .where(id: (start_id..stop_id))
+      .order(:id)
   end
 end

--- a/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class IdentifyUnmigratedOldConceptResultsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::MIGRATION
+
+  REPORT_RECIPIENT = 'thomas@quill.org'
+  BATCH_SIZE = 10_000_000
+
+  def perform()
+    max_id = OldConceptResult.maximum(:id)
+
+    start_id = 1
+
+    missing_id_ranges = []
+
+    while start_id < max_id do
+      stop_id = [(start_id + BATCH_SIZE - 1), max_id].min
+
+      missing_ids_query(start_id, stop_id).find_each(batch_size: 1_000) do |old_concept_result|
+        if missing_id_ranges.last&.last == old_concept_result.id - 1
+          missing_id_ranges.last[-1] = old_concept_result.id
+        else
+          missing_id_ranges.push([old_concept_result.id, old_concept_result.id])
+        end
+      end
+      start_id += BATCH_SIZE
+    end
+
+    csv_output = ""
+    missing_id_ranges.each do |id_range|
+      csv_output += CSV.generate_line(id_range)
+    end
+
+    send_report(csv_output)
+  end
+
+  def send_report(csv_output)
+    SendAttachmentMailer.send_attached_file(REPORT_RECIPIENT, 'Unmigrated OldConceptResult IDs', 'unmigrated_old_concept_result_id_ranges.csv', csv_output).deliver_now!
+  end
+
+  def missing_ids_query(start_id, stop_id)
+    OldConceptResult
+      .select(:id)
+      .left_outer_joins(:concept_result)
+      .where(concept_results: {id: nil})
+      .where(id: (start_id..stop_id))
+  end
+end

--- a/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
@@ -7,14 +7,14 @@ class IdentifyUnmigratedOldConceptResultsWorker
   REPORT_RECIPIENT = 'thomas@quill.org'
   BATCH_SIZE = 10_000_000
 
-  def perform()
+  def perform
     max_id = OldConceptResult.maximum(:id)
 
     start_id = 1
 
     missing_id_ranges = []
 
-    while start_id < max_id do
+    while start_id < max_id
       stop_id = [(start_id + BATCH_SIZE - 1), max_id].min
 
       missing_ids_query(start_id, stop_id).find_each(batch_size: 1_000) do |old_concept_result|

--- a/services/QuillLMS/spec/mailers/send_attachment_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/send_attachment_mailer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SendAttachmentMailer, type: :mailer do
+
+  describe '#send_attached_file' do
+    let(:recipient) { 'test@email.com' }
+    let(:email_subject) { 'Test Subject' }
+    let(:file_name) { 'file_name.csv' }
+    let(:file_stream) { 'the contents of the file as a string' }
+
+    it 'sets the attachment value' do
+      allow_any_instance_of(SendAttachmentMailer).to receive(:mail)
+
+      subject.send_attached_file(recipient, email_subject, file_name, file_stream)
+
+      expect(subject.attachments[file_name].body).to eq(file_stream)
+    end
+
+    it 'calls "mail" as expected' do
+      expect_any_instance_of(SendAttachmentMailer).to receive(:mail).with(to: recipient, subject: email_subject)
+
+      subject.send_attached_file(recipient, email_subject, file_name, file_stream)
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
@@ -26,19 +26,20 @@ describe IdentifyUnmigratedOldConceptResultsWorker, type: :worker do
     let(:old_concept_results) { (1..10).map { create(:old_concept_result, activity_session: activity_session) } }
     let!(:concept_result) { create(:concept_result, old_concept_result_id: old_concept_results[5].id, activity_session_id: activity_session.id) }
 
-    let(:unmigrated_ranges) { [
-      [old_concept_results[0].id, old_concept_results[4].id],
-      [old_concept_results[6].id, old_concept_results[-1].id]
-    ] }
+    let(:unmigrated_ranges) {
+      [
+        [old_concept_results[0].id, old_concept_results[4].id],
+        [old_concept_results[6].id, old_concept_results[-1].id]
+      ]
+    }
 
     it 'should identify OldConceptResult records with no corresponding ConceptResult' do
       csv_data = unmigrated_ranges.map { |range| CSV.generate_line(range) }.join
 
-      expect(subject).to receive(:send_report).with(csv_data)
+      expect_any_instance_of(IdentifyUnmigratedOldConceptResultsWorker).to receive(:send_report).with(csv_data)
 
       subject.perform
     end
-    
   end
 end
 

--- a/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IdentifyUnmigratedOldConceptResultsWorker, type: :worker do
+
+  context '#send_report' do
+    it 'should instantiate a mailer and call for delivery' do
+      send_me = 'test'
+
+      mailer_double = double
+      expect(mailer_double).to receive(:deliver_now!)
+      expect(SendAttachmentMailer).to receive(:send_attached_file)
+        .with(IdentifyUnmigratedOldConceptResultsWorker::REPORT_RECIPIENT,
+          'Unmigrated OldConceptResult IDs',
+          'unmigrated_old_concept_result_id_ranges.csv',
+          send_me)
+        .and_return(mailer_double)
+
+      subject.send_report(send_me)
+    end
+  end
+
+  context '#perform' do
+    let(:activity_session) { create(:activity_session_without_concept_results) }
+    let(:old_concept_results) { (1..10).map { create(:old_concept_result, activity_session: activity_session) } }
+    let!(:concept_result) { create(:concept_result, old_concept_result_id: old_concept_results[5].id, activity_session_id: activity_session.id) }
+
+    let(:unmigrated_ranges) { [
+      [old_concept_results[0].id, old_concept_results[4].id],
+      [old_concept_results[6].id, old_concept_results[-1].id]
+    ] }
+
+    it 'should identify OldConceptResult records with no corresponding ConceptResult' do
+      csv_data = unmigrated_ranges.map { |range| CSV.generate_line(range) }.join
+
+      expect(subject).to receive(:send_report).with(csv_data)
+
+      subject.perform
+    end
+    
+  end
+end
+


### PR DESCRIPTION
## WHAT
Add a background worker to figure out which old_concept_ids didn't migrate
## WHY
So that we can get a list of items to try migrating again in order to hopefully fill in all of our gaps.  We want all of our `OldConceptResult` records to be successfully migrated.
## HOW
Do a series of LEFT OUTER JOINS to figure out which `OldConceptResult`s don't have a corresponding `ConceptResult` record, then email a list of all of those ids to Thomas for later use.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
