### PR TITLE
lms/fix-diagnostic-report-completed-count

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -396,7 +396,7 @@ class Teachers::UnitsController < ApplicationController
         grouped_record[:post] = post_test || { activity_name: Activity.find_by_id(record['post_test_id'])&.name, unit_template_id: ActivitiesUnitTemplate.find_by_activity_id(record['post_test_id'])&.unit_template_id }
         grouped_record[:pre] = record_with_aggregated_activity_sessions(diagnostic_records, record['activity_id'], record['classroom_id'], nil)
       else
-        grouped_record[:pre]['completed_count'] = ActivitySession.where(activity_id: record['activity_id'], classroom_unit_id: record['classroom_unit_id'], state: 'finished', user_id: record['assigned_student_ids']).size
+        grouped_record[:pre]['completed_count'] = ActivitySession.select(:user_id).distinct.where(activity_id: record['activity_id'], classroom_unit_id: record['classroom_unit_id'], state: 'finished', user_id: record['assigned_student_ids']).size
         grouped_record[:pre]['assigned_count'] = record['assigned_student_ids'].size
       end
       if index_of_existing_classroom

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -151,6 +151,18 @@ describe Teachers::UnitsController, type: :controller do
         expect(response.body).to eq(expected_response.to_json)
       end
     end
+
+    it 'should not double-count a user for completed_count if they completed the activity twice' do
+      create(:activity_session,
+        user: student,
+        activity: diagnostic_activity,
+        classroom_unit: classroom_unit
+      )
+
+      get :diagnostic_units
+
+      expect(response.body).to eq(expected_response.to_json)
+    end
   end
 
   describe '#hide' do


### PR DESCRIPTION
## WHAT
Ensure that we do not count a user twice in completed_count
## WHY
In weird cases when a single user completes ActivitySessions for the same diagnostic assignment.  This basically never comes up, but does occur in some very weird edge cases where assignments are deleted and recreated and moved between classrooms
## HOW
Just add `.select(:user_id).distinct` to the query that we use a count on to figure out how many people have completed a given diagnostic.

### Notion Card Links
https://www.notion.so/quill/Can-t-see-all-assigned-packs-in-Demo-account-081b06628fe34e46a09519bf4e4f9bae

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
