### PR TITLE
use new env var in database.yml

### DIFF
--- a/services/QuillLMS/config/database.yml
+++ b/services/QuillLMS/config/database.yml
@@ -16,7 +16,7 @@ primary_db_env: &primary_db_env
 
 replica_db_env: &replica_db_env
   <<: *default
-  url: <%= ENV['REPLICA_DATABASE_URL'] || ENV['DATABASE_URL'] %>
+  url: <%= ENV['REPLICA_DATABASE_CONNECTION_POOL_URL'] || ENV['REPLICA_DATABASE_URL'] || ENV['DATABASE_URL'] %>
   replica: true
 
 heroku_env: &heroku_env


### PR DESCRIPTION
## WHAT
Have database.yml look for a connection pool variable first, if it exists. 
Ultimately, we will have PGBouncer instances in front of both the follower and leader. However, to minimize the complexity of the rollout, we're starting with the replica only.

## WHY
So that the app will recognize and use a connection pooler if it is available. This also lets us roll back PGBouncer using only env vars, rather than a full deploy.


## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Heroku-Connection-Limit-3979d6564d194b1da7fc50544ff1e51f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no code change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes 
