### PR TITLE
Lms/use concept results in raw sql

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -69,7 +69,7 @@ class ActivitySession < ApplicationRecord
   has_many :concept_results
   has_many :old_concept_results
   has_many :teachers, through: :classroom
-  has_many :concepts, -> { distinct }, through: :old_concept_results
+  has_many :concepts, -> { distinct }, through: :concept_results
   has_one :active_activity_session, foreign_key: :uid, primary_key: :uid
   has_one :activity_survey_response
 

--- a/services/QuillLMS/app/models/question_health_dashboard.rb
+++ b/services/QuillLMS/app/models/question_health_dashboard.rb
@@ -18,7 +18,7 @@ class QuestionHealthDashboard
   end
 
   def percent_reached_optimal_for_question
-    failed_attempts = attempt_data.select { |a| a["score"] == '0' }.count.to_f
+    failed_attempts = attempt_data.select { |a| a["score"] == 0 }.count.to_f
     all_attempts = attempt_data.count.to_f
 
     successful_attempts = all_attempts - failed_attempts
@@ -43,18 +43,18 @@ class QuestionHealthDashboard
   private def attempt_data
     query = <<-SQL
       SELECT
-      cr.metadata::json->>'questionScore' AS score,
+      cr.question_score AS score,
       cr.activity_session_id
-      FROM old_concept_results cr
+      FROM concept_results cr
       INNER JOIN (
         SELECT *
         FROM activity_sessions
         WHERE activity_id=#{@activity_id} LIMIT #{MAX_SESSIONS_VIEWED}
       ) act_s
       ON cr.activity_session_id = act_s.id
-      WHERE cr.metadata::json->>'questionNumber' = '#{@question_number}'
+      WHERE cr.question_number = '#{@question_number}'
       GROUP BY
-        cr.metadata::json->>'questionScore',
+        cr.question_score,
         cr.activity_session_id
     SQL
     @attempt_data ||= RawSqlRunner.execute(query).to_a

--- a/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
@@ -3,10 +3,10 @@
 class ProgressReports::Concepts::ConceptResult
 
   def self.results(teacher, filters)
