### PR TITLE
Lms/fix lesson concept results race condition

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -41,6 +41,7 @@ require 'new_relic/agent'
 
 class ActivitySession < ApplicationRecord
 
+  class ConceptResultSubmittedWithoutActivitySessionError < StandardError; end
   class LongTimeTrackingError < StandardError; end
 
   include ::NewRelic::Agent
@@ -403,6 +404,7 @@ class ActivitySession < ApplicationRecord
         metadata: concept_result[:metadata],
       })
     end
+    ErrorNotifier.report(ConceptResultSubmittedWithoutActivitySessionError.new("Received a request to record a ConceptResult with no related ActivitySession.")) if concept_results.any? { |cr| cr[:activity_session_id].blank? }
   end
 
   # this function is only for use by Lesson activities, which are not individually saved when the activity ends

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -405,16 +405,6 @@ class ActivitySession < ApplicationRecord
     end
   end
 
-  def self.delete_activity_sessions_with_no_concept_results(activity_sessions)
-    incomplete_activity_session_ids = []
-    activity_sessions.each do |as|
-      if as.concept_result_ids.empty?
-        incomplete_activity_session_ids.push(as.id)
-      end
-    end
-    ActivitySession.where(id: incomplete_activity_session_ids).destroy_all
-  end
-
   # this function is only for use by Lesson activities, which are not individually saved when the activity ends
   # other activity types make a call directly to the api/v1/activity_sessions controller with timetracking data included
   def self.save_timetracking_data_from_active_activity_session(activity_sessions)

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -404,6 +404,10 @@ class ActivitySession < ApplicationRecord
         metadata: concept_result[:metadata],
       })
     end
+    report_invalid_concept_results(concept_results)
+  end
+
+  def self.report_invalid_concept_results(concept_results)
     ErrorNotifier.report(ConceptResultSubmittedWithoutActivitySessionError.new("Received a request to record a ConceptResult with no related ActivitySession.")) if concept_results.any? { |cr| cr[:activity_session_id].blank? }
   end
 


### PR DESCRIPTION
## WHAT
This PR does two things:
1. It addresses a potential race condition (which I haven't been able to validate is actually happening in production, but might be) in which `ActivitySessions` for completed `Lesson` activities might get deleted out from under `ConceptResults` during the process of marking all completion data.
2. Adds some error reporting that aims to identify what's coming from the front-end that's causing some `Lesson` activities get at least some of their `ConceptResults` stuck in the Sidekiq retry queue with errors related to not having an `ActivitySession` to connect the `ConceptResult` to.  (I've traced the code from front-end to back-end, and can't see anywhere where this discrepancy might be getting added, so hopefully starting to report this issue in NewRelic before it gets to Sidekiq will be revelatory.)
## WHY
1. We don't want to erroneously delete data that we're going to use.
2. We want to understand what's going on with `ConceptResult` recording so that we can make sure we don't lose student data.
## HOW
1. Refactor the way we clean up "unused" `ActivitySessions` to use known input data rather than relying on the shifting state of data throughout the processing of that data.  (Basically, the old code relied on everything being synchronous and individual, apparently unrelated class methods not changing behavior while the new code just reads the incoming payload to figure out what to do.)
2. After we enqueue the `ConceptResult`s that have been provided from the Lessons front-end (even if they have bad data we don't want to just throw them away until we understand what's going on), we check to see if any of the payloads we just submitted are mal-formed, and if so, we call `ErrorNotifier.report` so that get alerted in NewRelic and Sentry of the problem.

### Notion Card Links
https://www.notion.so/quill/ConceptResult-migration-and-model-swap-over-plan-1736cf7e688a4af79bab08116832f852

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
