### PR TITLE
lms/normalize-evidence-responses-for-feedback

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -23,9 +23,9 @@ module Evidence
     }
 
     def self.get_feedback(entry, prompt, previous_feedback, feedback_types=nil)
-      entry = normalize_entry_text(entry)
+      normalized_entry = StringNormalizer.new(entry).run
 
-      triggered_check = find_triggered_check(entry, prompt, previous_feedback, feedback_types)
+      triggered_check = find_triggered_check(normalized_entry, prompt, previous_feedback, feedback_types)
 
       triggered_check || fallback_feedback
     end
@@ -79,17 +79,6 @@ module Evidence
       raise NoMatchedFeedbackTypesError, "None of the specified feedback_types (#{feedback_types}) were valid." if filtered_checks.empty?
 
       filtered_checks
-    end
-
-    def self.normalize_entry_text(entry)
-      # The first three replacements are duplicates of the normalization
-      # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
-      entry.gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
-        .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
-        .gsub(/[\u02CC\u201A\uFF0C]/, ',')
-        .gsub(/\u2013/, "–") # You may not be able to tell, but this is an endash
-        .gsub(/\u2014/, "—") # You may not be able to tell, but this is an emdash
-        .gsub(/\u2026/, "...")
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -83,7 +83,7 @@ module Evidence
 
     def self.normalize_entry_text(entry)
         # You may not be able to tell, but this is an endash
-      entry.gsub("\u2013", "–")
+      entry.gsub(/[\u2013]/, "–")
         # You may not be able to tell, but this is an emdash
         .gsub(/[\u2014]/, "—")
         .gsub(/[\u2026]/, "...")

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -82,16 +82,14 @@ module Evidence
     end
 
     def self.normalize_entry_text(entry)
-        # You may not be able to tell, but this is an endash
-      entry.gsub(/[\u2013]/, "–")
-        # You may not be able to tell, but this is an emdash
-        .gsub(/[\u2014]/, "—")
-        .gsub(/[\u2026]/, "...")
-        # The following three replacements are duplicates of the normalization
+        # The first three replacements are duplicates of the normalization
         # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
-        .gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
+      entry.gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
         .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
         .gsub(/[\u02CC\u201A\uFF0C]/, ',')
+        .gsub(/[\u2013]/, "–") # You may not be able to tell, but this is an endash
+        .gsub(/[\u2014]/, "—") # You may not be able to tell, but this is an emdash
+        .gsub(/[\u2026]/, "...")
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -23,6 +23,8 @@ module Evidence
     }
 
     def self.get_feedback(entry, prompt, previous_feedback, feedback_types=nil)
+      entry = normalize_entry_text(entry)
+
       triggered_check = find_triggered_check(entry, prompt, previous_feedback, feedback_types)
 
       triggered_check || fallback_feedback
@@ -77,6 +79,19 @@ module Evidence
       raise NoMatchedFeedbackTypesError, "None of the specified feedback_types (#{feedback_types}) were valid." if filtered_checks.empty?
 
       filtered_checks
+    end
+
+    def self.normalize_entry_text(entry)
+        # You may not be able to tell, but this is an endash
+      entry.gsub("\u2013", "–")
+        # You may not be able to tell, but this is an emdash
+        .gsub(/[\u2014]/, "—")
+        .gsub(/[\u2026]/, "...")
+        # The following three replacements are duplicates of the normalization
+        # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
+        .gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
+        .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
+        .gsub(/[\u02CC\u201A\uFF0C]/, ',')
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -87,9 +87,9 @@ module Evidence
       entry.gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
         .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
         .gsub(/[\u02CC\u201A\uFF0C]/, ',')
-        .gsub(/[\u2013]/, "–") # You may not be able to tell, but this is an endash
-        .gsub(/[\u2014]/, "—") # You may not be able to tell, but this is an emdash
-        .gsub(/[\u2026]/, "...")
+        .gsub(/\u2013/, "–") # You may not be able to tell, but this is an endash
+        .gsub(/\u2014/, "—") # You may not be able to tell, but this is an emdash
+        .gsub(/\u2026/, "...")
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check.rb
@@ -82,8 +82,8 @@ module Evidence
     end
 
     def self.normalize_entry_text(entry)
