### PR TITLE
lms/add-retries-to-concept-result-copying

### DIFF
--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -565,8 +565,6 @@ GEM
       remotipart (~> 1.3)
       sassc-rails (>= 1.3, < 3)
     rails_autoscale_agent (0.10.2)
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.1.6)
       actionpack (= 6.1.6)
       activesupport (= 6.1.6)

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -8,7 +8,7 @@ class SaveActivitySessionConceptResultsWorker
   def perform(old_concept_result_ids)
     OldConceptResult.where(id: old_concept_result_ids).each do |old_concept_result|
       concept_result = ConceptResult.find_or_create_from_old_concept_result(old_concept_result)
-      unless concept_result
+      unless concept_result&.id
         SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id])
         ErrorNotifier.report(ConceptResultCopyFailedException.new("Failed to copy OldConceptResult #{old_concept_result.id}.  Retrying."))
       end

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -3,9 +3,15 @@
 class SaveActivitySessionConceptResultsWorker
   include Sidekiq::Worker
 
+  class ConceptResultCopyFailedException < StandardError;end
+
   def perform(old_concept_result_ids)
     OldConceptResult.where(id: old_concept_result_ids).each do |old_concept_result|
-      ConceptResult.find_or_create_from_old_concept_result(old_concept_result)
+      concept_result = ConceptResult.find_or_create_from_old_concept_result(old_concept_result)
+      unless concept_result
+        SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id])
+        ErrorNotifier.report(ConceptResultCopyFailedException.new("Failed to copy OldConceptResult #{old_concept_result.id}.  Retrying."))
+      end
     end
   end
 end

--- a/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_concept_results_worker.rb
@@ -3,7 +3,7 @@
 class SaveActivitySessionConceptResultsWorker
   include Sidekiq::Worker
 
-  class ConceptResultCopyFailedException < StandardError;end
+  class ConceptResultCopyFailedException < StandardError; end
 
   def perform(old_concept_result_ids)
     OldConceptResult.where(id: old_concept_result_ids).each do |old_concept_result|

--- a/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_concept_results_worker_spec.rb
@@ -8,15 +8,22 @@ describe SaveActivitySessionConceptResultsWorker, type: :worker do
     let(:old_concept_result) { create(:old_concept_result) }
 
     it 'should save new ConceptResult records based on an array of OldConceptResult ids' do
-      expect { subject.perform(old_concept_result.id) }
+      expect { subject.perform([old_concept_result.id]) }
         .to change(ConceptResult, :count).by(1)
       expect(old_concept_result.concept_result).to be
     end
 
     it 'should create new ConceptResults that are related to the same ActivitySession as the original OldConceptResult' do
-      subject.perform(old_concept_result.id)
+      subject.perform([old_concept_result.id])
 
       expect(old_concept_result.concept_result.activity_session).to eq(old_concept_result.activity_session)
+    end
+
+    it 'should re-enqueue old_concept_result.ids if new concept_results are not created' do
+      expect(ConceptResult).to receive(:find_or_create_from_old_concept_result).and_return(nil)
+      expect(SaveActivitySessionConceptResultsWorker).to receive(:perform_async).with([old_concept_result.id])
+
+      subject.perform([old_concept_result.id])
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update worker to retry if initial copy doesn't work
## WHY
These are currently failing silently.  This will force a retry and also report the failure to Sentry and NewRelic (though it's not a straight-up `raise` given that we actually want the retry to enqueue only IDs that fail to migrate).
## HOW
After attempting a copy, check to see if we got a new record out of it.  If not, insert the `OldConceptResult.id` into the queue to try copying it again.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
