### PR TITLE
Fix bug involving reset_session and some general refactoring

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -46,7 +46,6 @@ gem 'carrierwave', '~> 1.3.2'
 gem 'fog-aws'
 
 # TIME
-gem 'time_difference'
 gem 'tzinfo'
 gem 'tzinfo-data'
 

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -733,8 +733,6 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     thor (1.2.1)
     tilt (2.0.10)
-    time_difference (0.5.0)
-      activesupport
     timecop (0.9.1)
     ttfunk (1.5.1)
     turbolinks (5.2.1)
@@ -899,7 +897,6 @@ DEPENDENCIES
   stripe (~> 5.30)
   super_diff
   terminal-notifier-guard
-  time_difference
   timecop
   ttfunk
   turbolinks

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  include NewRelicAttributable
   include QuillAuthentication
 
-  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
+  rescue_from ActionController::InvalidAuthenticityToken,
+    with: :handle_invalid_authenticity_token
 
   CLEVER_REDIRECT = :clever_redirect
   GOOGLE_REDIRECT = :google_redirect
@@ -18,11 +22,10 @@ class ApplicationController < ActionController::Base
   DIAGNOSTIC = 'diagnostic'
   LESSONS = 'lessons'
 
-  #helper CMS::Helper
   helper SegmentioHelper
 
-  include NewRelicAttributable
   before_action :set_raven_context
+  before_action :check_staff_for_extended_session
   before_action :confirm_valid_session
   before_action :set_default_cache_security_headers
 
@@ -127,6 +130,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  protected def check_staff_for_extended_session
+    return unless current_user&.staff_session_duration_exceeded?
+
+    sign_out
+  end
+
   protected def set_vary_header
     response.headers['Vary'] = 'Accept'
   end
@@ -142,53 +151,16 @@ class ApplicationController < ActionController::Base
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   protected def confirm_valid_session
-    # Don't do anything if there's no authorized user or session
-    return if !current_user || !session
+    return if current_user.nil? || session.nil? || session[:staff_id]
+    return unless reset_session? || current_user.google_access_expired?
 
-    # if user is staff, logout if last_sign_in was more than 4 hours ago
-    if current_user && current_user.role == 'staff' && current_user.last_sign_in
-      hours = time_diff(current_user.last_sign_in) / 3600
-      if hours > 4
-        user_id = current_user.id
-        auth_credential = AuthCredential.where(user_id: user_id).first
-        if auth_credential.present?
-          auth_credential.destroy!
-        end
-        return if !current_user || !session
-      end
-    end
-
-    return reset_session if user_inactive_for_too_long?
-
-    # If the user is google authed, but doesn't have a valid refresh
-    # token, then we need to invalidate their session
-    return reset_session if current_user.google_id && current_user.auth_credential && !current_user.auth_credential&.refresh_token
-
-    # Assuming that the refresh_token expires at (current_user.auth_credential.created_at  + 6 months),
-    # we can reset the session whenever (Time.current > (current_user.auth_credential.created_at + 5 months))
-    return reset_session if current_user.google_id && current_user.auth_credential && Time.current > (current_user.auth_credential.created_at + 5.months)
+    reset_session
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
-  protected def user_inactive_for_too_long?
+  protected def reset_session?
     return false if session[KEEP_ME_SIGNED_IN] || current_user.google_id || current_user.clever_id
 
-    seconds_in_day = 86400
-    max_inactivity = 30
-
-    days_since_last_sign_in = current_user.last_sign_in ? time_diff(current_user.last_sign_in)/seconds_in_day : 0
-    days_since_last_active = current_user.last_active ? time_diff(current_user.last_active)/seconds_in_day : max_inactivity
-
-    [days_since_last_active, days_since_last_sign_in].min >= max_inactivity
+    current_user.inactive_too_long?
   end
-
-  protected def time_diff(timestamp)
-    now = Time.current.utc
-
-    diff = now - timestamp
-    diff.round.abs
-  end
-
 end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -5,7 +5,8 @@ class ProfilesController < ApplicationController
 
   def show
     @user = current_user
