### PR TITLE
Segment/ remove activity pack assignment event

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -48,7 +48,6 @@ class SegmentAnalytics
     })
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def track_activity_pack_assignment(teacher_id, unit_id)
     unit = Unit.find_by_id(unit_id)
 
@@ -71,7 +70,6 @@ class SegmentAnalytics
       }
     })
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def track_activity_completion(user, student_id, activity)
     track({

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -62,15 +62,6 @@ class SegmentAnalytics
       activity_pack_type = 'Custom'
     end
 
-    # we don't want to have a unique event for teacher-named packs because that would be a potentially infinite number of unique events
-    activity_pack_name_string = unit&.unit_template&.name ? " | #{unit&.unit_template&.name}" : ''
-
-    # first event is for Vitally, which does not show properties
-    track({
-      user_id: teacher_id,
-      event: "#{SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT} | #{activity_pack_type}#{activity_pack_name_string}"
-    })
-    # second event is for Heap, which does
     track({
       user_id: teacher_id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT,

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -10,80 +10,80 @@ describe 'SegmentAnalytics' do
   let(:track_calls) { analytics.backend.track_calls }
   let(:identify_calls) { analytics.backend.identify_calls }
 
-  # context 'tracking classroom creation' do
-  #   let(:classroom) { create(:classroom) }
-  #   let(:classroom_with_no_teacher) { create(:classroom, :with_no_teacher) }
+  context 'tracking classroom creation' do
+    let(:classroom) { create(:classroom) }
+    let(:classroom_with_no_teacher) { create(:classroom, :with_no_teacher) }
 
-  #   it 'sends two events' do
-  #     analytics.track_classroom_creation(classroom)
-  #     expect(identify_calls.size).to eq(0)
-  #     expect(track_calls.size).to eq(2)
-  #     expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
-  #     expect(track_calls[0][:user_id]).to eq(classroom.owner.id)
-  #     expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
-  #     expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
-  #     expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
-  #     expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
-  #   end
+    it 'sends two events' do
+      analytics.track_classroom_creation(classroom)
+      expect(identify_calls.size).to eq(0)
+      expect(track_calls.size).to eq(2)
+      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
+      expect(track_calls[0][:user_id]).to eq(classroom.owner.id)
+      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
+      expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
+      expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
+      expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
+    end
 
-  #   it 'should not send event if there is no owner' do
-  #     analytics.track_classroom_creation(classroom_with_no_teacher)
-  #     expect(identify_calls.size).to eq(0)
-  #     expect(track_calls.size).to eq(0)
-  #   end
-  # end
+    it 'should not send event if there is no owner' do
+      analytics.track_classroom_creation(classroom_with_no_teacher)
+      expect(identify_calls.size).to eq(0)
+      expect(track_calls.size).to eq(0)
+    end
+  end
 
-  # context 'tracking activity assignment' do
-  #   let(:teacher) { create(:teacher) }
+  context 'tracking activity assignment' do
+    let(:teacher) { create(:teacher) }
 
-  #   context 'when the activity is a diagnostic activity' do
-  #     let(:activity) { create(:diagnostic_activity) }
+    context 'when the activity is a diagnostic activity' do
+      let(:activity) { create(:diagnostic_activity) }
 
-  #     it 'sends two events with information about the activity' do
-  #       analytics.track_activity_assignment(teacher.id, activity.id)
-  #       expect(identify_calls.size).to eq(0)
-  #       expect(track_calls.size).to eq(2)
-  #       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
-  #       expect(track_calls[0][:user_id]).to eq(teacher.id)
-  #       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-  #       expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
-  #       expect(track_calls[1][:event]).to eq("#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
-  #       expect(track_calls[1][:user_id]).to eq(teacher.id)
-  #     end
-  #   end
+      it 'sends two events with information about the activity' do
+        analytics.track_activity_assignment(teacher.id, activity.id)
+        expect(identify_calls.size).to eq(0)
+        expect(track_calls.size).to eq(2)
+        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+        expect(track_calls[0][:user_id]).to eq(teacher.id)
+        expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+        expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
+        expect(track_calls[1][:event]).to eq("#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
+        expect(track_calls[1][:user_id]).to eq(teacher.id)
+      end
+    end
 
-  #   context 'when the activity is not a diagnostic activity' do
-  #     let(:activity) { create(:connect_activity) }
+    context 'when the activity is not a diagnostic activity' do
+      let(:activity) { create(:connect_activity) }
 
-  #     it 'sends one events with information about the activity' do
-  #       analytics.track_activity_assignment(teacher.id, activity.id)
-  #       expect(identify_calls.size).to eq(0)
-  #       expect(track_calls.size).to eq(1)
-  #       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
-  #       expect(track_calls[0][:user_id]).to eq(teacher.id)
-  #       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-  #       expect(track_calls[0][:properties][:tool_name]).to eq('Connect')
-  #     end
-  #   end
+      it 'sends one events with information about the activity' do
+        analytics.track_activity_assignment(teacher.id, activity.id)
+        expect(identify_calls.size).to eq(0)
+        expect(track_calls.size).to eq(1)
+        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+        expect(track_calls[0][:user_id]).to eq(teacher.id)
+        expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+        expect(track_calls[0][:properties][:tool_name]).to eq('Connect')
+      end
+    end
 
-  # end
+  end
 
-  # context 'tracking activity completion' do
-  #   let(:teacher) { create(:teacher) }
-  #   let(:activity) { create(:diagnostic_activity) }
-  #   let(:student) { create(:student) }
+  context 'tracking activity completion' do
+    let(:teacher) { create(:teacher) }
+    let(:activity) { create(:diagnostic_activity) }
+    let(:student) { create(:student) }
 
-  #   it 'sends an event with information about the activity' do
-  #     analytics.track_activity_completion(teacher, student.id, activity)
-  #     expect(identify_calls.size).to eq(0)
-  #     expect(track_calls.size).to eq(1)
-  #     expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
-  #     expect(track_calls[0][:user_id]).to eq(teacher.id)
-  #     expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-  #     expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
-  #     expect(track_calls[0][:properties][:student_id]).to eq(student.id)
-  #   end
-  # end
+    it 'sends an event with information about the activity' do
+      analytics.track_activity_completion(teacher, student.id, activity)
+      expect(identify_calls.size).to eq(0)
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
+      expect(track_calls[0][:user_id]).to eq(teacher.id)
+      expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+      expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
+      expect(track_calls[0][:properties][:student_id]).to eq(student.id)
+    end
+  end
 
   context 'tracking activity pack assignment' do
     let(:teacher) { create(:teacher) }

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -10,127 +10,121 @@ describe 'SegmentAnalytics' do
   let(:track_calls) { analytics.backend.track_calls }
   let(:identify_calls) { analytics.backend.identify_calls }
 
-  context 'tracking classroom creation' do
-    let(:classroom) { create(:classroom) }
-    let(:classroom_with_no_teacher) { create(:classroom, :with_no_teacher) }
+  # context 'tracking classroom creation' do
+  #   let(:classroom) { create(:classroom) }
+  #   let(:classroom_with_no_teacher) { create(:classroom, :with_no_teacher) }
 
-    it 'sends two events' do
-      analytics.track_classroom_creation(classroom)
-      expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
-      expect(track_calls[0][:user_id]).to eq(classroom.owner.id)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
-      expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
-      expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
-      expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
-    end
+  #   it 'sends two events' do
+  #     analytics.track_classroom_creation(classroom)
+  #     expect(identify_calls.size).to eq(0)
+  #     expect(track_calls.size).to eq(2)
+  #     expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
+  #     expect(track_calls[0][:user_id]).to eq(classroom.owner.id)
+  #     expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
+  #     expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
+  #     expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
+  #     expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
+  #   end
 
-    it 'should not send event if there is no owner' do
-      analytics.track_classroom_creation(classroom_with_no_teacher)
-      expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(0)
-    end
-  end
+  #   it 'should not send event if there is no owner' do
+  #     analytics.track_classroom_creation(classroom_with_no_teacher)
+  #     expect(identify_calls.size).to eq(0)
+  #     expect(track_calls.size).to eq(0)
+  #   end
+  # end
 
-  context 'tracking activity assignment' do
-    let(:teacher) { create(:teacher) }
+  # context 'tracking activity assignment' do
+  #   let(:teacher) { create(:teacher) }
 
-    context 'when the activity is a diagnostic activity' do
-      let(:activity) { create(:diagnostic_activity) }
+  #   context 'when the activity is a diagnostic activity' do
+  #     let(:activity) { create(:diagnostic_activity) }
 
-      it 'sends two events with information about the activity' do
-        analytics.track_activity_assignment(teacher.id, activity.id)
-        expect(identify_calls.size).to eq(0)
-        expect(track_calls.size).to eq(2)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
-        expect(track_calls[0][:user_id]).to eq(teacher.id)
-        expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-        expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
-        expect(track_calls[1][:event]).to eq("#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
-        expect(track_calls[1][:user_id]).to eq(teacher.id)
-      end
-    end
+  #     it 'sends two events with information about the activity' do
+  #       analytics.track_activity_assignment(teacher.id, activity.id)
+  #       expect(identify_calls.size).to eq(0)
+  #       expect(track_calls.size).to eq(2)
+  #       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+  #       expect(track_calls[0][:user_id]).to eq(teacher.id)
+  #       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+  #       expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
+  #       expect(track_calls[1][:event]).to eq("#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
+  #       expect(track_calls[1][:user_id]).to eq(teacher.id)
+  #     end
+  #   end
 
-    context 'when the activity is not a diagnostic activity' do
-      let(:activity) { create(:connect_activity) }
+  #   context 'when the activity is not a diagnostic activity' do
+  #     let(:activity) { create(:connect_activity) }
 
-      it 'sends one events with information about the activity' do
-        analytics.track_activity_assignment(teacher.id, activity.id)
-        expect(identify_calls.size).to eq(0)
-        expect(track_calls.size).to eq(1)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
-        expect(track_calls[0][:user_id]).to eq(teacher.id)
-        expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-        expect(track_calls[0][:properties][:tool_name]).to eq('Connect')
-      end
-    end
+  #     it 'sends one events with information about the activity' do
+  #       analytics.track_activity_assignment(teacher.id, activity.id)
+  #       expect(identify_calls.size).to eq(0)
+  #       expect(track_calls.size).to eq(1)
+  #       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+  #       expect(track_calls[0][:user_id]).to eq(teacher.id)
+  #       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+  #       expect(track_calls[0][:properties][:tool_name]).to eq('Connect')
+  #     end
+  #   end
 
-  end
+  # end
 
-  context 'tracking activity completion' do
-    let(:teacher) { create(:teacher) }
-    let(:activity) { create(:diagnostic_activity) }
-    let(:student) { create(:student) }
+  # context 'tracking activity completion' do
+  #   let(:teacher) { create(:teacher) }
+  #   let(:activity) { create(:diagnostic_activity) }
+  #   let(:student) { create(:student) }
 
-    it 'sends an event with information about the activity' do
-      analytics.track_activity_completion(teacher, student.id, activity)
-      expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
-      expect(track_calls[0][:user_id]).to eq(teacher.id)
-      expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
-      expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
-      expect(track_calls[0][:properties][:student_id]).to eq(student.id)
-    end
-  end
+  #   it 'sends an event with information about the activity' do
+  #     analytics.track_activity_completion(teacher, student.id, activity)
+  #     expect(identify_calls.size).to eq(0)
+  #     expect(track_calls.size).to eq(1)
+  #     expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
+  #     expect(track_calls[0][:user_id]).to eq(teacher.id)
+  #     expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
+  #     expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
+  #     expect(track_calls[0][:properties][:student_id]).to eq(student.id)
+  #   end
+  # end
 
   context 'tracking activity pack assignment' do
     let(:teacher) { create(:teacher) }
 
-    it 'sends two events with information about the activity pack when it is a diagnostic activity pack' do
+    it 'sends one event with information about the activity pack when it is a diagnostic activity pack' do
       diagnostic_activity = create(:diagnostic_activity)
       diagnostic_unit_template = create(:unit_template)
       diagnostic_unit = create(:unit, unit_template_id: diagnostic_unit_template.id )
       unit_activity = create(:unit_activity, unit: diagnostic_unit, activity: diagnostic_activity)
       analytics.track_activity_pack_assignment(teacher.id, diagnostic_unit.id)
       expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT} | Diagnostic | #{diagnostic_unit_template.name}")
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
-      expect(track_calls[1][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:properties][:activity_pack_type]).to eq("Diagnostic")
-      expect(track_calls[1][:properties][:activity_pack_name]).to eq(diagnostic_unit_template.name)
+      expect(track_calls[0][:properties][:activity_pack_type]).to eq("Diagnostic")
+      expect(track_calls[0][:properties][:activity_pack_name]).to eq(diagnostic_unit_template.name)
     end
 
-    it 'sends two events with information about the activity pack when it is a custom activity pack' do
+    it 'sends one event with information about the activity pack when it is a custom activity pack' do
       unit = create(:unit)
       analytics.track_activity_pack_assignment(teacher.id, unit.id)
       expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT} | Custom")
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
-      expect(track_calls[1][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:properties][:activity_pack_type]).to eq("Custom")
-      expect(track_calls[1][:properties][:activity_pack_name]).to eq(unit.name)
+      expect(track_calls[0][:properties][:activity_pack_type]).to eq("Custom")
+      expect(track_calls[0][:properties][:activity_pack_name]).to eq(unit.name)
     end
 
-    it 'sends two events with information about the activity pack when it is a pre made activity pack' do
+    it 'sends one event with information about the activity pack when it is a pre made activity pack' do
       unit_template = create(:unit_template)
       unit = create(:unit, unit_template_id: unit_template.id)
       activity = create(:connect_activity)
       unit_activity = create(:unit_activity, activity: activity, unit: unit)
       analytics.track_activity_pack_assignment(teacher.id, unit.id)
       expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT} | Pre-made | #{unit_template.name}")
+      expect(track_calls.size).to eq(1)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
-      expect(track_calls[1][:user_id]).to eq(teacher.id)
-      expect(track_calls[1][:properties][:activity_pack_type]).to eq("Pre-made")
-      expect(track_calls[1][:properties][:activity_pack_name]).to eq(unit_template.name)
+      expect(track_calls[0][:properties][:activity_pack_type]).to eq("Pre-made")
+      expect(track_calls[0][:properties][:activity_pack_name]).to eq(unit_template.name)
     end
 
   end


### PR DESCRIPTION
## WHAT
remove activity pack assignment event

## WHY
we have two of these events and only one is actually needed

## HOW
just remove the first `track` call in `track_activity_assignment` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Remove-granular-Segment-event-for-activity-pack-assignment-4ed99395acb34962893fcdc953fc143f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
