### PR TITLE
Fix bug with stripe subscription creation

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -197,9 +197,11 @@ class User < ApplicationRecord
   end
 
   def self.find_by_stripe_customer_id_or_email!(stripe_customer_id, email)
-    return User.find_by(stripe_customer_id: stripe_customer_id) if stripe_customer_id.present?
-
-    User.find_by!(email: email)
+    if stripe_customer_id.present? && User.exists?(stripe_customer_id: stripe_customer_id)
+      User.find_by(stripe_customer_id: stripe_customer_id)
+    else
+      User.find_by!(email: email)
+    end
   end
 
   def self.valid_email?(email)

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1428,4 +1428,46 @@ describe User, type: :model do
       it { expect(subject).to eq true }
     end
   end
+
+  describe '.find_by_stripe_customer_id_or_email!' do
+    subject { User.find_by_stripe_customer_id_or_email!(stripe_customer_id, email) }
+
+    let(:email) { 'text@example.com' }
+
+    context 'stripe_customer_id nil' do
+      let(:stripe_customer_id) { nil }
+
+      context 'user does not exist with email' do
+        it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+      end
+
+      context 'user exists with email' do
+        let!(:user) { create(:user, email: email) }
+
+        it { expect(subject).to eq user }
+      end
+    end
+
+    context 'stripe_customer_id present' do
+      let(:stripe_customer_id) { "cus_#{SecureRandom.hex}" }
+
+      context 'user exists with stripe_customer_id' do
+        let!(:user) { create(:user, stripe_customer_id: stripe_customer_id) }
+
+        it { expect(subject).to eq user }
+      end
+
+      context 'user does not exist with stripe_customer_id' do
+        context 'user exists with email' do
+          let!(:user) { create(:user, email: email) }
+
+          it { expect(subject).to eq user }
+        end
+
+        context 'user does not exist with email' do
+          it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Fix a bug involving `User.find_by_stripe_customer_id_or_email!` that was giving a nil [here](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb#L39)

## WHY
We'd like subscription creation to go through to completion.

## HOW
The guard clause was wrongly returning a nil user when there was `stripe_customer_id` but none in our database yet.  Add clause to the conditional to check for that.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Newly-purchased-subscriptions-through-Stripe-not-showing-up-on-teacher-account-f061c7ef16ca4204981c5da6fe17de3e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
