### PR TITLE
Update pg gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -12,7 +12,7 @@ gem 'puma', '~> 5.6.4'
 gem 'dotenv-rails', '~> 2.6'
 
 # DB/MODEL
-gem 'pg', '0.18.4'
+gem 'pg', '1.4.2'
 gem 'ancestry', '~> 3.0.5'
 gem 'ranked-model', '~> 0.4.3'
 gem 'rails_admin', '~> 2.2'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (0.18.4)
+    pg (1.4.2)
     pragmatic_segmenter (0.3.23)
       unicode
     prawn (2.2.2)
@@ -835,7 +835,7 @@ DEPENDENCIES
   parslet
   pdf-core
   pdf-inspector
-  pg (= 0.18.4)
+  pg (= 1.4.2)
   prawn
   prawn-table
   premailer-rails

--- a/services/QuillLMS/engines/evidence/Gemfile.lock
+++ b/services/QuillLMS/engines/evidence/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     os (1.1.4)
-    pg (0.18.4)
+    pg (1.4.2)
     pragmatic_segmenter (0.3.23)
       unicode
     pry (0.13.1)
@@ -304,7 +304,7 @@ DEPENDENCIES
   httparty
   m (~> 1.5.0)
   minitest-stub_any_instance
-  pg (= 0.18.4)
+  pg (= 1.4.2)
   pry
   pry-byebug
   redis

--- a/services/QuillLMS/engines/evidence/evidence.gemspec
+++ b/services/QuillLMS/engines/evidence/evidence.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   # Gems needed for the test environment
   s.add_development_dependency 'factory_bot_rails'
-  s.add_development_dependency 'pg', '0.18.4'
+  s.add_development_dependency 'pg', '1.4.2'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda', '~> 4.0'
 end


### PR DESCRIPTION
## WHAT
Upgrade pg gem on the LMS from 0.18.4 -> 1.4.2

## WHY
In preparation for upgrading to Rails 6.1, this upgrade fixes the following error:

`LoadError: Error loading the 'postgresql' Active Record adapter. Missing a gem it depends on? can't activate pg (~> 1.1), already activated pg-0.18.4. Make sure all dependencies are added to Gemfile.`

It's also good to keep libraries current and we're on `0.18.4` which was released November 13, 2015

## HOW
Update Gemfile

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
