### PR TITLE
Migrate from Rails AutoScale Agent

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -150,7 +150,8 @@ gem 'rb-readline'
 gem 'awesome_print'
 
 group :production, :staging do
-  gem 'rails_autoscale_agent'
+  gem 'rails-autoscale-web'
+  gem 'rails-autoscale-sidekiq'
   gem 'lograge'
   gem 'sqreen'
 end

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -561,6 +561,13 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.6)
       sprockets-rails (>= 2.0.0)
+    rails-autoscale-core (1.0.1)
+    rails-autoscale-sidekiq (1.0.1)
+      rails-autoscale-core
+      sidekiq (>= 5.0)
+    rails-autoscale-web (1.0.1)
+      rails-autoscale-core
+      railties
     rails-controller-testing (0.0.3)
       rails (>= 4.2)
     rails-dom-testing (2.0.3)
@@ -580,7 +587,6 @@ GEM
       rails (>= 5.0, < 7)
       remotipart (~> 1.3)
       sassc-rails (>= 1.3, < 3)
-    rails_autoscale_agent (0.10.2)
     railties (6.1.6)
       actionpack (= 6.1.6)
       activesupport (= 6.1.6)
@@ -875,9 +881,10 @@ DEPENDENCIES
   rack-host-redirect
   rack-test (~> 0.6.3)
   rails (= 6.1.6)
+  rails-autoscale-sidekiq
+  rails-autoscale-web
   rails-controller-testing
   rails_admin (~> 2.2)
-  rails_autoscale_agent
   ranked-model (~> 0.4.3)
   rb-readline
   react_on_rails (= 11.3.0)


### PR DESCRIPTION
## WHAT
Upgrade Rails Autoscale gem to newer libraries

## WHY
The gem had some upgrades

## HOW
Add 'rails-autoscale-web' and' rails-autoscale-sidekiq' to Gemfile
Remove 'rails-autoscale-agent' from Gemfile.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Migrate-from-Rails-AutoScale-Agent-b5cbe44447d24a0bb1e67cdf233d66e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
