### PR TITLE
lms/sort-classrooms-by-order

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -182,8 +182,6 @@ class Teachers::ClassroomsController < ApplicationController
   # rubocop:enable Metrics/CyclomaticComplexity
 
   private def format_classrooms_for_index
-    has_classroom_order = ClassroomsTeacher.where(user_id: current_user.id).all? { |classroom| classroom.order }
-
     classrooms = Classroom.unscoped
       .joins(:classrooms_teachers)
       .where(classrooms_teachers: {user_id: current_user.id})
@@ -192,7 +190,7 @@ class Teachers::ClassroomsController < ApplicationController
         coteacher_classroom_invitations: :invitation,
         classrooms_teachers: :user
       )
-      .order(has_classroom_order ? 'classrooms_teachers.order' : 'created_at DESC')
+      .order('classrooms_teachers.order ASC, created_at DESC')
 
     student_ids = classrooms.flat_map(&:students).map(&:id)
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -245,7 +245,7 @@ describe Teachers::ClassroomsController, type: :controller do
             end
           end
 
-          it 'should return classrooms in order of creation date if only some classrooms_teacher entries have order property' do
+          it 'should return classrooms in order of order with a fallback to creation date if only some classrooms_teacher entries have order property' do
             ct1 = ClassroomsTeacher.where(classroom_id: classroom1.id).first
             ct1.order = 1
             ct1.save!
@@ -253,9 +253,9 @@ describe Teachers::ClassroomsController, type: :controller do
             get :index, as: :json
 
             parsed_response = JSON.parse(response.body)
-            expect(parsed_response["classrooms"][0]["id"]).to eq(classroom3.id)
-            expect(parsed_response["classrooms"][1]["id"]).to eq(classroom2.id)
-            expect(parsed_response["classrooms"][2]["id"]).to eq(classroom1.id)
+            expect(parsed_response["classrooms"][0]["id"]).to eq(classroom1.id)
+            expect(parsed_response["classrooms"][1]["id"]).to eq(classroom3.id)
+            expect(parsed_response["classrooms"][2]["id"]).to eq(classroom2.id)
           end
 
           it 'should return classrooms ordered by order properity if all classrooms_teacher entries have order property' do


### PR DESCRIPTION
## WHAT
Tweak sort order to work in cases where some classrooms are deleted
## WHY
We were running into issues in production where some teachers had classrooms that had been deleted (marked visible: false) before they ordered their classrooms.  This resulted in a mix of ordered and unordered classrooms which caused order to be ignored for sorting.
## HOW
Instead of using a ternary to sort two different ways, just combine the two sorting systems so that cases where there are mixed systems, it still sorts as expected.

### Notion Card Links
https://www.notion.so/quill/Reordering-classes-doesn-t-save-ea53232924f74743a7a7ead5700a4074

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
