### PR TITLE
Grammar hot fix - client response uses string keys.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/grammar.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/grammar.rb
@@ -4,8 +4,8 @@ module Evidence
   class Check::Grammar < Check::Base
 
     def run
-      grammar_client = Grammar::Client.new(entry: entry, prompt_text: prompt.text)
-      @response = Grammar::FeedbackAssembler.run(grammar_client.post)
+      grammar_client = ::Evidence::Grammar::Client.new(entry: entry, prompt_text: prompt.text)
+      @response = ::Evidence::Grammar::FeedbackAssembler.run(grammar_client.post)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
@@ -4,8 +4,8 @@ module Evidence
   class Check::Opinion < Check::Base
 
     def run
-      opinion_client = Opinion::Client.new(entry: entry, prompt_text: prompt.text)
-      @response = Opinion::FeedbackAssembler.run(opinion_client.post)
+      opinion_client = ::Evidence::Opinion::Client.new(entry: entry, prompt_text: prompt.text)
+      @response = ::Evidence::Opinion::FeedbackAssembler.run(opinion_client.post)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -85,7 +85,7 @@ module Evidence
 
       def self.highlight_texts(highlights)
         highlights
-          &.map {|hash| hash[:text]}
+          &.map {|hash| hash['text']}
           &.compact
           &.map(&:downcase)
       end

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
@@ -9,9 +9,9 @@ module Evidence
         let(:client_response) do
           {
             'highlight' => [{
-              'type': 'response',
-              'text': 'someText',
-              'character': 0
+              'type' => 'response',
+              'text' => 'someText',
+              'character' => 0
             }]
           }
         end
@@ -57,9 +57,9 @@ module Evidence
             let(:client_response) do
               {
                 'highlight' => [{
-                'type': 'response',
-                'text': exceptions.first,
-                'character': 0
+                'type' => 'response',
+                'text' => exceptions.first,
+                'character' => 0
                 }]
               }
             end
@@ -73,9 +73,9 @@ module Evidence
             let(:client_response) do
               {
                 'highlight' => [{
-                'type': 'response',
-                'text': exceptions.first.upcase,
-                'character': 0
+                'type' => 'response',
+                'text' => exceptions.first.upcase,
+                'character' => 0
                 }]
               }
             end
@@ -89,9 +89,9 @@ module Evidence
             let(:client_response) do
               {
                 'highlight' => [{
-                'type': 'response',
-                'text': exceptions.first.split.first,
-                'character': 0
+                'type' => 'response',
+                'text' => exceptions.first.split.first,
+                'character' => 0
                 }]
               }
             end


### PR DESCRIPTION
## WHAT
Small hotfix for a hotfix earlier. An API response we are using uses `strings` not `symbols` for its keys.
## WHY
I was finally able to get an accurate live test and found this issue. We want the earlier hotfix to work.
## HOW
Update tests to be strings. Fix code.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change, want to get it out.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | Yes
