### PR TITLE
remove app setting conditionals from blogs views

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -5,7 +5,6 @@ class BlogPostsController < ApplicationController
 
   before_action :redirect_legacy_topic_urls, only: [:show_topic]
   before_action :redirect_invalid_topics, only: [:show_topic]
-  before_action :redirect_unauthorized_topics, only: [:show_topic]
   before_action :set_announcement, only: [:index, :show, :show_topic]
   before_action :set_root_url
 
@@ -100,14 +99,6 @@ class BlogPostsController < ApplicationController
 
   private def set_root_url
     @root_url = root_url
-  end
-
-  private def redirect_unauthorized_topics
-    return if params[:topic] != "using-quill-for-reading-comprehension"
-    return if AppSetting.enabled?(name: AppSetting::COMPREHENSION, user: current_user)
-
-    flash[:error] = "You are unauthorized to view that topic"
-    redirect_to center_home_url and return
   end
 
   private def redirect_invalid_topics

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -8,17 +8,17 @@ module TeacherCenterHelper
   ALL = 'All'
 
   def teacher_center_tabs(large: true)
-    comprehension_tab = {
-      id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
-      name: COMPREHENSION,
-      url: 'teacher-center/topic/using-quill-for-reading-comprehension'
-    }
     premium_tab = {
       id: PREMIUM,
       name: PREMIUM,
       url: 'premium'
     }
     tabs = [
+      {
+        id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
+        name: COMPREHENSION,
+        url: 'teacher-center/topic/using-quill-for-reading-comprehension'
+      },
       {
         id: BlogPost::ALL_RESOURCES,
         name: ALL,
@@ -45,7 +45,6 @@ module TeacherCenterHelper
         url: 'faq'
       }
     ]
-    tabs.insert(1, comprehension_tab)
     tabs << premium_tab if !current_user
     tabs
   end

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -8,7 +8,6 @@ module TeacherCenterHelper
   ALL = 'All'
 
   def teacher_center_tabs(large: true)
-    is_comprehension_user = current_user && AppSetting.enabled?(name: AppSetting::COMPREHENSION, user: current_user)
     comprehension_tab = {
       id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
       name: COMPREHENSION,
@@ -46,7 +45,7 @@ module TeacherCenterHelper
         url: 'faq'
       }
     ]
-    tabs.insert(1, comprehension_tab) if is_comprehension_user
+    tabs.insert(1, comprehension_tab)
     tabs << premium_tab if !current_user
     tabs
   end

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -15,14 +15,14 @@ module TeacherCenterHelper
     }
     tabs = [
       {
-        id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
-        name: COMPREHENSION,
-        url: 'teacher-center/topic/using-quill-for-reading-comprehension'
-      },
-      {
         id: BlogPost::ALL_RESOURCES,
         name: ALL,
         url: 'teacher-center'
+      },
+      {
+        id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
+        name: COMPREHENSION,
+        url: 'teacher-center/topic/using-quill-for-reading-comprehension'
       },
       {
         id: BlogPost::GETTING_STARTED,

--- a/services/QuillLMS/app/views/navbar/_teacher_center.html.erb
+++ b/services/QuillLMS/app/views/navbar/_teacher_center.html.erb
@@ -10,16 +10,14 @@
       link: '/teacher-center',
       text: 'All Resources'
     %>
-    <% if current_user && AppSetting.enabled?(name: AppSetting::COMPREHENSION, user: current_user) %>
-      <%= render 'navbar/tooltip_link',
-        text: 'Reading Comprehension',
-        subtext: "Learn all about Quill's new reading and writing tool",
-        hover_image_src: 'https://assets.quill.org/images/icons/teacher-center-comprehension.svg',
-        image_src: 'https://assets.quill.org/images/icons/teacher-center-comprehension-hover.svg',
-        image_id: 'comprehension-img',
-        link: '/teacher-center/topic/using-quill-for-reading-comprehension'
-      %>
-    <% end %>
+    <%= render 'navbar/tooltip_link',
+      text: 'Reading Comprehension',
+      subtext: "Learn all about Quill's new reading and writing tool",
+      hover_image_src: 'https://assets.quill.org/images/icons/teacher-center-comprehension.svg',
+      image_src: 'https://assets.quill.org/images/icons/teacher-center-comprehension-hover.svg',
+      image_id: 'comprehension-img',
+      link: '/teacher-center/topic/using-quill-for-reading-comprehension'
+    %>
     <%= render 'navbar/tooltip_link',
       text: 'Getting Started',
       subtext: 'Set up your classroom on Quill with guides, videos, and presentations',

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -126,51 +126,6 @@ describe BlogPostsController, type: :controller do
       expect(assigns(:title)).to eq(topic)
     end
 
-    context 'topics requiring authorization' do
-      let(:app_setting) { create(:app_setting, name: AppSetting::COMPREHENSION) }
-      let(:topic) { BlogPost::USING_QUILL_FOR_READING_COMPREHENSION }
-      let(:slug) { topic.tr(' ', '-').downcase }
-      let!(:blog_posts) { create_list(:blog_post, 2, topic: topic) }
-
-      subject { get :show_topic, params: { topic: slug } }
-
-      before { allow(controller).to receive(:current_user) { user } }
-
-      context 'user is a teacher' do
-        let(:user) { create(:teacher) }
-
-        it 'when app_setting is enabled for user, all posts for using-quill-for-reading-comprehension are returned' do
-          app_setting.enabled = true
-          app_setting.user_ids_allow_list = [user.id]
-          app_setting.save!
-          subject
-          expect(assigns(:blog_posts)).to match_array blog_posts
-        end
-
-        it 'should redirect to teacher_center if user is unauthorized' do
-          subject
-          expect(response).to redirect_to '/teacher-center'
-        end
-      end
-
-      context 'user is a student' do
-        let(:user) { create(:student) }
-
-        it 'should redirect to student_center' do
-          subject
-          expect(response).to redirect_to '/student-center'
-        end
-      end
-
-      context 'current_user is nil' do
-        let(:user) { nil }
-
-        it 'should redirect to teacher_center' do
-          subject
-          expect(response).to redirect_to '/teacher-center'
-        end
-      end
-    end
   end
 
   describe '#search' do

--- a/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
@@ -20,11 +20,6 @@ describe TeacherCenterHelper do
       allow(helper).to receive(:current_user) { current_user }
     end
 
-    it 'should return the tabs without comprehension if app setting is false' do
-      create(:app_setting, name: "comprehension")
-      expect(helper.teacher_center_tabs).to eq tabs
-    end
-
     it 'should return the tabs with comprehension if app setting is true' do
       comprehension_tab = { id: "Using quill for reading comprehension", name: "Reading comprehension", url: "teacher-center/topic/using-quill-for-reading-comprehension" }
       app_setting.enabled = true
@@ -39,6 +34,7 @@ describe TeacherCenterHelper do
     let(:tabs) {
       [
         { id: "All resources", name: "All", url: "teacher-center" },
+        { id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION, name: 'Reading comprehension', url: 'teacher-center/topic/using-quill-for-reading-comprehension' },
         { id: "Getting started", name: "Getting started", url: "teacher-center/topic/getting-started" },
         { id: "Best practices", name: "Best practices", url: "teacher-center/topic/best-practices" },
         { id: "Writing instruction research", name: "Research", url: "teacher-center/topic/writing-instruction-research" },


### PR DESCRIPTION
## WHAT
remove Evidence conditionals in teacher center static pages 

## WHY
Everyone should see Evidence-related content. Even if an AppSetting is enabled for all, it will still return false if a user does not exist (i.e. is not logged in).


## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
no - rush order from PG

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
