### PR TITLE
fix spacing between lines in tooltip on small screen sizes

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/custom_activity_pack/activity_row.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/custom_activity_pack/activity_row.scss
@@ -269,9 +269,9 @@
         .vertical-divider {
           display: none;
         }
-      }
-      .grade-range {
-        margin: 0px 0px 8px;
+        .grade-range, .standard-level {
+          margin: 0px 0px 8px;
+        }
       }
       .non-toggle-buttons {
         .interactive-wrapper {


### PR DESCRIPTION
## WHAT
Fix spacing between lines in activity row tooltip on small screen sizes.

## WHY
We had a little style collision here that was messing with the spacing. This fixes it.

## HOW
Just make the rule more specific.

### Screenshots
<img width="247" alt="Screen Shot 2022-08-26 at 12 49 59 PM" src="https://user-images.githubusercontent.com/18669014/186954617-d7a6e6d8-5804-4589-bcf6-8e3c1913a562.png">

### Notion Card Links
https://www.notion.so/quill/Assign-Activity-Page-UI-Issue-Tooltip-UI-Bug-553998d4644341b7aba5c2035e9a5912

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A - CSS
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
