### PR TITLE
lms/bugfix-activity-session-teacher-fix

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -68,7 +68,9 @@ class TeacherFixController < ApplicationController
       if unit
         ClassroomUnit.unscoped.where(unit_id: unit.id).each do |cu|
           activity_sessions = ActivitySession.unscoped.where(classroom_unit_id: cu.id)
-          cu.update(visible: true, assigned_student_ids: activity_sessions.map(&:user_id))
+          recovered_assigned_students = activity_sessions.map(&:user_id)
+          cu.update(visible: true, assigned_student_ids: cu.assigned_student_ids.union(recovered_assigned_students))
+          #cu.update(visible: true, assigned_student_ids: activity_sessions.map(&:user_id))
           activity_sessions.update_all(visible: true)
         end
         render json: {}, status: 200

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -70,7 +70,6 @@ class TeacherFixController < ApplicationController
           activity_sessions = ActivitySession.unscoped.where(classroom_unit_id: cu.id)
           recovered_assigned_students = activity_sessions.map(&:user_id)
           cu.update(visible: true, assigned_student_ids: cu.assigned_student_ids.union(recovered_assigned_students))
-          #cu.update(visible: true, assigned_student_ids: activity_sessions.map(&:user_id))
           activity_sessions.update_all(visible: true)
         end
         render json: {}, status: 200

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -153,6 +153,14 @@ describe TeacherFixController do
           expect(classroom_unit.reload.assigned_student_ids).to eq [another_user.id]
           expect(response.code).to eq "200"
         end
+
+        it 'should not un-assign students from the ClassroomUnit just because they are missing an ActivitySession' do
+          other_student = create(:user)
+          classroom_unit.update(assigned_student_ids: [other_student.id])
+
+          post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
+          expect(classroom_unit.reload.assigned_student_ids).to include(another_user.id, other_student.id)
+        end
       end
 
       context 'when unit does not exist' do


### PR DESCRIPTION
## WHAT
Update teacher fix so that it maintains assigned students on ClassroomUnits, even for students who haven't started the activity yet.
## WHY
The old logic replaced the assignment list with the users who has ActivitySessions.  But only users who have started the activity have ActivitySessions.  This meant that students who hadn't started the activity when the teacher fix was run were being unassigned, which is not the intended behavior.
## HOW
Just use a `union` of the existing list of assignments and the list of assignments recovered from ActivitySessions rather than stomping the former with the latter.

### Notion Card Links
https://www.notion.so/quill/Adding-students-to-an-activity-pack-unchecks-other-students-names-a5ee8958fde94619ac59e4ccc079bdd8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
