### PR TITLE
Fix a bug with Stripe subscriptions and ClearUserDataWorker

### DIFF
--- a/services/QuillLMS/spec/models/stripe_integration/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_integration/subscription_spec.rb
@@ -20,10 +20,41 @@ RSpec.describe StripeIntegration::Subscription do
     end
 
     context 'stripe_invoice_id present' do
-      before { allow(Stripe::Invoice).to receive(:retrieve).with(stripe_invoice_id).and_return(stripe_invoice) }
+      before do
+        allow(Stripe::Invoice).to receive(:retrieve).with(stripe_invoice_id).and_return(stripe_invoice)
+        allow(Stripe::Subscription).to receive(:retrieve).with(stripe_subscription_id).and_return(stripe_subscription)
+      end
 
       it 'should set the cancel_at_period_end to true' do
         expect(Stripe::Subscription).to receive(:update).with(stripe_subscription_id, cancel_at_period_end: true)
+        subject
+      end
+    end
+
+    context 'stripe subscription is already canceled' do
+      before do
+        allow(Stripe::Invoice).to receive(:retrieve).with(stripe_invoice_id).and_return(stripe_invoice)
+        allow(Stripe::Subscription).to receive(:retrieve).with(stripe_subscription_id).and_return(stripe_subscription)
+      end
+
+      let(:stripe_subscription_status) { described_class::CANCELED }
+
+      it 'should return before attempting to update the subscription' do
+        expect(Stripe::Subscription).not_to receive(:update)
+        subject
+      end
+    end
+
+    context 'stripe subscription is already incomplete expired' do
+      before do
+        allow(Stripe::Invoice).to receive(:retrieve).with(stripe_invoice_id).and_return(stripe_invoice)
+        allow(Stripe::Subscription).to receive(:retrieve).with(stripe_subscription_id).and_return(stripe_subscription)
+      end
+
+      let(:stripe_subscription_status) { described_class::INCOMPLETE_EXPIRED }
+
+      it 'should return before attempting to update the subscription' do
+        expect(Stripe::Subscription).not_to receive(:update)
         subject
       end
     end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3469967761/?referrer=slack) involving Stripe subscriptions and ClearUserDataWorker 

## WHY
We'd like the ClearUserDataWorker to complete

## HOW
Part of the cleanup involved with clearing user data involves canceling Stripe Subscriptions.  We need to add a guard clause that checks a subscription's status for `canceled` or `incomplete_expired` otherwise, Stripe will raise an error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
