### PR TITLE
Evidence internal tool/ universal rules index UI updates

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/universalRules.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/universalRules.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UniversalRulesIndex component should render UniversalRulesIndex 1`] = `
+<ContextProvider
+  value={true}
+>
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
+      }
+    }
+  >
+    <UniversalRulesIndex
+      history={Object {}}
+      location={
+        Object {
+          "pathname": "universal-rules",
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {},
+          "path": "",
+          "url": "",
+        }
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
+`;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/universalRules.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/universalRules.test.tsx
@@ -6,10 +6,6 @@ import { DefaultReactQueryClient } from '../../../../Shared/index';
 import UniversalRulesIndex from '../universalRules/universalRules';
 
 const queryClient = new DefaultReactQueryClient();
-const mockUpdateRuleOrders = jest.fn().mockImplementation(() => Promise.resolve({}))
-jest.mock('../../../utils/evidence/ruleAPIs', () => ({
-  updateRuleOrders: mockUpdateRuleOrders
-}));
 
 describe('UniversalRulesIndex component', () => {
   const mockProps = {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/universalRules.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/universalRules.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { QueryClientProvider } from 'react-query'
+
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+import UniversalRulesIndex from '../universalRules/universalRules';
+
+const queryClient = new DefaultReactQueryClient();
+const mockUpdateRuleOrders = jest.fn().mockImplementation(() => Promise.resolve({}))
+jest.mock('../../../utils/evidence/ruleAPIs', () => ({
+  updateRuleOrders: mockUpdateRuleOrders
+}));
+
+describe('UniversalRulesIndex component', () => {
+  const mockProps = {
+    match: {
+      params: {},
+      isExact: true,
+      path: '',
+      url:''
+    },
+    history: {},
+    location: {
+      pathname: 'universal-rules'
+    }
+  }
+
+  const component = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <UniversalRulesIndex {...mockProps} />
+    </QueryClientProvider>
+  );
+
+  it('should render UniversalRulesIndex', () => {
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRule.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRule.tsx
@@ -186,7 +186,7 @@ const UniversalRule = ({ history, location, match }) => {
           headers={dataTableFields}
           rows={ruleRows(ruleData)}
         />
-        <div className="button-container">
+        <div className="buttons-container">
           <button className="quill-button fun primary contained" id="edit-rule-button" onClick={toggleShowEditRuleModal} type="button">
             Configure
           </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
@@ -33,6 +33,10 @@ const UniversalRulesIndex = ({ location, match }) => {
 
   React.useEffect(() => {
     handleUpdateRulesList();
+  }, [rules]);
+
+  React.useEffect(() => {
+    handleUpdateRulesList();
     setRuleOrderUpdated(false);
   }, [ruleType]);
 
@@ -102,9 +106,7 @@ const UniversalRulesIndex = ({ location, match }) => {
       } else {
         setErrors([]);
         toggleAddRuleModal();
-        queryClient.refetchQueries(`universal-rules`).then(() => {
-          handleUpdateRulesList(rule);
-        });
+        queryClient.refetchQueries(`universal-rules`);
       }
     });
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
@@ -59,10 +59,12 @@ const UniversalRulesIndex = ({ location, match }) => {
   function handleSetRuleType(ruleType: any) { setRuleType(ruleType) };
 
   function sortCallback(sortInfo) {
+    console.log("🚀 ~ file: universalRules.tsx ~ line 62 ~ sortCallback ~ sortInfo", sortInfo)
     const newRulesList = sortInfo.map(item => {
       const { key } = item;
       return rulesHash[key];
     });
+    console.log("🚀 ~ file: universalRules.tsx ~ line 67 ~ sortCallback ~ newRulesList", newRulesList)
     setRulesList(newRulesList);
     setRuleOrderUpdated(true);
   }
@@ -73,7 +75,6 @@ const UniversalRulesIndex = ({ location, match }) => {
       const universalRuleLink = (<Link to={`/universal-rules/${id}`}>View</Link>);
       return {
         id: uid,
-        api_order: ruleOrder[rule_type],
         type: rule_type,
         name,
         order: suborder,
@@ -140,7 +141,6 @@ const UniversalRulesIndex = ({ location, match }) => {
   }
 
   const dataTableFields = [
-    { name: "API Order", attribute:"api_order", width: "100px" },
     { name: "Type", attribute:"type", width: "100px" },
     { name: "Name", attribute:"name", width: "400px" },
     { name: "Rule Order Note", attribute:"order", width: "100px" },
@@ -154,18 +154,20 @@ const UniversalRulesIndex = ({ location, match }) => {
       <Navigation location={location} match={match} />
       <div className="universal-rules-index-container">
         {showAddRuleModal && renderRuleForm()}
-        <h2>Universal Rules Index</h2>
-        <section className="top-section">
-          <DropdownInput
-            className="rule-type-input"
-            handleChange={handleSetRuleType}
-            isSearchable={true}
-            label="Select Rule Type"
-            options={universalRuleTypeOptions}
-            value={ruleType}
-          />
-          <button className={`quill-button small primary contained ${disabledStatus}`} disabled={!!disabledStatus} type="button">Update Rule Order</button>
-          <button className="quill-button small primary contained" onClick={toggleAddRuleModal} type="button">{`Create New ${ruleType.label} Rule (Danger Zone!)`}</button>
+        <section className="header-section">
+          <h2>Universal Rules Index</h2>
+          <section className="top-section">
+            <DropdownInput
+              className="rule-type-input"
+              handleChange={handleSetRuleType}
+              isSearchable={true}
+              label="Select Rule Type"
+              options={universalRuleTypeOptions}
+              value={ruleType}
+            />
+            <button className={`quill-button small primary contained ${disabledStatus}`} disabled={!!disabledStatus} type="button">Update Rule Order</button>
+            <button className="quill-button small primary contained" onClick={toggleAddRuleModal} type="button">{`Create New ${ruleType.label} Rule (Danger Zone!)`}</button>
+          </section>
         </section>
         <p className="sortable-instructions">Change the rule order note by drag and drop</p>
         <DataTable

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/universalRules/universalRules.tsx
@@ -38,7 +38,7 @@ const UniversalRulesIndex = ({ location, match }) => {
 
   function handleUpdateRulesList(rule=null) {
     if(rules && rules.universalRules && rules.universalRules.length) {
-      let updatedRulesList = rules.universalRules.filter(rule => rule.rule_type === ruleType.value);
+      const updatedRulesList = rules.universalRules.filter(rule => rule.rule_type === ruleType.value);
       if(rule) {
         updatedRulesList.push(rule);
       }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rule.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rule.scss
@@ -59,7 +59,7 @@
   .universal-rules-table {
     height: 100%;
   }
-  .button-container {
+  .buttons-container {
     display: flex;
     justify-content: flex-start;
     width: 690px;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rules.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rules.scss
@@ -40,15 +40,18 @@
       overflow: auto;
       .data-table-row {
         min-height: auto;
-        span {
-          span {
-            a {
-              color: #00c2a2;
-            }
-            .a:hover {
-              cursor: pointer;
-              color: #29d8bc
-            }
+        td {
+          a {
+            color: #00c2a2;
+          }
+          .a:hover {
+            cursor: pointer;
+            color: #29d8bc
+          }
+        }
+        .reorder-section {
+          div:hover {
+            cursor: pointer;
           }
         }
       }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rules.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/universal_rules.scss
@@ -1,25 +1,24 @@
 .universal-rules-index-container {
   padding: 20px;
   width: 80vw;
-  .top-section {
+  .header-section {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    margin: 30px 0px 0px 3px;
-    .rule-type-input, button {
-      margin-right: 32px;
+    justify-content: space-between;
+    h2 {
+      margin-top: 0px
     }
-  }
-  .header-container {
-    a {
-      color: #00c2a2
-    }
-    a:hover {
-      color: #29d8bc;
+    .top-section {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      .rule-type-input, button {
+        margin-right: 32px;
+      }
     }
   }
   .sortable-instructions {
-    margin: 10px 0px 10px 3px;
+    margin-left: 4px;
     font-style: italic;
   }
   .universal-rules-table {
@@ -33,10 +32,14 @@
         margin: 0px
       }
     }
+    .data-table-headers {
+      min-height: auto;
+      padding-bottom: 8px;
+    }
     .data-table-body{
-      max-height: 500px;
       overflow: auto;
       .data-table-row {
+        min-height: auto;
         span {
           span {
             a {


### PR DESCRIPTION
## WHAT
various updates to the Universal Rules index for the Evidence internal tool (as well as adding logic for updating rule order)

## WHY
this was requested by curriculum

## HOW
various CSS changes and organization of `UniversalRulesIndex` component; adding a click handler to the "Update Rule Order" button which hooks into the `updateRuleOrders` API

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1436" alt="Screen Shot 2022-08-11 at 5 52 42 PM" src="https://user-images.githubusercontent.com/25959584/184248893-ba2e62f6-5610-4d44-b1d2-b7d3ca32d4c7.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/UX-Fixes-for-Universal-Rules-Page-Save-Order-Increase-Rows-6a2c227de9df4da3b24f091143890e90

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes