### PR TITLE
Fix a bug with shared activity links

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/share_activity_pack/shareActivityPackModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/share_activity_pack/shareActivityPackModal.tsx
@@ -90,7 +90,8 @@ export const ShareActivityPackModal = ({ activityPackData, closeModal, selectabl
     const { classroom } = classroomObject;
     if(singleActivity) {
       const { id } = classroomUnitObject;
-      return `${process.env.DEFAULT_URL}/classroom_units/${id}/activities/${singleActivity.id}`;
+      const activityId = singleActivity.activityId || singleActivity.id
+      return `${process.env.DEFAULT_URL}/classroom_units/${id}/activities/${activityId}`;
     }
     if(!singleActivity) {
       const { id } = classroom;
@@ -128,7 +129,8 @@ export const ShareActivityPackModal = ({ activityPackData, closeModal, selectabl
     setSelectedClass(classOption);
     if(singleActivity) {
       const classroomUnit = classroomUnits.filter(unit => unit.classroom_id === parseInt(value))[0];
-      setLink(`${process.env.DEFAULT_URL}/classroom_units/${classroomUnit.id}/activities/${singleActivity.id}`);
+      const activityId = singleActivity.activityId || singleActivity.id
+      setLink(`${process.env.DEFAULT_URL}/classroom_units/${classroomUnit.id}/activities/${activityId}`);
     } else {
       setLink(`${process.env.DEFAULT_URL}/classrooms/${value}?unit_id=${unitId}`);
     }
@@ -155,7 +157,7 @@ export const ShareActivityPackModal = ({ activityPackData, closeModal, selectabl
     const showContainerStyle = !showActivityLink ? 'hide-modal-element' : '';
     return(
       <div className={`activity-pack-data-container ${showContainerStyle}`}>
-        <p className="link-label">Activity pack link</p>
+        <p className="link-label">{singleActivity ? 'Activity link' : 'Activity pack link'}</p>
         <p className="activity-pack-link">{link}</p>
       </div>
     )


### PR DESCRIPTION
## WHAT
Fix a bug involving shared activity links

## WHY
The shared links that students are given from teachers do not work.

## HOW
Depending on the activity, the data shape for some of the associated  ClassroomUnitObject varies.  To fix this,
check for `const activity = singleActivity.activityId || singleActivity.id`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Shared-activity-links-are-not-working-a44279cb380a43faa83bb2d4a25099b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | No, small change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
