### PR TITLE
do not open links to teacher accounts in new tabs

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/teacher_link.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/teacher_link.tsx
@@ -5,13 +5,11 @@ const clickInvalidLink = () => alert('Your Premium Subscription has expired. Ple
 const TeacherLink = ({ name, path, isValid, }) => {
   let linkClass = 'green-link teacher-link';
   if (isValid) {
-    /* eslint-disable react/jsx-no-target-blank */
     return(
       <div>
-        <a className={linkClass} href={path} target="_blank">{name}</a>
+        <a className={linkClass} href={path}>{name}</a>
       </div>
     );
-    /* eslint-enable react/jsx-no-target-blank */
   }
   return(
     <div>


### PR DESCRIPTION
## WHAT
Stop opening links to teacher accounts in new tabs.

## WHY
Having them open in a new tab makes it seem like you should be able to just close that tab and open another one as a different teacher. In fact, the way our auth works, they need to actually log out of that impersonated user's account to be back in their admin one in order to log into another. Having it open in the same tab makes that flow clearer.

## HOW
Just remove `target="_blank"` here.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
Third issue here: https://www.notion.so/quill/Capital-City-Charter-Schools-Clever-issues-3c203cf4832641a2b2c86ec72fe0e560 (it seems to me like she doesn't get logged out if she follows the log in, log out, log in as another workflow - only when she tries to open multiple teachers at once).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
