### PR TITLE
change grade ranges for activity classifications and remove new tag

### DIFF
--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -136,28 +136,28 @@ class ActivitySearchWrapper
       h = {
         alias: 'Quill Proofreader',
         description: 'Fix Errors in Passages',
-        gradeText: '2nd - 12th Grade',
+        gradeText: '4th - 12th Grade',
         key: ActivityClassification::PROOFREADER_KEY
       }
     when ActivityClassification::GRAMMAR_KEY
       h = {
         alias: 'Quill Grammar',
         description: 'Practice Mechanics',
-        gradeText: '2nd - 12th Grade',
+        gradeText: '4th - 12th Grade',
         key: ActivityClassification::GRAMMAR_KEY
       }
     when ActivityClassification::DIAGNOSTIC_KEY
       h = {
         alias: 'Quill Diagnostic',
         description: 'Identify Learning Gaps',
-        gradeText: '2nd - 12th Grade',
+        gradeText: '4th - 12th Grade',
         key: ActivityClassification::DIAGNOSTIC_KEY
       }
     when ActivityClassification::CONNECT_KEY
       h = {
         alias: 'Quill Connect',
         description: 'Combine Sentences',
-        gradeText: '2nd - 12th Grade',
+        gradeText: '4th - 12th Grade',
         key: ActivityClassification::CONNECT_KEY
       }
     when ActivityClassification::LESSONS_KEY

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/activity_classification_filters.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/activity_classification_filters.tsx
@@ -75,7 +75,6 @@ const IndividualActivityClassificationFilterRow = ({ activityClassificationFilte
           <span>{activityClassification.alias}</span>
           <span className="description">{activityClassification.description}</span>
           <span className="grade-text">{activityClassification.gradeText}</span>
-          {activityClassification.new && <div className="activity-classification-new-tag">NEW</div>}
         </div>
       </div>
       <span>({activityCount})</span>


### PR DESCRIPTION
## WHAT
Small changes to activity classifications in the activity library.

## WHY
These were requested by PG.

## HOW
Just update the grade ranges for the individual classifications and remove the "new" tag for the individual classification.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Library-Two-Small-Edits-91c7c8b51aba4fb39cf0ecbf72575711

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
