### PR TITLE
lms/allow-recommendations-for-one-name-students

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -282,7 +282,7 @@ module PublicProgressReports
       {id: s&.id, name: s&.name || "Unknown Student", completed: completed }
     end
 
-    sorted_students = students.compact.sort_by {|stud| stud[:name].split()[1] || ''}
+    sorted_students = students.compact.sort_by {|stud| stud[:name].split().second || ''}
 
     recommendations = RecommendationsQuery.new(diagnostic.id).activity_recommendations.map do |activity_pack_recommendation|
       students = []

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -282,7 +282,7 @@ module PublicProgressReports
       {id: s&.id, name: s&.name || "Unknown Student", completed: completed }
     end
 
-    sorted_students = students.compact.sort_by {|stud| stud[:name].split()[1]}
+    sorted_students = students.compact.sort_by {|stud| stud[:name].split()[1] || ''}
 
     recommendations = RecommendationsQuery.new(diagnostic.id).activity_recommendations.map do |activity_pack_recommendation|
       students = []

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -194,6 +194,14 @@ describe PublicProgressReports, type: :model do
       expect(recommendations[:students].find { |s| s[:id] == student3.id}).not_to be
       expect(recommendations[:students].find { |s| s[:id] == student_not_in_class.id}).not_to be
     end
+
+    it 'will not crash when a relevant student has only one name' do
+      student2.update(name: 'First-only')
+      instance = FakeReports.new
+      expect do
+        instance.generate_recommendations_for_classroom(unit1.user, unit1.id, classroom.id, diagnostic_activity.id)
+      end.not_to raise_error
+    end
   end
 
   describe '#get_previously_assigned_recommendations_by_classroom' do


### PR DESCRIPTION


## WHAT
Allow recommendations to generate for students with only one name
## WHY
The original code crashed when trying to generate recommendations for a classroom that contained any students with only one name (where `.split[1]` produced `nil`), but since this sometimes happens in real classrooms, we should make sure this doesn't crash instead.
## HOW
In cases where we can't naively identify a last name via `name.split[1]`, use `""` as the sort key instead to sort single-name students to the beginning of the list.

### Notion Card Links
https://www.notion.so/quill/Spinning-wheel-on-diagnostic-recommendations-page-e0091fd3cf154959bb32ed60e85a6940

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
