### PR TITLE
Script to refresh local non-user data from prod follower

### DIFF
--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -10,6 +10,8 @@ namespace :local_data do
     ActiveRecord::Base.connection.execute(truncate_command)
   end
 
+  # Note, before running, populate:
+  # ENV['PROD_FOLLOWER_DB'], ENV['PROD_FOLLOWER_DB_HOST'], ENV['PROD_FOLLOWER_DB_USER']
   # bundle exec rake local_data:reset_nonuser_data_from_follower
   desc "import non-user tables"
   task reset_nonuser_data_from_follower: :environment do
@@ -18,7 +20,7 @@ namespace :local_data do
     pretty_print("Truncating non-user tables")
     ActiveRecord::Base.connection.execute(truncate_command)
 
-    pretty_print("Downloading data from follower (takes a few minutes)\nIgnore circular key warning")
+    pretty_print("Downloading data from follower\n(Ignore circular key warning)")
     run_cmd(dump_command)
 
     database = Rails.configuration.database_configuration["development"]["database"]
@@ -31,6 +33,7 @@ namespace :local_data do
 
   module LocalSeedCommands
     # Get these from Heroku, use a user marked 'read-only'
+    # You will be prompted for the password in the console when run
     DB_NAME = ENV['PROD_FOLLOWER_DB']
     DB_HOST = ENV['PROD_FOLLOWER_DB_HOST']
     DB_USER = ENV['PROD_FOLLOWER_DB_USER']
@@ -57,7 +60,7 @@ namespace :local_data do
     def dump_command(tables: TABLES, file: FILE_NAME)
       table_flags = tables.map {|table| "--table=#{table} "}.join(' ')
 
-      "pg_dump -h #{DB_HOST} -p 5432 -U #{DB_USER} -W #{table_flags} --data-only --disable-triggers #{DB_NAME} > #{file}"
+      "pg_dump -h #{DB_HOST} -p 5432 -U #{DB_USER} -W #{table_flags} --data-only #{DB_NAME} > #{file}"
     end
 
     def truncate_command(tables: TABLES)
@@ -99,7 +102,6 @@ namespace :local_data do
       authors
       blog_posts
       categories
-      checkboxes
       comprehension_activities
       comprehension_automl_models
       comprehension_highlights
@@ -131,12 +133,10 @@ namespace :local_data do
       questions
       recommendations
       sales_stage_types
-      sales_stages
       schools
       skill_concepts
       skill_group_activities
       title_cards
-      unit_activities
       unit_template_categories
       unit_templates
       zipcode_infos

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -142,5 +142,4 @@ namespace :local_data do
       zipcode_infos
     )
   end
-
 end

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+namespace :local_data do
+  desc "truncate local non-user tables"
+  task truncate_nonuser_tables: :environment do
+    include LocalSeedCommands
+
+    ActiveRecord::Base.connection.execute(truncate_command)
+  end
+
+  # bundle exec rake local_data:reset_nonuser_data_from_follower
+  desc "import non-user tables"
+  task reset_nonuser_data_from_follower: :environment do
+    include LocalSeedCommands
+
+    pretty_print("Truncating non-user tables")
+    ActiveRecord::Base.connection.execute(truncate_command)
+
+    pretty_print("Downloading data from follower (takes a few minutes)\nIgnore circular key warning")
+    run_cmd(dump_command)
+
+    database = Rails.configuration.database_configuration["development"]["database"]
+    pretty_print("Loading data to #{database}")
+    run_cmd(load_command(database: database))
+
+    pretty_print("removing datafile")
+    run_cmd(rm_file_command)
+  end
+
+  module LocalSeedCommands
+    # Get these from Heroku, use a user marked 'read-only'
+    DB_NAME = ENV['PROD_FOLLOWER_DB']
+    DB_HOST = ENV['PROD_FOLLOWER_DB_HOST']
+    DB_USER = ENV['PROD_FOLLOWER_DB_USER']
+    FILE_NAME = 'output.sql'
+
+    LINE = '*' * 20
+
+    def run_cmd(command)
+      stdout_str, stderr_str, status = Open3.capture3(command)
+
+      if !stderr_str.squish.empty?
+        puts "Errors: #{stderr_str}"
+      end
+    end
+
+    def rm_file_command(file: FILE_NAME)
+      "rm #{file}"
+    end
+
+    def load_command(file: FILE_NAME, database:)
+      "psql -h localhost -p 5432 #{database} -f #{file}"
+    end
+
+    def dump_command(tables: TABLES, file: FILE_NAME)
+      table_flags = tables.map {|table| "--table=#{table} "}.join(' ')
+
+      "pg_dump -h #{DB_HOST} -p 5432 -U #{DB_USER} -W #{table_flags} --data-only --disable-triggers #{DB_NAME} > #{file}"
+    end
+
+    def truncate_command(tables: TABLES)
+      "TRUNCATE #{tables.compact.join(',')} RESTART IDENTITY CASCADE;"
+    end
+
+    def pretty_print(text)
+      puts LINE
+      puts text
+      puts LINE
+    end
+
+    # Note this order is purposeful:
+    # Tables that other tables have foreign keys to are loaded first
+    # Or else they will raise FK errors
+    # Then the rest alphabetically
+    TABLES = %w(
+      standard_categories
+      standard_levels
+      standards
+      content_partners
+      raw_scores
+      districts
+      activities
+      skill_groups
+      skills
+      unit_templates
+      concepts
+      topics
+      comprehension_feedbacks
+      comprehension_rules
+      activities_unit_templates
+      activity_categories
+      activity_category_activities
+      activity_classifications
+      activity_healths
+      activity_topics
+      announcements
+      authors
+      blog_posts
+      categories
+      checkboxes
+      comprehension_activities
+      comprehension_automl_models
+      comprehension_highlights
+      comprehension_labels
+      comprehension_passages
+      comprehension_plagiarism_texts
+      comprehension_prompts
+      comprehension_prompts_rules
+      comprehension_regex_rules
+      concept_feedbacks
+      concept_result_directions
+      concept_result_instructions
+      concept_result_previous_feedbacks
+      concept_result_prompts
+      concept_result_question_types
+      content_partner_activities
+      criteria
+      evidence_hints
+      file_uploads
+      firebase_apps
+      images
+      milestones
+      oauth_applications
+      objectives
+      page_areas
+      partner_contents
+      plans
+      prompt_healths
+      questions
+      recommendations
+      sales_stage_types
+      sales_stages
+      schools
+      skill_concepts
+      skill_group_activities
+      title_cards
+      unit_activities
+      unit_template_categories
+      unit_templates
+      zipcode_infos
+    )
+  end
+
+end

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -47,16 +47,16 @@ namespace :local_data do
     def run_cmd(command)
       stdout_str, stderr_str, status = Open3.capture3(command)
 
