### PR TITLE
lms/show-evidence-completed-in-activity-feed

### DIFF
--- a/services/QuillLMS/app/models/teacher_activity_feed.rb
+++ b/services/QuillLMS/app/models/teacher_activity_feed.rb
@@ -47,11 +47,11 @@ class TeacherActivityFeed < RedisFeed
   end
 
   private def text_for_score(key, percentage)
-    return '' unless percentage
-
     if ActivityClassification.unscored?(key)
       return ActivitySession::COMPLETED
     end
+
+    return '' unless percentage
 
     if percentage >= ProficiencyEvaluator.proficiency_cutoff
       ActivitySession::PROFICIENT

--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -106,6 +106,8 @@ FactoryBot.define do
 
     factory :evidence_activity_session do
       activity { create(:evidence_activity) }
+      # We explicitly don't record percentraes for Evidence sessions
+      percentage { nil }
     end
 
     factory :proofreader_activity_session do

--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -106,7 +106,7 @@ FactoryBot.define do
 
     factory :evidence_activity_session do
       activity { create(:evidence_activity) }
-      # We explicitly don't record percentraes for Evidence sessions
+      # We explicitly don't record percentages for Evidence sessions
       percentage { nil }
     end
 


### PR DESCRIPTION
## WHAT
Ensure that Evidence activities show as 'completed' in activity feed
## WHY
We want the Activity Feed to accurately show Evidence activities as 'completed' the same way we do for Diagnostic activities
## HOW
There was an early return to protect this code from errors with calculating stuff around percentages, but it was accidentally early-returning on Evidence activities (which we explicitly don't record a `percentage` value for).  This wasn't caught in existing specs because the factory to create Evidence activity sessions wasn't explicitly using `nil` for percentage.  Updated the factory to confirm existing specs would catch this condition, then moved the early return to after the `unscored?` check.

### Notion Card Links
https://www.notion.so/quill/Show-Completed-in-the-activity-feed-for-Evidence-activities-39a3be9a81ea436885b9610b3ae9fc25

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