-    if current_user.role == 'student'
+
+    if current_user.student?
       @js_file = 'student'
       if current_user.classrooms.any?
         # in the future, we could use the following sql query to direct the student

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -18,24 +18,22 @@ module QuillAuthentication
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def current_user
-    begin
-      if session[:preview_student_id]
-        @current_user ||= User.find(session[:preview_student_id])
-      elsif session[:demo_id]
-        @current_user ||= User.find(session[:demo_id])
-      elsif session[:user_id]
-        @current_user ||= User.find(session[:user_id])
-      elsif doorkeeper_token
-        User.find_by_id(doorkeeper_token.resource_owner_id)
-      else
-        authenticate_with_http_basic do |username, password|
-          return @current_user ||= User.find_by_token!(username) if username.present?
-        end
+    if session[:preview_student_id]
+      @current_user ||= User.find(session[:preview_student_id])
+    elsif session[:demo_id]
+      @current_user ||= User.find(session[:demo_id])
+    elsif session[:user_id]
+      @current_user ||= User.find(session[:user_id])
+    elsif doorkeeper_token
+      User.find_by_id(doorkeeper_token.resource_owner_id)
+    else
+      authenticate_with_http_basic do |username, password|
+        return @current_user ||= User.find_by_token!(username) if username.present?
       end
-    rescue ActiveRecord::RecordNotFound
-      sign_out
-      nil
     end
+  rescue ActiveRecord::RecordNotFound
+    sign_out
+    nil
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -60,24 +58,14 @@ module QuillAuthentication
     auth_failed
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def sign_in(user)
-    remote_ip = (request.present? ? request.remote_ip : nil)
+    TestForEarnedCheckboxesWorker.perform_async(user.id) if user.teacher?
+    UserLoginWorker.perform_async(user.id, request&.remote_ip) unless staff_impersonating_user?(user)
 
-    if user.role == 'teacher'
-      TestForEarnedCheckboxesWorker.perform_async(user.id)
-    end
-
-    if (!session[:staff_id] || session[:staff_id] == user.id) && user&.id
-      # only kick off login worker if there is no staff id,
-      # or if the user getting logged into is staff
-      UserLoginWorker.perform_async(user.id, remote_ip)
-    end
     session[:user_id] = user.id
     session[:admin_id] = user.id if user.admin?
     @current_user = user
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def current_user_demo_id=(demo_id)
     session[:demo_id] = demo_id
@@ -176,5 +164,9 @@ module QuillAuthentication
 
     methods = Doorkeeper.configuration.access_token_methods
     @token = Doorkeeper::OAuth::Token.authenticate(request, *methods)
+  end
+
+  private def staff_impersonating_user?(user)
+    session[:staff_id].present? && session[:staff_id] != user.id
   end
 end

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -34,6 +34,10 @@ class AuthCredential < ApplicationRecord
   CLEVER_LIBRARY_PROVIDER = 'clever_library'
   CLEVER_EXPIRATION_DURATION = 23.hours
 
+  def google_access_expired?
+    google_provider? && !refresh_token_valid?
+  end
+
   def google_authorized?
     google_provider? && refresh_token_valid?
   end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -54,6 +54,8 @@
 #  users_to_tsvector_idx4             (to_tsvector('english'::regconfig, (username)::text)) USING gin
 #  users_to_tsvector_idx5             (to_tsvector('english'::regconfig, split_part((ip_address)::text, '/'::text, 1))) USING gin
 #
+
+# rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
   include Student
   include Teacher
@@ -61,16 +63,31 @@ class User < ApplicationRecord
   include UserCacheable
   include Subscriber
 
-  attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
-
   CHAR_FIELD_MAX_LENGTH = 255
+  STAFF_SESSION_DURATION= 4.hours
+  USER_INACTIVITY_DURATION = 30.days
+  USER_SESSION_DURATION = 30.days
 
