### PR TITLE
directly access full response for geocoder rather than relying on timezone method and add api key

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -183,7 +183,7 @@ class User < ApplicationRecord
   before_validation :generate_student_username_if_absent
   before_validation :prep_authentication_terms
   before_save :capitalize_name
-  before_save :set_time_zone, unless: :time_zone
+  before_save :set_time_zone, unless: :time_zone, if: proc { teacher? }
   after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }
@@ -664,7 +664,7 @@ class User < ApplicationRecord
       self.time_zone = school_timezone
     else
       geocoder_results = Geocoder.search(ip_address)
-      self.time_zone = geocoder_results&.first&.timezone
+      self.time_zone = geocoder_results.first&.data ? geocoder_results.first.data['timezone'] : nil
     end
   end
 

--- a/services/QuillLMS/config/initializers/geocoder.rb
+++ b/services/QuillLMS/config/initializers/geocoder.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+  api_key: ENV.fetch('IPINFO_IO_KEY', '')               # API key for geocoding service
+)

--- a/services/QuillLMS/spec/support/geocoder.rb
+++ b/services/QuillLMS/spec/support/geocoder.rb
@@ -5,7 +5,7 @@ Geocoder.configure(lookup: :test, ip_lookup: :test)
 Geocoder::Lookup::Test.set_default_stub(
   [
     {
-      timezone: 'America/New_York'
+      data: { 'timezone' => 'America/New_York' }
     }
   ]
 )


### PR DESCRIPTION
…ezone method and add api key

* directly access full response for geocoder rather than relying on timezone method

* fix cyclomatic complexity issue

* add the geocoder initializer

* remove trailing comma

* remove empty line

* only set time zone for teachers

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
