### PR TITLE
Segment/ add content properties to track calls

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -281,6 +281,10 @@ class Activity < ApplicationRecord
     Evidence::Activity.find_by(parent_activity_id: id)
   end
 
+  def segment_activity
+    SegmentIntegration::Activity.new(self)
+  end
+
   private def update_evidence_title?
     is_evidence? && saved_change_to_name?
   end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -21,7 +21,7 @@ module SegmentIntegration
         topic_level_zero: topics.find(&:level_zero?)&.name
       }.reject {|_,v| v.nil? }
     end
-    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity
 
   end
 end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -9,6 +9,7 @@ module SegmentIntegration
       }.reject {|_,v| v.nil? }
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def content_params
       {
         **common_params,
@@ -20,5 +21,7 @@ module SegmentIntegration
         topic_level_zero: topics.find(&:level_zero?)&.name
       }.reject {|_,v| v.nil? }
     end
+    # rubocop:disable Metrics/CyclomaticComplexity
+
   end
 end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -14,10 +14,10 @@ module SegmentIntegration
         **common_params,
         concepts: activity_categories.pluck(:name).join(", "),
         content_partners: content_partners.pluck(:name).join(", "),
-        topic_level_three: topics.select { |topic| topic.level == 3 }[0],
-        topic_level_two: topics.select { |topic| topic.level == 2 }[0],
-        topic_level_one: topics.select { |topic| topic.level == 1 }[0],
-        topic_level_zero: topics.select { |topic| topic.level == 0 }[0],
+        topic_level_three: topics.find { |topic| topic.level == 3 }.pluck(:name),
+        topic_level_two: topics.find { |topic| topic.level == 2 }.pluck(:name),
+        topic_level_one: topics.find { |topic| topic.level == 1 }.pluck(:name),
+        topic_level_zero: topics.find { |topic| topic.level == 0 }.pluck(:name),
       }.reject {|_,v| v.nil? }
     end
   end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -12,12 +12,12 @@ module SegmentIntegration
     def content_params
       {
         **common_params,
-        concepts: activity_categories&.pluck(:name).join(", "),
-        content_partners: content_partners&.pluck(:name).join(", "),
-        topic_level_three: topics&.select { |topic| topic.level == 3 }[0],
-        topic_level_two: topics&.select { |topic| topic.level == 2 }[0],
-        topic_level_one: topics&.select { |topic| topic.level == 1 }[0],
-        topic_level_zero: topics&.select { |topic| topic.level == 0 }[0],
+        concepts: activity_categories.pluck(:name).join(", "),
+        content_partners: content_partners.pluck(:name).join(", "),
+        topic_level_three: topics.select { |topic| topic.level == 3 }[0],
+        topic_level_two: topics.select { |topic| topic.level == 2 }[0],
+        topic_level_one: topics.select { |topic| topic.level == 1 }[0],
+        topic_level_zero: topics.select { |topic| topic.level == 0 }[0],
       }.reject {|_,v| v.nil? }
     end
   end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SegmentIntegration
+  class Activity < SimpleDelegator
+    def common_params
+      {
+        activity_name: name,
+        tool_name: classification.name.split[1]
+      }.reject {|_,v| v.nil? }
+    end
+
+    def content_params
+      {
+        **common_params,
+        concepts: activity_categories&.pluck(:name).join(", "),
+        content_partners: content_partners&.pluck(:name).join(", "),
+        topic_level_three: topics&.select { |topic| topic.level == 3 }[0],
+        topic_level_two: topics&.select { |topic| topic.level == 2 }[0],
+        topic_level_one: topics&.select { |topic| topic.level == 1 }[0],
+        topic_level_zero: topics&.select { |topic| topic.level == 0 }[0],
+      }.reject {|_,v| v.nil? }
+    end
+  end
+end

--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -14,10 +14,10 @@ module SegmentIntegration
         **common_params,
         concepts: activity_categories.pluck(:name).join(", "),
         content_partners: content_partners.pluck(:name).join(", "),
