### PR TITLE
Fix development connection pool bug

### DIFF
--- a/services/QuillCMS/config/environments/production.rb
+++ b/services/QuillCMS/config/environments/production.rb
@@ -110,9 +110,7 @@ Rails.application.configure do
   # DatabaseSelector middleware is designed as such you can define your own
   # strategy for connection switching and pass that into the middleware through
   # these configuration options.
-  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
-    config.active_record.database_selector = { delay: 0.seconds }
-    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  end
+  config.active_record.database_selector = { delay: 0.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -3,9 +3,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
-    connects_to database: { writing: :primary, reading: :replica }
-  else
-    connects_to database: { writing: :primary, reading: :primary }
-  end
+  connects_to database: { writing: :primary, reading: :replica }
 end

--- a/services/QuillLMS/config/environments/production.rb
+++ b/services/QuillLMS/config/environments/production.rb
@@ -126,9 +126,7 @@ EmpiricalGrammar::Application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
-    config.active_record.database_selector = { delay: 2.seconds }
-    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  end
+  config.active_record.database_selector = { delay: 2.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/services/QuillLMS/config/environments/staging.rb
+++ b/services/QuillLMS/config/environments/staging.rb
@@ -116,9 +116,7 @@ EmpiricalGrammar::Application.configure do
     'staging.quill.org.' => 'staging.quill.org'
   }
 
-  if ENV.fetch('USE_MULTI_DB_CONFIGURATION', false) == 'true'
-    config.active_record.database_selector = { delay: 2.seconds }
-    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  end
+  config.active_record.database_selector = { delay: 2.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end


### PR DESCRIPTION
## WHAT
Fix an `ActiveRecord::ConnectionNotEstablished - No connection pool for 'ApplicationRecord' found` bug that happens locally when in the development environment.

## WHY
The primary database configuration isn't resolving properly due to config/enviornments/development.rb and ApplicationRecord.rb `connects_to`.

## HOW
Get rid of the ENV['MULTI_DB_CONFIGURATION'] conditional and use the same configuration across all environments in ApplicationRecord.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES