### PR TITLE
Lms/refactor tooltip to use concept results

### DIFF
--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -23,16 +23,16 @@ class GradesController < ApplicationController
     RawSqlRunner.execute(
       <<-SQL
         SELECT
-          old_concept_results.metadata,
+          concept_results.correct,
           activities.description,
           concepts.name,
           activity_sessions.completed_at + INTERVAL '#{current_user.utc_offset} seconds' AS completed_at,
           unit_activities.due_date
         FROM activity_sessions
-        LEFT JOIN old_concept_results
-          ON old_concept_results.activity_session_id = activity_sessions.id
+        LEFT JOIN concept_results
+          ON concept_results.activity_session_id = activity_sessions.id
         LEFT JOIN concepts
-          ON old_concept_results.concept_id = concepts.id
+          ON concept_results.concept_id = concepts.id
         JOIN classroom_units
           ON classroom_units.id = activity_sessions.classroom_unit_id
         JOIN activities

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -80,12 +80,7 @@ export default class ActivityIconWithTooltip extends React.Component {
   loadTooltipTitle(crData) {
     let data;
     data = _.merge(this.props.data, { premium_state: this.props.premium_state, });
-    data.concept_results = crData.concept_results.map(cr => {
-      if (cr.metadata) {
-        cr.metadata = JSON.parse(cr.metadata)
-      }
-      return cr
-    })
+    data.concept_results = crData.concept_results
     data.scores = crData.scores;
     setTimeout(() => {this.setState({tooltipData: data})}, 200);
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/concept_result_stats.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/concept_result_stats.test.jsx
@@ -8,17 +8,17 @@ import ConceptResultStat from '../concept_result_stat.jsx'
 describe('ConceptResultStats component', () => {
 
   const moreThanTenConcepts = [
-    { name: 'A', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'C', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'D', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'E', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'F', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'G', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'H', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'I', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'J', metadata: { correct: 1, incorrect: 0 } },
-    { name: 'K', metadata: { correct: 1, incorrect: 0 } }
+    { name: 'A', correct: true },
+    { name: 'B', correct: true },
+    { name: 'C', correct: true },
+    { name: 'D', correct: true },
+    { name: 'E', correct: true },
+    { name: 'F', correct: true },
+    { name: 'G', correct: true },
+    { name: 'H', correct: true },
+    { name: 'I', correct: true },
+    { name: 'J', correct: true },
+    { name: 'K', correct: true }
   ];
 
   it('should render only up to 10 ConceptResultStat components + an information row', () => {
@@ -33,11 +33,11 @@ describe('ConceptResultStats component', () => {
     const wrapper = shallow(
       <ConceptResultStats
         results={[
-          { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-          { name: 'B', metadata: { correct: 0, incorrect: 1 } },
-          { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-          { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-          { name: 'B', metadata: { correct: 0, incorrect: 1 } },
+          { name: 'B', correct: true },
+          { name: 'B', correct: false },
+          { name: 'B', correct: true },
+          { name: 'B', correct: true },
+          { name: 'B', correct: false },
         ]}
       />
     );
@@ -50,7 +50,7 @@ describe('ConceptResultStats component', () => {
     const wrapper = shallow(
       <ConceptResultStats
         results={[
-          { name: 'B', metadata: { correct: 1, incorrect: 0 } }
+          { name: 'B', correct: true }
         ]}
       />
     );
@@ -67,17 +67,17 @@ describe('ConceptResultStats component', () => {
   it('should sort results properly by total, then percentage, then name', () => {
     const wrapper = shallow(
       <ConceptResultStats results={[
-        { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'B', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'B', metadata: { correct: 0, incorrect: 1 } },
-        { name: 'A', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'A', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'A', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'A', metadata: { correct: 0, incorrect: 1 } },
-        { name: 'Y', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'Y', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'X', metadata: { correct: 1, incorrect: 0 } },
-        { name: 'X', metadata: { correct: 0, incorrect: 1 } },
+        { name: 'B', correct: true },
+        { name: 'B', correct: true },
+        { name: 'B', correct: false },
+        { name: 'A', correct: true },
+        { name: 'A', correct: true },
+        { name: 'A', correct: true },
+        { name: 'A', correct: false },
+        { name: 'Y', correct: true },
+        { name: 'Y', correct: true },
+        { name: 'X', correct: true },
+        { name: 'X', correct: false },
       ]}
       />
     );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/concept_result_stats.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/concept_result_stats.jsx
@@ -70,8 +70,7 @@ export default class ConceptResultStats extends React.Component {
         incorrect: 0,
       };
       memo[conceptResult.name] = statsRow;
-      const correct = parseInt(conceptResult.correct);
-      if (correct) {
+      if (conceptResult.correct) {
         statsRow.correct += 1;
       } else {
         statsRow.incorrect += 1;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/concept_result_stats.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/concept_result_stats.jsx
@@ -64,21 +64,19 @@ export default class ConceptResultStats extends React.Component {
 
   calculateStats = () => {
     const stats = this.props.results.reduce((memo, conceptResult) => {
-      if (conceptResult.metadata) {
-        const statsRow = memo[conceptResult.name] || {
-          name: conceptResult.name,
-          correct: 0,
-          incorrect: 0,
-        };
-        memo[conceptResult.name] = statsRow;
-        const correct = parseInt(conceptResult.metadata.correct);
-        if (correct) {
-          statsRow.correct += 1;
-        } else {
-          statsRow.incorrect += 1;
-        }
-        return memo;
+      const statsRow = memo[conceptResult.name] || {
+        name: conceptResult.name,
+        correct: 0,
+        incorrect: 0,
+      };
+      memo[conceptResult.name] = statsRow;
+      const correct = parseInt(conceptResult.correct);
+      if (correct) {
+        statsRow.correct += 1;
+      } else {
+        statsRow.incorrect += 1;
       }
+      return memo;
     }, {});
     const statsAsArr = this.objectToArray(stats);
     const sortedStats = this.sortedStats(statsAsArr);

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -17,13 +17,29 @@ describe GradesController do
   end
 
   describe '#tooltip' do
-    let(:result) { ["query_result"] }
-
-    before { allow(RawSqlRunner).to receive(:execute) { result } }
+    let(:student_user) { create(:user) }
+    let(:activity_session) { create(:activity_session, user: student_user) }
+    let(:concept) { create(:concept) }
+    let!(:concept_result) { create(:concept_result, activity_session: activity_session, concept: concept) }
+    let(:due_date) { Time.current }
+    let!(:classrooms_teacher) { create(:classrooms_teacher, user: teacher, classroom: activity_session.classroom_unit.classroom) }
+    let(:timestamp_format) { '%Y-%m-%d %H:%M:%S.%6N' }
 
     it 'should render the correct json' do
-      get :tooltip, params: { user_id: teacher.id, completed: true, classroom_unit_id: "", activity_id: "" }
-      expect(response.body).to eq({concept_results: result, scores: result}.to_json)
+      get :tooltip, params: { user_id: student_user.id, completed: true, classroom_unit_id: activity_session.classroom_unit_id, activity_id: activity_session.activity_id }
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq({
+        concept_results: [{
+          correct: concept_result.correct,
+          description: activity_session.activity.description,
+          name: concept.name,
+          completed_at: activity_session.completed_at.strftime(timestamp_format),
+          due_date: activity_session.classroom_unit.unit_activities.first.due_date
+        }],
+        scores: [{
+          percentage: activity_session.percentage,
+          completed_at: activity_session.completed_at.strftime(timestamp_format)
+        }]
+      })
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update the Tooltip raw SQL query to use the new `concept_results` table instead of the `old_concept_results` table.  We didn't include this update in the last SQL update because it also involved some front-end tweaks.
## WHY
We want to pull all of our Concept Result data from the new table eventually, so this is a step along that path
## HOW
- Update the query in the raw SQL in the controller
- Tweak the front-end code so that instead of looking for the `correct` value inside a `metadata` key, just look for it on the `concept_result` directly
- Tweak the front-end code so that it expect `correct` to be a boolean value rather than an integer
- Update tests to more strictly ensure that we adhere to these formats


### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
