### PR TITLE
Lms/update public progress report concept results

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -440,14 +440,6 @@ class ActivitySession < ApplicationRecord
     end
   end
 
-  def self.activity_session_metadata(activity_sessions)
-    activity_sessions.map do |activity_session|
-      activity_session.old_concept_results.map do |concept_result|
-        concept_result.metadata
-      end
-    end.flatten
-  end
-
   def self.assign_follow_up_lesson(classroom_unit_id, activity_uid)
     activity = Activity.find_by_id_or_uid(activity_uid)
     classroom_unit = ClassroomUnit.find(classroom_unit_id)

--- a/services/QuillLMS/app/models/concerns/concepts.rb
+++ b/services/QuillLMS/app/models/concerns/concepts.rb
@@ -8,7 +8,7 @@ module Concepts
     return '' unless activity_session.present?
 
     @concepts = activity_session.concepts
-    @concept_results_by_question_type = activity_session.old_concept_results.group_by{|c| c.question_type}.values
+    @concept_results_by_question_type = activity_session.concept_results.group_by{|c| c.question_type}.values
     organize_by_type
   end
 
@@ -37,7 +37,7 @@ module Concepts
     concept_results.each do |result|
       next unless result.concept == concept
 
-      if result.correct?
+      if result.correct
         correct_count += 1
       else
         incorrect_count += 1

--- a/services/QuillLMS/app/models/concerns/concepts.rb
+++ b/services/QuillLMS/app/models/concerns/concepts.rb
@@ -22,7 +22,7 @@ module Concepts
     @concepts.map do |concept|
       @concept_results_by_question_type.map do |cr|
         if cr.any?
-          type = human_readable_question_type(cr.first['question_type'])
+          type = human_readable_question_type(cr.first.question_type)
           hash_object[type].push(stats_for_concept(concept, cr))
         end
       end

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -47,18 +47,18 @@ module PublicProgressReports
     activity = Activity.includes(:classification).find(activity_id)
     questions = Hash.new{|h,k| h[k]={} }
 
-    all_answers = ActivitySession.activity_session_metadata(@activity_sessions)
+    all_answers = @activity_sessions.map(&:concept_results).flatten
 
     all_answers.each do |answer|
-      curr_quest = questions[answer["questionNumber"]]
+      curr_quest = questions[answer.question_number]
       curr_quest[:correct] ||= 0
       curr_quest[:total] ||= 0
-      curr_quest[:correct] += answer["questionScore"] || answer["correct"]
+      curr_quest[:correct] += answer.question_score || answer.correct ? 1 : 0
       curr_quest[:total] += 1
-      curr_quest[:prompt] ||= answer["prompt"]
-      curr_quest[:question_number] ||= answer["question_number"]
-      if answer["attemptNumber"] == 1 || !curr_quest[:instructions]
-        direct = answer["directions"] || answer["instructions"] || ""
+      curr_quest[:prompt] ||= answer.concept_result_prompt&.text
+      curr_quest[:question_number] ||= answer.question_number
+      if answer.attempt_number == 1 || !curr_quest[:instructions]
+        direct = answer.concept_result_directions&.text || answer.concept_result_instructions&.text || ""
         curr_quest[:instructions] = direct.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", "")
       end
     end
@@ -142,7 +142,7 @@ module PublicProgressReports
     # Use DISTINCT ON to only pull one session per user
     final_sessions_by_user = ActivitySession
       .select("DISTINCT ON (activity_sessions.user_id) user_id, activity_sessions.*")
-      .includes(old_concept_results: :concept)
+      .includes(concept_results: :concept)
       .where(
         user_id: students.map(&:id),
         is_final_score: true,
@@ -179,7 +179,7 @@ module PublicProgressReports
   end
 
   def formatted_score_obj(final_activity_session, classification_key, student, average_score_on_quill)
-    formatted_concept_results = format_concept_results(final_activity_session, final_activity_session.old_concept_results)
+    formatted_concept_results = format_concept_results(final_activity_session, final_activity_session.concept_results)
     if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification_key)
       score = get_average_score(formatted_concept_results)
     elsif [ActivityClassification::EVIDENCE_KEY].include?(classification_key)
