### PR TITLE
add constraint for no spaces in emails and add rake task to clean up existing users

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -157,6 +157,7 @@ class User < ApplicationRecord
   validates :email,
     presence: { if: :email_required? },
     uniqueness:  { message: :taken, if: :email_required_or_present? },
+    format: { without: /\s/, message: :no_spaces_allowed },
     length: { maximum: CHAR_FIELD_MAX_LENGTH }
 
   validate :username_cannot_be_an_email

--- a/services/QuillLMS/config/locales/en.yml
+++ b/services/QuillLMS/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
             email:
               invalid: "Enter a valid email"
               taken: "That email is taken. Try another."
+              no_spaces_allowed: "That email is not valid because it has a space. Try another."
             username:
               invalid: "Enter a valid username"
               taken: "That username is taken. Try another."

--- a/services/QuillLMS/lib/tasks/remove_spaces_from_user_emails.rake
+++ b/services/QuillLMS/lib/tasks/remove_spaces_from_user_emails.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :user_emails do
+  desc 'Remove spaces from user emails'
+  task :remove_spaces => :environment do
+    users_with_spaces = User.where("email ILIKE '% %'")
+    users_with_spaces.each do |user|
+      previous_value = user.email
+      if user.update(email: previous_value.gsub(/\s/, ''))
+        ChangeLog.create(
+          action: ChangeLog::USER_ACTIONS[:update],
+          changed_attribute: :email,
+          changed_record: user,
+          explanation: 'Removing spaces from emails',
+          previous_value: previous_value
+        )
+      elsif user.username && user.update(email: nil)
+        ChangeLog.create(
+          action: ChangeLog::USER_ACTIONS[:update],
+          changed_attribute: :email,
+          changed_record: user,
+          explanation: 'Removing emails where they included a space, the version of the email without the space was not saveable, and there was a username',
+          previous_value: previous_value
+        )
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -901,6 +901,11 @@ describe User, type: :model do
         expect(user).to be_valid
       end
 
+      it 'is invalid when there is a space in it' do
+        user = build(:user,  email: 'test@test.lan ')
+        expect(user).to_not be_valid
+      end
+
       context 'when role requires email' do
         it 'is invalid without email' do
           user.safe_role_assignment 'teacher'


### PR DESCRIPTION
## WHAT
Add constraint against whitespace in emails and add rake task to clean up existing users with bad emails. 

## WHY
This is a constraint that already should have been in place. Valid emails don't have whitespace characters in them.

## HOW
Add constraint and spec, then a rake task to clean up all existing users with this issue (4403 currently on prod). On staging, which was replicated a few weeks ago, we had 4397. After running this rake task, it was down to 270 (1547 after just removing spaces). By spot-checking, most of these users seem inactive - a lot of them don't appear to have ever logged into their account after creating it, probably because the space in it was a typo and they couldn't get back in. I think we'll have to address it on a case-by-case basis if we have support issues come up as a result of this down the line.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
Discovered in the course of investigating this card: https://www.notion.so/quill/Capital-City-Charter-Schools-Clever-issues-3c203cf4832641a2b2c86ec72fe0e560

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change, but ran rake task on staging db
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
