### PR TITLE
Hotfix - Remove demo reseting.

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -8,7 +8,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   respond_to :json, :html
 
-  around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner, :view_demo]
+  around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner]
 
   before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
   # WARNING: these filter methods check against classroom_id, not id.
@@ -236,16 +236,11 @@ class Teachers::ClassroomManagerController < ApplicationController
     demo = User.find_by_email(Demo::ReportDemoCreator::EMAIL)
     return render json: {errors: "Demo Account does not exist"}, status: 422 if demo.nil?
 
-    # perform this inline to ensure account is in good shape on entry
-    Demo::ReportDemoCreator.reset_account(demo)
-
     self.current_user_demo_id = demo.id
     redirect_to '/profile'
   end
 
   def unset_view_demo
-    Demo::ResetAccountWorker.perform_async(session[:demo_id])
-
     self.current_user_demo_id = nil
     return redirect_to params[:redirect] if params[:redirect]
 

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -674,14 +674,12 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will call current_user_demo_id= if the demo account exists' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
       expect(controller).to receive(:current_user_demo_id=).with(demo_teacher.id)
 
       get :view_demo
     end
 
     it 'will redirect to the profile path' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
 
       get :view_demo
       expect(response).to redirect_to profile_path
@@ -689,7 +687,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will not call current_user_demo_id= and raise error if demo account does not exist' do
       demo_teacher.destroy
-      expect(Demo::ReportDemoCreator).to_not receive(:reset_account)
       expect(controller).not_to receive(:current_user_demo_id=)
 
       get :view_demo
@@ -697,7 +694,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will track event' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
       expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_DEMO)
 
       get :view_demo
@@ -727,7 +723,6 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will redirect to the redirect param if it exists' do
-      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       redirect = '/teachers/classes'
 
       get :unset_view_demo, params: { redirect: redirect }, session: {demo_id: demo_teacher.id}
@@ -735,14 +730,12 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will redirect to the profile path if there is no redirect param' do
-      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
 
       get :unset_view_demo, session: {demo_id: demo_teacher.id}
       expect(response).to redirect_to profile_path
     end
 
     it 'will call current_user_demo_id=' do
-      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       expect(controller).to receive(:current_user_demo_id=).with(nil)
 
       get :unset_view_demo, session: {demo_id: demo_teacher.id}


### PR DESCRIPTION
## WHAT
There seems to be an issue with the demo reset creating activity_sessions with nil ids. Need to test to figure out why that is happening.
## WHY
It's setting off alarms and leaving the demo account in a weird state.
## HOW
Remove the calls from the two controllers, the only places this code is called.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | No, small hotfix.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
