### PR TITLE
Rubocop - Ignore change for ambiguous block.

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -132,10 +132,6 @@ Lint/AmbiguousBlockAssociation:
   Enabled: true
   IgnoredMethods:
     - change
-  Exclude:
-    - "QuillLMS/spec/models/activity_session_spec.rb"
-    - "QuillLMS/spec/models/user_spec.rb"
-    - "QuillLMS/spec/controllers/pages_controller_spec.rb"
 
 Lint/AmbiguousOperatorPrecedence:
   Enabled: true

--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -130,6 +130,8 @@ Lint/AmbiguousAssignment:
 
 Lint/AmbiguousBlockAssociation:
   Enabled: true
+  IgnoredMethods:
+    - change
   Exclude:
     - "QuillLMS/spec/models/activity_session_spec.rb"
     - "QuillLMS/spec/models/user_spec.rb"

--- a/services/QuillLMS/spec/controllers/pages_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pages_controller_spec.rb
@@ -120,7 +120,7 @@ describe PagesController do
       get :activities
       expect(assigns(:body_class)).to eq 'full-width-page white-page'
       expect(assigns(:standard_level)).to eq standard_level
-      expect(assigns(:standards)).to eq standard_level.standards.map{ |standard| [standard, standard.activities.production] }.select{ |group| group.second.any? }
+      expect(assigns(:standards)).to eq(standard_level.standards.map{ |standard| [standard, standard.activities.production] }.select{ |group| group.second.any? })
     end
   end
 


### PR DESCRIPTION
## WHAT
Tiny PR for Rubocop config adjustment. For [ambiguous block linter](https://docs.rubocop.org/rubocop/cops_lint.html#lintambiguousblockassociation),  ignore rspec's `change` method 
## WHY
I'm stuck in an unfixable linter error loop in a branch with the `change` method (if I change the code, it either breaks or hits another Cop for empty params). The documentation of the Cop uses `change` as an example of a method you might ignore, so I'm assuming this is common.
## HOW
Add `IgnoreMethods`

This also allows us to remove 3 spec files being excluded from this rule (they also had this issue).
### Screenshots
<img width="1706" alt="Screen Shot 2022-09-16 at 10 51 55 AM" src="https://user-images.githubusercontent.com/1304933/190668293-88cfd2cc-8d83-427b-a53d-42f4d42addf4.png">


![Screen Shot 2022-09-16 at 10 57 17 AM](https://user-images.githubusercontent.com/1304933/190669122-e97546c8-1bf5-4cb6-9e34-11f740570637.png)



### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO - non-app change, NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? |  N/A