-        # The first three replacements are duplicates of the normalization
-        # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
+      # The first three replacements are duplicates of the normalization
+      # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
       entry.gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
         .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
         .gsub(/[\u02CC\u201A\uFF0C]/, ',')

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/string_normalizer.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/string_normalizer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Evidence
+  class StringNormalizer < ApplicationService
+    EMDASH = "—" # You may not be able to tell, but this is an emdash
+    ENDASH = "–" # You may not be able to tell, but this is an endash
+    HTML_TAG_REGEX = /<("[^"]*"|'[^']*'|[^'">])*>/
+    SPACE = " "
+
+    attr_reader :input
+
+    def initialize(input)
+      @input = input
+    end
+
+    def run
+      # The first three replacements are duplicates of the normalization
+      # we do in the Connect front-end: https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts
+      input.gsub(/[\u2018\u2019\u0301\u02BB\u02C8\u00B4\u0060]/, "'")
+        .gsub(/[\u201C\u201D\u02DD\u0308]/, '"')
+        .gsub(/[\u02CC\u201A\uFF0C]/, ',')
+        .gsub(/\u2013/, ENDASH)
+        .gsub(/\u2014/, EMDASH)
+        .gsub(/\u2026/, "...")
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -28,6 +28,17 @@ module Evidence
 
         expect(feedback).to eq(Check.fallback_feedback)
       end
+
+      it "should normalize the entry text before trying to get feedback" do
+        normalized_entry = "#{entry} with special characters replaced"
+        normalizer_double = double
+        expect(StringNormalizer).to receive(:new).with(entry).and_return(normalizer_double)
+        expect(normalizer_double).to receive(:run).and_return(normalized_entry)
+
+        expect(Check).to receive(:find_triggered_check).with(normalized_entry, prompt, previous_feedback, nil)
+
+        Check.get_feedback(entry, prompt, previous_feedback)
+      end
     end
 
     context "find_triggered_check" do
@@ -189,65 +200,6 @@ module Evidence
         expect do
           Check.checks_to_run(['NotARealCheck'])
         end.to raise_error(Check::NoMatchedFeedbackTypesError)
-      end
-    end
-
-    context 'normalize_entry_text' do
-      it 'should replace multiple instances of the same character' do
-        left_single_smart_quote = "\u2018"
-        expect(Check.normalize_entry_text(left_single_smart_quote * 3)).to eq("'''")
-      end
-
-      it 'should normalize single quotes' do
-        [
-          accute_accent = "\u00B4",
-          grave_accent = "\u0060",
-          left_single_quotation_mark = "\u2018",
-          right_single_quotation_mark = "\u2019",
-          combining_accute_accent = "\u0301",
-          modifier_letter_turned_comma = "\u02BB",
-          modifier_letter_vertical_line = "\u02C8"
-        ].each do |character|
-          expect(Check.normalize_entry_text(character)).to eq("'")
-        end
-      end
-
-      it 'should normalize double quotes' do
-        [
-          left_double_quotation_mark = "\u201C",
-          right_double_quotation_mark = "\u201D",
-          double_acute_accent = "\u02DD",
-          combining_diaeresis = "\u0308"
-        ].each do |character|
-          expect(Check.normalize_entry_text(character)).to eq('"')
-        end
-      end
-
-      it 'should normalize "commas"' do
-        [
-          modifier_letter_low_vertical_line = "\u02CC",
-          single_low9_quotation_mark = "\u201A",
-          fullwidth_comma = "\uFF0C"
-        ].each do |character|
-          expect(Check.normalize_entry_text(character)).to eq(',')
-        end
-      end
-
-      it 'should normalize the single elipsis character' do
-        ellipsis = "\u2026"
-        expect(Check.normalize_entry_text(ellipsis)).to eq("...")
-      end
-
-      it 'should normalize utf-8 emdash to ASCII mdash' do
-        emdash = "\u2014"
-        # This may not be visible on your screen, but the value in the eq is an ANSI emdash
-        expect(Check.normalize_entry_text(emdash)).to eq("—")
-      end
-
-      it 'should normalize utf-8 endash to ASCII ndash' do
-        endash = "\u2013"
-        # This may not be visible on your screen, but the value in the eq is an ANSI endash
-        expect(Check.normalize_entry_text(endash)).to eq("–")
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -217,7 +217,7 @@ module Evidence
           left_double_quotation_mark = "\u201C",
           right_double_quotation_mark = "\u201D",
           double_acute_accent = "\u02DD",
-          combining_diaeresis = "\u0308",
+          combining_diaeresis = "\u0308"
         ].each do |character|
           expect(Check.normalize_entry_text(character)).to eq('"')
         end

--- a/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check_spec.rb
@@ -191,5 +191,64 @@ module Evidence
         end.to raise_error(Check::NoMatchedFeedbackTypesError)
       end
     end