-    query = ::OldConceptResult.select(<<-SELECT
-      cast(old_concept_results.metadata->>'correct' as int) as is_correct,
+    query = ::ConceptResult.select(<<-SELECT
+      cast(concept_results.correct as int) as is_correct,
       activity_sessions.user_id,
-      old_concept_results.concept_id
+      concept_results.concept_id
     SELECT
   ).joins({activity_session: {classroom_unit: :classroom}})
      .joins("INNER JOIN classrooms_teachers ON classrooms.id = classrooms_teachers.classroom_id")
@@ -30,30 +30,4 @@ class ProgressReports::Concepts::ConceptResult
 
     query
   end
-  # # Used as a CTE (common table expression) by other models to get progress report data.
-  # def self.correct_results_for_progress_report(teacher, filters)
-
-  # end
-
-  # def self.grammar_counts
-  #   select("concept_tags.name, #{correct_result_count_sql} as correct_result_count, #{incorrect_result_count_sql}  as incorrect_result_count")
-  #   .joins(concept_tag: :concept_class)
-  #   .where(concept_classes: {name: "Grammar Concepts"})
-  #   .group("concept_tags.name")
-  #   .order("concept_tags.name asc")
-  #   .having("#{correct_result_count_sql} > 0 or #{incorrect_result_count_sql} > 0")
-  # end
-
-  # def self.correct_result_count_sql
-  #   "SUM(CASE WHEN cast(concept_tag_results.metadata->>'correct' as int) = 1 THEN 1 ELSE 0 END)"
-  # end
-
-  # def self.incorrect_result_count_sql
-  #   "SUM(CASE WHEN cast(concept_tag_results.metadata->>'correct' as int) = 0 THEN 1 ELSE 0 END)"
-  # end
-
-  # def self.total_result_count_sql
-  #   "DISTINCT(COUNT(concept_tag_results.id)) as total_result_count"
-  # end
-
 end

--- a/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
@@ -23,8 +23,8 @@ class ProgressReports::DistrictConceptReports
           classrooms.name AS classroom_name,
           students.name AS student_name,
           students.id AS student_id,
-          SUM(CAST(old_concept_results.metadata->>'correct' as INT)) AS correct,
-          COUNT(old_concept_results) AS old_concept_results_count
+          SUM(CAST(concept_results.correct as INT)) AS correct,
+          COUNT(concept_results) AS concept_results_count
         FROM schools_admins
         JOIN schools
           ON schools.id = schools_admins.school_id
@@ -43,8 +43,8 @@ class ProgressReports::DistrictConceptReports
           ON activity_sessions.classroom_unit_id = classroom_units.id
         JOIN users AS students
           ON students.id = activity_sessions.user_id
-        JOIN old_concept_results
-          ON old_concept_results.activity_session_id = activity_sessions.id
+        JOIN concept_results
+          ON concept_results.activity_session_id = activity_sessions.id
         WHERE schools_admins.user_id = #{@admin_id}
         GROUP BY
           student_id,
@@ -59,8 +59,8 @@ class ProgressReports::DistrictConceptReports
         classroom_name,
         student_name,
         correct,
-        (old_concept_results_count - correct) as incorrect,
-        FLOOR(( correct/old_concept_results_count::float ) * 100 ) as percentage
+        (concept_results_count - correct) as incorrect,
+        FLOOR(( correct/concept_results_count::float ) * 100 ) as percentage
       FROM results;
     SQL
   end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -91,10 +91,10 @@ class GetConceptsInUseIndividualConceptWorker
             ON concepts.parent_id = parent_concepts.id
           LEFT JOIN concepts AS grandparent_concepts
             ON parent_concepts.parent_id = grandparent_concepts.id
-          LEFT JOIN old_concept_results
-            ON old_concept_results.concept_id = concepts.id
+          LEFT JOIN concept_results
+            ON concept_results.concept_id = concepts.id
           LEFT JOIN activity_sessions
-            ON old_concept_results.activity_session_id = activity_sessions.id
+            ON concept_results.activity_session_id = activity_sessions.id
           LEFT JOIN activities
             ON activity_sessions.activity_id = activities.id
           LEFT JOIN activity_classifications

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -217,15 +217,15 @@ describe Api::V1::ActivitiesController, type: :controller do
     let!(:activity_session2) { create(:activity_session, activity: activity) }
     let!(:activity_session3) { create(:activity_session, activity: activity) }
     let!(:concept_result1) do
-      create(:old_concept_result, activity_session: activity_session1, metadata: {questionNumber: 1, questionScore: 1})
+      create(:concept_result, activity_session: activity_session1, question_number: 1, question_score: 1)
     end
 
     let!(:concept_result2) do
-      create(:old_concept_result, activity_session: activity_session2, metadata: {questionNumber: 1, questionScore: 0.75})
+      create(:concept_result, activity_session: activity_session2, question_number: 1, question_score: 0.75)
     end
 
     let!(:concept_result3) do
-      create(:old_concept_result, activity_session: activity_session3, metadata: {questionNumber: 1, questionScore: 0})
+      create(:concept_result, activity_session: activity_session3, question_number: 1, question_score: 0)
     end
 
     before do

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/concepts/students_controller_spec.rb
@@ -18,13 +18,13 @@ describe Teachers::ProgressReports::Concepts::StudentsController, type: :control
       before { session[:user_id] = teacher.id }
 
       it 'includes a list of students in the JSON' do
-        crs = alice.activity_sessions.map(&:old_concept_results).flatten.map(&:metadata)
+        crs = alice.activity_sessions.map(&:concept_results).flatten
         crs_correct = 0
-        crs.each{|cr| crs_correct += cr["correct"]}
+        crs.each{|cr| crs_correct += cr.correct ? 1 : 0}
         subject
         alice_json = json['students'][0]
         expect(alice_json['name']).to eq(alice.name)
-        expect(alice_json['total_result_count'].to_i).to eq(alice_session.old_concept_results.size)
+        expect(alice_json['total_result_count'].to_i).to eq(alice_session.concept_results.size)
         expect(alice_json['correct_result_count'].to_i).to eq(crs_correct)
         expect(alice_json['incorrect_result_count'].to_i).to eq(crs.length - crs_correct)
       end

--- a/services/QuillLMS/spec/helpers/concept_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/concept_helper_spec.rb
@@ -9,17 +9,13 @@ describe ConceptHelper, type: :helper do
 
   describe "#all_concept_stats" do
     before do
-      activity_session.old_concept_results.create!(
+      activity_session.concept_results.create!(
         concept: punctuation_concept,
-        metadata: {
-          correct: 0
-        }
+        correct: false
       )
-      activity_session.old_concept_results.create!(
+      activity_session.concept_results.create!(
         concept: prepositions_concept,
-        metadata: {
-          correct: 1
-        }
+        correct: true
       )
     end
 

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -50,7 +50,7 @@ describe ActivitySession, type: :model, redis: true do
   it { should have_one(:classroom).through(:classroom_unit) }
   it { should have_one(:unit).through(:classroom_unit) }
   it { should have_many(:concept_results) }
-  it { should have_many(:concepts).through(:old_concept_results) }
+  it { should have_many(:concepts).through(:concept_results) }
   it { should have_many(:teachers).through(:classroom) }
   it { should belong_to(:user) }
 

--- a/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
+++ b/services/QuillLMS/spec/models/progress_reports/concepts/concept_spec.rb
@@ -16,23 +16,21 @@ describe ProgressReports::Concepts::Concept do
     let(:filters) { {} }
 
     it 'can retrieve concepts based on no filters' do
-      expect(subject.size).to eq(teacher.classrooms_i_teach.map(&:activity_sessions).flatten.map(&:old_concept_results).flatten.map(&:concept).uniq.count)
+      expect(subject.size).to eq(teacher.classrooms_i_teach.map(&:activity_sessions).flatten.map(&:concept_results).flatten.map(&:concept).uniq.count)
     end
 
     it 'retrieves the total result count' do
-      expect(subject.first.total_result_count).to eq(OldConceptResult.where(concept: subject.first.concept_id).count)
+      expect(subject.first.total_result_count).to eq(ConceptResult.where(concept: subject.first.concept_id).count)
     end
 
     it 'retrieves the correct result count' do
-      cr_count = 0
-      OldConceptResult.where(concept: subject.first.concept_id).pluck(:metadata).each{|cr| cr_count += cr["correct"]}
+      cr_count = ConceptResult.where(concept: subject.first.concept_id, correct: true).count
       expect(subject.first.correct_result_count).to eq(cr_count)
     end
 
     it 'retrieves the incorrect result count' do
-      results = OldConceptResult.where(concept: subject.first.concept_id).pluck(:metadata)
-      cr_count = 0
-      results.each{|cr| cr_count += cr["correct"]}
+      results = ConceptResult.where(concept: subject.first.concept_id)
+      cr_count = results.where(correct: true).count
       incorrect_count = results.count - cr_count
       expect(subject.first.incorrect_result_count).to eq(incorrect_count)
     end

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -9,42 +9,34 @@ describe QuestionHealthDashboard, type: :model do
   let!(:activity_session3) { create(:activity_session, activity: activity) }
 
   let!(:concept_result1) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session1,
-      metadata: {
-        questionNumber: 1,
-        questionScore: 1
-      }
+      question_number: 1,
+      question_score: 1
     )
   end
 
   let!(:concept_result2) do
-    create(:old_concept_result,
+    create(:concept_result,
      activity_session: activity_session2,
-     metadata: {
-       questionNumber: 1,
-       questionScore: 0.75
-     }
+     question_number: 1,
+     question_score: 0.75
    )
   end
 
   let!(:concept_result3) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session3,
-      metadata: {
-        questionNumber: 1,
-        questionScore: 0
-      }
+      question_number: 1,
+      question_score: 0
     )
   end
 
   let!(:concept_result4) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session1,
-      metadata: {
-        questionNumber: 2,
-        questionScore: 1
-      }
+      question_number: 2,
+      question_score: 1
     )
   end
 

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -13,32 +13,26 @@ RSpec.describe QuestionHealthObj, type: :model do
     let!(:activity_session3) { create(:activity_session, activity: activity) }
 
     let!(:concept_result1) do
-      create(:old_concept_result,
+      create(:concept_result,
        activity_session: activity_session1,
-       metadata: {
-         questionNumber: 1,
-         questionScore: 1
-       }
+       question_number: 1,
+       question_score: 1
      )
     end
 
     let!(:concept_result2) do
-      create(:old_concept_result,
+      create(:concept_result,
        activity_session: activity_session2,
-       metadata: {
-         questionNumber: 1,
-         questionScore: 0.75
-       }
+       question_number: 1,
+       question_score: 0.75
      )
     end
 
     let!(:concept_result3) do
-      create(:old_concept_result,
+      create(:concept_result,
         activity_session: activity_session3,
-        metadata: {
-          questionNumber: 1,
-          questionScore: 0
-        }
+        question_number: 1,
+        question_score: 0
       )
     end
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -14,14 +14,14 @@ describe ProgressReports::DistrictConceptReports do
     let!(:classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: "owner", classroom: classroom) }
     let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id]) }
     let!(:activity_session) { create(:activity_session_without_concept_results, classroom_unit: classroom_unit, user_id: student.id) }
