### PR TITLE
make highlighting less annoying for sr users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ Checking out open issues is a great way to get started as an open source contrib
 Note, we have style guides for [Ruby](https://github.com/empirical-org/ruby) and [Javascript](https://github.com/empirical-org/javascript) and a [Code of Conduct](CODE_OF_CONDUCT.md)
 
 Thanks for your interest in Quill.org!
+
+## Accessibility testing
+We use [Assistiv](https://assistivlabs.com) to test our website for compatibility with screenreaders and other assistive software.

--- a/services/QuillLMS/client/app/bundles/Evidence/components/PageLayout.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/PageLayout.tsx
@@ -9,7 +9,6 @@ import { ScreenreaderInstructions, } from '../../Shared/index'
 const PageLayout: React.StatelessComponent<{}> = (props: any) => {
   const { user } = props;
 
-
   function handleSkipToMainContentClick () {
     const element = document.getElementById("main-content")
     if (!element) { return }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
@@ -2,16 +2,24 @@ import * as React from "react";
 
 import Footer from './footer';
 
+import useFocus from '../../../Shared/hooks/useFocus'
+
 export const ExplanationSlide = ({ slideData, onHandleClick }) => {
   const { buttonText, header, imageData, isBeta, step, subtext } = slideData;
   const { imageAlt, imageUrl } = imageData;
 
+  const [containerRef, setContainerFocus] = useFocus()
+
+  React.useEffect(() => {
+    setContainerFocus()
+  }, [slideData])
+
   return(
-    <div aria-live="polite" className="explanation-slide-container">
-      <section id="information-section">
-        <p className="subtext">Good to know</p>
+    <div className="explanation-slide-container">
+      <section id="information-section" ref={containerRef} tabIndex={-1}>
+        <p aria-hidden={true} className="subtext">Good to know</p>
         <section id="header-container">
-          <p id="header">{header}</p>
+          <h1>{header}</h1>
           {isBeta && <div id="beta-tag">BETA</div>}
         </section>
         <img alt={imageAlt} id="image" src={`${process.env.CDN_URL}/${imageUrl}`} />

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
@@ -16,7 +16,7 @@ export const ExplanationSlide = ({ slideData, onHandleClick }) => {
 
   return(
     <div className="explanation-slide-container">
-      <section id="information-section" ref={containerRef} tabIndex={-1}>
+      <section className="no-focus-outline" id="information-section" ref={containerRef} tabIndex={-1}>
         <p aria-hidden={true} className="subtext">Good to know</p>
         <section id="header-container">
           <h1>{header}</h1>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/welcomeSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/welcomeSlide.tsx
@@ -5,11 +5,11 @@ import Footer from './footer';
 export const WelcomeSlide = ({ onHandleClick, user }) => {
   const welcomeText = user ? `Hi, ${user}!` : 'Hi there!'
   return(
-    <div aria-live="polite" className="explanation-slide-container" id="welcome-slide-container">
+    <div className="explanation-slide-container" id="welcome-slide-container">
       <section id="information-section">
         <p className="subtext">{welcomeText}</p>
         <section id="header-container">
-          <p id="header">Welcome to Quill Reading for Evidence</p>
+          <h1>Welcome to Quill Reading for Evidence</h1>
         </section>
         <section id="instructions-container">
           <div className="instruction-container">

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/bottomNavigation.tsx
@@ -19,7 +19,7 @@ const ReadAndHighlightTracker = ({
   if(showReadTheDirectionsButton) {
     return(
       <div className="read-and-highlight-tracker bottom-navigation read-instructions">
-        <button className="quill-button contained primary large focus-on-light" onClick={handleReadTheDirectionsButtonClick} type="button">Got it</button>
+        <button aria-label="Next" className="quill-button contained primary large focus-on-light" onClick={handleReadTheDirectionsButtonClick} type="button">Got it</button>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -436,6 +436,11 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     refs[ref].current ? refs[ref].current.scrollIntoView(false) : null
   }
 
+  function handleHighlightKeyDown(e) {
+    if (e.key !== 'Enter') { return }
+    toggleStudentHighlight(e.target.textContent)
+  }
+
   function handleHighlightClick(e) {
     toggleStudentHighlight(e.target.textContent)
   }
@@ -511,8 +516,8 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       }
       className += shouldBeHighlightable  ? ' highlightable' : ''
       if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
-      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role, jsx-a11y/click-events-have-key-events*/
-      return <mark aria-pressed={highlighted} className={className} onClick={handleHighlightClick} role="button" tabIndex={0}>{innerElements}</mark>
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role */
+      return <mark aria-pressed={highlighted} className={className} onClick={handleHighlightClick} onKeyDown={handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -436,13 +436,8 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     refs[ref].current ? refs[ref].current.scrollIntoView(false) : null
   }
 
-  function handleHighlightKeyDown(e) {
-    if (e.key !== 'Enter') { return }
-    toggleStudentHighlight(e.target.textContent)
-  }
-
   function handleHighlightClick(e) {
-    toggleStudentHighlight(e.target.textContent, () => document.activeElement.blur())
+    toggleStudentHighlight(e.target.textContent)
   }
 
   function toggleStudentHighlight(text, callback=null) {
@@ -500,20 +495,24 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
     if (node.name === 'mark') {
       const shouldBeHighlightable = !doneHighlighting && !showReadTheDirectionsButton && hasStartedReadPassageStep
-      const innerElements = node.children.map((n, i) => convertNodeToElement(n, i, transformMarkTags))
+      let innerElements = node.children.map((n, i) => convertNodeToElement(n, i, transformMarkTags))
       const stringifiedInnerElements = node.children.map(n => {
         if (n.data) { return n.data }
         if (n.children[0]) { return n.children[0].data}
         return ''
       }).join('')
       let className = ''
-      if(activeStep === 1) {
-        className += studentHighlights.includes(stringifiedInnerElements) ? ' highlighted' : ''
+      const highlighted = studentHighlights.includes(stringifiedInnerElements)
+      if(activeStep === 1 && highlighted) {
+        className += ' highlighted'
+        const firstElement = <span className="sr-only">(highlighted text begins here)</span>
+        const lastElement = <span className="sr-only">(highlighted text ends here)</span>
+        innerElements = [firstElement, ...innerElements, lastElement]
       }
       className += shouldBeHighlightable  ? ' highlightable' : ''
       if (!shouldBeHighlightable) { return <mark className={className}>{innerElements}</mark>}
-      /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-      return <mark className={className} onClick={handleHighlightClick} onKeyDown={handleHighlightKeyDown} role="button" tabIndex={0}>{innerElements}</mark>
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role, jsx-a11y/click-events-have-key-events*/
+      return <mark aria-pressed={highlighted} className={className} onClick={handleHighlightClick} role="button" tabIndex={0}>{innerElements}</mark>
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 
 import { DEFAULT_HIGHLIGHT_PROMPT, } from '../../../Shared/utils/constants'
 import { informationIcon } from '../../../Shared/index'
+import useFocus from '../../../Shared/hooks/useFocus'
 
 const READ_PASSAGE_STEP = 1
 const promptDirections = [<li>Use information <b>from the text</b> to finish the sentence.</li>, <li>Put the information in your own words.</li>]
-const highlightDirections = [<li>First, read the highlighting task below.</li>, <li>Then, read the text and highlight sentences to complete the task.</li>, <li className="sr-only">Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.</li>]
+const highlightDirections = [<li>First, read the highlighting task below.</li>, <li>Then, read the text and highlight sentences to complete the task.</li>, <li className="sr-only">Screenreader users, please use your tab keys to navigate through the passage. Highlightable sentences are toggle-able buttons. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.</li>]
 
 const renderDirections = (directionElementsArray: JSX.Element[]) => (
   <section className="directions-section">
@@ -31,10 +32,16 @@ const essentialKnowledgeSection = ({ essential_knowledge_text }) => {
 }
 
 const DirectionsSection = ({ className, passage, inReflection, activeStep, }) => {
+  const [containerRef, setContainerFocus] = useFocus()
+
+  React.useEffect(() => {
+    setContainerFocus()
+  }, [inReflection])
+
   const uniquePartOfHighlightPrompt = passage.highlight_prompt ? passage.highlight_prompt.replace(DEFAULT_HIGHLIGHT_PROMPT, '') : ''
   if (inReflection) {
     return (
-      <div className={className}>
+      <div className={className} ref={containerRef} tabIndex={-1}>
         <section className="reflection-section">
           <h3>Directions</h3>
           <p>Great! Now take a moment to reflect on the sentences you highlighted. The ideas you highlighted may be helpful as you complete the writing prompts in the next section.</p>
@@ -48,7 +55,7 @@ const DirectionsSection = ({ className, passage, inReflection, activeStep, }) =>
   }
 
   return (
-    <div className={className}>
+    <div className={className} ref={containerRef} tabIndex={-1}>
       {renderDirections(highlightDirections)}
       <section className="task-section">
         <h3>Task</h3>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/directionsSection.tsx
@@ -41,7 +41,7 @@ const DirectionsSection = ({ className, passage, inReflection, activeStep, }) =>
   const uniquePartOfHighlightPrompt = passage.highlight_prompt ? passage.highlight_prompt.replace(DEFAULT_HIGHLIGHT_PROMPT, '') : ''
   if (inReflection) {
     return (
-      <div className={className} ref={containerRef} tabIndex={-1}>
+      <div className={`no-focus-outline ${className}`} ref={containerRef} tabIndex={-1}>
         <section className="reflection-section">
           <h3>Directions</h3>
           <p>Great! Now take a moment to reflect on the sentences you highlighted. The ideas you highlighted may be helpful as you complete the writing prompts in the next section.</p>
@@ -55,7 +55,7 @@ const DirectionsSection = ({ className, passage, inReflection, activeStep, }) =>
   }
 
   return (
-    <div className={className} ref={containerRef} tabIndex={-1}>
+    <div className={`no-focus-outline ${className}`} ref={containerRef} tabIndex={-1}>
       {renderDirections(highlightDirections)}
       <section className="task-section">
         <h3>Task</h3>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/displayStudentHighlight.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/displayStudentHighlight.tsx
@@ -8,7 +8,7 @@ const DisplayStudentHighlight = ({ studentHighlight, removeHighlight, inReflecti
   return (
     <div className="display-student-highlight">
       <span>{studentHighlight}</span>
-      {inReflection ? <span /> : <button aria-label="Remove highlight" className="interactive-wrapper focus-on-light" onClick={handleClickRemove} type="button"><img alt={removeIcon.alt} src={removeIcon.src} /></button>}
+      {inReflection ? <span /> : <button aria-label={`Remove highlight from the following sentence: ${studentHighlight}`} className="interactive-wrapper focus-on-light" onClick={handleClickRemove} type="button"><img alt={removeIcon.alt} src={removeIcon.src} /></button>}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/headerImage.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/headerImage.tsx
@@ -57,7 +57,7 @@ export const HeaderImage = ({ headerImage, passage }) => {
         {headerImage}
         <section className="header-image-information">
           {passage.image_caption && <p className="header-image-caption">{stripHtml(passage.image_caption)}</p>}
-          {passage.image_attribution && <Tooltip handleClick={handleImageAttributionClick} tooltipText={tooltipText} tooltipTriggerText="Image credit" tooltipTriggerTextClass="image-attribution-tooltip" />}
+          {passage.image_attribution && <Tooltip handleClick={handleImageAttributionClick} isTabbable={false} tooltipText={tooltipText} tooltipTriggerText="Image credit" tooltipTriggerTextClass="image-attribution-tooltip" />}
         </section>
       </section>
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/readAndHighlightInstructions.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/readAndHighlightInstructions.tsx
@@ -9,13 +9,9 @@ import useFocus from '../../../Shared/hooks/useFocus'
 const ReadAndHighlightInstructions = ({ passage, activeStep, studentHighlights, removeHighlight, inReflection, }) => {
   const [containerRef, setContainerFocus] = useFocus()
 
-  React.useEffect(() => {
-    setContainerFocus()
-  }, [])
-
-  React.useEffect(() => {
-    setContainerFocus()
-  }, [inReflection])
+  function handleRemoveHighlightClick(highlightText) {
+    removeHighlight(highlightText, setContainerFocus)
+  }
 
   let studentHighlightsOrHighlightInstructions = (
     <div className="highlight-instructions">
@@ -31,7 +27,7 @@ const ReadAndHighlightInstructions = ({ passage, activeStep, studentHighlights, 
       <DisplayStudentHighlight
         inReflection={inReflection}
         key={sh}
-        removeHighlight={removeHighlight}
+        removeHighlight={handleRemoveHighlightClick}
         studentHighlight={sh}
       />)
     )

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
@@ -80,7 +80,7 @@ const StepOverview = ({ activeStep, handleClick, }) => {
   if (activeStep === READ_PASSAGE_STEP_NUMBER) {
     return (
       <div className="step-overview">
-        <h1 ref={containerRef} tabIndex={-1}>Here’s what you’ll do</h1>
+        <h1 className="no-focus-outline" ref={containerRef} tabIndex={-1}>Here’s what you’ll do</h1>
         <Step
           active={true}
           handleClick={handleClick}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { whiteCheckGreenBackgroundIcon, READ_PASSAGE_STEP_NUMBER, BECAUSE_PASSAGE_STEP_NUMBER, BUT_PASSAGE_STEP_NUMBER, SO_PASSAGE_STEP_NUMBER } from '../../../Shared/index'
+import useFocus from '../../../Shared/hooks/useFocus'
 
 const steps = {
   [READ_PASSAGE_STEP_NUMBER]: {
@@ -70,10 +71,16 @@ const Step = ({ active, completed, handleClick, step }: StepProps) => {
 }
 
 const StepOverview = ({ activeStep, handleClick, }) => {
+  const [containerRef, setContainerFocus] = useFocus()
+
+  React.useEffect(() => {
+    setContainerFocus()
+  }, [activeStep])
+
   if (activeStep === READ_PASSAGE_STEP_NUMBER) {
     return (
       <div className="step-overview">
-        <h1>Here’s what you’ll do</h1>
+        <h1 ref={containerRef} tabIndex={-1}>Here’s what you’ll do</h1>
         <Step
           active={true}
           handleClick={handleClick}
@@ -97,7 +104,7 @@ const StepOverview = ({ activeStep, handleClick, }) => {
 
   return (
     <div className="step-overview">
-      <h1>Nice! Keep going!</h1>
+      <h1 ref={containerRef} tabIndex={-1}>Nice! Keep going!</h1>
       <Step
         active={false}
         completed={activeStep > READ_PASSAGE_STEP_NUMBER}

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
@@ -19,7 +19,7 @@
     #header-container {
       display: flex;
       align-items: center;
-      #header {
+      h1 {
         font-size: 40px;
         font-weight: bold;
         color: #ffffff;

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/explanationSlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/explanationSlide.test.tsx.snap
@@ -2,13 +2,15 @@
 
 exports[`ExplanationSlide Component should match snapshot 1`] = `
 <div
-  aria-live="polite"
   className="explanation-slide-container"
 >
   <section
+    className="no-focus-outline"
     id="information-section"
+    tabIndex={-1}
   >
     <p
+      aria-hidden={true}
       className="subtext"
     >
       Good to know
@@ -16,11 +18,9 @@ exports[`ExplanationSlide Component should match snapshot 1`] = `
     <section
       id="header-container"
     >
-      <p
-        id="header"
-      >
+      <h1>
         Test Header
-      </p>
+      </h1>
     </section>
     <img
       alt="test alt text"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/welcomeSlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/welcomeSlide.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`WelcomeSlide Component should match snapshot 1`] = `
 <div
-  aria-live="polite"
   className="explanation-slide-container"
   id="welcome-slide-container"
 >
@@ -17,11 +16,9 @@ exports[`WelcomeSlide Component should match snapshot 1`] = `
     <section
       id="header-container"
     >
-      <p
-        id="header"
-      >
+      <h1>
         Welcome to Quill Reading for Evidence
-      </p>
+      </h1>
     </section>
     <section
       id="instructions-container"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/container.test.tsx.snap
@@ -74,7 +74,6 @@ But how can democracies have representative governments unless all or most of th
     onHandleClick={[Function]}
   >
     <div
-      aria-live="polite"
       className="explanation-slide-container"
       id="welcome-slide-container"
     >
@@ -89,11 +88,9 @@ But how can democracies have representative governments unless all or most of th
         <section
           id="header-container"
         >
-          <p
-            id="header"
-          >
+          <h1>
             Welcome to Quill Reading for Evidence
-          </p>
+          </h1>
         </section>
         <section
           id="instructions-container"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/directionsSectionAndModal.test.tsx.snap
@@ -12,7 +12,8 @@ exports[`DirectionsSection component when the student is in reflection renders o
   }
 >
   <div
-    className=""
+    className="no-focus-outline "
+    tabIndex={-1}
   >
     <section
       className="reflection-section"
@@ -40,7 +41,8 @@ exports[`DirectionsSection component when the student is on the read passage ste
   }
 >
   <div
-    className=""
+    className="no-focus-outline "
+    tabIndex={-1}
   >
     <section
       className="directions-section"
@@ -58,7 +60,7 @@ exports[`DirectionsSection component when the student is on the read passage ste
         <li
           className="sr-only"
         >
-          Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
+          Screenreader users, please use your tab keys to navigate through the passage. Highlightable sentences are toggle-able buttons. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
         </li>
       </ul>
     </section>
@@ -123,7 +125,8 @@ exports[`DirectionsSection component when the student should see the modal rende
   showReadTheDirectionsButton={true}
 >
   <div
-    className=""
+    className="no-focus-outline "
+    tabIndex={-1}
   >
     <section
       className="directions-section"
@@ -141,7 +144,7 @@ exports[`DirectionsSection component when the student should see the modal rende
         <li
           className="sr-only"
         >
-          Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
+          Screenreader users, please use your tab keys to navigate through the passage. Highlightable sentences are toggle-able buttons. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
         </li>
       </ul>
     </section>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/displayStudentHighlight.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/displayStudentHighlight.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`DisplayStudentHighlight component when the student is on the read passa
       This is a sentence I chose to highlight.
     </span>
     <button
-      aria-label="Remove highlight"
+      aria-label="Remove highlight from the following sentence: This is a sentence I chose to highlight."
       className="interactive-wrapper focus-on-light"
       onClick={[Function]}
       type="button"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/headerImage.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/headerImage.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Header Image component should render Header Image 1`] = `
       />
       <Tooltip
         handleClick={[Function]}
-        isTabbable={true}
+        isTabbable={false}
         tooltipTriggerText="Image credit"
         tooltipTriggerTextClass="image-attribution-tooltip"
       />

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -29,7 +29,8 @@ exports[`ReadAndHighlightInstructions component when the student has not started
       }
     >
       <div
-        className="hide-on-mobile"
+        className="no-focus-outline hide-on-mobile"
+        tabIndex={-1}
       >
         <section
           className="directions-section"
@@ -47,7 +48,7 @@ exports[`ReadAndHighlightInstructions component when the student has not started
             <li
               className="sr-only"
             >
-              Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
+              Screenreader users, please use your tab keys to navigate through the passage. Highlightable sentences are toggle-able buttons. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
             </li>
           </ul>
         </section>
@@ -160,7 +161,8 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
       }
     >
       <div
-        className="hide-on-mobile"
+        className="no-focus-outline hide-on-mobile"
+        tabIndex={-1}
       >
         <section
           className="directions-section"
@@ -178,7 +180,7 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
             <li
               className="sr-only"
             >
-              Screenreader users, please use your tab keys to navigate through the passage. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
+              Screenreader users, please use your tab keys to navigate through the passage. Highlightable sentences are toggle-able buttons. Use the Enter key on a focused sentence to add it to your highlights or to remove it once it has already been highlighted.
             </li>
           </ul>
         </section>
@@ -259,7 +261,7 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
             This is a highlight made by a student.
           </span>
           <button
-            aria-label="Remove highlight"
+            aria-label="Remove highlight from the following sentence: This is a highlight made by a student."
             className="interactive-wrapper focus-on-light"
             onClick={[Function]}
             type="button"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
@@ -8,7 +8,10 @@ exports[`StepOverview component when the student is on step one renders 1`] = `
   <div
     className="step-overview"
   >
-    <h1>
+    <h1
+      className="no-focus-outline"
+      tabIndex={-1}
+    >
       Here’s what you’ll do
     </h1>
     <Step
@@ -177,7 +180,9 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
   <div
     className="step-overview"
   >
-    <h1>
+    <h1
+      tabIndex={-1}
+    >
       Nice! Keep going!
     </h1>
     <Step


### PR DESCRIPTION
## WHAT
A bunch of accessibility changes to the first half of Evidence activities (through highlighting), including:

- Add more focus management to ensure that SR users aren't getting taken to irrelevant sections of the page
- Add the "aria-pressed" attribute to highlight buttons, making it clearer whether they've been highlighted or not
- Use `aria-labels` and `aria-hidden` to remove unnecessary content that is sometimes confusing, and elaborate on content that isn't clear from the SR alone 

## WHY
These are all issues that were surfaced while we did our last accessibility audit.

## HOW
I used Assistiv's JAWS viewer to test out this interface in an environment that replicated Colleen's, and made changes to the HTML as I went in order to address these issues.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Figure-out-how-to-make-highlighting-smoother-for-SR-users-in-Evidence-4a1ac19d7e994609954613eaabe8ea3f

https://www.notion.so/quill/Miscellaneous-Evidence-accessibility-issues-530c51be9ea6442ab69b9a8db16a8595

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
