### PR TITLE
Send HasOpportunity trait to a school's district in Vitally

### DIFF
--- a/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
@@ -40,10 +40,15 @@ class SyncSalesFormSubmissionToVitallyWorker
   def send_opportunity_to_vitally
     api.create(SalesFormSubmission::VITALLY_SALES_FORMS_TYPE, @sales_form_submission.vitally_sales_form_data)
 
+    flag_school_and_district_in_vitally
+  end
+
+  def flag_school_and_district_in_vitally
     if @sales_form_submission.district_collection? && @sales_form_submission.district.present?
       api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.district.id, vitally_has_opportunity_trait)
     elsif @sales_form_submission.school_collection? && @sales_form_submission.school.present?
       api.update(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, @sales_form_submission.school.id, vitally_has_opportunity_trait)
+      api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.school.district.id, vitally_has_opportunity_trait)
     end
   end
 

--- a/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
@@ -48,7 +48,10 @@ class SyncSalesFormSubmissionToVitallyWorker
       api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.district.id, vitally_has_opportunity_trait)
     elsif @sales_form_submission.school_collection? && @sales_form_submission.school.present?
       api.update(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, @sales_form_submission.school.id, vitally_has_opportunity_trait)
-      api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.school.district.id, vitally_has_opportunity_trait)
+
+      if @sales_form_submission.school.district.present?
+        api.update(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, @sales_form_submission.school.district.id, vitally_has_opportunity_trait)
+      end
     end
   end
 

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -17,8 +17,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   describe '#perform' do
     it 'should run all three steps: create school/district in vitally, create user in vitally, send opportunity to vitally' do
-      district = create(:district)
-      create(:school, name: sales_form_submission.school_name, district: district)
+      create(:school, name: sales_form_submission.school_name)
 
       fake_id = 1
 
@@ -89,8 +88,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   context '#send_opportunity_to_vitally' do
     it 'should send the appropriate payload for forms with a school collection type' do
-      district = create(:district)
-      school = create(:school, district: district)
+      school = create(:school)
       vitally_school_id = '123'
       expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => vitally_school_id})
 
@@ -155,8 +153,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send a payload with the id for Unknown School if the school does not exist in the db' do
-      district = create(:district)
-      school = create(:school, name: 'Unknown School', district: district)
+      school = create(:school, name: 'Unknown School')
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, submission_type: 'quote request', school_name: 'nonexistent school name', source: SalesFormSubmission::FORM_SOURCE)
 
       vitally_school_id = '123'
@@ -190,8 +187,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send update call to update school with custom hasOpportunity trait' do
-      district = create(:district)
-      school = create(:school, district: district)
+      school = create(:school)
       vitally_school_id = '123'
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
 
@@ -200,21 +196,6 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
       has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
       expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
-      subject.send_opportunity_to_vitally
-    end
-
-    it 'should send update call to update a schools district with custom hasOpportunity trait' do
-      district = create(:district)
-      school = create(:school, district: district)
-      vitally_school_id = '123'
-      sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
-
-      allow(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({"id": vitally_school_id})
-      allow(stub_api).to receive(:create)
-
-      has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
-      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
-      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, district.id, has_opportunity_payload)
       subject.send_opportunity_to_vitally
     end
   end

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -198,5 +198,20 @@ describe SyncSalesFormSubmissionToVitallyWorker do
       expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
       subject.send_opportunity_to_vitally
     end
+
+    it 'should send update call to update a schools district with custom hasOpportunity trait' do
+      district = create(:district)
+      school = create(:school, district: district)
+      vitally_school_id = '123'
+      sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
+
+      allow(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({"id": vitally_school_id})
+      allow(stub_api).to receive(:create)
+
+      has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
+      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
+      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, district.id, has_opportunity_payload)
+      subject.send_opportunity_to_vitally
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -17,7 +17,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   describe '#perform' do
     it 'should run all three steps: create school/district in vitally, create user in vitally, send opportunity to vitally' do
-      create(:school, name: sales_form_submission.school_name)
+      district = create(:district)
+      create(:school, name: sales_form_submission.school_name, district: district)
 
       fake_id = 1
 
@@ -88,7 +89,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   context '#send_opportunity_to_vitally' do
     it 'should send the appropriate payload for forms with a school collection type' do
-      school = create(:school)
+      district = create(:district)
+      school = create(:school, district: district)
       vitally_school_id = '123'
       expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => vitally_school_id})
 
@@ -153,7 +155,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send a payload with the id for Unknown School if the school does not exist in the db' do
-      school = create(:school, name: 'Unknown School')
+      district = create(:district)
+      school = create(:school, name: 'Unknown School', district: district)
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, submission_type: 'quote request', school_name: 'nonexistent school name', source: SalesFormSubmission::FORM_SOURCE)
 
       vitally_school_id = '123'
@@ -187,7 +190,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send update call to update school with custom hasOpportunity trait' do
-      school = create(:school)
+      district = create(:district)
+      school = create(:school, district: district)
       vitally_school_id = '123'
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
 
@@ -196,6 +200,21 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
       has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
       expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
+      subject.send_opportunity_to_vitally
+    end
+
+    it 'should send update call to update a schools district with custom hasOpportunity trait' do
+      district = create(:district)
+      school = create(:school, district: district)
+      vitally_school_id = '123'
+      sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
+
+      allow(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({"id": vitally_school_id})
+      allow(stub_api).to receive(:create)
+
+      has_opportunity_payload = { traits: { "vitally.custom.hasOpportunity": true } }
+      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id, has_opportunity_payload)
+      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, district.id, has_opportunity_payload)
       subject.send_opportunity_to_vitally
     end
   end


### PR DESCRIPTION
## WHAT
When a Vitally school gets an opportunity created through a sales form submission, we want to also flag that school's district as "hasOpportunity" in Vitally.

## WHY
Vitally has some restrictions on its data such that a school won't show up in our filters unless its district is flagged.

## HOW
When a school is flagged in Vitally, send an additional update call to update that school's district.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | Yes