-        topic_level_three: topics.find { |topic| topic.level == 3 }.pluck(:name),
-        topic_level_two: topics.find { |topic| topic.level == 2 }.pluck(:name),
-        topic_level_one: topics.find { |topic| topic.level == 1 }.pluck(:name),
-        topic_level_zero: topics.find { |topic| topic.level == 0 }.pluck(:name),
+        topic_level_three: topics.find(&:level_three?)&.name,
+        topic_level_two: topics.find(&:level_two?)&.name,
+        topic_level_one: topics.find(&:level_one?)&.name,
+        topic_level_zero: topics.find(&:level_zero?)&.name
       }.reject {|_,v| v.nil? }
     end
   end

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -35,6 +35,14 @@ class Topic < ApplicationRecord
     throw(:abort) unless valid_parent_structure?
   end
 
+  def level_zero?
+    level == 0
+  end
+
+  def level_one?
+    level == 1
+  end
+
   def level_two?
     level == 2
   end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -36,7 +36,7 @@ class SegmentAnalytics
     track({
       user_id: teacher_id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT,
-      properties: activity&.segment_activity.content_params
+      properties: activity.segment_activity.content_params
     })
 
     # this event is for Vitally, which does not show properties
@@ -75,7 +75,7 @@ class SegmentAnalytics
     track({
       user_id: user&.id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
-      properties: activity&.segment_activity.content_params.merge({student_id: student_id})
+      properties: activity.segment_activity.content_params.merge({student_id: student_id})
     })
   end
 
@@ -129,7 +129,7 @@ class SegmentAnalytics
     track({
       user_id: user_id,
       event: SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
-      properties: activity&.segment_activity.common_params
+      properties: activity.segment_activity.common_params
     })
 
   end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -36,7 +36,7 @@ class SegmentAnalytics
     track({
       user_id: teacher_id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT,
-      properties: activity_info_for_tracking(activity)
+      properties: activity&.segment_activity.content_params
     })
 
     # this event is for Vitally, which does not show properties
@@ -75,7 +75,7 @@ class SegmentAnalytics
     track({
       user_id: user&.id,
       event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
-      properties: activity_info_for_tracking(activity).merge({student_id: student_id})
+      properties: activity&.segment_activity.content_params.merge({student_id: student_id})
     })
   end
 
@@ -129,10 +129,7 @@ class SegmentAnalytics
     track({
       user_id: user_id,
       event: SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
-      properties: {
-        activity_name: activity&.name,
-        tool_name: activity&.classification&.name
-      }
+      properties: activity&.segment_activity.common_params
     })
 
   end
@@ -202,12 +199,5 @@ class SegmentAnalytics
 
   private def user_traits(user)
     SegmentAnalyticsUserSerializer.new(user).as_json(root: false)
-  end
-
-  private def activity_info_for_tracking(activity)
-    {
-      activity_name: activity.name,
-      tool_name: activity.classification.name.split[1]
-    }
   end
 end

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe SegmentIntegration::Activity do
       activity.save
       params = {
         **activity.segment_activity.common_params,
-        concepts: activity.activity_categories&.pluck(:name).join(", "),
-        content_partners: activity.content_partners&.pluck(:name).join(", "),
-        topic_level_three: activity.topics&.select { |topic| topic.level == 3 }[0],
-        topic_level_two: activity.topics&.select { |topic| topic.level == 2 }[0],
-        topic_level_one: activity.topics&.select { |topic| topic.level == 1 }[0],
-        topic_level_zero: activity.topics&.select { |topic| topic.level == 0 }[0],
+        concepts: activity.activity_categories.pluck(:name).join(", "),
+        content_partners: activity.content_partners.pluck(:name).join(", "),
+        topic_level_three: activity.topics.select { |topic| topic.level == 3 }[0],
+        topic_level_two: activity.topics.select { |topic| topic.level == 2 }[0],
+        topic_level_one: activity.topics.select { |topic| topic.level == 1 }[0],
+        topic_level_zero: activity.topics.select { |topic| topic.level == 0 }[0],
       }.reject {|_,v| v.nil? }
       expect(activity.segment_activity.content_params).to eq params
     end

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe SegmentIntegration::Activity do
         **activity.segment_activity.common_params,
         concepts: activity.activity_categories.pluck(:name).join(", "),
         content_partners: activity.content_partners.pluck(:name).join(", "),
