### PR TITLE
Ortto webhook

### DIFF
--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -3,16 +3,11 @@
 module OrttoIntegration
   class WebhooksController < ApplicationController
     protect_from_forgery except: :create
-    http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
+    #http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
 
     before_action :valid_params?, only: [:create]
 
     class OrttoWebhookBadRequestException < StandardError; end
-
-    VALID_ACTIONS = [
-      SUBSCRIBE   = 'subscribe',
-      UNSUBSCRIBE = 'unsubscribe'
-    ]
 
     def create
       unless valid_params?
@@ -22,23 +17,19 @@ module OrttoIntegration
         return head(:bad_request)
       end
 
-      # user = User.find_by_email(params[:email])
-      # return unless user
+      email = params.dig(:activity, :contact, :email)
+      user = User.find_by_email(email)
+      return unless user
 
-      # user.update!(send_newsletter: params[:action_name] == SUBSCRIBE)
+      user.update!(send_newsletter: false)
       head :ok
     end
 
     private def valid_params?
       puts "\n\n --- PARAMS: #{params.inspect}"
+      return false unless params.dig(:activity, :contact, :email)
+
       true
-      # return false unless params[:activity]
-      # activity_param = params[:activity]
-      # return false unless
-
-      # return false unless params[:action_name] && VALID_ACTIONS.include?(params[:action_name])
-
-      # true
     end
 
   end

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -3,17 +3,12 @@
 module OrttoIntegration
   class WebhooksController < ApplicationController
     protect_from_forgery except: :create
-    before_action :create, :authenticate
-    #http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
+    before_action :authenticate
 
     class OrttoWebhookBadRequestException < StandardError; end
 
     def create
-      puts "\n\n --- PARAMS: #{params.inspect}"
-      puts "\nactivity: #{params.dig(:activity).class} #{params.dig(:activity)}"
-      puts "\ncontact: #{params.dig(:activity, :contact).class} #{params.dig(:activity, :contact)}"
-
-      email = params.dig(:activity, :contact, :email)
+      email = params[:email]
       user = User.find_by_email(email)
 
       if email.nil? || user.nil?
@@ -27,15 +22,9 @@ module OrttoIntegration
       head :ok
     end
 
-    # private def valid_params?
-    #   return false unless params.dig(:activity, :contact, :email)
-    #   true
-    # end
+    def authenticate
+      return head :forbidden unless params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']
+    end
 
-  end
-
-  def authenticate
-    puts "authenticate value: {params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']}"
-    params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']
   end
 end

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -3,6 +3,8 @@
 module OrttoIntegration
   class WebhooksController < ApplicationController
     protect_from_forgery except: :create
+    http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
+
     before_action :valid_params?, only: [:create]
 
     class OrttoWebhookBadRequestException < StandardError; end
@@ -28,6 +30,7 @@ module OrttoIntegration
     end
 
     private def valid_params?
+      puts "\n\n --- PARAMS: #{params.inspect}"
       return false unless params[:email]
       return false unless params[:action_name] && VALID_ACTIONS.include?(params[:action_name])
 

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -3,7 +3,8 @@
 module OrttoIntegration
   class WebhooksController < ApplicationController
     protect_from_forgery except: :create
-    http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
+    before_action :create, :authenticate
+    #http_basic_authenticate_with name: 'ortto_webhook_user', password: ENV['ORTTO_WEBHOOK_PASSWORD']
 
     class OrttoWebhookBadRequestException < StandardError; end
 
@@ -31,5 +32,10 @@ module OrttoIntegration
     #   true
     # end
 
+  end
+
+  def authenticate
+    puts "authenticate value: {params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']}"
+    params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']
   end
 end

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -26,7 +26,7 @@ module OrttoIntegration
       # return unless user
 
       # user.update!(send_newsletter: params[:action_name] == SUBSCRIBE)
-      head :no_content
+      head :ok
     end
 
     private def valid_params?

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -22,19 +22,23 @@ module OrttoIntegration
         return head(:bad_request)
       end
 
-      user = User.find_by_email(params[:email])
-      return unless user
+      # user = User.find_by_email(params[:email])
+      # return unless user
 
-      user.update!(send_newsletter: params[:action_name] == SUBSCRIBE)
+      # user.update!(send_newsletter: params[:action_name] == SUBSCRIBE)
       head :no_content
     end
 
     private def valid_params?
       puts "\n\n --- PARAMS: #{params.inspect}"
-      return false unless params[:email]
-      return false unless params[:action_name] && VALID_ACTIONS.include?(params[:action_name])
-
       true
+      # return false unless params[:activity]
+      # activity_param = params[:activity]
+      # return false unless
+
+      # return false unless params[:action_name] && VALID_ACTIONS.include?(params[:action_name])
+
+      # true
     end
 
   end

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -9,13 +9,21 @@ module OrttoIntegration
 
     def create
       email = params[:email]
-      user = User.find_by_email(email)
 
-      if email.nil? || user.nil?
+      if email.nil?
         ErrorNotifier.report(
           OrttoWebhookBadRequestException.new("Bad request with params: #{params}")
         )
-        return head :accepted
+        return head 202
+      end
+
+      user = User.find_by_email(email)
+
+      if user.nil?
+        ErrorNotifier.report(
+          OrttoWebhookBadRequestException.new("Bad request with params: #{params}")
+        )
+        return head 202
       end
 
       user.update!(send_newsletter: false)
@@ -23,7 +31,7 @@ module OrttoIntegration
     end
 
     def authenticate
-      return head :forbidden unless params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']
+      return head 403 unless params['secret'] == ENV['ORTTO_WEBHOOK_PASSWORD']
     end
 
   end

--- a/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe OrttoIntegration::WebhooksController, type: :controller do
 
   describe '#create' do
     let(:ortto_secret) { 'xyz' }
+
     context 'valid event payload' do
       let!(:subscribed_user) { create(:user, email: 'a@b.com', send_newsletter: true) }
 
@@ -21,7 +22,7 @@ RSpec.describe OrttoIntegration::WebhooksController, type: :controller do
     context 'invalid payload' do
       context 'bad authentication' do
         it 'should return 401' do
-          post :create, params: { email: 'an email' }
+          post :create, params: { email: 'an email', secret: 'incorrect secret' }
           expect(response.status).to eq 403
         end
       end

--- a/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
@@ -9,15 +9,8 @@ RSpec.describe OrttoIntegration::WebhooksController, type: :controller do
       let!(:unsubscribed_user) {create(:user, email: 'a@b.com', send_newsletter: false)}
       let!(:subscribed_user) {create(:user, email: 'b@c.com', send_newsletter: true)}
 
-      it 'should update the user\'s send_newsletter property to true' do
-        post :create, params: {action_name: 'subscribe', email: unsubscribed_user.email }
-
-        expect(User.find(unsubscribed_user.id).send_newsletter).to eq true
-        expect(response.status).to eq 204
-      end
-
       it 'should update the user\'s send_newsletter property to false' do
-        post :create, params: {action_name: 'unsubscribe', email: subscribed_user }
+        post :create, params: {activity: {contact: {email: subscribed_user}}}
 
         expect(User.find(subscribed_user.id).send_newsletter).to eq true
         expect(response.status).to eq 204

--- a/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OrttoIntegration::WebhooksController, type: :controller do
 
     context 'invalid payload' do
       context 'bad authentication' do
-        it 'should return 401' do
+        it 'should return 403' do
           post :create, params: { email: 'an email', secret: 'incorrect secret' }
           expect(response.status).to eq 403
         end

--- a/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/ortto_integration/webhooks_controller_spec.rb
@@ -5,23 +5,35 @@ require 'rails_helper'
 RSpec.describe OrttoIntegration::WebhooksController, type: :controller do
 
   describe '#create' do
+    let(:ortto_secret) { 'xyz' }
     context 'valid event payload' do
-      let!(:unsubscribed_user) {create(:user, email: 'a@b.com', send_newsletter: false)}
-      let!(:subscribed_user) {create(:user, email: 'b@c.com', send_newsletter: true)}
+      let!(:subscribed_user) { create(:user, email: 'a@b.com', send_newsletter: true) }
 
       it 'should update the user\'s send_newsletter property to false' do
-        post :create, params: {activity: {contact: {email: subscribed_user}}}
+        stub_const('ENV', { 'ORTTO_WEBHOOK_PASSWORD' => ortto_secret } )
 
-        expect(User.find(subscribed_user.id).send_newsletter).to eq true
-        expect(response.status).to eq 204
+        post :create, params: { email: subscribed_user.email, secret: ortto_secret }
+        expect(User.find(subscribed_user.id).send_newsletter).to eq false
+        expect(response.status).to eq 200
       end
     end
 
     context 'invalid payload' do
-      it "handles the JSON format error and reports to new relic" do
-        post :create, params: {invalid_param: 'xyz' }
+      context 'bad authentication' do
+        it 'should return 401' do
+          post :create, params: { email: 'an email' }
+          expect(response.status).to eq 403
+        end
+      end
 
-        expect(response.status).to eq 400
+      context 'user not found' do
+        it 'should return 202 and trigger an error report' do
+          stub_const('ENV', { 'ORTTO_WEBHOOK_PASSWORD' => ortto_secret } )
+          expect(ErrorNotifier).to receive(:report)
+          post :create, params: { email: 'an email', secret: ortto_secret }
+
+          expect(response.status).to eq 202
+        end
       end
     end
 


### PR DESCRIPTION
## WHAT
Addresses integrations issues with the Ortto webhook. 
- sending basic auth via an HTTP header was causing Heroku to 401 at the router level, for unknown reasons. Ortto support suggested passing the basic other in the query string, which worked. 
- we don't need 'subscribe' functionality, only 'unsubscribe', so I removed logic pertaining to that
- relaxed param checking, since Ortto issues a 'test connection' request, whose payload is different than the standard webhook request.

## WHY
So Peter Sharkey can use this webhook for Ortto funnel sequences. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=0d07dee76d7842a695882af4e719bddc&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A)
