### PR TITLE
Put proper Gemfile.lock back in place

### DIFF
--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -10,8 +10,14 @@ PATH
       rails (= 6.1.6)
 
 GEM
-  remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
+  specs:
+    sidekiq-pro (4.0.5)
+      concurrent-ruby (>= 1.0.5)
+      sidekiq (>= 5.2.1)
+
+GEM
+  remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.3)
     actioncable (6.1.6)
@@ -687,9 +693,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (~> 4.5, < 4.6.0)
-    sidekiq-pro (4.0.5)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.1)
     sidekiq-retries (0.4.0)
       sidekiq (>= 3.2.4)
     signet (0.12.0)


### PR DESCRIPTION
## WHAT
I don't know why, but a [previous commit](https://github.com/empirical-org/Empirical-Core/pull/9641/files#diff-a3bf01a1c6891093c41a22b32e9060ddbe1247fb388d669c62e380d8cb98e74aR690) of mine moved around items in Gemfile.lock, specifically making the `sidekiq-pro` source less specific. When I run `bundle install` it puts it back in the original place. So putting this back in place. I think I has an outdated version of bundler when I ran this originally.
## WHY
We want this file to be consistent.
## HOW
`bundle install`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, config change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Looks amazing.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
