### PR TITLE
When importing teacher/students from clever, remove google_id and vice versa

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/student_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_updater.rb
@@ -38,7 +38,7 @@ module CleverIntegration
     end
 
     private def student_attrs
-      data.merge(account_type: ACCOUNT_TYPE, role: ROLE, signed_up_with_google: false)
+      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: ROLE, signed_up_with_google: false)
     end
 
     private def update

--- a/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
@@ -18,7 +18,7 @@ module CleverIntegration
     end
 
     private def teacher_attrs
-      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: ROLE)
+      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: ROLE, signed_up_with_google: false)
     end
 
     private def update

--- a/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
@@ -18,7 +18,7 @@ module CleverIntegration
     end
 
     private def teacher_attrs
-      data.merge(account_type: ACCOUNT_TYPE, role: ROLE)
+      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: ROLE)
     end
 
     private def update

--- a/services/QuillLMS/app/services/google_integration/classroom_student_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_student_updater.rb
@@ -27,7 +27,7 @@ module GoogleIntegration
     end
 
     private def update
-      student.update!(account_type: ACCOUNT_TYPE, google_id: google_id)
+      student.update!(account_type: ACCOUNT_TYPE, clever_id: nil, google_id: google_id)
     end
 
     private def log_role_change

--- a/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
@@ -81,6 +81,12 @@ describe CleverIntegration::StudentUpdater do
         it { updates_student_with_data_except_username }
       end
     end
+
+    context 'student also has a google_id' do
+      before { student.update(google_id: '12345678') }
+
+      it { updates_student_with_data }
+    end
   end
 
   def updates_student_with_data
@@ -91,6 +97,7 @@ describe CleverIntegration::StudentUpdater do
     expect(student.email).to eq email
     expect(student.name).to eq name
     expect(student.username).to eq username
+    expect(student.google_id).to eq nil
   end
 
   def updates_student_with_data_except_username
@@ -101,5 +108,6 @@ describe CleverIntegration::StudentUpdater do
     expect(student.email).to eq email
     expect(student.name).to eq name
     expect(student.username).not_to eq username
+    expect(student.google_id).to eq nil
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CleverIntegration::TeacherUpdater do
 
     it { expect { subject }.to change(teacher, :clever_id).from(nil).to(data_clever_id) }
     it { expect { subject }.to change(teacher, :name).from(name).to(data_name) }
+    it { expect { subject }.to change(teacher, :google_id).to(nil) }
     it { expect { subject}.not_to change(teacher, :email) }
   end
 

--- a/services/QuillLMS/spec/services/google_integration/classroom_student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_student_updater_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe GoogleIntegration::ClassroomStudentUpdater do
     it { expect { subject }.not_to change(ChangeLog, :count) }
   end
 
+  context 'student has a clever_id' do
+    let(:student) { create(:student, :signed_up_with_clever, email: email) }
+
+    it { updates_student_attributes }
+  end
+
   context 'student has role teacher' do
     let(:student) { create(:teacher, email: email )}
 
@@ -34,5 +40,6 @@ RSpec.describe GoogleIntegration::ClassroomStudentUpdater do
     expect(student.role).to eq role
     expect(student.account_type).to eq account_type
     expect(student.google_id).to eq google_id
+    expect(student.clever_id).to eq nil
   end
 end


### PR DESCRIPTION
## WHAT
When importing from [google classroom | clever ] set the [clever_id | google_id ] of that user to nil.

## WHY
It's easier to keep authorization logic clean if we prevent users from having both a google_id and clever_id.  Also our UI doesn't really support dual providers.

## HOW
When importing existing teachers and students into clever, set the google_id to nil
When importing existing students into google classroom, set their clever_id to nil.  The case for importing google teachers is already covered in our [codebase](https://github.com/empirical-org/Empirical-Core/blob/5c8e23a12f947d63620a84c1a6d270568ea2e717/services/QuillLMS/app/services/google_integration/user.rb#L34).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
