### PR TITLE
lms/handle-vitally-sync-rate-limit

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
@@ -10,9 +10,10 @@ class SyncVitallyOrganizationWorker
     district = District.find(district_id)
     api = VitallyRestApi.new
     response = api.create("organizations", district.vitally_data)
-    if request_rate_limited?(response)
-      requeue_after_rate_limit(district_id)
-    end
+
+    return unless request_rate_limited?(response)
+
+    requeue_after_rate_limit(district_id)
   end
 
   private def request_rate_limited?(response)

--- a/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
@@ -3,9 +3,24 @@
 class SyncVitallyOrganizationWorker
   include Sidekiq::Worker
 
+  MINIMUM_REQUEUE_WAIT_MINUTES = 2
+  MAXIMUM_REQUEUE_WAIT_MINUTES = 20
+
   def perform(district_id)
     district = District.find(district_id)
     api = VitallyRestApi.new
-    api.create("organizations", district.vitally_data)
+    response = api.create("organizations", district.vitally_data)
+    if request_rate_limited?(response)
+      requeue_after_rate_limit(district_id)
+    end
+  end
+
+  private def request_rate_limited?(response)
+    response.code == 429
+  end
+
+  private def requeue_after_rate_limit(district_id)
+    delay = rand(MINIMUM_REQUEUE_WAIT_MINUTES..MAXIMUM_REQUEUE_WAIT_MINUTES)
+    SyncVitallyOrganizationWorker.perform_in(delay.minutes, district_id)
   end
 end

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -6,6 +6,8 @@ class SyncVitallyWorker
   USER_ROLES_TO_SYNC = ['teacher', 'admin', 'auditor']
   FIRST_DAY_OF_SCHOOL_YEAR_MONTH = 7
   FIRST_DAY_OF_SCHOOL_YEAR_DAY = 1
+  # We actually have a 1000/minute rate limit, but we can play it safe
+  ORGANIZATION_RATE_LIMIT_PER_MINUTE = 950
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def perform
@@ -16,8 +18,14 @@ class SyncVitallyWorker
     # Don't synchronize non-production data
     return unless ENV['SYNC_TO_VITALLY'] == 'true'
 
-    districts_to_sync.each do |district|
-      SyncVitallyOrganizationWorker.perform_async(district.id)
+    districts_to_sync.each_slice(ORGANIZATION_RATE_LIMIT_PER_MINUTE).with_index do |slice, index|
+      slice.each do |district|
+        # Our rate limit resets every 60 seconds, but we use a two minute
+        # delay to ensure that we don't run into clock differences between
+        # our servers and Vitally's
+        delay = (2 * index)
+        SyncVitallyOrganizationWorker.perform_in(delay.minutes, district.id)
+      end
     end
     schools_to_sync.each_slice(100) do |school_batch|
       school_ids = school_batch.map { |school| school.id }

--- a/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
@@ -6,13 +6,24 @@ describe SyncVitallyOrganizationWorker do
   subject { described_class.new }
 
   let(:district) { create(:district) }
+  let(:response_double) { double }
+  let(:vitally_api_double) { double }
 
   describe '#perform' do
     it 'build payload from district object and send them to Vitally' do
-      vitally_api_double = double
-
+      expect(response_double).to receive(:code).and_return(200)
+      expect(vitally_api_double).to receive(:create).with('organizations', district.vitally_data).and_return(response_double)
       expect(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
-      expect(vitally_api_double).to receive(:create).with('organizations', district.vitally_data)
+      subject.perform(district.id)
+    end
+
+    it 'should re-queue via perform_in when the Vitally API call rate limits us' do
+      expect(response_double).to receive(:code).and_return(429)
+      expect(vitally_api_double).to receive(:create).and_return(response_double)
+      expect(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
+
+      expect(SyncVitallyOrganizationWorker).to receive(:perform_in).with(anything, district.id)
+
       subject.perform(district.id)
     end
   end

--- a/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
@@ -19,9 +19,9 @@ describe SyncVitallyOrganizationWorker do
 
     context 'hitting API rate limit' do
       before do
-        expect(response_double).to receive(:code).and_return(429)
-        expect(vitally_api_double).to receive(:create).and_return(response_double)
-        expect(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
+        allow(response_double).to receive(:code).and_return(429)
+        allow(vitally_api_double).to receive(:create).and_return(response_double)
+        allow(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
       end
 
       it 'should re-queue via perform_in when the Vitally API call rate limits us' do

--- a/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
@@ -17,14 +17,25 @@ describe SyncVitallyOrganizationWorker do
       subject.perform(district.id)
     end
 
-    it 'should re-queue via perform_in when the Vitally API call rate limits us' do
-      expect(response_double).to receive(:code).and_return(429)
-      expect(vitally_api_double).to receive(:create).and_return(response_double)
-      expect(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
+    context 'hitting API rate limit' do
+      before do
+        expect(response_double).to receive(:code).and_return(429)
+        expect(vitally_api_double).to receive(:create).and_return(response_double)
+        expect(VitallyRestApi).to receive(:new).and_return(vitally_api_double)
+      end
 
-      expect(SyncVitallyOrganizationWorker).to receive(:perform_in).with(anything, district.id)
+      it 'should re-queue via perform_in when the Vitally API call rate limits us' do
+        expect(SyncVitallyOrganizationWorker).to receive(:perform_in).with(anything, district.id)
 
-      subject.perform(district.id)
+        subject.perform(district.id)
+      end
+
+      it 'should report an error to Sentry and NewRelic whenever we hit an API rate limit' do
+        expected_error = SyncVitallyOrganizationWorker::VitallyApiRateLimitException.new("Hit the Vitally REST API rate limit trying to sync District ##{district.id}.  Automatically enqueueing to retry.")
+        expect(ErrorNotifier).to receive(:report).with(expected_error)
+
+        subject.perform(district.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Allow SyncOrganization worker to handle rate-limiting from the API
## WHY
Organizations (`District` records in our database) are synced to Vitally via a different API than users or schools.  This different API has rate-limiting built in rate limiting.  Our limited rate is 1000 items per minute, and resets 60 seconds after the first request, but the API is fast and we're currently attempting to sync 12k items in this 60 second window without checking to see if they succeed.
## HOW
The new code examines the result of our API call, and if it is rate limited (as indicated by a 429 response code, according to Vitally documentation: https://docs.vitally.io/pushing-data-to-vitally/rest-api#rate-limiting) we schedule a retry to happen randomly between 2 and 20 minutes in the future.  The two minute floor should ensure we don't retry until after our current rate limit window passes, and allowing reschedules out to 20 minutes should, on average, allow us to submit around 19~20k records that don't trigger a second rate-limit response.  Given that we only have around 12k records to sync at the moment, that should give us plenty of overhead.

### Notion Card Links
https://www.notion.so/quill/Modify-SyncVitallyOrganizationsWorker-to-gracefully-handle-rate-limiting-from-Vitally-s-new-API-fe0fd9f61d26402786109da6aa697bf6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
