### PR TITLE
LMS/ trim trailing whitespace for co-teacher email invitation

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
@@ -5,6 +5,11 @@ import InviteCoteacherModal from '../invite_coteachers_modal'
 import { Input, DataTable, } from '../../../../Shared/index'
 
 import { classroomWithStudents, classroomProps } from './test_data/test_data'
+import { requestPost } from '../../../../../modules/request';
+
+jest.mock('../../../../../modules/request/index.js', () => ({
+  requestPost: jest.fn()
+}))
 
 describe('InviteCoteacherModal component', () => {
 
@@ -30,7 +35,6 @@ describe('InviteCoteacherModal component', () => {
     it('should render a datatable', () => {
       expect(wrapper.find(DataTable).exists()).toBe(true)
     })
-
   })
 
   describe('if a coteacher does not get passed', () => {
@@ -53,6 +57,12 @@ describe('InviteCoteacherModal component', () => {
 
     it('should render a datatable', () => {
       expect(wrapper.find(DataTable).exists()).toBe(true)
+    })
+
+    it('should trim trailing whitespace for coteacher email after submission', () => {
+      wrapper.setState({ email: "test-user@gmail.com "})
+      wrapper.instance().inviteCoteachers()
+      expect(requestPost).toHaveBeenCalledWith("/invitations/create_coteacher_invitation", {classroom_ids: [285383], invitee_email: "test-user@gmail.com"}, expect.any(Function))
     })
   })
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -84,7 +84,7 @@ export default class InviteCoteachersModal extends React.Component<InviteCoteach
   inviteCoteachers() {
     const { onSuccess, close, } = this.props
     const { email, selectedClassroomIds } = this.state
-    const dataForInvite = { classroom_ids: selectedClassroomIds, invitee_email: email }
+    const dataForInvite = { classroom_ids: selectedClassroomIds, invitee_email: email.trim() }
     requestPost('/invitations/create_coteacher_invitation', dataForInvite, (body) => {
       onSuccess('Co-teacher invited')
       close()


### PR DESCRIPTION
## WHAT
trim trailing whitespace for coteacher email invitation

## WHY
it was causing invitations to now show in the invited teacher's dashboard

## HOW
just add a `.trim()` call on the email value before submission

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Co-Teacher-Invitations-Not-Added-to-Classes-Page-2-Teachers-4d8a22fa634b4f6faec29f05b601c68c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
