### PR TITLE
fix bug with admins logging into teacher accounts

### DIFF
--- a/services/QuillLMS/app/queries/teachers_data.rb
+++ b/services/QuillLMS/app/queries/teachers_data.rb
@@ -85,13 +85,19 @@ module TeachersData
         email: hash_value[:email],
         school: hash_value[:school]
       )
+
       user.define_singleton_method(:number_of_students) do
         hash_value[:number_of_students]
       end
+
       user.define_singleton_method(:number_of_activities_completed) do
         hash_value[:number_of_activities_completed]
       end
+
       user.define_singleton_method(:time_spent) { hash_value[:time_spent] }
+
+      user.define_singleton_method(:has_valid_subscription) { User.find_by_id(key)&.subscription_is_valid? }
+
       user
     end
 

--- a/services/QuillLMS/app/queries/teachers_data.rb
+++ b/services/QuillLMS/app/queries/teachers_data.rb
@@ -96,7 +96,7 @@ module TeachersData
 
       user.define_singleton_method(:time_spent) { hash_value[:time_spent] }
 
-      user.define_singleton_method(:has_valid_subscription) { User.find_by_id(key)&.subscription_is_valid? }
+      user.define_singleton_method(:has_valid_subscription) { User.find_by_id(key).subscription_is_valid? }
 
       user
     end

--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -8,7 +8,8 @@ class Admin::TeacherSerializer < ApplicationSerializer
             :links,
             :number_of_students,
             :number_of_activities_completed,
-            :time_spent
+            :time_spent,
+            :has_valid_subscription
 
   type :teacher
 

--- a/services/QuillLMS/app/serializers/user_admin_serializer.rb
+++ b/services/QuillLMS/app/serializers/user_admin_serializer.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
 class UserAdminSerializer < ApplicationSerializer
-  attributes :id, :name, :email, :teachers, :valid_subscription, :schools
+  attributes :id, :name, :email, :teachers, :schools
   type :user_admin
 
   def teachers
     teacher_ids = User.find(object.id).admins_teachers
     teachers_data = TeachersData.run(teacher_ids)
     teachers_data.map { |teacher_data| Admin::TeacherSerializer.new(teacher_data).as_json(root: false) }
-  end
-
-  def valid_subscription
-    admin = User.find(object.id)
-    admin.subscription_is_valid? && admin&.subscription&.school_subscription?
   end
 
   def schools

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/admins_teachers.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/admins_teachers.tsx
@@ -6,7 +6,6 @@ import { ReactTable, DropdownInput, } from '../../Shared/index'
 
 interface AdminsTeachersProps {
   data: Array<Object>;
-  isValid: boolean;
   refreshData(): void;
 }
 
@@ -14,7 +13,6 @@ const ALL_SCHOOLS_OPTION = 'All Schools'
 
 const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
   data,
-  isValid,
   refreshData,
 }) => {
   const [selectedSchool, setSelectedSchool] = React.useState(ALL_SCHOOLS_OPTION)
@@ -54,7 +52,7 @@ const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
       Header: 'Log In As Teacher',
       accessor: 'link_components',
       Cell: ({row}) => {
-        return <TeacherLinks isValid={isValid} links={row.original.links} />;
+        return <TeacherLinks isValid={row.original.has_valid_subscription} links={row.original.links} />;
       },
       resizable: false,
     },

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
@@ -88,7 +88,6 @@ export default class AdminDashboard extends React.Component {
             <PremiumFeatures />
             <AdminsTeachers
               data={this.state.model.teachers}
-              isValid={!!this.state.model.valid_subscription}
               refreshData={this.getData}
             />
             <CreateNewAccounts

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe Admin::TeacherSerializer do
   it_behaves_like 'serializer' do
-    let(:teacher) { create(:teacher) }
-    let(:record_instance) { TeachersData.run([teacher.id]) }
+    let!(:teacher) { create(:teacher) }
+    let(:record_instance) { TeachersData.run([teacher.id])[0] }
     let(:result_key) { "teacher" }
 
     let(:expected_serialized_keys) do

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -17,6 +17,7 @@ describe Admin::TeacherSerializer do
         number_of_students
         number_of_activities_completed
         time_spent
+        has_valid_subscription
       }
     end
   end

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Admin::TeacherSerializer do
   it_behaves_like 'serializer' do
     let(:teacher) { create(:teacher) }
-    let(:record_instance) { TeachersData.run(teacher.id) }
+    let(:record_instance) { TeachersData.run([teacher.id]) }
     let(:result_key) { "teacher" }
 
     let(:expected_serialized_keys) do

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe Admin::TeacherSerializer do
   it_behaves_like 'serializer' do
-    let(:record_instance) { create(:teacher) }
+    let(:teacher) { create(:teacher) }
+    let(:record_instance) { TeachersData.run(teacher.id) }
     let(:result_key) { "teacher" }
 
     let(:expected_serialized_keys) do

--- a/services/QuillLMS/spec/serializers/user_admin_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/user_admin_serializer_spec.rb
@@ -17,7 +17,6 @@ describe UserAdminSerializer do
         name
         email
         teachers
-        valid_subscription
         schools
       }
     end


### PR DESCRIPTION
## WHAT
Fix bug with school admins getting a "premium expired" message when they try to log into teacher accounts.

## WHY
We want admins of premium schools to be able to access those teachers' accounts.

## HOW
This code was flawed in that it was looking at the school administrator's subscription status, which could be a falsy value because we don't actually require that school admins "belong" to the school they administrate, meaning they don't actually themselves have the premium subscription. Further, it is possible to have different schools you administer have different subscriptions, meaning some could have active premium status while some don't, so it made more sense to move this check to the teacher.

We will have to run this: 

```
user_ids = SchoolsAdmins.all.map(&:user_id)
user_ids.each { |id| $redis.del("SERIALIZED_ADMIN_USERS_FOR_#{id}") }
```

when it is deployed to make sure cached data is up to date.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Admin-does-not-have-access-to-Teacher-Access-feature-c8ffef9428684e448da0eeac55abe07b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | No, but tested locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
