### PR TITLE
Segment/ add flags property

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -281,6 +281,10 @@ class Activity < ApplicationRecord
     Evidence::Activity.find_by(parent_activity_id: id)
   end
 
+  def segment_activity
+    SegmentIntegration::Activity.new(self)
+  end
+
   private def update_evidence_title?
     is_evidence? && saved_change_to_name?
   end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SegmentIntegration
+  class Activity < SimpleDelegator
+    def common_params
+      {
+        activity_name: name,
+        tool_name: classification.name.split[1]
+      }.reject {|_,v| v.nil? }
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def content_params
+      {
+        **common_params,
+        concepts: activity_categories.pluck(:name).join(", "),
+        content_partners: content_partners.pluck(:name).join(", "),
+        topic_level_three: topics.find(&:level_three?)&.name,
+        topic_level_two: topics.find(&:level_two?)&.name,
+        topic_level_one: topics.find(&:level_one?)&.name,
+        topic_level_zero: topics.find(&:level_zero?)&.name
+      }.reject {|_,v| v.nil? }
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+  end
+end

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -10,7 +10,8 @@ module SegmentIntegration
           auditor: auditor?,
           first_name: first_name,
           last_name: last_name,
-          email: email
+          email: email,
+          flags: flags&.join(", ")
         }.reject {|_,v| v.nil? },
         integrations: integration_rules
       }

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -35,6 +35,14 @@ class Topic < ApplicationRecord
     throw(:abort) unless valid_parent_structure?
   end
 
+  def level_zero?
+    level == 0
+  end
+
+  def level_one?
+    level == 1
+  end
+
   def level_two?
     level == 2
   end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -36,7 +36,7 @@ class SegmentAnalytics
     track({
       user_id: teacher_id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT,
-      properties: activity_info_for_tracking(activity)
+      properties: activity.segment_activity.content_params
     })
 
     # this event is for Vitally, which does not show properties
@@ -75,7 +75,7 @@ class SegmentAnalytics
     track({
       user_id: user&.id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
-      properties: activity_info_for_tracking(activity).merge({student_id: student_id})
+      properties: activity.segment_activity.content_params.merge({student_id: student_id})
     })
   end
 
@@ -129,10 +129,7 @@ class SegmentAnalytics
     track({
       user_id: user_id,
       event: SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
-      properties: {
-        activity_name: activity&.name,
-        tool_name: activity&.classification&.name
-      }
+      properties: activity.segment_activity.common_params
     })
 
   end
@@ -202,12 +199,5 @@ class SegmentAnalytics
 
   private def user_traits(user)
     SegmentAnalyticsUserSerializer.new(user).as_json(root: false)
-  end
-
-  private def activity_info_for_tracking(activity)
-    {
-      activity_name: activity.name,
-      tool_name: activity.classification.name.split[1]
-    }
   end
 end

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SegmentIntegration::Activity do
+  let(:activity_category) { create(:activity_category) }
+  let(:activity_classification) { create(:activity_classification) }
+  let(:level3_topic) { create(:topic, level: 3) }
+  let(:level2_topic) { create(:topic, level: 2) }
+  let(:level1_topic) { create(:topic, level: 1) }
+  let(:level0_topic) { create(:topic, level: 0) }
+  let(:activity) { create(:activity, activity_classification_id: activity_classification.id, activity_categories: [activity_category]) }
+  let(:activity_category_activity) { create(:activity_category_activity, activity: activity, activity_category: activity_category) }
+
+  context '#common_params' do
+
+    it 'returns the expected params hash' do
+      params = {
+        activity_name: activity.name,
+        tool_name: activity.classification.name.split[1]
+      }.reject {|_,v| v.nil? }
+      expect(activity.segment_activity.common_params).to eq params
+    end
+  end
+
+  context '#content_params' do
+
+    it 'returns the expected params hash' do
+      activity.topics = [level0_topic, level1_topic, level2_topic, level3_topic]
+      activity.save
+      params = {
+        **activity.segment_activity.common_params,
+        concepts: activity.activity_categories.pluck(:name).join(", "),
+        content_partners: activity.content_partners.pluck(:name).join(", "),
+        topic_level_three: activity.topics.find(&:level_three?)&.name,
+        topic_level_two: activity.topics.find(&:level_two?)&.name,
+        topic_level_one: activity.topics.find(&:level_one?)&.name,
+        topic_level_zero: activity.topics.find(&:level_zero?)&.name
+      }.reject {|_,v| v.nil? }
+      expect(activity.segment_activity.content_params).to eq params
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -3,23 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe SegmentIntegration::User do
-  let(:teacher) { create(:teacher) }
+  let(:teacher1) { create(:teacher) }
+  let(:teacher2) { create(:teacher, flags: ["private", "beta"]) }
 
   context '#identify_params' do
 
     it 'returns the expected params hash' do
       params = {
-        user_id: teacher.id,
+        user_id: teacher1.id,
         traits: {
-          **teacher.segment_user.common_params,
-          auditor: teacher.auditor?,
-          first_name: teacher.first_name,
-          last_name: teacher.last_name,
-          email: teacher.email
+          **teacher1.segment_user.common_params,
+          auditor: teacher1.auditor?,
+          first_name: teacher1.first_name,
+          last_name: teacher1.last_name,
+          email: teacher1.email,
+          flags: teacher1.flags&.join(", ")
         }.reject {|_,v| v.nil? },
-        integrations: teacher.segment_user.integration_rules
+        integrations: teacher1.segment_user.integration_rules
       }
