### PR TITLE
Fix xhr JSON redirection bug

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -30,9 +30,7 @@ class Auth::GoogleController < ApplicationController
 
   private def redirect_to_profile_or_post_auth
     if session[ApplicationController::POST_AUTH_REDIRECT].present?
-      url = session[ApplicationController::POST_AUTH_REDIRECT]
-      session.delete(ApplicationController::POST_AUTH_REDIRECT)
-      redirect_to url
+      redirect_to session.delete(ApplicationController::POST_AUTH_REDIRECT)
     elsif staff?
       redirect_to locker_path
     else
@@ -44,7 +42,8 @@ class Auth::GoogleController < ApplicationController
     user = User.find_by('google_id = ? OR email = ?', @profile.google_id&.to_s, @profile.email&.downcase)
     return if user.nil? || user.google_authorized?
 
-    redirect_to new_session_path(google_offline_access_expired: true)
+    session[ApplicationController::GOOGLE_OFFLINE_ACCESS_EXPIRED] = true
+    redirect_to new_session_path
   end
 
   private def run_background_jobs

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -111,7 +111,8 @@ class SessionsController < ApplicationController
     @user = User.new
     @title = 'Log In'
     @clever_link = clever_link
-    @google_offline_access_expired = (params[:google_offline_access_expired] == 'true')
+    @google_offline_access_expired = session.delete(ApplicationController::GOOGLE_OFFLINE_ACCESS_EXPIRED)
+    @expired_session_redirect = session.delete(ApplicationController::EXPIRED_SESSION_REDIRECT)
     session[:role] = nil
     session[ApplicationController::POST_AUTH_REDIRECT] = params[:redirect] if params[:redirect]
   end

--- a/services/QuillLMS/app/views/sessions/new.html.erb
+++ b/services/QuillLMS/app/views/sessions/new.html.erb
@@ -1,5 +1,6 @@
 <%= react_component('LoginFormApp', props: {
       cleverLink: @clever_link,
+      expiredSessionRedirect: @expired_session_redirect,
       googleOfflineAccessExpired: @google_offline_access_expired
     })
 %>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -7,6 +7,7 @@ import PasswordWrapper from '../shared/password_wrapper'
 import AssignActivityPackBanner from '../assignActivityPackBanner'
 import getAuthToken from '../../modules/get_auth_token'
 import { Input, } from '../../../../Shared/index'
+import { Snackbar } from '../../../../Shared/index'
 
 const smallWhiteCheckSrc = `${process.env.CDN_URL}/images/shared/check-small-white.svg`
 
@@ -136,13 +137,14 @@ class LoginFormApp extends React.Component {
   }
 
   render() {
-    const { googleOfflineAccessExpired } = this.props
+    const { googleOfflineAccessExpired, expiredSessionRedirect } = this.props
     const { errors, email, password, timesSubmitted, authToken, } = this.state;
 
     if (googleOfflineAccessExpired) { return this.renderGoogleOfflineAccessConsent() }
 
     return (
       <div>
+        {expiredSessionRedirect && <Snackbar text="Your session has expired. Please re-authenticate." visible={true} />}
         <AssignActivityPackBanner login={true} />
         <div className="container account-form">
           <h1>Good to see you again!</h1>

--- a/services/QuillLMS/client/app/modules/request/index.js
+++ b/services/QuillLMS/client/app/modules/request/index.js
@@ -18,7 +18,10 @@ function buildRequestCallback(success, error) {
       if (success) {
         success(body);
       }
-    } else {
+    } else if (httpStatus && httpStatus.statusCode === 303 && body.redirect) {
+      window.location.href = body.redirect
+    }
+    else {
       if (error) {
         error(body);
       } else {


### PR DESCRIPTION
## WHAT
Fix a `ActionController::UnknownFormat ApplicationController#routing_error` [bug](https://one.newrelic.com/nr1-core/errors/overview/MjYzOTExM3xBUE18QVBQTElDQVRJT058NTQ4ODU2ODc1?account=2639113&duration=1800000&state=a84801f4-3336-e599-4a68-4512a03e23c3) 

## WHY
When a logged in user's session expires and an xhr request is made, the `before_action: :confirm_valid_session` attempts to redirect but there isn't a JSON format so it fails.

## HOW
Add in a respond to block to handle format.json redirects.  Set `session[EXPIRED_SESSION_REDIRECT] = true` and then use that value on the `sessions#new` to initiate a snackbar: "Your session has expired. Please re-authenticate." (see [screencast](https://user-images.githubusercontent.com/2057805/182893552-82e9e192-cec2-4c27-bdc0-d15af841f33f.mov))

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
