### PR TITLE
lms/add-organization-diagnostics-to-vitally

### DIFF
--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -62,8 +62,9 @@ class District < ApplicationRecord
         zipcode: zipcode,
         phone: phone,
         total_students: total_students,
-        total_schools: total_schools
-      }.merge(vitally_diagnostic_rollups)
+        total_schools: total_schools,
+        **vitally_diagnostic_rollups
+      }
     }
   end
 

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -63,7 +63,57 @@ class District < ApplicationRecord
         phone: phone,
         total_students: total_students,
         total_schools: total_schools
-      }
+      }.merge(vitally_diagnostic_rollups)
     }
+  end
+
+  def vitally_diagnostic_rollups
+    school_year_start = School.school_year_start(Time.current)
+
+    diagnostics_assigned_this_year = diagnostics_assigned_between_count(school_year_start, school_year_start + 1.year)
+    diagnostics_assigned_last_year = diagnostics_assigned_between_count(school_year_start - 1.year, school_year_start)
+    diagnostics_completed_this_year = diagnostics_completed_between(school_year_start, school_year_start + 1.year)
+    diagnostics_completed_last_year = diagnostics_completed_between(school_year_start - 1.year, school_year_start)
+    percent_completed_this_year = diagnostics_assigned_this_year > 0 ? (1.0 * diagnostics_completed_this_year / diagnostics_assigned_this_year) : 0.0
+    percent_completed_last_year = diagnostics_assigned_last_year > 0 ? (1.0 * diagnostics_completed_last_year / diagnostics_assigned_last_year) : 0.0
+
+    {
+      diagnostics_assigned_this_year: diagnostics_assigned_this_year,
+      diagnostics_assigned_last_year: diagnostics_assigned_last_year,
+      diagnostics_completed_this_year: diagnostics_completed_this_year,
+      diagnostics_completed_last_year: diagnostics_completed_last_year,
+      percent_diagnostics_completed_this_year: percent_completed_this_year,
+      percent_diagnostics_completed_last_year: percent_completed_last_year
+    }
+  end
+
+  def diagnostics_assigned_between_count(start, stop)
+    schools.select("array_length(classroom_units.assigned_student_ids, 1) AS assigned_students")
+      .joins(users: {
+      classrooms_i_teach: {
+        classroom_units: {
+          unit_activities: {
+           activity: :classification
+          }
+        }
+      }
+    }).where(classification: {key: ActivityClassification::DIAGNOSTIC_KEY})
+      .where(classroom_units: {created_at: start..stop})
+      .map(&:assigned_students).reject(&:blank?).sum
+  end
+
+  def diagnostics_completed_between(start, stop)
+    schools.joins(users: {
+      classrooms_i_teach: {
+        classroom_units: {
+          activity_sessions: {
+            activity: :classification
+          }
+        }
+      }
+    }).where(classification: {key: ActivityClassification::DIAGNOSTIC_KEY})
+      .where(activity_sessions: {completed_at: start..stop})
+      .distinct
+      .count
   end
 end

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -105,7 +105,7 @@ describe District, type: :model do
       end
 
       it 'should roll up diagnostic data when diagnostics are assigned last year' do
