### PR TITLE
Fix bug involving admins impersonating teachers

### DIFF
--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -48,7 +48,7 @@ class AdminsController < ApplicationController
   end
 
   private def admin_of_this_teacher!
-    return if SchoolsAdmins.where(user_id: current_user.id, school_id: @teacher.school.id).limit(1).exists?
+    return if SchoolsAdmins.exists?(school: @teacher.school, user: current_user)
 
     auth_failed
   end

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -146,7 +146,7 @@ class ApplicationController < ActionController::Base
   end
 
   protected def confirm_valid_session
-    return if current_user.nil? || session.nil? || session[:staff_id]
+    return if current_user.nil? || session.nil? || session[:staff_id] || admin_impersonating_user?(current_user)
     return unless reset_session? || current_user.google_access_expired?
 
     reset_session_and_redirect_to_sign_in

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -173,4 +173,8 @@ module QuillAuthentication
   private def staff_impersonating_user?(user)
     session[:staff_id].present? && session[:staff_id] != user.id
   end
+
+  private def admin_impersonating_user?(user)
+    session[:admin_id].present? && session[:admin_id] != user.id
+  end
 end

--- a/services/QuillLMS/spec/controllers/admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admins_controller_spec.rb
@@ -3,16 +3,16 @@
 require 'rails_helper'
 
 describe AdminsController  do
-  before { allow(controller).to receive(:current_user) { user } }
+  before { allow(controller).to receive(:current_user) { admin } }
 
   it { should use_before_action :admin! }
   it { should use_before_action :set_teacher }
   it { should use_before_action :admin_of_this_teacher! }
   it { should use_before_action :sign_in }
 
-  let(:user) { create(:admin) }
+  let(:admin) { create(:teacher) }
   let!(:teacher) { create(:teacher_with_school) }
-  let!(:schools_admins) { create(:schools_admins, school: teacher.reload.school, user: user) }
+  let!(:schools_admins) { create(:schools_admins, school: teacher.reload.school, user: admin) }
 
 
   describe '#show' do
@@ -20,7 +20,7 @@ describe AdminsController  do
 
     it 'should render the correct json' do
       get :show, params: { id: teacher.id }
-      expect(response.body).to eq(({id: user.id}).to_json)
+      expect(response.body).to eq(({id: admin.id}).to_json)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
   let(:unaffiliated_teacher) { create(:teacher) }
   let(:student) { classroom.students.first }
   let(:unaffiliated_student) { create(:student) }
-  let(:admin) { create(:admin) }
+  let(:admin) { create(:teacher) }
 
   context '#activities_scores_by_classroom_data' do
     it 'should return ProgressReports::ActivitiesScoresByClassroom for my classes' do

--- a/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
@@ -56,15 +56,6 @@ describe Api::V1::UsersController do
       end
     end
 
-    context 'admins' do
-      let(:user) { create(:admin) }
-
-      it 'should return admin for admin users' do
-        get :current_user_role, as: :json
-        expect(response.body).to eq({ role: "admin" }.to_json)
-      end
-    end
-
     context 'students' do
       let(:user)  { create(:student) }
 

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -101,6 +101,17 @@ describe ApplicationController, type: :controller do
           expect(controller).to receive(:reset_session_and_redirect_to_sign_in)
           subject
         end
+
+        context 'when admin is impersonating current user' do
+          let(:admin) { create(:user) }
+
+          before { session[:admin_id] = admin.id }
+
+          it do
+            expect(controller).not_to receive(:reset_session_and_redirect_to_sign_in)
+            subject
+          end
+        end
       end
     end
 

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -166,7 +166,7 @@ describe SessionsController, type: :controller do
     before { allow(controller).to receive(:current_user) { user } }
 
     context 'when session admin id present' do
-      let!(:admin) { create(:admin) }
+      let!(:admin) { create(:teacher) }
 
       before { session[:admin_id] = admin.id }
 

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -36,6 +36,8 @@ FactoryBot.define do
       provider AuthCredential::GOOGLE_PROVIDER
       expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.from_now
       association :user, factory: [:teacher, :signed_up_with_google]
+
+      trait(:expired) { expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.ago }
     end
 
     factory :clever_district_auth_credential do

--- a/services/QuillLMS/spec/factories/schools_admins.rb
+++ b/services/QuillLMS/spec/factories/schools_admins.rb
@@ -19,6 +19,6 @@
 FactoryBot.define do
   factory :schools_admins do
     school { create(:school) }
