### PR TITLE
change beta and gamma flag logic

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -89,8 +89,8 @@ class Activity < ApplicationRecord
   ALPHA = 'alpha'
   ARCHIVED = 'archived'
 
-  scope :gamma_user, -> { where("'#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
-  scope :beta_user, -> { where("'#{BETA}' = ANY(activities.flags) OR '#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
+  scope :gamma_user, -> { where("'#{GAMMA}' = ANY(activities.flags) OR '#{BETA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
+  scope :beta_user, -> { where("'#{BETA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
   scope :alpha_user, -> { where("'#{ALPHA}' = ANY(activities.flags) OR '#{BETA}' = ANY(activities.flags) OR '#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
 
   scope :with_classification, -> { includes(:classification).joins(:classification) }

--- a/services/QuillLMS/app/queries/activity_search.rb
+++ b/services/QuillLMS/app/queries/activity_search.rb
@@ -12,9 +12,9 @@ class ActivitySearch
     when 'alpha'
       flags = "'alpha', 'beta', 'gamma', 'production'"
     when 'beta'
-      flags = "'beta', 'gamma', 'production'"
+      flags = "'beta', 'production'"
     when 'gamma'
-      flags = "'gamma', 'production'"
+      flags = "'gamma', 'production', 'beta'"
     else
       flags = "'production'"
     end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -307,7 +307,7 @@ describe Activity, type: :model, redis: true do
 
     context 'the production scope' do
       it 'must show only production flagged activities' do
-        expect(all_types - Activity.production.all).to eq [gamma_activity, beta_activity, alpha_activity, archived_activity]
+        expect(Activity.production.map(&:flags).flatten.uniq).to contain_exactly(:production)
       end
 
       it 'must return the same thing as Activity.user_scope(nil)' do
@@ -316,8 +316,8 @@ describe Activity, type: :model, redis: true do
     end
 
     context 'the gamma scope' do
-      it 'must show only production and gamma flagged activities' do
-        expect(all_types - Activity.gamma_user).to eq [beta_activity, alpha_activity, archived_activity]
+      it 'must show only production, beta, and gamma flagged activities' do
+        expect(Activity.gamma_user.map(&:flags).flatten.uniq).to contain_exactly(:production, :beta, :gamma)
       end
 
       it 'must return the same thing as Activity.user_scope(gamma)' do
@@ -326,8 +326,8 @@ describe Activity, type: :model, redis: true do
     end
 
     context 'the beta scope' do
-      it 'must show only production, beta, and gamma flagged activities' do
-        expect(all_types - Activity.beta_user).to eq [alpha_activity, archived_activity]
+      it 'must show only production, and beta flagged activities' do
+        expect(Activity.beta_user.map(&:flags).flatten.uniq).to contain_exactly(:production, :beta)
       end
 
       it 'must return the same thing as Activity.user_scope(beta)' do
@@ -337,7 +337,7 @@ describe Activity, type: :model, redis: true do
 
     context 'the alpha scope' do
       it 'must show all types of flags except for archived with alpha_user scope' do
-        expect(all_types - Activity.alpha_user).to eq [archived_activity]
+        expect(Activity.alpha_user.map(&:flags).flatten.uniq).to contain_exactly(:production, :beta, :gamma, :alpha)
       end
 
       it 'must return the same thing as Activity.user_scope(alpha)' do


### PR DESCRIPTION
## WHAT
Changing activity flagging logic. 
- Gamma now includes gamma + beta. 
- Beta no longer includes gamma. 
- made existing rspecs more readable. 

## WHY
Product request. 

## HOW
Update Activity scope logic. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=a8906a7321c6439586a3b3aef14f9d54&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
