### PR TITLE
add clever id and account type to cms user edit page

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -147,7 +147,7 @@ class Cms::UsersController < Cms::CmsController
   end
 
   protected def user_params
-    params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :classcode, :password, :password_confirmation, :flags =>[]] + default_params
+    params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :classcode, :password, :password_confirmation, :account_type, :clever_id, :flags =>[]] + default_params
     )
   end
 
@@ -318,7 +318,7 @@ class Cms::UsersController < Cms::CmsController
   end
 
   private def log_attribute_change
-    previous_user_params = User.where(:id => @user.id).select(:name, :email, :username, :title, :role, :classcode, :flags).first.as_json
+    previous_user_params = User.where(:id => @user.id).select(:name, :email, :username, :title, :role, :classcode, :flags, :account_type, :clever_id).first.as_json
 
     #omit password field if password not filled in
     if user_params[:password].blank?

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -91,6 +91,10 @@ class User < ApplicationRecord
 
   GOOGLE_CLASSROOM_ACCOUNT = 'Google Classroom'
   CLEVER_ACCOUNT = 'Clever'
+  TEACHER_CREATED_ACCOUNT = 'Teacher Created Account'
+  STUDENT_CREATED_ACCOUNT = 'Student Created Account'
+  UNKNOWN = 'unknown'
+  ACCOUNT_TYPES = [GOOGLE_CLASSROOM_ACCOUNT, CLEVER_ACCOUNT, TEACHER_CREATED_ACCOUNT, STUDENT_CREATED_ACCOUNT, UNKNOWN]
 
   attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 

--- a/services/QuillLMS/app/views/cms/users/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/users/_form.html.erb
@@ -38,6 +38,14 @@
       <%= f.select :flagset, UserFlagset::FLAGSETS.keys.map(&:to_s) %>
     </div>
     <div class='cms-form-row'>
+      <%= f.label :account_type %>
+      <%= f.select :account_type, User::ACCOUNT_TYPES %>
+    </div>
+    <div class='cms-form-row'>
+      <%= f.label :clever_id %>
+      <%= f.text_field :clever_id, autocomplete: 'off' %>
+    </div>
+    <div class='cms-form-row'>
       <%= f.label :classcode %>
       <%= f.text_field :classcode, autocomplete: 'off' %>
     </div>

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -236,6 +236,23 @@ describe Cms::UsersController do
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
       expect(ChangeLog.last.new_value).to include('new@test.com')
     end
+
+    it 'should update the attributes for the given user and update change_log when the attribute is the clever id' do
+      post :update, params: { id: another_user.id, user: { clever_id: 'abc' } }
+      expect(another_user.reload.clever_id).to eq 'abc'
+      expect(response).to redirect_to cms_users_path
+      expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
+      expect(ChangeLog.last.new_value).to include('abc')
+    end
+
+    it 'should update the attributes for the given user and update change_log when the attribute is the account_type' do
+      post :update, params: { id: another_user.id, user: { account_type: User::CLEVER } }
+      expect(another_user.reload.account_type).to eq User::CLEVER
+      expect(response).to redirect_to cms_users_path
+      expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
+      expect(ChangeLog.last.new_value).to include(User::CLEVER)
+    end
+
   end
 
   describe '#clear_data' do

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -246,11 +246,11 @@ describe Cms::UsersController do
     end
 
     it 'should update the attributes for the given user and update change_log when the attribute is the account_type' do
-      post :update, params: { id: another_user.id, user: { account_type: User::CLEVER } }
-      expect(another_user.reload.account_type).to eq User::CLEVER
+      post :update, params: { id: another_user.id, user: { account_type: User::CLEVER_ACCOUNT } }
+      expect(another_user.reload.account_type).to eq User::CLEVER_ACCOUNT
       expect(response).to redirect_to cms_users_path
       expect(ChangeLog.last.action).to eq(ChangeLog::USER_ACTIONS[:update])
-      expect(ChangeLog.last.new_value).to include(User::CLEVER)
+      expect(ChangeLog.last.new_value).to include(User::CLEVER_ACCOUNT)
     end
 
   end


### PR DESCRIPTION
## WHAT
Add Clever ID and Account Type to the CMS user edit page.

## WHY
I used the console to update a student's clever id, and Scarlet asked about how I did it and expressed that they have a complicated workaround to perform that action. This will make this change easier.

## HOW
Just update the erb file and the controller to accept the new params.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/No-student-present-message-when-student-logs-in-with-Clever-8eb5c96103974f91bb6925adfb4da3a2?d=d211860a668043ba8bde4a7a3c51d0de

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tested locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
