### PR TITLE
backfill college_board flag

### DIFF
--- a/services/QuillLMS/app/models/concerns/flags.rb
+++ b/services/QuillLMS/app/models/concerns/flags.rb
@@ -2,7 +2,7 @@
 
 module Flags
   extend ActiveSupport::Concern
-  FLAGS = %w(production archived alpha beta gamma private)
+  FLAGS = %w(production archived alpha beta gamma private college_board)
 
   module ClassMethods
     def flag_all(flag)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -82,7 +82,8 @@ class User < ApplicationRecord
   GAMMA = 'gamma'
   PRIVATE = 'private'
   ARCHIVED = 'archived'
-  TESTING_FLAGS = [ALPHA, BETA, GAMMA, PRIVATE, ARCHIVED]
+  COLLEGE_BOARD = 'college_board'
+  TESTING_FLAGS = [ALPHA, BETA, GAMMA, PRIVATE, ARCHIVED, COLLEGE_BOARD]
   PERMISSIONS_FLAGS = %w(auditor purchaser school_point_of_contact)
   VALID_FLAGS = TESTING_FLAGS.dup.concat(PERMISSIONS_FLAGS)
 

--- a/services/QuillLMS/lib/tasks/flags.rake
+++ b/services/QuillLMS/lib/tasks/flags.rake
@@ -3,7 +3,29 @@
 require 'csv'
 
 namespace :flags do
+  namespace :activities do
+    desc 'Add college_board flag to all activity holders of gamma flag'
+    task :add_college_board_flag_to_gamma_activities => :environment do
+      ids = Activity.find_by_sql("select id from activities where flags::text[] @> ARRAY['gamma']").pluck(:id)
+      puts ids
+      ids.each do |id|
+        activity = Activity.find(id)
+        activity.update!(flags: activity.flags << 'college_board')
+      end
+    end
+  end
+
   namespace :users do
+    desc 'Add college_board flag to all holders of gamma flag'
+    task :add_college_board_flag_to_gamma_users => :environment do
+      ids = User.find_by_sql("select id from users where flags::text[] @> ARRAY['gamma']").pluck(:id)
+      puts ids
+      ids.each do |id|
+        user = User.find(id)
+        user.update!(flags: user.flags << 'college_board')
+      end
+    end
+
     desc 'Update User.flags from a CSV file'
     task :update_from_csv, [:filepath] => :environment do |t, args|
       iostream = File.read(args[:filepath])


### PR DESCRIPTION
## WHAT
Prep for the flagset project. All activities and users with flag `gamma` should now also have flag `college_board`. Note: all this code (flags.rake, flags.rb) is going away soon, to be replaced with Flagsets.


## WHY
Product request. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-Flag-Hierarchy-Create-New-Beta-Flags-to-Enable-Reading-for-Evidence-Testing-afd471842d74402d9a616545f8917d9b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A)
