### PR TITLE
force integration spec to wait until necessary content has loaded

### DIFF
--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
-    # the following line checks for the presence of an element that only loads once activity data has loaded, ensuring that the assign click will be successful 
+    # the following line checks for the presence of an element that only loads once activity data has loaded, ensuring that the assign click will be successful
     first('.review-activities-data-table-section').click
     click_on 'Assign pack to classes'
     click_on 'Next'

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
-    driver.wait.until.find_element(:class, "review-activities-data-table-section")
+    wait.until.find_element(:class, "review-activities-data-table-section")
     click_on 'Assign pack to classes'
     click_on 'Next'
     click_on 'Take me to my dashboard'

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
-    find('.review-activities-data-table-section').click
+    first('.review-activities-data-table-section').click
     click_on 'Assign pack to classes'
     click_on 'Next'
     click_on 'Take me to my dashboard'

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
+    # the following line checks for the presence of an element that only loads once activity data has loaded, ensuring that the assign click will be successful 
     first('.review-activities-data-table-section').click
     click_on 'Assign pack to classes'
     click_on 'Next'

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
+    driver.wait.until.find_element(:class, "review-activities-data-table-section")
     click_on 'Assign pack to classes'
     click_on 'Next'
     click_on 'Take me to my dashboard'

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Assign a diagnostic'
     first(:button, 'Select').click
     find('span.all-classes-text', text: 'All classes and students').sibling('span').click
-    wait.until.find_element(:class, "review-activities-data-table-section")
+    find('.review-activities-data-table-section').click
     click_on 'Assign pack to classes'
     click_on 'Next'
     click_on 'Take me to my dashboard'


### PR DESCRIPTION
## WHAT
Update the Activity Pack Assignment spec to wait until the activity data has loaded before attempting to click "assign".

## WHY
This test kept failing, because the data hadn't loaded yet.

## HOW
Add a "click" to an element that only appears once the activity data has loaded - capybara will wait for it to load before attempting that click, ensuring that the next click (on the assign button) will be successful instead of erroring.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
