### PR TITLE
allow nil nces ids for districts

### DIFF
--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -27,7 +27,7 @@ class District < ApplicationRecord
   include Subscriber
 
   validates :name, presence: true
-  validates_uniqueness_of :nces_id, message: "A district with this NCES ID already exists."
+  validates_uniqueness_of :nces_id, allow_blank: true, message: "A district with this NCES ID already exists."
 
   has_many :schools
   has_many :district_admins, dependent: :destroy

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -29,6 +29,7 @@ describe District, type: :model do
   let!(:district) { create(:district) }
 
   it { should validate_uniqueness_of(:nces_id).with_message("A district with this NCES ID already exists.") }
+  it { should allow_value("", nil).for(:nces_id) }
 
   it { should have_many(:schools) }
   it { should have_many(:district_admins) }


### PR DESCRIPTION
## WHAT
Allow districts to have nil NCES ids.

## WHY
The partnerships team sometimes uses district records to organize schools that don't actually have an NCES id (like international districts). We have a uniqueness constraint that was preventing nil values.

## HOW
Just add an `allow_blank` to the validation.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Error-Message-When-Adding-a-New-District-to-CMS-aa5a5a35080b49c0992b6d2c77443117

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
