### PR TITLE
Fix bug with changing subscription account type in CMS

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -243,7 +243,7 @@ export default class EditOrCreateSubscription extends React.Component {
       <React.Fragment>
         <label>Premium Status</label>
         <ItemDropdown
-          callback={this.changeAccountType}
+          callback={this.handleChangeAccountType}
           className="subscription-dropdown"
           items={premiumTypes}
           selectedItem={subscription.account_type || ''}


### PR DESCRIPTION
## WHAT
Fix bug with changing subscription account type in CMS

## WHY
Staff users should be able to change the account type of a subscription to Lifetime

## HOW
Name the dropdown handler the correct name.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Cannot-save-subscriptions-as-CB-Lifetime-Premium-6c587b79f67c40b8882db7c12afdecf1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Manual testing
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
