### PR TITLE
Demo Reset - Fix Race Condition

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -8,7 +8,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   respond_to :json, :html
 
-  around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner, :view_demo]
+  around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner]
 
   before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
   # WARNING: these filter methods check against classroom_id, not id.

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -236,8 +236,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     demo = User.find_by_email(Demo::ReportDemoCreator::EMAIL)
     return render json: {errors: "Demo Account does not exist"}, status: 422 if demo.nil?
 
-    # perform this inline to ensure account is in good shape on entry
-    Demo::ReportDemoCreator.reset_account(demo)
+    Demo::ResetAccountWorker.perform_async(demo.id)
 
     self.current_user_demo_id = demo.id
     redirect_to '/profile'

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -520,7 +520,7 @@ class ActivitySession < ApplicationRecord
       begin
         raise 'Student was not assigned this activity'
       rescue => e
-        NewRelic::Agent.notice_error(e)
+        ErrorNotifier.report(e)
         errors.add(:incorrectly_assigned, "student was not assigned this activity")
       end
     else

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -271,6 +271,7 @@ module Demo::ReportDemoCreator
       create_demo_classroom_data(teacher, teacher_demo: teacher_demo)
     end
   rescue ActiveRecord::RecordInvalid
+    # ignore invalid records
   end
 
   def self.create_demo_classroom_data(teacher, teacher_demo: false)
@@ -315,6 +316,7 @@ module Demo::ReportDemoCreator
       end
     end
   rescue ActiveRecord::RecordInvalid
+    # ignore invalid records
   end
 
   def self.demo_classroom_modified?(teacher)

--- a/services/QuillLMS/app/workers/demo/reset_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/reset_account_worker.rb
@@ -6,10 +6,8 @@ class Demo::ResetAccountWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(teacher_id)
-    teacher = User.find_by(id: teacher_id, role: User::TEACHER)
+    return if teacher_id.nil?
 
-    return unless teacher
-
-    Demo::ReportDemoCreator.reset_account(teacher)
+    Demo::ReportDemoCreator.reset_account(teacher_id)
   end
 end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -674,14 +674,14 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will call current_user_demo_id= if the demo account exists' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
+     expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       expect(controller).to receive(:current_user_demo_id=).with(demo_teacher.id)
 
       get :view_demo
     end
 
     it 'will redirect to the profile path' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
 
       get :view_demo
       expect(response).to redirect_to profile_path
@@ -689,7 +689,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will not call current_user_demo_id= and raise error if demo account does not exist' do
       demo_teacher.destroy
-      expect(Demo::ReportDemoCreator).to_not receive(:reset_account)
+      expect(Demo::ResetAccountWorker).to_not receive(:perform_async)
       expect(controller).not_to receive(:current_user_demo_id=)
 
       get :view_demo
@@ -697,7 +697,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will track event' do
-      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_DEMO)
 
       get :view_demo

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -674,7 +674,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will call current_user_demo_id= if the demo account exists' do
-     expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       expect(controller).to receive(:current_user_demo_id=).with(demo_teacher.id)
 
       get :view_demo

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -674,12 +674,14 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will call current_user_demo_id= if the demo account exists' do
+      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
       expect(controller).to receive(:current_user_demo_id=).with(demo_teacher.id)
 
       get :view_demo
     end
 
     it 'will redirect to the profile path' do
+      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
 
       get :view_demo
       expect(response).to redirect_to profile_path
@@ -687,6 +689,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will not call current_user_demo_id= and raise error if demo account does not exist' do
       demo_teacher.destroy
+      expect(Demo::ReportDemoCreator).to_not receive(:reset_account)
       expect(controller).not_to receive(:current_user_demo_id=)
 
       get :view_demo
@@ -694,6 +697,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will track event' do
+      expect(Demo::ReportDemoCreator).to receive(:reset_account).with(demo_teacher)
       expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_DEMO)
 
       get :view_demo
@@ -723,6 +727,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will redirect to the redirect param if it exists' do
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       redirect = '/teachers/classes'
 
       get :unset_view_demo, params: { redirect: redirect }, session: {demo_id: demo_teacher.id}
@@ -730,12 +735,14 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will redirect to the profile path if there is no redirect param' do
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
 
       get :unset_view_demo, session: {demo_id: demo_teacher.id}
       expect(response).to redirect_to profile_path
     end
 
     it 'will call current_user_demo_id=' do
+      expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
       expect(controller).to receive(:current_user_demo_id=).with(nil)
 
       get :unset_view_demo, session: {demo_id: demo_teacher.id}

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -198,19 +198,18 @@ RSpec.describe Demo::ReportDemoCreator do
     describe "#reset_account" do
       before do
         stub_const("Demo::ReportDemoCreator::UNITS_COUNT", 1)
-        stub_const("Demo::ReportDemoCreator::SESSIONS_COUNT", 6)
 
         Demo::ReportDemoCreator.create_demo_classroom_data(teacher, teacher_demo: true)
       end
 
-      subject { Demo::ReportDemoCreator.reset_account(teacher) }
+      subject { Demo::ReportDemoCreator.reset_account(teacher.id) }
 
       context "untouched demo account" do
