### PR TITLE
Lms/fix concept result instructions

### DIFF
--- a/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
+++ b/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
@@ -5,8 +5,6 @@ class CleanConceptResultInstructionsWorker
   sidekiq_options queue: SidekiqQueue::MIGRATION
 
   def perform(start, stop)
-    stop ||= ConceptResult.maximum(:id)
-
     ConceptResult.includes(:concept_result_instructions).where(id: start..stop).find_each do |concept_result|
       next unless concept_result.concept_result_instructions&.text
       next unless concept_result.concept_result_instructions.text == concept_result.extra_metadata['instructions']

--- a/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
+++ b/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
@@ -5,11 +5,11 @@ class CleanConceptResultInstructionsWorker
   sidekiq_options queue: SidekiqQueue::MIGRATION
 
   def perform(start, stop)
-    stop = ConceptResult.maximum(:id) unless stop
+    stop ||= ConceptResult.maximum(:id)
 
     ConceptResult.includes(:concept_result_instructions).where(id: start..stop).find_each do |concept_result|
-      return unless concept_result.concept_result_instructions&.text
-      return unless concept_result.concept_result_instructions.text == concept_result.extra_metadata['instructions']
+      next unless concept_result.concept_result_instructions&.text
+      next unless concept_result.concept_result_instructions.text == concept_result.extra_metadata['instructions']
 
       concept_result.update(extra_metadata: concept_result.extra_metadata.except('instructions'))
     end

--- a/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
+++ b/services/QuillLMS/app/workers/clean_concept_result_instructions_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CleanConceptResultInstructionsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::MIGRATION
+
+  def perform(start, stop)
+    stop = ConceptResult.maximum(:id) unless stop
+
+    ConceptResult.includes(:concept_result_instructions).where(id: start..stop).find_each do |concept_result|
+      return unless concept_result.concept_result_instructions&.text
+      return unless concept_result.concept_result_instructions.text == concept_result.extra_metadata['instructions']
+
+      concept_result.update(extra_metadata: concept_result.extra_metadata.except('instructions'))
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/concept_results_migration.rake
+++ b/services/QuillLMS/lib/tasks/concept_results_migration.rake
@@ -19,4 +19,18 @@ namespace :concept_results_migration do
       puts "Failed to enqueue worker for range (#{row['start_id']}..#{row['max_id']})"
     end
   end
+
+  desc 'Enqueue all ConceptResult records for clean-up of their possibly duplicated "instructions" values'
+  task clean_up_instructions: :environment do
+    BATCH_SIZE=1_000_000
+
+    start = 1
+    finish = ConceptResult.maximum(:id)
+
+    while start < finish
+      end_of_batch = [start + BATCH_SIZE - 1, finish].min
+      CleanConceptResultInstructionsWorker.perform_async(start, end_of_batch)
+      start += BATCH_SIZE
+    end
+  end
 end

--- a/services/QuillLMS/spec/factories/concept_result_instructions.rb
+++ b/services/QuillLMS/spec/factories/concept_result_instructions.rb
@@ -14,6 +14,6 @@
 #
 FactoryBot.define do
   factory :concept_result_instructions do
-    sequence(:text) { |n| "This a student response directions #{n}." }
+    sequence(:text) { |n| "These are student response instructions #{n}." }
   end
 end

--- a/services/QuillLMS/spec/workers/clean_concept_result_instructions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/clean_concept_result_instructions_worker_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CleanConceptResultInstructionsWorker, type: :worker do
+
+  context '#perform' do
+    let(:concept_result_instructions) { create(:concept_result_instructions) }
+    let!(:concept_result) { create(:concept_result, concept_result_instructions: concept_result_instructions, extra_metadata: {'instructions': concept_result_instructions.text}) }
+
+    it 'should delete the instructions value in extra_metadata if it is just a copy of the normalized value' do
+      expect_any_instance_of(ConceptResult).to receive(:update).with(extra_metadata: {}).and_call_original
+
+      subject.perform(concept_result.id, concept_result.id)
+
+      expect(concept_result.reload.extra_metadata['instructions']).to be(nil)
+    end
+
+    it 'should return early if the ConceptResult has no normalized instructions' do
+      concept_result.update(concept_result_instructions: nil)
+
+      expect_any_instance_of(ConceptResult).not_to receive(:save!)
+
+      subject.perform(concept_result.id, concept_result.id)
+    end
+
+    it 'should return early if normalized instructions are different from the value in extra_metadata' do
+      concept_result_instructions.update(text: 'This is new text that definitely was not there before.')
+
+      expect_any_instance_of(ConceptResult).not_to receive(:save!)
+
+      subject.perform(concept_result.id, concept_result.id)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a Worker to process `ConceptResult` records and remove the `instructions` key from their `extra_metadata` if the value in that key is already stored in the related `concept_result_instructions` record.
## WHY
A bug that we fixed a while ago (#9593) was causing this data to be written to `extra_metadata` even though we were normalizing it.  While we no longer produce records with this duplication, we should clean up the places where we did it to reduce redunancy.
## HOW
Just cycle across `ConceptResult` records, confirm that the value in `extra_metadata['instructions']` matches the value in `concept_result_instructions.text`, and if so, remove the value in `extra_metadata`.

### Notion Card Links
https://www.notion.so/quill/Write-a-script-to-strip-instructions-from-ConceptResult-extra_metadata-if-a-related-instructions--2e23118c244e4bdcbebc93df54ae0ce0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A