### PR TITLE
Pin flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,8 @@ jobs:
       - run:
           name: Pip Install
           command: |
-            pip install --user flake8
+            pip install --user flake8==4.0.1
+
       - run:
           name: Run Flake8
           command: |


### PR DESCRIPTION
## WHAT
Pin the python linter library flake8 to version 4.0.1

## WHY
There's a [regression](https://github.com/PyCQA/flake8/issues/1637
) in 5.0.1 causing broken [builds](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/17064/workflows/aaacfc1d-dc3e-4bda-98c5-bc7972a2bfc0/jobs/230118)

## HOW
Update circleci config.yml with the version.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
