### PR TITLE
Lms/write old concept results in workers

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -85,12 +85,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     concept_results_to_save = @concept_results.map { |c| concept_results_hash(c) }.reject(&:empty?)
     return if concept_results_to_save.empty?
 
-    bulk_inserter = OldConceptResult.custom_bulk_insert(values: concept_results_to_save, return_primary_keys: true)
-    old_concept_result_ids = bulk_inserter.result_sets.first.map { |result| result['id'] }
-    # Note that this will need to be overhauled when we stop writing OldConceptResult
-    # records, but we have to have this here now because we have to have the id value
-    # from the OldConceptResult to record the new ConceptResult
-    SaveActivitySessionConceptResultsWorker.perform_async(old_concept_result_ids)
+    SaveActivitySessionOldConceptResultsWorker.perform_async(concept_results_to_save)
   end
 
   private def concept_results_hash(concept_result)

--- a/services/QuillLMS/app/workers/save_activity_session_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_old_concept_results_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SaveActivitySessionOldConceptResultsWorker
+  include Sidekiq::Worker
+
+  def perform(concept_results_hashes)
+    ocr_ids = []
+    OldConceptResult.transaction do
+      concept_results_hashes.each do |concept_result_hash|
+        ocr_ids.append(OldConceptResult.create!(concept_result_hash).id)
+      end
+    end
+    SaveActivitySessionConceptResultsWorker.perform_async(ocr_ids)
+  end
+end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -97,7 +97,9 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       end
 
       it 'saves the concept tag relationship (ID) in the result' do
-        put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
+        Sidekiq::Testing.inline! do
+          put :update, params: { id: activity_session.uid, concept_results: concept_results }, as: :json
+        end
         expect(OldConceptResult.where(activity_session_id: activity_session, concept_id: writing_concept.id).count).to eq 2
       end
     end

--- a/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
@@ -42,8 +42,11 @@ describe SaveActivitySessionOldConceptResultsWorker, type: :worker do
     end
 
     it 'should save OldConceptResult records' do
-      expect { subject.perform(concept_results) }
-        .to change { OldConceptResult.count }.by(3)
+      Sidekiq::Testing.inline! do
+        expect { subject.perform(concept_results) }
+          .to change { OldConceptResult.count }.by(3)
+          .and change { ConceptResult.count }.by(3)
+      end
     end
 
     it 'should pass on an array of IDs for the created OldConceptResults to the next worker' do

--- a/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
@@ -44,8 +44,8 @@ describe SaveActivitySessionOldConceptResultsWorker, type: :worker do
     it 'should save OldConceptResult records' do
       Sidekiq::Testing.inline! do
         expect { subject.perform(concept_results) }
-          .to change { OldConceptResult.count }.by(3)
-          .and change { ConceptResult.count }.by(3)
+          .to change(OldConceptResult, :count).by(3)
+          .and change(ConceptResult, :count).by(3)
       end
     end
 

--- a/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SaveActivitySessionOldConceptResultsWorker, type: :worker do
+
+  context '#perform' do
+    let!(:activity_session) { create(:activity_session_without_concept_results) }
+
+    let(:writing_concept) { create(:concept, name: 'Creative Writing') }
+
+    let(:concept_result1) do
+      create(:old_concept_result,
+        activity_session_id: activity_session.id,
+        concept: writing_concept,
+        metadata: { foo: 'bar', correct: true }
+      )
+    end
+
+    let(:concept_result2) do
+      create(:old_concept_result,
+        activity_session_id: activity_session.id,
+        metadata: { baz: 'foo', correct: true }
+      )
+    end
+
+    let(:concept_result3) do
+      create(:old_concept_result,
+        activity_session_id: activity_session.id,
+        metadata: { correct: true }
+      )
+    end
+
+    let!(:concept_results) do
+      results = JSON.parse([concept_result1, concept_result2, concept_result3].to_json)
+
+      results[0] = results[0].except('id').merge('concept_uid' => concept_result1.concept.uid)
+      results[1] = results[1].except('id').merge('concept_uid' => concept_result2.concept.uid)
+      results[2] = results[2].except('id').merge('concept_uid' => concept_result3.concept.uid)
+
+      results
+    end
+
+    it 'should save OldConceptResult records' do
+      expect { subject.perform(concept_results) }
+        .to change { OldConceptResult.count }.by(3)
+    end
+
+    it 'should pass on an array of IDs for the created OldConceptResults to the next worker' do
+      expect(OldConceptResult).to receive(:create!).and_return(concept_result1, concept_result2, concept_result3)
+      expect(SaveActivitySessionConceptResultsWorker).to receive(:perform_async).with([concept_result1.id, concept_result2.id, concept_result3.id])
+
+      subject.perform(concept_results)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Refactor the way we write `OldConceptResult` records and `ConceptResult` records whenever we mark an `ActivitySession` as complete
## WHY
It appears that the old code that was intended to use `bulk_insert` to create a bunch of `OldConceptResult` records and then get their IDs to use in the subsequent creation of `ConceptResult` records was sometimes failing to actually provide IDs.  Without the IDs, the subsequent attempt to create `ConceptResult` records fails.

By moving the code into a worker we can keep the load on the controller small while allowing more flexible ways of handling the insertions than mucking around with `bulk_insert`.
## HOW
- Create a new Worker to handle the creation of `OldConceptResult` records when an `ActivitySession` is completed
- Use that new worker instead of `bulk_insert` to create the `OldConceptResult` records
- Once the `OldConceptResult` records are persisted, pass their IDs into a Worker to create `ConceptResults` for them

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
