### PR TITLE
sync flagset trait to vitally

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -46,6 +46,7 @@ class SerializeVitallySalesUser
         auditor: @user.auditor?,
         purchaser: @user.purchaser?,
         flags: @user.flags.to_s,
+        flagset: @user.flagset,
         school_point_of_contact: @user.school_poc?,
         premium_status: premium_status,
         premium_expiry_date: subscription_expiration_date,

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -64,6 +64,7 @@ describe 'SerializeVitallySalesUser' do
 
     expect(teacher_data[:traits]).to include(
       email: 'teach@teaching.edu',
+      flagset: 'production',
       name: 'Pops Mcgee',
       school: 'Kool Skool',
       account_uid: school.id.to_s,


### PR DESCRIPTION
## WHAT
Send `flagset` as trait to Vitally 

## WHY
So that this trait is available for reporting withing Vitally. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=0c1e669911c14964a5e522ceeb3493ee&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
