### PR TITLE
A Passage-specific spelling error synthetic generator (#9678)

### DIFF
--- a/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
@@ -9,10 +9,12 @@ module Evidence
       uploader = Evidence.file_uploader.new
       uploader.retrieve_from_store!(filename)
 
-      csv_array = CSV.parse(uploader.file.read)
-      csv_hash = Evidence::Synthetic::LabeledDataGenerator.csvs_from_run(csv_array, filename)
-
       activity = Evidence::Activity.find(activity_id)
+      passage = activity.passages.first&.text
+
+      csv_array = CSV.parse(uploader.file.read)
+      csv_hash = Evidence::Synthetic::LabeledDataGenerator.csvs_from_run(csv_array, filename, passage)
+
       subject = "Evidence Labeled Synthetic Data: #{activity_id} - #{activity.title}"
 
       Evidence.file_mailer.send_multiple_files(Evidence::Synthetic::EMAIL, subject, csv_hash).deliver_now!

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/html_tag_remover.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/html_tag_remover.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Evidence
+  class HTMLTagRemover < ApplicationService
+    HTML_TAG_REGEX = /<("[^"]*"|'[^']*'|[^'">])*>/
+    SPACE = " "
+
+    attr_reader :html
+
+    def initialize(html)
+      @html = html
+    end
+
+    def run
+      html
+        .gsub(HTML_TAG_REGEX, SPACE) # remove html tags
+        .gsub("&#x27;", "'") # replace html single quotes
+        .gsub(/(‘|’)/,"'") # replace html single curly quotes
+        .gsub("&quot;","\"") # replace html double quotes
+        .gsub(/(“|”)/,"\"") # replace html double curly quotes
+        .gsub(/\s+/, SPACE) # replace multiple spaces with single space
+        .strip
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/generators/spelling_passage_specific.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/generators/spelling_passage_specific.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Synthetic
+    module Generators
+      class SpellingPassageSpecific < Synthetic::Generators::Base
+
+        LONG_WORDS_LENGTH = 10
+        REPEATED_WORD_COUNT = 5
+        REPEATED_WORD_MIN_LENGTH = 5
+        REGEX_PUNCTUATION = /(,|\.|;|\?|!|"|'|:|-|—|–|…)/
+        REGEX_QUOTES = /('|")/
+        REGEX_BRACKETS = /(\(|\)|\[|\])/
+        WORD_BOUNDARY = '\b'
+        BLANK = ''
+        SPACE = ' '
+
+        attr_reader :passage, :random_seed
+
+        def initialize(string_array, options = {})
+          super
+
+          @passage = HTMLTagRemover.run(options[:passage] || "")
+          @random_seed = options[:random_seed]
+        end
+
+        # generate spelling errors for long words in the passage
+        def generate
+          return if passage.empty?
+
+          strings.each do |string|
+            important_words.each do |word|
+              padded_word = WORD_BOUNDARY + word + WORD_BOUNDARY
+              next unless string.match?(padded_word)
+
+              text_with_misspell = string.gsub(Regexp.new(padded_word), misspell(word))
+              results_hash[string][word] = text_with_misspell
+            end
+          end
+        end
+
+        def important_words
+          (repeated_words + long_words).uniq
+        end
+
+        def long_words
+          @long_words ||= passage_words
+            .select {|w| w.length >= LONG_WORDS_LENGTH}
+            .uniq
+        end
+
+        def repeated_words
+          @repeated_words ||= passage_words
+            .tally
+            .select {|_,count| count >= REPEATED_WORD_COUNT}
+            .keys
+            .select {|w| w.length >= REPEATED_WORD_MIN_LENGTH}
+        end
+
+        def passage_words
+          passage
+            .gsub(REGEX_PUNCTUATION, SPACE)
+            .gsub(REGEX_QUOTES, SPACE)
+            .gsub(REGEX_BRACKETS, SPACE)
+            .split(SPACE)
+            .reject(&:empty?)
+        end
+
+        # drop a random middle character
+        # use a seed for sampling to make testing consistent
+        def misspell(word)
+          random_middle_index = (1...word.length).to_a.sample(random: random_seed || Random.new)
+          word_array = word.split(BLANK)
+          word_array.delete_at(random_middle_index)
+
+          word_array.join(BLANK)
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_result.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_result.rb
@@ -34,7 +34,7 @@ module Evidence
       private def generated_flattened
         generated
           .map {|generator, hash| hash.transform_keys {|key| [generator,key].join('-')}}
-          &.reduce(&:merge)
+          &.reduce(&:merge) || {}
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -10,7 +10,6 @@ module Evidence
       BLANK = ''
       PERIOD = '.'
       CSV_SUFFIX = '.csv'
-      HTML_TAG_REGEX = /<("[^"]*"|'[^']*'|[^'">])*>/
 
       FULL_COUNT = ENV.fetch('SYNTHETIC_SEED_PASSAGE_COUNT', 128).to_i
       FULL_NOUN_COUNT = ENV.fetch('SYNTHETIC_SEED_NOUN_COUNT', 50).to_i
