### PR TITLE
Staggered Release Prework Part 2

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -251,7 +251,7 @@ class TeacherFixController < ApplicationController
       provider_classrooms_with_unsynced_students.each do |provider_classroom|
         StudentsClassrooms
           .where(classroom_id: provider_classroom.id, student_id: provider_classroom.unsynced_students.pluck(:id))
-          .each { |sc| sc.archive }
+          .each { |sc| sc.archive! }
       end
 
       render json: {}, status: 200

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -67,7 +67,8 @@ class Teachers::ClassroomsController < ApplicationController
   def remove_students
     StudentsClassrooms
       .where(student_id: params[:student_ids], classroom_id: params[:classroom_id])
-      .each { |sc| sc.archive }
+      .each { |sc| sc.archive! }
+
     render json: {}
   end
 

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -26,6 +26,7 @@
 #
 class ClassroomUnit < ApplicationRecord
   include ::NewRelic::Agent
+  include Archivable
   include AtomicArrays
 
   belongs_to :unit # Note, there is a touch in the unit -> classroom_unit direction, so don't add one here.
@@ -103,6 +104,7 @@ class ClassroomUnit < ApplicationRecord
 
   private def check_for_assign_on_join_and_update_students_array_if_true
     student_ids = StudentsClassrooms.where(classroom_id: classroom_id).pluck(:student_id)
+
     if assigned_student_ids&.any? &&
        !assign_on_join &&
        assigned_student_ids.length >= student_ids.length &&

--- a/services/QuillLMS/app/models/concerns/archivable.rb
+++ b/services/QuillLMS/app/models/concerns/archivable.rb
@@ -7,11 +7,11 @@ module Archivable
     !visible
   end
 
-  def archive
-    update(visible: false)
+  def archive!
+    update!(visible: false)
   end
 
-  def unarchive
-    update(visible: true)
+  def unarchive!
+    update!(visible: true)
   end
 end

--- a/services/QuillLMS/app/services/classroom_unit_updater.rb
+++ b/services/QuillLMS/app/services/classroom_unit_updater.rb
@@ -11,7 +11,7 @@ class ClassroomUnitUpdater < ApplicationService
   end
 
   def run
