### PR TITLE
lms/fix-minor-documentation-string

### DIFF
--- a/services/QuillLMS/lib/tasks/concept_results_migration.rake
+++ b/services/QuillLMS/lib/tasks/concept_results_migration.rake
@@ -6,10 +6,10 @@ namespace :concept_results_migration do
 
     unless pipe_data
       puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
-      puts '  rake users:refresh_school_subscriptions < path/to/local/file.csv'
+      puts '  rake concept_results_migration:migrate_from_csv < path/to/local/file.csv'
       puts ''
       puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
-      puts '  heroku run rake users:refresh_school_subscriptions -a empirical-grammar --no-tty < path/to/local/file.csv'
+      puts '  heroku run rake concept_results_migration:migrate_from_csv -a empirical-grammar --no-tty < path/to/local/file.csv'
       exit 1
     end
 


### PR DESCRIPTION
## WHAT
Fix copy/pasted documentation for a rake task
## WHY
While it's unlikely that this will ever need to be run again, it's worth making this correct now that I've noticed it
## HOW
Update the name of the rake task in the help documentation which was originally copy/pasted from another task, and so was inaccurate

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
