### PR TITLE
LMS Multi-database configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
           RAILS_ENV: test
           RACK_ENV: test
       - image: postgres:13.7-alpine
-        name: test_primary
         environment:
           POSTGRES_DB: quill_test_db
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           RAILS_ENV: test
           RACK_ENV: test
       - image: postgres:13.7-alpine
+        name: test_primary
         environment:
           POSTGRES_DB: quill_test_db
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,17 @@ jobs:
           PG_USER: ubuntu
           RAILS_ENV: test
           RACK_ENV: test
-      - image: postgres:10.5-alpine
+      - image: postgres:13.7-alpine
         environment:
-          POSTGRES_USER: ubuntu
           POSTGRES_DB: quill_test_db
-          POSTGRES_PASSWORD: ""
+          POSTGRES_USER: ubuntu
+          POSTGRES_PASSWORD: password
+      - image: postgres:13.7-alpine
+        name: test_replica
+        environment:
+          POSTGRES_DB: quill_test_db
+          POSTGRES_USER: ubuntu
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       - restore_cache:
@@ -73,7 +79,7 @@ jobs:
           RACK_ENV: test
           SELENIUM_DRIVER_URL: http://127.0.0.1:4444/wd/hub
           DEFAULT_URL: http://127.0.0.1:3000
-      - image: postgres:10.5-alpine
+      - image: postgres:13.7-alpine
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: quill_test_db
@@ -176,11 +182,11 @@ jobs:
           PG_USER: ubuntu
           RAILS_ENV: test
           RACK_ENV: test
-      - image: postgres:10.5-alpine
+      - image: postgres:13.7-alpine
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: quill_cms_test_db
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: password
       - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.2
         environment:
           - xpack.security.enabled: false

--- a/services/QuillCMS/config/database.yml
+++ b/services/QuillCMS/config/database.yml
@@ -29,7 +29,7 @@ test:
     database: quill_cms_test
     replica: true
 
-elastic_beanstalk_primary_env: &elastic_beanstalk_primary_env
+aws_rds_primary_env: &aws_rds_primary_env
   <<: *default
   database: <%= ENV['RDS_DB_NAME'] %>
   user: <%= ENV['RDS_DB_USERNAME'] %>
@@ -37,7 +37,7 @@ elastic_beanstalk_primary_env: &elastic_beanstalk_primary_env
   host: <%= ENV['RDS_HOSTNAME'] %>
   port: <%= ENV['RDS_PORT'] %>
 
-elastic_beanstalk_replica_env: &elastic_beanstalk_replica_env
+aws_rds_replica_env: &aws_rds_replica_env
   <<: *default
   database: <%= ENV['RDS_REPLICA_NAME'] %>
   user: <%= ENV['RDS_REPLICA_USERNAME'] %>
@@ -48,9 +48,9 @@ elastic_beanstalk_replica_env: &elastic_beanstalk_replica_env
 
 production_env: &production_env
   primary:
-    <<: *elastic_beanstalk_primary_env
+    <<: *aws_rds_primary_env
   replica:
-    <<: *elastic_beanstalk_replica_env
+    <<: *aws_rds_replica_env
 
 staging:
   <<: *production_env

--- a/services/QuillCMS/config/database.yml
+++ b/services/QuillCMS/config/database.yml
@@ -30,6 +30,7 @@ test:
     replica: true
 
 elastic_beanstalk_primary_env: &elastic_beanstalk_primary_env
+  <<: *default
   database: <%= ENV['RDS_DB_NAME'] %>
   user: <%= ENV['RDS_DB_USERNAME'] %>
   password: <%= ENV['RDS_DB_PASSWORD'] %>
@@ -37,20 +38,19 @@ elastic_beanstalk_primary_env: &elastic_beanstalk_primary_env
   port: <%= ENV['RDS_PORT'] %>
 
 elastic_beanstalk_replica_env: &elastic_beanstalk_replica_env
