### PR TITLE
Hotfix to add exceptions to skip grammar feedback. (#9562)

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/client.rb
@@ -4,7 +4,9 @@ module Evidence
   module Grammar
     class Client
       API_TIMEOUT = 5
-      ALLOWED_PAYLOAD_KEYS = ['gapi_error', 'highlight']
+      HIGHLIGHT_KEY = 'highlight'
+      ERROR_KEY = 'gapi_error'
+      ALLOWED_PAYLOAD_KEYS = [ERROR_KEY, HIGHLIGHT_KEY]
       API_ENDPOINT = ENV['GRAMMAR_API_DOMAIN']
 
       class APIError < StandardError; end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -65,6 +65,31 @@ module Evidence
         'who_s_vs_whose' => 'b4d8997f-736b-41fc-92c5-b410981b43cb'
       }
 
+      EXCEPTIONS = [
+        "cloning mammals",
+        "United States",
+        "Texas"
+      ]
+
+      def self.run(client_response)
+        return default_payload if contains_exception?(client_response)
+
+        super(client_response)
+      end
+
+      def self.contains_exception?(client_response)
+        highlights = client_response[Evidence::Grammar::Client::HIGHLIGHT_KEY]
+
+        highlight_texts(highlights).any?{|h| EXCEPTIONS.any? {|e| h.match(e)}}
+      end
+
+      def self.highlight_texts(highlights)
+        highlights
+          &.map {|hash| hash[:text]}
+          &.compact
+          &.map(&:downcase)
+      end
+
       def self.error_to_rule_uid
         RULE_MAPPING
       end
@@ -74,9 +99,8 @@ module Evidence
       end
 
       def self.error_name
-        'gapi_error'
+        Evidence::Grammar::Client::ERROR_KEY
       end
     end
-
   end
 end


### PR DESCRIPTION
* Hotfix to add exceptions to skip grammar feedback.

* Rename for lint

* Lint refactor.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
