### PR TITLE
Bump LMS test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lms_rails_build:
     working_directory: ~/Empirical-Core
-    parallelism: 4
+    parallelism: 6
     docker:
       - image: cimg/ruby:2.7.6
         environment:


### PR DESCRIPTION
## WHAT
Bump the LMS test parallelism by 50% (`4` -> `6`)
## WHY
We've added a lot of tests and the suite is getting slower.
## HOW
Hacked the yml file.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
