### PR TITLE
lms/bulk-update-activity-names-thrice

### DIFF
--- a/services/QuillLMS/lib/tasks/activities.rake
+++ b/services/QuillLMS/lib/tasks/activities.rake
@@ -67,7 +67,10 @@ namespace :activities do
       raise "New name column is empty" if new_name.blank?
 
       activity.name = new_name
-      activity.data['name'] = new_name
+      if activity.data
+        activity.data['name'] = new_name
+        activity.data['title'] = new_name
+      end
       activity.save!
     rescue
       puts "Failed to update for activity with id '#{activity_id}'"


### PR DESCRIPTION
## WHAT
Update data in a third place when we bulk update activity name
## WHY
So it turns out that there's a THIRD source of truth for this data?  Grammar and Proofreader look for `data['title']` rather than either of the places for "name".
## HOW
Just add another value that we update during the bulk update script

### Notion Card Links
https://www.notion.so/quill/Update-Activity-Names-Descriptions-and-Theme-Tags-via-a-Script-360c2816197b444494245da12651e1e4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
