### PR TITLE
Remove rescue handling of invalid authenticity token

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -8,9 +8,6 @@ class ApplicationController < ActionController::Base
   include QuillAuthentication
   include DemoAccountBannerLinkGenerator
 
-  rescue_from ActionController::InvalidAuthenticityToken,
-    with: :handle_invalid_authenticity_token
-
   # session keys
   CLEVER_REDIRECT = :clever_redirect
   EXPIRED_SESSION_REDIRECT = :expired_session_redirect
@@ -124,15 +121,6 @@ class ApplicationController < ActionController::Base
       route_redirects_to_classrooms_index?(route) ||
       route_redirects_to_diagnostic?(route)
     )
-  end
-
-  private def handle_invalid_authenticity_token
-    flash[:error] = t('actioncontroller.errors.invalid_authenticity_token')
-
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: root_path) }
-      format.json { render json: { redirect: URI.parse(request.referer).path }, status: 303 }
-    end
   end
 
   protected def check_staff_for_extended_session

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -183,34 +183,4 @@ describe ApplicationController, type: :controller do
       end
     end
   end
-
-  context '#handle_invalid_inauthenticity_token' do
-    controller do
-      def custom
-        raise ActionController::InvalidAuthenticityToken
-      end
-    end
-
-    let(:referer) { 'http://test.host/referer_path' }
-    let(:redirect_path) { URI.parse(referer).path }
-
-    before do
-      routes.draw { post 'custom' => "anonymous#custom" }
-      request.headers['HTTP_REFERER'] = referer
-    end
-
-    it 'handles InvalidAuthenticityToken error with format: :json' do
-      post :custom, params: {}, as: :json
-
-      expect(flash[:error]).to eq(I18n.t('actioncontroller.errors.invalid_authenticity_token'))
-      expect(response.body).to eq({ redirect: redirect_path }.to_json)
-    end
-
-    it 'handles InvalidAuthenticityToken error with format: :html' do
-      post :custom, params: {}
-
-      expect(flash[:error]).to eq(I18n.t('actioncontroller.errors.invalid_authenticity_token'))
-      expect(response).to redirect_to(redirect_path)
-    end
-  end
 end


### PR DESCRIPTION
## WHAT
Remove a rescue clause for handling invalid authenticity token

## WHY
Users are encountering unexpected behavior that I believe is happening due to redirects with this rescue clause.  I added this in over the summer, but it might be too blunt of an approach for handling these invalid tokens.

## HOW
Remove the rescue_from related code for invalid authenticity token.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Google-synced-users-asked-to-reauthorize-account-every-time-they-log-in-c0420e9ec6cb4dcc9ef3067a6d380fbc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