+
+    context 'normalize_entry_text' do
+      it 'should replace multiple instances of the same character' do
+        left_single_smart_quote = "\u2018"
+        expect(Check.normalize_entry_text(left_single_smart_quote * 3)).to eq("'''")
+      end
+
+      it 'should normalize single quotes' do
+        [
+          accute_accent = "\u00B4",
+          grave_accent = "\u0060",
+          left_single_quotation_mark = "\u2018",
+          right_single_quotation_mark = "\u2019",
+          combining_accute_accent = "\u0301",
+          modifier_letter_turned_comma = "\u02BB",
+          modifier_letter_vertical_line = "\u02C8"
+        ].each do |character|
+          expect(Check.normalize_entry_text(character)).to eq("'")
+        end
+      end
+
+      it 'should normalize double quotes' do
+        [
+          left_double_quotation_mark = "\u201C",
+          right_double_quotation_mark = "\u201D",
+          double_acute_accent = "\u02DD",
+          combining_diaeresis = "\u0308",
+        ].each do |character|
+          expect(Check.normalize_entry_text(character)).to eq('"')
+        end
+      end
+
+      it 'should normalize "commas"' do
+        [
+          modifier_letter_low_vertical_line = "\u02CC",
+          single_low9_quotation_mark = "\u201A",
+          fullwidth_comma = "\uFF0C"
+        ].each do |character|
+          expect(Check.normalize_entry_text(character)).to eq(',')
+        end
+      end
+
+      it 'should normalize the single elipsis character' do
+        ellipsis = "\u2026"
+        expect(Check.normalize_entry_text(ellipsis)).to eq("...")
+      end
+
+      it 'should normalize utf-8 emdash to ASCII mdash' do
+        emdash = "\u2014"
+        # This may not be visible on your screen, but the value in the eq is an ANSI emdash
+        expect(Check.normalize_entry_text(emdash)).to eq("—")
+      end
+
+      it 'should normalize utf-8 endash to ASCII ndash' do
+        endash = "\u2013"
+        # This may not be visible on your screen, but the value in the eq is an ANSI endash
+        expect(Check.normalize_entry_text(endash)).to eq("–")
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/string_normalizer_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/string_normalizer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(HTMLTagRemover, type: :module) do
+    context '#run' do
+      it 'should replace all expected characters (not just UTF codes)' do
+        # Note that \u0301 and \u0308 don't render in Terminal.
+        # I'd be tempted to remove it from our list of characters, but they're
+        # explicitly used on the front-end, so I want to remain consistent
+        all_target_characters = '´`‘’ʻˈ“”˝ˌ‚，…—–'
+        conversion_target = "''''''\"\"\",,,...—–"
+        expect(StringNormalizer.new(all_target_characters).run).to eq(conversion_target)
+      end
+
+      it 'should replace multiple instances of the same character' do
+        left_single_smart_quote = "\u2018"
+        expect(StringNormalizer.new(left_single_smart_quote * 3).run).to eq("'''")
+      end
+
+      it 'should normalize single quotes' do
+        [
+          accute_accent = "\u00B4",
+          grave_accent = "\u0060",
+          left_single_quotation_mark = "\u2018",
+          right_single_quotation_mark = "\u2019",
+          combining_accute_accent = "\u0301",
+          modifier_letter_turned_comma = "\u02BB",
+          modifier_letter_vertical_line = "\u02C8"
+        ].each do |character|
+          expect(StringNormalizer.new(character).run).to eq("'")
+        end
+      end
+
+      it 'should normalize double quotes' do
+        [
+          left_double_quotation_mark = "\u201C",
+          right_double_quotation_mark = "\u201D",
+          double_acute_accent = "\u02DD",
+          combining_diaeresis = "\u0308"
+        ].each do |character|
+          expect(StringNormalizer.new(character).run).to eq('"')
+        end
+      end
+
+      it 'should normalize "commas"' do
+        [
+          modifier_letter_low_vertical_line = "\u02CC",
+          single_low9_quotation_mark = "\u201A",
+          fullwidth_comma = "\uFF0C"
+        ].each do |character|
+          expect(StringNormalizer.new(character).run).to eq(',')
+        end
+      end
+
+      it 'should normalize the single elipsis character' do
+        ellipsis = "\u2026"
+        expect(StringNormalizer.new(ellipsis).run).to eq("...")
+      end
+
+      it 'should normalize utf-8 emdash to ASCII mdash' do
+        emdash = "\u2014"
+        # This may not be visible on your screen, but the value in the eq is an ANSI emdash
+        expect(StringNormalizer.new(emdash).run).to eq("—")
+      end
+
+      it 'should normalize utf-8 endash to ASCII ndash' do
+        endash = "\u2013"
+        # This may not be visible on your screen, but the value in the eq is an ANSI endash
+        expect(StringNormalizer.new(endash).run).to eq("–")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a string-normalization step before sending entries for feedback
## WHY
We want to make sure that we process out any special characters (like "smart" quotes) that might make it into a student's response before we send the response to our various algorithms for feedback.  This lets us avoid the work of making each of our algorithms special-character tolerant separately.
## HOW
- Copy the replacement logic we use in the front-end string normalizer (https://github.com/empirical-org/quill-string-normalizer/blob/master/src/main.ts)
- Add some additional normalization from the spec in Notion

### Notion Card Links
https://www.notion.so/quill/Normalize-common-UTF-8-characters-in-Evidence-student-responses-063b5c5c29214e9991252dd438fd5c3d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
