### PR TITLE
Add "Has Opportunity" trait to Vitally Schools and Districts (#9655)

### DIFF
--- a/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
@@ -39,6 +39,12 @@ class SyncSalesFormSubmissionToVitallyWorker
 
   def send_opportunity_to_vitally
     api.create(SalesFormSubmission::VITALLY_SALES_FORMS_TYPE, @sales_form_submission.vitally_sales_form_data)
+
+    if @sales_form_submission.district_collection? && @sales_form_submission.district.present?
+      api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.district.id, vitally_has_opportunity_trait)
+    elsif @sales_form_submission.school_collection? && @sales_form_submission.school.present?
+      api.update(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, @sales_form_submission.school.id, vitally_has_opportunity_trait)
+    end
   end
 
   private def api
@@ -99,5 +105,13 @@ class SyncSalesFormSubmissionToVitallyWorker
     else
       [district_vitally_id]
     end
+  end
+
+  private def vitally_has_opportunity_trait
+    {
+      traits: {
+        "vitally.custom.hasOpportunity": true
+      }
+    }
   end
 end

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -10,6 +10,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   before do
     allow(VitallyRestApi).to receive(:new).and_return(stub_api)
+    allow(stub_api).to receive(:update)
 
     subject.sales_form_submission=(sales_form_submission)
   end
@@ -182,6 +183,19 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
       expect(stub_api).to receive(:create).with(SalesFormSubmission::VITALLY_SALES_FORMS_TYPE, payload)
 
+      subject.send_opportunity_to_vitally
+    end
+
+    it 'should send update call to update school with custom hasOpportunity trait' do
+      school = create(:school)
+      vitally_school_id = '123'
+      sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
+
+      allow(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({"id": vitally_school_id})
+      allow(stub_api).to receive(:create)
+
+      has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
+      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
       subject.send_opportunity_to_vitally
     end
   end


### PR DESCRIPTION
* remove unit id query string from redirect string

* change specs

* change to front end tweak

* add a 300px margin to footer

* add has opportunity update call to vitally worker and spec

* remove accidental footer change

* Revert extra change

* linting

* typo fix

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
