### PR TITLE
Student reports/ Diagnostic reports buttons

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
@@ -166,7 +166,7 @@
       }
       .diagnostic-reports-button {
         border: none;
-        font-weight: 700;
+        font-weight: 700 !important;
         font-size: 14px;
         padding-left: 0;
         margin-top: 20px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
@@ -128,6 +128,17 @@
             border-right: 1px solid #e0e0e0;
           }
         }
+        .post {
+          .post-buttons-container {
+            display: flex;
+            button:first-of-type {
+              margin-right: 8px;
+            }
+            button:focus {
+              outline-offset: 4px;
+            }
+          }
+        }
       }
     }
   }
@@ -152,6 +163,14 @@
         &.pre, &.post {
           max-width: 100%;
         }
+      }
+      .diagnostic-reports-button {
+        border: none;
+        font-weight: 700;
+        font-size: 14px;
+        padding-left: 0;
+        margin-top: 20px;
+        color: #5C5C5C;
       }
     }
   }

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_activity_packs.scss
@@ -131,13 +131,20 @@
         .post {
           .post-buttons-container {
             display: flex;
-            button:first-of-type {
+            a:first-of-type {
               margin-right: 8px;
             }
-            button:focus {
+            a:focus, button:focus {
               outline-offset: 4px;
             }
           }
+        }
+        .diagnostic-reports-button {
+          color: #000000;
+          font-size: 13px;
+        }
+        .diagnostic-reports-button:hover, .diagnostic-reports-button:focus {
+          background-color: #f5f5f5;
         }
       }
     }
@@ -162,6 +169,20 @@
         }
         &.pre, &.post {
           max-width: 100%;
+        }
+      }
+      .post {
+        .post-buttons-container {
+          align-items: baseline;
+          a {
+            text-align: left;
+            margin-right: 8px;
+            padding-right: 0;
+            min-width: auto;
+          }
+          button {
+            margin-top: 0px;
+          }
         }
       }
       .diagnostic-reports-button {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
@@ -79,7 +79,9 @@
       background-color: #cccccc;
     }
   }
-
+  &.unbolded {
+    font-weight: 400 !important;
+  }
 }
 
 #teacher-preview-menu-button {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/diagnostic_activity_packs.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/diagnostic_activity_packs.test.jsx.snap
@@ -1644,12 +1644,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/992/classroom/6/summary?unit=110"
                       >
                         View results and recommendations
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </AssignedSection>
@@ -1903,12 +1903,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/992/classroom/1/summary?unit=110"
                       >
                         View results and recommendations
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2029,12 +2029,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1678/classroom/1/summary"
                       >
                         View results and recommendations
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2101,12 +2101,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <button
+                        <a
                           className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                          onClick={[Function]}
+                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1680/classroom/1/growth_summary"
                         >
                           View results and recommendations
-                        </button>
+                        </a>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2125,12 +2125,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1680/classroom/1/growth_summary"
                       >
                         View growth
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </GrowthSummarySection>
@@ -2227,12 +2227,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1668/classroom/1/summary"
                       >
                         View results and recommendations
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2299,12 +2299,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <button
+                        <a
                           className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                          onClick={[Function]}
+                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1669/classroom/1/growth_summary"
                         >
                           View results and recommendations
-                        </button>
+                        </a>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2323,12 +2323,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1669/classroom/1/growth_summary"
                       >
                         View growth
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </GrowthSummarySection>
@@ -2425,12 +2425,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1663/classroom/1/summary"
                       >
                         View results and recommendations
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2497,12 +2497,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <button
+                        <a
                           className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                          onClick={[Function]}
+                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1664/classroom/1/growth_summary"
                         >
                           View results and recommendations
-                        </button>
+                        </a>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2521,12 +2521,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <button
+                      <a
                         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-                        onClick={[Function]}
+                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1664/classroom/1/growth_summary"
                       >
                         View growth
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </GrowthSummarySection>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/diagnostic_activity_packs.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/diagnostic_activity_packs.test.jsx.snap
@@ -1644,12 +1644,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/992/classroom/6/summary?unit=110"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View results and recommendations
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </AssignedSection>
@@ -1903,12 +1903,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/992/classroom/1/summary?unit=110"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View results and recommendations
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2029,12 +2029,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1678/classroom/1/summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View results and recommendations
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2101,12 +2101,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <a
-                          className="focus-on-light"
-                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1680/classroom/1/growth_summary"
+                        <button
+                          className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                          onClick={[Function]}
                         >
                           View results and recommendations
-                        </a>
+                        </button>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2125,12 +2125,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1680/classroom/1/growth_summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View growth
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </GrowthSummarySection>
@@ -2227,12 +2227,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1668/classroom/1/summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View results and recommendations
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2299,12 +2299,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <a
-                          className="focus-on-light"
-                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1669/classroom/1/growth_summary"
+                        <button
+                          className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                          onClick={[Function]}
                         >
                           View results and recommendations
-                        </a>
+                        </button>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2323,12 +2323,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1669/classroom/1/growth_summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View growth
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </GrowthSummarySection>
@@ -2425,12 +2425,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </p>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1663/classroom/1/summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View results and recommendations
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </AssignedSection>
@@ -2497,12 +2497,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                         </p>
                       </div>
                       <div>
