### PR TITLE
Segment/ add identify call for client side events

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/modules/analytics/index.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/modules/analytics/index.ts
@@ -59,6 +59,7 @@ class SegmentAnalytics {
     }
 
     const eventProperties = Object.assign({...customProperties}, this.getDefaultProperties());
+    this.analytics['identify'](teacherId, { event: event.name });
     this.analytics['track'](event.name, eventProperties);
     return true;
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
@@ -45,6 +45,7 @@ class SegmentAnalytics {
     }
 
     const eventProperties = Object.assign(this.formatCustomProperties(customProperties), this.getDefaultProperties());
+    this.analytics().identify(teacherId, { event: event.name });
     this.analytics().track(event.name, eventProperties);
     return true;
   }


### PR DESCRIPTION
## WHAT
add identify call for client side events

## WHY
- when sent from the client-side, the `userId` value used for Ortto ingestion is auto-populated by [an earlier identify call](https://segment.com/docs/connections/spec/track/#identities) (which we do not do for student users) so it's getting sent with a `null` value
- when performing an anonymous client-side event, it's only possible to pass that `userId` value via the properties object 
- in order for this `userId` value to be correctly auto-populated, we need to add an identify call before the track call that uses the student user's teacher's ID

## HOW
just add an `identify` call before the `track` call that uses the teacher's user ID

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-a-new-Student-rated-activity-Segment-track-event-e17ae40ec35d4324a477e12b5003f66a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested on Segment/Ortto
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
