### PR TITLE
Resolve existing users with both google_id and clever_id

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -102,11 +102,18 @@ class ChangeLog < ApplicationRecord
     update: 'Edited User',
     skipped_import: 'Skipped User import'
   }
+
   GENERIC_USER_ACTIONS = [
     'Visited User Directory',
     'Searched Users'
   ]
-  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values
+
+  RAKE_ACTIONS = [
+    SET_USER_ACCOUNT_TYPE_CLEVER = 'Set user account type clever',
+    SET_USER_ACCOUNT_TYPE_GOOGLE = 'Set user account type google'
+  ]
+
+  ALL_ACTIONS = USER_ACTIONS.values + CONCEPT_ACTIONS + TOPIC_ACTIONS + STANDARD_ACTIONS + STANDARD_CATEGORY_ACTIONS + STANDARD_LEVEL_ACTIONS + EVIDENCE_ACTIONS.values + RAKE_ACTIONS
 
   belongs_to :changed_record, polymorphic: true
   belongs_to :user

--- a/services/QuillLMS/app/services/dual_google_id_and_clever_id_resolver.rb
+++ b/services/QuillLMS/app/services/dual_google_id_and_clever_id_resolver.rb
@@ -15,7 +15,7 @@ class DualGoogleIdAndCleverIdResolver < ApplicationService
   end
 
   def run
-    RESOLVERS.detect { |resolver| send(resolver) }
+    RESOLVERS.find { |resolver| send(resolver) }
   end
 
   private def log_account_type_change(changed_attribute, previous_value, action)
@@ -27,6 +27,7 @@ class DualGoogleIdAndCleverIdResolver < ApplicationService
       previous_value: previous_value
     )
   end
+
   private def resolve_by_account_type
     case user.account_type
     when User::GOOGLE_CLASSROOM_ACCOUNT then set_user_account_type_google

--- a/services/QuillLMS/app/services/dual_google_id_and_clever_id_resolver.rb
+++ b/services/QuillLMS/app/services/dual_google_id_and_clever_id_resolver.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class DualGoogleIdAndCleverIdResolver < ApplicationService
+  attr_reader :user
+
+  RESOLVERS = %i[
+    resolve_by_account_type
+    resolve_by_auth_credential
+    resolve_by_last_classroom
+  ].freeze
+
+
+  def initialize(user)
+    @user = user
+  end
+
+  def run
+    RESOLVERS.detect { |resolver| send(resolver) }
+  end
+
+  private def log_account_type_change(changed_attribute, previous_value, action)
+    ChangeLog.create(
+      action: action,
+      changed_attribute: changed_attribute,
+      changed_record: user,
+      explanation: caller_locations[0].to_s,
+      previous_value: previous_value
+    )
+  end
+  private def resolve_by_account_type
+    case user.account_type
+    when User::GOOGLE_CLASSROOM_ACCOUNT then set_user_account_type_google
+    when User::CLEVER_ACCOUNT then set_user_account_type_clever
+    end
+  end
+
+  private def resolve_by_auth_credential
+    return set_user_account_type_google if user.google_authorized?
+    return set_user_account_type_clever if user.clever_authorized?
+  end
+
+  private def resolve_by_last_classroom
+    last_classroom = user&.classrooms&.order(:updated_at)&.last
+
+    return false unless last_classroom.present?
+    return set_user_account_type_google if last_classroom.google_classroom_id.present?
+    return set_user_account_type_clever if last_classroom.clever_id.present?
+  end
+
+  private def set_user_account_type_clever
+    google_id = user.google_id
+    user.update!(account_type: User::CLEVER_ACCOUNT, google_id: nil)
+    log_account_type_change(:google_id, google_id, ChangeLog::SET_USER_ACCOUNT_TYPE_CLEVER)
+    true
+  end
+
+  private def set_user_account_type_google
+    clever_id = user.clever_id
+    user.update!(account_type: User::GOOGLE_CLASSROOM_ACCOUNT, clever_id: nil)
+    log_account_type_change(:clever_id, clever_id, ChangeLog::SET_USER_ACCOUNT_TYPE_CLEVER)
+    true
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -20,4 +20,13 @@ namespace :users do
 
     puts "\nUpdated #{num_updates} user emails"
   end
+
+  task resolve_dual_google_id_and_clever_id: :environment do
+    puts "Going to resolve #{users.count} google_id and clever_id"
+    ActiveRecord::Base.transaction do
+      User.where.not(clever_id: nil).where.not(google_id: nil).find_each do |user|
+        DualGoogleIdAndCleverIdResolver.run(user)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -22,11 +22,8 @@ namespace :users do
   end
 
   task resolve_dual_google_id_and_clever_id: :environment do
-    puts "Going to resolve #{users.count} google_id and clever_id"
-    ActiveRecord::Base.transaction do
-      User.where.not(clever_id: nil).where.not(google_id: nil).find_each do |user|
-        DualGoogleIdAndCleverIdResolver.run(user)
-      end
+    User.where.not(clever_id: nil).where.not(google_id: nil).find_each do |user|
+      DualGoogleIdAndCleverIdResolver.run(user)
     end
   end
 end

