### PR TITLE
update the generate_user_account_info method to return no selected school

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -562,7 +562,7 @@ class User < ApplicationRecord
       user_attributes[:school] = school
       user_attributes[:school_type] = School::ALTERNATIVE_SCHOOLS_DISPLAY_NAME_MAP[school.name] || School::US_K12_SCHOOL_DISPLAY_NAME
     else
-      user_attributes[:school] = School.find_by_name(School::NOT_LISTED_SCHOOL_NAME)
+      user_attributes[:school] = School.find_by_name(School::NO_SCHOOL_SELECTED_SCHOOL_NAME)
       user_attributes[:school_type] = School::US_K12_SCHOOL_DISPLAY_NAME
     end
     user_attributes

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -538,22 +538,31 @@ describe User, type: :model do
   describe '#generate_teacher_account_info' do
     let(:user) { create(:user) }
     let(:premium_state) { double(:premium_state) }
-    let(:school) { create(:school) }
-    let(:hash) {
-      user.attributes.merge!({
-        subscription: {'subscriptionType' => premium_state},
-        school: school,
-        school_type: School::US_K12_SCHOOL_DISPLAY_NAME
-        })
-    }
 
     before do
-      allow(user).to receive(:school).and_return(school)
-      allow(user).to receive(:subscription).and_return(false)
+      allow(user).to receive(:subscription).and_return(nil)
       allow(user).to receive(:premium_state).and_return(premium_state)
     end
 
     it 'should give the correct hash' do
+      school = create(:school)
+      SchoolsUsers.create(school: school, user: user)
+      user.reload
+      hash = user.attributes.merge!({
+        subscription: {'subscriptionType' => premium_state},
+        school: school,
+        school_type: School::US_K12_SCHOOL_DISPLAY_NAME
+      })
+      expect(user.generate_teacher_account_info).to eq(hash)
+    end
+
+    it 'should have the no school selected school if the user has no school' do
+      school = create(:school, name: School::NO_SCHOOL_SELECTED_SCHOOL_NAME)
+      hash = user.attributes.merge!({
+        subscription: {'subscriptionType' => premium_state},
+        school: school,
+        school_type: School::US_K12_SCHOOL_DISPLAY_NAME
+      })
       expect(user.generate_teacher_account_info).to eq(hash)
     end
   end


### PR DESCRIPTION
…hool (#9688)

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | (Yes or N/A)
