### PR TITLE
user manager updates, cms controller search updates

### DIFF
--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -9,8 +9,8 @@ class ActivitiesController < ApplicationController
   DIAGNOSTIC = 'diagnostic'
 
   def search
-    flag = params[:flag] || current_user&.testing_flag
-    search_result = Activity.search_results(flag)
+    flagset = params[:flagset] || current_user&.flagset
+    search_result = Activity.search_results(flagset)
     render json: search_result.to_json
   end
 

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -147,12 +147,12 @@ class Cms::UsersController < Cms::CmsController
   end
 
   protected def user_params
-    params.require(:user).permit([:name, :email, :username, :title, :role, :classcode, :password, :password_confirmation, :flags =>[]] + default_params
+    params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :classcode, :password, :password_confirmation, :flags =>[]] + default_params
     )
   end
 
   protected def user_query_params
-    params.permit(@text_search_inputs.map(&:to_sym) + default_params + [:page, :user_role, :user_flag, :sort, :sort_direction, :user_premium_status, :class_code])
+    params.permit(@text_search_inputs.map(&:to_sym) + default_params + [:flagset, :page, :user_role, :user_flag, :sort, :sort_direction, :user_premium_status, :class_code])
   end
 
   protected def user_query(params)
@@ -228,7 +228,7 @@ class Cms::UsersController < Cms::CmsController
     # User email: users.email
     # User IP: users.ip_address
     # School name: schools.name
-    # User flag: user.flags
+    # User flagset: user.flagset
     # Premium status: subscriptions.account_type
     sanitized_fuzzy_param_value = ActiveRecord::Base.connection.quote("%#{param_value}%")
     sanitized_param_value = ActiveRecord::Base.connection.quote(param_value)
@@ -244,8 +244,9 @@ class Cms::UsersController < Cms::CmsController
       "users.email = LOWER(TRIM(#{(sanitized_param_value)}))"
     when 'user_email'
       "users.email ILIKE #{(sanitized_fuzzy_param_value)}"
-    when 'user_flag'
-      "#{(sanitized_param_value)} = ANY (users.flags::text[])"
+    when 'flagset'
+      "users.flagset = #{(sanitized_param_value)}"
+      #"#{(sanitized_param_value)} = ANY (users.flags::text[])"
     when 'user_ip'
       "users.ip_address = #{(sanitized_param_value)}"
     when 'school_name'
@@ -291,7 +292,7 @@ class Cms::UsersController < Cms::CmsController
     @text_search_inputs = ['user_name', 'user_username', 'user_email', 'user_email_exact', 'user_ip', 'school_name', 'class_code']
     @school_premium_types = Subscription.account_types
     @user_role_types = User::ROLES
-    @all_search_inputs = @text_search_inputs + ['user_premium_status', 'user_role', 'page', 'user_flag']
+    @all_search_inputs = @text_search_inputs + ['user_premium_status', 'user_role', 'page', 'flagset']
   end
 
   protected def filter_zeroes_from_checkboxes

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -246,7 +246,6 @@ class Cms::UsersController < Cms::CmsController
       "users.email ILIKE #{(sanitized_fuzzy_param_value)}"
     when 'flagset'
       "users.flagset = #{(sanitized_param_value)}"
-      #"#{(sanitized_param_value)} = ANY (users.flags::text[])"
     when 'user_ip'
       "users.ip_address = #{(sanitized_param_value)}"
     when 'school_name'

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -208,7 +208,7 @@ class Activity < ApplicationRecord
   end
 
   def self.set_activity_search_cache
-    $redis.set('default_activity_search', ActivitySearchWrapper.new.search.to_json)
+    $redis.set('default_activity_search', ActivitySearchWrapper.new('production').search.to_json)
   end
 
   def is_lesson?

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -219,10 +219,10 @@ class Activity < ApplicationRecord
     is_evidence?
   end
 
-  def self.search_results(flag)
-    substring = flag ? "#{flag}_" : ""
+  def self.search_results(flagset)
+    substring = flagset ? "#{flagset}_" : ""
     activity_search_results = $redis.get("default_#{substring}activity_search")
-    activity_search_results ||= ActivitySearchWrapper.search_cache_data(flag)
+    activity_search_results ||= ActivitySearchWrapper.search_cache_data(flagset)
     JSON.parse(activity_search_results)
   end
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -67,6 +67,9 @@ module UserFlagset
     FLAGSETS.map{|key, value| {value: key.to_s, label: value[:display_name]}}
   end
 