-  before_validation :generate_student_username_if_absent
-  before_validation :prep_authentication_terms
-  before_save :capitalize_name
-  after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
-  after_save :check_for_school
-  after_create :generate_referrer_id, if: proc { teacher? }
+  TEACHER = 'teacher'
+  STUDENT = 'student'
+  STAFF = 'staff'
+  ROLES      = [TEACHER, STUDENT, STAFF]
+  SAFE_ROLES = [STUDENT, TEACHER]
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+
+  ALPHA = 'alpha'
+  BETA = 'beta'
+  GAMMA = 'gamma'
+  PRIVATE = 'private'
+  ARCHIVED = 'archived'
+  TESTING_FLAGS = [ALPHA, BETA, GAMMA, PRIVATE, ARCHIVED]
+  PERMISSIONS_FLAGS = %w(auditor purchaser school_point_of_contact)
+  VALID_FLAGS = TESTING_FLAGS.dup.concat(PERMISSIONS_FLAGS)
+
+  GOOGLE_CLASSROOM_ACCOUNT = 'Google Classroom'
+  CLEVER_ACCOUNT = 'Clever'
+
+  attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 
   has_secure_password validations: false
   has_one :auth_credential, dependent: :destroy
@@ -118,55 +135,53 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :auth_credential
 
-  delegate :name, :mail_city, :mail_state, to: :school, allow_nil: true, prefix: :school
+  delegate :name, :mail_city, :mail_state,
+    to: :school,
+    allow_nil: true,
+    prefix: :school
 
-  validates :name,                  presence: true,
-                                    format:       {without: /\t/, message: 'cannot contain tabs'},
-                                    length:       { maximum:  CHAR_FIELD_MAX_LENGTH}
+  validates :name,
+    presence: true,
+    format: { without: /\t/, message: 'cannot contain tabs' },
+    length: { maximum:  CHAR_FIELD_MAX_LENGTH}
 
   validates_with ::FullnameValidator
 
-  validates :password,              presence:     { if: :requires_password? },
-                                    length:       { maximum: CHAR_FIELD_MAX_LENGTH}
+  validates :password,
+    presence: { if: :requires_password? },
+    length: { maximum: CHAR_FIELD_MAX_LENGTH}
 
-  validates :email,                 presence:     { if: :email_required? },
-                                    uniqueness:   { message: :taken, if: :email_required_or_present?},
-                                    length:       { maximum: CHAR_FIELD_MAX_LENGTH}
+  validates :email,
+    presence: { if: :email_required? },
+    uniqueness:  { message: :taken, if: :email_required_or_present? },
+    length: { maximum: CHAR_FIELD_MAX_LENGTH }
 
   validate :username_cannot_be_an_email
 
-  validates :clever_id,             uniqueness:   { if: :clever_id_present_and_has_changed? }
+  validates :clever_id,
+    uniqueness:   { if: :clever_id_present_and_has_changed? }
 
-  validates :google_id, uniqueness:   { if: ->(u) { u.google_id.present? && u.student? }}
+  validates :google_id,
+    uniqueness: { if: ->(u) { u.google_id.present? && u.student? } }
 
-  # gem validates_email_format_of
-  validates_email_format_of :email, if: :email_required_or_present?, message: :invalid
+  validates_email_format_of :email,
+    if: :email_required_or_present?,
+    message: :invalid
 
-  validates :username,              presence:     { if: ->(m) { m.email.blank? && m.permanent? } },
-                                    uniqueness:   { allow_blank: true, message: :taken },
-                                    format:       { without: /\s/, message: :no_spaces_allowed, if: :validate_username? },
-                                    length:       { maximum: CHAR_FIELD_MAX_LENGTH}
+  validates :username,
+    presence: { if: ->(m) { m.email.blank? && m.permanent? } },
+    uniqueness: { allow_blank: true, message: :taken },
+    format: { without: /\s/, message: :no_spaces_allowed, if: :validate_username? },
+    length: { maximum: CHAR_FIELD_MAX_LENGTH }
 
   validate :validate_flags
 
-  TEACHER = 'teacher'
-  STUDENT = 'student'
-  STAFF = 'staff'
-  ROLES      = [TEACHER, STUDENT, STAFF]
-  SAFE_ROLES = [STUDENT, TEACHER]
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-
-  ALPHA = 'alpha'
-  BETA = 'beta'
-  GAMMA = 'gamma'
-  PRIVATE = 'private'
-  ARCHIVED = 'archived'
-  TESTING_FLAGS = [ALPHA, BETA, GAMMA, PRIVATE, ARCHIVED]
-  PERMISSIONS_FLAGS = %w(auditor purchaser school_point_of_contact)
-  VALID_FLAGS = TESTING_FLAGS.dup.concat(PERMISSIONS_FLAGS)
-
-  GOOGLE_CLASSROOM_ACCOUNT = 'Google Classroom'
-  CLEVER_ACCOUNT = 'Clever'
+  before_validation :generate_student_username_if_absent
+  before_validation :prep_authentication_terms
+  before_save :capitalize_name
+  after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
+  after_save :check_for_school
+  after_create :generate_referrer_id, if: proc { teacher? }
 
   scope :teacher, -> { where(role: TEACHER) }
   scope :student, -> { where(role: STUDENT) }
