### PR TITLE
New Staff UI to add up to three topics to Activities

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/activities.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/activities.scss
@@ -1,0 +1,13 @@
+.topic-groups-container {
+  display: grid;
+  padding: 10px;
+}
+
+.topic-group {
+  display: flex;
+  padding: 10px;
+}
+
+.topic-column {
+  min-width: 300px;
+}

--- a/services/QuillLMS/app/assets/stylesheets/cms/activities.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/activities.scss
@@ -11,3 +11,11 @@
 .topic-column {
   min-width: 300px;
 }
+
+.record-cell {
+  border: 1px solid lightgray;
+  padding: 5px;
+  width: 100%;
+  text-align: left;
+  background-color: white;
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/cms_activity_classifications.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/cms_activity_classifications.scss
@@ -1,0 +1,21 @@
+.topic-groups-container {
+  display: grid;
+  padding: 10px;
+}
+
+.topic-group {
+  display: flex;
+  padding: 10px;
+}
+
+.topic-column {
+  min-width: 300px;
+}
+
+.record-cell {
+  border: 1px solid lightgray;
+  padding: 5px;
+  width: 100%;
+  text-align: left;
+  background-color: white;
+}

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
-import { ReactTable, TextFilter, } from '../../../Shared/index'
 
-const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilteredOptionsForLevelNew, topic, removeTopic }) => {
+const TopicColumn = ({ createNewTopic, levelNumber, selectTopic, getFilteredOptionsForLevel, topic, removeTopic }) => {
   const [newTopicName, setNewTopicName] = React.useState('')
 
-  const options = getFilteredOptionsForLevelNew(levelNumber, topic.id)
+  const options = getFilteredOptionsForLevel(levelNumber, topic.id)
 
   function handleNewTopicNameChange(e) {
     setNewTopicName(e.target.value)
@@ -16,26 +15,17 @@ const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilter
       level: 1,
       name: newTopicName
     }
-    createNewTopicNew(newTopic)
+    createNewTopic(newTopic)
     setNewTopicName('')
   }
 
+  const handleClickSelectTopic = (id) => {
+    selectTopic(id, levelNumber)
+  }
 
-  const columns = (selectedOption) => ([
-    {
-      Header: 'Name',
-      accessor: 'name',
-      key: 'name',
-      Cell: ({row}) => (<div className={`record-cell ${selectedOption && selectedOption.id === row.original.id  ? 'selected' : ''}`} onClick={() => selectTopicNew(row.original.id, levelNumber)}>{row.original.name}</div>),
-      sortType:  (a, b) => (a && b ? a.original.name.localeCompare(b.original.name) : 0),
-      Filter: TextFilter,
-      filter: (rows, idArray, filterValue) => {
-        return rows.filter(row => {
-          return row.original.name ? row.original.name.toLowerCase().includes(filterValue.toLowerCase()) : ''
-        })
-      },
-    }
-  ]);
+  function handleClickRemoveTopic(e) {
+    removeTopic(levelNumber)
+  }
 
   const selectedOption = topic
 
@@ -45,7 +35,7 @@ const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilter
   if (selectedOption) {
     selectedOptionElement = (<div className="selected-option" >
       <span>{selectedOption.name}</span>
-      <button className="interactive-wrapper" onClick={(e) => removeTopic(levelNumber)}><i className="fas fa-times" /></button>
+      <button aria-label="remove topic" className="interactive-wrapper" onClick={handleClickRemoveTopic} type="button"><i className="fas fa-times" /></button>
     </div>)
   }
 
@@ -55,7 +45,7 @@ const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilter
       buttonClassName+= ' disabled'
     }
     newTopicField = (<div className="new-topic-field">
-      <label>New Topic Level 1</label>
+      <span>New Topic Level 1</span>
       <input disabled={!options.length} onChange={handleNewTopicNameChange} value={newTopicName} />
       <button className={buttonClassName} disabled={!options.length} onClick={handleClickAddTopic}>Add</button>
     </div>)
@@ -65,12 +55,20 @@ const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilter
     <div className="topic-column">
       <label>Topic Level {levelNumber}</label>
       {selectedOptionElement}