+  def self.flags_for_flagset(flagset)
+    FLAGSETS[flagset.to_sym][:flags].keys.map{|k| "'#{k}'"}.join(',')
+  end
 
   def activity_viewable?(activity)
     return false unless activity.is_a?(::Activity)

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -4,7 +4,6 @@
 module UserFlagset
   extend ActiveSupport::Concern
 
-
   included do
     FLAGSETS = {
 
@@ -63,6 +62,15 @@ module UserFlagset
 
     validates :flagset, inclusion: { in: FLAGSETS.keys.map(&:to_s) }
   end
+
+  def self.decorated(type:)
+    if type == :label_value_hash
+      FLAGSETS.map{|key, value| {value: key.to_s, label: value[:display_name]}}
+    else
+      raise NotImplementedError('Type #{type} not implemented.')
+    end
+  end
+
 
   def activity_viewable?(activity)
     return false unless activity.is_a?(::Activity)

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -64,11 +64,7 @@ module UserFlagset
   end
 
   def self.decorated(type:)
-    if type == :label_value_hash
-      FLAGSETS.map{|key, value| {value: key.to_s, label: value[:display_name]}}
-    else
-      raise NotImplementedError('Type #{type} not implemented.')
-    end
+    FLAGSETS.map{|key, value| {value: key.to_s, label: value[:display_name]}}
   end
 
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -69,6 +69,7 @@ module UserFlagset
 
   def self.flags_for_flagset(flagset)
     return nil unless flagset
+
     FLAGSETS[flagset.to_sym][:flags].keys.map{|k| "'#{k}'"}.join(',')
   end
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -68,6 +68,7 @@ module UserFlagset
   end
 
   def self.flags_for_flagset(flagset)
+    return nil unless flagset
     FLAGSETS[flagset.to_sym][:flags].keys.map{|k| "'#{k}'"}.join(',')
   end
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -63,7 +63,7 @@ module UserFlagset
     validates :flagset, inclusion: { in: FLAGSETS.keys.map(&:to_s) }
   end
 
-  def self.decorated(type:)
+  def self.decorated
     FLAGSETS.map{|key, value| {value: key.to_s, label: value[:display_name]}}
   end
 

--- a/services/QuillLMS/app/queries/activity_search.rb
+++ b/services/QuillLMS/app/queries/activity_search.rb
@@ -3,21 +3,8 @@
 class ActivitySearch
   # filters = hash of model_name/model_id pairs
   # sort = hash with 'field' and 'asc_or_desc' (?) as keys
-  def self.search(flag)
-    case flag
-    when 'archived'
-      flags = "'private', 'alpha', 'beta', 'gamma', 'production', 'archived'"
-    when 'private'
-      flags = "'private', 'alpha', 'beta', 'gamma', 'production'"
-    when 'alpha'
-      flags = "'alpha', 'beta', 'gamma', 'production'"
-    when 'beta'
-      flags = "'beta', 'production'"
-    when 'gamma'
-      flags = "'gamma', 'production', 'beta'"
-    else
-      flags = "'production'"
-    end
+  def self.search(flagset)
+    flags = UserFlagset.flags_for_flagset(flagset).to_s
 
     RawSqlRunner.execute(
       <<-SQL

--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -3,7 +3,7 @@
 class ActivitySearchWrapper
   RESULTS_PER_PAGE = 12
 
-  def initialize(flag=nil, user_id=nil)
+  def initialize(flagset=nil, user_id=nil)
     @activities = nil
     @activity_classifications = []
     @standards = []

--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -9,7 +9,7 @@ class ActivitySearchWrapper
     @standards = []
     @activity_categories = []
     @standard_levels = []
-    @flag = flag
+    @flagset = flagset
     @user_id = user_id
   end
 
@@ -30,9 +30,9 @@ class ActivitySearchWrapper
     }
   end
 
-  def self.search_cache_data(flag = nil)
-    substring = flag ? "#{flag}_" : ""
-    activity_search_json = ActivitySearchWrapper.new(flag).search.to_json
+  def self.search_cache_data(flagset = nil)
+    substring = flagset ? "#{flagset}_" : ""
+    activity_search_json = ActivitySearchWrapper.new(flagset).search.to_json
     $redis.set("default_#{substring}activity_search", activity_search_json)
     activity_search_json
   end
@@ -44,7 +44,7 @@ class ActivitySearchWrapper
   end
 
   private def activity_search
-    @activities = ActivitySearch.search(@flag)
+    @activities = ActivitySearch.search(@flagset)
   end
 
   private def formatted_search_results

--- a/services/QuillLMS/app/views/cms/users/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/users/_form.html.erb
@@ -34,10 +34,8 @@
       <%= f.select :role, [['student', 'student'], ['teacher', 'teacher'], ['staff', 'staff']], autocomplete: 'off' %>
     </div>
     <div class='cms-form-row'>
-      <% @valid_flags.each do |flag| -%>
-        <%= f.label flag.to_sym %>
-        <%=check_box('user', "flags", {multiple: true, checked: @user.flags.include?(flag) || nil}, flag.to_sym, )%>
-      <% end -%>
+      <%= f.label :flagset %>
+      <%= f.select :flagset, UserFlagset::FLAGSETS.keys.map(&:to_s) %>
     </div>
     <div class='cms-form-row'>
       <%= f.label :classcode %>

--- a/services/QuillLMS/app/views/cms/users/index.html.erb
+++ b/services/QuillLMS/app/views/cms/users/index.html.erb
@@ -6,7 +6,7 @@
       </h1>
     </div>
     <div class='cms-container-meta'>
-      <%= react_component('CmsUserIndexApp', props: {queryResults: @user_search_query_results, userFlags: @user_flags, query: @user_search_query, userRoleTypes: @user_role_types, schoolPremiumTypes: @school_premium_types}) %>
+      <%= react_component('CmsUserIndexApp', props: {flagsets: UserFlagset.decorated(type: :label_value_hash), queryResults: @user_search_query_results, userFlags: @user_flags, query: @user_search_query, userRoleTypes: @user_role_types, schoolPremiumTypes: @school_premium_types}) %>
     </div>
   </article>
 </div>

--- a/services/QuillLMS/app/views/cms/users/index.html.erb
+++ b/services/QuillLMS/app/views/cms/users/index.html.erb
@@ -6,7 +6,7 @@
       </h1>
     </div>
     <div class='cms-container-meta'>
-      <%= react_component('CmsUserIndexApp', props: {flagsets: UserFlagset.decorated(type: :label_value_hash), queryResults: @user_search_query_results, userFlags: @user_flags, query: @user_search_query, userRoleTypes: @user_role_types, schoolPremiumTypes: @school_premium_types}) %>
+      <%= react_component('CmsUserIndexApp', props: {flagsets: UserFlagset.decorated, queryResults: @user_search_query_results, userFlags: @user_flags, query: @user_search_query, userRoleTypes: @user_role_types, schoolPremiumTypes: @school_premium_types}) %>
     </div>
   </article>
 </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -212,7 +212,6 @@ export default class CmsUserIndex extends React.Component {
 
   renderUserFlagsetSelect() {
     const options = this.props.flagsets.map(pair => <option value={pair.value}>{pair.label}</option>)
-    console.log("options: ", options)
     return (
       <select onChange={e => this.updateField(e, 'flagset')}>
         {options}

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { sortTableByLastName, sortTableFromSQLTimeStamp } from 'modules/sortingMethods';
 import getAuthToken from '../components/modules/get_auth_token';
 import LoadingIndicator from '../components/shared/loading_indicator'
-import { ReactTable, } from '../../Shared/index'
+import { FlagDropdown, ReactTable, } from '../../Shared/index'
 
 export default class CmsUserIndex extends React.Component {
   constructor(props) {
@@ -210,10 +210,11 @@ export default class CmsUserIndex extends React.Component {
 
   }
 
-  renderUserFlagSelect() {
-    const options = [<option value />].concat(this.props.userFlags.map(o => <option value={o}>{o}</option>))
+  renderUserFlagsetSelect() {
+    const options = this.props.flagsets.map(pair => <option value={pair.value}>{pair.label}</option>)
+    console.log("options: ", options)
     return (
-      <select onChange={e => this.updateField(e, 'user_flag')}>
+      <select onChange={e => this.updateField(e, 'user_flagset')}>
         {options}
       </select>
     )
@@ -269,8 +270,8 @@ export default class CmsUserIndex extends React.Component {
               </div>
 
               <div className='cms-form-row'>
-                <label>Flags Contain</label>
-                {this.renderUserFlagSelect()}
+                <label>Flagset</label>
+                {this.renderUserFlagsetSelect()}
               </div>
               <div className='cms-form-row'>
                 <label>Role</label>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -214,7 +214,7 @@ export default class CmsUserIndex extends React.Component {
     const options = this.props.flagsets.map(pair => <option value={pair.value}>{pair.label}</option>)
     console.log("options: ", options)
     return (
-      <select onChange={e => this.updateField(e, 'user_flagset')}>
+      <select onChange={e => this.updateField(e, 'flagset')}>
         {options}
       </select>
     )

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsUserIndexAppClient.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { sortTableByLastName, sortTableFromSQLTimeStamp } from 'modules/sortingMethods';
 import getAuthToken from '../components/modules/get_auth_token';
 import LoadingIndicator from '../components/shared/loading_indicator'
-import { FlagDropdown, ReactTable, } from '../../Shared/index'
+import { ReactTable, } from '../../Shared/index'
 
 export default class CmsUserIndex extends React.Component {
   constructor(props) {

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -17,22 +17,21 @@ describe Cms::UsersController do
   describe '#index' do
     before { allow(RawSqlRunner).to receive(:execute) { ["results"] } }
 
-    it 'should assign the search query, the results, user flags and number of spaces' do
+    it 'should assign the search query, the results, and number of spaces' do
       get :index
       expect(assigns(:user_search_query)).to eq({sort: 'last_sign_in', sort_direction: 'desc'})
       expect(assigns(:user_search_query_results)).to eq []
-      expect(assigns(:user_flags)).to eq User::VALID_FLAGS
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:index])
     end
   end
 
   describe '#search' do
 
-    it 'should search for the users with user_flag' do
-      get :search, params: { user_flag: "auditor" }
-      expect(response.body).to eq({numberOfPages: 0, userSearchQueryResults: [], userSearchQuery: {user_flag: "auditor"}}.to_json)
+    it 'should search for the users with given flagset' do
+      get :search, params: { flagset: 'alpha' }
+      expect(response.body).to eq({numberOfPages: 0, userSearchQueryResults: [], userSearchQuery: {flagset: 'alpha'}}.to_json)
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:search])
-      expect(ChangeLog.last.explanation).to include('auditor')
+      expect(ChangeLog.last.explanation).to include('alpha')
     end
 
     context 'email search' do
@@ -231,12 +230,11 @@ describe Cms::UsersController do
     let!(:another_user) { create(:user) }
 
     it 'should update the attributes for the given user and update change_log' do
-      post :update, params: { id: another_user.id, user: { email: "new@test.com", flags: ["purchaser"] } }
+      post :update, params: { id: another_user.id, user: { email: "new@test.com" } }
       expect(another_user.reload.email).to eq "new@test.com"
       expect(response).to redirect_to cms_users_path
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
-      expect(ChangeLog.last.changed_attribute).to eq('flags')
-      expect(ChangeLog.last.new_value).to include('purchaser')
+      expect(ChangeLog.last.new_value).to include('new@test.com')
     end
   end
 

--- a/services/QuillLMS/spec/models/concerns/user_flagset_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_flagset_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe UserFlagset, type: :model do
     end
   end
 
+  context '#flags_for_flagset' do
+    it 'should return an string array of flags' do
+      result = UserFlagset.flags_for_flagset('college_board')
+      expect(result).to eq "'#{Flags::COLLEGE_BOARD}','#{Flags::PRODUCTION}'"
+    end
+  end
+
   context '#activity_viewable?' do
     let(:normal_user) { create(:user, flagset: 'production' ) }
     let(:alpha_user) { create(:user, flagset: 'alpha' ) }


### PR DESCRIPTION
## WHAT
- Updates the user manager to search users via flagsets instead of flags
- updates activity search to use flagsets instead of flags 

Note: In the interests of time, not all legacy flags-related code has been cleaned up. Example: 
https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/index.tsx#L333

## WHY
Because these interactions should now deal with flagsets (easier for curriculum to work with). 

## HOW
Updates to DB query, various components and view.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-Flag-Hierarchy-Create-New-Beta-Flags-to-Enable-Reading-for-Evidence-Testing-afd471842d74402d9a616545f8917d9b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (N/A)
