### PR TITLE
filter student options for data export if classroom is selected

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -143,20 +143,13 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
 
       page_count = (count.to_f / PAGE_SIZE).ceil
 
-      if params[:without_filters]
-        {
-          activity_sessions: activity_sessions,
-          page_count: page_count,
-        }
-      else
-        {
-          classrooms: current_user.ids_and_names_of_affiliated_classrooms,
-          students: current_user.ids_and_names_of_affiliated_students,
-          units: current_user.ids_and_names_of_affiliated_units,
-          activity_sessions: activity_sessions,
-          page_count: page_count,
-        }
-      end
+      {
+        classrooms: current_user.ids_and_names_of_affiliated_classrooms,
+        students: current_user.ids_and_names_of_affiliated_students(params[:classroom_id]),
+        units: current_user.ids_and_names_of_affiliated_units,
+        activity_sessions: activity_sessions,
+        page_count: page_count,
+      }
     else
       csv_string(activity_sessions)
     end

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -582,7 +582,9 @@ module Teacher
     ).to_a
   end
 
-  def ids_and_names_of_affiliated_students
+  def ids_and_names_of_affiliated_students(classroom_id=nil)
+    students_classrooms_filter = classroom_id.blank? ? '' : " AND students_classrooms.classroom_id = #{classroom_id.to_i}"
+
     RawSqlRunner.execute(
       <<-SQL
         SELECT DISTINCT
@@ -596,6 +598,7 @@ module Teacher
         JOIN students_classrooms
           ON students_classrooms.classroom_id = classrooms.id
           AND students_classrooms.visible = TRUE
+          #{students_classrooms_filter}
         JOIN users
           ON users.id = students_classrooms.student_id
         WHERE classrooms_teachers.user_id = #{id}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
@@ -77,13 +77,13 @@ export default createReactClass({
           loadingNewTableData: false,
           results: data.activity_sessions,
           numPages: data.page_count,
+          classroomFilters,
+          studentFilters,
+          unitFilters,
         };
 
         if (!filtersLoaded) {
           newState = Object.assign(newState, {
-            classroomFilters,
-            studentFilters,
-            unitFilters,
             filtersLoaded: true
           })
         }
@@ -115,7 +115,7 @@ export default createReactClass({
         Header: 'Student',
         accessor: 'student_id',
         resizeable: false,
-        Cell: ({row}) => studentFilters.find(student => student.value == row.original.student_id).name,
+        Cell: ({row}) => studentFilters.find(student => student.value == row.original.student_id)?.name,
         className: this.nonPremiumBlur(),
         maxWidth: 200
       },

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/activity_sessions_controller_spec.rb
@@ -36,6 +36,7 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
       it 'can filter by classroom' do
         get :index, params: { classroom_id: empty_classroom.id, page: 1}, as: :json
         expect(json['activity_sessions'].size).to eq(0)
+        expect(json['students'].size).to eq(0)
       end
 
       it 'can filter by student' do
@@ -44,9 +45,9 @@ describe Teachers::ProgressReports::ActivitySessionsController, type: :controlle
       end
 
       it 'fetches classroom and student data for the filter options' do
-        get :index, params: { page: 1 }, as: :json
+        get :index, params: { page: 1, classroom_id: full_classroom.id }, as: :json
         expect(json['classrooms']).to eq(teacher.ids_and_names_of_affiliated_classrooms)
-        expect(json['students']).to eq(teacher.ids_and_names_of_affiliated_students)
+        expect(json['students']).to eq(teacher.ids_and_names_of_affiliated_students(full_classroom.id))
         expect(json['units']).to eq(teacher.ids_and_names_of_affiliated_units)
       end
 


### PR DESCRIPTION
## WHAT
Filter the student options for the data export page when a classroom is selected.

## WHY
It's confusing to have these dropdowns be completely independent.

## HOW
Just add a filter on the backend to the student query if there is a classroom id, and make sure to save the value of the new filters on every request, not just the first.

Because this data is cached, we'll have to run this:

```
def last_updated_classroom(user_id)
    Classroom.select("classrooms.*, MAX(classrooms.updated_at)").unscoped.joins(:classrooms_teachers).where(classrooms_teachers: {user_id: user_id}).order(updated_at: :desc).first
  end

Subscription.active.each do |s|
  s.users.each { |u| last_updated_classroom(u.id)&.touch }
end
```

at deploy.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Data-Export-dropdown-does-not-sort-students-by-class-860eb3e3324e45e0a53157a378045411

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - deployed locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
