### PR TITLE
add publish date to unit activities and update student query to use them

### DIFF
--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -166,7 +166,12 @@ class UnitActivity < ApplicationRecord
           AND cu.visible = true
           AND unit.visible = true
           AND ua.visible = true
-          AND (ua.publish_date IS NULL OR ua.publish_date <= NOW() at time zone '#{supply_timezone(teachers.time_zone)}')
+          AND
+          (
+            ua.publish_date IS NULL
+            OR (teachers.time_zone IS NOT NULL AND ua.publish_date <= NOW() at time zone teachers.time_zone)
+            OR (teachers.time_zone IS NULL AND ua.publish_date <= NOW())
+          )
         GROUP BY
           unit.id,
           unit.name,
@@ -177,6 +182,7 @@ class UnitActivity < ApplicationRecord
           activity.id,
           activity.uid,
           ua.due_date,
+          ua.publish_date,
           ua.created_at,
           unit_activity_id,
           cuas.completed,
@@ -195,10 +201,6 @@ class UnitActivity < ApplicationRecord
           ua.id ASC
       SQL
     ).to_a
-  end
-
-  def supply_timezone(teachers_timezone)
-    teachers_timezone || DEFAULT_TIMEZONE
   end
 
 end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -36,8 +36,6 @@ class UnitActivity < ApplicationRecord
 
   after_save :hide_appropriate_activity_sessions, :teacher_checkbox
 
-  DEFAULT_TIMEZONE = "UTC"
-
   def teacher_checkbox
     return unless unit
     return unless unit.user

--- a/services/QuillLMS/db/migrate/20220927124042_add_publish_date_to_unit_activities.rb
+++ b/services/QuillLMS/db/migrate/20220927124042_add_publish_date_to_unit_activities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPublishDateToUnitActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :unit_activities, :publish_date, :datetime
+  end
+end

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -232,6 +232,7 @@ describe ProfilesController, type: :controller do
                 'act_sesh_updated_at' => activity_session&.updated_at,
                 'order_number' => unit_activity.order_number,
                 'due_date' => unit_activity.due_date,
+                'publish_date' => unit_activity.publish_date,
                 'pre_activity_id' => pre_test&.id,
                 'unit_activity_created_at' => classroom_unit.created_at,
                 'locked' => unit_activity.classroom_unit_activity_states[0].locked,

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -187,14 +187,14 @@ describe UnitActivity, type: :model, redis: true do
         publish_date = Time.now.utc - 1.hour
         unit_activity.update(publish_date: publish_date)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
-        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_datetime).to eq((publish_date - teacher.utc_offset).to_datetime)
+        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_time.strftime('%a %b %d %H:%M:%S %Z %Y')).to eq((publish_date - teacher.utc_offset).to_time.strftime('%a %b %d %H:%M:%S %Z %Y'))
       end
 
       it 'leaves the publish date in utc if the teacher does not have a time zone' do
         publish_date = Time.now.utc - 1.hour
         unit_activity.update(publish_date: publish_date)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
-        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_datetime).to eq(publish_date.to_datetime)
+        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_time.strftime('%a %b %d %H:%M:%S %Z %Y')).to eq(publish_date.to_time.strftime('%a %b %d %H:%M:%S %Z %Y'))
       end
 
     end

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -177,8 +177,8 @@ describe UnitActivity, type: :model, redis: true do
 
       it 'includes unit activities that have a publish date that have already passed when the teacher has no timezone' do
         teacher.update(time_zone: nil)
-        unit_activity.update(publish_date: Time.now - 1.hour)
-        lessons_unit_activity.update(publish_date: Time.now - 1.minute)
+        unit_activity.update(publish_date: Time.now.utc - 1.hour)
+        lessons_unit_activity.update(publish_date: Time.now.utc - 1.minute)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
         expect(unit_activities.count).to eq(2)
       end
@@ -194,8 +194,8 @@ describe UnitActivity, type: :model, redis: true do
 
       it 'does not include unit activities that have a publish date that has not yet passed when the teacher has no time zone' do
         teacher.update(time_zone: nil)
-        unit_activity.update(publish_date: Time.now + 1.hour)
-        lessons_unit_activity.update(publish_date: Time.now + 1.month)
+        unit_activity.update(publish_date: Time.now.utc + 1.hour)
+        lessons_unit_activity.update(publish_date: Time.now.utc + 1.month)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
         expect(unit_activities.count).to eq(0)
       end


### PR DESCRIPTION
## WHAT
Add `publish_date` to unit activities and update the student query to use them to filter activities for display.

## WHY
This is pre-work for the scheduled activities feature, which will rely on this background logic.

## HOW
Add a migration and update the SQL query used to generate the data for the student profile to filter out activities that have a publish date that is after the current time in their teacher's timezone. Then update tests (including some test file cleanup).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-publish-date-to-unit-activities-9a2cd31390694496afad5d3d4acce991
https://www.notion.so/quill/Update-student-query-to-take-publish-date-into-account-with-teacher-s-timezone-0371a4638eb549fc8a6c8a139408b299

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES