### PR TITLE
Lms/refactor activity sessions concept results

### DIFF
--- a/services/QuillLMS/app/graphql/types/user_type.rb
+++ b/services/QuillLMS/app/graphql/types/user_type.rb
@@ -77,8 +77,8 @@ class Types::UserType < Types::BaseObject
 
   private def concept_results_by_count activity_session
     hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
-    activity_session.old_concept_results.each do |concept_result|
-      hash[concept_result.concept.uid]["correct"] += concept_result["metadata"]["correct"]
+    activity_session.concept_results.each do |concept_result|
+      hash[concept_result.concept.uid]["correct"] += concept_result.correct ? 1 : 0
       hash[concept_result.concept.uid]["total"] += 1
     end
     hash

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -315,9 +315,9 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:concept) { create(:concept) }
     let!(:skill) { create(:skill, skill_group: pre_test_skill_group_activity.skill_group) }
     let!(:skill_concept) { create(:skill_concept, concept: concept, skill: skill) }
-    let!(:pre_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: pre_test_activity_session) }
-    let!(:post_test_correct_concept_result) { create(:concept_result_with_correct_answer, concept: concept, activity_session: post_test_activity_session) }
-    let!(:pre_test_incorrect_concept_result) { create(:concept_result_with_incorrect_answer, concept: concept, activity_session: pre_test_activity_session) }
+    let!(:pre_test_correct_concept_result) { create(:concept_result, concept: concept, activity_session: pre_test_activity_session, correct: true) }
+    let!(:post_test_correct_concept_result) { create(:concept_result, concept: concept, activity_session: post_test_activity_session, correct: true) }
+    let!(:pre_test_incorrect_concept_result) { create(:concept_result, concept: concept, activity_session: pre_test_activity_session, correct: false) }
 
     it 'should return the total number of acquired skills' do
       get :skills_growth, params: ({classroom_id: classroom.id, post_test_activity_id: post_test_unit_activity.activity_id, pre_test_activity_id: pre_test_unit_activity.activity_id})

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -506,15 +506,15 @@ end
   describe '#parse_for_results' do
     let!(:activity_session) { create(:activity_session) }
     let!(:proficient_concept) { create(:concept)}
-    let!(:proficient_concept_result) { create(:concept_result_with_correct_answer, concept: proficient_concept, activity_session: activity_session)}
+    let!(:proficient_concept_result) { create(:concept_result, concept: proficient_concept, activity_session: activity_session, correct: true)}
     let!(:nearly_proficient_concept) { create(:concept)}
-    let!(:nearly_proficient_concept_result_positive1) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_positive2) { create(:concept_result_with_correct_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
-    let!(:nearly_proficient_concept_result_negative) { create(:concept_result_with_incorrect_answer, concept: nearly_proficient_concept, activity_session: activity_session)}
+    let!(:nearly_proficient_concept_result_positive1) { create(:concept_result, concept: nearly_proficient_concept, activity_session: activity_session, correct: true)}
+    let!(:nearly_proficient_concept_result_positive2) { create(:concept_result, concept: nearly_proficient_concept, activity_session: activity_session, correct: true)}
+    let!(:nearly_proficient_concept_result_negative) { create(:concept_result, concept: nearly_proficient_concept, activity_session: activity_session, correct: false)}
     let!(:not_yet_proficient_concept) { create(:concept)}
-    let!(:not_yet_proficient_concept_result) { create(:concept_result_with_incorrect_answer, concept: not_yet_proficient_concept, activity_session: activity_session)}
+    let!(:not_yet_proficient_concept_result) { create(:concept_result, concept: not_yet_proficient_concept, activity_session: activity_session, correct: false)}
     let!(:ignored_concept) { create(:concept, uid: ActivitySession::CONCEPT_UIDS_TO_EXCLUDE_FROM_REPORT[0])}
-    let!(:ignored_concept_result) { create(:concept_result_with_incorrect_answer, concept: ignored_concept, activity_session: activity_session)}
+    let!(:ignored_concept_result) { create(:concept_result, concept: ignored_concept, activity_session: activity_session, correct: false)}
 
     it 'should return an object with concept results organized by category' do
       expect(activity_session.parse_for_results[ActivitySession::PROFICIENT]).to be_present
@@ -543,7 +543,7 @@ end
     it 'should return the ignored concept result if there are at least four concept results for it' do
       3.times do |i|
         ignored_concept_result.id = nil
-        OldConceptResult.create(ignored_concept_result.attributes)
+        ConceptResult.create(ignored_concept_result.attributes)
       end
       expect(activity_session.parse_for_results[ActivitySession::NOT_YET_PROFICIENT]).to include(ignored_concept.name)
     end
@@ -851,7 +851,7 @@ end
     let!(:activity_session1) { create(:activity_session, activity: activity, classroom_unit: classroom_unit) }
 
     it 'should delete the activity sessions without the concept results' do
-      activity_session.old_concept_results.destroy_all
+      create(:concept_result, activity_session: activity_session)
       expect{ ActivitySession.delete_activity_sessions_with_no_concept_results([activity_session, activity_session1]) }.to change(ActivitySession, :count).by(-1)
     end
   end


### PR DESCRIPTION
## WHAT
- Clean up `ActivitySession` model references to `old_concept_results`
- Update a test that was sneakily using `OldConceptResult` factories
- Update the Graphql code to use `concept_results` instead of `old_concept_results`
## WHY
We want to stop using `OldConceptResult` data everywhere
## HOW
Pretty straightforward repetition of previously-used logic to use new `concept_results` instead of `old_concept_results`

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
