### PR TITLE
add screenreader-only fill in the blank instructions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -83,6 +83,12 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
               </div>
             </div>
           </Feedback>
+          <span
+            className="sr-only"
+          >
+            Screenreader users: make sure to read through the whole sentence before filling in the blanks.
+          </span>
+          span&gt;
           <Cues
             displayArrowAndText={true}
             question={
@@ -182,7 +188,7 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   
                 </span>,
                 <input
-                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                  aria-label="Choose which one of the following options fits best in the blank  or leave it empty: the, an, a."
                   autoComplete="off"
                   className="fill-in-blank-input"
                   disabled={false}
@@ -260,7 +266,7 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   
                 </span>,
                 <input
-                  aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                  aria-label="Choose which one of the following options fits best in the blank  or leave it empty: the, an, a."
                   autoComplete="off"
                   className="fill-in-blank-input"
                   disabled={false}
@@ -338,7 +344,7 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 }
               />
               <input
-                aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                aria-label="Choose which one of the following options fits best in the blank  or leave it empty: the, an, a."
                 autoComplete="off"
                 className="fill-in-blank-input"
                 disabled={false}
@@ -374,7 +380,7 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 }
               />
               <input
-                aria-label="Complete the sentence with one of the following options or leave it blank: the, an, a"
+                aria-label="Choose which one of the following options fits best in the blank  or leave it empty: the, an, a."
                 autoComplete="off"
                 className="fill-in-blank-input"
                 disabled={false}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -88,7 +88,6 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
           >
             Screenreader users: make sure to read through the whole sentence before filling in the blanks.
           </span>
-          span&gt;
           <Cues
             displayArrowAndText={true}
             question={

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/playFillInTheBlankQuestion.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/playFillInTheBlankQuestion.tsx
@@ -362,6 +362,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
           <div style={fullPageInstructions}>
             <div className="flex-column-reverse">
               {this.renderFeedback()}
+              <span className="sr-only">Screenreader users: make sure to read through the whole sentence before filling in the blanks.</span>
               <Cues
                 diagnosticID={diagnosticID}
                 displayArrowAndText={true}

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/fillInTheBlank.test.jsx.snap
@@ -131,7 +131,7 @@ exports[`FillInTheBlank component projector view inactive renders 1`] = `
               }
             />
             <input
-              aria-label="Complete the sentence with one of the following options: the, a"
+              aria-label="Choose which one of the following options fits best in the blank : the, a."
               autoComplete="off"
               className="disabled"
               disabled={true}
@@ -236,7 +236,7 @@ exports[`FillInTheBlank component projector view inactive renders 1`] = `
             key="store.6"
           />
           <input
-            aria-label="Complete the sentence with one of the following options: the, a"
+            aria-label="Choose which one of the following options fits best in the blank : the, a."
             autoComplete="off"
             className="disabled"
             disabled={true}
@@ -540,7 +540,7 @@ exports[`FillInTheBlank component projector view when an answer is being display
               }
             />
             <input
-              aria-label="Complete the sentence with one of the following options: the, a"
+              aria-label="Choose which one of the following options fits best in the blank : the, a."
               autoComplete="off"
               className="disabled"
               disabled={true}
@@ -645,7 +645,7 @@ exports[`FillInTheBlank component projector view when an answer is being display
             key="store.6"
           />
           <input
-            aria-label="Complete the sentence with one of the following options: the, a"
+            aria-label="Choose which one of the following options fits best in the blank : the, a."
             autoComplete="off"
             className="disabled"
             disabled={true}
@@ -903,7 +903,7 @@ exports[`FillInTheBlank component student view inactive renders 1`] = `
               }
             />
             <input
-              aria-label="Complete the sentence with one of the following options: the, a"
+              aria-label="Choose which one of the following options fits best in the blank : the, a."
               autoComplete="off"
               className=""
               id="input0"
@@ -1007,7 +1007,7 @@ exports[`FillInTheBlank component student view inactive renders 1`] = `
             key="store.6"
           />
           <input
-            aria-label="Complete the sentence with one of the following options: the, a"
+            aria-label="Choose which one of the following options fits best in the blank : the, a."
             autoComplete="off"
             className=""
             id="input0"
@@ -1277,7 +1277,7 @@ exports[`FillInTheBlank component student view when an answer is being displayed
               }
             />
             <input
-              aria-label="Complete the sentence with one of the following options: the, a"
+              aria-label="Choose which one of the following options fits best in the blank : the, a."
               autoComplete="off"
               className=""
               id="input0"
@@ -1381,7 +1381,7 @@ exports[`FillInTheBlank component student view when an answer is being displayed
             key="store.6"
           />
           <input
-            aria-label="Complete the sentence with one of the following options: the, a"
+            aria-label="Choose which one of the following options fits best in the blank : the, a."
             autoComplete="off"
             className=""
             id="input0"
@@ -1645,7 +1645,7 @@ exports[`FillInTheBlank component student view when the student has submitted an
               }
             />
             <input
-              aria-label="Complete the sentence with one of the following options: the, a"
+              aria-label="Choose which one of the following options fits best in the blank : the, a."
               autoComplete="off"
               className=""
               id="input0"
@@ -1749,7 +1749,7 @@ exports[`FillInTheBlank component student view when the student has submitted an
             key="store.6"
           />
           <input
-            aria-label="Complete the sentence with one of the following options: the, a"
+            aria-label="Choose which one of the following options fits best in the blank : the, a."
             autoComplete="off"
             className=""
             id="input0"

--- a/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputLabel.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputLabel.tsx
@@ -1,8 +1,8 @@
 export const fillInBlankInputLabel = (cues, blankAllowed=false) => {
-  const blankAllowedText = blankAllowed ? ' or leave it blank' : ''
+  const blankAllowedText = blankAllowed ? ' or leave it empty' : ''
   if (!cues || !cues.length) {
-    return `Add words to complete the sentence${blankAllowedText}`
+    return `Add words to fill the blank${blankAllowedText}.`
   }
 
-  return `Complete the sentence with one of the following options${blankAllowedText}: ${cues.join(', ')}`
+  return `Choose which one of the following options fits best in the blank ${blankAllowedText}: ${cues.join(', ')}.`
 }


### PR DESCRIPTION
## WHAT
Add screenreader-only fill in the blank instructions.

## WHY
I resolved the bug with screenreaders from yesterday, but the student still felt confused about how to complete the question. Hopefully these additional instructions and the clarified labels will help mitigate that.

## HOW
Just copy change.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Accessibility-JAWS-does-not-read-entire-fill-in-the-blank-prompt-5c3af30e1b6e44b08c5c745074202860

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
