### PR TITLE
update totalresponsesbyconjunction value when relevant data changes

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -150,7 +150,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   }, [selectedPrompt, selectedRuleType])
 
   React.useEffect(() => {
-    if(!totalResponsesByConjunction && dataForTotalResponseCount && dataForTotalResponseCount.ruleFeedbackHistories) {
+    if(dataForTotalResponseCount && dataForTotalResponseCount.ruleFeedbackHistories) {
       let count = 0;
       const { ruleFeedbackHistories } = dataForTotalResponseCount;
       ruleFeedbackHistories.map(feedbackHistory => {
@@ -161,7 +161,7 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
       count = count * 1.0;
       setTotalResponsesByConjunction(count);
     }
-  });
+  }, [dataForTotalResponseCount, startDate, endDate, startDateForQuery, endDateForQuery]);
 
   React.useEffect(() => {
     if(selectedPrompt && ruleFeedbackHistory && ruleFeedbackHistory.ruleFeedbackHistories && ruleFeedbackHistory.ruleFeedbackHistories) {


### PR DESCRIPTION
## WHAT
Fix issue where percentages on Rules Analysis page weren't adding up to 100 when date changed.

## WHY
This was confusing for the curriculum team.

## HOW
It turned out we just were never recalculating this after initial load, so I just added some parameters to the React hook to make sure it would update when the relevant data updates.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Percentages-on-Rules-Analysis-page-don-t-add-up-to-100-when-start-date-is-changed-2ab6015f4d74419e87dc78aa00954e97

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
