### PR TITLE
lms/fix-instructions-in-concept-results

### DIFF
--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -48,6 +48,7 @@ class ConceptResult < ApplicationRecord
     :attemptNumber,
     :correct,
     :directions,
+    :instructions,
     :lastFeedback,
     :prompt,
     :questionNumber,

--- a/services/QuillLMS/spec/models/concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ConceptResult, type: :model do
         {
           "correct": 1,
           "directions": "Combine the sentences. (And)",
+          "instructions": "Combine the sentences. (And)",
           "lastFeedback": "Proofread your work. Check your spelling.",
           "prompt": "Deserts are very dry. Years go by without rain.",
           "attemptNumber": 2,
@@ -100,16 +101,18 @@ RSpec.describe ConceptResult, type: :model do
       end
 
       it 'should create NormalizedText records when new text is provided' do
-        expect { ConceptResult.create_from_json(json) }
-          .to change(ConceptResultDirections, :count).by(1)
+        expect do
+          cr =  ConceptResult.create_from_json(json)
+          expect(cr.extra_metadata).to be(nil)
+        end.to change(ConceptResultDirections, :count).by(1)
           .and change(ConceptResultPreviousFeedback, :count).by(1)
           .and change(ConceptResultPrompt, :count).by(1)
           .and change(ConceptResultQuestionType, :count).by(1)
-          .and not_change(ConceptResultInstructions, :count)
-        # No change expected above when "instructions" aren't in the payload
+          .and change(ConceptResultInstructions, :count).by(1)
       end
 
       it 'should not link to records when the appropriate keys are not provided' do
+        json[:metadata].delete(:instructions)
         concept_result = ConceptResult.create_from_json(json)
 
         expect(concept_result.reload.concept_result_instructions).to be_nil


### PR DESCRIPTION
## WHAT
Add 'instructions' as a known metadata key
## WHY
We already do handle this value by normalizing it, so we don't need to also store it as part of `extra_metadata`.
## HOW
Just add `instructions` to `KNOWN_METADATA_KEYS` so we know it doesn't need to get stashed in `extra_metadata`

### Notion Card Links
https://www.notion.so/quill/Add-instructions-to-ConceptResult-KNOWN_METADATA_KEYS-139ed56852d24ae9bb03dc6e0e6009c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
