### PR TITLE
make sidekiq redis config clearer

### DIFF
--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+sidekiq_url = ENV['SIDEKIQ_REDIS_URL'] || 'redis://localhost:6379'
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
+end
+
 module SidekiqQueue
   # QUEUE DEFINITIONS
 


### PR DESCRIPTION
## WHAT
Directly specify which env var for Sidekiq to get its redis URL from. 

Note: I have already provisioned redis addons and pointed SIDEKIQ_REDIS_URL to the associated redis URLs in all staging and prod environments, so this change will be backwards compatible when deployed. 

## WHY
The [default behavior](https://github.com/mperham/sidekiq/wiki/Using-Redis) (using REDIS_PROVIDER to point to an additional env var) is confusing. 

## HOW
Modify sidekiq.rb 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Deprecate-LMS-Redis-to-go-4b5127c661bc488dac3540d98027aa56

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config change only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
