### PR TITLE
Fix unknown attribute reference bug

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -91,8 +91,8 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
 
       if pre_test && pre_test_activity_session
         concept_results = {
-          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) },
-          post: { questions: format_concept_results(activity_session, activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) }
+          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) },
+          post: { questions: format_concept_results(activity_session, activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) }
         }
         formatted_skills = skills.map do |skill|
           {
@@ -102,7 +102,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
         end
         skill_results = { skills: formatted_skills.uniq { |formatted_skill| formatted_skill[:pre][:skill] } }
       else
-        concept_results = { questions: format_concept_results(activity_session, activity_session.old_concept_results.order("(metadata->>'questionNumber')::int")) }
+        concept_results = { questions: format_concept_results(activity_session, activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) }
         skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.old_concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
       end
       { concept_results: concept_results, skill_results: skill_results, name: student.name }


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3469675409/?project=11238&query=is%3Aunresolved&statsPeriod=14d) involving raw sql on an order clause.

## WHY
By default, Rails 6.1 prevents raw sql calls using order clauses with non model attributes.  More details are in an earlier [PR](https://github.com/empirical-org/Empirical-Core/pull/9288)

## HOW
Wrap the offending queries in Arel.sql.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
