### PR TITLE
Force Synthetic CSV to UTF-8 encoding.

### DIFF
--- a/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
@@ -12,7 +12,7 @@ module Evidence
       activity = Evidence::Activity.find(activity_id)
       passage = activity.passages.first&.text
 
-      csv_array = CSV.parse(uploader.file.read)
+      csv_array = CSV.parse(uploader.file.read, encoding: 'utf-8')
       csv_hash = Evidence::Synthetic::LabeledDataGenerator.csvs_from_run(csv_array, filename, passage)
 
       subject = "Evidence Labeled Synthetic Data: #{activity_id} - #{activity.title}"

--- a/services/QuillLMS/engines/evidence/spec/fixtures/files/test_with_utf8.csv
+++ b/services/QuillLMS/engines/evidence/spec/fixtures/files/test_with_utf8.csv
@@ -1,0 +1,1 @@
+hello’s,world

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
@@ -43,6 +43,26 @@ module Evidence
 
         subject.perform(filename, activity.id)
       end
+
+      context 'utf-8 encoding' do
+        let(:filename) {'test_with_utf8.csv'}
+        let(:file_as_array) {[['hello’s', 'world']]}
+
+        it 'call generate and call file_mailer' do
+          expect(FileUploader).to receive(:new).and_return(mock_uploader)
+          expect(mock_uploader).to receive(:retrieve_from_store!).with(filename)
+
+          expect(Evidence::Synthetic::LabeledDataGenerator).to receive(:csvs_from_run)
+            .with(file_as_array, filename, passage_text)
+            .and_return(generator_response)
+
+          expect(FileMailer).to receive(:send_multiple_files)
+            .with(email, email_subject, generator_response)
+            .and_return(mailer)
+
+          subject.perform(filename, activity.id)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
We're getting errors (`Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8`) when the synthetic uploaded `csv` has special characters (it happens when the json apis try to convert it). 
## WHY
We want this to work for the files that curriculum creates (which seem to have `utf-8` characters).


## HOW
Add a failing test, fix that test (and some smoke testing).  Force a conversion to `UTF-8`


### Screenshots
Failing test
<img width="1408" alt="Screen Shot 2022-09-14 at 12 46 23 PM" src="https://user-images.githubusercontent.com/1304933/190214234-86664e3c-34e9-4a89-b630-3bd553ef5231.png">

Before
<img width="1261" alt="Screen Shot 2022-09-14 at 12 45 17 PM" src="https://user-images.githubusercontent.com/1304933/190214267-0d07a619-50b5-43d4-9fd1-b48218529731.png">

After
<img width="1316" alt="Screen Shot 2022-09-14 at 12 46 04 PM" src="https://user-images.githubusercontent.com/1304933/190214287-3c64176b-48e1-474c-baa3-763b57c4bd6f.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
