### PR TITLE
Fix stripe PurchaserNotFound bug

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -2,6 +2,8 @@
 
 module StripeIntegration
   class SubscriptionCheckoutSessionsController < ApplicationController
+    class CustomerNotFoundError < StandardError; end
+
     SUBSCRIPTION_MODE = 'subscription'
 
     def create
@@ -30,6 +32,8 @@ module StripeIntegration
 
     private def customer
       User.find_by_stripe_customer_id_or_email!(stripe_customer_id, customer_email)
+    rescue ActiveRecord::RecordNotFound
+      raise CustomerNotFoundError
     end
 
     private def customer_arg

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -29,7 +29,7 @@ module StripeIntegration
     end
 
     private def customer
-      User.find_by_stripe_customer_id_or_email(stripe_customer_id, customer_email)
+      User.find_by_stripe_customer_id_or_email!(stripe_customer_id, customer_email)
     end
 
     private def customer_arg

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -181,10 +181,10 @@ class User < ApplicationRecord
     )
   end
 
-  def self.find_by_stripe_customer_id_or_email(stripe_customer_id, email)
+  def self.find_by_stripe_customer_id_or_email!(stripe_customer_id, email)
     return User.find_by(stripe_customer_id: stripe_customer_id) if stripe_customer_id.present?
 
-    User.find_by(email: email)
+    User.find_by!(email: email)
   end
 
   def self.valid_email?(email)

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -61,7 +61,7 @@ module StripeIntegration
       end
 
       private def purchaser
-        @purchaser ||= User.find_by!(email: purchaser_email)
+        @purchaser ||= User.find_by_stripe_customer_id_or_email!(stripe_customer_id, purchaser_email)
       rescue ActiveRecord::RecordNotFound
         raise PurchaserNotFoundError
       end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
@@ -12,20 +12,30 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
     let(:params) { { customer_email: customer_email, stripe_price_id: stripe_price_id } }
     let(:url) { '/stripe_integration/subscription_checkout_sessions' }
 
-    before { allow(StripeCheckoutSession).to receive(:custom_find_or_create_by!).and_return(stripe_checkout_session) }
+    subject { post url, params: params, as: :json }
 
-    it 'creates a stripe checkout session and provides a redirect' do
-      post url, params: params, as: :json
-      expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
-    end
-
-    context 'customer already has stripe_customer_id attached' do
-      before { customer.update(stripe_customer_id: stripe_customer_id) }
+    context 'happy path' do
+      before { allow(StripeCheckoutSession).to receive(:custom_find_or_create_by!).and_return(stripe_checkout_session) }
 
       it 'creates a stripe checkout session and provides a redirect' do
-        post url, params: params, as: :json
+        subject
         expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
       end
+
+      context 'customer already has stripe_customer_id attached' do
+        before { customer.update(stripe_customer_id: stripe_customer_id) }
+
+        it 'creates a stripe checkout session and provides a redirect' do
+          subject
+          expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
+        end
+      end
+    end
+
+    context 'customer not found' do
+      before { allow(User).to receive(:find_by_stripe_customer_id_or_email!).and_raise(ActiveRecord::RecordNotFound) }
+
+      it { expect { subject }.to raise_error described_class::CustomerNotFoundError }
     end
   end
 end

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
   end
 
   context 'purchaser does not exist' do
-    before { allow(User).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound) }
+    before { allow(User).to receive(:find_by_stripe_customer_id_or_email!).and_raise(ActiveRecord::RecordNotFound) }
 
     it { expect { subject }.to raise_error described_class::PurchaserNotFoundError }
   end


### PR DESCRIPTION
## WHAT
Fix an error with StripeIntegration::SubscriptionCreator where PurchaserNotFound exception is raised

## WHY
We'd like subscription creation to go through so that users can use their subscription.

## HOW
Users sometimes have a different email associated with their stripe_customer_id on the stripe website from the email found in our User table.  If we add in a disjunction to check for `stripe_customer_id`, this edge case should be handled.

The first half of this handled already [here](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb#L32) but we need to have  the same call when the webhook is received.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://sentry.io/organizations/quillorg-5s/issues/3469766303/?referrer=slack

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