+  <<: *default
   database: <%= ENV['RDS_REPLICA_NAME'] %>
   user: <%= ENV['RDS_REPLICA_USERNAME'] %>
   password: <%= ENV['RDS_REPLICA_PASSWORD'] %>
   host: <%= ENV['RDS_REPLICA_HOSTNAME'] %>
   port: <%= ENV['RDS_REPLICA_PORT'] %>
+  replica: true
 
 production_env: &production_env
   primary:
-    <<: *default
     <<: *elastic_beanstalk_primary_env
   replica:
-    <<: *default
     <<: *elastic_beanstalk_replica_env
-    replica: true
 
 staging:
   <<: *production_env

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -2,7 +2,11 @@
 
 class ActivitySessionsController < ApplicationController
   include HTTParty
+
   layout :determine_layout
+
+  around_action :force_writer_db_role, only: [:activity_session_from_classroom_unit_and_activity]
+
   before_action :activity_session_from_id, only: [:play, :concept_results]
   before_action :activity_session_from_uid, only: [:result]
   before_action :activity_session_for_update, only: [:update]
@@ -11,6 +15,7 @@ class ActivitySessionsController < ApplicationController
   before_action :activity_session_authorize_teacher!, only: [:concept_results]
   before_action :authorize_student_belongs_to_classroom_unit!, only: [:activity_session_from_classroom_unit_and_activity]
   before_action :redirect_if_student_has_not_completed_pre_test, only: [:play]
+
   after_action  :update_student_last_active, only: [:play, :result]
 
   def play

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  include ForceDbWriterRole
   include NewRelicAttributable
   include QuillAuthentication
 

--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -2,6 +2,8 @@
 
 module Auth
   class CleverController < ApplicationController
+    around_action :force_writer_db_role, only: :clever
+
     def clever
       update_current_user_email
       result = CleverIntegration::SignUp::Main.run(auth_hash)

--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -2,7 +2,7 @@
 
 module Auth
   class CleverController < ApplicationController
-    around_action :force_writer_db_role, only: :clever
+    around_action :force_writer_db_role, only: [:clever]
 
     def clever
       update_current_user_email

--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Auth::GoogleController < ApplicationController
+  around_action :force_writer_db_role, only: [:offline_access_callback, :online_access_callback]
+
   before_action :set_profile, only: [:offline_access_callback, :online_access_callback]
   before_action :check_for_authorization, only: :online_access_callback
   before_action :set_user,
@@ -8,7 +10,6 @@ class Auth::GoogleController < ApplicationController
     :save_student_from_google_signup,
     :follow_google_redirect,
     only: [:offline_access_callback, :online_access_callback]
-
 
   # Control flow arrives at :offline_access_callback after the user authorized Quill access to their Google account via
   # a prompt. :run_background_jobs can now run since a refresh_token will exist jin the user's auth_credential.

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BlogPostsController < ApplicationController
-  around_action :force_writer_db_role, only: :show
+  around_action :force_writer_db_role, only: [:show]
 
   before_action :redirect_legacy_topic_urls, only: [:show_topic]
   before_action :redirect_invalid_topics, only: [:show_topic]

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class BlogPostsController < ApplicationController
+  around_action :force_writer_db_role, only: :show
+
   before_action :redirect_legacy_topic_urls, only: [:show_topic]
   before_action :redirect_invalid_topics, only: [:show_topic]
   before_action :redirect_unauthorized_topics, only: [:show_topic]
-
   before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_root_url
+
 
   def index
     topic_names = BlogPost::TEACHER_TOPICS
@@ -20,6 +22,7 @@ class BlogPostsController < ApplicationController
   def student_center_index
     @title = 'Resources'
     topic_names = BlogPost::STUDENT_TOPICS
+
     @topics = []
     topic_names.each do |name|
       @topics.push({ name: name, slug: CGI::escape(name.downcase.gsub(' ','-'))})

--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Cms::BlogPostsController < Cms::CmsController
+  around_action :force_writer_db_role, only: [:destroy, :unpublish]
+
   before_action :set_blog_post, only: [:update, :destroy, :edit, :show, :unpublish]
   before_action :authors, :topics, only: [:index, :edit, :new]
 

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Cms::UsersController < Cms::CmsController
+  around_action :force_writer_db_role, only: [:index, :edit, :show, :sign_in]
+
   before_action :signed_in!
   before_action :set_flags
   before_action :set_user, only: [:show, :edit, :show_json, :update, :destroy, :new_subscription, :edit_subscription, :complete_sales_stage]

