### PR TITLE
lms/additional-concept-result-cleanup

### DIFF
--- a/services/QuillLMS/app/helpers/concept_helper.rb
+++ b/services/QuillLMS/app/helpers/concept_helper.rb
@@ -5,7 +5,7 @@ module ConceptHelper
     return '' unless activity_session.present?
 
     # Generate a header for each applicable concept class (activity session has concept tag results for that class)
-    concept_results = activity_session.old_concept_results
+    concept_results = activity_session.concept_results
     concepts = activity_session.concepts
     concepts.reduce "" do |html, concept|
       html += stats_for_concept(concept, concept_results)
@@ -19,7 +19,7 @@ module ConceptHelper
     concept_results.each do |result|
       next unless result.concept == concept
 
-      if result.correct?
+      if result.correct
         correct_count += 1
       else
         incorrect_count += 1


### PR DESCRIPTION
## WHAT
Update the `ConceptHelper` to look in ConceptResult records
## WHY
We want to get away from `OldConceptResult` records and use `ConceptResult` records exclusively.
## HOW
Pull data from `concept_results` instead of `old_concept_results` and update the functions so that they understand how to calculate correct vs incorrect with the new data shape

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No behavior change, so no test update
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