-    let!(:concept_result) { create(:old_concept_result, activity_session: activity_session) }
+    let!(:concept_result) { create(:concept_result, activity_session: activity_session) }
 
     subject { described_class.new(admin.id) }
 
     it 'should return the correct results' do
-      correct = concept_result.metadata["correct"]
-      incorrect = OldConceptResult.count - correct
-      percentage = (100 * correct.to_f / OldConceptResult.count).floor
+      correct = concept_result.correct ? 1 : 0
+      incorrect = ConceptResult.count - correct
+      percentage = (100 * correct.to_f / ConceptResult.count).floor
 
       expect(subject.results).to eq(
         [{

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
@@ -28,10 +28,10 @@ describe ProgressReports::Concepts::ConceptSerializer, type: :serializer do
       completed_at: 5.minutes.ago,
       classroom_unit: classroom_unit
     )
-    activity_session.old_concept_results
-      .create!(concept: concept, metadata: {'correct' => 1})
-    activity_session.old_concept_results
-      .create!(concept: concept, metadata: {'correct' => 0})
+    activity_session.concept_results
+      .create!(concept: concept, correct: true)
+    activity_session.concept_results
+      .create!(concept: concept, correct: false)
   end
 
   describe '#to_json' do

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
@@ -28,8 +28,8 @@ describe ProgressReports::Concepts::StudentSerializer, type: :serializer do
       state: 'finished',
       completed_at: 5.minutes.ago,
     )
-    activity_session.old_concept_results.create!(concept: concept, metadata: {'correct' => 1})
-    activity_session.old_concept_results.create!(concept: concept, metadata: {'correct' => 0})
+    activity_session.concept_results.create!(concept: concept, correct: true)
+    activity_session.concept_results.create!(concept: concept, correct: false)
   end
 
   describe '#to_json' do

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -47,42 +47,34 @@ describe 'SerializeActivityHealth' do
   let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
 
   let!(:concept_result1) do
-    create(:old_concept_result,
+    create(:concept_result,
      activity_session: activity_session1,
-     metadata: {
-       questionNumber: 1,
-       questionScore: 1
-     }
+     question_number: 1,
+     question_score: 1
    )
   end
 
   let!(:concept_result2) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session2,
-      metadata: {
-        questionNumber: 1,
-        questionScore: 0.75
-      }
+      question_number: 1,
+      question_score: 0.75
     )
   end
 
   let!(:concept_result3) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session3,
-      metadata: {
-        questionNumber: 1,
-        questionScore: 0
-      }
+      question_number: 1,
+      question_score: 0
     )
   end
 
   let!(:concept_result4) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session1,
