### PR TITLE
Fix race condition with UserLoginWorker and confirm_valid_session

### DIFF
--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -3,13 +3,9 @@
 class UserLoginWorker
   include Sidekiq::Worker
 
-  def perform(id, ip_address)
-
+  def perform(id)
     @user = User.find_by(id: id)
     return unless @user
-
-    @user.update(ip_address: ip_address, last_sign_in: Time.current)
-    @user.save
 
     analytics = Analyzer.new
     case @user.role

--- a/services/QuillLMS/spec/workers/user_login_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/user_login_worker_spec.rb
@@ -9,22 +9,19 @@ describe UserLoginWorker, type: :worker do
   let(:teacher) { classroom.owner }
   let(:student) { create(:student, classrooms: [classroom]) }
 
-  before do
-    allow(Analyzer).to receive(:new) { analyzer }
-  end
+  before { allow(Analyzer).to receive(:new) { analyzer } }
 
   context 'when a teacher logs in' do
     it 'track teacher sign in' do
       expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHER_SIGNIN)
-      worker.perform(teacher.id, "127.0.0.1")
+      worker.perform(teacher.id)
     end
   end
 
   context 'when student with teacher logs in' do
-
     it 'track teacher student sign in' do
       expect(analyzer).to receive(:track_with_attributes).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN, properties: {student_id: student.id})
-      worker.perform(student.id, "127.0.0.1")
+      worker.perform(student.id)
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a race condition involving UserLoginWorker and the before_action hooks `confirm_valid_session` and  `:check_staff_for_extended_session`

## WHY
We'd like to cleanup a confusing situation where users click 'Login in with Google' button and then snackbar says "Your session has expired. Please re-authenticate".  See [screencast](https://user-images.githubusercontent.com/2057805/183452085-5a540139-93d9-4f57-a71c-1ee172d5291b.mov
). Before the recent [PR](https://github.com/empirical-org/Empirical-Core/pull/9472) of the snackbar message, the UI would not return anything at all.

## HOW
We need to update the user `last_sign_in` immediately rather than through the UserLogin worker.  Otherwise, if the worker has not completed in updating the user's last_sign_in attribute, the user will be redirected back to sessions#new


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A