### PR TITLE
Add skipToPrompts=true to Evidence activities path only when viewed anonymously

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -320,6 +320,7 @@ class Activity < ApplicationRecord
     # Rename "student" to "session" because it's called "student" in all tools other than Evidence
     initial_params[:session] = initial_params.delete :student if initial_params[:student]
     initial_params[:uid] = Evidence::Activity.find_by(parent_activity_id: id).id
+    initial_params[:skipToPrompts] = true if initial_params[:anonymous]
     construct_redirect_url(base_url, initial_params)
   end
 

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -265,7 +265,7 @@ describe Activity, type: :model, redis: true do
         notes: 'Test Evidence Activity')
       expect(classified_activity).to receive(:evidence_url_helper).with({anonymous: true}).and_call_original
       result = classified_activity.anonymous_module_url
-      expect(result.to_s).to eq("#{classification.module_url}?anonymous=true&uid=#{comp_activity.id}")
+      expect(result.to_s).to eq("#{classification.module_url}?anonymous=true&skipToPrompts=true&uid=#{comp_activity.id}")
     end
   end
 


### PR DESCRIPTION
## WHAT
We want teachers to be able to skip the highlighting steps when they preview an activity, but we don't want students to be able to do so. 
This PR adds `skipToPrompts=true` to the Evidence activity path only when the activity is being viewed anonymously, which is something only teachers can do.

## WHY
To allow teachers to skip the highlighting parts of an Evidence activity while still requiring students to do them.

## HOW
Add `skipToPrompts=true` only when the path also has `anonymous=true` prepended.

### Screenshots
<img width="1354" alt="Screen Shot 2022-09-29 at 1 10 17 PM" src="https://user-images.githubusercontent.com/57366100/192944107-f14d6626-8650-4f7d-aad0-627372acb93f.png">


### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