-    if student_ids.empty?
+    if student_ids == false
       classroom_unit.archive!
     elsif classroom_unit.assigned_student_ids != student_ids
       classroom_unit.update!(

--- a/services/QuillLMS/app/services/classroom_unit_updater.rb
+++ b/services/QuillLMS/app/services/classroom_unit_updater.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ClassroomUnitUpdater < ApplicationService
+  attr_reader :assign_on_join, :student_ids, :classroom_unit, :concatenate_existing_student_ids
+
+  def initialize(classroom_data, classroom_unit, concatenate_existing_student_ids)
+    @assign_on_join = classroom_data[:assign_on_join]
+    @student_ids = classroom_data[:student_ids]
+    @classroom_unit = classroom_unit
+    @concatenate_existing_student_ids = concatenate_existing_student_ids
+  end
+
+  def run
+    if student_ids.empty?
+      classroom_unit.archive!
+    elsif classroom_unit.assigned_student_ids != student_ids
+      classroom_unit.update!(
+        assign_on_join: assign_on_join,
+        assigned_student_ids: assigned_student_ids,
+        visible: true
+      )
+    elsif classroom_unit.assign_on_join != assign_on_join
+      classroom_unit.update!(
+        assign_on_join: assign_on_join,
+        visible: true
+      )
+    elsif classroom_unit.archived?
+      classroom_unit.unarchive!
+    end
+  end
+
+  private def assigned_student_ids
+    concatenate_existing_student_ids ? classroom_unit.assigned_student_ids.concat(student_ids).uniq.sort : student_ids
+  end
+end

--- a/services/QuillLMS/app/services/classroom_units_saver.rb
+++ b/services/QuillLMS/app/services/classroom_units_saver.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ClassroomUnitsSaver < ApplicationService
+  attr_reader :classrooms_data, :concatenate_existing_student_ids, :new_classroom_units_data, :unit_id
+
+  def initialize(classrooms_data, concatenate_existing_student_ids, unit_id)
+    @concatenate_existing_student_ids = concatenate_existing_student_ids
+    @new_classroom_units_data = []
+    @unit_id = unit_id
+
+    @classrooms_data =
+      classrooms_data
+        .map(&:symbolize_keys)
+        .select { |classroom_data| classroom_data.key?(:id) }
+        .reject { |classroom_data| classroom_data[:id].nil? }
+        .uniq { |classroom_data| classroom_data[:id].to_i }
+  end
+
+  def run
+    update_existing_classroom_units_and_aggregate_new_classroom_units_data
+    bulk_create_classroom_units
+  end
+
+  private def bulk_create_classroom_units
+    ClassroomUnit.create!(new_classroom_units_data)
+  end
+
+  private def classroom_units
+    @classroom_units ||= ClassroomUnit.where(unit_id: unit_id)
+  end
+
+  private def update_existing_classroom_units_and_aggregate_new_classroom_units_data
+    classrooms_data.each do |classroom_data|
+      classroom_id = classroom_data[:id].to_i
+      classroom_unit = classroom_units.find { |cu| cu.classroom_id == classroom_id }
+
+      if classroom_unit
+        ClassroomUnitUpdater.run(classroom_data, classroom_unit, concatenate_existing_student_ids)
+      else
+        new_classroom_units_data.push(
+          assign_on_join: classroom_data[:assign_on_join],
+          assigned_student_ids: classroom_data[:student_ids],
+          classroom_id: classroom_id,
+          unit_id: unit_id
+        )
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/classroom_units_saver.rb
+++ b/services/QuillLMS/app/services/classroom_units_saver.rb
@@ -36,7 +36,7 @@ class ClassroomUnitsSaver < ApplicationService
 
       if classroom_unit
         ClassroomUnitUpdater.run(classroom_data, classroom_unit, concatenate_existing_student_ids)
-      else
+      elsif classroom_data[:student_ids] || classroom_data[:assign_on_join]
         new_classroom_units_data.push(
           assign_on_join: classroom_data[:assign_on_join],
           assigned_student_ids: classroom_data[:student_ids],

--- a/services/QuillLMS/app/services/unit_activities_saver.rb
+++ b/services/QuillLMS/app/services/unit_activities_saver.rb
@@ -12,7 +12,7 @@ class UnitActivitiesSaver < ApplicationService
         .map(&:symbolize_keys)
         .select { |activity_data| activity_data.key?(:id) }
         .reject { |activity_data| activity_data[:id].nil? }
-        .uniq { |activity_data| activity_data[:id] }
+        .uniq { |activity_data| activity_data[:id].to_i }
   end
 
   def run
@@ -21,14 +21,14 @@ class UnitActivitiesSaver < ApplicationService
   end
 
   private def bulk_create_unit_activities
-    UnitActivity.create(new_unit_activities_data)
+    UnitActivity.create!(new_unit_activities_data)
   end
 
   private def update_existing_unit_activities_and_aggregate_new_unit_activities_data
     activities_data.each.with_index(1) do |activity_data, order_number|
       activity_id = activity_data[:id].to_i
       due_date = activity_data[:due_date]
-      unit_activity = unit_activities.find { |ua| ua.activity_id == activity_id}
+      unit_activity = unit_activities.find { |ua| ua.activity_id == activity_id }
 
       if unit_activity
         unit_activity.update!(

--- a/services/QuillLMS/app/services/units/creator.rb
+++ b/services/QuillLMS/app/services/units/creator.rb
@@ -74,7 +74,7 @@ module Units::Creator
     unit.reload
     unit.save
     unit.email_lesson_plan
-    # activity_sessions in the state of 'unstarted' are automatically created in an after_create callback in the classroom_activity model
+
     AssignActivityWorker.perform_async((current_user_id || teacher.id), unit.id)
   end
 end

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -21,43 +21,8 @@ module Units::Updater
     update_helper(unit_id, activities_data, classrooms_data, current_user_id || teacher_id)
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def self.matching_or_new_classroom_unit(classroom, existing_classroom_units, new_cus, hidden_cus_ids, unit_id, concatenate_existing_student_ids)
-    classroom_id = classroom[:id].to_i || classroom['id'].to_i
-    matching_cu = existing_classroom_units.find{|cu| cu.classroom_id == classroom_id}
-    if matching_cu
-      if classroom[:student_ids] == false
-        # then there are no assigned students and we should hide the cas
-        hidden_cus_ids.push(matching_cu.id)
-      elsif (matching_cu.assigned_student_ids != classroom[:student_ids]) || matching_cu.assign_on_join != classroom[:assign_on_join]
-        # then something changed and we should update
-        new_recipients = classroom[:student_ids] - matching_cu.assigned_student_ids
-        new_student_ids = concatenate_existing_student_ids ? matching_cu.assigned_student_ids.concat(classroom[:student_ids]).uniq : classroom[:student_ids]
-        matching_cu.update!(assign_on_join: classroom[:assign_on_join], assigned_student_ids: new_student_ids, visible: true)
-      elsif !matching_cu.visible
-        matching_cu.update!(visible: true)
-      end
-    elsif classroom[:student_ids] || classroom[:assign_on_join]
-      # making an array of hashes to create in one bulk option
-      new_cus.push({classroom_id: classroom_id,
-         unit_id: unit_id,
-         assign_on_join: classroom[:assign_on_join],
-         assigned_student_ids: classroom[:student_ids]})
-    end
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity
-
   def self.update_helper(unit_id, activities_data, classrooms_data, current_user_id, concatenate_existing_student_ids: false)
-    new_cus = []
-    existing_classroom_units = ClassroomUnit.where(unit_id: unit_id)
-    hidden_cus_ids = []
-    classrooms_data.each do |classroom|
-      matching_or_new_classroom_unit(classroom, existing_classroom_units, new_cus, hidden_cus_ids, unit_id, concatenate_existing_student_ids)
-    end
-    new_cus = new_cus.uniq { |cu| cu['classroom_id'] || cu[:classroom_id] }
-    new_cus.each { |cu| ClassroomUnit.create(cu) }
-    ClassroomUnit.where(id: hidden_cus_ids).update_all(visible: false)
-
+    ClassroomUnitsSaver.run(classrooms_data, concatenate_existing_student_ids, unit_id)
     UnitActivitiesSaver.run(activities_data, unit_id)
 
     unit = Unit.find(unit_id)

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
@@ -16,37 +16,38 @@ export default class ClassroomsWithStudents extends React.Component {
   }
 
   classroomUpdates = () => {
-    const classrooms_data = [];
-    let classroomsWithNoAssignedStudents = 0;
-    this.props.classrooms.forEach((classy) => {
-      if (classy.edited) {
-        const class_data = { id: classy.id, };
-        if (classy.allSelected) {
-          class_data.student_ids = classy.students.map(s => s.id);
-          class_data.assign_on_join = true;
+    const classroomsData = []
+    let classroomsWithNoAssignedStudents = 0
+
+    this.props.classrooms.forEach((classroom) => {
+      if (classroom.edited) {
+        const classroomData = { id: classroom.id, }
+
+        if (classroom.allSelected) {
+          classroomData.student_ids = classroom.students.map(student => student.id)
+          classroomData.assign_on_join = true
         } else {
-          const student_ids_arr = [];
-          class_data.assign_on_join = false;
-          classy.students.forEach((stud) => {
-            if (stud.isSelected) {
-              student_ids_arr.push(stud.id);
-            }
-          });
-          if (student_ids_arr.length > 0) {
-            class_data.student_ids = student_ids_arr;
-          } else {
-            class_data.student_ids = false;
-            classroomsWithNoAssignedStudents += 1;
-          }
+          const studentIds = []
+
+          classroomData.assign_on_join = false
+
+          classroom.students.forEach((student) => {
+            if (student.isSelected) { studentIds.push(student.id) }
+          })
+
+          classroomData.student_ids = studentIds
+
+          if (studentIds.length == 0) { classroomsWithNoAssignedStudents += 1 }
         }
-        classrooms_data.push(class_data);
-      }			else if (classy.noneSelected) {
-        classroomsWithNoAssignedStudents += 1;
+        classroomsData.push(classroomData)
+
+      }	else if (classroom.noneSelected) {
+        classroomsWithNoAssignedStudents += 1
       }
-    }
-    );
-    return classrooms_data;
-  };
+    })
+
+    return classroomsData
+  }
 
   createButton() {
     if (!this.props.isSaveButtonEnabled) { return null }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
@@ -17,35 +17,31 @@ export default class ClassroomsWithStudents extends React.Component {
 
   classroomUpdates = () => {
     const classroomsData = []
-    let classroomsWithNoAssignedStudents = 0
 
     this.props.classrooms.forEach((classroom) => {
       if (classroom.edited) {
         const classroomData = { id: classroom.id, }
 
         if (classroom.allSelected) {
-          classroomData.student_ids = classroom.students.map(student => student.id)
+          classroomData.student_ids = classroom.students.map(s => s.id)
           classroomData.assign_on_join = true
         } else {
           const studentIds = []
 
           classroomData.assign_on_join = false
+          classroom.students.forEach((student) => { if (student.isSelected) { studentIds.push(student.id) } })
 
-          classroom.students.forEach((student) => {
-            if (student.isSelected) { studentIds.push(student.id) }
-          })
-
-          classroomData.student_ids = studentIds
-
-          if (studentIds.length == 0) { classroomsWithNoAssignedStudents += 1 }
+          if (studentIds.length > 0) {
+            classroomData.student_ids = studentIds
+          } else {
+            classroomData.student_ids = false
+          }
         }
+
         classroomsData.push(classroomData)
-
-      }	else if (classroom.noneSelected) {
-        classroomsWithNoAssignedStudents += 1
       }
-    })
-
+    }
+    )
     return classroomsData
   }
 

--- a/services/QuillLMS/spec/services/analytics/classroom_unit_updater_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/classroom_unit_updater_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomUnitUpdater do
+  let!(:classroom) { create(:classroom) }
+  let!(:student1) { create(:students_classrooms, classroom: classroom).student }
+  let!(:student2) { create(:students_classrooms, classroom: classroom).student }
+  let!(:student3) { create(:students_classrooms, classroom: classroom).student }
+
+  let(:assigned_student_ids) { [student1.id] }
+  let(:classroom_unit) { create(:classroom_unit, assigned_student_ids: assigned_student_ids, classroom: classroom) }
+
+  let(:student_ids) { assigned_student_ids }
+  let(:assign_on_join) { false }
+  let(:classroom_data) { { assign_on_join: assign_on_join, student_ids: student_ids } }
+
+  let(:concatenate_existing_student_ids) { true }
+
+  subject { described_class.run(classroom_data, classroom_unit, concatenate_existing_student_ids) }
+
+  context 'student_ids is empty' do
+    let(:student_ids) { [] }
+
+    it { expect { subject }.to change { classroom_unit.reload.visible }.from(true).to(false) }
+
+    context 'classroom_unit is archived' do
+      before { classroom_unit.update(visible: false) }
+
+      it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(false) }
+    end
+  end
+
+  context 'student_ids different than assigned_student_ids' do
+    let(:assigned_student_ids) { [student1.id, student2.id] }
+    let(:student_ids) { [student1.id, student3.id] }
+    let(:concatenated_students_ids) { [student1.id, student2.id, student3.id] }
+    let(:concatenate_existing_student_ids) { true }
+
+    before { classroom_unit.update(assigned_student_ids: assigned_student_ids) }
+
+    it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to(concatenated_students_ids) }
+    it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(true) }
+    it { unarchives_an_archived_classroom_unit }
+
+    context 'concatenate_existing_student_ids is false' do
+      let(:concatenate_existing_student_ids) { false }
+
+      it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to(student_ids) }
+      it { unarchives_an_archived_classroom_unit }
+    end
+  end
+
+  context 'assign_on_join changed from false to true' do
+    let(:assign_on_join) { true }
+
+    before { classroom_unit.update!(assign_on_join: false) }
+
+    it { expect { subject }.to change { classroom_unit.reload.assign_on_join }.from(false).to(true) }
+    it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(true) }
+    it { unarchives_an_archived_classroom_unit }
+  end
+
+  it { unarchives_an_archived_classroom_unit }
+
+  def unarchives_an_archived_classroom_unit
+    classroom_unit.update(visible: false)
+
+    expect { subject }.to change { classroom_unit.reload.visible}.from(false).to(true)
+  end
+end