@@ -46,14 +45,8 @@ module Evidence
         csvs
       end
 
-
       def initialize(passage:, stem:, nouns: [])
-        @passage = passage
-          .gsub(HTML_TAG_REGEX, " ") # remove html tags
-          .gsub("&#x27;", "'") # replace html single quotes
-          .gsub("&quot;","\"") # replace html double quotes
-          .gsub(/\s+/," ") # replace multiple spaces with single space
-          .strip
+        @passage = Evidence::HTMLTagRemover.run(passage)
         @stem = stem
         @nouns = nouns
         @results = []

--- a/services/QuillLMS/engines/evidence/spec/lib/html_tag_remover_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/html_tag_remover_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(HTMLTagRemover, type: :module) do
+    let(:html) {' <p><strong>&quot;It&#x27;s</strong> a good day&quot;, he said.</p>  '}
+
+    describe "#run" do
+      it "should remove html tags" do
+        expect(described_class.run(' <p>hello</p>')).to eq('hello')
+        expect(described_class.run(' <p><strong>hello</strong></p>')).to eq('hello')
+        expect(described_class.run(' <p><strong>hello</p>')).to eq('hello')
+      end
+
+      it "should replace quotes" do
+        expect(described_class.run(' ‘<p>&quot;hello&quot;</p>’')).to eq('\' "hello" \'')
+        expect(described_class.run(' “He said <p>&quot;It&#x27;s&quot;</p>”')).to eq('"He said "It\'s" "')
+      end
+
+      it "should remove start and end space" do
+        expect(described_class.run('    hello  ')).to eq('hello')
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/generators/spelling_passage_specific_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/generators/spelling_passage_specific_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Evidence::Synthetic::Generators::SpellingPassageSpecific do
+  let(:text1) {'the dancing step'}
+  let(:random_seed) {double('seed', rand: 1)}
+  let(:passage) {"passage text #{'dancing '* 5}"}
+
+  describe '#generate - repeated word' do
+    subject { described_class.new([text1], passage: passage, random_seed: random_seed).run}
+
+    it 'should return spelling item of word common in passage' do
+      expect(subject.count).to eq 1
+      expect(subject.class).to eq Hash
+      expect(subject[text1].count).to eq 1
+      expect(subject[text1]['dancing']).to eq 'the dacing step'
+    end
+  end
+
+  describe '#generate - long word' do
+    let(:text1) {'the longlonglong word'}
+    let(:passage) {'the longlonglong word appears once'}
+
+    subject { described_class.new([text1], passage: passage, random_seed: random_seed).run}
+
+    it 'should return spelling item of long word in passage' do
+      expect(subject.count).to eq 1
+      expect(subject.class).to eq Hash
+      expect(subject[text1].count).to eq 1
+      expect(subject[text1]['longlonglong']).to eq 'the loglonglong word'
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
@@ -42,7 +42,7 @@ describe Evidence::Synthetic::LabeledDataGenerator do
     let(:generator) { described_class.run(labeled_data, languages: [:es], generators: [:translation])}
 
     it 'fetch and store translations' do
