### PR TITLE
Add rake tasks to copy staging configs to all staging environments.

### DIFF
--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -6,7 +6,7 @@ namespace :staging_config do
 
   # bundle exec rake staging_config:copy_from_staging_to_personals\[SOME_KEY\]
   desc "copy a config from main staging to all other staging envs"
-  task :copy_from_staging_to_personals, [:config] do |t,args|
+  task :copy_from_staging_to_personals, [:config] => :environment do |t,args|
     include StagingConfigCommands
 
     config = args[:config]
@@ -21,7 +21,7 @@ namespace :staging_config do
 
   # bundle exec rake staging_config:set_all\[TEST_KEY='some_value'\]
   desc "set a config key/value on all staging envs"
-  task :set_all, [:config_setting] do |t,args|
+  task :set_all, [:config_setting] => :environment do |t,args|
     include StagingConfigCommands
     config_setting = args[:config_setting]
 
@@ -32,7 +32,7 @@ namespace :staging_config do
 
   # bundle exec rake staging_config:remove_all\[TEST_KEY\]
   desc "delete a config from all staging envs"
-  task :remove_all, [:config] do |t,args|
+  task :remove_all, [:config] => :environment do |t,args|
     include StagingConfigCommands
     config = args[:config]
 
@@ -58,10 +58,10 @@ namespace :staging_config do
     end
 
     def run_cmd(command)
-      stdout_str, stderr_str, _ = Open3.capture3(command)
+      stdout_str, stderr_str, = Open3.capture3(command)
 
-      puts "#{stdout_str}"
-      puts "#{stderr_str}"
+      puts stdout_str
+      puts stderr_str
 
       stdout_str
     end

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+namespace :staging_config do
+
+  # bundle exec rake staging_config:copy_from_staging_to_personals\[SOME_KEY\]
+  desc "copy a config from main staging to all other staging envs"
+  task :copy_from_staging_to_personals, [:config] do |t,args|
+    include StagingConfigCommands
+
+    config = args[:config]
+
+    staging_value = get_config(config, STAGING_APP)
+    config_setting = "#{config}=#{staging_value}"
+
+    STAGING_PERSONAL_APPS.each do |app|
+      set_config(config_setting, app)
+    end
+  end
+
+  # bundle exec rake staging_config:set_all\[TEST_KEY='some_value'\]
+  desc "set a config key/value on all staging envs"
+  task :set_all, [:config_setting] do |t,args|
+    include StagingConfigCommands
+    config_setting = args[:config_setting]
+
+    ALL_STAGING_APPS.each do |app|
+      set_config(config_setting, app)
+    end
+  end
+
+  # bundle exec rake staging_config:remove_all\[TEST_KEY\]
+  desc "delete a config from all staging envs"
+  task :remove_all, [:config] do |t,args|
+    include StagingConfigCommands
+    config = args[:config]
+
+    ALL_STAGING_APPS.each do |app|
+      remove_config(config, app)
+    end
+  end
+
+  module StagingConfigCommands
+    def get_config(config, app)
+      # returns a newline, so chomp it
+      run_cmd("heroku config:get #{config} --app=#{app}").chomp
+    end
+
+    def set_config(config_setting, app)
+      run_cmd("heroku config:set #{config_setting} --app=#{app}")
+    end
+
+    def remove_config(config, app)
+      puts "Removing config for #{app}: #{config}"
+
+      run_cmd("heroku config:unset #{config} --app=#{app}")
+    end
+
+    def run_cmd(command)
+      stdout_str, stderr_str, _ = Open3.capture3(command)
+
+      puts "#{stdout_str}"
+      puts "#{stderr_str}"
+
+      stdout_str
+    end
+
+    STAGING_APP = 'empirical-grammar-staging'
+    STAGING_PERSONAL_APPS = %w(
+      quill-lms-brendan
+      quill-lms-cissy
+      quill-lms-dan
+      quill-lms-emilia
+      quill-lms-eric
+      quill-lms-pkong
+      quill-lms-thomas
+      empirica-grammar-security
+    )
+    ALL_STAGING_APPS = STAGING_PERSONAL_APPS + [STAGING_APP]
+  end
+end

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -41,6 +41,8 @@ namespace :staging_config do
     end
   end
 
+  # Add basic wrapper around heroku commands:
+  # Reference: https://devcenter.heroku.com/articles/config-vars
   module StagingConfigCommands
     def get_config(config, app)
       # returns a newline, so chomp it

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -54,8 +54,6 @@ namespace :staging_config do
     end
 
     def remove_config(config, app)
-      puts "Removing config for #{app}: #{config}"
-
       run_cmd("heroku config:unset #{config} --app=#{app}")
     end
 


### PR DESCRIPTION
## WHAT
Add a rake task that allows you to:
1. Set a config and value for all staging environments
2. Remove a config from all staging environments
3. Copy a config on main staging to the rest of the staging environments
## WHY
We have a lot of staging environments and are changing configs a good amount. That can lead to broken environments, manual fixes, or just drift from the correct settings.
## HOW
Simple wrapper around the heroku commands.
### Screenshots
<img width="1460" alt="Screen Shot 2022-08-22 at 12 04 39 PM" src="https://user-images.githubusercontent.com/1304933/185967219-57251d87-5b27-4969-b959-31dcc82e3341.png">


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, just going to write rake tasks from now on and live on the edge.
Have you deployed to Staging? |  No deploy, but I set and unset staging vars
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
