### PR TITLE
Lms/migrate missing old concept results

### DIFF
--- a/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
@@ -10,6 +10,7 @@ class CopyOldConceptResultsToConceptResultsWorker
 
   def perform(start, finish, batch_inserts)
     return bulk_insert(start, finish) if batch_inserts
+
     enqueue_individual_inserts(start, finish)
   end
 

--- a/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/copy_old_concept_results_to_concept_results_worker.rb
@@ -4,9 +4,66 @@ class CopyOldConceptResultsToConceptResultsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::MIGRATION
 
-  def perform(start, finish)
+  class ConceptResultMigrationDeadlocked < StandardError; end
+
+  BATCH_SIZE = 1_000
+
+  def perform(start, finish, batch_inserts)
+    return bulk_insert(start, finish) if batch_inserts
+    enqueue_individual_inserts(start, finish)
+  end
+
+  def enqueue_individual_inserts(start, finish)
     (start..finish).each do |old_concept_result_id|
       CopySingleConceptResultWorker.perform_async(old_concept_result_id)
     end
   end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def bulk_insert(start, finish)
+    directions_cache = {}
+    instructions_cache = {}
+    previous_feedbacks_cache = {}
+    prompts_cache = {}
+    question_types_cache = {}
+
+    ConceptResult.bulk_insert(ignore: true) do |bulk_inserter|
+      OldConceptResult.where(id: start..finish).find_each(batch_size: BATCH_SIZE) do |old_concept_result|
+
+        directions = old_concept_result.metadata['directions']
+        instructions = old_concept_result.metadata['instructions']
+        previous_feedback = old_concept_result.metadata['lastFeedback']
+        prompt = old_concept_result.metadata['prompt']
+        question_type = old_concept_result.question_type
+
+        directions_cache[directions] ||= ConceptResultDirections.find_or_create_by(text: directions)&.id if directions
+        instructions_cache[instructions] ||= ConceptResultInstructions.find_or_create_by(text: instructions)&.id if instructions
+        previous_feedbacks_cache[previous_feedback] ||= ConceptResultPreviousFeedback.find_or_create_by(text: previous_feedback)&.id if previous_feedback
+        prompts_cache[prompt] ||= ConceptResultPrompt.find_or_create_by(text: prompt)&.id if prompt
+        question_types_cache[question_type] ||= ConceptResultQuestionType.find_or_create_by(text: question_type)&.id if question_type
+
+        extra_metadata = ConceptResult.parse_extra_metadata(old_concept_result.metadata)
+
+        bulk_inserter.add({
+          answer: old_concept_result.metadata['answer'],
+          attempt_number: old_concept_result.metadata['attemptNumber'],
+          concept_id: old_concept_result.concept_id,
+          correct: old_concept_result.metadata['correct'] == 1,
+          extra_metadata: extra_metadata,
+          question_number: old_concept_result.metadata['questionNumber'],
+          question_score: old_concept_result.metadata['questionScore'],
+          activity_session_id: old_concept_result.activity_session_id,
+          old_concept_result_id: old_concept_result.id,
+          concept_result_directions_id: directions_cache[directions],
+          concept_result_instructions_id: instructions_cache[instructions],
+          concept_result_previous_feedback_id: previous_feedbacks_cache[previous_feedback],
+          concept_result_prompt_id: prompts_cache[prompt],
+          concept_result_question_type_id: question_types_cache[question_type]
+        })
+      end
+    end
+  rescue ActiveRecord::Deadlocked => e
+    raise(ConceptResultMigrationDeadlocked.new, e.message)
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/services/QuillLMS/lib/tasks/concept_results_migration.rake
+++ b/services/QuillLMS/lib/tasks/concept_results_migration.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :concept_results_migration do
+  task migrate_from_csv: :environment do
+    pipe_data = $stdin.read unless $stdin.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake users:refresh_school_subscriptions < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake users:refresh_school_subscriptions -a empirical-grammar --no-tty < path/to/local/file.csv'
+      exit 1
+    end
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      CopyOldConceptResultsToConceptResultsWorker.perform_async(row['start_id'], row['max_id'], true)
+    rescue
+      puts "Failed to enqueue worker for range (#{row['start_id']}..#{row['max_id']})"
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/copy_old_concept_results_to_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/copy_old_concept_results_to_concept_results_worker_spec.rb
@@ -5,14 +5,106 @@ require 'rails_helper'
 describe CopyOldConceptResultsToConceptResultsWorker, type: :worker do
 
   context '#perform' do