--- a/services/QuillLMS/app/controllers/concerns/force_db_writer_role.rb
+++ b/services/QuillLMS/app/controllers/concerns/force_db_writer_role.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ForceDbWriterRole
+  extend ActiveSupport::Concern
+
+  def force_writer_db_role(&block)
+    ActiveRecord::Base.connected_to(role: :writing, &block)
+  end
+end

--- a/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class CoteacherClassroomInvitationsController < ApplicationController
+  around_action :force_writer_db_role,
+    only: [:accept_pending_coteacher_invitations, :reject_pending_coteacher_invitations]
+
   before_action :signed_in!
 
   def accept_pending_coteacher_invitations

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SchoolsController < ApplicationController
-  around_action :force_writer_db_role, only: :select_school
+  around_action :force_writer_db_role, only: [:select_school]
 
   before_action :require_user, only: [:select_school]
 

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SchoolsController < ApplicationController
+  around_action :force_writer_db_role, only: :select_school
+
   before_action :require_user, only: [:select_school]
 
   include CheckboxCallback

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -3,7 +3,7 @@
 class StatusesController < ApplicationController
   protect_from_forgery with: :null_session
 
-  around_action :force_writer_db_role, only: :database_write
+  around_action :force_writer_db_role, only: [:database_write]
 
   def index
     render plain: 'OK'

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -3,6 +3,8 @@
 class StatusesController < ApplicationController
   protect_from_forgery with: :null_session
 
+  around_action :force_writer_db_role, only: :database_write
+
   def index
     render plain: 'OK'
   end

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -3,6 +3,8 @@
 class StudentsController < ApplicationController
   include QuillAuthentication
 
+  around_action :force_writer_db_role, only: [:demo_ap, :join_classroom, :student_demo]
+
   before_action :authorize!, except: [:student_demo, :demo_ap, :join_classroom]
   before_action :redirect_to_profile, only: [:index]
 

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -4,15 +4,18 @@ class Teachers::ClassroomManagerController < ApplicationController
   include CheckboxCallback
   include CleverAuthable
   include DiagnosticReports
+  include QuillAuthentication
+  include ScorebookHelper
 
   respond_to :json, :html
+
+  around_action :force_writer_db_role, only: :dashboard
+
   before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
   # WARNING: these filter methods check against classroom_id, not id.
   before_action :authorize_owner!, except: [:scores, :scorebook, :lesson_planner, :preview_as_student, :unset_preview_as_student, :view_demo, :unset_view_demo, :activity_feed]
   before_action :authorize_teacher!, only: [:scores, :scorebook, :lesson_planner]
   before_action :set_alternative_schools, only: [:my_account, :update_my_account, :update_my_password]
-  include ScorebookHelper
-  include QuillAuthentication
 
   MY_ACCOUNT = 'my_account'
   ASSIGN = 'assign'

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -9,7 +9,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   respond_to :json, :html
 
-  around_action :force_writer_db_role, only: :dashboard
+  around_action :force_writer_db_role, only: [:dashboard]
 
   before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
   # WARNING: these filter methods check against classroom_id, not id.

--- a/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
+require 'pusher'
+
 class Teachers::ClassroomUnitsController < ApplicationController
   include QuillAuthentication
-  require 'pusher'
+
   respond_to :json
+
+  around_action :force_writer_db_role, only: :launch_lesson
+
   before_action :authorize!, except: [
     :lessons_activities_cache,
-    :lessons_units_and_activities,
-    :update_multiple_due_dates
+    :lessons_units_and_activities
   ]
   before_action :teacher!
   before_action :lesson, only: :launch_lesson
@@ -104,7 +108,6 @@ class Teachers::ClassroomUnitsController < ApplicationController
     @classroom_unit = ClassroomUnit.find_by(id: params[:id])
     if !current_user || @classroom_unit.classroom.teacher_ids.exclude?(current_user.id) then auth_failed end
   end