-      expect(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(translation_response)
+      expect(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(translation_response)
       expect(generator.results.count).to eq 2
 
       first_result = generator.results.first
@@ -56,8 +56,8 @@ describe Evidence::Synthetic::LabeledDataGenerator do
   describe '#run spelling errors' do
     let(:generator) { described_class.run(labeled_data, languages: [:es], generators: [:spelling])}
 
-    it 'fetch and store translations' do
-      expect(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(spelling_response)
+    it 'fetch and store spelling errors' do
+      expect(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(spelling_response)
       expect(generator.results.count).to eq 2
 
       first_result = generator.results.first
@@ -68,12 +68,30 @@ describe Evidence::Synthetic::LabeledDataGenerator do
     end
   end
 
+  describe '#run spelling-passage-specific errors' do
+    let(:text1) {'the dancing step'}
+    let(:passage) {"passage text #{'dancing '* 5}"}
+
+    let(:generator) { described_class.run([[text1,label1]], languages: [:es], generators: [:spelling_passage_specific], passage: passage)}
+
+    it 'fetch and store spelling changes' do
+      expect(generator.results.count).to eq 1
+
+      first_result = generator.results.first
+
+      expect(first_result.text).to eq text1
+      expect(first_result.label).to eq label1
+      expect(first_result.generated[:spelling_passage_specific]['dancing']).to be_present
+    end
+  end
+
+
   describe 'data exports' do
     let(:generator) { described_class.run(labeled_data, languages: [:es], generators: [:translation, :spelling])}
 
     before do
-      allow(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(translation_response)
-      allow(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(spelling_response)
+      allow(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(translation_response)
+      allow(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(spelling_response)
     end
 
     describe "#training_data_rows" do
@@ -116,8 +134,8 @@ describe Evidence::Synthetic::LabeledDataGenerator do
       stub_const("Evidence::Synthetic::ManualTypes::MIN_TEST_PER_LABEL", 0)
       stub_const("Evidence::Synthetic::ManualTypes::MIN_TRAIN_PER_LABEL", 0)
 
-      allow(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(translation_response)
-      allow(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es]}).and_return(spelling_response)
+      allow(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(translation_response)
+      allow(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es], passage: nil}).and_return(spelling_response)
     end
 
     it "should generate a hash of csv_strings" do

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
@@ -19,6 +19,8 @@ module Evidence
       let(:file) { fixture_file_upload(filename) }
       let(:file_as_array) {[['hello', 'world'], ['data','here']]}
       let(:activity) { create(:evidence_activity) }
+      let(:passage_text) {"some passage text" * 20}
+      let!(:passage) { create(:evidence_passage, activity: activity, text: passage_text) }
 
       let(:generator_response) { double }
 
@@ -32,7 +34,7 @@ module Evidence
         expect(mock_uploader).to receive(:retrieve_from_store!).with(filename)
 
         expect(Evidence::Synthetic::LabeledDataGenerator).to receive(:csvs_from_run)
-          .with(file_as_array, filename)
+          .with(file_as_array, filename, passage_text)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)


### PR DESCRIPTION
* Move HTMLTagRemover to its own class for reuse.

* Add Passage specific spelling errors.

* Update main generator specs.

* Use the passage in generation.

* Simplify some regex.

* Use env variable for easier config testing.

* Fix to only generate synthetic data for TRAIN.

* Remove duplicate line.

* Update comments.

* Use repeated words as “important words” for spelling.

* Fix nil error.

* Fix original file attachment.

* Test using both long and repeated words.

* Revert back to regex for now., more special chars.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
