### PR TITLE
fix accessibility issues in the second part of evidence activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
@@ -3,6 +3,7 @@ import ReactCSSTransitionReplace from 'react-css-transition-replace'
 import stripHtml from "string-strip-html";
 
 import { GRAMMAR, SPELLING, RULES_BASED_3, } from '../../../../constants/evidence'
+import useFocus from '../../../Shared/hooks/useFocus'
 
 const loopSrc = `${process.env.CDN_URL}/images/icons/loop.svg`
 const smallCheckCircleSrc = `${process.env.CDN_URL}/images/icons/check-circle-small.svg`
@@ -48,10 +49,12 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
   const { entry, optimal, hint, highlight, } = lastSubmittedResponse
   const [reportAProblemExpanded, setReportAProblemExpanded] = React.useState(false)
   const [reportSubmitted, setReportSubmitted] = React.useState(false)
+  const [containerRef, setContainerFocus] = useFocus()
 
   React.useEffect(() => {
     setReportAProblemExpanded(false)
     setReportSubmitted(false)
+    setContainerFocus()
   }, [lastSubmittedResponse])
 
   React.useEffect(() => {
@@ -156,7 +159,7 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
   }
 
   return (
-    <div aria-live="polite" className={`feedback-section ${reportAProblemExpanded ? 'expanded' : ''}`} role="status">
+    <div className={`feedback-section ${reportAProblemExpanded ? 'expanded' : ''}`}>
       <ReactCSSTransitionReplace
         transitionEnterTimeout={1000}
         transitionLeaveTimeout={400}
@@ -168,9 +171,11 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
               <img alt={imageAlt} src={imageSrc} />
               <p>Feedback</p>
             </div>
-            <p className="feedback-text" dangerouslySetInnerHTML={feedbackForInnerHTML(feedback)} />
-            {screenreaderPassageHighlightText}
-            {screenreaderResponseHighlightText}
+            <div className="feedback-wrapper" ref={containerRef} tabIndex={-1}>
+              <p className="feedback-text" dangerouslySetInnerHTML={feedbackForInnerHTML(feedback)} />
+              {screenreaderPassageHighlightText}
+              {screenreaderResponseHighlightText}
+            </div>
             <div className="report-a-problem-button-container">{reportAProblemButton}</div>
           </div>
           {reportAProblemSection}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/stepOverview.tsx
@@ -54,6 +54,7 @@ const Step = ({ active, completed, handleClick, step }: StepProps) => {
       <section className="step-overview-step-container">
         <div className="step-overview-step completed">
           <img alt={whiteCheckGreenBackgroundIcon.alt} src={whiteCheckGreenBackgroundIcon.src} />
+          <span className="sr-only">Completed step:</span>
           {html}
         </div>
       </section>

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/step.scss
@@ -113,6 +113,9 @@
       color: #808080;
       font-size: 14px;
     }
+    .feedback-wrapper:focus-visible {
+      outline: none;
+    }
     .report-a-problem-section {
       padding: 9px 16px 16px;
       border-radius: 0px 0px 6px 6px;

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/stepOverview.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/stepOverview.scss
@@ -13,6 +13,9 @@
       line-height: 1.2;
       color: #ffffff;
       margin-bottom: 36px;
+      &:focus-visible {
+        outline: none;
+      }
     }
     .step-overview-step-container {
       .step-overview-step {

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/feedback.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/feedback.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`Feedback component should render Feedback 1`] = `
 <div
-  aria-live="polite"
   className="feedback-section "
-  role="status"
 >
   <ReactCSSTransitionReplace
     changeWidth={false}
@@ -34,14 +32,19 @@ exports[`Feedback component should render Feedback 1`] = `
           Feedback
         </p>
       </div>
-      <p
-        className="feedback-text"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": undefined,
+      <div
+        className="feedback-wrapper"
+        tabIndex={-1}
+      >
+        <p
+          className="feedback-text"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": undefined,
+            }
           }
-        }
-      />
+        />
+      </div>
       <div
         className="report-a-problem-button-container"
       >

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -112,9 +112,11 @@ exports[`PromptStep component active state before any responses have been submit
           >
             <span />
             <button
+              aria-label="Get feedback"
               className="quill-button focus-on-light disabled"
+              disabled={true}
               onClick={[Function]}
-              type="button"
+              type="submit"
             >
               <span>
                 Get feedback
@@ -122,6 +124,13 @@ exports[`PromptStep component active state before any responses have been submit
             </button>
           </div>
         </div>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>
@@ -249,9 +258,11 @@ exports[`PromptStep component active state when a suboptimal response has been s
           >
             <span />
             <button
+              aria-label="You already submitted this response. You must edit it before you can submit it again."
               className="quill-button focus-on-light disabled"
+              disabled={true}
               onClick={[Function]}
-              type="button"
+              type="submit"
             >
               <span>
                 Get feedback
@@ -293,9 +304,7 @@ exports[`PromptStep component active state when a suboptimal response has been s
           }
         >
           <div
-            aria-live="polite"
             className="feedback-section "
-            role="status"
           >
             <ReactCSSTransitionReplace
               changeWidth={false}
@@ -340,14 +349,19 @@ exports[`PromptStep component active state when a suboptimal response has been s
                           Feedback
                         </p>
                       </div>
-                      <p
-                        className="feedback-text"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Good start! You stated that compulsory voting will ensure that more voices are heard. Now take it one step further—according to the passage, why is it important that more voices are heard?",
+                      <div
+                        className="feedback-wrapper"
+                        tabIndex={-1}
+                      >
+                        <p
+                          className="feedback-text"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Good start! You stated that compulsory voting will ensure that more voices are heard. Now take it one step further—according to the passage, why is it important that more voices are heard?",
+                            }
                           }
-                        }
-                      />
+                        />
+                      </div>
                       <div
                         className="report-a-problem-button-container"
                       >
@@ -367,6 +381,13 @@ exports[`PromptStep component active state when a suboptimal response has been s
             </ReactCSSTransitionReplace>
           </div>
         </Feedback>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>
@@ -494,9 +515,11 @@ exports[`PromptStep component active state when an optimal response has been sub
           >
             <span />
             <button
+              aria-label="Get feedback"
               className="quill-button focus-on-light"
+              disabled={false}
               onClick={[Function]}
-              type="button"
+              type="submit"
             >
               <span>
                 Next
@@ -538,9 +561,7 @@ exports[`PromptStep component active state when an optimal response has been sub
           }
         >
           <div
-            aria-live="polite"
             className="feedback-section "
-            role="status"
           >
             <ReactCSSTransitionReplace
               changeWidth={false}
@@ -585,14 +606,19 @@ exports[`PromptStep component active state when an optimal response has been sub
                           Feedback
                         </p>
                       </div>
-                      <p
-                        className="feedback-text"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "That's a really strong sentence! You used evidence from the text to identify why governments should make voting compulsory.",
+                      <div
+                        className="feedback-wrapper"
+                        tabIndex={-1}
+                      >
+                        <p
+                          className="feedback-text"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "That's a really strong sentence! You used evidence from the text to identify why governments should make voting compulsory.",
+                            }
                           }
-                        }
-                      />
+                        />
+                      </div>
                       <div
                         className="report-a-problem-button-container"
                       >
@@ -612,6 +638,13 @@ exports[`PromptStep component active state when an optimal response has been sub
             </ReactCSSTransitionReplace>
           </div>
         </Feedback>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>
@@ -763,9 +796,11 @@ exports[`PromptStep component active state when the max attempts have been reach
           >
             <span />
             <button
+              aria-label="Get feedback"
               className="quill-button focus-on-light"
+              disabled={false}
               onClick={[Function]}
-              type="button"
+              type="submit"
             >
               <span>
                 Next
@@ -831,9 +866,7 @@ exports[`PromptStep component active state when the max attempts have been reach
           }
         >
           <div
-            aria-live="polite"
             className="feedback-section "
-            role="status"
           >
             <ReactCSSTransitionReplace
               changeWidth={false}
@@ -878,16 +911,21 @@ exports[`PromptStep component active state when the max attempts have been reach
                           Feedback
                         </p>
                       </div>
-                      <p
-                        className="feedback-text"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
+                      <div
+                        className="feedback-wrapper"
+                        tabIndex={-1}
+                      >
+                        <p
+                          className="feedback-text"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Nice effort! You made some strong revisions. Here is an example of a strong response. What is similar or different about your response? 
 
  Governments should make voting compulsory because otherwise not everyone will vote.",
+                            }
                           }
-                        }
-                      />
+                        />
+                      </div>
                       <div
                         className="report-a-problem-button-container"
                       >
@@ -929,6 +967,13 @@ exports[`PromptStep component active state when the max attempts have been reach
             </div>
           </div>
         </Feedback>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>
@@ -1056,8 +1101,10 @@ exports[`PromptStep component active state when the max attempts have been reach
           >
             <span />
             <button
+              aria-label="Get feedback"
               className="quill-button focus-on-light"
-              type="button"
+              disabled={false}
+              type="submit"
             >
               <span>
                 Done
@@ -1099,9 +1146,7 @@ exports[`PromptStep component active state when the max attempts have been reach
           }
         >
           <div
-            aria-live="polite"
             className="feedback-section "
-            role="status"
           >
             <ReactCSSTransitionReplace
               changeWidth={false}
@@ -1146,14 +1191,19 @@ exports[`PromptStep component active state when the max attempts have been reach
                           Feedback
                         </p>
                       </div>
-                      <p
-                        className="feedback-text"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "That's a really strong sentence! You used evidence from the text to identify why governments should make voting compulsory.",
+                      <div
+                        className="feedback-wrapper"
+                        tabIndex={-1}
+                      >
+                        <p
+                          className="feedback-text"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "That's a really strong sentence! You used evidence from the text to identify why governments should make voting compulsory.",
+                            }
                           }
-                        }
-                      />
+                        />
+                      </div>
                       <div
                         className="report-a-problem-button-container"
                       >
@@ -1173,6 +1223,13 @@ exports[`PromptStep component active state when the max attempts have been reach
             </ReactCSSTransitionReplace>
           </div>
         </Feedback>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>
@@ -1290,9 +1347,11 @@ exports[`PromptStep component inactive state renders 1`] = `
           >
             <span />
             <button
+              aria-label="Get feedback"
               className="quill-button focus-on-light disabled"
+              disabled={true}
               onClick={[Function]}
-              type="button"
+              type="submit"
             >
               <span>
                 Get feedback
@@ -1300,6 +1359,13 @@ exports[`PromptStep component inactive state renders 1`] = `
             </button>
           </div>
         </div>
+        <button
+          className="skip-main"
+          onClick={[Function]}
+          type="button"
+        >
+          Return to editor
+        </button>
       </div>
     </div>
   </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/stepOverview.test.tsx.snap
@@ -208,6 +208,11 @@ exports[`StepOverview component when the student is past step one renders 1`] = 
             alt="White check with green background icon"
             src="undefined/images/icons/icons-check-circle-dark.svg"
           />
+          <span
+            className="sr-only"
+          >
+            Completed step:
+          </span>
           <p>
             Read a text and highlight sentences.
           </p>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/promptStep.test.tsx
@@ -118,8 +118,9 @@ describe('PromptStep component', () => {
         describe('when a prompt with only one sentence, but containing a known abbreviation is submitted', () => {
           it('should not set custom feedback or a custom feedback key', () => {
             const entry = "Governments should make voting compulsory because the U.S.A. is a democracy."
+            const e = { preventDefault: () => {}, }
             wrapper.setState({ customFeedback: null, customFeedbackKey: null, })
-            wrapper.instance().handleGetFeedbackClick(entry, prompt.prompt_id, prompt.text)
+            wrapper.instance().handleGetFeedbackClick(e, entry, prompt.prompt_id, prompt.text)
             expect(wrapper.state('customFeedback')).toBe(null)
             expect(wrapper.state('customFeedbackKey')).toBe(null)
           })


### PR DESCRIPTION
## WHAT
Fix Evidence accessibility issues in the second half (answering prompts) part of the activity, specifically by:

- updating the feedback section so the entire thing isn't read on every change, but instead the feedback itself is focused and read and the user can navigate through the rest of it
- more descriptive aria-labels for button in disabled state
- adding a tab-only button after the feedback section to return the user to the prompt
- handle the case where a user is in the text field and selects and deletes all text (cursor should go back to the end)

## WHY
These are issues we identified in testing with Colleen.

## HOW
Relying more heavily on `useFocus` and less on `aria-live` regions, updates that are only available to SR/keyboard users (aria-labels, buttons that are invisible until you tab into them, sr-only classNames), and then some general usability updates (like the cursor in the text box).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Better-handle-focus-ordering-control-in-Evidence-e3932ab07be1456cb82db32fc4fe69e9
https://www.notion.so/quill/Figure-out-how-to-handle-text-editor-in-Evidence-a4448b2edcf44692afc9e3e2934190f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
