### PR TITLE
fix accessibility issue with diagnostic fill in blanks

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
@@ -198,20 +198,18 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     const width = longestCue ? (longestCue.length * 15) + 10 : 50
     const styling = { width: `${width}px`}
     return (
-      <span key={`span${i}`}>
-        <input
-          aria-label={fillInBlankInputLabel(cues, blankAllowed)}
-          autoComplete="off"
-          className={className}
-          disabled={maxAttemptsReached || responseOptimal}
-          id={`input${i}`}
-          key={i + 100}
-          onChange={this.getChangeHandler(i)}
-          style={styling}
-          type="text"
-          value={inputVals[i]}
-        />
-      </span>
+      <input
+        aria-label={fillInBlankInputLabel(cues, blankAllowed)}
+        autoComplete="off"
+        className={className}
+        disabled={maxAttemptsReached || responseOptimal}
+        id={`input${i}`}
+        key={i + 100}
+        onChange={this.getChangeHandler(i)}
+        style={styling}
+        type="text"
+        value={inputVals[i]}
+      />
     );
   }
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/turk/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/turk/fillInBlank.tsx
@@ -153,19 +153,17 @@ export class PlayFillInTheBlankQuestion extends React.Component<any, any> {
     const width = longestCue ? (longestCue.length * 15) + 10 : 50
     const styling = { width: `${width}px`}
     return (
-      <span key={`span${i}`}>
-        <input
-          aria-label={fillInBlankInputLabel(cues, blankAllowed)}
-          className={className}
-          id={`input${i}`}
-          key={i + 100}
-          onBlur={this.getBlurHandler(i)}
-          onChange={this.getChangeHandler(i)}
-          style={styling}
-          type="text"
-          value={inputVals[i]}
-        />
-      </span>
+      <input
+        aria-label={fillInBlankInputLabel(cues, blankAllowed)}
+        className={className}
+        id={`input${i}`}
+        key={i + 100}
+        onBlur={this.getBlurHandler(i)}
+        onChange={this.getChangeHandler(i)}
+        style={styling}
+        type="text"
+        value={inputVals[i]}
+      />
     );
   }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -41,272 +41,48 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
           }
         }
       >
-        <div>
-          <Prompt
-            elements={
-              Array [
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
+        <div
+          className="flex-column-reverse"
+        >
+          <Feedback
+            feedback={
+              <p
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "Rewrite the sentence. Fill in the blank with one of these articles: a, an, the. If no article is needed, remove the blank.
+<br/><br/>
+Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se necesita ninguna palabra, quite el espacio en blanco.",
                   }
-                >
-                  I
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  have
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  
-                </span>,
-                <span>
-                  <input
-                    aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
-                    autoComplete="off"
-                    className="fill-in-blank-input"
-                    disabled={false}
-                    id="input0"
-                    onChange={[Function]}
-                    style={
-                      Object {
-                        "width": "55px",
-                      }
-                    }
-                    type="text"
-                    value=""
-                  />
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  friend
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  named
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  Marco
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  who
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  loves
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  
-                </span>,
-                <span>
-                  <input
-                    aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
-                    autoComplete="off"
-                    className="fill-in-blank-input"
-                    disabled={false}
-                    id="input1"
-                    onChange={[Function]}
-                    style={
-                      Object {
-                        "width": "55px",
-                      }
-                    }
-                    type="text"
-                    value=""
-                  />
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  
-                </span>,
-                <span
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                >
-                  football.
-                </span>,
-              ]
+                }
+              />
             }
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flexWrap": "wrap",
-                "fontSize": 24,
-                "marginBottom": 18,
-                "marginTop": 35,
-              }
-            }
+            feedbackType="instructions"
           >
             <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flexWrap": "wrap",
-                  "fontSize": 24,
-                  "marginBottom": 18,
-                  "marginTop": 35,
-                }
-              }
+              aria-live="assertive"
+              className="student-feedback-container default"
+              role="status"
             >