-        it { expect{ subject }.to_not change(teacher, :google_id).from(nil) }
-        it { expect{ subject }.to_not change(teacher, :clever_id).from(nil) }
+        it { expect{ subject }.to_not change{teacher.reload.google_id}.from(nil) }
+        it { expect{ subject }.to_not change{teacher.reload.clever_id}.from(nil) }
         it { expect{ subject }.to_not change{teacher.classrooms_i_teach.count}.from(1) }
         it { expect{ subject }.to_not change{teacher.classrooms_i_teach.map(&:id)} }
-        it { expect{ subject }.to_not change(teacher, :auth_credential).from(nil) }
+        it { expect{ subject }.to_not change{teacher.reload.auth_credential}.from(nil) }
       end
 
       context "teacher account has added data" do
@@ -219,11 +218,11 @@ RSpec.describe Demo::ReportDemoCreator do
         let(:classroom) {create(:classroom)}
         let!(:classrooms_teacher) {create(:classrooms_teacher, classroom: classroom, user: teacher)}
 
-        it { expect{ subject }.to change(teacher, :google_id).from("1234").to(nil) }
-        it { expect{ subject }.to change(teacher, :clever_id).from("5678").to(nil) }
-        it { expect{ subject }.to change {teacher.classrooms_i_teach.count}.from(2).to(1) }
+        it { expect{ subject }.to change{teacher.reload.google_id}.from("1234").to(nil) }
+        it { expect{ subject }.to change{teacher.reload.clever_id}.from("5678").to(nil) }
+        it { expect{ subject }.to change {teacher.reload.classrooms_i_teach.count}.from(2).to(1) }
         it { expect{ subject }.to change(AuthCredential, :count).from(1).to(0) }
-        it { expect{ subject }.to_not change{Demo::ReportDemoCreator.demo_classroom(teacher).id} }
+        it { expect{ subject }.to_not change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
       end
 
       context "demo classroom changed" do
@@ -232,7 +231,7 @@ RSpec.describe Demo::ReportDemoCreator do
           demo_classroom.update(name: "my classroom name")
         end
 
-        it { expect{ subject }.to change{Demo::ReportDemoCreator.demo_classroom(teacher).id} }
+        it { expect{ subject }.to change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
       end
     end
   end

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -232,6 +232,14 @@ RSpec.describe Demo::ReportDemoCreator do
         end
 
         it { expect{ subject }.to change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
+
+        it "should not raise an error with two occurences running at once" do
+          threads = Array.new(2) do
+            Thread.new { subject }.tap {|thread| thread.report_on_exception = false}
+          end
+
+          expect{threads.map(&:join)}.to_not raise_error
+        end
       end
     end
   end

--- a/services/QuillLMS/spec/workers/demo/reset_account_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/demo/reset_account_worker_spec.rb
@@ -4,22 +4,21 @@ require 'rails_helper'
 
 describe Demo::ResetAccountWorker, type: :worker do
   let(:worker) { described_class.new }
-  let(:teacher) { create(:teacher) }
 
   describe "#perform" do
     context 'no teacher found' do
       it "should NOT call reset_account" do
         expect(Demo::ReportDemoCreator).to_not receive(:reset_account)
 
-        worker.perform(1234)
+        worker.perform(nil)
       end
     end
 
     context 'teacher found' do
       it "should call reset_account" do
-        expect(Demo::ReportDemoCreator).to receive(:reset_account).with(teacher).once
+        expect(Demo::ReportDemoCreator).to receive(:reset_account).with(1234).once
 
-        worker.perform(teacher.id)
+        worker.perform(1234)
       end
     end
   end


### PR DESCRIPTION
## WHAT
The Demo `reset_account` method deletes a `classroom` and recreates it. There is a race condition in which the demo reset gets in a conflicting state when it's triggered again before finishing, i.e. the `classroom` being populated with data gets deleted. This causes `activity_sessions` being created to fail (`null` id) because the `student` is no longer in the `classroom_unit`. This validation on [activity_session](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/activity_session.rb#L518-L529) is the error being thrown..

This PR wraps the `reset_account` and `create_demo` methods transactions to prevent the data from changing while it's being created.

Also, I moved the call to reset_account to a worker for all calls for now, just in case there are other issues (they won't be user facing).

## WHY
We don't want users to get an error while going to the demo account, and we don't want to leave the demo in a weird state.

Given that `reset_account` takes 10 seconds+ or so to run, this race condition is easy to trigger using two rails consoles (I don't have a great way to write a test for it though).
## HOW
Wrap the methods in transactions to ensure only one set is committed, and use the ActiveRecord method calls that raise errors, e.g. `create!`, and rescue `ActiveRecord::RecordInvalid` so it halts execution at that point and does not re-run. 

### Screenshots
**Activity Session Error**
<img width="904" alt="Screen Shot 2022-09-29 at 5 10 54 PM" src="https://user-images.githubusercontent.com/1304933/193146124-52bb9f2c-6a94-4591-b30a-5b17da5f0ccf.png">
**Code triggering it**
<img width="948" alt="Screen Shot 2022-09-29 at 5 34 29 PM" src="https://user-images.githubusercontent.com/1304933/193146483-8c14c23f-ae88-4263-bf66-9fc51d022450.png">
**Subsequent Errored job with a null activity session**
<img width="951" alt="Screen Shot 2022-09-29 at 5 35 22 PM" src="https://user-images.githubusercontent.com/1304933/193146570-da27a7a6-c9a3-4ce3-9f2b-d570268f8f95.png">



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
