### PR TITLE
add more opportunities to register the teacher during a lesson

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/teach/container.tsx
@@ -47,9 +47,15 @@ class TeachClassroomLessonContainer extends React.Component<any, any> {
 
     const classroomUnitId: ClassroomUnitId|null = getParameterByName('classroom_unit_id')
     const activityUid = props.match.params.lessonID
+    const classroomSessionId = classroomUnitId ? classroomUnitId.concat(activityUid) : null
+
     this.state = {
       classroomUnitId,
-      classroomSessionId: classroomUnitId ? classroomUnitId.concat(activityUid) : null
+      classroomSessionId
+    }
+
+    if (classroomSessionId) {
+      registerTeacherPresence(classroomSessionId);
     }
 
     props.dispatch(getCurrentUserAndCoteachersFromLMS())
@@ -64,7 +70,6 @@ class TeachClassroomLessonContainer extends React.Component<any, any> {
       startLesson(classroomUnitId, classroomSessionId, () => {
         dispatch(startListeningToSessionForTeacher(activityId, classroomUnitId, classroomSessionId));
       });
-      registerTeacherPresence(classroomSessionId);
     } else {
       this.setupPreviewSession()
     }
@@ -79,6 +84,11 @@ class TeachClassroomLessonContainer extends React.Component<any, any> {
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.setInitialData(nextProps)
+  }
+
+  componentDidUpdate() {
+    const { classroomSessionId, } = this.state
+    registerTeacherPresence(classroomSessionId)
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## WHAT
Hopefully fix issue where the projector view for Quill Lessons activities are sometimes showing that the teacher has left the lesson, even though the teacher is still in it.

## WHY
From testing, which has been limited because it's tricky to reproduce, it looks like this isn't specific to the projector view (students would also see it). Since it's so tricky to reproduce I haven't been able to 100% isolate what's causing it, but since it has to result from a `disconnection` event and should resolve when a `connection` is fired, my hope is that adding more opportunities for connection to fire will alleviate the issue.

## HOW
Update Quill Lessons so that the `registerTeacher` event fires in the constructor, instead of `DidMount`, and also `onUpdate`. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-has-left-the-lesson-message-on-projector-view-f510678ee6564899a1d3ce3a1767248c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
