### PR TITLE
lms/provide-old-concept-result-worker

### DIFF
--- a/services/QuillLMS/app/workers/save_activity_session_old_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/save_activity_session_old_concept_results_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SaveActivitySessionOldConceptResultsWorker
+  include Sidekiq::Worker
+
+  def perform(json_payload)
+    SaveActivitySessionConceptResultsWorker.perform_async(json_payload)
+  end
+end

--- a/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_activity_session_old_concept_results_worker_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SaveActivitySessionOldConceptResultsWorker, type: :worker do
+
+  context '#perform' do
+    let(:json_payload) {
+      {
+        foo: 'bar'
+      }
+    }
+
+    it 'should perform a direct pass-through to the SaveActivitySessionConceptResultsWorker which replaces this worker' do
+      expect(SaveActivitySessionConceptResultsWorker).to receive(:perform_async).with(json_payload)
+      subject.perform(json_payload)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a worker to clear outstanding jobs lingering in the Sidekiq queue
## WHY
I forgot that there might be existing jobs of this old type still in the queue from earlier even though we no longer enqueue them after the deploy
## HOW
Re-create a worker with the name of the deprecated worker that just passes the data through to the new worker.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