-      if !stderr_str.squish.empty?
-        puts "Errors: #{stderr_str}"
-      end
+      return if stderr_str.squish.empty?
+
+      puts "Errors: #{stderr_str}"
     end
 
     def rm_file_command(file: FILE_NAME)
       "rm #{file}"
     end
 
-    def load_command(file: FILE_NAME, database:)
+    def load_command(database:, file: FILE_NAME)
       "psql -h localhost -p 5432 #{database} -f #{file}"
     end
 

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -10,9 +10,12 @@ namespace :local_data do
     ActiveRecord::Base.connection.execute(truncate_command)
   end
 
-  # Note, before running, populate:
-  # ENV['PROD_FOLLOWER_DB'], ENV['PROD_FOLLOWER_DB_HOST'], ENV['PROD_FOLLOWER_DB_USER']
-  # bundle exec rake local_data:reset_nonuser_data_from_follower
+  # Note, before running, populate these ENV vars with a 'read-only' user from Heroku:
+  # PROD_FOLLOWER_DB
+  # PROD_FOLLOWER_DB_HOST
+  # PROD_FOLLOWER_DB_USER
+  # You will be prompted for the password in the console when run
+  # To Run: bundle exec rake local_data:reset_nonuser_data_from_follower
   desc "import non-user tables"
   task reset_nonuser_data_from_follower: :environment do
     include LocalSeedCommands

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -60,13 +60,13 @@ namespace :local_data do
       "psql -h localhost -p 5432 #{database} -f #{file}"
     end
 
-    def dump_command(tables: TABLES, file: FILE_NAME)
+    def dump_command(tables: NONUSER_TABLES, file: FILE_NAME)
       table_flags = tables.map {|table| "--table=#{table} "}.join(' ')
 
       "pg_dump -h #{DB_HOST} -p 5432 -U #{DB_USER} -W #{table_flags} --data-only #{DB_NAME} > #{file}"
     end
 
-    def truncate_command(tables: TABLES)
+    def truncate_command(tables: NONUSER_TABLES)
       "TRUNCATE #{tables.compact.join(',')} RESTART IDENTITY CASCADE;"
     end
 
@@ -80,7 +80,7 @@ namespace :local_data do
     # Tables that other tables have foreign keys to are loaded first
     # Or else they will raise FK errors
     # Then the rest alphabetically
-    TABLES = %w(
+    NONUSER_TABLES = %w(
       standard_categories
       standard_levels
       standards


### PR DESCRIPTION
## WHAT
Add a `rake` task to pull all non-user-related tables from the prod follower and load them locally.
## WHY
This is an easy way to keep activities up to date for local testing without touching PII. I wrote this because I'm on a new-ish computer and don't have any of the Evidence activities to test with.
## HOW
1. Compile a list of the all the non-user tables
2. `pg_dump` those specific tables to a `.sql` file
3. Truncate those tables locally and load the `.sql` file
4. Remove downloaded `.sql` file
5. Profit


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Rake task, live on the edge.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
