### PR TITLE
Segment/ update params

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
@@ -125,6 +125,7 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
     }
     const callback = () => setSubmittedActivitySurvey(true)
     dispatch(TrackAnalyticsEvent(Events.STUDENT_RATED_AN_ACTIVITY, {}, trackingProperties))
+    dispatch(TrackAnalyticsEvent(Events.STUDENT_RATED_ACTIVITY, {}, { rating: selectedEmoji }))
     saveActivitySurveyResponse({ sessionID, activitySurveyResponse, callback, })
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
@@ -117,15 +117,14 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
       multiple_choice_selections: selectedMultipleChoiceOptions,
       survey_question: SURVEY_QUESTION,
     }
-    const trackingProperties = {
+    const trackingParams = {
       activity_name: activity?.title,
       tool_name: "Reading",
       rating: selectedEmoji,
       ...mapMultipleChoiceOptionsForEventParams()
     }
     const callback = () => setSubmittedActivitySurvey(true)
-    dispatch(TrackAnalyticsEvent(Events.STUDENT_RATED_AN_ACTIVITY, {}, trackingProperties))
-    dispatch(TrackAnalyticsEvent(Events.STUDENT_RATED_ACTIVITY, {}, { rating: selectedEmoji }))
+    dispatch(TrackAnalyticsEvent(Events.STUDENT_RATED_AN_ACTIVITY, trackingParams))
     saveActivitySurveyResponse({ sessionID, activitySurveyResponse, callback, })
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
@@ -90,11 +90,6 @@ const EventDefinitions = [
     'event',
     'user_id',
     'properties'
-  ])},
-  {STUDENT_RATED_ACTIVITY: new Event('Student rated activity', [
-    'event',
-    'user_id',
-    'properties'
   ])}
 ];
 

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/event_definitions.ts
@@ -90,6 +90,11 @@ const EventDefinitions = [
     'event',
     'user_id',
     'properties'
+  ])},
+  {STUDENT_RATED_ACTIVITY: new Event('Student rated activity', [
+    'event',
+    'user_id',
+    'properties'
   ])}
 ];
 

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
@@ -43,7 +43,7 @@ class SegmentAnalytics {
       return false;
     }
 
-    const eventProperties = Object.assign(this.formatCustomProperties(customProperties), this.getDefaultProperties());
+    const eventProperties = Object.assign({...customProperties}, this.getDefaultProperties());
     this.analytics().identify(teacherId, { event: event.name });
     this.analytics().track(event.name, eventProperties);
     return true;

--- a/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/modules/analytics/index.ts
@@ -10,7 +10,7 @@ class SegmentAnalytics {
     return window.analytics
   }
 
-  async track(event: Event, params?: object, properties?: object) {
+  async track(event: Event, params?: object) {
     const sessionID = getParameterByName('session', window.location.href)
     const idData = await fetchUserIdsForSession(sessionID)
 
@@ -22,8 +22,7 @@ class SegmentAnalytics {
       event: event.name,
       user_id: teacherId,
       properties: {
-        student_id: studentId,
-        ...properties
+        student_id: studentId
       }
     }
     try {


### PR DESCRIPTION
## WHAT
slight tweak to how we pass Segment params

## WHY
we can't have any params nested under `properties` because Ortto won't be able to recognize them

## HOW
just moved nested params from within properties into the root level of the object

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-a-new-Student-rated-activity-Segment-track-event-e17ae40ec35d4324a477e12b5003f66a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes-- manually tested on Segment/Ortto
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