@@ -209,35 +209,35 @@ module PublicProgressReports
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_concept_results(activity_session, concept_results)
-    concept_results.group_by{|cr| cr[:metadata]["questionNumber"]}.map { |key, cr|
+    concept_results.group_by{|cr| cr.question_number}.map { |key, cr|
       # if we don't sort them, we can't rely on the first result being the first attemptNum
       # however, it would be more efficient to make them a hash with attempt numbers as keys
-      cr.sort!{|x,y| (x[:metadata]['attemptNumber'] || 0) <=> (y[:metadata]['attemptNumber'] || 0)}
-      directfirst = cr.first[:metadata]["directions"] || cr.first[:metadata]["instructions"] || ""
-      prompt_text = cr.first[:metadata]["prompt"]
+      cr.sort!{|x,y| (x.attempt_number || 0) <=> (y.attempt_number || 0)}
+      directfirst = cr.first.concept_result_directions&.text || cr.first.concept_result_instructions&.text || ""
+      prompt_text = cr.first.concept_result_prompt&.text
       hash = {
         directions: directfirst.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", ""),
         prompt: prompt_text,
-        answer: cr.first[:metadata]["answer"],
+        answer: cr.first.answer,
         score: get_score_for_question(cr),
         concepts: cr.map { |crs|
-          attempt_number = crs[:metadata]["attemptNumber"]
-          direct = crs[:metadata]["directions"] || crs[:metadata]["instructions"] || ""
+          attempt_number = crs.attempt_number
+          direct = crs.concept_result_directions&.text || crs.concept_result_instructions&.text || ""
           {
             id: crs.concept_id,
-            name: crs.concept.name,
-            correct: crs[:metadata]["correct"] == 1,
+            name: crs.concept&.name,
+            correct: crs.correct,
             feedback: get_feedback_from_feedback_history(activity_session, prompt_text, attempt_number),
-            lastFeedback: crs[:metadata]["lastFeedback"],
+            lastFeedback: crs.concept_result_previous_feedback&.text,
             attempt: attempt_number || 1,
-            answer: crs[:metadata]["answer"],
+            answer: crs.answer,
             directions: direct.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", "")
           }
         },
-        question_number: cr.first[:metadata]["questionNumber"]
+        question_number: cr.first.question_number
       }
-      if cr.first[:metadata]['questionScore']
-        hash[:questionScore] = cr.first[:metadata]['questionScore']
+      if cr.first.question_score
+        hash[:questionScore] = cr.first.question_score
       end
       hash
     }
@@ -245,10 +245,10 @@ module PublicProgressReports
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def get_score_for_question(concept_results)
-    if !concept_results.empty? && concept_results.first[:metadata]['questionScore']
-      concept_results.first[:metadata]['questionScore'] * 100
+    if !concept_results.empty? && concept_results.first.question_score
+      concept_results.first.question_score * 100
     else
-      concept_results.inject(0) {|sum, crs| sum + crs[:metadata]["correct"]} / concept_results.length * 100
+      concept_results.inject(0) {|sum, crs| sum + (crs.correct ? 1 : 0)} / concept_results.length * 100
     end
   end
 
@@ -358,8 +358,8 @@ module PublicProgressReports
 
   def concept_results_by_count(activity_session)
     hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
-    activity_session.old_concept_results.each do |concept_result|
-      hash[concept_result.concept.uid]["correct"] += concept_result["metadata"]["correct"]
+    activity_session.concept_results.each do |concept_result|
+      hash[concept_result.concept.uid]["correct"] += concept_result.correct ? 1 : 0
       hash[concept_result.concept.uid]["total"] += 1
     end
     hash

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -36,8 +36,11 @@ describe PublicProgressReports, type: :model do
 
       last_feedback = "This is the last feedback the student received."
       directions = "Combine the sentences."
-      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
-      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt", "questionNumber": 1, "questionScore": 0.75})
+      cr_directions = create(:concept_result_directions, text: directions)
+      cr_prompt = create(:concept_result_prompt, text: 'prompt')
+      cr_previous_feedback = create(:concept_result_previous_feedback, text: last_feedback)
+      create(:concept_result, activity_session: activity_session_two, attempt_number: 1, answer: 'Arbitrary sample incorrect answer.', correct: false, concept_result_directions: cr_directions, concept_result_prompt: cr_prompt, question_number: 1, question_score: 0.75)
+      create(:concept_result, activity_session: activity_session_two, attempt_number: 2, answer: 'Arbitrary sample correct answer.', correct: true, concept_result_previous_feedback: cr_previous_feedback, concept_result_directions: cr_directions, concept_result_prompt: cr_prompt, question_number: 1, question_score: 0.75)
       report = FakeReports.new.results_for_classroom(classroom_unit.unit_id, activity.id, classroom.id)
 
       expect(report[:students].count).to eq 1
@@ -56,8 +59,11 @@ describe PublicProgressReports, type: :model do
 
       last_feedback = "This is the last feedback the student received."
       directions = "Combine the sentences."
-      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 1, "answer": 'Arbitrary sample incorrect answer.', "correct": 0, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
-      create(:old_concept_result, activity_session: activity_session_two, metadata: { "attemptNumber": 2, "answer": 'Arbitrary sample correct answer.', "correct": 1, "lastFeedback": last_feedback, "directions": directions, "prompt": "prompt text", "questionNumber": 1, "questionScore": 0.75})
+      cr_directions = create(:concept_result_directions, text: directions)
+      cr_prompt = create(:concept_result_prompt, text: prompt.text)
+      cr_previous_feedback = create(:concept_result_previous_feedback, text: last_feedback)
+      create(:concept_result, activity_session: activity_session_two, attempt_number: 1, answer: 'Arbitrary sample incorrect answer.', correct: false, concept_result_directions: cr_directions, concept_result_prompt: cr_prompt, question_number: 1, question_score: 0.75)
+      create(:concept_result, activity_session: activity_session_two, attempt_number: 2, answer: 'Arbitrary sample correct answer.', correct: true, concept_result_previous_feedback: cr_previous_feedback, concept_result_directions: cr_directions, concept_result_prompt: cr_prompt, question_number: 1, question_score: 0.75)
       report = FakeReports.new.results_for_classroom(classroom_unit.unit_id, activity.id, classroom.id)
 
       expect(report[:students].count).to eq 1


### PR DESCRIPTION
## WHAT
Update the `PublicProgressReport` concern to utilize the new `ConceptResult` model instead of the `OldConceptResult` model.
## WHY
We want to pull all data from the new model instead of the old one
## HOW
Pull the data from the new model instead of the old one, and then work through the rest of the concern to ensure that it looks in the new locations for the data it cares about rather than the old location.  Update tests to pre-generate new models, but don't change any conditions or expectations.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
