### PR TITLE
update readability grade level mapping

### DIFF
--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -84,7 +84,7 @@ class Cms::ActivitiesController < Cms::CmsController
   protected def set_raw_score_options_and_raw_score_to_readability_grade_band
     @raw_score_options = RawScore.order_by_name
     @raw_score_to_readability_grade_band = {}
-    @raw_score_options.each { |rs| @raw_score_to_readability_grade_band[rs.name] = rs.readability_grade_level(@activity_classification.id) }
+    @raw_score_options.each { |rs| @raw_score_to_readability_grade_band[rs.name] = rs.readability_grade_level }
     @readability_grade_band_to_minimum_grade_level = Activity::READABILITY_GRADE_LEVEL_TO_MINIMUM_GRADE_LEVEL
   end
 

--- a/services/QuillLMS/app/controllers/cms/raw_scores_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/raw_scores_controller.rb
@@ -17,7 +17,7 @@ class Cms::RawScoresController < Cms::CmsController
       conversion_table = raw_scores.map do |rs|
         {
           raw_score: rs.name,
-          grade_band: rs.readability_grade_level(ac.id),
+          grade_band: rs.readability_grade_level,
           activity_count: Activity.where(raw_score_id: rs.id, activity_classification_id: ac.id).count
         }
       end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -243,7 +243,7 @@ class Activity < ApplicationRecord
   end
 
   def readability_grade_level
-    raw_score&.readability_grade_level(activity_classification_id)
+    raw_score&.readability_grade_level
   end
 
   def default_minimum_grade_level

--- a/services/QuillLMS/app/models/raw_score.rb
+++ b/services/QuillLMS/app/models/raw_score.rb
@@ -30,7 +30,6 @@ class RawScore < ApplicationRecord
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def readability_grade_level
     case name
     when "1200-1300", "1300-1400", "1400-1500"
@@ -47,5 +46,5 @@ class RawScore < ApplicationRecord
       ""
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+
 end

--- a/services/QuillLMS/app/models/raw_score.rb
+++ b/services/QuillLMS/app/models/raw_score.rb
@@ -31,36 +31,17 @@ class RawScore < ApplicationRecord
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def readability_grade_level(activity_classification_id=nil)
-    activity_classification = ActivityClassification.find_by_id(activity_classification_id)
+  def readability_grade_level
     case name
-    when "1200-1300"
-      if ActivityClassification::EVIDENCE_KEY == activity_classification.key
-        EIGHTH_THROUGH_NINTH
-      else
-        TENTH_THROUGH_TWELFTH
-      end
-    when "1300-1400", "1400-1500"
+    when "1200-1300", "1300-1400", "1400-1500"
       TENTH_THROUGH_TWELFTH
-    when "900-1000", "1000-1100", "1100-1200"
+    when "1000-1100", "1100-1200"
       EIGHTH_THROUGH_NINTH
-    when "600-700", "700-800", "800-900"
+    when "800-900", "900-1000"
       SIXTH_THROUGH_SEVENTH
-    when "500-600"
-      if [ActivityClassification::PROOFREADER_KEY, ActivityClassification::EVIDENCE_KEY].include?(activity_classification.key)
-        FOURTH_THROUGH_FIFTH
-      else
-        SIXTH_THROUGH_SEVENTH
-      end
-    when "400-500"
+    when "500-600", "600-700", "700-800"
       FOURTH_THROUGH_FIFTH
-    when "300-400"
-      if [ActivityClassification::PROOFREADER_KEY, ActivityClassification::EVIDENCE_KEY].include?(activity_classification.key)
-        SECOND_THROUGH_THIRD
-      else
-        FOURTH_THROUGH_FIFTH
-      end
-    when "BR100-0", "0-100", "100-200", "200-300"
+    when "BR100-0", "0-100", "100-200", "200-300", "300-400", "400-500"
       SECOND_THROUGH_THIRD
     else
       ""

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -486,14 +486,6 @@ describe Activity, type: :model, redis: true do
       expect(activity.readability_grade_level).to eq('6th-7th')
     end
 
-    it 'should behave differently based on activity classification' do
-      raw_score = create(:raw_score, :five_hundred_to_six_hundred)
-      connect_activity = create(:connect_activity, raw_score_id: raw_score.id)
-      proofreader_activity = create(:proofreader_activity, raw_score_id: raw_score.id)
-      expect(proofreader_activity.readability_grade_level).to eq('4th-5th')
-      expect(connect_activity.readability_grade_level).to eq('6th-7th')
-    end
-
     it 'should return nil if there is no raw_score_id' do
       activity = create(:activity, raw_score_id: nil)
       expect(activity.readability_grade_level).to eq(nil)

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -58,7 +58,7 @@ describe UnitTemplate, redis: true, type: :model do
 
       unit_template = create(:unit_template, activity_ids: [activity_one.id, activity_two.id])
 
-      expect(unit_template.readability).to eq("4th-7th")
+      expect(unit_template.readability).to eq("2nd-7th")
     end
 
     it 'calculates readability as nil if the activities do not have readability' do
@@ -78,7 +78,7 @@ describe UnitTemplate, redis: true, type: :model do
 
       unit_template = create(:unit_template, activity_ids: [activity_one.id, activity_two.id])
 
-      expect(unit_template.readability).to eq("4th-5th")
+      expect(unit_template.readability).to eq("2nd-3rd")
     end
   end
 


### PR DESCRIPTION
## WHAT
Update readability grade level mapping.

## WHY
This was a request from the curriculum team.

## HOW
Just update this method in accordance with the new mapping (https://docs.google.com/spreadsheets/d/1Xu0MemcC4ArLO2lnxVa8yjXy8Uir5h5OvX6bVs636LY/edit#gid=1190603534) which no longer uses activity classifications. We could also just make this into a hash now that we don't need to take the extra parameter into account - if anyone feels strongly about that let me know. Once this is live, I'm going to run `Activity.all.each { |a| a.set_minimum_and_maximum_grade_levels_to_default_values }` to make sure the new grade ranges (aka `minimum_grade_level` and `maximum_grade_level` match the new readability values).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-lexile-score-to-readability-grade-level-mapping-804103f5feae4fd49fb8c95cb6ec39db

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES (just removed the test around how the grade levels should change if the activity classification is different)
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
