### PR TITLE
Lms/coaches copy updates

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -26,7 +26,7 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
       </div>
       {showBadges && <div className="school-premium-badge-container">
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> 2 PD sessions</div>
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> 3 coaching sessions</div>
+        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> onboarding training</div>
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Custom reports</div>
       </div>}
     </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -25,8 +25,8 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
         <p>Request Quote or Buy Now</p>
       </div>
       {showBadges && <div className="school-premium-badge-container">
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> 2 PD sessions</div>
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> onboarding training</div>
+        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Onboarding training</div>
+        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> 2 PD workshops</div>
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Custom reports</div>
       </div>}
     </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
@@ -125,58 +125,29 @@ const professionalDevelopmentSessions = (
   </section>
 )
 
-const oneOnOneCoaching = (
+const professionalLearningTeam = (
   <section>
-    <h3>One-on-one coaching sessions with our Senior Instructional Coaches</h3>
-    <p>Once per quarter, teachers are invited to schedule 1:1 coaching sessions to work directly with a senior instructional coach on Quill&#39;s team. Our sessions empower teachers to solve issues, learn how to analyze reports, and support curriculum implementation. By reviewing their Quill dashboard with the coach, teachers will leave the session with more confidence in our tool.</p>
-    <div className="premium-features-row">
-      <div className="testimonial long">
-        <p>Totally personalized! I told the Quill coach my background and what my familiarity with Quill was, and she was able to walk me through exactly what I needed. Also appreciate that she could show me with her screen, walking through my classes with me.</p>
-        <span>Teacher, Glacier View Junior High School</span>
-      </div>
-      <div className="testimonial">
-        <p>I appreciated the time given to analyze our own data while in the training.</p>
-        <span>Teacher, Meeting Street Elementary at Burns</span>
-      </div>
-      <div className="testimonial">
-        <p>Our Quill coach is a really engaging facilitator! I appreciated her expertise and the built-in work time.</p>
-        <span>Director of Academics, Thurgood Marshall</span>
-      </div>
-      <div className="testimonial">
-        <p>I appreciated the facilitator&#39;s responsiveness to the needs specific to our network. I also appreciate the thoughtfulness of applying Quill remotely.</p>
-        <span>Administrator, Mastery Charter Schools</span>
-      </div>
-      <div className="testimonial">
-        <p>Our Quill coach was very knowledgeable and friendly. I felt as though I could ask her anything and there would be no judgement!!</p>
-        <span>Teacher, Union High School</span>
-      </div>
-    </div>
-  </section>
-)
-
-const coachingTeam = (
-  <section>
-    <h3>Meet the coaching team</h3>
+    <h3>Meet the professional learning team</h3>
     <div className="premium-features-row">
       <PremiumFeature
         header="Erika Parker-Havens"
         imageAlt="Photograph of Quill's coach, Erika"
         imageSrc={erikaSrc}
-        subheader={[<span key="years">13 years in Education</span>, <span key="title">Former MS English teacher and Academic Dean</span>]}
+        subheader={[<span key="years">15+ years in Education</span>, <span key="title">Former MS English teacher and Academic Dean</span>]}
         text="Expert in culturally responsive teaching practices, writing in the content areas and helping teachers practically use tools to facilitate learning through writing"
       />
       <PremiumFeature
         header="Shannon Browne"
         imageAlt="Photograph of Quill's coach, Shannon"
         imageSrc={shannonSrc}
-        subheader={[<span key="years">13 years in Education</span>, <span key="title">Former HS English Teacher and Director of Instruction</span>]}
+        subheader={[<span key="years">15+ years in Education</span>, <span key="title">Former HS English Teacher and Director of Instruction</span>]}
         text="Expert in data-informed instructional strategies and prioritizing the needs of special populations in writing practice routines"
       />
       <PremiumFeature
         header="Sherry Lewkowicz"
         imageAlt="Photograph of Quill's coach, Sherry"
         imageSrc={sherrySrc}
-        subheader={[<span key="years">14 years in Education</span>, <span key="title">Former AP English Literature teacher</span>]}
+        subheader={[<span key="years">15+ years in Education</span>, <span key="title">Former AP English Literature teacher</span>]}
         text="Expert in writing instruction best practices and helping teachers incorporate those best practices into their teaching"
       />
     </div>
@@ -196,8 +167,7 @@ const SchoolPremium = () => {
       <div className='premium-features-body'>
         {actionableFeaturesAndSupport}
         {professionalDevelopmentSessions}
-        {oneOnOneCoaching}
-        {coachingTeam}
+        {professionalLearningTeam}
       </div>
     </div>
   );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
@@ -125,7 +125,34 @@ const professionalDevelopmentSessions = (
   </section>
 )
 
-const professionalLearningTeam = (
+const testimonials = (
+  <section>
+    <div className="premium-features-row">
+      <div className="testimonial long">
+        <p>Totally personalized! I told the Quill coach my background and what my familiarity with Quill was, and she was able to walk me through exactly what I needed. Also appreciate that she could show me with her screen, walking through my classes with me.</p>
+        <span>Teacher, Glacier View Junior High School</span>
+      </div>
+      <div className="testimonial">
+        <p>I appreciated the time given to analyze our own data while in the training.</p>
+        <span>Teacher, Meeting Street Elementary at Burns</span>
+      </div>
+      <div className="testimonial">
+        <p>Our Quill coach is a really engaging facilitator! I appreciated her expertise and the built-in work time.</p>
+        <span>Director of Academics, Thurgood Marshall</span>
+      </div>
+      <div className="testimonial">
+        <p>I appreciated the facilitator&#39;s responsiveness to the needs specific to our network. I also appreciate the thoughtfulness of applying Quill remotely.</p>
+        <span>Administrator, Mastery Charter Schools</span>
+      </div>
+      <div className="testimonial">
+        <p>Our Quill coach was very knowledgeable and friendly. I felt as though I could ask her anything and there would be no judgement!!</p>
+        <span>Teacher, Union High School</span>
+      </div>
+    </div>
+  </section>
+)
+
+const coachingTeam = (
   <section>
     <h3>Meet the professional learning team</h3>
     <div className="premium-features-row">
@@ -167,7 +194,8 @@ const SchoolPremium = () => {
       <div className='premium-features-body'>
         {actionableFeaturesAndSupport}
         {professionalDevelopmentSessions}
-        {professionalLearningTeam}
+        {testimonials}
+        {coachingTeam}
       </div>
     </div>
   );


### PR DESCRIPTION
## WHAT
- Remove copy on the premium page about one-on-one coaching since that's no longer something Partnerships does
- Update the description of Partnerships from "coaches" to "professional learning team"
- Update "years of experience" for partnerships staff
## WHY
These updates were requested by Partnerships as a way to make the description of our offerings more clear and accurate.
## HOW
Just update copy

### Screenshots
![image](https://user-images.githubusercontent.com/331565/185456468-7f854d1f-5db2-47ca-8f32-ed0243928a25.png)

### Notion Card Links
https://www.notion.so/quill/Copy-Change-Premium-Page-c0be74ae47bb4733af07b424daec41fe

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around copy
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