-        topic_level_three: activity.topics.find { |topic| topic.level == 3 }.pluck(:name),
-        topic_level_two: activity.topics.find { |topic| topic.level == 2 }.pluck(:name),
-        topic_level_one: activity.topics.find { |topic| topic.level == 1 }.pluck(:name),
-        topic_level_zero: activity.topics.find { |topic| topic.level == 0 }.pluck(:name),
+        topic_level_three: activity.topics.find(&:level_three?)&.name,
+        topic_level_two: activity.topics.find(&:level_two?)&.name,
+        topic_level_one: activity.topics.find(&:level_one?)&.name,
+        topic_level_zero: activity.topics.find(&:level_zero?)&.name
       }.reject {|_,v| v.nil? }
       expect(activity.segment_activity.content_params).to eq params
     end

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SegmentIntegration::Activity do
+  let(:activity_category) { create(:activity_category) }
+  let(:activity_classification) { create(:activity_classification) }
+  let(:level3_topic) { create(:topic, level: 3) }
+  let(:level2_topic) { create(:topic, level: 2) }
+  let(:level1_topic) { create(:topic, level: 1) }
+  let(:level0_topic) { create(:topic, level: 0) }
+  let(:activity) { create(:activity, activity_classification_id: activity_classification.id, activity_categories: [activity_category]) }
+  let(:activity_category_activity) { create(:activity_category_activity, activity: activity, activity_category: activity_category) }
+
+  context '#common_params' do
+
+    it 'returns the expected params hash' do
+      params = {
+        activity_name: activity.name,
+        tool_name: activity.classification.name.split[1]
+      }.reject {|_,v| v.nil? }
+      expect(activity.segment_activity.common_params).to eq params
+    end
+  end
+
+  context '#content_params' do
+
+    it 'returns the expected params hash' do
+      activity.topics = [level0_topic, level1_topic, level2_topic, level3_topic]
+      activity.save
+      params = {
+        **activity.segment_activity.common_params,
+        concepts: activity.activity_categories&.pluck(:name).join(", "),
+        content_partners: activity.content_partners&.pluck(:name).join(", "),
+        topic_level_three: activity.topics&.select { |topic| topic.level == 3 }[0],
+        topic_level_two: activity.topics&.select { |topic| topic.level == 2 }[0],
+        topic_level_one: activity.topics&.select { |topic| topic.level == 1 }[0],
+        topic_level_zero: activity.topics&.select { |topic| topic.level == 0 }[0],
+      }.reject {|_,v| v.nil? }
+      expect(activity.segment_activity.content_params).to eq params
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe SegmentIntegration::Activity do
         **activity.segment_activity.common_params,
         concepts: activity.activity_categories.pluck(:name).join(", "),
         content_partners: activity.content_partners.pluck(:name).join(", "),
-        topic_level_three: activity.topics.select { |topic| topic.level == 3 }[0],
-        topic_level_two: activity.topics.select { |topic| topic.level == 2 }[0],
-        topic_level_one: activity.topics.select { |topic| topic.level == 1 }[0],
-        topic_level_zero: activity.topics.select { |topic| topic.level == 0 }[0],
+        topic_level_three: activity.topics.find { |topic| topic.level == 3 }.pluck(:name),
+        topic_level_two: activity.topics.find { |topic| topic.level == 2 }.pluck(:name),
+        topic_level_one: activity.topics.find { |topic| topic.level == 1 }.pluck(:name),
+        topic_level_zero: activity.topics.find { |topic| topic.level == 0 }.pluck(:name),
       }.reject {|_,v| v.nil? }
       expect(activity.segment_activity.content_params).to eq params
     end


### PR DESCRIPTION
## WHAT
add content properties to track calls

## WHY
we want to track this data

## HOW
pull out activity params into SimpleDelegator and add content-related params

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-new-content-related-properties-to-Segment-track-events-de4272059f104178a373cac035612d5d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
