### PR TITLE
Lms/fix diagnostic student reports

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -16,8 +16,8 @@ module DiagnosticReports
 
   def data_for_skill_by_activity_session(all_concept_results, skill)
     concept_results = all_concept_results.select {|cr| cr.concept_id.in?(skill.concept_ids)}
-    number_correct = concept_results.select(&:correct?).length
-    number_incorrect = concept_results.reject(&:correct?).length
+    number_correct = concept_results.select(&:correct).length
+    number_incorrect = concept_results.reject(&:correct).length
     {
       id: skill.id,
       skill: skill.name,
@@ -45,14 +45,14 @@ module DiagnosticReports
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
       @assigned_students = User.where(id: classroom_unit.assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:old_concept_results, activity: {skills: :concepts})
+        .includes(:concept_results, activity: {skills: :concepts})
         .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids, activity_id: activity_id)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
       assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
-        .includes(:old_concept_results, activity: {skills: :concepts})
+        .includes(:concept_results, activity: {skills: :concepts})
         .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, is_final_score: true, user_id: assigned_student_ids)
         .order(completed_at: :desc)
         .uniq { |activity_session| activity_session.user_id }
@@ -69,7 +69,7 @@ module DiagnosticReports
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @pre_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @pre_test_activity_sessions = ActivitySession
-      .includes(:old_concept_results, activity: {skills: :concepts})
+      .includes(:concept_results, activity: {skills: :concepts})
       .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }
@@ -84,7 +84,7 @@ module DiagnosticReports
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     @post_test_assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
     @post_test_activity_sessions = ActivitySession
-      .includes(:old_concept_results, activity: :skills)
+      .includes(:concept_results, activity: :skills)
       .where(activity_id: activity_id, classroom_unit_id: classroom_units.ids, state: 'finished', user_id: assigned_student_ids)
       .order(completed_at: :desc)
       .uniq { |activity_session| activity_session.user_id }

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -57,8 +57,8 @@ module GrowthResultsSummary
     skill_groups.map do |skill_group|
       skills = skill_group.skills.map do |skill|
         {
-          pre: data_for_skill_by_activity_session(pre_test_activity_session.old_concept_results, skill),
-          post: data_for_skill_by_activity_session(post_test_activity_session.old_concept_results, skill)
+          pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
+          post: data_for_skill_by_activity_session(post_test_activity_session.concept_results, skill)
         }
       end
       pre_correct_skills = skills.select { |skill| skill[:pre][:summary] == FULLY_CORRECT }

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -48,7 +48,7 @@ module ResultsSummary
   # rubocop:disable Metrics/CyclomaticComplexity
   private def skill_groups_for_session(skill_groups, activity_session, student_name)
     skill_groups.map do |skill_group|
-      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.old_concept_results, skill) }
+      skills = skill_group.skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }
       present_skill_number = skills.reduce(0) { |sum, skill| sum += skill[:summary] == NOT_PRESENT ? 0 : 1 }
       correct_skills = skills.select { |skill| skill[:summary] == FULLY_CORRECT }
       correct_skill_ids = correct_skills.map { |s| s[:id] }

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -91,19 +91,19 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
 
       if pre_test && pre_test_activity_session
         concept_results = {
-          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) },
-          post: { questions: format_concept_results(activity_session, activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) }
+          pre: { questions: format_concept_results(pre_test_activity_session, pre_test_activity_session.concept_results.order("question_number::int")) },
+          post: { questions: format_concept_results(activity_session, activity_session.concept_results.order("question_number::int")) }
         }
         formatted_skills = skills.map do |skill|
           {
-            pre: data_for_skill_by_activity_session(pre_test_activity_session.old_concept_results, skill),
-            post: data_for_skill_by_activity_session(activity_session.old_concept_results, skill)
+            pre: data_for_skill_by_activity_session(pre_test_activity_session.concept_results, skill),
+            post: data_for_skill_by_activity_session(activity_session.concept_results, skill)
           }
         end
         skill_results = { skills: formatted_skills.uniq { |formatted_skill| formatted_skill[:pre][:skill] } }
       else
