### PR TITLE
fix test for student profile data

### DIFF
--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -174,7 +174,8 @@ describe UnitActivity, type: :model, redis: true do
       end
 
       it 'does not include unit activities that have a publish date that has not yet passed' do
-        teacher.update(time_zone: nil)
+        # have to do update_columns here because time_zone is set by a callback
+        teacher.update_columns(time_zone: nil)
         unit_activity.update(publish_date: Time.now.utc + 1.hour)
         lessons_unit_activity.update(publish_date: Time.now.utc + 1.month)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
@@ -191,6 +192,8 @@ describe UnitActivity, type: :model, redis: true do
       end
 
       it 'leaves the publish date in utc if the teacher does not have a time zone' do
+        # have to do update_columns here because time_zone is set by a callback
+        teacher.update_columns(time_zone: nil)
         publish_date = Time.now.utc - 1.hour
         unit_activity.update(publish_date: publish_date)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)


### PR DESCRIPTION
## WHAT
Fix failing test by setting a teacher's timezone to nil without callbacks.

## WHY
Two branches that had passing tests separately caused one to break when they were merged (one was testing for a condition where a teacher had no time zone, while the other automatically set teachers' time zones).

## HOW
Just update how we're saving their timezone.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES - that's the PR
Have you deployed to Staging? | N/A
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
