### PR TITLE
Lms/show standards in unit template activities

### DIFF
--- a/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_templates_controller.rb
@@ -10,7 +10,7 @@ class Cms::UnitTemplatesController < Cms::CmsController
       format.json do
         unit_templates =
           UnitTemplate
-            .includes(activities: [:raw_score])
+            .includes(activities: [:raw_score, {standard: :standard_category}])
             .includes(:unit_template_category)
             .order(order_number: :asc)
 

--- a/services/QuillLMS/config/initializers/active_model_serializers.rb
+++ b/services/QuillLMS/config/initializers/active_model_serializers.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 ActiveModelSerializers.config.adapter = :json
+ActiveModelSerializers.config.default_includes = '**'

--- a/services/QuillLMS/spec/serializers/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/activity_serializer_spec.rb
@@ -57,4 +57,12 @@ describe ActivitySerializer, type: :serializer do
          supporting_info)
     end
   end
+
+  it 'deep serializes relationships' do
+    activity = create(:activity)
+
+    serialization = ActivitySerializer.new(activity)
+
+    expect(serialization.as_json[:activity][:standard][:standard_category][:id]).to eq(activity.standard.standard_category.id)
+  end
 end


### PR DESCRIPTION
## WHAT
Set `ActiveModelSerializer` config to `default_include` `**`.  This makes the serializer serialize descendants across multiple levels.
## WHY
This was the old default behavior for the Gem, and was changed without clear documentation in the version that we updated to in July (#9350).  So this basically restores us to default behavior we were already relying on.
## HOW
- set `ActiveModelSerializer.config.default_include = '**'` in the intitializer.
- as a side issue, add an `include` value that we're using in this query to mildly reduce database load

### Notion Card Links
https://www.notion.so/quill/CCSS-and-Tool-showing-as-NA-in-activity-pack-editor-94857edfc0fb4921aaded5aa7d6340b7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
