### PR TITLE
Grammar hotfix - Match downcast exception in grammar model.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/grammar/feedback_assembler.rb
@@ -65,10 +65,11 @@ module Evidence
         'who_s_vs_whose' => 'b4d8997f-736b-41fc-92c5-b410981b43cb'
       }
 
+
       EXCEPTIONS = [
         "cloning mammals",
-        "United States",
-        "Texas"
+        "united states",
+        "texas"
       ]
 
       def self.run(client_response)
@@ -80,7 +81,7 @@ module Evidence
       def self.contains_exception?(client_response)
         highlights = client_response[Evidence::Grammar::Client::HIGHLIGHT_KEY]
 
-        highlight_texts(highlights).any?{|h| EXCEPTIONS.any? {|e| h.match(e)}}
+        highlight_texts(highlights).any?{|h| EXCEPTIONS.any? {|e| h.match(e.downcase)}}
       end
 
       def self.highlight_texts(highlights)

--- a/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/grammar/feedback_assembler_spec.rb
@@ -100,9 +100,25 @@ module Evidence
               expect(subject[:optimal]).to be false
             end
           end
+
+          context 'capitalization in exception' do
+            let(:exceptions) { ['Some Phrase']}
+            let(:client_response) do
+              {
+                'highlight' => [{
+                'type' => 'response',
+                'text' => exceptions.first,
+                'character' => 0
+                }]
+              }
+            end
+
+            it 'should return optimal=true' do
+              expect(subject[:optimal]).to be true
+            end
+          end
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
## WHAT
Fix for the hotfix for grammar exceptions to check for downcase on both sides of equation.
## WHY
Because haste makes waste and I missed this in testing.
## HOW
`.downcase`. Make a failing test then fix it.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'.
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | Yes