@@ -528,7 +543,6 @@ class User < ApplicationRecord
     UnsubscribeFromNewsletterWorker.perform_async(id)
   end
 
-  # Create the user from a Clever info hash
   def self.create_from_clever(hash, role_override = nil)
     user = User.where(email: hash[:info][:email]).first_or_initialize
     user = User.new if user.email.nil?
@@ -606,6 +620,10 @@ class User < ApplicationRecord
     google_id && auth_credential&.google_authorized?
   end
 
+  def google_access_expired?
+    google_id && auth_credential&.google_access_expired?
+  end
+
   # Note this is an incremented count, so could be off.
   def completed_activity_count
     user_activity_classifications.sum(:count)
@@ -615,8 +633,30 @@ class User < ApplicationRecord
     [school].concat(administered_schools).uniq.select { |s| s.present? && School::ALTERNATIVE_SCHOOL_NAMES.exclude?(s.name) }
   end
 
+  def staff_session_duration_exceeded?
+    return false unless staff?
+    return false if last_sign_in.nil?
+
+    last_sign_in < STAFF_SESSION_DURATION.ago
+  end
+
+  def inactive_too_long?
+    last_sign_in_too_long_ago? && last_active_too_long_ago?
+  end
+
+  def last_sign_in_too_long_ago?
+    return false if last_sign_in.nil?
+
+    last_sign_in < USER_SESSION_DURATION.ago
+  end
+
+  def last_active_too_long_ago?
+    return true if last_active.nil?
+
+    last_active < USER_INACTIVITY_DURATION.ago
+  end
+
   private def validate_flags
-    # ensures there are no items in the flags array that are not in the VALID_FLAGS const
     invalid_flags = flags - VALID_FLAGS
 
     return if invalid_flags.none?
@@ -635,7 +675,6 @@ class User < ApplicationRecord
     find_or_create_checkbox('Add School', self)
   end
 
-  # validation filters
   private def email_required_or_present?
     email_required? or email.present?
   end
@@ -663,11 +702,6 @@ class User < ApplicationRecord
     permanent? && new_record?
   end
 
-  # FIXME: may not be being called anywhere
-  private def password?
-    password.present?
-  end
-
   private def get_class_code(classroom_id)
     return 'student' if classroom_id.nil?
 
@@ -678,3 +712,4 @@ class User < ApplicationRecord
     Invitation.where(invitee_email: email_before_last_save).update_all(invitee_email: email)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/services/QuillLMS/client/webpack.client.dev.base.config.js
+++ b/services/QuillLMS/client/webpack.client.dev.base.config.js
@@ -8,8 +8,8 @@ const railsEnv = process.env.RAILS_ENV || process.env.NODE_ENV
 
 const goFanoutUrl = process.env.GOLANG_FANOUT_URL;
 const pusherKey = process.env.PUSHER_KEY;
-const defaultUrl = process.env.DEFAULT_URL;
-const cdnUrl = process.env.CDN_URL;
+const defaultUrl = process.env.DEFAULT_UR || 'http://localhost:3000'
+const cdnUrl = process.env.CDN_URL || 'https://assets.quill.org'
 const grammarUrl = process.env.QUILL_GRAMMAR_URL || 'http://localhost:3000/grammar/#';
 const lessonsWebsocketsUrl = process.env.LESSONS_WEBSOCKETS_URL || 'http://localhost:3200';
 const quillCmsUrl = process.env.QUILL_CMS || 'http://localhost:3100';

