### PR TITLE
A few stripe integration updates

### DIFF
--- a/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
+++ b/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
@@ -8,7 +8,7 @@ module StripeIntegration
     CHARGE_DISPUTE_CREATED_URL = "#{STRIPE_DASHBOARD_URL}/disputes?statuses[0]=needs_response"
 
     def charge_dispute_created
-      mail(to: QUILL_TEAM_EMAIL_ADDRESS, subject: 'Charge Dispute Created') do |format|
+      mail(to: ENV.fetch('STRIPE_NOTIFICATIONS_EMAIL'), subject: 'Charge Dispute Created') do |format|
         format.text do
           render plain: "A response is needed on a disupted stripe subscription charge: #{CHARGE_DISPUTE_CREATED_URL}"
         end

--- a/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
+++ b/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
@@ -5,10 +5,11 @@ module StripeIntegration
     default from: QUILL_TEAM_EMAIL_ADDRESS
 
     STRIPE_DASHBOARD_URL = 'https://dashboard.stripe.com'
+    STRIPE_NOTIFICATIONS_EMAIL = ENV.fetch('STRIPE_NOTIFICATIONS_EMAIL', '')
     CHARGE_DISPUTE_CREATED_URL = "#{STRIPE_DASHBOARD_URL}/disputes?statuses[0]=needs_response"
 
     def charge_dispute_created
-      mail(to: ENV.fetch('STRIPE_NOTIFICATIONS_EMAIL'), subject: 'Charge Dispute Created') do |format|
+      mail(to: STRIPE_NOTIFICATIONS_EMAIL, subject: 'Charge Dispute Created') do |format|
         format.text do
           render plain: "A response is needed on a disupted stripe subscription charge: #{CHARGE_DISPUTE_CREATED_URL}"
         end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/ignored_event_handler.rb
@@ -10,6 +10,7 @@ module StripeIntegration
         'charge.failed',
         'charge.refunded',
         'charge.succeeded',
+        'credit_note.created',
         'customer.created',
         'customer.source.created',
         'customer.source.deleted',
@@ -20,6 +21,7 @@ module StripeIntegration
         'file.created',
         'invoice.created',
         'invoice.finalized',
+        'invoice.payment_action_required',
         'invoice.payment_failed',
         'invoice.payment_succeeded',
         'invoice.sent',
@@ -31,16 +33,20 @@ module StripeIntegration
         'payment_intent.canceled',
         'payment_intent.created',
         'payment_intent.payment_failed',
+        'payment_intent.requires_action',
         'payment_intent.succeeded',
         'payment_method.attached',
         'payment_method.automatically_updated',
+        'payment_method.detached',
         'payout.created',
         'payout.paid',
         'product.updated',
         'quote.canceled',
         'quote.created',
         'quote.finalized',
-        'setup_intent.created'
+        'setup_intent.created',
+        'setup_intent.requires_action',
+        'setup_intent.setup_failed'
       ]
 
       EVENT_HANDLER_LOOKUP = IGNORED_EVENT_NAMES.to_h { |event_name| [event_name, self] }

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -22,7 +22,6 @@ module StripeIntegration
       end
 
       def run
-        raise NilPurchaserEmailError if purchaser_email.nil?
         raise NilStripePriceIdError if stripe_price_id.nil?
         raise NilStripeInvoiceIdError if stripe_invoice.id.nil?
         raise DuplicateSubscriptionError if duplicate_subscription?

--- a/services/QuillLMS/spec/mailers/stripe_integration/mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/stripe_integration/mailer_spec.rb
@@ -7,9 +7,13 @@ describe StripeIntegration::Mailer, type: :mailer do
   describe '#charge_dispute_created' do
     subject { described_class.charge_dispute_created}
 
+    let(:to_email) { 'stripe_notifications@example.com' }
+
+    before { stub_const('ENV', {'STRIPE_NOTIFICATIONS_EMAIL' => 'stripe_notifications@example.com' }) }
+
     it 'mails a notification email to Quill Team email address' do
       expect(subject.subject).to eq 'Charge Dispute Created'
-      expect(subject.to).to eq [described_class::QUILL_TEAM_EMAIL_ADDRESS]
+      expect(subject.to).to eq [to_email]
       expect(subject.from).to eq [described_class::QUILL_TEAM_EMAIL_ADDRESS]
     end
   end

--- a/services/QuillLMS/spec/mailers/stripe_integration/mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/stripe_integration/mailer_spec.rb
@@ -9,7 +9,7 @@ describe StripeIntegration::Mailer, type: :mailer do
 
     let(:to_email) { 'stripe_notifications@example.com' }
 
-    before { stub_const('ENV', {'STRIPE_NOTIFICATIONS_EMAIL' => 'stripe_notifications@example.com' }) }
+    before { stub_const('StripeIntegration::Mailer::STRIPE_NOTIFICATIONS_EMAIL', to_email) }
 
     it 'mails a notification email to Quill Team email address' do
       expect(subject.subject).to eq 'Charge Dispute Created'


### PR DESCRIPTION
## WHAT
1.  Remove guard clause for nil purchaser email
2. Add some webhook event types to ignore list
3. Add ENV configuration for stripe notifications mailer

## WHY
1.  This should have been removed in an earlier PR. 
2. This will result in less noise in our handling of webhooks
3. We might want this email to go somewhere other than hello@quill.org 

## HOW
1.  Delete the associated guard clause
2. Add the items to the IGNORED_EVENT_TYPES array
3. Set the to: field equal to ENV['STRIPE_NOTIFICATIONS_EMAIL'

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
