### PR TITLE
Lms/write concept results for lessons

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -397,12 +397,13 @@ class ActivitySession < ApplicationRecord
       concept_result[:activity_session_id] = activity_session_id
       concept_result.delete(:activity_session_uid)
 
-      OldConceptResult.create(
+      old_concept_result = OldConceptResult.create(
         concept_id: concept_result[:concept_id],
         question_type: concept_result[:question_type],
         activity_session_id: concept_result[:activity_session_id],
         metadata: concept_result[:metadata],
       )
+      SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id]) if old_concept_result
     end
   end
 

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -216,7 +216,8 @@ module Demo::ReportDemoAPCreator
             metadata: cr.metadata,
             question_type: cr.question_type
           }
-          OldConceptResult.create(values)
+          old_concept_result = OldConceptResult.create(values)
+          SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id]) if old_concept_result
         end
       end
     end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -385,7 +385,8 @@ module Demo::ReportDemoCreator
         metadata: cr.metadata,
         question_type: cr.question_type
       }
-      OldConceptResult.create(values)
+      old_concept_result = OldConceptResult.create(values)
+      SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id]) if old_concept_result
     end
   end
 
@@ -409,7 +410,8 @@ module Demo::ReportDemoCreator
               metadata: cr.metadata,
               question_type: cr.question_type
             }
-            OldConceptResult.create(values)
+            old_concept_result = OldConceptResult.create(values)
+            SaveActivitySessionConceptResultsWorker.perform_async([old_concept_result.id]) if old_concept_result
           end
         end
       end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -834,7 +834,12 @@ end
         concept_id: concept.id,
         metadata: metadata,
         question_type: 'lessons-slide'
-      })
+      }).and_call_original
+      ActivitySession.save_concept_results([activity_session], concept_results)
+    end
+
+    it 'should enqueue the creation of new concept results based on the OldConceptResult created' do
+      expect(SaveActivitySessionConceptResultsWorker).to receive(:perform_async)
       ActivitySession.save_concept_results([activity_session], concept_results)
     end
   end


### PR DESCRIPTION
## WHAT
Make sure to write new `ConceptResult` records at the same time as `OldConceptResult` records when creating records through secondary pathways
## WHY
It was my impression that we only created `ConceptResult` records for `ActivitySession`s through one codepath in the `ActivitySessionController`.  However, it turns out that (of course) Lessons uses its own unique path instead, and then it makes sense that Demo-data creation bypasses the normal pathways.
## HOW
- Enqueue the creation of new `ConceptResult` records when a Lessons session is completed and `ActivitySession.save_concept_results` is called.  (Ironically, of course, that function is not called for 95%+ of our ActivitySessions.)
- Make sure to create `ConceptResult` records whenever we create `OldConceptResult` records in the demo.  This is to make sure we maintain complete parity between the two tables.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
