### PR TITLE
fix link for diagnostic recommendation pack preview

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
@@ -337,47 +337,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Compound-Complex Sentences
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/320' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/320"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -396,47 +366,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Appositive Phrases
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/322' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/322"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -455,47 +395,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Relative Clauses
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/324' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/324"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -514,47 +424,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Participial Phrases
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/327' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/327"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -573,47 +453,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Parallel Structure
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/329' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/329"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -632,47 +482,17 @@ exports[`RecommendationsTable component should render when no students have comp
                   <span>
                     Advanced Combining
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/331' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/331"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11422,47 +11242,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Capitalization
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/308' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/308"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11481,47 +11271,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Plural and Possessive Nouns
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/310' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/310"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11540,47 +11300,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Adjectives and Adverbs
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/312' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/312"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11599,47 +11329,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Prepositional Phrases
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/314' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/314"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11658,47 +11358,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Compound Subjects, Objects, and Predicates
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/316' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/316"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"
@@ -11717,47 +11387,17 @@ exports[`RecommendationsTable component should render when there are recommendat
                   <span>
                     Commonly Confused Words
                   </span>
-                  <Tooltip
-                    isTabbable={true}
-                    tooltipText="<a href='/activities/packs/318' target=\\"_blank\\">Preview the activity pack</a>"
-                    tooltipTriggerText={
-                      <img
-                        alt="Question mark icon"
-                        src="undefined/images/icons/icons-help.svg"
-                      />
-                    }
+                  <a
+                    aria-label="Preview the activity pack"
+                    href="/activities/packs/318"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    <span
-                      aria-hidden={false}
-                      className="quill-tooltip-trigger "
-                      role="tooltip"
-                    >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <img
-                          alt="Question mark icon"
-                          src="undefined/images/icons/icons-help.svg"
-                        />
-                      </span>
-                      <span
-                        className="quill-tooltip-wrapper"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="quill-tooltip"
-                        />
-                      </span>
-                    </span>
-                  </Tooltip>
+                    <img
+                      alt=""
+                      src="undefined/images/icons/icons-help.svg"
+                    />
+                  </a>
                 </div>
                 <span
                   className="activity-count"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendationsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendationsTable.tsx
@@ -171,15 +171,12 @@ const RecommendationsTable = ({ recommendations, responsesLink, students, select
   }, [handleScroll]);
 
   const tableHeaders = recommendations && recommendations.map(recommendation => {
-    const { activity_pack_id, name, activity_count, students, } = recommendation
+    const { activity_pack_id, name, activity_count, } = recommendation
     return (
       <th className="recommendation-header" key={name}>
         <div className="name-and-tooltip">
           <span>{name}</span>
-          <Tooltip
-            tooltipText={`<a href='/activities/packs/${activity_pack_id}' target="_blank">Preview the activity pack</a>`}
-            tooltipTriggerText={<img alt={helpIcon.alt} src={helpIcon.src} />}
-          />
+          <a aria-label="Preview the activity pack" href={`/activities/packs/${activity_pack_id}`} rel="noopener noreferrer" target="_blank"><img alt="" src={helpIcon.src} /></a>
         </div>
         <span className="activity-count">{activity_count} activities</span>
       </th>


### PR DESCRIPTION
## WHAT
Fix link for diagnostic recommendation pack preview.

## WHY
We previously had this link inside of a tooltip, but when we changed the tooltips recently so that they don't stick around after you move your cursor out of the hitbox, the link was no longer accessible. I talked to Jack and we agreed that interactive components inside of tooltips are kind of an antipattern anyway, so we just changed this to a straightforward link.

## HOW
Remove the tooltip and just have the image itself be a link.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Preview-Pack-link-on-Diagnostic-Recommendations-report-is-not-clickable-891c004cd92745dc94e79ef865558f55

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES