### PR TITLE
Fix Activity Pack Editor Bugs

### DIFF
--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -15,12 +15,12 @@ class ActivitiesController < ApplicationController
   end
 
   def index_with_unit_templates
-    json = Activity
-      .includes(:standard, :raw_score, :classification, :unit_templates, :activities_unit_templates)
-      .all
-      .map { |activity| Cms::ActivitySerializer.new(activity).as_json(root: false) }
+    activities =
+      Activity
+        .includes(:standard, :raw_score, :classification, :unit_templates, :activities_unit_templates)
+        .all
 
-    render json: json
+    render json: activities, each_serializer: Cms::ActivitySerializer
   end
 
   def count

--- a/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
@@ -10,11 +10,11 @@ class Cms::UnitTemplatesController < Cms::CmsController
       format.json do
         unit_templates =
           UnitTemplate
-            .includes(activities: [:classification, :standard])
+            .includes(activities: [:raw_score])
             .includes(:unit_template_category)
             .order(order_number: :asc)
 
-        render json: { unit_templates: unit_templates, each_serializer: Cms::UnitTemplateSerializer }
+        render json: unit_templates, each_serializer: Cms::UnitTemplateSerializer
       end
     end
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/UnitTemplates/unitTemplateActivityRow.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/UnitTemplates/unitTemplateActivityRow.tsx
@@ -63,7 +63,7 @@ export const UnitTemplateActivityRow = ({
         ccss: showStandardData(standard),
         concept: activity_category && activity_category.name ? activity_category.name : NOT_APPLICABLE,
         tool: classification && classification.id ? getIconForActivityClassification(classification.id) : NOT_APPLICABLE,
-        edit: <a className="action-button focus-on-light" href={editActivityLink(classification.id, id)} rel="noopener noreferrer" target="_blank">edit</a>,
+        edit: classification && classification.id ? <a className="action-button focus-on-light" href={editActivityLink(classification.id, id)} rel="noopener noreferrer" target="_blank">edit</a> : NOT_APPLICABLE,
         remove: <button className="action-button interactive-wrapper focus-on-light" onClick={handleRemoveClick} type="button" value={id}>remove</button>
       }
     });


### PR DESCRIPTION
## WHAT
Fix a [bug](https://www.notion.so/quill/Activity-Pack-Editor-Bugs-682c5c41837c439c9942b557eb634073) involving the unit template serializer.

## WHY
We need proper payloads to fill the unit templates page.

## HOW
Fix the each_serializer calls for the associated templates.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