-                        <a
-                          className="focus-on-light"
-                          href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1664/classroom/1/growth_summary"
+                        <button
+                          className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                          onClick={[Function]}
                         >
                           View results and recommendations
-                        </a>
+                        </button>
                       </div>
                     </section>
                   </AssignedSection>
@@ -2521,12 +2521,12 @@ exports[`DiagnosticActivityPacks component should render when there are classroo
                       </h4>
                     </div>
                     <div>
-                      <a
-                        className="focus-on-light"
-                        href="/teachers/progress_reports/diagnostic_reports/#/diagnostics/1664/classroom/1/growth_summary"
+                      <button
+                        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+                        onClick={[Function]}
                       >
                         View growth
-                      </a>
+                      </button>
                     </div>
                   </section>
                 </GrowthSummarySection>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/growthSummary.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/growthSummary.test.jsx.snap
@@ -58,12 +58,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </p>
     </div>
     <div>
-      <a
-        className="focus-on-light"
-        href=""
+      <button
+        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+        onClick={[Function]}
       >
         View growth
-      </a>
+      </button>
     </div>
   </section>
 </GrowthSummarySection>
@@ -103,12 +103,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </p>
     </div>
     <div>
-      <a
-        className="focus-on-light"
-        href=""
+      <button
+        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+        onClick={[Function]}
       >
         View growth
-      </a>
+      </button>
     </div>
   </section>
 </GrowthSummarySection>
@@ -130,12 +130,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </h4>
     </div>
     <div>
-      <a
-        className="focus-on-light"
-        href=""
+      <button
+        className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
+        onClick={[Function]}
       >
         View growth
-      </a>
+      </button>
     </div>
   </section>
 </GrowthSummarySection>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/growthSummary.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/growthSummary.test.jsx.snap
@@ -58,12 +58,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </p>
     </div>
     <div>
-      <button
+      <a
         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-        onClick={[Function]}
+        href=""
       >
         View growth
-      </button>
+      </a>
     </div>
   </section>
 </GrowthSummarySection>
@@ -103,12 +103,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </p>
     </div>
     <div>
-      <button
+      <a
         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-        onClick={[Function]}
+        href=""
       >
         View growth
-      </button>
+      </a>
     </div>
   </section>
 </GrowthSummarySection>
@@ -130,12 +130,12 @@ exports[`GrowthSummarySection component should render showGrowthSummarySection i
       </h4>
     </div>
     <div>
-      <button
+      <a
         className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light"
-        onClick={[Function]}
+        href=""
       >
         View growth
-      </button>
+      </a>
     </div>
   </section>
 </GrowthSummarySection>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/diagnostic_activity_packs.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/diagnostic_activity_packs.tsx
@@ -40,10 +40,6 @@ const AssignedSection = ({ activity, sectionTitle, isPostDiagnostic, }) => {
   if (window.innerWidth > MOBILE_WIDTH && ((activityPackText.length * AVERAGE_FONT_WIDTH) > ACTIVITY_PACK_TEXT_MAX_WIDTH)) {
     activityPackElement = <Tooltip tooltipText={activityPackText} tooltipTriggerText={activityPackText} tooltipTriggerTextClass="activity-pack-name" />
   }
-  function handleClick() {
-    const location = summaryLink(isPostDiagnostic, activity_id, classroom_id, unit_id);
-    window.location.href = location;
-  }
   return (
     <section className="pre">
       <div>
@@ -53,7 +49,7 @@ const AssignedSection = ({ activity, sectionTitle, isPostDiagnostic, }) => {
         <p>{multipleUsersIcon}<span>Completed: {completed_count} of {assigned_count}</span></p>
       </div>
       <div>
-        <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleClick}>View results and recommendations</button>
+        <a className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" href={summaryLink(isPostDiagnostic, activity_id, classroom_id, unit_id)}>View results and recommendations</a>
       </div>
     </section>
   )
@@ -79,13 +75,6 @@ const PostSection = ({ post, activityId, unitTemplateId, name, }) => {
     goToAssign(unitTemplateId, name, activityId)
   }
 
-  function handlePreviewClick(e) {
-    const { target } = e
-    const { value } = target
-    const link = `/activity_sessions/anonymous?activity_id=${value}`
-    window.open(link, '_blank')
-  }
-
   return (
     <section className="post">
       <div>
@@ -93,7 +82,7 @@ const PostSection = ({ post, activityId, unitTemplateId, name, }) => {
         <p>{calendarDateIcon}<span>Not assigned</span></p>
       </div>
       <div className="post-buttons-container">
-        <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handlePreviewClick} value={activityId}>Preview</button>
+        <a className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" href={`/activity_sessions/anonymous?activity_id=${activityId}`} rel="noopener noreferrer" target="_blank">Preview</a>
         <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleAssignClick} type="button">Assign</button>
       </div>
     </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/diagnostic_activity_packs.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/diagnostic_activity_packs.tsx
@@ -40,6 +40,10 @@ const AssignedSection = ({ activity, sectionTitle, isPostDiagnostic, }) => {
   if (window.innerWidth > MOBILE_WIDTH && ((activityPackText.length * AVERAGE_FONT_WIDTH) > ACTIVITY_PACK_TEXT_MAX_WIDTH)) {
     activityPackElement = <Tooltip tooltipText={activityPackText} tooltipTriggerText={activityPackText} tooltipTriggerTextClass="activity-pack-name" />
   }
+  function handleClick() {
+    const location = summaryLink(isPostDiagnostic, activity_id, classroom_id, unit_id);
+    window.location.href = location;
+  }
   return (
     <section className="pre">
       <div>
@@ -49,7 +53,7 @@ const AssignedSection = ({ activity, sectionTitle, isPostDiagnostic, }) => {
         <p>{multipleUsersIcon}<span>Completed: {completed_count} of {assigned_count}</span></p>
       </div>
       <div>
-        <a className="focus-on-light" href={summaryLink(isPostDiagnostic, activity_id, classroom_id, unit_id)}>View results and recommendations</a>
+        <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleClick}>View results and recommendations</button>
       </div>
     </section>
   )
@@ -75,15 +79,22 @@ const PostSection = ({ post, activityId, unitTemplateId, name, }) => {
     goToAssign(unitTemplateId, name, activityId)
   }
 
+  function handlePreviewClick(e) {
+    const { target } = e
+    const { value } = target
+    const link = `/activity_sessions/anonymous?activity_id=${value}`
+    window.open(link, '_blank')
+  }
+
   return (
     <section className="post">
       <div>
         <h4>Post</h4>
         <p>{calendarDateIcon}<span>Not assigned</span></p>
       </div>
-      <div>
-        <a className="focus-on-light" href={`/activity_sessions/anonymous?activity_id=${activityId}`} rel="noopener noreferrer" target="_blank">Preview</a>
-        <button className="focus-on-light fake-link" onClick={handleAssignClick} type="button">Assign</button>
+      <div className="post-buttons-container">
+        <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handlePreviewClick} value={activityId}>Preview</button>
+        <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleAssignClick} type="button">Assign</button>
       </div>
     </section>
   )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummarySection.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummarySection.tsx
@@ -12,6 +12,11 @@ interface GrowthSummaryProps {
 }
 
 const GrowthSummarySection = ({ showGrowthSummary, skillsGrowth, name, growthSummaryLink, }: GrowthSummaryProps) => {
+
+  function handleClick() {
+    window.location.href = growthSummaryLink;
+  }
+
   if (showGrowthSummary) {
     const growth = skillsGrowth > 0 ? <span className="growth">{triangleUpIcon}{skillsGrowth}</span> : <span className="no-growth">No growth yet</span>
     return (
@@ -21,7 +26,7 @@ const GrowthSummarySection = ({ showGrowthSummary, skillsGrowth, name, growthSum
           {skillsGrowth !== null && <p>{barGraphIncreasingIcon}<span>Skills growth: {growth}</span></p>}
         </div>
         <div>
-          <a className="focus-on-light" href={growthSummaryLink}>View growth</a>
+          <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleClick}>View growth</button>
         </div>
       </section>
     )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummarySection.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummarySection.tsx
@@ -13,10 +13,6 @@ interface GrowthSummaryProps {
 
 const GrowthSummarySection = ({ showGrowthSummary, skillsGrowth, name, growthSummaryLink, }: GrowthSummaryProps) => {
 
-  function handleClick() {
-    window.location.href = growthSummaryLink;
-  }
-
   if (showGrowthSummary) {
     const growth = skillsGrowth > 0 ? <span className="growth">{triangleUpIcon}{skillsGrowth}</span> : <span className="no-growth">No growth yet</span>
     return (
@@ -26,7 +22,7 @@ const GrowthSummarySection = ({ showGrowthSummary, skillsGrowth, name, growthSum
           {skillsGrowth !== null && <p>{barGraphIncreasingIcon}<span>Skills growth: {growth}</span></p>}
         </div>
         <div>
-          <button className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" onClick={handleClick}>View growth</button>
+          <a className="diagnostic-reports-button quill-button fun secondary outlined unbolded focus-on-light" href={growthSummaryLink}>View growth</a>
         </div>
       </section>
     )


### PR DESCRIPTION
## WHAT
update styling for buttons on the Diagnostic reports page

## WHY
we want to address the lack of affordance on buttons

## HOW
just switch from using a tags to buttons, add click handlers and update styling

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1008" alt="Screen Shot 2022-09-06 at 2 08 51 PM" src="https://user-images.githubusercontent.com/25959584/188708508-b5afe72c-5a09-4854-aab9-2866d873dbf0.png">
<img width="185" alt="Screen Shot 2022-09-06 at 2 10 14 PM" src="https://user-images.githubusercontent.com/25959584/188708517-6d2d5926-2a6e-4881-bbe8-e594ad5cdcd7.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Design-Address-lack-of-affordance-for-buttons-in-the-Student-Reports-page-fc0d02ffb71a449fb0e3cbb843cdae2f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