--- a/services/QuillLMS/client/webpack.client.dev.base.config.js
+++ b/services/QuillLMS/client/webpack.client.dev.base.config.js
@@ -8,7 +8,7 @@ const railsEnv = process.env.RAILS_ENV || process.env.NODE_ENV
 
 const goFanoutUrl = process.env.GOLANG_FANOUT_URL;
 const pusherKey = process.env.PUSHER_KEY;
-const defaultUrl = process.env.DEFAULT_UR || 'http://localhost:3000'
+const defaultUrl = process.env.DEFAULT_URL || 'http://localhost:3000'
 const cdnUrl = process.env.CDN_URL || 'https://assets.quill.org'
 const grammarUrl = process.env.QUILL_GRAMMAR_URL || 'http://localhost:3000/grammar/#';
 const lessonsWebsocketsUrl = process.env.LESSONS_WEBSOCKETS_URL || 'http://localhost:3200';

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -3,59 +3,146 @@
 require 'rails_helper'
 
 describe ApplicationController, type: :controller do
-  let(:user) { create(:user) }
+  context 'protected methods' do
+    let(:user) { create(:user) }
 
-  describe "#user_inactive_for_too_long?" do
-    before do
-      ApplicationController.send(:public, *ApplicationController.protected_instance_methods)
-    end
+    before { allow(controller).to receive(:current_user) { user } }
 
-    context "when KEEP_ME_SIGNED_IN is true" do
+    describe '#check_staff_for_extended_session' do
+      before { ApplicationController.send(:public, :check_staff_for_extended_session) }
 
-      it 'should always return false' do
-        session[ApplicationController::KEEP_ME_SIGNED_IN] = true
+      subject { controller.check_staff_for_extended_session }
 
-        expect(controller.user_inactive_for_too_long?).not_to be
+      context 'current_user is nil' do
+        let(:user) { nil }
+
+        it do
+          expect(controller).to_not receive(:sign_out)
+          subject
+        end
       end
 
-    end
+      context 'current_user.staff_session_duration is exceeded is false' do
+        before { allow(user).to receive(:staff_session_duration_exceeded?).and_return(false) }
 
-    context "when user is a Google user" do
-      before do
-        user = create(:user, google_id: 123)
-        allow(controller).to receive(:current_user) { user }
+        it do
+          expect(controller).to_not receive(:sign_out)
+          subject
+        end
       end
 
-      it 'should always return false' do
-        expect(controller.user_inactive_for_too_long?).not_to be
-      end
+      context 'current_user.staff_session_duration is exceeded is true' do
+        before { allow(user).to receive(:staff_session_duration_exceeded?).and_return(true) }
 
-    end
-
-    context "when user is a Clever user" do
-      before do
-        user = create(:user, clever_id: 123)
-        allow(controller).to receive(:current_user) { user }
-      end
-
-      it 'should always return false' do
-        expect(controller.user_inactive_for_too_long?).not_to be
-      end
-
-    end
-
-    context "when user has a last active value and a last sign in value that are both more than 30 days old" do
-
-      before do
-        user = create(:user, last_active: 31.days.ago, last_sign_in: 31.days.ago)
-        allow(controller).to receive(:current_user) { user }
-      end
-
-      it 'should return true' do
-        expect(controller.user_inactive_for_too_long?).to be
+        it do
+          expect(controller).to receive(:sign_out)
+          subject
+        end
       end
     end
 
