### PR TITLE
lms/update-missing-migration-identifier

### DIFF
--- a/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/identify_unmigrated_old_concept_results_worker.rb
@@ -7,10 +7,10 @@ class IdentifyUnmigratedOldConceptResultsWorker
   REPORT_RECIPIENT = 'thomas@quill.org'
   BATCH_SIZE = 10_000_000
 
-  def perform
-    max_id = OldConceptResult.maximum(:id)
+  def perform(start_id, max_id)
+    max_id ||= OldConceptResult.maximum(:id)
 
-    start_id = 1
+    start_id ||= 1
 
     missing_id_ranges = []
 

--- a/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_unmigrated_old_concept_results_worker_spec.rb
@@ -38,7 +38,23 @@ describe IdentifyUnmigratedOldConceptResultsWorker, type: :worker do
 
       expect_any_instance_of(IdentifyUnmigratedOldConceptResultsWorker).to receive(:send_report).with(csv_data)
 
-      subject.perform
+      subject.perform(nil, nil)
+    end
+
+    it 'should allow specification of the OldConceptResult ID to start with' do
+      csv_data = CSV.generate_line(unmigrated_ranges.last)
+
+      expect_any_instance_of(IdentifyUnmigratedOldConceptResultsWorker).to receive(:send_report).with(csv_data)
+
+      subject.perform(unmigrated_ranges.last.first, nil)
+    end
+
+    it 'should allow specification of the OldConceptResult ID to stop with' do
+      csv_data = CSV.generate_line(unmigrated_ranges.first)
+
+      expect_any_instance_of(IdentifyUnmigratedOldConceptResultsWorker).to receive(:send_report).with(csv_data)
+
+      subject.perform(nil, unmigrated_ranges.first.last)
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add the ability to specify start and stop ids for reporting
## WHY
So that we can split up the work into smaller chunks to complete jobs faster
## HOW
Allow `start_id` and `max_id` to be specified when running the job in case we want to run the report on sub-sets of data.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