-    user { create(:user) }
+    user { create(:teacher) }
   end
 end

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -74,10 +74,6 @@ FactoryBot.define do
       role 'staff'
     end
 
-    factory :admin do
-      role 'admin'
-    end
-
     factory :teacher do
       role 'teacher'
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -6,7 +6,7 @@ describe ProgressReports::DistrictConceptReports do
   describe '#results' do
     let!(:school) { create(:school) }
     let!(:teacher) { create(:teacher) }
-    let!(:admin) { create(:admin) }
+    let!(:admin) { create(:teacher) }
     let!(:classroom) { create(:classroom) }
     let!(:student) { create(:student) }
     let!(:schools_admins) { create(:schools_admins, school: school, user: admin) }

--- a/services/QuillLMS/spec/support/helpers/authentication_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/authentication_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module AuthenticationHelper
+  def login_user(email_or_username, password)
+    visit root_path
+    click_link 'Log In'
+    fill_in 'email-or-username', with: email_or_username
+    fill_in 'password', with: password
+    click_on 'Log in'
+  end
+
+  def logout_user(user)
+    find('span', text: user.name).click
+    click_on 'Logout'
+  end
+end

--- a/services/QuillLMS/spec/support/shared/teacher.rb
+++ b/services/QuillLMS/spec/support/shared/teacher.rb
@@ -48,11 +48,11 @@ shared_examples_for "teacher" do
   end
 
   describe "default scope" do
-    let(:teacher){create(:teacher)}
-    let(:user){create(:user)}
-    let(:student){create(:student)}
-    let(:admin){create(:admin)}
-    let(:staff){create(:staff)}
+    let(:teacher) { create(:teacher) }
+    let(:user) { create(:user) }
+    let(:student) { create(:student) }
+    let(:admin) { create(:teacher) }
+    let(:staff) { create(:staff) }
 
     it "must list only teacher users" do
       Teacher.all.each do |teacher|

--- a/services/QuillLMS/spec/support/system.rb
+++ b/services/QuillLMS/spec/support/system.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   Capybara.register_driver :local_selenium_chrome_headless do |app|
     options = Selenium::WebDriver::Chrome::Options.new(
       args: [
-        'headless',
+        # 'headless',
         'window-size=1920x1280'
       ]
     )

--- a/services/QuillLMS/spec/support/system.rb
+++ b/services/QuillLMS/spec/support/system.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   Capybara.register_driver :local_selenium_chrome_headless do |app|
     options = Selenium::WebDriver::Chrome::Options.new(
       args: [
-        # 'headless',
+        'headless',
         'window-size=1920x1280'
       ]
     )

--- a/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
+++ b/services/QuillLMS/spec/system/activity_pack_assignment_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Activity Pack Assignment' do
+  include AuthenticationHelper
+
   let!(:teacher) { create(:teacher_with_a_couple_classrooms_with_one_student_each) }
   let!(:student) { teacher.students.first }
   let!(:classroom) { student.classrooms.first }
@@ -78,18 +80,5 @@ RSpec.describe 'Activity Pack Assignment' do
     click_on 'Begin'
     expect(page).to have_content question_instructions
     click_on 'Save and exit'
-  end
-
-  def login_user(email_or_username, password)
-    visit root_path
-    click_link 'Log In'
-    fill_in 'email-or-username', with: email_or_username
-    fill_in 'password', with: password
-    click_on 'Log in'
-  end
-
-  def logout_user(user)
-    find('span', text: user.name).click
-    click_on 'Logout'
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug where admins attempting to sign in as a teacher are redirected to sessions/new

## WHY
This happens when the teacher being impersonated is a google user that has expired credentials.  When the admin attempts to sign_in as the teacher, the session is labeled invalid which calls `reset_session_and_redirect_to_sign_in`.

While investigating this bug, I noticed the nested factory `:admin` under the `:user` factory which assigns a role: 'admin'.
I believe this is a vestigial factory (there are no users on production with role 'admin') since the admin relationship is currently modeled via `SchoolsAdmins` and `DistrictsAdmins` tables.  As a result, uses of `{ create(:admin) }` were replaced with `{ create(:teacher) }` since that more accurately represents how our system currently operates.

## HOW
Add a clause to the `confirm_valid_session` that checks to see if an admin is attempting to impersonate a teacher.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Google-loop-on-admin-dashboard-8f1034020df44942ac0a379a4007a879

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
Back-to-school 2022: Have you checked the [webinar schedule](https://www.notion.so/quill/Back-to-school-webinar-banners-2022-a75a89cfad9f434899ef6be3eb184733) to avoid for downtime/risky deploys? | N/A
