### PR TITLE
Flagset bugfix

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -202,7 +202,7 @@ class Activity < ApplicationRecord
   end
 
   def self.clear_activity_search_cache
-    UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+    UserFlagset::FLAGSETS.keys.map{|x| "#{x}_"}.push("").each do |flagset|
       $redis.del("default_#{flagset}activity_search")
     end
   end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -202,8 +202,8 @@ class Activity < ApplicationRecord
   end
 
   def self.clear_activity_search_cache
-    %w(private_ production_ gamma_ beta_ alpha_ archived_).push('').each do |flag|
-      $redis.del("default_#{flag}activity_search")
+    UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+      $redis.del("default_#{flagset}activity_search")
     end
   end
 

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -362,13 +362,13 @@ describe Activity, type: :model, redis: true do
     end
 
     it 'deletes all redis keys as defined in UserFlagset' do
-      UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+      UserFlagset::FLAGSETS.keys.map{|x| "#{x}_"}.push("").each do |flagset|
         $redis.set("default_#{flagset}activity_search", {a_key: 'a_value'} )
       end
 
       Activity.clear_activity_search_cache
 
-      UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+      UserFlagset::FLAGSETS.keys.map{|x| "#{x}_"}.push("").each do |flagset|
         expect(
           $redis.del("default_#{flagset}activity_search")
         ).to eq 0

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -361,6 +361,20 @@ describe Activity, type: :model, redis: true do
       expect($redis.get('default_activity_search')).to eq nil
     end
 
+    it 'deletes all redis keys as defined in UserFlagset' do
+      UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+        $redis.set("default_#{flagset}activity_search", {a_key: 'a_value'} )
+      end
+
+      Activity.clear_activity_search_cache
+
+      UserFlagset::FLAGSETS.keys.map{|x| "#{x.to_s}_"}.push("").each do |flagset|
+        expect(
+          $redis.del("default_#{flagset}activity_search")
+        ).to eq 0
+      end
+    end
+
     it 'should call clear_activity_search_cache' do
       expect(Activity).to receive(:clear_activity_search_cache)
       activity.clear_activity_search_cache

--- a/services/QuillLMS/spec/queries/activity_search_spec.rb
+++ b/services/QuillLMS/spec/queries/activity_search_spec.rb
@@ -8,6 +8,7 @@ describe ActivitySearch do
     let!(:standard) { create(:standard) }
     let!(:standard_level) { create(:standard_level) }
     let!(:activity) { create(:activity, activity_categories: [], flags: %w{beta production}, activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
+    let!(:beta_flagset_activity) { create(:activity, activity_categories: [], name: 'special activity', flags: %w{evidence_beta1}, activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
     let!(:activity_category) { create(:activity_category) }
     let!(:activity_category_activity) { create(:activity_category_activity, activity_category: activity_category, activity: activity) }
     let!(:content_partner) { create(:content_partner) }
@@ -15,33 +16,44 @@ describe ActivitySearch do
     let!(:topic) { create(:topic) }
     let!(:activity_topic) { create(:activity_topic, topic: topic, activity: activity)}
 
-    it 'should get the correct attributes based on the flag given' do
-      expect(described_class.search("beta").first).to eq(
-        {
-          "activity_name" => activity.name,
-          "activity_description" => activity.description ,
-          "activity_flag" => "{beta,production}",
-          "activity_id" => activity.id,
-          "activity_maximum_grade_level" => activity.maximum_grade_level,
-          "activity_minimum_grade_level" => activity.minimum_grade_level,
-          "activity_uid" => activity.uid,
-          "activity_category_id" => activity_category.id,
-          "activity_category_name" => activity_category.name,
-          "standard_level_id" => standard_level.id,
-          "standard_level_name" => standard_level.name,
-          "standard_name" => standard.name,
-          "topic_id" => topic.id,
-          "topic_level" => topic.level,
-          "topic_name" => topic.name,
-          "topic_parent_id" => topic.parent_id,
-          "content_partner_description" => content_partner.description,
-          "content_partner_id" => content_partner.id,
-          "content_partner_name" => content_partner.name,
-          "order_number" => activity_category_activity.order_number,
-          "classification_id" => activity_classification.id,
-          "classification_key" => activity_classification.key
-        }
-      )
+    context 'beta flagset input' do
+      it 'should get the correct attributes based on the flag given' do
+        expect(described_class.search("beta").first).to eq(
+          {
+            "activity_name" => activity.name,
+            "activity_description" => activity.description ,
+            "activity_flag" => "{beta,production}",
+            "activity_id" => activity.id,
+            "activity_maximum_grade_level" => activity.maximum_grade_level,
+            "activity_minimum_grade_level" => activity.minimum_grade_level,
+            "activity_uid" => activity.uid,
+            "activity_category_id" => activity_category.id,
+            "activity_category_name" => activity_category.name,
+            "standard_level_id" => standard_level.id,
+            "standard_level_name" => standard_level.name,
+            "standard_name" => standard.name,
+            "topic_id" => topic.id,
+            "topic_level" => topic.level,
+            "topic_name" => topic.name,
+            "topic_parent_id" => topic.parent_id,
+            "content_partner_description" => content_partner.description,
+            "content_partner_id" => content_partner.id,
+            "content_partner_name" => content_partner.name,
+            "order_number" => activity_category_activity.order_number,
+            "classification_id" => activity_classification.id,
+            "classification_key" => activity_classification.key
+          }
+        )
+      end
     end
+
+    context 'production flagset input' do
+      it 'should not retrieve evidence_beta1-flagged activities' do
+        results = described_class.search('production')
+        expect(results.count).to eq 1
+        expect(results.first['activity_name']).to_not eq beta_flagset_activity.name
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## WHAT
Due to a hardcoded flag list, activity search caches were not being refreshed properly, resulting in newly-created activities not showing up in search. 

This fix removes the hardcoded logic, preventing future instances of this bug if/when flagsets change. 

## WHY
Activity search cache should be up to date ( < 5 mins). 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=68bd96b3151947b3964b5f69358cf1f7&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A)
