### PR TITLE
Add skipToPrompts=true to redirect URL for viewing Evidence Activities

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -320,6 +320,7 @@ class Activity < ApplicationRecord
     # Rename "student" to "session" because it's called "student" in all tools other than Evidence
     initial_params[:session] = initial_params.delete :student if initial_params[:student]
     initial_params[:uid] = Evidence::Activity.find_by(parent_activity_id: id).id
+    initial_params[:skipToPrompts] = true
     construct_redirect_url(base_url, initial_params)
   end
 

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -230,7 +230,7 @@ describe Activity, type: :model, redis: true do
         notes: 'Test Evidence Activity')
       expect(classified_activity).to receive(:evidence_url_helper).with({student: activity_session.uid}).and_call_original
       result = classified_activity.module_url(activity_session)
-      expect(result.to_s).to eq("#{classification.module_url}?session=#{activity_session.uid}&uid=#{comp_activity.id}")
+      expect(result.to_s).to eq("#{classification.module_url}?session=#{activity_session.uid}&skipToPrompts=true&uid=#{comp_activity.id}")
     end
 
   end
@@ -265,7 +265,7 @@ describe Activity, type: :model, redis: true do
         notes: 'Test Evidence Activity')
       expect(classified_activity).to receive(:evidence_url_helper).with({anonymous: true}).and_call_original
       result = classified_activity.anonymous_module_url
-      expect(result.to_s).to eq("#{classification.module_url}?anonymous=true&uid=#{comp_activity.id}")
+      expect(result.to_s).to eq("#{classification.module_url}?anonymous=true&skipToPrompts=true&uid=#{comp_activity.id}")
     end
   end
 


### PR DESCRIPTION
## WHAT
Add skipToPrompts=true to the redirect URL for Evidence Activities.

## WHY
We want to redirect teachers to the step right before the Activity begins to minimize the amount of clicks they have to perform to see the activity.

## HOW
Add skipToPrompts=true to the URL we generate when previewing Evidence Activities.

### Screenshots
<img width="999" alt="Screen Shot 2022-09-20 at 4 56 52 PM" src="https://user-images.githubusercontent.com/57366100/191214820-4fe86f62-495f-4d7e-a577-addc355b54e9.png">

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=0168d4b4988644debeb6f9a967e35ea9&pm=c)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
