### PR TITLE
lms/only-prohibit-unarchived-classroom-unit-names

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -27,7 +27,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def prohibited_unit_names
-    unit_names = current_user.units.pluck(:name).map(&:downcase)
+    unit_names = current_user.units.joins(:classrooms).where(classrooms: {visible: true}).pluck(:name).map(&:downcase)
     render json: { prohibitedUnitNames: unit_names }.to_json
   end
 

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -18,6 +18,14 @@ describe Teachers::UnitsController, type: :controller do
    )
   end
 
+  let!(:classroom_unit2) do
+    create(:classroom_unit,
+     unit: unit2,
+     classroom: classroom,
+     assigned_student_ids: [student.id]
+   )
+  end
+
   let!(:diagnostic) { create(:diagnostic) }
   let!(:diagnostic_activity) { create(:diagnostic_activity)}
   let!(:unit_activity) { create(:unit_activity, unit: unit, activity: diagnostic_activity, due_date: Time.current )}
@@ -61,9 +69,21 @@ describe Teachers::UnitsController, type: :controller do
 
     it 'should render the correct json' do
       get :prohibited_unit_names, as: :json
-      expect(response.body).to eq({
-          prohibitedUnitNames: unit_names.concat(unit_template_names)
-      }.to_json)
+      expect(JSON.parse(response.body)['prohibitedUnitNames']).to match_array(unit_names.concat(unit_template_names))
+    end
+
+    it 'should not include unit names from archived classrooms' do
+      classroom2 = create(:classroom, visible: false)
+      create(:classrooms_teacher, classroom: classroom2, user: teacher, role: 'owner')
+      unit3 = create(:unit, user: teacher)
+      create(:classroom_unit,
+        unit: unit3,
+        classroom: classroom2,
+        assigned_student_ids: [student.id]
+      )
+
+      get :prohibited_unit_names, as: :json
+      expect(JSON.parse(response.body)['prohibitedUnitNames']).not_to include(unit3.name.downcase)
     end
   end
 


### PR DESCRIPTION
## WHAT
Do not prohibit names from units assigned to archived classrooms
## WHY
Some teachers intend to archive their classrooms from last year and then reuse the activity pack names from then this year
## HOW
Modify the code that generates prohibited names to check whether the classroom a unit is attached to is `visible` or not, and allow users to re-use unit names if their classrooms are `visible: false`

### Notion Card Links
https://www.notion.so/quill/Teacher-Is-Prompted-to-Rename-Activity-Packs-That-Have-Not-Been-Assigned-Yet-44eefd4648544f56bdb56f9a6ee9e43c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
