### PR TITLE
lms/reduce-vitally-api-rate

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -7,7 +7,7 @@ class SyncVitallyWorker
   FIRST_DAY_OF_SCHOOL_YEAR_MONTH = 7
   FIRST_DAY_OF_SCHOOL_YEAR_DAY = 1
   # We actually have a 1000/minute rate limit, but we can play it safe
-  ORGANIZATION_RATE_LIMIT_PER_MINUTE = 950
+  ORGANIZATION_RATE_LIMIT_PER_MINUTE = 500
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def perform


### PR DESCRIPTION
## WHAT
Tweak how many requests we feed to the Vitally REST API overnight
## WHY
We were trying to send 50 under our minute-ly limit, and send only every other minute, but we're still getting some rate limiting overnight.  So let's just play it extra safe and send half of our allotment at a time.  Hopefully that'll get all our data through without running into rate limits at all.
## HOW
Reduce our "per minute" rate limit from 950 to 500.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  There's no actual behavior change, so no tests to update
Have you deployed to Staging? | No, this is a tiny change that will only run into issues with production scales of data
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
