### PR TITLE
fix grade level warning modal on safari

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/grade_level_warning_modal.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/grade_level_warning_modal.scss
@@ -8,9 +8,10 @@
   }
 
   .modal-body::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba(0, 0, 0, .5);
-    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
+    background: #7f7f7f;
+    -webkit-box-shadow: inset 0 0 6px #7f7f7f;
   }
 
   .quill-modal.grade-level-warning-modal {

--- a/services/QuillLMS/app/assets/stylesheets/pages/grade_level_warning_modal.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/grade_level_warning_modal.scss
@@ -1,82 +1,100 @@
-.quill-modal.grade-level-warning-modal {
-  max-width: 816px;
-  width: calc(100vw - 20px);
-  min-height: min-content;
-  max-height: calc(100vh - 20px);
-  overflow: scroll;
-  .title {
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 32px;
-    padding: 32px 32px 0px;
-  }
-  .data-table {
-    max-height: 199px;
-    margin-bottom: 32px;
-    a {
-      color: #027360;
-    }
-    .data-table-row:last-of-type {
-      border-bottom: 1px solid #e0e0e0 !important;
-    }
-  }
-  .modal-body {
-    margin-bottom: 0px;
-    padding: 16px 32px 32px;
-    p:last-of-type {
-      margin-bottom: 0px;
-    }
-    .warning {
-      margin: 0px;
-      color: #EB4F47;
-      display: flex;
-      img {
-        margin-right: 8px;
-      }
-    }
-  }
-  .grade-level-warning-modal-footer {
-    display: flex;
-    padding: 0px 32px 32px;
-    justify-content: space-between;
-    align-items: center;
-    .checkbox-wrapper {
-      display: flex;
-      .quill-checkbox {
-        margin-right: 8px;
-      }
-    }
-    .buttons {
-      display: flex;
-      .quill-button:first-of-type {
-        margin-right: 8px;
-      }
-    }
+.modal-container.grade-level-warning-modal-container {
+  .modal-background {
+    z-index: 3;
   }
 
-  @media (max-width: 710px) {
-    .grade-level-warning-modal-footer {
-      flex-direction: column;
-      align-items: flex-start;
-      .checkbox-wrapper {
-        margin-bottom: 16px;
+  .modal-body::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  .modal-body::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+  }
+
+  .quill-modal.grade-level-warning-modal {
+    max-width: 816px;
+    width: calc(100vw - 20px);
+    min-height: min-content;
+    max-height: calc(100vh - 20px);
+    overflow: scroll;
+    .title {
+      font-weight: 700;
+      font-size: 24px;
+      line-height: 32px;
+      padding: 32px 32px 0px;
+    }
+    .data-table {
+      max-height: 199px;
+      margin-bottom: 32px;
+      a {
+        color: #027360;
+      }
+      .data-table-row:last-of-type {
+        border-bottom: 1px solid #e0e0e0 !important;
       }
     }
-  }
-  @media (max-width: 477px) {
-    h3 {
-      padding: 16px 16px 0px;
-    }
     .modal-body {
-      padding: 16px;
+      margin-bottom: 0px;
+      padding: 16px 32px 32px;
+      max-height: 80vh;
+      overflow: scroll;
+      p:last-of-type {
+        margin-bottom: 0px;
+      }
+      .warning {
+        margin: 0px;
+        color: #EB4F47;
+        display: flex;
+        img {
+          margin-right: 8px;
+        }
+      }
     }
     .grade-level-warning-modal-footer {
-      padding: 0px 16px 16px;
+      display: flex;
+      padding: 0px 32px 32px;
+      justify-content: space-between;
+      align-items: center;
+      .checkbox-wrapper {
+        display: flex;
+        .quill-checkbox {
+          margin-right: 8px;
+        }
+      }
+      .buttons {
+        display: flex;
+        .quill-button:first-of-type {
+          margin-right: 8px;
+        }
+      }
     }
-    .buttons {
-      flex-direction: column;
-      .quill-button:first-of-type {
-        margin-bottom: 16px;
+
+    @media (max-width: 710px) {
+      .grade-level-warning-modal-footer {
+        flex-direction: column;
+        align-items: flex-start;
+        .checkbox-wrapper {
+          margin-bottom: 16px;
+        }
+      }
+    }
+    @media (max-width: 477px) {
+      h3 {
+        padding: 16px 16px 0px;
+      }
+      .modal-body {
+        padding: 16px;
+      }
+      .grade-level-warning-modal-footer {
+        padding: 0px 16px 16px;
+      }
+      .buttons {
+        flex-direction: column;
+        .quill-button:first-of-type {
+          margin-bottom: 16px;
+        }
       }
     }
   }


### PR DESCRIPTION
## WHAT
Make sure Grade Level Warning Modal doesn't exceed height of the page on Safari.

## WHY
There is a [bug](https://stackoverflow.com/a/19121022) where `max-height` does not work for the table elements on Safari, resulting in a bad UI where with enough activities, the modal can exceed the height of the page.

## HOW
I couldn't quite get the CSS working to mimic the view on Chrome, but I was able to cap the height of the `modal-body` so that it will stay within the confines of the page and just scroll for extra content.

### Screenshots
<img width="1366" alt="Screen Shot 2022-08-22 at 2 56 50 PM" src="https://user-images.githubusercontent.com/18669014/185998088-357727de-b4fa-4eb7-a2db-d72ca763685e.png">


### Notion Card Links
https://www.notion.so/quill/Bug-Assign-Activity-Grade-Level-Warning-Modal-Safari-doesn-t-recognize-max-height-in-tables-099c27e126b84b2cb2a698a3d5880a11

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for CSS
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? |  YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