-              <span
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "I have ",
-                  }
-                }
-                key="0"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
-              <span
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
-              <span
-                key="span0"
+              <div
+                className="feedback-row student-feedback-inner-container"
               >
-                <input
-                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
-                  autoComplete="off"
-                  className="fill-in-blank-input"
-                  disabled={false}
-                  id="input0"
-                  key="100"
-                  onChange={[Function]}
-                  style={
+                <img
+                  alt="Directions Icon"
+                  className="info"
+                  src="https://assets.quill.org/images/icons/direction.svg"
+                />
+                <p
+                  dangerouslySetInnerHTML={
                     Object {
-                      "width": "55px",
+                      "__html": "Rewrite the sentence. Fill in the blank with one of these articles: a, an, the. If no article is needed, remove the blank.
+<br/><br/>
+Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se necesita ninguna palabra, quite el espacio en blanco.",
                     }
                   }
-                  type="text"
-                  value=""
                 />
-              </span>
-              <span
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": " friend named Marco who loves ",
-                  }
-                }
-                key="3"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
-              <span
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
-              <span
-                key="span1"
-              >
-                <input
-                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
-                  autoComplete="off"
-                  className="fill-in-blank-input"
-                  disabled={false}
-                  id="input1"
-                  key="101"
-                  onChange={[Function]}
-                  style={
-                    Object {
-                      "width": "55px",
-                    }
-                  }
-                  type="text"
-                  value=""
-                />
-              </span>
-              <span
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": " football.",
-                  }
-                }
-                key="6"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
+              </div>
             </div>
-          </Prompt>
+          </Feedback>
           <Cues
             displayArrowAndText={true}
             question={
@@ -375,45 +151,259 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
               </CueExplanation>
             </div>
           </Cues>
-          <Feedback
-            feedback={
-              <p
+          <Prompt
+            elements={
+              Array [
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  I
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  have
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  
+                </span>,
+                <input
+                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                  autoComplete="off"
+                  className="fill-in-blank-input"
+                  disabled={false}
+                  id="input0"
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "width": "55px",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  friend
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  named
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  Marco
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  who
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  loves
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  
+                </span>,
+                <input
+                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                  autoComplete="off"
+                  className="fill-in-blank-input"
+                  disabled={false}
+                  id="input1"
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "width": "55px",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  
+                </span>,
+                <span
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
+                  }
+                >
+                  football.
+                </span>,
+              ]
+            }
+            style={
+              Object {
+                "alignItems": "center",
+                "display": "flex",
+                "flexWrap": "wrap",
+                "fontSize": 24,
+                "marginBottom": 18,
+                "marginTop": 35,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexWrap": "wrap",
+                  "fontSize": 24,
+                  "marginBottom": 18,
+                  "marginTop": 35,
+                }
+              }
+            >
+              <span
                 dangerouslySetInnerHTML={
                   Object {
-                    "__html": "Rewrite the sentence. Fill in the blank with one of these articles: a, an, the. If no article is needed, remove the blank.
-<br/><br/>
-Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se necesita ninguna palabra, quite el espacio en blanco.",
+                    "__html": "I have ",
+                  }
+                }
+                key="0"
+                style={
+                  Object {
+                    "marginRight": 5,
                   }
                 }
               />
-            }
-            feedbackType="instructions"
-          >
-            <div
-              aria-live="assertive"
-              className="student-feedback-container default"
-              role="status"
-            >
-              <div
-                className="feedback-row student-feedback-inner-container"
-              >
-                <img
-                  alt="Directions Icon"
-                  className="info"
-                  src="https://assets.quill.org/images/icons/direction.svg"
-                />
-                <p
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "Rewrite the sentence. Fill in the blank with one of these articles: a, an, the. If no article is needed, remove the blank.
-<br/><br/>
-Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se necesita ninguna palabra, quite el espacio en blanco.",
-                    }
+              <span
+                style={
+                  Object {
+                    "marginRight": 5,
                   }
-                />
-              </div>
+                }
+              />
+              <input
+                aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                autoComplete="off"
+                className="fill-in-blank-input"
+                disabled={false}
+                id="input0"
+                key="100"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "width": "55px",
+                  }
+                }
+                type="text"
+                value=""
+              />
+              <span
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": " friend named Marco who loves ",
+                  }
+                }
+                key="3"
+                style={
+                  Object {
+                    "marginRight": 5,
+                  }
+                }
+              />
+              <span
+                style={
+                  Object {
+                    "marginRight": 5,
+                  }
+                }
+              />
+              <input
+                aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                autoComplete="off"
+                className="fill-in-blank-input"
+                disabled={false}
+                id="input1"
+                key="101"
+                onChange={[Function]}
+                style={
+                  Object {
+                    "width": "55px",
+                  }
+                }
+                type="text"
+                value=""
+              />
+              <span
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": " football.",
+                  }
+                }
+                key="6"
+                style={
+                  Object {
+                    "marginRight": 5,
+                  }
+                }
+              />
             </div>
