### PR TITLE
LMS/ fix schools with missing 0 in zipcode

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -94,8 +94,7 @@ class Cms::SchoolsController < Cms::CmsController
     if new_school.save
       redirect_to cms_school_path(new_school.id)
     else
-      flash[:error] = new_school.errors
-      redirect_to new_cms_school_path
+      redirect_to new_cms_school_path, flash: { error: new_school.errors }
     end
   end
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -94,7 +94,8 @@ class Cms::SchoolsController < Cms::CmsController
     if new_school.save
       redirect_to cms_school_path(new_school.id)
     else
-      render :new
+      flash[:error] = new_school.errors
+      redirect_to new_cms_school_path
     end
   end
 

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -66,7 +66,7 @@ class School < ApplicationRecord
   after_save :attach_new_district_school_admins, if: :saved_change_to_district_id?
 
   validate :lower_grade_within_bounds, :upper_grade_within_bounds,
-           :lower_grade_greater_than_upper_grade
+           :lower_grade_greater_than_upper_grade, :zipcode_length
 
   ALTERNATIVE_SCHOOL_NAMES = [
     HOME_SCHOOL_SCHOOL_NAME = 'home school',
@@ -208,5 +208,10 @@ class School < ApplicationRecord
     schools_admins
       .where(user: old_district_admins)
       .destroy_all
+  end
+
+  private def zipcode_length
+    return true unless zipcode && zipcode.length != 5
+    errors.add(:zipcode, 'must be 5 digits')
   end
 end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -67,7 +67,7 @@ class School < ApplicationRecord
 
   validate :lower_grade_within_bounds, :upper_grade_within_bounds,
            :lower_grade_greater_than_upper_grade
-  validates :zipcode, length: { min: 5 }, allow_blank: true
+  validates :zipcode, length: { minimum: 5 }, allow_blank: true
 
   ALTERNATIVE_SCHOOL_NAMES = [
     HOME_SCHOOL_SCHOOL_NAME = 'home school',

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -212,6 +212,7 @@ class School < ApplicationRecord
 
   private def zipcode_length
     return true unless zipcode && zipcode.length != 5
+
     errors.add(:zipcode, 'must be 5 digits')
   end
 end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -66,7 +66,8 @@ class School < ApplicationRecord
   after_save :attach_new_district_school_admins, if: :saved_change_to_district_id?
 
   validate :lower_grade_within_bounds, :upper_grade_within_bounds,
-           :lower_grade_greater_than_upper_grade, :zipcode_length
+           :lower_grade_greater_than_upper_grade
+  validates :zipcode, length: { min: 5 }, allow_blank: true
 
   ALTERNATIVE_SCHOOL_NAMES = [
     HOME_SCHOOL_SCHOOL_NAME = 'home school',

--- a/services/QuillLMS/app/views/cms/schools/edit.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/edit.html.erb
@@ -11,6 +11,7 @@
       <li>Private schools don't have a district.</li>
       <li>Charter schools should have the charter network name as district.</li>
       <li>Free and Reduced Price lunch is just a number (e.g. 75 &mdash; not 75%).</li>
+      <li>For zipcodes that start with 0, please do not omit the 0.</li>
     </strong></ul><br />
     <div class='cms-form'>
       <%= form_for @school, url: cms_school_path(@school.id) do |f| %>

--- a/services/QuillLMS/app/views/cms/schools/new.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/new.html.erb
@@ -11,6 +11,7 @@
       <li>Private schools don't have a district.</li>
       <li>Charter schools should have the charter network name as district.</li>
       <li>Free and Reduced Price lunch is just a number (e.g. 75 &mdash; not 75%).</li>
+      <li>For zipcodes that start with 0, please do not omit the 0.</li>
     </strong></ul>
     <br />
     <div class='cms-form'>

--- a/services/QuillLMS/lib/tasks/update_schools_with_4_digit_zipcodes.rake
+++ b/services/QuillLMS/lib/tasks/update_schools_with_4_digit_zipcodes.rake
@@ -4,7 +4,7 @@ namespace :update_schools_with_4_digit_zipcodes do
   desc 'update schools with 4 digit zipcodes to append missing 0'
   task :run => :environment do
     School.all.each do |school|
-      if school.zipcode&.length === 4
+      if school.zipcode&.length == 4
         school.zipcode = "0#{school.zipcode}"
         school.save!
       end

--- a/services/QuillLMS/lib/tasks/update_schools_with_4_digit_zipcodes.rake
+++ b/services/QuillLMS/lib/tasks/update_schools_with_4_digit_zipcodes.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :update_schools_with_4_digit_zipcodes do
+  desc 'update schools with 4 digit zipcodes to append missing 0'
+  task :run => :environment do
+    School.all.each do |school|
+      if school.zipcode&.length === 4
+        school.zipcode = "0#{school.zipcode}"
+        school.save!
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -112,13 +112,13 @@ describe Cms::SchoolsController do
           name: "test",
           city: "test city",
           state: "test state",
-          zipcode: "1100",
+          zipcode: "11000",
           free_lunches: 2
       } }
       expect(School.last.name).to eq "test"
       expect(School.last.city).to eq "test city"
       expect(School.last.state).to eq "test state"
-      expect(School.last.zipcode).to eq "1100"
+      expect(School.last.zipcode).to eq "11000"
       expect(School.last.free_lunches).to eq 2
       expect(response).to redirect_to cms_school_path(School.last.id)
     end

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -151,7 +151,7 @@ describe School, type: :model do
     it 'zipcode is present and is not 5 digits' do
       school.zipcode = "123"
       expect(school).not_to be_valid
-      expect(school.errors[:zipcode]).to eq(['must be 5 digits'])
+      expect(school.errors.messages).to eq(zipcode: ["is too short (minimum is 5 characters)"])
     end
 
     it 'zipcode is present and is 5 digits' do

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -148,6 +148,17 @@ describe School, type: :model do
       expect(school.errors[:lower_grade]).to eq(['must be less than or equal to upper grade'])
     end
 
+    it 'zipcode is present and is not 5 digits' do
+      school.zipcode = "123"
+      expect(school).not_to be_valid
+      expect(school.errors[:zipcode]).to eq(['must be 5 digits'])
+    end
+
+    it 'zipcode is present and is 5 digits' do
+      school.zipcode = "12345"
+
+      expect(school).to be_valid
+    end
   end
 
   describe 'school_year_start method' do


### PR DESCRIPTION
## WHAT
add a check for 5 digit zipcode length for new schools and rake task to append missing lead 0 for School's with 4 digit zipcodes in our database

## WHY
it was causing these schools to be unsearchable in the school search on teacher accounts

## HOW
add rake task to append 0 for these Schools and add a validation that checks for a zipcode of length 5 when zipcode is present

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Zip-codes-on-School-Selection-screen-for-teachers-are-missing-initial-0-when-applicable-31c6bf39e73746498d747ea2a2b05bf8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
