### PR TITLE
Fix a null variable bug in Vitally Sync Worker

### DIFF
--- a/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_sales_form_submission_to_vitally_worker.rb
@@ -99,7 +99,7 @@ class SyncSalesFormSubmissionToVitallyWorker
 
   private def school_array_for_existing_user
     previous_school = @sales_form_submission.find_or_create_user&.school
-    if previous_school.present? && previous_school != school
+    if previous_school.present? && previous_school != @sales_form_submission.school
       [api.get(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, previous_school.id)["id"], school_vitally_id]
     else
       [school_vitally_id]
@@ -108,7 +108,7 @@ class SyncSalesFormSubmissionToVitallyWorker
 
   private def district_array_for_existing_user
     previous_district = @sales_form_submission.find_or_create_user&.school&.district
-    if previous_district.present? && previous_district != district
+    if previous_district.present? && previous_district != @sales_form_submission.district
       [api.get(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, previous_district.id)["id"], district_vitally_id]
     else
       [district_vitally_id]

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -116,8 +116,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   context '#send_opportunity_to_vitally' do
     it 'should send the appropriate payload for forms with a school collection type' do
-      district = create(:district)
-      school = create(:school, district: district)
+      school = create(:school)
       vitally_school_id = '123'
       expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => vitally_school_id})
 

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -17,7 +17,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   describe '#perform' do
     it 'should run all three steps: create school/district in vitally, create user in vitally, send opportunity to vitally' do
-      create(:school, name: sales_form_submission.school_name)
+      district = create(:district)
+      create(:school, name: sales_form_submission.school_name, district: district)
 
       fake_id = 1
 
@@ -88,7 +89,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   context '#send_opportunity_to_vitally' do
     it 'should send the appropriate payload for forms with a school collection type' do
-      school = create(:school)
+      district = create(:district)
+      school = create(:school, district: district)
       vitally_school_id = '123'
       expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => vitally_school_id})
 
@@ -153,7 +155,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send a payload with the id for Unknown School if the school does not exist in the db' do
-      school = create(:school, name: 'Unknown School')
+      district = create(:district)
+      school = create(:school, name: 'Unknown School', district: district)
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, submission_type: 'quote request', school_name: 'nonexistent school name', source: SalesFormSubmission::FORM_SOURCE)
 
       vitally_school_id = '123'
@@ -187,7 +190,8 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send update call to update school with custom hasOpportunity trait' do
-      school = create(:school)
+      district = create(:district)
+      school = create(:school, district: district)
       vitally_school_id = '123'
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
 

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -85,32 +85,36 @@ describe SyncSalesFormSubmissionToVitallyWorker do
       subject.create_vitally_user_if_none_exists
     end
 
-    it 'should update a Vitally user if with two different districts if the users school already has a different district attached' do
-      other_district = create(:district)
-      school = create(:school, district: other_district)
-      create(:schools_users, school: school, user: user)
+    context 'when a users school has a different district from the district in the sales form submission' do
+      it 'should send a payload with both district IDs' do
+        other_district = create(:district)
+        school = create(:school, district: other_district)
+        create(:schools_users, school: school, user: user)
 
-      expect(stub_api).to receive(:exists?).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id).and_return(true)
-      expect(stub_api).to receive(:get).twice.with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, other_district.id).and_return({'id' => other_district.id})
-      expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, district.id).and_return({'id' => district.id})
-      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id, subject.send(:vitally_user_update_data))
+        expect(stub_api).to receive(:exists?).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id).and_return(true)
+        expect(stub_api).to receive(:get).twice.with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, other_district.id).and_return({'id' => other_district.id})
+        expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_DISTRICTS_TYPE, district.id).and_return({'id' => district.id})
+        expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id, subject.send(:vitally_user_update_data))
 
-      subject.create_vitally_user_if_none_exists
+        subject.create_vitally_user_if_none_exists
+      end
     end
 
-    it 'should update a Vitally user if with two different schools if the user already has a different school attached' do
-      school = create(:school)
-      other_school = create(:school)
-      create(:schools_users, school: school, user: user)
-      school_sales_form_submission = create(:sales_form_submission, collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, school_name: other_school.name, email: user.email)
-      subject.sales_form_submission = school_sales_form_submission
+    context 'when a user has a different school in our DB from the school they designated on the sales form submission' do
+      it 'should send a payload with both school IDs in an array' do
+        school = create(:school)
+        other_school = create(:school)
+        create(:schools_users, school: school, user: user)
+        school_sales_form_submission = create(:sales_form_submission, collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, school_name: other_school.name, email: user.email)
+        subject.sales_form_submission = school_sales_form_submission
 
-      expect(stub_api).to receive(:exists?).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id).and_return(true)
-      expect(stub_api).to receive(:get).twice.with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => school.id})
-      expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, other_school.id).and_return({'id' => other_school.id})
-      expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id, subject.send(:vitally_user_update_data))
+        expect(stub_api).to receive(:exists?).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id).and_return(true)
+        expect(stub_api).to receive(:get).twice.with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, school.id).and_return({'id' => school.id})
+        expect(stub_api).to receive(:get).with(SalesFormSubmission::VITALLY_SCHOOLS_TYPE, other_school.id).and_return({'id' => other_school.id})
+        expect(stub_api).to receive(:update).with(SalesFormSubmission::VITALLY_USERS_TYPE, user.id, subject.send(:vitally_user_update_data))
 
-      subject.create_vitally_user_if_none_exists
+        subject.create_vitally_user_if_none_exists
+      end
     end
   end
 

--- a/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_sales_form_submission_to_vitally_worker_spec.rb
@@ -6,7 +6,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
   subject { described_class.new }
 
   let(:sales_form_submission) { create(:sales_form_submission) }
-  let!(:stub_api) { double.as_null_object }
+  let!(:stub_api) { double }
 
   before do
     allow(VitallyRestApi).to receive(:new).and_return(stub_api)
@@ -17,8 +17,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
 
   describe '#perform' do
     it 'should run all three steps: create school/district in vitally, create user in vitally, send opportunity to vitally' do
-      district = create(:district)
-      create(:school, name: sales_form_submission.school_name, district: district)
+      create(:school, name: sales_form_submission.school_name)
 
       fake_id = 1
 
@@ -183,8 +182,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send a payload with the id for Unknown School if the school does not exist in the db' do
-      district = create(:district)
-      school = create(:school, name: 'Unknown School', district: district)
+      school = create(:school, name: 'Unknown School')
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, submission_type: 'quote request', school_name: 'nonexistent school name', source: SalesFormSubmission::FORM_SOURCE)
 
       vitally_school_id = '123'
@@ -218,8 +216,7 @@ describe SyncSalesFormSubmissionToVitallyWorker do
     end
 
     it 'should send update call to update school with custom hasOpportunity trait' do
-      district = create(:district)
-      school = create(:school, district: district)
+      school = create(:school)
       vitally_school_id = '123'
       sales_form_submission.update(collection_type: SalesFormSubmission::SCHOOL_COLLECTION_TYPE, source: SalesFormSubmission::FORM_SOURCE, submission_type: 'quote request', school_name: school.name)
 


### PR DESCRIPTION
## WHAT
We have a bug in the code right now where it calls the undefined variables `school` and `district` instead of the defined variables `@sales_form_submission.school` and `@sales_form_submission.district`. I'm fixing this in the PR.

## WHY
This is preventing our Intercom tags from properly sending Vitally calls because the worker runs into this nil error and fails.

## HOW
Replace the undefined variables with defined variables.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  Yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | Yes