+    describe "#confirm_valid_session" do
+      before { ApplicationController.send(:public, :confirm_valid_session) }
+
+      subject { controller.confirm_valid_session }
+
+      context 'when no current_user' do
+        before { allow(user).to receive(:nil?).and_return(true) }
+
+        it do
+          expect(controller).to_not receive(:reset_session)
+          subject
+        end
+      end
+
+      context 'when no session' do
+        before { allow(session).to receive(:nil?).and_return(true) }
+
+        it do
+          expect(controller).to_not receive(:reset_session)
+          subject
+        end
+      end
+
+      context 'when staff is logged in' do
+        before { session[:staff_id] = 123 }
+
+        it do
+          expect(controller).to_not receive(:reset_session)
+          subject
+        end
+      end
+
+      context "when a reset_session? and current_user.google_access_expired? both false" do
+        before do
+          allow(controller).to receive(:reset_session?).and_return(false)
+          allow(user).to receive(:google_access_expired?).and_return(false)
+        end
+
+        it do
+          expect(controller).to_not receive(:reset_session)
+          subject
+        end
+      end
+
+      context "when reset_session? is true" do
+        before { allow(controller).to receive(:reset_session?).and_return(true) }
+
+        it do
+          expect(controller).to receive(:reset_session)
+          subject
+        end
+      end
+
+      context "when current_user.google_access_expired? is true" do
+        before { allow(user).to receive(:google_access_expired?).and_return(true) }
+
+        it do
+          expect(controller).to receive(:reset_session)
+          subject
+        end
+      end
+    end
+
+    describe "#reset_session?" do
+      before { ApplicationController.send(:public, :reset_session?) }
+
+      context "when a user.inactive_too_long? is false" do
+        before { allow(user).to receive(:inactive_too_long?).and_return(false) }
+
+        it { expect(controller.reset_session?).to be false }
+      end
+
+      context "when a user.inactive_too_long? is true" do
+        before { allow(user).to receive(:inactive_too_long?).and_return(true) }
+
+        it { expect(controller.reset_session?).to be true }
+
+        context "when KEEP_ME_SIGNED_IN is false" do
+          before { session[ApplicationController::KEEP_ME_SIGNED_IN] = false }
+
+          it { expect(controller.reset_session?).to be true }
+        end
+
+        context "when KEEP_ME_SIGNED_IN is true" do
+          before { session[ApplicationController::KEEP_ME_SIGNED_IN] = true }
+
+          it { expect(controller.reset_session?).to be false }
+        end
+
+        context "when user is a Google user" do
+          before { allow(user).to receive(:google_id).and_return('123') }
+
+          it { expect(controller.reset_session?).to be false }
+        end
+
+        context "when user is a Clever user" do
+          before { allow(user).to receive(:clever_id).and_return('123') }
+
+          it { expect(controller.reset_session?).to be false }
+        end
+      end
+    end
   end
 
   context '#handle_invalid_inauthenticity_token' do

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -250,16 +250,6 @@ describe Cms::UsersController do
     end
   end
 
-  # no route for this action
-  # describe '#destroy' do
-  #   let!(:another_user) { create(:user) }
-  #
-  #   it 'should destroy the given user' do
-  #     delete :destoy, id: another_user.id
-  #     expect{User.find another_user.id}.to raise_exception ActiveRecord::RecordNotFound
-  #   end
-  # end
-
   describe '#complete_sales_stage' do
     let!(:another_user) { create(:user) }
     let(:updater) { double(:updater, call: true) }

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -92,3 +92,4 @@ describe AuthCredential, type: :model do
     expect(auth_credential.clever_authorized?).to be false
   end
 end
+


### PR DESCRIPTION
## WHAT

Note:  I'm tagging everyone on this PR since it the code is in ApplicationController which affects a large segment of our site.  but, specifically note the new `before_action hook :check_staff_for_extended_session` since that will affect all of us.

This PR fixes a [bug](https://www.notion.so/quill/Stuck-in-a-loop-when-attempting-to-sign-into-teacher-account-c67531bea440471ab67b4dd1071b4d31) where staff are unable to sign_in for users that had been inactive for too long.

In the process of uncovering this edge case, I refactored some of the logic, but also noticed a [comment](https://github.com/empirical-org/Empirical-Core/blob/be48add06ab38897bf9df928d8247293ec50697b/services/QuillLMS/app/controllers/application_controller.rb#L150) about staff sign out.

NB.  Unrelated, I've removed the time_difference gem as it appears it is no longer used.

## WHY
If staff tries to login to a user that has not been active in awhile, the staff's session gets reset (not the user they are attempting to impersonate).  This logs the staff out and then confusingly redirects to the sessions/new page.

## HOW
To fix this, we need to a [guard clause](https://github.com/empirical-org/Empirical-Core/blob/0fbe35716f3118af309a8bf911885127e67eb2b1/services/QuillLMS/app/controllers/application_controller.rb#L155) to check for `session[:staff_id]` before resetting the session.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Stuck-in-a-loop-when-attempting-to-sign-into-teacher-account-c67531bea440471ab67b4dd1071b4d31

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
