### PR TITLE
update session handling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/actions/session.ts
@@ -34,9 +34,6 @@ interface FetchActiveActivitySessionArguments {
 }
 
 interface SaveActiveActivitySessionArguments {
-  sessionID: string,
-  submittedResponses: { [key: string]: FeedbackObject[] }|{},
-  activeStep: number,
   completedSteps: number[],
   timeTracking: { [key: number]: number },
   callback: Function
@@ -110,8 +107,9 @@ export const fetchActiveActivitySession = ({ sessionID, activityUID, callback, }
   }
 }
 
-export const saveActiveActivitySession = ({ sessionID, submittedResponses, activeStep, completedSteps, timeTracking, studentHighlights, callback, }: SaveActiveActivitySessionArguments) => {
-  return (dispatch: Function) => {
+export const saveActiveActivitySession = ({ completedSteps, timeTracking, studentHighlights, callback, }: SaveActiveActivitySessionArguments) => {
+  return (dispatch: Function, getState: Function) => {
+    const { sessionID, submittedResponses, activeStep, } = getState().session
     const activeActivitySessionUrl = `${process.env.DEFAULT_URL}/api/v1/active_activity_sessions/${sessionID}`
 
     const requestObject = {


### PR DESCRIPTION
## WHAT
Make anonymous sessions resumable via url and fix race condition in saving active activity sessions.

## WHY
We had a two-part card - allowing anonymous users to stay on their current step when they reload the page, and storing each attempt for students.

## HOW
I handled anonymous users by putting the session uid, which we were already generating, in the url on load, so reloading will resume the session same way it does for a student. For storing each attempt, that was already supposed to be happening, but wasn't due to a race condition.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Evidence-Refresh-Issue-1-Restart-Progress-on-Signed-In-2-Stay-on-Page-in-Signed-Out-ff0519b17ca3465aac8c87bd15bf7585

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | No, tested locally with tstaging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (YES