### PR TITLE
Remove unused code coverage libraries from test suite.

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -198,16 +198,12 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'codeclimate-test-reporter', require: nil
-  gem 'codecov'
   gem 'mini_racer', '= 0.4.0'
   gem 'fakeredis', '~> 0.7.0'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver', '~> 3'
   gem 'shoulda-matchers', '~> 4'
   gem 'shoulda-callback-matchers', '~> 1.1.1'
-  gem 'simplecov'
-  gem 'simplecov-json', require: false
   gem 'super_diff', require: false
   gem 'vcr'
   gem 'webmock'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -171,14 +171,7 @@ GEM
       json (>= 1.8, < 3)
       typhoeus (~> 1.0, >= 1.0.1)
     climate_control (0.2.0)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
-    codecov (0.2.6)
-      colorize
-      json
-      simplecov
     coderay (1.1.3)
-    colorize (0.8.1)
     concurrent-ruby (1.1.10)
     configs (1.4.0)
       activesupport (> 3.0)
@@ -194,7 +187,6 @@ GEM
       rack
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
-    docile (1.4.0)
     doorkeeper (5.0.3)
       railties (>= 4.2)
     dotenv (2.7.6)
@@ -706,15 +698,6 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov-json (0.2)
-      json
-      simplecov
-    simplecov_json_formatter (0.1.4)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -815,8 +798,6 @@ DEPENDENCIES
   capybara-screenshot
   carrierwave (~> 1.3.2)
   clever-ruby (~> 2.0.1)
-  codeclimate-test-reporter
-  codecov
   configs
   cypress-on-rails (~> 1.0)
   doorkeeper (= 5.0.3)
@@ -909,8 +890,6 @@ DEPENDENCIES
   sidekiq (~> 5.2.10)
   sidekiq-pro!
   sidekiq-retries
-  simplecov
-  simplecov-json
   slim-rails
   spring
   spring-commands-rspec

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 ENV["RAILS_ENV"] = 'test'
-require 'simplecov'
-SimpleCov.start "rails"
 
 require File.expand_path("../../config/environment", __FILE__)
 
@@ -99,10 +97,6 @@ RSpec.configure do |config|
       allow($stdout).to receive(:write)
     end
   end
-end
-
-if defined?(Coveralls)
-  Coveralls.wear!('rails')
 end
 
 def vcr_ignores_localhost

--- a/services/QuillLMS/spec/spec_helper.rb
+++ b/services/QuillLMS/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-require 'simplecov-json'
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!
@@ -14,17 +12,5 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
-  end
-end
-
-if ENV['CONTINUOUS_INTEGRATION'] == true
-  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::JSONFormatter,
-  ])
-
-  SimpleCov.start do
-    track_files '{app,lib}/**/*.rb'
-    add_filter '/spec/'
   end
 end


### PR DESCRIPTION
## WHAT
We have a few code coverage libraries that make running tests slow, I'm proposing we remove them since I don't think anyone is looking at these reports (we can always add them back). **You will definitely notice the speed difference.**

To be specific, this is when the tests finish and rspec is still running for some reason, then you hit `Ctrl + c` and it says `RSpec is shutting down and will print the summary report... Interrupt again to force quit.`, then you hit `Ctrl + c` again and it finally finishes . . . all of that is the Code Coverage gems trying to generate/update reports. Without it, rspec ends almost instantly. 

Note, the reports gets slower the more tests you run, since some of these update previous reports, so the reports grow and grow, and eventually writing to them is very slow.
## WHY
Fast tests are very nice and I don't think anyone is using these reports.

Note, we could fix the setup to prevent large files (the slow part) or only run them on full suite runs, but it's easier to just remove if they aren't actively used.
## HOW
Removing gems.
### Screenshots
<img width="1118" alt="Screen Shot 2022-09-21 at 6 13 19 PM" src="https://user-images.githubusercontent.com/1304933/191619831-dade4cca-a6e5-4014-9ed5-0c6fa366bf60.png">


### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