-      <ReactTable
-        columns={columns(selectedOption)}
-        data={options}
-        defaultFilterMethod={(filter, row) => row._original.name ? row._original.name.toLowerCase().includes(filter.value.toLowerCase()) : ''}
-        filterable
-      />
+      <div>
+        {
+          options.map((option, i) => {
+            let clickEventHelper = () => {
+              handleClickSelectTopic(option.id)
+            };
+            return (
+              <button className="record-cell" key={i} onClick={clickEventHelper} onKeyDown={clickEventHelper} type="button">
+                {option.name}
+              </button>
+            )
+          })
+        }
+      </div>
       {newTopicField}
     </div>
   );

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
@@ -51,23 +51,23 @@ const TopicColumn = ({ createNewTopic, levelNumber, selectTopic, getFilteredOpti
     </div>)
   }
 
+  const optionsList = options.map((option, i) => {
+    const clickEventHelper = () => {
+      handleClickSelectTopic(option.id)
+    };
+    return (
+      <button className="record-cell" key={i} onClick={clickEventHelper} type="button">
+        {option.name}
+      </button>
+    )
+  })
+
   return (
     <div className="topic-column">
       <label>Topic Level {levelNumber}</label>
       {selectedOptionElement}
       <div>
-        {
-          options.map((option, i) => {
-            let clickEventHelper = () => {
-              handleClickSelectTopic(option.id)
-            };
-            return (
-              <button className="record-cell" key={i} onClick={clickEventHelper} onKeyDown={clickEventHelper} type="button">
-                {option.name}
-              </button>
-            )
-          })
-        }
+        {optionsList}
       </div>
       {newTopicField}
     </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicColumn.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { ReactTable, TextFilter, } from '../../../Shared/index'
 
-const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, selectTopic, getSelectedOptionForLevel, }) => {
+const TopicColumn = ({ createNewTopicNew, levelNumber, selectTopicNew, getFilteredOptionsForLevelNew, topic, removeTopic }) => {
   const [newTopicName, setNewTopicName] = React.useState('')
 
-  const options = getFilteredOptionsForLevel(levelNumber)
+  const options = getFilteredOptionsForLevelNew(levelNumber, topic.id)
 
   function handleNewTopicNameChange(e) {
     setNewTopicName(e.target.value)
@@ -13,10 +13,10 @@ const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, 
   function handleClickAddTopic(e) {
     e.preventDefault()
     const newTopic = {
-      level: 0,
+      level: 1,
       name: newTopicName
     }
-    createNewTopic(newTopic)
+    createNewTopicNew(newTopic)
     setNewTopicName('')
   }
 
@@ -26,7 +26,7 @@ const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, 
       Header: 'Name',
       accessor: 'name',
       key: 'name',
-      Cell: ({row}) => (<div className={`record-cell ${selectedOption && selectedOption.id === row.original.id  ? 'selected' : ''}`} onClick={() => selectTopic(row.original.id)}>{row.original.name}</div>),
+      Cell: ({row}) => (<div className={`record-cell ${selectedOption && selectedOption.id === row.original.id  ? 'selected' : ''}`} onClick={() => selectTopicNew(row.original.id, levelNumber)}>{row.original.name}</div>),
       sortType:  (a, b) => (a && b ? a.original.name.localeCompare(b.original.name) : 0),
       Filter: TextFilter,
       filter: (rows, idArray, filterValue) => {
@@ -37,7 +37,7 @@ const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, 
     }
   ]);
 
-  const selectedOption = getSelectedOptionForLevel(levelNumber)
+  const selectedOption = topic
 
   let selectedOptionElement = <div className="selected-option" />
   let newTopicField
@@ -45,17 +45,17 @@ const TopicColumn = ({ createNewTopic, levelNumber, getFilteredOptionsForLevel, 
   if (selectedOption) {
     selectedOptionElement = (<div className="selected-option" >
       <span>{selectedOption.name}</span>
-      <button className="interactive-wrapper" onClick={(e) => selectTopic(selectedOption.id, e)}><i className="fas fa-times" /></button>
+      <button className="interactive-wrapper" onClick={(e) => removeTopic(levelNumber)}><i className="fas fa-times" /></button>
     </div>)
   }
 
-  if (levelNumber === 0) {
+  if (levelNumber === 1) {
     let buttonClassName = "quill-button secondary small outlined"
     if (!newTopicName.length) {
       buttonClassName+= ' disabled'
     }
     newTopicField = (<div className="new-topic-field">
-      <label>New Topic Level 0</label>
+      <label>New Topic Level 1</label>
       <input disabled={!options.length} onChange={handleNewTopicNameChange} value={newTopicName} />
       <button className={buttonClassName} disabled={!options.length} onClick={handleClickAddTopic}>Add</button>
     </div>)

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
@@ -6,11 +6,28 @@ const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, hand
 
   const [levelOneTopic, setLevelOneTopic] = React.useState(topic)
   const [levelTwoTopic, setLevelTwoTopic] = levelOneTopic.id ? React.useState(findParentTopic(topic)) : React.useState({})
-  const [levelThreeTopic, setLevelThreeTopic] = levelOneTopic.id ? React.useState(findParentTopic(levelTwoTopic)) : React.useState({})
+  const [levelThreeTopic, setLevelThreeTopic] = levelTwoTopic && levelTwoTopic.id ? React.useState(findParentTopic(levelTwoTopic)) : React.useState({})
+  const levelNumberToFunction = {
+    1: setLevelOneTopic,
+    2: setLevelTwoTopic,
+    3: setLevelThreeTopic
+  }
+
+  function usePrevious(value) {
+    const ref = React.useRef();
+    React.useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  }
+  const prevLevelOneTopic = usePrevious(levelOneTopic);
+
+  React.useEffect(() => {
+    handleLevelOneChange(prevLevelOneTopic?.id, levelOneTopic.id)
+  }, [levelOneTopic]);
 
   React.useEffect(() => {
     if (levelOneTopic.parent_id !== levelTwoTopic.id) {
-      handleLevelOneChange(levelOneTopic.id, null)
       setLevelOneTopic({})
     }
   }, [levelTwoTopic]);
@@ -23,25 +40,11 @@ const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, hand
 
   function selectTopic(topicId, level) {
     const newTopic = topicOptions.find(t => t.id === topicId)
-    if (level === 1) {
-      handleLevelOneChange(levelOneTopic.id, newTopic.id)
-      setLevelOneTopic(newTopic)
-    } else if (level === 2) {
-      setLevelTwoTopic(newTopic)
-    } else if (level === 3) {
-      setLevelThreeTopic(newTopic)
-    }
+    levelNumberToFunction[level](newTopic)
   }
 
   function removeTopic(level: number) {
-    if (level === 1) {
-      setLevelOneTopic({})
-    } else if (level === 2) {
-      setLevelTwoTopic({})
-    } else if (level === 3) {
-      setLevelThreeTopic({})
-    }
-    handleLevelOneChange(levelOneTopic.id, null)
+    levelNumberToFunction[level]({})
   }
 
   function getOptionsForLevel(level: number) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+
+import TopicColumn from './topicColumn'
+
+const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, handleLevelOneChange }) => {
+
+  const [levelOneTopic, setLevelOneTopic] = React.useState(topic)
+  const [levelTwoTopic, setLevelTwoTopic] = levelOneTopic.id ? React.useState(findParentTopic(topic)) : React.useState({})
+  const [levelThreeTopic, setLevelThreeTopic] = levelOneTopic.id ? React.useState(findParentTopic(levelTwoTopic)) : React.useState({})
+
+  React.useEffect(() => {
+    if (levelOneTopic.parent_id != levelTwoTopic.id) {
+      setLevelOneTopic({})
+    }
+  }, [levelTwoTopic]);
+
+  React.useEffect(() => {
+    if (levelTwoTopic.parent_id != levelThreeTopic.id) {
+      setLevelTwoTopic({})
+    }
+  }, [levelThreeTopic]);
+
+  function selectTopicNew(topicId, level) {
+    const newTopic = topicOptions.find(t => t.id === topicId)
+    if (level === 1) {
+      handleLevelOneChange(levelOneTopic.id, newTopic.id)
+      setLevelOneTopic(newTopic)
+    } else if (level === 2) {
+      setLevelTwoTopic(newTopic)
+    } else if (level === 3) {
+      setLevelThreeTopic(newTopic)
+    }
+  }
+
+  function removeTopic(level: number) {
+    if (level === 1) {
+      setLevelOneTopic({})
+    } else if (level === 2) {
+      setLevelTwoTopic({})
+    } else if (level === 3) {
+      setLevelThreeTopic({})
+    }
+    handleLevelOneChange(levelOneTopic.id, null)
+  }
+
+  function getOptionsForLevel(level: number) {
+    return topicOptions.filter(to => to.level === level)
+  }
+
+  function getFilteredOptionsForLevelNew(level: number, selectedId: number) {
+    let allOptions = getOptionsForLevel(level)
+    allOptions = allOptions.filter(o => o.id !== selectedId)
+
+    if (level === 2 && levelThreeTopic) {
+      return allOptions.filter(o => o.parent_id === levelThreeTopic.id)
+    }
+
+    if (level === 1 && levelTwoTopic) {
+      return allOptions.filter(o => o.parent_id === levelTwoTopic.id)
+    }
+
+    return allOptions
+  }
+
+  function createNewTopicNew(topic: object) {
+    topic.parent_id = levelTwoTopic.id
+    createNewTopic(topic)
+  }
+
+  console.log(topic)
+  console.log(levelOneTopic)
+
+  return (
+    <div className="topic-group">
+      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={3} selectTopicNew={selectTopicNew} topic={levelThreeTopic} removeTopic={removeTopic} />
+      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={2} selectTopicNew={selectTopicNew} topic={levelTwoTopic} removeTopic={removeTopic} />
+      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={1} selectTopicNew={selectTopicNew} topic={levelOneTopic} removeTopic={removeTopic} />
+    </div>
+  );
+}
+
+export default TopicGroup

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topicGroup.tsx
@@ -9,18 +9,19 @@ const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, hand
   const [levelThreeTopic, setLevelThreeTopic] = levelOneTopic.id ? React.useState(findParentTopic(levelTwoTopic)) : React.useState({})
 
   React.useEffect(() => {
-    if (levelOneTopic.parent_id != levelTwoTopic.id) {
+    if (levelOneTopic.parent_id !== levelTwoTopic.id) {
+      handleLevelOneChange(levelOneTopic.id, null)
       setLevelOneTopic({})
     }
   }, [levelTwoTopic]);
 
   React.useEffect(() => {
-    if (levelTwoTopic.parent_id != levelThreeTopic.id) {
+    if (levelTwoTopic.parent_id !== levelThreeTopic.id) {
       setLevelTwoTopic({})
     }
   }, [levelThreeTopic]);
 
-  function selectTopicNew(topicId, level) {
+  function selectTopic(topicId, level) {
     const newTopic = topicOptions.find(t => t.id === topicId)
     if (level === 1) {
       handleLevelOneChange(levelOneTopic.id, newTopic.id)
@@ -47,7 +48,7 @@ const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, hand
     return topicOptions.filter(to => to.level === level)
   }
 
-  function getFilteredOptionsForLevelNew(level: number, selectedId: number) {
+  function getFilteredOptionsForLevel(level: number, selectedId: number) {
     let allOptions = getOptionsForLevel(level)
     allOptions = allOptions.filter(o => o.id !== selectedId)
 
@@ -62,19 +63,16 @@ const TopicGroup = ({ createNewTopic, findParentTopic, topic, topicOptions, hand
     return allOptions
   }
 
-  function createNewTopicNew(topic: object) {
+  function createNewLevelOneTopic(topic: object) {
     topic.parent_id = levelTwoTopic.id
     createNewTopic(topic)
   }
 
-  console.log(topic)
-  console.log(levelOneTopic)
-
   return (
     <div className="topic-group">
-      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={3} selectTopicNew={selectTopicNew} topic={levelThreeTopic} removeTopic={removeTopic} />
-      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={2} selectTopicNew={selectTopicNew} topic={levelTwoTopic} removeTopic={removeTopic} />
-      <TopicColumn createNewTopicNew={createNewTopicNew} getFilteredOptionsForLevelNew={getFilteredOptionsForLevelNew} levelNumber={1} selectTopicNew={selectTopicNew} topic={levelOneTopic} removeTopic={removeTopic} />
+      <TopicColumn createNewTopic={createNewLevelOneTopic} getFilteredOptionsForLevel={getFilteredOptionsForLevel} levelNumber={3} removeTopic={removeTopic} selectTopic={selectTopic} topic={levelThreeTopic} />
+      <TopicColumn createNewTopic={createNewLevelOneTopic} getFilteredOptionsForLevel={getFilteredOptionsForLevel} levelNumber={2} removeTopic={removeTopic} selectTopic={selectTopic} topic={levelTwoTopic} />
+      <TopicColumn createNewTopic={createNewLevelOneTopic} getFilteredOptionsForLevel={getFilteredOptionsForLevel} levelNumber={1} removeTopic={removeTopic} selectTopic={selectTopic} topic={levelOneTopic} />
     </div>
   );
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 
 import TopicGroup from './topicGroup'
 
+import '../../../../../../app/assets/stylesheets/cms/activities.scss'
+
 const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, }) => {
   const [topicsEnabled, setTopicsEnabled] = React.useState(!!activity.topic_ids.length)
 
@@ -21,7 +23,7 @@ const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, })
 
   function handleLevelOneChange(oldId, newId) {
     let newTopicIds = activity.topic_ids.filter(t => t !== oldId)
-    newTopicIds.push(newId)
+    if (newId) { newTopicIds.push(newId) }
     handleTopicsChange(newTopicIds)
   }
 
@@ -36,13 +38,13 @@ const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, })
   return (
     <section className="topics-container enabled-attribute-container">
       <section className="enable-topics-container checkbox-container">
-        <input checked={topicsEnabled} onChange={toggleTopicsEnabled} type="checkbox" />
+        <input aria-label="Topics enabled?" checked={topicsEnabled} onChange={toggleTopicsEnabled} type="checkbox" />
         <label>Topics enabled</label>
       </section>
       <div className="topic-groups-container">
-        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={firstTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
-        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={secondTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
-        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={thirdTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} handleLevelOneChange={handleLevelOneChange} topic={firstTopic} topicOptions={topicOptions} />
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} handleLevelOneChange={handleLevelOneChange} topic={secondTopic} topicOptions={topicOptions} />
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} handleLevelOneChange={handleLevelOneChange} topic={thirdTopic} topicOptions={topicOptions} />
       </div>
     </section>
   )

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 
 import TopicGroup from './topicGroup'
 
-import '../../../../../../app/assets/stylesheets/cms/activities.scss'
-
 const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, }) => {
   const [topicsEnabled, setTopicsEnabled] = React.useState(!!activity.topic_ids.length)
 
@@ -23,7 +21,7 @@ const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, })
 
   function handleLevelOneChange(oldId, newId) {
     let newTopicIds = activity.topic_ids.filter(t => t !== oldId)
-    if (newId) { newTopicIds.push(newId) }
+    if (newId && !newTopicIds.includes(newId)) { newTopicIds.push(newId) }
     handleTopicsChange(newTopicIds)
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/activityForm/topics.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import TopicColumn from './topicColumn'
+import TopicGroup from './topicGroup'
 
 const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, }) => {
   const [topicsEnabled, setTopicsEnabled] = React.useState(!!activity.topic_ids.length)
@@ -11,89 +11,27 @@ const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, })
     }
   }, [topicsEnabled])
 