-        classroom_unit.update(created_at: Time.current - 1.year)
+        classroom_unit.update(created_at: 1.year.ago)
 
         expect(district.vitally_data[:traits]).to include(
           diagnostics_assigned_this_year: 0,
@@ -148,7 +148,7 @@ describe District, type: :model do
       end
 
       it 'should roll up diagnostic completions from last year' do
-        activity_session1.update(completed_at: Time.current - 1.year)
+        activity_session1.update(completed_at: 1.year.ago)
 
         expect(district.vitally_data[:traits]).to include(
           diagnostics_completed_this_year: 0,
@@ -197,13 +197,13 @@ describe District, type: :model do
         create(:activity_session, activity: diagnostic, classroom_unit: classroom_unit1, user: student1, completed_at: Time.current)
 
         expect(district.vitally_data[:traits]).to include(
-	  percent_diagnostics_completed_this_year: 0.5
+          percent_diagnostics_completed_this_year: 0.5
         )
       end
 
       it 'should set the completion rate to 0.0 if no activities were assigned' do
         expect(district.vitally_data[:traits]).to include(
-	  percent_diagnostics_completed_this_year: 0.0
+          percent_diagnostics_completed_this_year: 0.0
         )
       end
     end

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -59,9 +59,17 @@ describe District, type: :model do
   end
 
   context '#vitally_data' do
-    let!(:district) { create(:district)}
+    let!(:district) { create(:district) }
+    let!(:school1) { create(:school, district: district) }
+    let!(:teacher1) { create(:teacher, school: school1) }
+    let!(:classroom1) { create(:classroom) }
+    let!(:classroom_teacher1) { create(:classrooms_teacher, user: teacher1, classroom: classroom1) }
+    let!(:student1) { create(:student, student_in_classroom: [classroom1]) }
+    let!(:student2) { create(:student, student_in_classroom: [classroom1]) }
+    let!(:diagnostic) { create(:diagnostic_activity) }
+    let!(:unit) { create(:unit, activities: [diagnostic]) }
 
-    it 'should return vitally payload with correct data' do
+    it 'should return vitally payload with correct data when no diagnostics have been assigned' do
       expect(district.vitally_data).to eq({
         externalId: district.id.to_s,
         name: district.name,
@@ -74,9 +82,130 @@ describe District, type: :model do
           zipcode: district.zipcode,
           phone: district.phone,
           total_students: district.total_students,
-          total_schools: district.total_schools
+          total_schools: district.total_schools,
+          diagnostics_assigned_this_year: 0,
+          diagnostics_assigned_last_year: 0,
+          diagnostics_completed_this_year: 0,
+          diagnostics_completed_last_year: 0,
+          percent_diagnostics_completed_this_year: 0,
+          percent_diagnostics_completed_last_year: 0
         }
       })
+    end
+
+    context 'diagnostic assignment rollups' do
+      let!(:classroom_unit) { create(:classroom_unit, classroom: classroom1, unit: unit, assigned_student_ids: [student1.id, student2.id]) }
+
+      it 'should roll up diagnostic data when diagnostics are assigned, but not completed' do
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_assigned_this_year: 2,
+          diagnostics_completed_this_year: 0,
+          diagnostics_assigned_last_year: 0
+        )
+      end
+
+      it 'should roll up diagnostic data when diagnostics are assigned last year' do
+        classroom_unit.update(created_at: Time.current - 1.year)
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_assigned_this_year: 0,
+          diagnostics_assigned_last_year: 2
+        )
+      end
+
+      it 'should roll up diagnostic data across multiple classrooms' do
+        school2 = create(:school, district: district)
+        teacher2 = create(:teacher, school: school2)
+        classroom2 = create(:classroom)
+        create(:classrooms_teacher, user: teacher2, classroom: classroom2)
+        student3 = create(:student)
+        create(:classroom_unit, classroom: classroom2, unit: unit, assigned_student_ids: [student2.id, student3.id])
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_assigned_this_year: 4
+        )
+      end
+
+      it 'should ignore assigned activities that are not diagnostics' do
+        classification = create(:connect)
+        diagnostic.update(classification: classification)
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_assigned_last_year: 0
+        )
+      end
+    end
+
+    context 'diagnostic completion rollups' do
+      let!(:classroom_unit) { create(:classroom_unit, classroom: classroom1, unit: unit, assigned_student_ids: [student1.id, student2.id]) }
+      let!(:activity_session1) { create(:activity_session, activity: diagnostic, classroom_unit: classroom_unit, user: student1, completed_at: Time.current) }
+
+      it 'should roll up diagnostic completions this year' do
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_completed_this_year: 1,
+          diagnostics_completed_last_year: 0
+        )
+      end
+
+      it 'should roll up diagnostic completions from last year' do
+        activity_session1.update(completed_at: Time.current - 1.year)
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_completed_this_year: 0,
+          diagnostics_completed_last_year: 1
+        )
+      end
+
+      it 'should not count activity_session records that are not completed' do
+        activity_session1.update(completed_at: nil, state: 'started')
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_completed_this_year: 0
+        )
+      end
+
+      it 'should roll up data across multiple schools' do
+        school2 = create(:school, district: district)
+        teacher2 = create(:teacher, school: school2)
+        classroom2 = create(:classroom)
+        student3 = create(:student)
+        create(:classrooms_teacher, user: teacher2, classroom: classroom2)
+        classroom_unit2 = create(:classroom_unit, classroom: classroom2, unit: unit, assigned_student_ids: [student2.id, student3.id])
+
+        create(:activity_session, activity: diagnostic, classroom_unit: classroom_unit2, user: student2, completed_at: Time.current)
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_completed_this_year: 2
+        )
+      end
+
+      it 'should not count activity_sessions for non-diagnostic activities' do
+        classification = create(:connect)
+        diagnostic.update(classification: classification)
+
+        expect(district.vitally_data[:traits]).to include(
+          diagnostics_completed_this_year: 0
+        )
+      end
+    end
+
+    context 'diagnostic completion percentage rollups' do
+
+      it 'should calculate completion percentages' do
+        student2 = create(:student, student_in_classroom: [classroom1])
+        classroom_unit1 = create(:classroom_unit, classroom: classroom1, unit: unit, assigned_student_ids: [student1.id, student2.id])
+        create(:activity_session, activity: diagnostic, classroom_unit: classroom_unit1, user: student1, completed_at: Time.current)
+
+        expect(district.vitally_data[:traits]).to include(
+	  percent_diagnostics_completed_this_year: 0.5
+        )
+      end
+
+      it 'should set the completion rate to 0.0 if no activities were assigned' do
+        expect(district.vitally_data[:traits]).to include(
+	  percent_diagnostics_completed_this_year: 0.0
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add diagnostic roll-up stats to Vitally payloads for districts
## WHY
Partnerships wants to be able to generate reports about this data directly from Vitally instead of having to use Metabase and copying that data into emails.
## HOW
Write some functions to do the roll-up calculations and add those to the `vitally_data` function on the `District` model

### Notion Card Links
https://www.notion.so/quill/PS-Add-diagnostic-assignment-traits-to-accounts-in-Vitally-953745c1d1a74996b108e54a9e75f235

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A