-
 
   private def lessons_units_and_activities_data
     # collapses lessons cache into unique array of activity ids

--- a/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
@@ -7,7 +7,7 @@ class Teachers::ClassroomUnitsController < ApplicationController
 
   respond_to :json
 
-  around_action :force_writer_db_role, only: :launch_lesson
+  around_action :force_writer_db_role, only: [:launch_lesson]
 
   before_action :authorize!, except: [
     :lessons_activities_cache,

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -5,7 +5,7 @@ class Teachers::ClassroomsController < ApplicationController
 
   respond_to :json, :html, :pdf
 
-  around_action :force_writer_db_role, only: :hide
+  around_action :force_writer_db_role, only: [:hide]
 
   before_action :teacher!
 

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -4,7 +4,11 @@ class Teachers::ClassroomsController < ApplicationController
   include CleverAuthable
 
   respond_to :json, :html, :pdf
+
+  around_action :force_writer_db_role, only: :hide
+
   before_action :teacher!
+
   # The excepted/only methods below are ones that should be accessible to coteachers.
   # TODO This authing could probably be refactored.
   before_action :authorize_owner!, only: [:update,  :transfer_ownership]

--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Teachers::ProgressReportsController < ApplicationController
+  layout 'progress_reports'
+
+  around_action :force_writer_db_role, only: [:admin_demo, :coach_demo, :staff_demo, :demo]
+
   before_action :authorize!, except: [:demo, :admin_demo, :coach_demo, :staff_demo]
   before_action :set_vary_header, if: -> { request.xhr? || request.format == :json }
-  layout 'progress_reports'
 
   def demo
     set_user

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TeachersController < ApplicationController
+  around_action :force_writer_db_role, only: :add_school
+
   before_action :require_user, only: [:classrooms_i_teach_with_students, :classrooms_i_own_with_students]
 
   def create

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeachersController < ApplicationController
-  around_action :force_writer_db_role, only: :add_school
+  around_action :force_writer_db_role, only: [:add_school]
 
   before_action :require_user, only: [:classrooms_i_teach_with_students, :classrooms_i_own_with_students]
 

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -2,4 +2,6 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: { writing: :primary, reading: :replica }
 end

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -3,5 +3,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  connects_to database: { writing: :primary, reading: :replica }
+  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
+    connects_to database: { writing: :primary, reading: :replica }
+  else
+    connects_to database: { writing: :primary, reading: :primary }
+  end
 end

--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -47,10 +47,10 @@ test:
     replica: true
 
 staging:
-  <<: &heroku_env
+  <<: *heroku_env
 
 sprint:
-  <<: &heroku_env
+  <<: *heroku_env
 
 production:
-  <<: &heroku_env
+  <<: *heroku_env

--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -1,46 +1,56 @@
 default: &default
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("MAX_THREADS") { 5 } %>
   prepared_statements: false
-  adapter: postgresql
   timeout: 5000
 
-development_shared: &development_shared
-  encoding: unicode
-  host:     localhost
+local_shared: &local_shared
+  <<: *default
+  host: localhost
   port: 5432
 
-test_env: &test_env
-  <<: *development_shared
-  database: emp_gr_test
-
-# While we don't actually connect to any follower DBs, they
-# do exist within our infrastructure, so naming conventions
-# here are intended to simplify later decision to use followers
-# as well as disambiguate similarly-named ENV variables.
-leader_db_env: &leader_db_env
+primary_db_env: &primary_db_env
+  <<: *default
   url: <%= ENV['DATABASE_CONNECTION_POOL_URL'] || ENV['DATABASE_URL'] %>
 
-
-development: &development
+replica_db_env: &replica_db_env
   <<: *default
-  <<: *development_shared
-  <<: *leader_db_env
-  database: emp_gr_development
+  url: <%= ENV['REPLICA_DATABASE_URL'] || ENV['DATABASE_URL'] %>
+  replica: true
+
+heroku_env: &heroku_env
+  primary:
+    <<: *primary_db_env
+  replica:
+    <<: *replica_db_env
+
+development:
+  primary:
+    <<: *local_shared
+    database: emp_gr_development
+  replica:
+    <<: *local_shared
+    database: emp_gr_development
+    replica: true
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  <<: *test_env
+  primary:
+    <<: *local_shared
+    database: emp_gr_test
+  replica:
+    <<: *local_shared
+    database: emp_gr_test
+    replica: true
 
-staging: &staging
-  <<: *default
-  <<: *leader_db_env
+staging:
+  <<: &heroku_env
 
 sprint:
-  <<: *staging
+  <<: &heroku_env
 
 production:
-  <<: *default
-  <<: *leader_db_env
+  <<: &heroku_env

--- a/services/QuillLMS/config/database.yml.circle
+++ b/services/QuillLMS/config/database.yml.circle
@@ -1,14 +1,17 @@
 default: &default
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-test_env: &test_env
+  adapter: postgresql
   encoding: unicode
-  host:     localhost
-  database: <%= ENV.fetch("PG_DB") %>
+  host: localhost
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  prepared_statements: false
+  timeout: 5000
   user: <%= ENV.fetch("PG_USER") %>
 
 test:
-  <<: *default
-  adapter: postgresql
-  <<: *test_env
+  primary:
+    <<: *default
+    database: <%= ENV.fetch("PG_DB") %>
+  replica:
+    <<: *default
+    database: <%= ENV.fetch("PG_DB") %>
+    replica: true

--- a/services/QuillLMS/config/environments/development.rb
+++ b/services/QuillLMS/config/environments/development.rb
@@ -47,9 +47,6 @@ EmpiricalGrammar::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-
-
-
   config.sass.line_comments = true
   config.sass.line_numbers = true
   config.sass.debug_info = true
@@ -75,4 +72,8 @@ EmpiricalGrammar::Application.configure do
   end
 
   config.reload_plugins = true if Rails.env.development?
+
+  config.active_record.database_selector = { delay: 0.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/services/QuillLMS/config/environments/production.rb
+++ b/services/QuillLMS/config/environments/production.rb
@@ -125,4 +125,10 @@ EmpiricalGrammar::Application.configure do
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
+
+  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
+    config.active_record.database_selector = { delay: 2.seconds }
+    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  end
 end

--- a/services/QuillLMS/config/environments/staging.rb
+++ b/services/QuillLMS/config/environments/staging.rb
@@ -35,8 +35,6 @@ EmpiricalGrammar::Application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
-
-
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 
@@ -117,4 +115,8 @@ EmpiricalGrammar::Application.configure do
   config.middleware.use Rack::HostRedirect, {
     'staging.quill.org.' => 'staging.quill.org'
   }
+
+  config.active_record.database_selector = { delay: 0.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/services/QuillLMS/config/environments/staging.rb
+++ b/services/QuillLMS/config/environments/staging.rb
@@ -116,7 +116,9 @@ EmpiricalGrammar::Application.configure do
     'staging.quill.org.' => 'staging.quill.org'
   }
 
-  config.active_record.database_selector = { delay: 0.seconds }
-  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
+    config.active_record.database_selector = { delay: 2.seconds }
+    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  end
 end

--- a/services/QuillLMS/config/environments/test.rb
+++ b/services/QuillLMS/config/environments/test.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'test/multi_db/custom_resolver'
+require_relative 'test/multi_db/custom_session'
+
 EmpiricalGrammar::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -35,8 +38,13 @@ EmpiricalGrammar::Application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { :host => "test.yourhost.com" }
 
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   config.cache_store = :memory_store, {size: 64.megabytes}
+
+  config.active_record.database_selector = { delay: 0.seconds }
+  config.active_record.database_resolver = Test::MultiDb::CustomResolver
+  config.active_record.database_resolver_context = Test::MultiDb::CustomSession
 end

--- a/services/QuillLMS/config/environments/test/multi_db/custom_resolver.rb
+++ b/services/QuillLMS/config/environments/test/multi_db/custom_resolver.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Test
+  module MultiDb
+    class CustomResolver < ActiveRecord::Middleware::DatabaseSelector::Resolver
+      delegate :log_db_selection, to: :context
+
+      def read_from_primary(&blk)
+        super do
+          log_db_selection(__method__)
+          yield
+        end
+      end
+
+      def read_from_replica(&blk)
+        super do
+          log_db_selection(__method__)
+          yield
+        end
+      end
+
+      def write_to_primary(&blk)
+        super do
+          log_db_selection(__method__)
+          yield
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/config/environments/test/multi_db/custom_session.rb
+++ b/services/QuillLMS/config/environments/test/multi_db/custom_session.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Test
+  module MultiDb
+    class CustomSession < ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+      def db_selection_methods
+        session[:db_selection_methods] ||= []
+      end
+
+      def log_db_selection(method)
+        db_selection_methods << method
+      end
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/requests/multi_db_request_spec.rb
+++ b/services/QuillLMS/spec/requests/multi_db_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WidgetsController, type: :request do
 
   after { Rails.application.reload_routes! }
 
-  subject { http_request}
+  subject { http_request }
 
   context 'GET' do
     let(:http_request) { get url }

--- a/services/QuillLMS/spec/requests/multi_db_request_spec.rb
+++ b/services/QuillLMS/spec/requests/multi_db_request_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class WidgetsController < ApplicationController
+  def index
+    head :ok
+  end
+
+  def show
+    head :ok
+  end
+
+  def new
+    head :ok
+  end
+
+  def create
+    head :ok
+  end
+
+  def edit
+    head :ok
+  end
+
+  def update
+    head :ok
+  end
+
+  def destroy
+    head :ok
+  end
+end
+
+RSpec.describe WidgetsController, type: :request do
+  let(:widget) { double(:widget, id: 1) }
+
+  before { Rails.application.routes.draw { resources :widgets } }
+
+  after { Rails.application.reload_routes! }
+
+  subject { http_request}
+
+  context 'GET' do
+    let(:http_request) { get url }
+
+    describe 'widget#index' do
+      let(:url) { '/widgets' }
+
+      it { should_only_read_from_replica }
+    end
+
+    describe 'widgets#new' do
+      let(:url) { '/widgets/new' }
+
+      it { should_only_read_from_replica }
+    end
+
+    describe 'widgets#edit' do
+      let(:url) { "/widgets/#{widget.id}/edit" }
+
+      it { should_only_read_from_replica }
+    end
+
+    describe 'widgets#show' do
+      let(:url) { "/widgets/#{widget.id}" }
+
+      it { should_only_read_from_replica }
+    end
+  end
+
+  context 'POST' do
+    let(:http_request) { post url, params: {} }
+
+    describe 'widgets#create' do
+      let(:params) { {} }
+      let(:url) { '/widgets' }
+
+      it { should_only_write_to_primary }
+    end
+  end
+
+  context 'PUT' do
+    let(:http_request) { put url, params: {} }
+
+    describe 'widgets#update' do
+      let(:url) { "/widgets/#{widget.id}" }
+
+      it { should_only_write_to_primary }
+    end
+  end
+
+  context 'PATCH' do
+    let(:http_request) { patch url, params: {} }
+
+    describe 'widgets#update' do
+      let(:url) { "/widgets/#{widget.id}" }
+
+      it { should_only_write_to_primary }
+    end
+  end
+
+  context 'DELETE' do
+    let(:http_request) { delete url }
+
+    describe 'widgets#destroy' do
+      let(:url) { "/widgets/#{widget.id}" }
+
+      it { should_only_write_to_primary }
+    end
+  end
+
+  def should_only_read_from_replica
+    subject
+    expect(request.session[:db_selection_methods]).to eq [:read_from_replica]
+  end
+
+  def should_only_write_to_primary
+    subject
+    expect(request.session[:db_selection_methods]).to eq [:write_to_primary]
+  end
+end


### PR DESCRIPTION
## WHAT
Add multiple database configuration for the LMS.

Also, identify GET requests that make writes and wrap those in an around_action that forces using the primary db as described [here](https://medium.com/grailed-engineering/distributing-database-reads-across-replicas-with-rails-6-and-activerecord-23a24aa90c84). 

## WHY
Utilizing a replica database for reads will improve site performance without increasing cost.

## HOW
Much of the configuration is adapted from an earlier [PR](https://github.com/empirical-org/Empirical-Core/pull/7292) for the CMS.

1) Update the environment configurations with something of the form:
```
config.active_record.database_selector = { delay: 0.seconds }
config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
```
2) Configure database.yml
3) Add  `connects_to database: { writing: :primary, reading: :replica }` to ApplicationRecord
4) Manual smoke test on staging that the correct database is accessed based on the type of req
uest.  GET requests (except those that do writes) should go to the replica and all others should go to primary.  
Since heroku logs only broad samples of database usage, for smoke testing I had to temporarily add logging statements to application_controller and force_db_writer_role ![Screen Shot 2022-08-10 at 11 19 20 AM](https://user-images.githubusercontent.com/2057805/183942401-ba7517b8-e801-4abd-a860-43f6101aedd7.png) which was then confirmed on staging:
![Screen Shot 2022-08-10 at 11 03 22 AM](https://user-images.githubusercontent.com/2057805/183942904-58685316-b2bb-4bb7-9636-0b07b24986b6.png)


5) A nuance to the previous smoke test concerns GET requests that write to the database.   For now, we'll wrap them in around_action hook.   In a later PR we can individually refactor them and make them idempotent.  A listing of these offenders plus possible dead routes is [here](https://docs.google.com/spreadsheets/d/1J4xHwyBlEgHrpNP5hUa1MsZ3AEgWMsi_OrK0CgcF1oU/edit#gid=0)

| controller#action | write method |
| ----------------- | ------------- |
| activity_sessions#activity_session_from_classroom_unit_and_activity | def self.find_or_create_started_activity_session(student_id, classroom_unit_id, activity_id) |
| auth/clever#clever | update_current_user_email; and signup main |
| auth/google#online_access_callback | various before_action |
| auth/google#online_access_callback | various before_action |
| blog_posts#show | @blog_post.increment_read_count |
| cms/blog_posts#destroy | destroy |
| cms/blog_posts#unpublish | update |
| cms/users#edit | log_user_action |
| cms/users#index | log_non_user_action |
| cms/users#show | log_user_action |
| cms/users#sign_in | log_user_action |
| coteacher_classroom_invitations#accept_pending_coteacher_invitations | ClassroomsTeacher.create |
| coteacher_classroom_invitations#reject_pending_coteacher_invitations | coteacher_invitation.destroy |
| schools#select_school | school = School.find_or_create_by |
| statuses#database_write | Blog.first.touch |
| students#demo_ap | Demo::ReportDemoAPCreator.create_demo(nil) |
| students#join_classroom | Associators::StudentsToClassrooms.run(current_user, classroom) |
| students#student_demo | Demo::ReportDemoDestroyer.destroy_demo(nil); Demo::ReportDemoCreator.create_demo(nil) |
| teachers/classroom_manager#dashboard | UserMilestone.find_or_create_by(user_id: current_user.id, milestone_id: | welcome_milestone.id) |
| teachers/classroom_units#launch_lesson | cuas = ClassroomUnitActivityState.find_or_create_by( |
| teachers/classrooms#hide | classroom.save |
| teachers/progress_reports#admin_demo | set_admin_user |
| teachers/progress_reports#coach_demo | set_ap_user |
| teachers/progress_reports#demo | set_user |
| teachers/progress_reports#staff_demo | set_staff_user |
| teachers#add_school | if school_user.save |

Misc links:
  https://blog.saeloun.com/2022/06/22/rails-allows-overriding-reading-request.html
  https://stackoverflow.com/questions/50956650/multiple-posgres-databases-in-circleci-2-0
  https://stackoverflow.com/questions/62056781/adding-additional-databases-in-postgresql-using-circleci
  https://www.citusdata.com/blog/2019/05/23/rails-6-multiple-databases/
  https://medium.com/williamdesk/implement-read-replica-database-on-rails-6-101-7091d535154a

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES 
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
