### PR TITLE
Add webinar schedule to PR template.

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -16,3 +16,4 @@ Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If y
 Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
 Self-Review: Have you done an initial self-review of the code below on Github? |
 Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
+Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)


### PR DESCRIPTION
## WHAT
Add a temporary question to PR template to avoid risky deploys during webinars.
## WHY
So we don't disrupt Partnerships
## HOW
Added a temporary question to the PR template
### Screenshots
![Screen Shot 2022-08-12 at 5 33 59 PM](https://user-images.githubusercontent.com/1304933/184447860-ea465e3f-7cb1-4fd0-98d2-e2d47ede99c7.png)



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, non-app change
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup, looks greate
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
