### PR TITLE
Lms/maintain access to assigned archived activities

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -215,13 +215,9 @@ class Teachers::UnitsController < ApplicationController
 
     return [] if teach_own_or_coteach_classrooms_array.empty?
 
-    scores, completed, archived_activities = ''
+    scores, completed = ''
 
-    if report
-      completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0"
-    else
-      archived_activities = "AND 'archived' != ANY(activities.flags)"
-    end
+    completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0" if report
 
     if lessons
       lessons = "AND activities.activity_classification_id = 6"
@@ -291,7 +287,6 @@ class Teachers::UnitsController < ApplicationController
           AND units.visible = true
           AND cu.visible = true
           AND ua.visible = true
-          #{archived_activities}
           #{lessons}
         GROUP BY
           units.name,

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -217,7 +217,9 @@ class Teachers::UnitsController < ApplicationController
 
     scores, completed = ''
 
-    completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0" if report
+    if report
+      completed = lessons ? "HAVING ca.completed" : "HAVING SUM(CASE WHEN act_sesh.visible = true AND act_sesh.state = 'finished' THEN 1 ELSE 0 END) > 0"
+    end
 
     if lessons
       lessons = "AND activities.activity_classification_id = 6"

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -162,7 +162,6 @@ class UnitActivity < ApplicationRecord
           AND cu.visible = true
           AND unit.visible = true
           AND ua.visible = true
-          AND 'archived' != ANY(activity.flags)
         GROUP BY
           unit.id,
           unit.name,

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -47,7 +47,6 @@ class Scorebook::Query
           AND unit_activities.visible
           AND cu.visible
           AND sc.visible
-          AND 'archived' != ANY(activity.flags)
           #{last_unit}
           #{date_conditional_string(begin_date, end_date, offset)}
         GROUP BY

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -595,10 +595,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
         is_last_page: true
       }.to_json)
     end
-
-    it 'should render records even if the underlying activities are archived' do
-      raise NotImplementedError
-    end
   end
 
   describe '#retreive_google_clasrooms' do

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -595,6 +595,10 @@ describe Teachers::ClassroomManagerController, type: :controller do
         is_last_page: true
       }.to_json)
     end
+
+    it 'should render records even if the underlying activities are archived' do
+      raise NotImplementedError
+    end
   end
 
   describe '#retreive_google_clasrooms' do

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -223,6 +223,15 @@ describe Teachers::UnitsController, type: :controller do
       expect(parsed_response[0]['number_of_assigned_students']).to eq(original_assigned_student_ids_length)
     end
 
+    it 'should return activities even if they have been archived' do
+      diagnostic_activity.update(flags: [Activity::ARCHIVED])
+
+      response = get :index, params: { report: false }
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response.length).to eq(1)
+    end
+
     # TODO: write a VCR-like test to check when this request returns something other than what we expect.
   end
 

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -154,5 +154,11 @@ describe UnitActivity, type: :model, redis: true do
       units = UnitActivity.get_classroom_user_profile(nil, nil)
       expect(units.count).to eq(0)
     end
+
+    it 'includes units even if their activities are archived' do
+      activity.update(flags: [Activity::ARCHIVED])
+      units = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
+      expect(units.count).to eq(2)
+    end
   end
 end

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -35,6 +35,13 @@ describe 'ScorebookQuery' do
     expect(results.map{|res| res["id"]}).to include(activity_session2.id)
   end
 
+  it 'returns activities even if the underlying activity has been archived' do
+    activity2.update(flags: [Activity::ARCHIVED])
+
+    results = Scorebook::Query.run(classroom.id)
+    expect(results.map{|res| res["id"]}).to include(activity_session2.id)
+  end
+
   describe 'support date constraints' do
     it 'returns activities completed between the specified dates' do
       begin_date = activity_session1.completed_at - 1.day

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -32,14 +32,14 @@ describe 'ScorebookQuery' do
 
   it 'returns a completed activity that is a final scores' do
     results = Scorebook::Query.run(classroom.id)
-    expect(results.map{|res| res["id"]}).to include(activity_session2.id)
+    expect(results.pluck('id')).to include(activity_session2.id)
   end
 
   it 'returns activities even if the underlying activity has been archived' do
     activity2.update(flags: [Activity::ARCHIVED])
 
     results = Scorebook::Query.run(classroom.id)
-    expect(results.map{|res| res["id"]}).to include(activity_session2.id)
+    expect(results.pluck('id')).to include(activity_session2.id)
   end
 
   describe 'support date constraints' do


### PR DESCRIPTION
## WHAT
Ensure that Students and Teachers maintain access to assigned activities even in rare cases where Curriculum later marks that activity as "archived".
## WHY
It's confusing to both students and teachers to have activities that they've seen, and know that they are working on, just disappear from their dashboards with no explanation.  We'd prefer not to confuse our users, and it's been decided that letting a small handful of users access an activity that's been archived for whatever reason is better.  If we, for some reason, absolutely need to prevent access to an activity or question, there are other methods (removing questions from the Activity or just deleting the record altogether).
## HOW
Remove `WHERE` conditions from raw SQL queries that were excluding results where `activities.flags` included "archived" in three different places (one student-facing API endpoint, and two teacher-facing API endpoints).

### Notion Card Links
https://www.notion.so/quill/Archiving-Activities-that-are-already-assigned-Only-Hide-in-Assignment-Flow-for-New-Teachers-Not-06034161a4f2420983680ba3c9cb8d48

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
