### PR TITLE
lms/remove-autoscale-link-in-deploy

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -8,7 +8,6 @@ case $1 in
     DEPLOY_GIT_BRANCH=deploy-lms-prod
     HEROKU_APP=empirical-grammar
     URL="https://www.quill.org/"
-    AUTOSCALE_URL="https://app.railsautoscale.com/empirical-grammar/settings/edit"
     NR_URL="https://rpm.newrelic.com/accounts/2639113/applications/548856875"
     current_branch="origin/production"
     ;;
@@ -91,7 +90,6 @@ then
     if [ $1 == 'prod' ]
     then
         sh ../../scripts/post_slack_deploy_description.sh $app_name
-        open $AUTOSCALE_URL
 
         # For production, push directly from the remote production branch without going local
         # This 'remote merge' requires your local git history/pointers of the remote branches to be up-to-date, so we run a 'git fetch' to do that.


### PR DESCRIPTION
## WHAT
Remove the code that opens the autoscale dashboard from our deploy script
## WHY
The link that we were using no longer works, and our current deveops config means that we don't need to adjust this config every deploy anymore
## HOW
Just remove references to Autoscale


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on bash scripts
Have you deployed to Staging? | Yes.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
