### PR TITLE
Segment/ update keys for student rated an activity event

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
@@ -95,9 +95,18 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
 
   function mapMultipleChoiceOptionsForEventParams() {
     const options = {}
-    positiveMultipleChoiceOptions.forEach(option => options[option] = false)
-    negativeMultipleChoiceOptions.forEach(option => options[option] = false)
-    selectedMultipleChoiceOptions.forEach(option => options[option] = true);
+    positiveMultipleChoiceOptions.forEach(option => {
+      const key = option.split(' ').join('_')
+      options[key] = false
+    })
+    negativeMultipleChoiceOptions.forEach(option => {
+      const key = option.split(' ').join('_')
+      options[key] = false
+    })
+    selectedMultipleChoiceOptions.forEach(option => {
+      const key = option.split(' ').join('_')
+      options[key] = true
+    });
     return options
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
@@ -50,12 +50,11 @@ const EventDefinitions = [
     'activityID',
     'attemptNumber',
     'promptID',
+    'hint',
     'promptStemText',
     'returnedFeedback',
-    'returnedFeedbackID',
     'sessionID',
     'startingFeedback',
-    'startingFeedbackID',
     'submittedEntry',
     'user_id',
     'properties'


### PR DESCRIPTION
## WHAT
update keys for student rated an activity event in Evidence

## WHY
it turns out that these keys cannot be string values in order to be mapped to Ortto

## HOW
just update the function that handles mapping the multiple choice options to keys. This also updates the event definition for `EVIDENCE_FEEDBACK_RECEIVED` so that it is correctly ingested by Segment

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-a-new-Student-rated-activity-Segment-track-event-e17ae40ec35d4324a477e12b5003f66a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | tested on [Segment](https://app.segment.com/empirical/sources/core-staging/debugger), (note: Ortto isn't integrated to be able to receive events through the Segment staging env so at the moment, we're only able to know these issues once they hit prod)
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
