### PR TITLE
fix issue where activity row tooltip was rendering too narrow

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/custom_activity_pack/activity_row.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/custom_activity_pack/activity_row.scss
@@ -22,6 +22,7 @@
       .name-and-checkbox-wrapper {
         display: flex;
         align-items: flex-start;
+        width: 100%;
         .quill-checkbox {
           margin-right: 16px;
           margin-top: 2px;


### PR DESCRIPTION
## WHAT
Fix issue on smaller screen sizes where activities with short names were having the activity row tooltip render too narrowly.

## WHY
We want the tooltip width to be consistent (and not ugly).

## HOW
Just add an additional CSS rule and test a couple of different configurations to confirm this doesn't mess with anything else.

### Screenshots
<img width="862" alt="Screen Shot 2022-08-23 at 11 21 21 AM" src="https://user-images.githubusercontent.com/18669014/186198828-d03b7885-0d0f-4ec6-9b79-ffec4010d2ee.png">

### Notion Card Links
https://www.notion.so/quill/Tooltip-rendering-too-narrow-on-tablet-and-below-c0c734f924c84cdfa1ee8434f37d06b0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No tests for CSS
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
