### PR TITLE
Fix bug with admin sign_in

### DIFF
--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class AdminsController < ApplicationController
+  around_action :force_writer_db_role,
+    only: [
+      :sign_in_classroom_manager,
+      :sign_in_progress_reports,
+      :sign_in_account_settings
+    ]
+
   before_action :admin!
   before_action :set_teacher,
     :admin_of_this_teacher!,

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -8,6 +8,8 @@ class SessionsController < ApplicationController
 
   CLEAR_ANALYTICS_SESSION_KEY = "clear_analytics_session"
 
+  around_action :force_writer_db_role, only: [:destroy]
+
   before_action :signed_in!, only: [:destroy]
 
   # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
## WHAT
Fix a `ActiveRecord::ReadOnlyError` on AdminsController#sign_in_classroom_manager [bug](https://sentry.io/organizations/quillorg-5s/issues/3493480787/?project=11238&query=is%3Aunresolved) 

There's a `super` call to sign_in that has a `user.update` call.

Also add one in for sessions#destroy since it uses sign_in as well.

## WHY
Fix a bug with a readonly route making a write to the database.

## HOW
Add around_action hook to force using primary db instead of replica.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