-        concept_results = { questions: format_concept_results(activity_session, activity_session.old_concept_results.order(Arel.sql("(metadata->>'questionNumber')::int"))) }
-        skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.old_concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
+        concept_results = { questions: format_concept_results(activity_session, activity_session.concept_results.order("question_number::int")) }
+        skill_results = { skills: skills.map { |skill| data_for_skill_by_activity_session(activity_session.concept_results, skill) }.uniq { |formatted_skill| formatted_skill[:skill] } }
       end
       { concept_results: concept_results, skill_results: skill_results, name: student.name }
     end
@@ -355,7 +355,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       activity_session = @activity_sessions[student.id]
 
       if activity_session
-        formatted_concept_results = format_concept_results(activity_session, activity_session.old_concept_results)
+        formatted_concept_results = format_concept_results(activity_session, activity_session.concept_results)
         score = get_average_score(formatted_concept_results)
         if score >= (ProficiencyEvaluator.proficiency_cutoff * 100)
           proficiency = ActivitySession::PROFICIENT
@@ -382,7 +382,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     @post_test_activity_sessions.reduce(0) do |sum, as|
       post_correct_skill_ids = as&.correct_skill_ids
       pre_correct_skill_ids = ActivitySession
-        .includes(:old_concept_results, activity: {skills: :concepts})
+        .includes(:concept_results, activity: {skills: :concepts})
         .where(user_id: as.user_id, activity_id: pre_test_activity_id)
         .order(completed_at: :desc)
         .first

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -9,11 +9,11 @@ describe DiagnosticReports do
     let!(:activity_session) { create(:activity_session) }
     let!(:concept) { create(:concept) }
     let!(:skill_concept) { create(:skill_concept, concept: concept) }
-    let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-    let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+    let!(:correct_concept_result) { create(:concept_result, concept: concept, activity_session: activity_session, correct: true) }
+    let!(:incorrect_concept_result) { create(:concept_result, concept: concept, activity_session: activity_session, correct: false) }
 
     it 'should return data with the name of the skill, number of correct concept results, number of incorrect concept results, and a summary' do
-      expect(data_for_skill_by_activity_session(activity_session.old_concept_results, skill_concept.skill)).to eq({
+      expect(data_for_skill_by_activity_session(activity_session.concept_results, skill_concept.skill)).to eq({
         id: skill_concept.skill.id,
         skill: skill_concept.skill.name,
         number_correct: 1,

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -24,9 +24,9 @@ describe GrowthResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-  let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-  let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+  let!(:pre_test_correct_concept_result) { create(:concept_result, concept: concept, activity_session: pre_test_activity_session, correct: true) }
+  let!(:post_test_correct_concept_result) { create(:concept_result, concept: concept, activity_session: post_test_activity_session, correct: true) }
+  let!(:pre_test_incorrect_concept_result) { create(:concept_result, concept: concept, activity_session: pre_test_activity_session, correct: false) }
 
   describe '#growth_results_summary' do
     it 'should return data with the student results and skill group summaries' do

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -18,8 +18,8 @@ describe ResultsSummary do
   let!(:concept) { create(:concept) }
   let!(:skill) { create(:skill, skill_group: skill_group_activity.skill_group) }
   let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-  let!(:correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: activity_session) }
-  let!(:incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: activity_session) }
+  let!(:correct_concept_result) { create(:concept_result, concept: concept, activity_session: activity_session, correct: true) }
+  let!(:incorrect_concept_result) { create(:concept_result, concept: concept, activity_session: activity_session, correct: false) }
 
   describe '#results_summary' do
     it 'should return data with the student results and skill group summaries' do


### PR DESCRIPTION
## WHAT
Fix diagnostic report segments to use new concept results
## WHY
1. We want to do this in general: using `concept_results` instead of `old_concept_results`
2. We actually deployed code that we didn't realize this was dependent on and already made the switch, so we want this code to not be broken in prod
## HOW
Tweak these controller functions to pass `concept_results` instead of `old_concept_results` into functions

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