-      metadata: {
-        questionNumber: 2,
-        questionScore: 1
-      }
+      question_number: 2,
+      question_score: 1
     )
   end
 

--- a/services/QuillLMS/spec/support/shared/concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/concept_progress_report.rb
@@ -37,52 +37,42 @@ shared_context 'Concept Progress Report' do
 
 
   let!(:correct_writing_result1) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session,
       concept: writing_concept,
-      metadata: {
-        "correct" => 1
-      }
+      correct: true
     )
   end
 
   let!(:correct_writing_result2) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session,
       concept: writing_concept,
-      metadata: {
-        "correct" => 1
-      }
+      correct: true
     )
   end
 
   let!(:incorrect_writing_result) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session,
       concept: writing_concept,
-      metadata: {
-        "correct" => 0
-      }
+      correct: false
     )
   end
 
   let!(:correct_grammar_result) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session,
       concept: grammar_tag,
-      metadata: {
-        "correct" => 1
-      }
+      correct: true
     )
   end
 
   let!(:incorrect_grammar_result) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: activity_session,
       concept: grammar_tag,
-      metadata: {
-        "correct" => 0
-      }
+      correct: false
     )
   end
 
@@ -115,12 +105,10 @@ shared_context 'Concept Progress Report' do
   end
 
   let!(:other_grammar_result) do
