### PR TITLE
support private activity search

### DIFF
--- a/services/QuillLMS/app/models/concerns/flags.rb
+++ b/services/QuillLMS/app/models/concerns/flags.rb
@@ -10,7 +10,8 @@ module Flags
     EVIDENCE_BETA2 = 'evidence_beta2',
     BETA = 'beta',
     GAMMA = 'gamma',
-    COLLEGE_BOARD = 'college_board'
+    COLLEGE_BOARD = 'college_board',
+    PRIVATE = 'private'
   ]
 
   module ClassMethods

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -57,7 +57,21 @@ module UserFlagset
           Flags::COLLEGE_BOARD  =>    { display_name: 'College Board' },
           Flags::PRODUCTION =>        { display_name: 'Production' }
         }
-      }
+      },
+
+      private: {
+        display_name: 'Private',
+        flags: {
+          Flags::ALPHA =>             { display_name: 'Alpha' },
+          Flags::EVIDENCE_BETA1 =>    { display_name: 'Evidence Beta 1' },
+          Flags::EVIDENCE_BETA2 =>    { display_name: 'Evidence Beta 2' },
+          Flags::BETA =>              { display_name: 'Beta' },
+          Flags::COLLEGE_BOARD =>     { display_name: 'College Board' },
+          Flags::PRODUCTION =>        { display_name: 'Production' },
+          Flags::PRIVATE =>           { display_name: 'Private' }
+        }
+      },
+
     }
 
     validates :flagset, inclusion: { in: FLAGSETS.keys.map(&:to_s) }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/create_unit.jsx
@@ -94,7 +94,7 @@ export default class CreateUnit extends React.Component {
   getActivities = () => {
     const { match, } = this.props
     const { stage, } = this.state
-    const privateFlag = [2, 3].includes(stage) ? "?flag=private" : ''
+    const privateFlag = [2, 3].includes(stage) ? "?flagset=private" : ''
     requestGet(`/activities/search${privateFlag}`, (body) => {
       const { activities, } = body
       const activityIdsArray = match.params.activityIdsArray || window.localStorage.getItem(ACTIVITY_IDS_ARRAY)


### PR DESCRIPTION
## WHAT
Fix private activity search (final view for assign activity packs) by adding a `private` flagset and updating the querystring on the frontend.

## WHY
We always do a `private` flagged activity search on this page because users can't actually perform a search here, just see previously-selected activities, and we use the `private` flag specifically for some activities that are never supposed to show up in search but should still be assignable (like the growth diagnostics). 

## HOW
Update the query string from `flag` to `flagset` since that's what the backend expects now, and add a `private` flagset that encompasses all the other flagsets so the query will work correctly.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/ELL-Intermediate-Growth-Diagnostic-cannot-be-assigned-a52ad1c24d7545f78634eb46d128fa4a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
