### PR TITLE
lms/bulk-update-activity-names-twice

### DIFF
--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -66,7 +66,9 @@ namespace :activities do
       new_name = row['New Name'].gsub(/\s/, ' ')
       raise "New name column is empty" if new_name.blank?
 
-      activity.update!(name: new_name)
+      activity.name = new_name
+      activity.data['name'] = new_name
+      activity.save!
     rescue
       puts "Failed to update for activity with id '#{activity_id}'"
     else


### PR DESCRIPTION
## WHAT
Update both places that we store Activity "name" in
## WHY
We want to show the new names to users no matter which code path they're using, and currently the place we source the Activity name information from depends on which bit of code the user is running through.
## HOW
Update the bulk rename script to change the name value in both places it gets read from

### Notion Card Links
https://www.notion.so/quill/Update-Activity-Names-Descriptions-and-Theme-Tags-via-a-Script-360c2816197b444494245da12651e1e4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A