### PR TITLE
Fix Stripe::Subscription last4 bug

### DIFF
--- a/services/QuillLMS/app/models/stripe_integration/subscription.rb
+++ b/services/QuillLMS/app/models/stripe_integration/subscription.rb
@@ -62,8 +62,14 @@ module StripeIntegration
       stripe_subscription.default_payment_method || stripe_customer.invoice_settings.default_payment_method
     end
 
+    private def stripe_default_source
+      stripe_customer&.default_source
+    end
+
     private def stripe_source
-      Stripe::Customer.retrieve_source(stripe_customer_id, stripe_customer&.default_source)
+      return nil if stripe_default_source.nil?
+
+      Stripe::Customer.retrieve_source(stripe_customer_id, stripe_default_source)
     rescue Stripe::InvalidRequestError
       nil
     end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3486837242/?project=11238&referrer=slack) involving a call to last_four on stripe subscriptions.

## WHY
Our system attempts to find the `last_four` associated with a stripe subscription via some different mechanisms on Stripe.  If no `default_source` is associated with the customer and we attempt to retrieve source, instead of raising an error, Stripe surprisingly returns an Stripe:ListObject that is empty.  `last4` is then called on this empty list object.

## HOW
Add a check in to make sure the default_source has a value before attempting retrieval of source.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
