### PR TITLE
do not render demo account banner from tool page

### DIFF
--- a/services/QuillLMS/app/views/application/_demo_account_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_demo_account_banner.html.erb
@@ -1,9 +1,9 @@
 <% current_path = request.env['PATH_INFO'] %>
 
-<% if viewing_demo_account? && !previewing_student_dashboard? %>
-<%= react_component('DemoAccountBanner', props: {
-  signedInOutsideDemo: signed_in_outside_demo?,
-  recommendationsLink: demo_account_recommendations_link,
-  growthSummaryLink: demo_account_growth_summary_link
-})%>
+<% if viewing_demo_account? && !previewing_student_dashboard? && !current_path.include?('tools') %>
+  <%= react_component('DemoAccountBanner', props: {
+    signedInOutsideDemo: signed_in_outside_demo?,
+    recommendationsLink: demo_account_recommendations_link,
+    growthSummaryLink: demo_account_growth_summary_link
+  })%>
 <% end %>


### PR DESCRIPTION
## WHAT
Don't render the demo account banner from the tool page.

## WHY
The demo account component isn't part of the bundle we use to render the tool page, so the Evidence page won't load if you're in demo. We don't want that to happen.

## HOW
Just add a condition to when we render the banner, since it isn't really relevant on this page anyway (there are no data-changing actions to take).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Evidence-Tool-Page-Doesn-t-Load-From-Demo-Account-58143961e04a49aea4ed281691434a1f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
