### PR TITLE
remove incorrect caching to fix bug

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/concepts/concepts_controller.rb
@@ -13,11 +13,8 @@ class Teachers::ProgressReports::Concepts::ConceptsController < Teachers::Progre
   end
 
   private def json_payload
-    concepts_json = current_user.all_classrooms_cache(key: 'teachers.progress_reports.concepts.concepts') do
-      concepts_as_json
-    end
     {
-      concepts: concepts_json,
+      concepts: concepts_as_json,
       student: {name: student.name}
     }
   end


### PR DESCRIPTION
## WHAT
Remove caching that was overly greedy, causing the same report to display for different students.

Note: We could also address the issue by caching every single student key. I'd like to see a compelling reason for this though. It would result in this controller action generating a multiplicative number of new keys, which, in a our current caching strategy, would result in many other keys getting evacuated from the cache store. CC @anathomical 

## WHY
Report data should be tailored to individual students, not just the first student that was cached. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef&p=450b080433ad4a628be360d6044a478e&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Tested manually. This PR is removing logic, not adding it.
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
