### PR TITLE
Evidence internal tool/ remove building essential knowledge placeholder text

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -10,10 +10,7 @@ import ImageSection from "./imageSection";
 import { validateForm, buildActivity, validateFormSection } from '../../../helpers/evidence/miscHelpers';
 import { renderInvalidHighlightLinks} from '../../../helpers/evidence/renderHelpers';
 import { getActivityPrompt, promptsByConjunction, buildBlankPrompt, getActivityPromptSetter, trimmedPrompt  } from '../../../helpers/evidence/promptHelpers';
-import {
-  BECAUSE, BUT, SO, activityFormKeys, PASSAGE, HIGHLIGHT_PROMPT, ESSENTIAL_KNOWLEDGE_TEXT_FILLER,
-  BUILDING_ESSENTIAL_KNOWLEDGE, HIGHLIGHTING_PROMPT, IMAGE, MAX_ATTEMPTS_FEEDBACK, BREAK_TAG, TEXT, PROMPTS
-} from '../../../../../constants/evidence';
+import { BECAUSE, BUT, SO, activityFormKeys, PASSAGE, HIGHLIGHT_PROMPT, BUILDING_ESSENTIAL_KNOWLEDGE, HIGHLIGHTING_PROMPT, IMAGE, MAX_ATTEMPTS_FEEDBACK, BREAK_TAG, TEXT, PROMPTS } from '../../../../../constants/evidence';
 import { ActivityInterface, PromptInterface, PassagesInterface, InputEvent, ClickEvent,  TextAreaEvent } from '../../../interfaces/evidenceInterfaces';
 import { Input, TextEditor, ToggleComponentSection, DataTable, titleCase } from '../../../../Shared/index'
 import { DEFAULT_HIGHLIGHT_PROMPT } from '../../../../Shared/utils/constants'
@@ -26,7 +23,7 @@ interface ActivityFormProps {
 
 const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormProps) => {
   const { id, parent_activity_id, invalid_highlights, passages, prompts, title, notes, flag, } = activity;
-  const formattedPassage = passages && passages.length ? passages : [{ text: '', highlight_prompt: DEFAULT_HIGHLIGHT_PROMPT, essential_knowledge_text: ESSENTIAL_KNOWLEDGE_TEXT_FILLER }];
+  const formattedPassage = passages && passages.length ? passages : [{ text: '', highlight_prompt: DEFAULT_HIGHLIGHT_PROMPT, essential_knowledge_text: '' }];
   const formattedPrompts = promptsByConjunction(prompts);
   const becausePrompt = formattedPrompts && formattedPrompts[BECAUSE] ? formattedPrompts[BECAUSE] : buildBlankPrompt(BECAUSE);
   const butPrompt = formattedPrompts && formattedPrompts[BUT] ? formattedPrompts[BUT] : buildBlankPrompt(BUT);

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.ts
@@ -14,7 +14,6 @@ import {
   FLAG,
   TEXT,
   BUILDING_ESSENTIAL_KNOWLEDGE,
-  ESSENTIAL_KNOWLEDGE_TEXT_FILLER,
   MAX_ATTEMPTS_FEEDBACK,
   HIGHLIGHTING_PROMPT,
   IMAGE,
@@ -186,7 +185,6 @@ export function validateFormSection({
       const essentialKnowledgePresent = (
         activityPassages && activityPassages[0] &&
         !!activityPassages[0].essential_knowledge_text &&
-        activityPassages[0].essential_knowledge_text !== ESSENTIAL_KNOWLEDGE_TEXT_FILLER &&
         activityPassages[0].essential_knowledge_text !== BREAK_TAG
       );
       return getCheckIcon(essentialKnowledgePresent);

--- a/services/QuillLMS/client/app/constants/evidence.ts
+++ b/services/QuillLMS/client/app/constants/evidence.ts
@@ -36,7 +36,6 @@ export const HIGHLIGHT_REMOVAL = 'highlight removal'
 export const HIGHLIGHT_TYPE = 'highlight type'
 export const FEEDBACK_LAYER_ADDITION = 'feedback layer addition'
 export const FEEDBACK_LAYER_REMOVAL = 'feedback layer removal'
-export const ESSENTIAL_KNOWLEDGE_TEXT_FILLER = '<p>In this activity, you’ll read about how skateboarding gained popularity through a process called hierarchical diffusion.</p><br/><p><i>Hierarchical diffusion</i>, happens when an idea spreads through an established social structure (a hierarchy), usually from a person or place with more power and connections to people or places with less power and fewer connections.</p>'
 export const BREAK_TAG = '<br/>';
 
 export const TEXT = 'text';


### PR DESCRIPTION
## WHAT
remove building essential knowledge placeholder text

## WHY
this was requested by Curriculum

## HOW
just remove placeholder text from form component

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/All-Evidence-activities-in-alpha-have-text-in-the-Building-Essential-Knowledge-box-c1785f7a782a4c50b86f302707b8038b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