-          </Feedback>
+          </Prompt>
         </div>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/playFillInTheBlankQuestion.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/playFillInTheBlankQuestion.tsx
@@ -184,20 +184,18 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     const styling = { width: `${width}px` }
     const inputProperties = this.getInputProperties(i);
     return (
-      <span key={`span${i}`}>
-        <input
-          aria-label={fillInBlankInputLabel(cues, blankAllowed)}
-          autoComplete="off"
-          className={className}
-          disabled={inputProperties['disabled']}
-          id={`input${i}`}
-          key={i + 100}
-          onChange={this.getChangeHandler(i)}
-          style={styling}
-          type="text"
-          value={inputProperties['value']}
-        />
-      </span>
+      <input
+        aria-label={fillInBlankInputLabel(cues, blankAllowed)}
+        autoComplete="off"
+        className={className}
+        disabled={inputProperties['disabled']}
+        id={`input${i}`}
+        key={i + 100}
+        onChange={this.getChangeHandler(i)}
+        style={styling}
+        type="text"
+        value={inputProperties['value']}
+      />
     );
   }
 
@@ -362,8 +360,8 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
       <div className="student-container-inner-diagnostic">
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <div style={fullPageInstructions}>
-            <div>
-              <Prompt elements={this.getPromptElements()} style={styles.container} />
+            <div className="flex-column-reverse">
+              {this.renderFeedback()}
               <Cues
                 diagnosticID={diagnosticID}
                 displayArrowAndText={true}
@@ -371,7 +369,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
                 question={question}
                 translate={translate}
               />
-              {this.renderFeedback()}
+              <Prompt elements={this.getPromptElements()} style={styles.container} />
             </div>
           </div>
           {this.renderMedia()}

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
@@ -130,23 +130,21 @@ exports[`FillInTheBlank component projector view inactive renders 1`] = `
                 }
               }
             />
-            <span>
-              <input
-                aria-label="Complete the sentence with one of the following options: the, a"
-                autoComplete="off"
-                className="disabled"
-                disabled={true}
-                id="input0"
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "70px",
-                  }
+            <input
+              aria-label="Complete the sentence with one of the following options: the, a"
+              autoComplete="off"
+              className="disabled"
+              disabled={true}
+              id="input0"
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "70px",
                 }
-                type="text"
-                value=""
-              />
-            </span>
+              }
+              type="text"
+              value=""
+            />
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -237,26 +235,22 @@ exports[`FillInTheBlank component projector view inactive renders 1`] = `
             }
             key="store.6"
           />