-      expect(teacher.segment_user.identify_params).to eq params
+      expect(teacher1.segment_user.identify_params).to eq params
+    end
+
+    it 'returns a comma separated string value for the flags array' do
+      expect(teacher2.segment_user.identify_params[:traits][:flags]).to eq "private, beta"
     end
   end
 
@@ -27,21 +33,21 @@ RSpec.describe SegmentIntegration::User do
 
     it 'returns the expected params hash' do
       params = {
-        district: teacher.school&.district&.name,
-        school_id: teacher.school&.id,
-        school_name: teacher.school&.name,
-        premium_state: teacher.premium_state,
-        premium_type: teacher.subscription&.account_type,
-        is_admin: teacher.admin?
+        district: teacher1.school&.district&.name,
+        school_id: teacher1.school&.id,
+        school_name: teacher1.school&.name,
+        premium_state: teacher1.premium_state,
+        premium_type: teacher1.subscription&.account_type,
+        is_admin: teacher1.admin?
       }.reject {|_,v| v.nil? }
-      expect(teacher.segment_user.common_params).to eq params
+      expect(teacher1.segment_user.common_params).to eq params
     end
   end
 
   context '#integration_rules' do
 
     it 'returns the expected params hash for no user' do
-      expect(teacher.segment_user.integration_rules).to eq({ all: true, Intercom: true })
+      expect(teacher1.segment_user.integration_rules).to eq({ all: true, Intercom: true })
     end
   end
 end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -3,29 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe SegmentIntegration::User do
-  let(:teacher1) { create(:teacher) }
-  let(:teacher2) { create(:teacher, flags: ["private", "beta"]) }
+  let(:teacher) { create(:teacher, flags: ["private", "beta"]) }
 
   context '#identify_params' do
 
     it 'returns the expected params hash' do
       params = {
-        user_id: teacher1.id,
+        user_id: teacher.id,
         traits: {
-          **teacher1.segment_user.common_params,
-          auditor: teacher1.auditor?,
-          first_name: teacher1.first_name,
-          last_name: teacher1.last_name,
-          email: teacher1.email,
-          flags: teacher1.flags&.join(", ")
+          **teacher.segment_user.common_params,
+          auditor: teacher.auditor?,
+          first_name: teacher.first_name,
+          last_name: teacher.last_name,
+          email: teacher.email,
+          flags: teacher.flags&.join(", ")
         }.reject {|_,v| v.nil? },
-        integrations: teacher1.segment_user.integration_rules
+        integrations: teacher.segment_user.integration_rules
       }
-      expect(teacher1.segment_user.identify_params).to eq params
-    end
-
-    it 'returns a comma separated string value for the flags array' do
-      expect(teacher2.segment_user.identify_params[:traits][:flags]).to eq "private, beta"
+      expect(teacher.segment_user.identify_params).to eq params
     end
   end
 
@@ -33,21 +28,21 @@ RSpec.describe SegmentIntegration::User do
 
     it 'returns the expected params hash' do
       params = {
-        district: teacher1.school&.district&.name,
-        school_id: teacher1.school&.id,
-        school_name: teacher1.school&.name,
-        premium_state: teacher1.premium_state,
-        premium_type: teacher1.subscription&.account_type,
-        is_admin: teacher1.admin?
+        district: teacher.school&.district&.name,
+        school_id: teacher.school&.id,
+        school_name: teacher.school&.name,
+        premium_state: teacher.premium_state,
+        premium_type: teacher.subscription&.account_type,
+        is_admin: teacher.admin?
       }.reject {|_,v| v.nil? }
-      expect(teacher1.segment_user.common_params).to eq params
+      expect(teacher.segment_user.common_params).to eq params
     end
   end
 
   context '#integration_rules' do
 
     it 'returns the expected params hash for no user' do
-      expect(teacher1.segment_user.integration_rules).to eq({ all: true, Intercom: true })
+      expect(teacher.segment_user.integration_rules).to eq({ all: true, Intercom: true })
     end
   end
 end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -238,7 +238,7 @@ describe 'SegmentAnalytics' do
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
-      expect(identify_calls[0][:traits].length).to eq(9)
+      expect(identify_calls[0][:traits].length).to eq(10)
     end
 
     it 'sends events to Intercom when the user is an admin' do
@@ -252,14 +252,14 @@ describe 'SegmentAnalytics' do
       expect(identify_calls[0][:traits][:school_name]).to eq(school.name)
       expect(identify_calls[0][:traits][:school_id]).to eq(school.id)
       expect(identify_calls[0][:traits][:district]).to eq(district.name)
-      expect(identify_calls[0][:traits].length).to eq(9)
+      expect(identify_calls[0][:traits].length).to eq(10)
     end
 
     it 'omits trait properties that have nil values' do
       analytics.identify(teacher3)
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
-      expect(identify_calls[0][:traits].length).to eq(8)
+      expect(identify_calls[0][:traits].length).to eq(9)
     end
   end
 end


### PR DESCRIPTION
## WHAT
add flags property to Segment identify calls

## WHY
we want to track this property for our users

## HOW
just add this property to the `identify_params` method

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-new-flags-trait-to-Segment-Identify-call-6432214d04ac4c61b5e9eed569d19143

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
