### PR TITLE
Fix bug with pack-type select

### DIFF
--- a/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
@@ -7,9 +7,7 @@ class Cms::UnitTemplateCategoriesController < Cms::CmsController
     @unit_template_categories = UnitTemplateCategory.all
     respond_to do |format|
       format.html
-      format.json do
-        render json: @unit_template_categories
-      end
+      format.json { render json: { unit_template_categories: @unit_template_categories } }
     end
   end
 


### PR DESCRIPTION
## WHAT
Fix a bug with the pack-type select drop down used in Activity Pack editor

## WHY
The dropdown isn't populating

## HOW
Add a root key back in that was accidentally removed with the ActiveModelSerializers refactor

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Manual testing
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A