-          <span
-            key="span0"
-          >
-            <input
-              aria-label="Complete the sentence with one of the following options: the, a"
-              autoComplete="off"
-              className="disabled"
-              disabled={true}
-              id="input0"
-              key="100"
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "70px",
-                }
+          <input
+            aria-label="Complete the sentence with one of the following options: the, a"
+            autoComplete="off"
+            className="disabled"
+            disabled={true}
+            id="input0"
+            key="100"
+            onChange={[Function]}
+            style={
+              Object {
+                "width": "70px",
               }
-              type="text"
-              value=""
-            />
-          </span>
+            }
+            type="text"
+            value=""
+          />
           <div
             dangerouslySetInnerHTML={
               Object {
@@ -545,23 +539,21 @@ exports[`FillInTheBlank component projector view when an answer is being display
                 }
               }
             />
-            <span>
-              <input
-                aria-label="Complete the sentence with one of the following options: the, a"
-                autoComplete="off"
-                className="disabled"
-                disabled={true}
-                id="input0"
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "70px",
-                  }
+            <input
+              aria-label="Complete the sentence with one of the following options: the, a"
+              autoComplete="off"
+              className="disabled"
+              disabled={true}
+              id="input0"
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "70px",
                 }
-                type="text"
-                value=""
-              />
-            </span>
+              }
+              type="text"
+              value=""
+            />
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -652,26 +644,22 @@ exports[`FillInTheBlank component projector view when an answer is being display
             }
             key="store.6"
           />
-          <span
-            key="span0"
-          >
-            <input
-              aria-label="Complete the sentence with one of the following options: the, a"
-              autoComplete="off"
-              className="disabled"
-              disabled={true}
-              id="input0"
-              key="100"
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "70px",
-                }
+          <input
+            aria-label="Complete the sentence with one of the following options: the, a"
+            autoComplete="off"
+            className="disabled"
+            disabled={true}
+            id="input0"
+            key="100"
+            onChange={[Function]}
+            style={
+              Object {
+                "width": "70px",
               }
-              type="text"
-              value=""
-            />
-          </span>
+            }
+            type="text"
+            value=""
+          />
           <div
             dangerouslySetInnerHTML={
               Object {
@@ -914,22 +902,20 @@ exports[`FillInTheBlank component student view inactive renders 1`] = `
                 }
               }
             />
-            <span>
-              <input
-                aria-label="Complete the sentence with one of the following options: the, a"
-                autoComplete="off"
-                className=""
-                id="input0"
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "70px",
-                  }
+            <input
+              aria-label="Complete the sentence with one of the following options: the, a"
+              autoComplete="off"
+              className=""
+              id="input0"
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "70px",
                 }
-                type="text"
-                value=""
-              />
-            </span>
+              }
+              type="text"
+              value=""
+            />
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -1020,25 +1006,21 @@ exports[`FillInTheBlank component student view inactive renders 1`] = `
             }
             key="store.6"
           />
-          <span
-            key="span0"
-          >
-            <input
-              aria-label="Complete the sentence with one of the following options: the, a"
-              autoComplete="off"
-              className=""
-              id="input0"
-              key="100"
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "70px",
-                }
+          <input
+            aria-label="Complete the sentence with one of the following options: the, a"
+            autoComplete="off"
+            className=""
+            id="input0"
+            key="100"
+            onChange={[Function]}
+            style={
+              Object {
+                "width": "70px",
               }
-              type="text"
-              value=""
-            />
-          </span>
+            }
+            type="text"
+            value=""
+          />
           <div
             dangerouslySetInnerHTML={
               Object {
@@ -1294,22 +1276,20 @@ exports[`FillInTheBlank component student view when an answer is being displayed
                 }
               }
             />
-            <span>
-              <input
-                aria-label="Complete the sentence with one of the following options: the, a"
-                autoComplete="off"
-                className=""
-                id="input0"
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "70px",
-                  }
+            <input
+              aria-label="Complete the sentence with one of the following options: the, a"
+              autoComplete="off"
+              className=""
+              id="input0"
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "70px",
                 }
-                type="text"
-                value=""
-              />
-            </span>
+              }
+              type="text"
+              value=""
+            />
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -1400,25 +1380,21 @@ exports[`FillInTheBlank component student view when an answer is being displayed
             }
             key="store.6"
           />
-          <span
-            key="span0"
-          >
-            <input
-              aria-label="Complete the sentence with one of the following options: the, a"
-              autoComplete="off"
-              className=""
-              id="input0"
-              key="100"
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "70px",
-                }
+          <input
+            aria-label="Complete the sentence with one of the following options: the, a"
+            autoComplete="off"
+            className=""
+            id="input0"
+            key="100"
+            onChange={[Function]}
+            style={
+              Object {
+                "width": "70px",
               }
-              type="text"
-              value=""
-            />
-          </span>
+            }
+            type="text"
+            value=""
+          />
           <div
             dangerouslySetInnerHTML={
               Object {
@@ -1668,22 +1644,20 @@ exports[`FillInTheBlank component student view when the student has submitted an
                 }
               }
             />
-            <span>
-              <input
-                aria-label="Complete the sentence with one of the following options: the, a"
-                autoComplete="off"
-                className=""
-                id="input0"
-                onChange={[Function]}
-                style={
-                  Object {
-                    "width": "70px",
-                  }
+            <input
+              aria-label="Complete the sentence with one of the following options: the, a"
+              autoComplete="off"
+              className=""
+              id="input0"
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "70px",
                 }
-                type="text"
-                value=""
-              />
-            </span>
+              }
+              type="text"
+              value=""
+            />
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -1774,25 +1748,21 @@ exports[`FillInTheBlank component student view when the student has submitted an
             }
             key="store.6"
           />
-          <span
-            key="span0"
-          >
-            <input
-              aria-label="Complete the sentence with one of the following options: the, a"
-              autoComplete="off"
-              className=""
-              id="input0"
-              key="100"
-              onChange={[Function]}
-              style={
-                Object {
-                  "width": "70px",
-                }
+          <input
+            aria-label="Complete the sentence with one of the following options: the, a"
+            autoComplete="off"
+            className=""
+            id="input0"
+            key="100"
+            onChange={[Function]}
+            style={
+              Object {
+                "width": "70px",
               }
-              type="text"
-              value=""
-            />
-          </span>
+            }
+            type="text"
+            value=""
+          />
           <div
             dangerouslySetInnerHTML={
               Object {

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/fillInTheBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/fillInTheBlank.tsx
@@ -164,20 +164,18 @@ class FillInTheBlank extends React.Component<fillInTheBlankProps, fillInTheBlank
     const styling = { width: `${width}px` }
     const updateBlankValue = (e) => this.updateBlankValue(e, i)
     return (
-      <span key={`span${i}`}>
-        <input
-          aria-label={fillInBlankInputLabel(cues)}
-          autoComplete="off"
-          className={inputClass}
-          disabled={disabled}
-          id={`input${i}`}
-          key={i + 100}
-          onChange={updateBlankValue}
-          style={styling}
-          type="text"
-          value={value}
-        />
-      </span>
+      <input
+        aria-label={fillInBlankInputLabel(cues)}
+        autoComplete="off"
+        className={inputClass}
+        disabled={disabled}
+        id={`input${i}`}
+        key={i + 100}
+        onChange={updateBlankValue}
+        style={styling}
+        type="text"
+        value={value}
+      />
     );
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
@@ -37,3 +37,8 @@
     outline: none;
   }
 }
+
+.flex-column-reverse {
+  display: flex;
+  flex-direction: column-reverse;
+}


### PR DESCRIPTION
## WHAT
Fix issue (I think from nested elements) where it wasn't possible to get out of the blank in a diagnostic fill in blank.

## WHY
We want users to be able to navigate these easily.

## HOW
Remove unnecessary wrapping element, and also use flex reverse to make instructions a little clearer.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Accessibility-JAWS-does-not-read-entire-fill-in-the-blank-prompt-5c3af30e1b6e44b08c5c745074202860

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - but tested locally with Assistiv
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
