### PR TITLE
Adding back to school webinar banners.

### DIFF
--- a/services/QuillLMS/app/models/one_off_banner.rb
+++ b/services/QuillLMS/app/models/one_off_banner.rb
@@ -5,12 +5,44 @@ class OneOffBanner < WebinarBanner
   # ONE-OFFS have the key format Month-Day-Hour
   # RECURRING have the key format DayOfWeek-Hour
 
+  LINK_TEXT = "Click here to register and join."
+
+  WEBINAR_BASIC = {
+    title: "The webinar <strong>Back to School with Quill: Learn the Basics</strong> is live now!",
+    link_display_text: LINK_TEXT,
+    link: "#{ZOOM_URL}/WN_2LfW2CGRSfyfJzv79kF_2Q#/registration"
+  }
+
+  WEBINAR_BEYOND = {
+    title: "The webinar <strong>Back to School with Quill: Beyond the Basics</strong> is live now!",
+    link_display_text: LINK_TEXT,
+    link: "#{ZOOM_URL}/WN_h2usGleLTRqPBLv9D5KNvw#/registration"
+  }
+
+  WEBINAR_EVIDENCE = {
+    title: "The webinar <strong>Introducing Quill’s Newest Tool: Reading for Evidence (grades 8 & up)</strong> is live now!",
+    link_display_text: LINK_TEXT,
+    link: "#{ZOOM_URL}/WN_SBH_CLO5TIucJSlH7j2lkQ#/registration",
+    custom_length: 30
+  }
+
   WEBINARS = {
-    '5-12-11' => {
-      title: "<strong>Webinar: Wrapping Up the School Year with Quill</strong> is live now!",
-      link_display_text: "Click here to register and join.",
-      link: "#{ZOOM_URL}/WN_m7Yc_C87RUu5sLW8yTz4eA#/registration"
-    }
+    '8-10-11' => WEBINAR_BASIC,
+    '8-17-18' => WEBINAR_BASIC,
+    '8-24-11' => WEBINAR_BASIC,
+    '8-31-18' => WEBINAR_BASIC,
+    '9-07-16' => WEBINAR_BASIC,
+    '9-14-11' => WEBINAR_BASIC,
+    '8-11-11' => WEBINAR_BEYOND,
+    '8-18-18' => WEBINAR_BEYOND,
+    '8-25-11' => WEBINAR_BEYOND,
+    '9-01-18' => WEBINAR_BEYOND,
+    '9-08-16' => WEBINAR_BEYOND,
+    '9-15-11' => WEBINAR_BEYOND,
+    '8-09-16' => WEBINAR_EVIDENCE,
+    '8-23-11' => WEBINAR_EVIDENCE,
+    '9-06-16' => WEBINAR_EVIDENCE,
+    '9-20-11' => WEBINAR_EVIDENCE,
   }
 
   private def values

--- a/services/QuillLMS/app/models/webinar_banner.rb
+++ b/services/QuillLMS/app/models/webinar_banner.rb
@@ -27,6 +27,10 @@ class WebinarBanner
     values&.dig(:title)
   end
 
+  def custom_length
+    values&.dig(:custom_length)
+  end
+
   def subscription_only?
     values&.dig(:subscription_only)
   end
@@ -36,8 +40,13 @@ class WebinarBanner
   end
 
   def show?(account_type = nil)
-    (link.present? && title.present? && link_display_text.present? && !skipped_day? &&
-     show_with_subscription?(account_type) && show_with_month_restrictions)
+    link.present? &&
+      title.present? &&
+      link_display_text.present? &&
+      !skipped_day? &&
+      show_with_subscription?(account_type) &&
+      show_with_month_restrictions &&
+      still_live?
   end
 
   def show_with_subscription?(account_type)
@@ -46,6 +55,12 @@ class WebinarBanner
 
   def show_with_month_restrictions
     !second_or_fourth_only || second_or_fourth_week_of_month?(time)
+  end
+
+  private def still_live?
+    return true unless custom_length
+
+    time.min <= custom_length
   end
 
   private def skipped_day?

--- a/services/QuillLMS/spec/models/one_off_banner_spec.rb
+++ b/services/QuillLMS/spec/models/one_off_banner_spec.rb
@@ -18,7 +18,7 @@ describe OneOffBanner, type: :model do
   end
 
   it "does return true for show? when the key does have an associated webinar" do
-    time =  DateTime.new(2022,5,12,11,1,0)
+    time =  DateTime.new(2022,8,10,11,1,0)
     banner = OneOffBanner.new(time)
     expect(banner.show?).to eq(true)
   end
@@ -30,10 +30,38 @@ describe OneOffBanner, type: :model do
   end
 
   it "does return correct link and title when the key does have an associated recurring webinar" do
-    time =  DateTime.new(2022,5,12,11,1,0)
+    time =  DateTime.new(2022,8,10,11,1,0)
     banner = OneOffBanner.new(time)
-    expect(banner.title).to eq("<strong>Webinar: Wrapping Up the School Year with Quill</strong> is live now!")
-    expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_m7Yc_C87RUu5sLW8yTz4eA#/registration")
+    expect(banner.title).to eq("The webinar <strong>Back to School with Quill: Learn the Basics</strong> is live now!")
+    expect(banner.link).to eq("https://quill-org.zoom.us/webinar/register/WN_2LfW2CGRSfyfJzv79kF_2Q#/registration")
+    expect(banner.link_display_text).to eq("Click here to register and join.")
   end
 
+  describe "custom_length" do
+    let(:hour_minute1) {DateTime.new(2022,8,15,10,1,0)}
+    let(:hour_minute30) {DateTime.new(2022,8,15,10,30,0)}
+    let(:banner_minute1) {OneOffBanner.new(hour_minute1)}
+    let(:banner_minute30) {OneOffBanner.new(hour_minute30)}
+
+    let(:banner_config) do
+      {
+        title: "title!",
+        link_display_text: 'link_text',
+        link: "url",
+        custom_length: 29
+      }
+    end
+
+    before do
+      stub_const("OneOffBanner::WEBINARS", {'8-15-10' => banner_config})
+    end
+
+    it "should show before the custom length ends" do
+      expect(banner_minute1.show?).to be true
+    end
+
+    it "should hide after the custom length ends" do
+      expect(banner_minute30.show?).to be false
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Adding banners for the Partnership webinar banners.
## WHY
So more teachers attend these sessions.
## HOW
Following this PR https://github.com/empirical-org/Empirical-Core/pull/9136 as guidance. Adding the ability to have a webinar less than 1 hour.

### Notion Card Links
https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  Yes
