### PR TITLE
Handle expired sessions with pdf requests

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -159,6 +159,7 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html { redirect_to new_session_path }
       format.json { render json: { redirect: new_session_path }, status: 303 }
+      format.pdf { redirect_to new_session_path }
     end
   end
 

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -146,14 +146,15 @@ describe ApplicationController, type: :controller do
 
     describe '#reset_session_and_redirect_to_sign_in' do
       controller { def custom; end }
+      subject { get :custom, as: format }
 
       before do
-        routes.draw { get 'custom' => "anonymous#custom", format: [:html, :json] }
+        routes.draw { get 'custom' => "anonymous#custom", format: [:html, :json, :pdf] }
         allow(user).to receive(:staff_session_duration_exceeded?).and_return(true)
       end
 
       context 'html request' do
-        subject { get :custom }
+        let(:format) { :html }
 
         it 'resets the session' do
           expect(controller).to receive(:reset_session)
@@ -165,7 +166,7 @@ describe ApplicationController, type: :controller do
       end
 
       context 'json request' do
-        subject { get :custom, as: :json }
+        let(:format) { :json }
 
         it 'resets the session' do
           expect(controller).to receive(:reset_session)
@@ -180,6 +181,18 @@ describe ApplicationController, type: :controller do
           expect(response.content_type).to eq('application/json; charset=utf-8')
           expect(response.body).to eq({ redirect: new_session_path }.to_json )
         end
+      end
+
+      context 'pdf request' do
+        let(:format) { :pdf }
+
+        it 'resets the session' do
+          expect(controller).to receive(:reset_session)
+          subject
+        end
+
+        it { expect { subject }.to change { session[described_class::EXPIRED_SESSION_REDIRECT] }.from(nil).to(true) }
+        it { expect(subject).to redirect_to new_session_path }
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix a bug with PDF requests.

## WHY
If a user has an an invalid session and tries to generate a login pdf, the system will return a unknown format error.

## HOW
Add a `format.pdf` block for the the `reset_session_and_redirect_to_sign_in`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Teachers-ClassroomsController-generate_login_pdf-b2a43e43548541d88ca7983ea6b21bee

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | YES
