### PR TITLE
lms/fix-recommended-activities-category-selector

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_templates_manager.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_templates_manager.jsx
@@ -111,7 +111,7 @@ export default class UnitTemplatesManager extends React.Component {
       displayedModels = this.modelsInGrade(grade)
     }
     if (category) {
-      const categoryName = category.toUpperCase() === 'ELL' ? category.toUpperCase() : _l.capitalize(category)
+      const categoryName = category.toUpperCase() === 'ELL' ? category.toUpperCase() : category
       selectedCategoryId = unitTemplatesManager.categories.find(cat => cat.name === categoryName).id
       displayedModels = displayedModels.filter(ut =>
         ut.unit_template_category.name === categoryName


### PR DESCRIPTION
## WHAT
Fix a small bug that's causing the selector to crash for some categories
## WHY
Now that we source the list of categories from the back-end, we don't really need to manipulate the values before we compare them
## HOW
Just use the value of the category without manipulating them now that they're sourced from the same place on both sides of the comparison.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No change in behavior, so no test changes
Have you deployed to Staging? | Small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
