### PR TITLE
Lms/reset activity feed on classroom archive

### DIFF
--- a/services/QuillLMS/app/models/redis_feed.rb
+++ b/services/QuillLMS/app/models/redis_feed.rb
@@ -55,7 +55,7 @@ class RedisFeed
 
   def reset!
     temp_ids = ids
-    $redis.ltrim(redis_key, 0, 0)
+    $redis.del(redis_key)
     temp_ids
   end
 

--- a/services/QuillLMS/app/workers/teacher_activity_feed_refill_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_activity_feed_refill_worker.rb
@@ -13,9 +13,10 @@ class TeacherActivityFeedRefillWorker
 
     ids = ids_for_activity_feed(teacher)
 
+    TeacherActivityFeed.reset!(user_id)
+
     return if ids.empty?
 
-    TeacherActivityFeed.reset!(user_id)
     TeacherActivityFeed.add(user_id, ids)
   end
 

--- a/services/QuillLMS/spec/models/redis_feed_spec.rb
+++ b/services/QuillLMS/spec/models/redis_feed_spec.rb
@@ -61,6 +61,15 @@ describe RedisFeed, type: :model do
         expect(test_feed_class.get(1)).to eq([{id: "17"}])
         expect(test_feed_class.get(2)).to eq([{id: "18"}])
       end
+
+      it 'should empty the data set on reset!' do
+        test_feed_class.add(1, 17)
+        test_feed_class.add(1, "19")
+        test_feed_class.add(1, "word")
+        test_feed_class.reset!(1)
+
+        expect(test_feed_class.get(1)).to eq([])
+      end
     end
   end
 

--- a/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
@@ -20,7 +20,7 @@ describe TeacherActivityFeedRefillWorker, type: :worker do
     let(:teacher) { create(:teacher) }
 
     it 'should not reset and refill activity feed' do
-      expect(TeacherActivityFeed).to_not receive(:reset!)
+      expect(TeacherActivityFeed).to receive(:reset!)
       expect(TeacherActivityFeed).to_not receive(:add)
 
       worker.perform(teacher.id)
@@ -32,7 +32,7 @@ describe TeacherActivityFeedRefillWorker, type: :worker do
     let(:teacher) { classroom.owner}
 
     it 'should not reset and refill activity feed' do
-      expect(TeacherActivityFeed).to_not receive(:reset!)
+      expect(TeacherActivityFeed).to receive(:reset!)
       expect(TeacherActivityFeed).to_not receive(:add)
 
       worker.perform(teacher.id)

--- a/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
@@ -54,5 +54,17 @@ describe TeacherActivityFeedRefillWorker, type: :worker do
 
       worker.perform(teacher.id)
     end
+
+    it 'should exclude activities from archived classes' do
+      classroom2 = create(:classroom, visible: false)
+      create(:classrooms_teacher, classroom: classroom2, user: teacher)
+      classroom_unit2 = create(:classroom_unit, classroom_id: classroom2.id, assigned_student_ids: [student1.id, student2.id], assign_on_join: false)
+      activity_session3 = create(:activity_session, classroom_unit_id: classroom_unit2.id, user_id: student1.id, completed_at: 2.days.ago)
+
+      expect(TeacherActivityFeed).to receive(:reset!).with(teacher.id).once
+      expect(TeacherActivityFeed).to receive(:add).with(teacher.id, [activity_session2.id, activity_session1.id])
+
+      worker.perform(teacher.id)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Reset and rebuild the ActivityFeed whenever a teacher's classroom is changed between visible and non-visible
## WHY
When a classroom is archived we don't want its events to show up in the activity feed anymore, and if a classroom was then subsequently unarchived, we want its data to appear in the activity feed again
## HOW
- Add an `after_save` hook to `Classroom` to trigger the `ActivityFeedRefillWorker` for related teachers when its `visible` value changes.
- Update the `ActivityFeedRefillWorker` so that it calls `reset!` on a given ActivityFeed even in cases where it isn't going to have any data to replace that feed with.  If a teacher archives all their classes, we expect their feed to become empty.

### Notion Card Links
https://www.notion.so/quill/Last-Year-s-Activities-showing-up-in-activity-feed-for-eacher-2c85fa52b10b44d6b11bcbf502b269ab

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
