### PR TITLE
Sales forms/ add scroll to top

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/salesForm/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/salesForm/index.tsx
@@ -134,6 +134,7 @@ export const SalesForm = ({ type }) => {
           setErrors(submissionError)
         } else {
           setShowSubmissionConfirmation(true);
+          window.scrollTo(0, 0);
         }
       });
     }


### PR DESCRIPTION
## WHAT
add scroll to top after a user has submitted a sales form

## WHY
users weren't seeing the submission message if they were scrolled to the bottom

## HOW
just add `window.scrollTo(0, 0)` after a successful submission

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/PS-Anchor-to-the-top-of-the-page-after-a-sales-form-is-submitted-79c06d0b8a244e3c95ed4d1535a72df3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