-    create(:old_concept_result,
+    create(:concept_result,
       activity_session: other_activity_session,
       concept: writing_concept,
-      metadata: {
-        "correct" => 1
-      }
+      correct: true
     )
   end
 

--- a/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
@@ -55,31 +55,23 @@ shared_context 'Student Concept Progress Report' do
 
   before do
     # Incorrect result for Alice
-    alice_session.old_concept_results.create!(
+    alice_session.concept_results.create!(
       concept: create(:concept_with_grandparent),
-      metadata: {
-        "correct" => 0
-      })
+      correct: false)
 
     # Correct result for Alice
-    alice_session.old_concept_results.create!(
+    alice_session.concept_results.create!(
       concept: concept,
-      metadata: {
-        "correct" => 1
-      })
+      correct: true)
 
     # Incorrect result for Fred
-    fred_session.old_concept_results.create!(
+    fred_session.concept_results.create!(
       concept: concept,
-      metadata: {
-        "correct" => 0
-      })
+      correct: true)
 
     # Correct result for Fred for hidden tag (not displayed)
-    fred_session.old_concept_results.create!(
+    fred_session.concept_results.create!(
       concept: hidden_concept,
-      metadata: {
-        "correct" => 1
-      })
+      correct: true)
   end
 end

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -54,42 +54,34 @@ describe PopulateActivityHealthWorker do
     let!(:recommendation) { create(:recommendation, activity: diagnostic, unit_template: unit_template)}
 
     let!(:concept_result1) do
-      create(:old_concept_result,
+      create(:concept_result,
         activity_session: activity_session1,
-        metadata: {
-          questionNumber: 1,
-          questionScore: 1
-        }
+        question_number: 1,
+        question_score: 1
       )
     end
 
     let!(:concept_result2) do
-      create(:old_concept_result,
+      create(:concept_result,
         activity_session: activity_session2,
-        metadata: {
-          questionNumber: 1,
-          questionScore: 0.75
-        }
+        question_number: 1,
+        question_score: 0.75
       )
     end
 
     let!(:concept_result3) do
-      create(:old_concept_result,
+      create(:concept_result,
         activity_session: activity_session3,
-        metadata: {
-          questionNumber: 1,
-          questionScore: 0
-        }
+        question_number: 1,
+        question_score: 0
       )
     end
 
     let!(:concept_result4) do
-      create(:old_concept_result,
+      create(:concept_result,
         activity_session: activity_session1,
-        metadata: {
-          questionNumber: 2,
-          questionScore: 1
-        }
+        question_number: 2,
+        question_score: 1
       )
     end
 


### PR DESCRIPTION
## WHAT
Update our code that reference `old_concept_results` via raw SQL queries to reference the new `concept_results` table and the correct location for the queried data in the new structure.
## WHY
We want to remove the `old_concept_results` table when we can, and this is a good first step
## HOW
- Update the various raw SQL references to `old_concept_results` to point to `concept_results` instead
- Tweak any column references to look at where the data is in the new schema over the old schema
- Find all the failing tests and update their setup conditions to instantiate `ConceptResult` models instead of `OldConceptResult` models

### Notion Card Links
https://www.notion.so/quill/Add-code-to-read-ConceptResult-data-from-Responses-records-d03eaa99d4a545cfb9e4d9a8d18bc4c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
