### PR TITLE
do not allow demo users to buy premium and add spec

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -404,7 +404,7 @@ class PagesController < ApplicationController
   # for link to premium within 'about' (discover) pages
   # rubocop:disable Metrics/CyclomaticComplexity
   def premium
-    @user_is_eligible_for_new_subscription= current_user&.eligible_for_new_subscription?
+    @user_is_eligible_for_new_subscription = current_user&.eligible_for_new_subscription? && session[:demo_id].nil?
     @user_is_eligible_for_trial = current_user&.subscriptions&.none?
     @user_has_school = !!current_user&.school && !current_user.school.alternative?
     @user_belongs_to_school_that_has_paid = !!current_user&.school&.ever_paid_for_subscription?

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -136,6 +136,12 @@ describe PagesController do
       expect(assigns(:user_has_school)).to eq false
       expect(assigns(:user_belongs_to_school_that_has_paid)).to eq false
     end
+
+    it 'should set :user_is_eligible_for_new_subscription to false if there is a demo account' do
+      allow(controller).to receive(:session) { { demo_id: 'something' } }
+      get :premium
+      expect(assigns(:user_is_eligible_for_new_subscription)).to eq false
+    end
   end
 
   describe '#locker' do


### PR DESCRIPTION
## WHAT
Prevent demo users from buying premium.

## WHY
We have had at least one person do this this school year, and it's an issue for the support team.

## HOW
Just ensure that `user_is_eligible_to_buy_new_subscription` is never true in the controller if it's a demo account.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-purchased-Premium-on-the-demo-account-9dc71e3475694e2bada807790aba6938

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | No - small change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
