### PR TITLE
lms/dynamically-populate-type-dropdown-for-recommended-activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
@@ -92,39 +92,9 @@ exports[`UnitTemplateMinis component should render dropdowns when on mobile 1`] 
                     "value": null,
                   },
                   Object {
-                    "label": "Starter",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Intermediate",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Advanced",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "ELL",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
                     "label": "Diagnostic",
                     "link": "/assign/featured-activity-packs?category=Diagnostic",
                     "value": 9,
-                  },
-                  Object {
-                    "label": "Themed",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Skill Practice",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
                   },
                 ]
               }
@@ -282,39 +252,9 @@ exports[`UnitTemplateMinis component should render without createYourOwn mini wh
                     "value": null,
                   },
                   Object {
-                    "label": "Starter",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Intermediate",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Advanced",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "ELL",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
                     "label": "Diagnostic",
                     "link": "/activities/packs?category=Diagnostic",
                     "value": 9,
-                  },
-                  Object {
-                    "label": "Themed",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Skill Practice",
-                    "link": "/activities/packs",
-                    "value": null,
                   },
                 ]
               }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/unit_template_minis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/unit_template_minis.test.jsx
@@ -5,8 +5,8 @@ import UnitTemplateMinis from '../unit_template_minis';
 
 const sharedProps = {
   types: [{name: "Diagnostic", id: "diagnostic"}],
-  displayedModels: [
-    {
+  displayedModels: {
+    20: {
       id: 20,
       name: "Sentence Structure Diagnostic",
       time: 30,
@@ -31,7 +31,7 @@ const sharedProps = {
       },
       grades: ['1','2']
     }
-  ],
+  },
   data: {
     categories: [
       { primary_color: "#00c2a2",
@@ -40,8 +40,8 @@ const sharedProps = {
         id: 9}
     ],
     stage: "index",
-    models: [
-      {
+    displayedModels: {
+      20: {
         id: 20,
         name: "Sentence Structure Diagnostic",
         time: 30,
@@ -66,7 +66,7 @@ const sharedProps = {
         },
         grades: ['1','2']
       }
-    ]
+    }
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
@@ -30,7 +30,10 @@ export default class UnitTemplateMinis extends React.Component {
 
   generateCategoryOptions(gradeLevel, selectedTypeId) {
     const { data, } = this.props
-    const categoryOrder = [ALL, 'Starter', 'Intermediate', 'Advanced', 'ELL', 'Diagnostic', 'Themed', 'Skill Practice']
+    const usedCategories = Object.values(data.displayedModels).map(dm => dm.unit_template_category.name)
+    const usedUniqueCategories = usedCategories.filter((v, i, a) => a.indexOf(v) === i)
+    const sortedUsedCategories = usedUniqueCategories.sort((a,b) => a.localeCompare(b))
+    const categoryOrder = [ALL].concat(sortedUsedCategories)
     return categoryOrder.map((name) => {
       const category = data.categories.find(cat => cat.name === name)
       if (category) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
@@ -32,7 +32,7 @@ export default class UnitTemplateMinis extends React.Component {
     const { data, } = this.props
     const usedCategories = Object.values(data.displayedModels).map(dm => dm.unit_template_category.name)
     const usedUniqueCategories = usedCategories.filter((v, i, a) => a.indexOf(v) === i)
-    const sortedUsedCategories = usedUniqueCategories.sort((a,b) => a.localeCompare(b))
+    const sortedUsedCategories = usedUniqueCategories.sort((a,b) => (a && b) ? a.localeCompare(b) : (a < b) ? -1 : 1)
     const categoryOrder = [ALL].concat(sortedUsedCategories)
     return categoryOrder.map((name) => {
       const category = data.categories.find(cat => cat.name === name)


### PR DESCRIPTION
## WHAT
Dynamically generate the list of "Pack types" from used categories
## WHY
Instead of having a hard-coded list of categories on the front-end, we should just get the list of categories that are actually being used by the activity packs returned from the back-end.  This prevents us from easily controlling order, but Curriculum says that alphabetical order is fine.
## HOW
Generate the drop-down options dynamically from data fetched from the API instead of hard-coding it

### Screenshots
![image](https://user-images.githubusercontent.com/331565/184715464-f8bf6759-88a5-4a8e-91d5-7fd077abd12e.png)
![image](https://user-images.githubusercontent.com/331565/184724450-b1512850-f147-4d07-bb91-b575f8ccbfb2.png)


### Notion Card Links
https://www.notion.so/quill/Pack-type-drop-down-in-featured-activity-pack-page-not-showing-new-pack-types-for-teachers-7fe24dca8f5e4452850521aa23c08f6f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