--- a/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
+++ b/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomUnitsSaver do
+  let(:classroom1) { create(:classroom) }
+  let(:classroom2) { create(:classroom) }
+  let(:classroom_data1) { { id: classroom1.id, assign_on_join: true, student_ids: [] } }
+  let(:classroom_data2) { { "id" => classroom2.id.to_s, "assign_on_join" => true, "student_ids" => [] } }
+  let(:classroom_data3) { classroom_data1 }
+  let(:classroom_data4) { { id: nil } }
+  let(:classroom_data5) { { assign_on_join: false, student_ids: [] } }
+  let(:classrooms_data) { [classroom_data1, classroom_data2, classroom_data3, classroom_data4, classroom_data5] }
+
+  let(:concatenate_existing_student_ids) { true }
+
+  let(:unit) { create(:unit) }
+
+  subject { described_class.run(classrooms_data, concatenate_existing_student_ids, unit.id) }
+
+  it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(2) }
+
+  context 'classroom_unit already exists' do
+    let!(:classroom_unit) { create(:classroom_unit, classroom: classroom1, unit: unit) }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(1).to(2) }
+
+    it do
+      expect(ClassroomUnitsSaver).to receive(:run).once
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
+++ b/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
@@ -4,26 +4,61 @@ require 'rails_helper'
 
 RSpec.describe ClassroomUnitsSaver do
   let(:classroom1) { create(:classroom) }
