### PR TITLE
Hotfix to add exceptions to skip grammar feedback.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -4,7 +4,9 @@ module Evidence
   module Grammar
     class Client
       API_TIMEOUT = 5
-      ALLOWED_PAYLOAD_KEYS = ['gapi_error', 'highlight']
+      HIGHLIGHT_KEY = 'highlight'
+      ERROR_KEY = 'gapi_error'
+      ALLOWED_PAYLOAD_KEYS = [ERROR_KEY, HIGHLIGHT_KEY]
       API_ENDPOINT = ENV['GRAMMAR_API_DOMAIN']
 
       class APIError < StandardError; end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -72,12 +72,12 @@ module Evidence
       ]
 
       def self.run(client_response)
-        return default_payload if has_exception(client_response)
+        return default_payload if contains_exception?(client_response)
 
         super(client_response)
       end
 
-      def self.has_exception(client_response)
+      def self.contains_exception?(client_response)
         highlights = client_response[Evidence::Grammar::Client::HIGHLIGHT_KEY]
         highlight_texts = highlights
           &.map {|hash| hash[:text]}

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -79,12 +79,15 @@ module Evidence
 
       def self.contains_exception?(client_response)
         highlights = client_response[Evidence::Grammar::Client::HIGHLIGHT_KEY]
-        highlight_texts = highlights
+
+        highlight_texts(highlights).any?{|h| EXCEPTIONS.any? {|e| h.match(e)}}
+      end
+
+      def self.highlight_texts(highlights)
+        highlights
           &.map {|hash| hash[:text]}
           &.compact
           &.map(&:downcase)
-
-        highlight_texts.any?{|h| EXCEPTIONS.any? {|e| h.match(e)}}
       end
 
       def self.error_to_rule_uid

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -65,6 +65,28 @@ module Evidence
         'who_s_vs_whose' => 'b4d8997f-736b-41fc-92c5-b410981b43cb'
       }
 
+      EXCEPTIONS = [
+        "cloning mammals",
+        "United States",
+        "Texas"
+      ]
+
+      def self.run(client_response)
+        return default_payload if has_exception(client_response)
+
+        super(client_response)
+      end
+
+      def self.has_exception(client_response)
+        highlights = client_response[Evidence::Grammar::Client::HIGHLIGHT_KEY]
+        highlight_texts = highlights
+          &.map {|hash| hash[:text]}
+          &.compact
+          &.map(&:downcase)
+
+        highlight_texts.any?{|h| EXCEPTIONS.any? {|e| h.match(e)}}
+      end
+
       def self.error_to_rule_uid
         RULE_MAPPING
       end
@@ -74,9 +96,8 @@ module Evidence
       end
 
       def self.error_name
-        'gapi_error'
+        Evidence::Grammar::Client::ERROR_KEY
       end
     end
-
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
@@ -90,7 +90,7 @@ module Evidence
               {
                 'highlight' => [{
                 'type': 'response',
-                'text': exceptions.first.split(' ').first,
+                'text': exceptions.first.split.first,
                 'character': 0
                 }]
               }

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
@@ -6,8 +6,6 @@ module Evidence
   module Grammar
     RSpec.describe 'FeedbackAssembler' do
       describe '#run' do
-        let(:example_error) { 'example_error' }
-        let(:example_rule_uid) { 123 }
         let(:client_response) do
           {
             'highlight' => [{
@@ -17,20 +15,20 @@ module Evidence
             }]
           }
         end
+        let!(:rule) do
+          create(:evidence_rule, uid: 'e4cf078b-a838-445e-a873-c795da9f7ed8', optimal: false, rule_type: 'grammar')
+        end
+        let(:error_name) { 'their_vs_there_vs_they_re_they_re_optimal' }
 
         context 'specific rule checks' do
           context 'their_vs_there_vs_they_re_they_re_optimal' do
-            let!(:rule) do
-              create(:evidence_rule, uid: 'e4cf078b-a838-445e-a873-c795da9f7ed8', optimal: false, rule_type: 'grammar')
-            end
-
             it 'should return the expected rule uid' do
-              error_name = 'their_vs_there_vs_they_re_they_re_optimal'
+              uid = rule.uid
               expect(
                 FeedbackAssembler.run(
                   client_response.merge({FeedbackAssembler.error_name => error_name})
                 )[:rule_uid]
-              ).to eq rule.uid
+              ).to eq uid
             end
           end
         end
@@ -42,6 +40,65 @@ module Evidence
                 client_response.merge({FeedbackAssembler.error_name => ''})
               )[:optimal]
             ).to eq true
+          end
+        end
+
+
+        context 'grammar highlight has an exception' do
+          before do
+            stub_const("Evidence::Grammar::FeedbackAssembler::EXCEPTIONS", exceptions)
+          end
+
+          let(:exceptions) { ['some phrase', 'other']}
+
+          subject { FeedbackAssembler.run(client_response.merge({FeedbackAssembler.error_name => error_name}))}
+
+          context 'exact match' do
+            let(:client_response) do
+              {
+                'highlight' => [{
+                'type': 'response',
+                'text': exceptions.first,
+                'character': 0
+                }]
+              }
+            end
+
+            it 'should return optimal=true' do
+              expect(subject[:optimal]).to be true
+            end
+          end
+
+          context 'not matching capitalization' do
+            let(:client_response) do
+              {
+                'highlight' => [{
+                'type': 'response',
+                'text': exceptions.first.upcase,
+                'character': 0
+                }]
+              }
+            end
+
+            it 'should return optimal=true' do
+              expect(subject[:optimal]).to be true
+            end
+          end
+
+          context 'partial match' do
+            let(:client_response) do
+              {
+                'highlight' => [{
+                'type': 'response',
+                'text': exceptions.first.split(' ').first,
+                'character': 0
+                }]
+              }
+            end
+
+            it 'should return optimal=false' do
+              expect(subject[:optimal]).to be false
+            end
           end
         end
       end


### PR DESCRIPTION
## WHAT
For a new Subject Verb Agreement (SVA) grammar rule we are incorrectly flagging some items as grammar errors when they are not. Notably `"United States is", "cloning mammals is", "Texas is"` are all being flagged. This created
## WHY
So students can finish these activities.
## HOW
Check if the highlight matches a case insensitive version of the string, if so, flag as `optimal`. Note this is a blunt object, and will essentially ignore all grammar errors for phrases involving these strings.
### Screenshots


### Notion Card Links
https://www.notion.so/quill/SVA-with-plural-to-be-optimal-Exception-List-3d402d8c76b146ef8e9186c201715795

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | Yes
