### PR TITLE
Fix bug with updating canceled_at stripe subscriptions

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
@@ -22,8 +22,12 @@ module StripeIntegration
       params[:stripe_subscription_id]
     end
 
+    private def stripe_subscription
+      @stripe_subscription ||= Stripe::Subscription.retrieve(stripe_subscription_id)
+    end
+
     private def stripe_subscription_canceled?
-      Stripe::Subscription.retrieve(stripe_subscription_id).canceled_at.present?
+      stripe_subscription.status == StripeIntegration::Subscription::CANCELED
     end
   end
 end

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
   end
 
   context 'Stripe Subscription exists but was canceled' do
-    let(:stripe_subscription_canceled_at) { Time.current.to_i }
+    let(:stripe_subscription_status) { StripeIntegration::Subscription::CANCELED }
 
     it 'returns 500 since updates are not allowed on canceled subscriptions' do
       expect(ErrorNotifier)


### PR DESCRIPTION
## WHAT
Fix a bug where a user attempts to update a subscription that is set to be canceled at a specific date.

## WHY
With stripe subscriptions, there are two cancellation options:
1. cancel immediately:  the subscription is locked and no more updates can be made.
2. cancel_at_period_now: the subscription is active but set to expire at the given date. Updates to the subscription are still allowed.

I mistakenly interpreted the method `canceled_at` to mean that the subscription was in fact canceled.  Instead, it only [means](https://stripe.com/docs/api/subscriptions/object#subscription_object-canceled_at) that a request for cancellation has been made.

## HOW
Instead of using `canceled_at`, check the subscription status as [canceled](https://stripe.com/docs/api/subscriptions/cancel)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | No, tiny change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
