### PR TITLE
Bug fix for invitations controller.

### DIFF
--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -59,14 +59,14 @@ class InvitationsController < ApplicationController
   end
 
   private def validate_email_format
-    return if @invitee_email =~ /.+@.+\..+/i
+    return if @invitee_email =~ User::VALID_EMAIL_REGEX
 
     raise StandardError, "Please make sure you've entered a valid email."
   end
 
   private def set_classroom_ids_and_inviteee_email
     @classroom_ids = params[:classroom_ids]
-    @invitee_email = params[:invitee_email]
+    @invitee_email = params[:invitee_email].gsub(/\s/, '') #strip whitespace
   end
 
 

--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -66,7 +66,7 @@ class InvitationsController < ApplicationController
 
   private def set_classroom_ids_and_inviteee_email
     @classroom_ids = params[:classroom_ids]
-    @invitee_email = params[:invitee_email]&.gsub(/\s/, '') #strip whitespace
+    @invitee_email = params[:invitee_email]&.gsub(/\s/, '') # strip whitespace
   end
 
 

--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -66,7 +66,7 @@ class InvitationsController < ApplicationController
 
   private def set_classroom_ids_and_inviteee_email
     @classroom_ids = params[:classroom_ids]
-    @invitee_email = params[:invitee_email].gsub(/\s/, '') #strip whitespace
+    @invitee_email = params[:invitee_email]&.gsub(/\s/, '') #strip whitespace
   end
 
 

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -42,6 +42,11 @@ describe InvitationsController, type: :controller do
       expect(response.body).to eq({error: "Please make sure you've entered a valid email and selected at least one classroom."}.to_json)
     end
 
+    it 'should give error for a nil email' do
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id] }
+      expect(response.body).to eq({error: "Please make sure you've entered a valid email and selected at least one classroom."}.to_json)
+    end
+
     it 'should give error for empty classroom ids' do
       post :create_coteacher_invitation,
         params: {

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -32,6 +32,11 @@ describe InvitationsController, type: :controller do
       expect(response.body).to eq({error: "Please make sure you've entered a valid email."}.to_json)
     end
 
+    it 'should give error when multiple emails entered' do
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "email@one.com email@two.com" }
+      expect(response.body).to eq({error: "Please make sure you've entered a valid email."}.to_json)
+    end
+
     it 'should give error for empty email' do
       post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "" }
       expect(response.body).to eq({error: "Please make sure you've entered a valid email and selected at least one classroom."}.to_json)
@@ -72,6 +77,17 @@ describe InvitationsController, type: :controller do
       expect(Invitation.last.inviter).to eq user
       expect(Invitation.last.invitee_email).to eq "test@test.com"
       expect(Invitation.last.invitation_type).to eq Invitation::TYPES[:coteacher]
+    end
+
+    it 'should correct an email with spaces' do
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@test .com" }
+
+      invite = Invitation.last
+
+      expect(response.body).to eq ({invite_id: invite.id}.to_json)
+      expect(invite.inviter).to eq user
+      expect(invite.invitee_email).to eq "test@test.com"
+      expect(invite.invitation_type).to eq Invitation::TYPES[:coteacher]
     end
   end
 


### PR DESCRIPTION
## WHAT
Fixing two validation bug in the invitations controller that I'm seeing show up a lot in our dead sidekiq jobs for unsendable emails:
1. Emails with spaces (fix these)
2. Two emails entered at once (return an error, so the user fixes it).

We could try to parse the second one into `n` number of emails, but that's a larger refactor (I'm making a card to explore it), so we should least give the user a chance to fix it (and not have it fail silently).
## WHY
Invites are important to our growth. These fail silently on send.
## HOW
Add failing tests, fix them. Strip whitespace and use a different regex validator (`User::VALID_EMAIL_REGEX`).
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