-  let(:classroom2) { create(:classroom) }
   let(:classroom_data1) { { id: classroom1.id, assign_on_join: true, student_ids: [] } }
-  let(:classroom_data2) { { "id" => classroom2.id.to_s, "assign_on_join" => true, "student_ids" => [] } }
-  let(:classroom_data3) { classroom_data1 }
-  let(:classroom_data4) { { id: nil } }
-  let(:classroom_data5) { { assign_on_join: false, student_ids: [] } }
-  let(:classrooms_data) { [classroom_data1, classroom_data2, classroom_data3, classroom_data4, classroom_data5] }
-
   let(:concatenate_existing_student_ids) { true }
-
   let(:unit) { create(:unit) }
 
   subject { described_class.run(classrooms_data, concatenate_existing_student_ids, unit.id) }
 
-  it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(2) }
+  context 'classroom_data1 with symbol based keys' do
+    let(:classrooms_data) { [classroom_data1] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with string based keys' do
+    let(:classrooms_data) { [classroom_data1.stringify_keys] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with duplicates' do
+    let(:classrooms_data) { [classroom_data1, classroom_data1] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with nil id' do
+    let(:classrooms_data) { [classroom_data1.merge(id: nil)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'classroom_data1 with no id' do
+    let(:classrooms_data) { [classroom_data1.except(:id)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'classroom_data1 with student_ids = false and assign_on_join = false' do
+    let(:classrooms_data) { [classroom_data1.merge(student_ids: false, assign_on_join: false)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'two classroom_data1' do
+    let(:classroom2) { create(:classroom) }
+    let(:classroom_data2) { classroom_data1.merge(id: classroom2.id) }
+    let(:classrooms_data) { [classroom_data1, classroom_data2] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(2) }
+  end
 
   context 'classroom_unit already exists' do
     let!(:classroom_unit) { create(:classroom_unit, classroom: classroom1, unit: unit) }
+    let(:classrooms_data) { [classroom_data1] }
 
-    it { expect { subject }.to change(ClassroomUnit, :count).from(1).to(2) }
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(1) }
 
     it do
       expect(ClassroomUnitsSaver).to receive(:run).once


### PR DESCRIPTION
## WHAT
Refactor some code in Units::Updater#update_helper, part 2

## WHY
The code in update_helper has high cyclotomic complexity making the addition of new features difficult.

## HOW
This focuses on refactoring out a `ClassroomUnitsSaver` method. This service object will also pull in the class method `def self.matching_or_new_classroom_unit`, which handles the creation / updating of ClassroomUnits.

In the process of refactoring, I extracted another class `ClassroomUnitUpdater` to handle the complexity of updates made to existing classroom units.

Note:  I originally tried to fix `student_ids` to remove the overloaded types on the the variable.  Specifically this [block](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx#L35) where it can be set either an array type or a boolean type.  Unfortunately, fixing this ambiguity had effects elsewhere.  At some point we should fix this assignment. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