-  function getOptionsForLevel(level: number) {
-    if (!topicsEnabled) { return [] }
-    return topicOptions.filter(to => to.level === level)
+  function getTopicFromId(id: number) {
+    return topicOptions.find(to => to.id === id)
   }
 
-  function getFilteredOptionsForLevel(level: number) {
-    const allOptions = getOptionsForLevel(level)
-    const selectedLevelTwo = getSelectedOptionForLevel(2)
-    const selectedLevelThree = getSelectedOptionForLevel(3)
-
-    if (level === 3 && selectedLevelTwo) {
-      return allOptions.filter(o => o.id === selectedLevelTwo.parent_id)
-    }
-
-    if (level === 2 && selectedLevelThree) {
-      return allOptions.filter(o => o.parent_id === selectedLevelThree.id)
-    }
-
-    return allOptions
+  function findParentTopic(topic) {
+    return topicOptions.find(t => t.id === topic.parent_id)
   }
 
-  function getSelectedOptionForLevel(level: number) {
-    const levelOptionsForLevel = getOptionsForLevel(level)
-    const option = levelOptionsForLevel.find(t => activity.topic_ids.includes(t.id))
-    return option
-  }
-
-  function onChangeTopics(topicId) {
-    let newTopicIds = activity.topic_ids
-    const newTopic = topicOptions.find(t => t.id === topicId)
-    const previousTopic = getSelectedOptionForLevel(newTopic.level)
-
-    newTopicIds = removeExistingTopicAndParents(newTopicIds, previousTopic)
-
-    if (previousTopic?.id != newTopic.id) {
-      newTopicIds = addNewTopicAndParents(newTopicIds, newTopic)
-    }
-
+  function handleLevelOneChange(oldId, newId) {
+    let newTopicIds = activity.topic_ids.filter(t => t !== oldId)
+    newTopicIds.push(newId)
     handleTopicsChange(newTopicIds)
-  }
-
-  function removeExistingTopicAndParents(listToFilter, existingTopic) {
-    if (existingTopic) {
-      const existingParentTopic = findParentTopic(topicOptions, existingTopic)
-      listToFilter = listToFilter.filter(id => id !== existingTopic.id)
-      if (existingParentTopic) {
-        listToFilter = listToFilter.filter(id => id !== existingParentTopic.id)
-        const existingGrandparentTopic = findParentTopic(topicOptions, existingParentTopic)
-        if (existingGrandparentTopic) {
-          listToFilter = listToFilter.filter(id => id !== existingGrandparentTopic.id)
-        }
-      }
-    }
-    return listToFilter
-  }
-
-  function addNewTopicAndParents(listToModify, newTopic) {
-    listToModify.push(newTopic.id)
-    if (newTopic.parent_id) {
-      const newParentTopic = findParentTopic(topicOptions, newTopic)
-      listToModify.push(newParentTopic.id)
-      if (newParentTopic.parent_id) {
-        const newGrandparentTopic = findParentTopic(topicOptions, newParentTopic)
-        listToModify.push(newGrandparentTopic.id)
-      }
-    }
-    return listToModify
-  }
-
-  function findParentTopic(topicList, topic) {
-    return topicList.find(t => t.id === topic.parent_id)
   }
 
   function toggleTopicsEnabled(e) {
     setTopicsEnabled(!topicsEnabled)
   }
 
-  const sharedTopicColumnProps = {
-    getFilteredOptionsForLevel,
-    selectTopic: onChangeTopics,
-    getSelectedOptionForLevel,
-    createNewTopic
-  }
+  const firstTopic = getTopicFromId(activity.topic_ids[0]) || {}
+  const secondTopic = getTopicFromId(activity.topic_ids[1]) || {}
+  const thirdTopic = getTopicFromId(activity.topic_ids[2]) || {}
 
   return (
     <section className="topics-container enabled-attribute-container">
@@ -101,10 +39,11 @@ const Topics = ({ activity, createNewTopic, topicOptions, handleTopicsChange, })
         <input checked={topicsEnabled} onChange={toggleTopicsEnabled} type="checkbox" />
         <label>Topics enabled</label>
       </section>
-      <TopicColumn {...sharedTopicColumnProps} levelNumber={3} />
-      <TopicColumn {...sharedTopicColumnProps} levelNumber={2} />
-      <TopicColumn {...sharedTopicColumnProps} levelNumber={1} />
-      <TopicColumn {...sharedTopicColumnProps} levelNumber={0} />
+      <div className="topic-groups-container">
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={firstTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={secondTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
+        <TopicGroup createNewTopic={createNewTopic} findParentTopic={findParentTopic} topic={thirdTopic} topicOptions={topicOptions} handleLevelOneChange={handleLevelOneChange} />
+      </div>
     </section>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/activity_form.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/activity_form.scss
@@ -74,3 +74,25 @@
     }
   }
 }
+
+.topic-groups-container {
+  display: grid;
+  padding: 10px;
+}
+
+.topic-group {
+  display: flex;
+  padding: 10px;
+}
+
+.topic-column {
+  min-width: 300px;
+}
+
+.record-cell {
+  border: 1px solid lightgray;
+  padding: 5px;
+  width: 100%;
+  text-align: left;
+  background-color: white;
+}


### PR DESCRIPTION
## WHAT
Created a new React UI for staff to add up to three level one topics to Activities.

## WHY
We want staff to be able to set topics on activities and create new topics.

## HOW
Create a React class TopicGroup that contains all 3 selector elements you would need to select a new level one topic (the level 3 topic selector, level 2 topic selector, and level 1 topic selector). Make the parent class Topic create three of these TopicGroups instead of three TopicColumns like it was doing before.

### Screenshots
![Screen Shot 2022-09-28 at 3 50 46 PM](https://user-images.githubusercontent.com/57366100/192737217-4d3ac9a0-38c1-40f1-b62b-3ffa45d08730.png)


### Notion Card Links
https://www.notion.so/quill/Activity-UI-Supports-3-tags-163deee555324ebbb7baa1b6e08a8af3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
