### PR TITLE
activity form bugfix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/containers/ActivityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/containers/ActivityForm.tsx
@@ -36,7 +36,8 @@ const ActivityForm = ({ activity, activityClassification, contentPartnerOptions,
 
   function submitClassName() {
     let className = "quill-button primary contained large"
-    if (!editedActivity.name.length) {
+
+    if (!editedActivity.name?.length) {
       className+= ' disabled'
     }
     return className
@@ -188,7 +189,7 @@ const ActivityForm = ({ activity, activityClassification, contentPartnerOptions,
           <input onChange={handleMaximumGradeLevelChange} value={editedActivity.maximum_grade_level} />
         </section>
         <Topics activity={editedActivity} createNewTopic={createNewTopic} handleTopicsChange={handleTopicsChange} topicOptions={topicOptions} />
-        <input className={submitClassName()} disabled={!editedActivity.name.length} type="submit" value="Save" />
+        <input className={submitClassName()} disabled={!editedActivity.name?.length} type="submit" value="Save" />
         <p>When you&apos;ve saved the activity, please head over to the <a href='/assign/activity-library'>Activity Library</a> to make sure the activity metadata looks right in production.</p>
       </form>
     </section>


### PR DESCRIPTION
## WHAT
The 'New Activity' button, which renders ActivityFormIndex, is throwing an unhandled expection. 

## WHY
Unclear as to whether this is the result of recent code, or a long running issue. I happened to encounter it while testing for something else, and it was a quick patch.


## HOW
Add nil guard.

### Screenshots
<img width="1216" alt="Screen Shot 2022-08-30 at 2 09 20 PM" src="https://user-images.githubusercontent.com/90669/187535684-22cc4b37-eeab-466e-b039-df6279802f86.png">



### Notion Card Links
None

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no; tiny change
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
