### PR TITLE
Add in retry for integration spec

### DIFF
--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Activity Pack Assignment' do
 
   before { student.update(password: 'password') }
 
-  it 'teachers can assign an activity packs to their students', :js do
+  it 'teachers can assign an activity packs to their students', :js, retry: 3 do
     login_user(teacher.email, teacher.password)
     click_button "Let's go!"
     click_on 'Student Reports'


### PR DESCRIPTION
## WHAT
Add automatic retry for integration specs.

## WHY
I've used this in the past.  Hopefully it will catch some bizarre constant loading issues like this one: https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/17541/workflows/bf311c02-5aa0-49fc-a92f-2c91cbf55393/jobs/234559

## HOW
Add `retry: 3` to the spec in question.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
