### PR TITLE
Fix readonly bugs with classroom manager

### DIFF
--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class StudentsController < ApplicationController
-  include QuillAuthentication
-
   around_action :force_writer_db_role, only: [:demo_ap, :join_classroom, :student_demo]
 
   before_action :authorize!, except: [:student_demo, :demo_ap, :join_classroom]

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -4,12 +4,11 @@ class Teachers::ClassroomManagerController < ApplicationController
   include CheckboxCallback
   include CleverAuthable
   include DiagnosticReports
-  include QuillAuthentication
   include ScorebookHelper
 
   respond_to :json, :html
 
-  around_action :force_writer_db_role, only: [:dashboard]
+  around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner]
 
   before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
   # WARNING: these filter methods check against classroom_id, not id.

--- a/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
@@ -3,8 +3,6 @@
 require 'pusher'
 
 class Teachers::ClassroomUnitsController < ApplicationController
-  include QuillAuthentication
-
   respond_to :json
 
   around_action :force_writer_db_role, only: [:launch_lesson]

--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require 'pusher'
+
 class Teachers::UnitActivitiesController < ApplicationController
-  include QuillAuthentication
-  require 'pusher'
   respond_to :json
+
   before_action :authorize!, :except => ["update_multiple_due_dates"]
   before_action :teacher!
   before_action :set_unit_activities, only: [:update, :hide]


### PR DESCRIPTION
## WHAT
Force a couple of endpoints to use the primary database.

Also remove a few `include QuillAuthentication` calls since they are redundant via the parent ApplicationController already having included it.

## WHY
There's a find_or_create_checkbox which has potential for write.  There's also a referrer user bug referenced on  [assign](https://one.newrelic.com/nr1-core/errors/overview/MjYzOTExM3xBUE18QVBQTElDQVRJT058NTQ4ODU2ODc1?account=2639113&duration=1800000&state=9e546748-354d-5072-c44f-23567a2e0fa8) and [lesson_planner](https://one.newrelic.com/nr1-core/errors/overview/MjYzOTExM3xBUE18QVBQTElDQVRJT058NTQ4ODU2ODc1?account=2639113&duration=1800000&state=ba7854ed-b173-fb9f-7be1-156f243348a1) but it's not clear to my where this is happening.

We'd like writes to go through and refactor these later.

## HOW
Add around_action to the necessary actions. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
