### PR TITLE
bugfix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
@@ -178,8 +178,10 @@ export default class StandardsAllClassroomsProgressReport extends React.Componen
       ['Standard Level', 'Standard Name', 'Students', 'Proficient', 'Activities', 'Time Spent']
     ]
     standardsData.forEach((row) => {
+      const profiencyRow = row.is_evidence ? NOT_SCORED_DISPLAY_TEXT : `${row.proficient_count} of ${row.total_student_count}`
+
       csvData.push([
-        row['standard_level_name'], row['name'], row['total_student_count'], `${row['proficient_count']} of ${row['total_student_count']}`, row['total_activity_count'], getTimeSpent(row['timespent'])
+        row['standard_level_name'], row['name'], row['total_student_count'], profiencyRow, row['total_activity_count'], getTimeSpent(row['timespent'])
       ])
     })
     return csvData


### PR DESCRIPTION
## WHAT
Simple patch to improve the display of Standards report CSV files. 

## WHY
So that it aligns with the non-CSV web display.

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - tiny change
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