--- a/services/QuillLMS/spec/services/dual_google_id_and_clever_id_resolver_spec.rb
+++ b/services/QuillLMS/spec/services/dual_google_id_and_clever_id_resolver_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DualGoogleIdAndCleverIdResolver do
+  let(:google_id) { '12345' }
+  let(:clever_id) { '67890' }
+  let(:account_type) { nil }
+  let(:user) { create(:user, account_type: account_type, clever_id: clever_id, google_id: google_id) }
+
+  subject { described_class.run(user) }
+
+  it { does_not_change_the_account_type }
+
+  context 'resolve_by_account_type' do
+    context 'clever account_type' do
+      let(:account_type) { User::CLEVER_ACCOUNT }
+
+      it { sets_the_account_to_clever }
+    end
+
+    context 'google account_type' do
+      let(:account_type) { User::GOOGLE_CLASSROOM_ACCOUNT }
+
+      it { sets_the_account_to_google }
+    end
+  end
+
+  context 'resolve_by_auth_credential' do
+    context 'clever district auth credential' do
+      before { create(:clever_district_auth_credential, user: user) }
+
+      it { sets_the_account_to_clever }
+    end
+
+    context 'clever library auth credential' do
+      before { create(:clever_library_auth_credential, user: user) }
+
+      it { sets_the_account_to_clever }
+    end
+
+    context 'google auth credential' do
+      before { create(:google_auth_credential, user: user) }
+
+      it { sets_the_account_to_google }
+    end
+  end
+
+  context 'resolve_by_last_classroom' do
+    before { allow(user).to receive(:classrooms).and_return(Classroom.all) }
+
+    let(:quill_classroom) { create(:simple_classroom) }
+    let(:google_classroom) { create(:simple_classroom, google_classroom_id: '54321') }
+    let(:clever_classroom) { create(:simple_classroom, clever_id: '54321') }
+
+    context 'last classroom is google classroom' do
+      let!(:classrooms) { [quill_classroom, clever_classroom, google_classroom] }
+
+      it { sets_the_account_to_google }
+    end
+
+    context 'last classroom is clever classroom' do
+      let!(:classrooms) { [google_classroom, quill_classroom, clever_classroom] }
+
+      it { sets_the_account_to_clever }
+    end
+
+    context 'last classroom is quill classroom' do
+      let(:classrooms) { [google_classroom, clever_classroom, quill_classroom] }
+
+      it { does_not_change_the_account_type }
+    end
+  end
+
+  def does_not_change_the_account_type
+    subject
+    user.reload
+    expect(user.clever_id).to eq clever_id
+    expect(user.google_id).to eq google_id
+    expect(user.account_type).to eq nil
+    expect(ChangeLog.where(changed_attribute: :clever_id).count).to eq 0
+    expect(ChangeLog.where(changed_attribute: :google_id).count).to eq 0
+  end
+
+  def sets_the_account_to_clever
+    subject
+    user.reload
+    expect(user.clever_id).to eq clever_id
+    expect(user.google_id).to eq nil
+    expect(user.account_type).to eq User::CLEVER_ACCOUNT
+    expect(ChangeLog.where(changed_attribute: :clever_id).count).to eq 0
+    expect(ChangeLog.where(changed_attribute: :google_id).count).to eq 1
+  end
+
+  def sets_the_account_to_google
+    subject
+    user.reload
+    expect(user.clever_id).to eq nil
+    expect(user.google_id).to eq google_id
+    expect(user.account_type).to eq User::GOOGLE_CLASSROOM_ACCOUNT
+    expect(ChangeLog.where(changed_attribute: :clever_id).count).to eq 1
+    expect(ChangeLog.where(changed_attribute: :google_id).count).to eq 0
+  end
+end


### PR DESCRIPTION
## WHAT
There are some users with both a `google_id` and a `clever_id`.  We'd like to sensibly set one of those values to nil.

## WHY
There's an issue with the `reset_session` [logic](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/application_controller.rb#L149) and google authorization where a teacher has switched over a classroom of students to clever but the students have an existing auth_credential pointing to google.  This results in a loop where students cannot login.

## HOW
There are three strategies for resolving the two terms
1) account_type:  this was set to `User::CLEVER_ACCOUNT` or `User::GOOGLE_CLASSROOM_ACCOUNT` in a recent update of the google clever code.  Having an account_type of one of these two values represents the most recent update to the user and therefore points to whether google_id or clever_id should be removed
2) auth_credential: if there's a recent authorization grant, we can use this to infer the current account status
3) last_classroom:  the last updated classroom can have a value for `google_classroom_id`, `clever_id`, or neither.  (I've verified there are no classrooms with both `google_classroom_id` and `clever_id set`)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
