### PR TITLE
enable skipping to specific conjunctions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -54,7 +54,8 @@ const ALL_STEPS = [READ_PASSAGE_STEP_NUMBER, 2, 3, 4]
 const MINIMUM_STUDENT_HIGHLIGHT_COUNT = 2
 
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user }: StudentViewContainerProps) => {
-  const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts')
+  const skipToSpecificStep = window.location.href.includes('skipToStep')
+  const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || skipToSpecificStep
   const defaultCompletedSteps = shouldSkipToPrompts ? [READ_PASSAGE_STEP_NUMBER] : []
   const sessionFromUrl = getUrlParam('session', location, isTurk)
   const activityUID = getUrlParam('uid', location, isTurk)
@@ -78,7 +79,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   const [studentHighlights, setStudentHighlights] = React.useState([])
   const [scrolledToEndOfPassage, setScrolledToEndOfPassage] = React.useState(shouldSkipToPrompts)
   const [hasStartedReadPassageStep, setHasStartedReadPassageStep] = React.useState(shouldSkipToPrompts)
-  const [hasStartedPromptSteps, setHasStartedPromptsSteps] = React.useState(shouldSkipToPrompts)
+  const [hasStartedPromptSteps, setHasStartedPromptsSteps] = React.useState(skipToSpecificStep)
   const [doneHighlighting, setDoneHighlighting] = React.useState(shouldSkipToPrompts)
   const [showReadTheDirectionsButton, setShowReadTheDirectionsButton] = React.useState(false)
   const [timeTracking, setTimeTracking] = React.useState({

--- a/services/QuillLMS/client/app/bundles/Evidence/reducers/sessionReducer.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/reducers/sessionReducer.ts
@@ -24,7 +24,7 @@ type SessionAction = Action & {
   activityIsComplete: boolean
 }
 
-const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts')
+const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || window.location.href.includes('skipToStep')
 const activityCompletionCount = parseInt(getParameterByName('activities', window.location.href)) || 0;
 const ACTIVITY_COMPLETION_MAXIMUM_FOR_ONBOARDING = 3;
 
@@ -34,7 +34,7 @@ export default (
     // page load
     sessionID: uuid4(),
     submittedResponses: {},
-    activeStep: shouldSkipToPrompts ? READ_PASSAGE_STEP_NUMBER + 1 : READ_PASSAGE_STEP_NUMBER,
+    activeStep: shouldSkipToPrompts ? parseInt(getParameterByName('skipToStep', window.location.href)) || READ_PASSAGE_STEP_NUMBER + 1 : READ_PASSAGE_STEP_NUMBER,
     explanationSlidesCompleted: shouldSkipToPrompts || (activityCompletionCount > ACTIVITY_COMPLETION_MAXIMUM_FOR_ONBOARDING),
     activityIsComplete: false
   },

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/upperFormSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/upperFormSection.tsx
@@ -37,8 +37,11 @@ export const UpperFormSection = ({
       />
       <div className="button-and-id-container">
         {parentActivityId && renderIDorUID(parentActivityId, PARENT_ACTIVITY_ID)}
-        {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Test Activity</a>}
         {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}`} rel="noopener noreferrer" target="_blank">Play Student Activity</a>}
+        {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}&skipToPrompts=true`} rel="noopener noreferrer" target="_blank">Play Test Activity</a>}
+        {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}&skipToStep=2`} rel="noopener noreferrer" target="_blank">Play Because</a>}
+        {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}&skipToStep=3`} rel="noopener noreferrer" target="_blank">Play But</a>}
+        {activity.id && <a className="quill-button fun secondary outlined focus-on-light" href={`/evidence/#/play?uid=${activity.id}&skipToStep=4`} rel="noopener noreferrer" target="_blank">Play So</a>}
         <button className="quill-button fun primary contained focus-on-light" id="activity-submit-button" onClick={handleSubmitActivity} type="submit">Save</button>
       </div>
       <DropdownInput


### PR DESCRIPTION
## WHAT
Add support for curriculum team members to skip to a given conjunction, while also having the generic `skipToPrompts` link take you to the menu before the "because" prompt rather than directly to because.

## WHY
This offers more flexibility to curriculum team members, and also lets teachers who are following the `skipToPrompts` link see the menu with all the prompts before they have to play through because.

## HOW
Just introduce an additional query param and use it to create links.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-a-play-test-button-for-each-prompt-so-we-can-jump-straight-to-a-specific-conjunction-for-testing-5b645a9748fc4611a6e0d590decc0519

https://www.notion.so/quill/Preview-Links-go-to-the-writing-prompt-skip-highlighting-Ideally-go-to-the-menu-before-the-first--e34cc2510e6243e580e3410d73969277

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES