### PR TITLE
LMS/ add sort by order for Activity Summary classroom dropdown

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -363,6 +363,7 @@ class Teachers::ClassroomManagerController < ApplicationController
           ON ct.classroom_id = classrooms.id
           AND classrooms.visible = true
         WHERE ct.user_id = #{current_user.id}
+        ORDER BY ct.order ASC
       SQL
     ).to_a
   end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -341,19 +341,23 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
   describe '#scorebook' do
     let(:teacher) { create(:teacher) }
-    let(:classroom) { create(:classroom) }
     let(:classroom1) { create(:classroom) }
+    let(:classroom2) { create(:classroom) }
+    let(:classroom3) { create(:classroom) }
+    let(:classrooms_teacher1) {create(:classrooms_teacher, user_id: teacher.id, classroom_id: classroom1.id, order: 1)}
+    let(:classrooms_teacher2) {create(:classrooms_teacher, user_id: teacher.id, classroom_id: classroom2.id, order: 0)}
+    let(:classrooms_teacher3) {create(:classrooms_teacher, user_id: teacher.id, classroom_id: classroom3.id, order: 2)}
 
     before do
       allow(controller).to receive(:current_user) { teacher }
-      allow(RawSqlRunner).to receive(:execute).and_return([classroom, classroom1])
+      allow(RawSqlRunner).to receive(:execute).and_return([classroom2, classroom1, classroom3])
       allow(controller).to receive(:classroom_teacher!) { true }
     end
 
     context 'when classroom id is passed' do
-      it 'should assign the classrooms and classroom' do
+      it 'should assign the classrooms (sorted by order) and classroom' do
         get :scorebook, params: { classroom_id: classroom1.id }
-        expect(assigns(:classrooms)).to eq ([classroom, classroom1].as_json)
+        expect(assigns(:classrooms)).to eq ([classroom2, classroom1, classroom3].as_json)
         expect(assigns(:classroom)).to eq (classroom1.as_json)
       end
     end


### PR DESCRIPTION
## WHAT
add sort by order for classroom selection in the Activity Summary

## WHY
some teachers were confused by the order being applied in the Classroom tab, but not in this section of the dashboard

## HOW
just add an `ORDER BY` on `order` for `classrooms_teacher` in the manager controller

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Reordered-classes-are-not-updating-on-reports-76f655c85bf446238a5f9776071f7b83

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | yes
