### PR TITLE
lms/sometimes-hide-vitally-districts

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -16,7 +16,7 @@ class SerializeVitallySalesAccount
     activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count("DISTINCT activity_sessions.id")
     {
       accountId: @school.id.to_s,
-      organizationId: @school.district&.id&.to_s || "",
+      organizationId: organization_id,
       # Type is used by Vitally to determine which data type the payload contains in batches
       type: 'account',
       # Vitally requires a unique messageId for dedupication purposes
@@ -101,5 +101,11 @@ class SerializeVitallySalesAccount
     School.joins(users: {classrooms_i_teach: :activity_sessions})
           .where(id: @school.id)
           .maximum('activity_sessions.completed_at')
+  end
+
+  private def organization_id
+    return @school.district.id.to_s if @school.district&.schools&.any?(&:subscription)
+
+    ""
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -49,7 +49,7 @@ describe 'SerializeVitallySalesAccount' do
   it 'includes the organizationId if a different school in the district has a subscription' do
     different_school = create(:school, district: district)
     create(:school_subscription, school: different_school, subscription: subscription)
-   
+
     school_data = SerializeVitallySalesAccount.new(school).data
 
     expect(school_data).to include(organizationId: school.district_id.to_s)

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -19,6 +19,7 @@ describe 'SerializeVitallySalesAccount' do
       ulocal: '41'
     )
   end
+  let(:subscription) { create(:subscription, account_type: Subscription::SCHOOL_PAID) }
 
   before do
     previous_year_data = {
@@ -37,10 +38,35 @@ describe 'SerializeVitallySalesAccount' do
     expect(school_data).to include(accountId: school.id.to_s)
   end
 
-  it 'includes the organizationId' do
+  it 'includes the organizationId if the school has a subscription' do
+    create(:school_subscription, school: school, subscription: subscription)
+
     school_data = SerializeVitallySalesAccount.new(school).data
 
     expect(school_data).to include(organizationId: school.district_id.to_s)
+  end
+
+  it 'includes the organizationId if a different school in the district has a subscription' do
+    different_school = create(:school, district: district)
+    create(:school_subscription, school: different_school, subscription: subscription)
+   
+    school_data = SerializeVitallySalesAccount.new(school).data
+
+    expect(school_data).to include(organizationId: school.district_id.to_s)
+  end
+
+  it 'does not include the organizationId if no schools in the district have a subscription' do
+    school_data = SerializeVitallySalesAccount.new(school).data
+
+    expect(school_data).to include(organizationId: '')
+  end
+
+  it 'does not include the organizationId if the school is not part of a district' do
+    school.update(district: nil)
+
+    school_data = SerializeVitallySalesAccount.new(school).data
+
+    expect(school_data).to include(organizationId: '')
   end
 
   it 'generates basic school params' do


### PR DESCRIPTION
## WHAT
Only sync Vitally School district.id if there are active subscriptions
## WHY
We only want to organize Schools under Districts in Vitally if there's someone paying for something.  So if a district doesn't have at least one school with a subscription, don't attach it to any schools during the sync process.
## HOW
When determining what `organizationId` to attach to a school, first check to see if the district in question has any schools with active subscriptions.  If not, send `""` as the `organizationId` so that the school doesn't get assigned to a District since we only use District-level organization in Vitally for sales management.

### Notion Card Links
https://www.notion.so/quill/Overview-Only-Send-Vitally-Districts-for-Schools-in-Districts-that-Contain-Paying-Schools-10f355b54d494679b9e1510192bd34e5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