-    it 'should enqueue CopySingleConceptResultWorker job for each id passed in' do
-      min_id = 1
-      max_id = 5
-      (min_id..max_id).each do |id|
-        expect(CopySingleConceptResultWorker).to receive(:perform_async).once.with(id)
+    let(:question) { create(:question) }
+    let(:activity) { create(:activity, data: {questions: [{key: question.uid}]}) }
+    let(:activity_session) { create(:activity_session_without_concept_results, activity: activity) }
+    let(:metadata) do
+      {
+        "correct": 1,
+        "directions": "Combine the sentences. (And)",
+        "lastFeedback": "Proofread your work. Check your spelling.",
+        "prompt": "Deserts are very dry. Years go by without rain.",
+        "attemptNumber": 2,
+        "answer": "Deserts are very dry, and years go by without rain.",
+        "questionNumber": 1,
+        "questionScore": 0.8
+      }
+    end
+    let(:old_concept_result) { create(:sentence_combining, metadata: metadata, activity_session: activity_session) }
+
+    context 'batch_insert is true' do
+      it 'should create a Student ConceptResult record with Normalized Texts' do
+        expect { subject.perform(old_concept_result.id, old_concept_result.id, true) }.to change(ConceptResult, :count).by(1)
+
+        concept_result = old_concept_result.concept_result
+
+        expect(concept_result.activity_session).to eq(old_concept_result.activity_session)
+        expect(concept_result.concept).to eq(old_concept_result.concept)
+        expect(concept_result.correct).to be(true)
+        expect(concept_result.attempt_number).to eq(metadata[:attemptNumber])
+        expect(concept_result.question_number).to eq(metadata[:questionNumber])
+        expect(concept_result.question_score).to eq(metadata[:questionScore])
+        expect(concept_result.answer).to eq(metadata[:answer])
+        expect(concept_result.concept_result_directions.text).to eq(metadata[:directions])
+        expect(concept_result.concept_result_instructions).to be(nil)
+        expect(concept_result.concept_result_previous_feedback.text).to eq(metadata[:lastFeedback])
+        expect(concept_result.concept_result_prompt.text).to eq(metadata[:prompt])
+        expect(concept_result.concept_result_question_type.text).to eq(old_concept_result.question_type)
       end
 
-      subject.perform(min_id, max_id)
+      it 'should normalize empty string values as nil references to normalized tables' do
+        new_metadata = metadata.merge({'instructions': ''})
+        old_concept_result.update(metadata: new_metadata)
+
+        expect { subject.perform(old_concept_result.id, old_concept_result.id, true) }.to change(ConceptResult, :count).by(1)
+
+        concept_result = old_concept_result.concept_result
+
+        expect(concept_result.concept_result_instructions).to eq(nil)
+      end
+
+      it 'should be idempotent so that if the same ID is present twice, only one new record is created' do
+        expect do
+          subject.perform(old_concept_result.id, old_concept_result.id, true)
+          subject.perform(old_concept_result.id, old_concept_result.id, true)
+        end.to change(ConceptResult, :count).by(1)
+      end
+
+      it 'should skip items with IDs lower than start' do
+        old_concept_result
+        activity_session2 = create(:activity_session_without_concept_results, activity: activity)
+        used_old_concept_result = create(:sentence_combining, metadata: metadata, activity_session: activity_session2)
+
+        bulk_insert_worker_stub = double
+        expect(ConceptResult).to receive(:bulk_insert).and_yield(bulk_insert_worker_stub)
+
+        expect(bulk_insert_worker_stub).to receive(:add).with(hash_including(old_concept_result_id: used_old_concept_result.id))
+        expect(bulk_insert_worker_stub).not_to receive(:add).with(hash_including(old_concept_result_id: old_concept_result.id))
+
+        subject.perform(used_old_concept_result.id, used_old_concept_result.id, true)
+      end
+
+      it 'should not process items with IDs higher than finish' do
+        old_concept_result
+        activity_session2 = create(:activity_session_without_concept_results, activity: activity)
+        unused_old_concept_result = create(:sentence_combining, metadata: metadata, activity_session: activity_session2)
+
+        bulk_insert_worker_stub = double
+        expect(ConceptResult).to receive(:bulk_insert).and_yield(bulk_insert_worker_stub)
+
+        expect(bulk_insert_worker_stub).to receive(:add).with(hash_including(old_concept_result_id: old_concept_result.id))
+        expect(bulk_insert_worker_stub).not_to receive(:add).with(hash_including(old_concept_result_id: unused_old_concept_result.id))
+
+        subject.perform(old_concept_result.id, old_concept_result.id, true)
+      end
+
+      it 'should raise custom ConceptResultMigrationDeadlocked error when it triggers and ActiveRecord::Deadlocked error' do
+        expect(ConceptResult).to receive(:bulk_insert).and_raise(ActiveRecord::Deadlocked)
+
+        expect { subject.perform(1,1, true) }.to raise_error(CopyOldConceptResultsToConceptResultsWorker::ConceptResultMigrationDeadlocked)
+      end
+    end
+
+    context 'batch_insert is false' do
+      it 'should enqueue CopySingleConceptResultWorker job for each id passed in' do
+        min_id = 1
+        max_id = 5
+        (min_id..max_id).each do |id|
+          expect(CopySingleConceptResultWorker).to receive(:perform_async).once.with(id)
+        end
+
+        subject.perform(min_id, max_id, false)
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
- Refactor the bulk `OldConceptResult` migration worker to allow both the old (bulk insert) approach and the new (individual row) approach to be selected between
- Add a rake task to enqueue blocks of `OldConceptResult` records to migrate from a CSV file (which we're generating via another process)
## WHY
This allows us to fill in the gaps that the previous bulk migration left behind.  The hope here is that once this is done, we'll have a 100% complete migration
## HOW
- Checked out the old version of the worker and combined that code with the new worker code
- Wrote a new simple rake task

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A