### PR TITLE
Lms/bulk rename activities

### DIFF
--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -61,7 +61,6 @@ namespace :activities do
     CSV.parse(pipe_data, headers: true) do |row|
       activity = Activity.find(row['Activity ID'])
       activity.update!(name: row['New Name'])
- 
     rescue
       puts "Failed to update for activity with id '#{row['Activity ID']}'"
     else

--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -44,4 +44,25 @@ namespace :activities do
       puts "Failed to update for activity named '#{row['name']}'"
     end
   end
+
+  desc 'Take a pipe of CSV with activity IDs and new names, set the specified Activities to their new name'
+  task bulk_update_names: :environment do
+    pipe_data = $stdin.read unless $stdin.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake activities:bulk_update_names < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake activities:bulk_update_names -a empirical-grammar --no-tty < path/to/local/file.csv'
+      exit 1
+    end
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      activity = Activity.find(row['Activity ID'])
+      activity.update!(name: row['New Name'])
+    rescue
+      puts "Failed to update for activity with id '#{row['Activity ID']}'"
+    end
+  end
 end

--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -61,8 +61,11 @@ namespace :activities do
     CSV.parse(pipe_data, headers: true) do |row|
       activity = Activity.find(row['Activity ID'])
       activity.update!(name: row['New Name'])
+ 
     rescue
       puts "Failed to update for activity with id '#{row['Activity ID']}'"
+    else
+      puts "Updated activity with id '#{row['Activity ID']}' to '#{row['New Name']}'"
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -59,12 +59,18 @@ namespace :activities do
     end
 
     CSV.parse(pipe_data, headers: true) do |row|
-      activity = Activity.find(row['Activity ID'])
-      activity.update!(name: row['New Name'])
+      activity_id = row['Activity ID']
+      activity = Activity.find(activity_id)
+
+      # Normalize any whitespace from the spreadsheet
+      new_name = row['New Name'].gsub(/\s/, ' ')
+      raise "New name column is empty" if new_name.blank?
+
+      activity.update!(name: new_name)
     rescue
-      puts "Failed to update for activity with id '#{row['Activity ID']}'"
+      puts "Failed to update for activity with id '#{activity_id}'"
     else
-      puts "Updated activity with id '#{row['Activity ID']}' to '#{row['New Name']}'"
+      puts "Updated activity with id '#{activity_id}' to '#{new_name}'"
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add a rake task that can be used to upload a Curriculum-provided CSV and rename a large number of Activities based on that data
## WHY
Curriculum wants to provide better names for a large swath of activities, and we shouldn't make them do it all by hand with a ton of clicks
## HOW
Write a rake task that takes a CSV input and parses it for `update!` calls to the specified Activities

### Notion Card Links
https://www.notion.so/quill/Update-Activity-Names-Descriptions-and-Theme-Tags-via-a-Script-360c2816197b444494245da12651e1e4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
