### PR TITLE
Staggered release prework attempt 2

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -252,7 +252,7 @@ class TeacherFixController < ApplicationController
       provider_classrooms_with_unsynced_students.each do |provider_classroom|
         StudentsClassrooms
           .where(classroom_id: provider_classroom.id, student_id: provider_classroom.unsynced_students.pluck(:id))
-          .each { |sc| sc.archive }
+          .each { |sc| sc.archive! }
       end
 
       render json: {}, status: 200

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -67,7 +67,8 @@ class Teachers::ClassroomsController < ApplicationController
   def remove_students
     StudentsClassrooms
       .where(student_id: params[:student_ids], classroom_id: params[:classroom_id])
-      .each { |sc| sc.archive }
+      .each { |sc| sc.archive! }
+
     render json: {}
   end
 

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -64,10 +64,11 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def update_activities
-    data = params[:data]
+    activities_data = params[:data].permit(activities_data: [:id, :due_date])[:activities_data].map(&:to_h)
     classrooms_data = formatted_classrooms_data(params[:id])
+
     if classrooms_data.any?
-      Units::Updater.run(params[:id], data[:activities_data], classrooms_data, current_user.id)
+      Units::Updater.run(params[:id], activities_data, classrooms_data, current_user.id)
       render json: {}
     else
       render json: {errors: 'Unit can not be found'}, status: 422

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -9,14 +9,13 @@ class Teachers::UnitsController < ApplicationController
   before_action :authorize!
 
   def create
-    if params[:unit][:create]
-      params[:unit][:classrooms] = JSON.parse(params[:unit][:classrooms])
-      params[:unit][:activities] = JSON.parse(params[:unit][:activities])
-    end
     units_with_same_name = units_with_same_name_by_current_user(params[:unit][:name], current_user.id)
     includes_ell_starter_diagnostic = params[:unit][:activities].include?({"id"=>1161})
+
     if units_with_same_name.any?
-      Units::Updater.run(units_with_same_name.first.id, params[:unit][:activities], params[:unit][:classrooms], current_user.id)
+      activities_data = unit_params[:activities].map(&:to_h)
+      classrooms_data = unit_params[:classrooms].map(&:to_h)
+      Units::Updater.run(units_with_same_name.first.id, activities_data, classrooms_data, current_user.id)
     else
       Units::Creator.run(current_user, params[:unit][:name], params[:unit][:activities], params[:unit][:classrooms], params[:unit][:unit_template_id], current_user.id)
     end
@@ -54,6 +53,7 @@ class Teachers::UnitsController < ApplicationController
 
   def update_classroom_unit_assigned_students
     activities_data = UnitActivity.where(unit_id: params[:id]).order(:order_number).pluck(:activity_id).map { |id| { id: id } }
+
     if activities_data.any?
       classroom_data = JSON.parse(params[:unit][:classrooms], symbolize_names: true)
       Units::Updater.run(params[:id], activities_data, classroom_data, current_user.id)
@@ -184,7 +184,16 @@ class Teachers::UnitsController < ApplicationController
   end
 
   private def unit_params
-    params.require(:unit).permit(:id, :create, :name, classrooms: [:id, :all_students, student_ids: []], activities: [:id, :due_date])
+    params
+      .require(:unit)
+      .permit(
+        :id,
+        :create,
+        :name,
+        :unit_template_id,
+        activities: [:id, :due_date],
+        classrooms: [:id, :assign_on_join, student_ids: []]
+      )
   end
 
   private def authorize!

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -26,6 +26,7 @@
 #
 class ClassroomUnit < ApplicationRecord
   include ::NewRelic::Agent
+  include Archivable
   include AtomicArrays
 
   belongs_to :unit # Note, there is a touch in the unit -> classroom_unit direction, so don't add one here.
@@ -103,6 +104,7 @@ class ClassroomUnit < ApplicationRecord
 
   private def check_for_assign_on_join_and_update_students_array_if_true
     student_ids = StudentsClassrooms.where(classroom_id: classroom_id).pluck(:student_id)
+
     if assigned_student_ids&.any? &&
        !assign_on_join &&
        assigned_student_ids.length >= student_ids.length &&

--- a/services/QuillLMS/app/models/concerns/archivable.rb
+++ b/services/QuillLMS/app/models/concerns/archivable.rb
@@ -7,11 +7,11 @@ module Archivable
     !visible
   end
 
-  def archive
-    update(visible: false)
+  def archive!
+    update!(visible: false)
   end
 
-  def unarchive
-    update(visible: true)
+  def unarchive!
+    update!(visible: true)
   end
 end

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -52,7 +52,7 @@ class Unit < ApplicationRecord
   after_commit :touch_all_classrooms_and_classroom_units
 
   def hide_if_no_visible_unit_activities
-    return if unit_activities.where(visible: true).exists?
+    return if unit_activities.exists?(visible: true)
 
     update(visible: false)
   end
@@ -60,8 +60,8 @@ class Unit < ApplicationRecord
   def hide_classroom_units_and_unit_activities_if_visible_false
     return if visible
 
-    UnitActivity.where(unit_id: id, visible: true).each{|ua| ua.update(visible: false)}
-    ClassroomUnit.where(unit_id: id, visible: true).each{|cu| cu.update(visible: false)}
+    unit_activities.where(visible: true).update(visible: false)
+    classroom_units.where(visible: true).update(visible: false)
   end
 
   def email_lesson_plan

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -32,8 +32,6 @@ class UnitActivity < ApplicationRecord
   belongs_to :activity
   has_many :classroom_unit_activity_states
 
-  # validates :unit, uniqueness: { scope: :activity }
-
   after_save :hide_appropriate_activity_sessions, :teacher_checkbox
 
   def teacher_checkbox

--- a/services/QuillLMS/app/services/classroom_unit_updater.rb
+++ b/services/QuillLMS/app/services/classroom_unit_updater.rb
@@ -30,6 +30,11 @@ class ClassroomUnitUpdater < ApplicationService
   end
 
   private def assigned_student_ids
-    concatenate_existing_student_ids ? classroom_unit.assigned_student_ids.concat(student_ids).uniq.sort : student_ids
+    return student_ids unless concatenate_existing_student_ids
+
+    classroom_unit
+      .assigned_student_ids
+      .union(student_ids)
+      .sort
   end
 end

--- a/services/QuillLMS/app/services/classroom_unit_updater.rb
+++ b/services/QuillLMS/app/services/classroom_unit_updater.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ClassroomUnitUpdater < ApplicationService
+  attr_reader :assign_on_join, :student_ids, :classroom_unit, :concatenate_existing_student_ids
+
+  def initialize(classroom_data, classroom_unit, concatenate_existing_student_ids)
+    @assign_on_join = classroom_data[:assign_on_join]
+    @student_ids = classroom_data[:student_ids]
+    @classroom_unit = classroom_unit
+    @concatenate_existing_student_ids = concatenate_existing_student_ids
+  end
+
+  def run
+    if student_ids == false
+      classroom_unit.archive!
+    elsif classroom_unit.assigned_student_ids != student_ids
+      classroom_unit.update!(
+        assign_on_join: assign_on_join,
+        assigned_student_ids: assigned_student_ids,
+        visible: true
+      )
+    elsif classroom_unit.assign_on_join != assign_on_join
+      classroom_unit.update!(
+        assign_on_join: assign_on_join,
+        visible: true
+      )
+    elsif classroom_unit.archived?
+      classroom_unit.unarchive!
+    end
+  end
+
+  private def assigned_student_ids
+    concatenate_existing_student_ids ? classroom_unit.assigned_student_ids.concat(student_ids).uniq.sort : student_ids
+  end
+end

--- a/services/QuillLMS/app/services/classroom_units_saver.rb
+++ b/services/QuillLMS/app/services/classroom_units_saver.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ClassroomUnitsSaver < ApplicationService
+  attr_reader :classrooms_data, :concatenate_existing_student_ids, :new_classroom_units_data, :unit_id
+
+  def initialize(classrooms_data, concatenate_existing_student_ids, unit_id)
+    @concatenate_existing_student_ids = concatenate_existing_student_ids
+    @new_classroom_units_data = []
+    @unit_id = unit_id
+
+    @classrooms_data =
+      classrooms_data
+        .map(&:symbolize_keys)
+        .select { |classroom_data| classroom_data.key?(:id) }
+        .reject { |classroom_data| classroom_data[:id].nil? }
+        .uniq { |classroom_data| classroom_data[:id].to_i }
+  end
+
+  def run
+    update_existing_classroom_units_and_aggregate_new_classroom_units_data
+    bulk_create_classroom_units
+  end
+
+  private def bulk_create_classroom_units
+    ClassroomUnit.create!(new_classroom_units_data)
+  end
+
+  private def classroom_units
+    @classroom_units ||= ClassroomUnit.where(unit_id: unit_id)
+  end
+
+  private def update_existing_classroom_units_and_aggregate_new_classroom_units_data
+    classrooms_data.each do |classroom_data|
+      classroom_id = classroom_data[:id].to_i
+      classroom_unit = classroom_units.find { |cu| cu.classroom_id == classroom_id }
+
+      if classroom_unit
+        ClassroomUnitUpdater.run(classroom_data, classroom_unit, concatenate_existing_student_ids)
+      elsif classroom_data[:student_ids] || classroom_data[:assign_on_join]
+        new_classroom_units_data.push(
+          assign_on_join: classroom_data[:assign_on_join],
+          assigned_student_ids: classroom_data[:student_ids],
+          classroom_id: classroom_id,
+          unit_id: unit_id
+        )
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/classroom_units_saver.rb
+++ b/services/QuillLMS/app/services/classroom_units_saver.rb
@@ -11,8 +11,7 @@ class ClassroomUnitsSaver < ApplicationService
     @classrooms_data =
       classrooms_data
         .map(&:symbolize_keys)
-        .select { |classroom_data| classroom_data.key?(:id) }
-        .reject { |classroom_data| classroom_data[:id].nil? }
+        .select { |classroom_data| classroom_data[:id] }
         .uniq { |classroom_data| classroom_data[:id].to_i }
   end
 

--- a/services/QuillLMS/app/services/unit_activities_saver.rb
+++ b/services/QuillLMS/app/services/unit_activities_saver.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class UnitActivitiesSaver < ApplicationService
+  attr_reader :activities_data, :new_unit_activities_data, :unit_id
+
+  def initialize(activities_data, unit_id)
+    @new_unit_activities_data = []
+    @unit_id = unit_id
+
+    @activities_data =
+      activities_data
+        .map(&:symbolize_keys)
+        .select { |activity_data| activity_data.key?(:id) }
+        .reject { |activity_data| activity_data[:id].nil? }
+        .uniq { |activity_data| activity_data[:id].to_i }
+  end
+
+  def run
+    update_existing_unit_activities_and_aggregate_new_unit_activities_data
+    bulk_create_unit_activities
+  end
+
+  private def bulk_create_unit_activities
+    UnitActivity.create!(new_unit_activities_data)
+  end
+
+  private def update_existing_unit_activities_and_aggregate_new_unit_activities_data
+    activities_data.each.with_index(1) do |activity_data, order_number|
+      activity_id = activity_data[:id].to_i
+      due_date = activity_data[:due_date]
+      unit_activity = unit_activities.find { |ua| ua.activity_id == activity_id }
+
+      if unit_activity
+        unit_activity.update!(
+          due_date: due_date || unit_activity.due_date,
+          order_number: order_number,
+          visible: true
+        )
+      else
+        new_unit_activities_data.push(
+          activity_id: activity_id,
+          due_date: due_date,
+          order_number: order_number,
+          unit_id: unit_id
+        )
+      end
+    end
+  end
+
+  private def unit_activities
+    @unit_activities ||= UnitActivity.where(unit_id: unit_id)
+  end
+end

--- a/services/QuillLMS/app/services/unit_activities_saver.rb
+++ b/services/QuillLMS/app/services/unit_activities_saver.rb
@@ -10,8 +10,7 @@ class UnitActivitiesSaver < ApplicationService
     @activities_data =
       activities_data
         .map(&:symbolize_keys)
-        .select { |activity_data| activity_data.key?(:id) }
-        .reject { |activity_data| activity_data[:id].nil? }
+        .select { |activity_data| activity_data[:id] }
         .uniq { |activity_data| activity_data[:id].to_i }
   end
 

--- a/services/QuillLMS/app/services/units/creator.rb
+++ b/services/QuillLMS/app/services/units/creator.rb
@@ -74,8 +74,7 @@ module Units::Creator
     unit.reload
     unit.save
     unit.email_lesson_plan
-    # unit.hide_if_no_visible_unit_activities
-    # activity_sessions in the state of 'unstarted' are automatically created in an after_create callback in the classroom_activity model
+
     AssignActivityWorker.perform_async((current_user_id || teacher.id), unit.id)
   end
 end

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -11,13 +11,13 @@ module Units::Updater
   end
 
   def self.assign_unit_template_to_one_class(unit_id, classrooms_data, unit_template_id, current_user_id=nil, concatenate_existing_student_ids: false)
-    activities_data = UnitTemplate.find(unit_template_id).activities.map { |a| {id: a.id, due_date: nil} }
+    activities_data = UnitTemplate.find(unit_template_id).activities.pluck(:id).map { |id| {id: id, due_date: nil} }
     update_helper(unit_id, activities_data, [classrooms_data], current_user_id, concatenate_existing_student_ids: concatenate_existing_student_ids)
   end
 
   def self.fast_assign_unit_template(teacher_id, unit_template, unit_id, current_user_id=nil)
     activities_data = unit_template.activities.pluck(:id).map { |activity_id| { id: activity_id, due_date: nil } }
-    classrooms_data = User.find(teacher_id).classrooms_i_teach.map { |classroom| {id: classroom.id, student_ids: [], assign_on_join: true } }
+    classrooms_data = User.find(teacher_id).classrooms_i_teach.pluck(:id).map { |id| {id: id, student_ids: [], assign_on_join: true } }
     update_helper(unit_id, activities_data, classrooms_data, current_user_id || teacher_id)
   end
 

--- a/services/QuillLMS/app/services/units/updater.rb
+++ b/services/QuillLMS/app/services/units/updater.rb
@@ -11,91 +11,23 @@ module Units::Updater
   end
 
   def self.assign_unit_template_to_one_class(unit_id, classrooms_data, unit_template_id, current_user_id=nil, concatenate_existing_student_ids: false)
-    classroom_array = [classrooms_data]
-    # converted to array so we can map in helper function as we would otherwise
-    unit_template = UnitTemplate.find(unit_template_id)
-    activities_data = unit_template.activities.map{ |a| {id: a.id, due_date: nil} }
-    update_helper(unit_id, activities_data, classroom_array, current_user_id, concatenate_existing_student_ids: concatenate_existing_student_ids)
+    activities_data = UnitTemplate.find(unit_template_id).activities.map { |a| {id: a.id, due_date: nil} }
+    update_helper(unit_id, activities_data, [classrooms_data], current_user_id, concatenate_existing_student_ids: concatenate_existing_student_ids)
   end
 
   def self.fast_assign_unit_template(teacher_id, unit_template, unit_id, current_user_id=nil)
-    activities_data = unit_template.activities.select('activities.id AS id, NULL as due_date')
-    classrooms_data = User.find(teacher_id).classrooms_i_teach.map{|classroom| {id: classroom.id, student_ids: [], assign_on_join: true}}
+    activities_data = unit_template.activities.pluck(:id).map { |activity_id| { id: activity_id, due_date: nil } }
+    classrooms_data = User.find(teacher_id).classrooms_i_teach.map { |classroom| {id: classroom.id, student_ids: [], assign_on_join: true } }
     update_helper(unit_id, activities_data, classrooms_data, current_user_id || teacher_id)
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def self.matching_or_new_classroom_unit(classroom, existing_classroom_units, new_cus, hidden_cus_ids, unit_id, concatenate_existing_student_ids)
-    classroom_id = classroom[:id].to_i || classroom['id'].to_i
-    matching_cu = existing_classroom_units.find{|cu| cu.classroom_id == classroom_id}
-    if matching_cu
-      if classroom[:student_ids] == false
-        # then there are no assigned students and we should hide the cas
-        hidden_cus_ids.push(matching_cu.id)
-      elsif (matching_cu.assigned_student_ids != classroom[:student_ids]) || matching_cu.assign_on_join != classroom[:assign_on_join]
-        # then something changed and we should update
-        new_recipients = classroom[:student_ids] - matching_cu.assigned_student_ids
-        new_student_ids = concatenate_existing_student_ids ? matching_cu.assigned_student_ids.concat(classroom[:student_ids]).uniq : classroom[:student_ids]
-        matching_cu.update!(assign_on_join: classroom[:assign_on_join], assigned_student_ids: new_student_ids, visible: true)
-      elsif !matching_cu.visible
-        matching_cu.update!(visible: true)
-      end
-    elsif classroom[:student_ids] || classroom[:assign_on_join]
-      # making an array of hashes to create in one bulk option
-      new_cus.push({classroom_id: classroom_id,
-         unit_id: unit_id,
-         assign_on_join: classroom[:assign_on_join],
-         assigned_student_ids: classroom[:student_ids]})
-    end
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity
-
-  def self.matching_or_new_unit_activity(activity_data, existing_unit_activities, new_uas, hidden_ua_ids, unit_id, order_number)
-    activity_data_id = activity_data[:id].to_i || activity_data['id'].to_i
-    activity_data_due_date = activity_data[:due_date] || activity_data['due_date']
-    matching_ua = existing_unit_activities.find{|ua| (ua.activity_id == activity_data_id )}
-    if matching_ua
-      matching_ua.update!(visible: true,
-        due_date: activity_data_due_date || matching_ua.due_date,
-        order_number: order_number)
-    elsif activity_data_id
-      # making an array of hashes to create in one bulk option
-      new_uas.push({activity_id: activity_data_id,
-         unit_id: unit_id,
-         due_date: activity_data_due_date,
-         order_number: order_number})
-    end
-  end
-
-  # rubocop:disable Metrics/CyclomaticComplexity
   def self.update_helper(unit_id, activities_data, classrooms_data, current_user_id, concatenate_existing_student_ids: false)
-    existing_classroom_units = ClassroomUnit.where(unit_id: unit_id)
-    new_cus = []
-    hidden_cus_ids = []
-    existing_unit_activities = UnitActivity.where(unit_id: unit_id)
-    new_uas = []
-    hidden_ua_ids = []
-    classrooms_data.each do |classroom|
-      matching_or_new_classroom_unit(classroom, existing_classroom_units, new_cus, hidden_cus_ids, unit_id, concatenate_existing_student_ids)
-    end
-    activities_data.each_with_index do |activity, index|
-      order_number = index + 1
-      matching_or_new_unit_activity(activity, existing_unit_activities, new_uas, hidden_ua_ids, unit_id, order_number)
-    end
-    new_cus = new_cus.uniq { |cu| cu['classroom_id'] || cu[:classroom_id] }
-    new_uas = new_uas.uniq { |ua| ua['activity_id'] || ua[:activity_id] }
-    new_cus.each { |cu| ClassroomUnit.create(cu) }
+    ClassroomUnitsSaver.run(classrooms_data, concatenate_existing_student_ids, unit_id)
+    UnitActivitiesSaver.run(activities_data, unit_id)
 
-    ClassroomUnit.where(id: hidden_cus_ids).update_all(visible: false)
-    UnitActivity.create(new_uas)
-    UnitActivity.where(id: hidden_ua_ids).update_all(visible: false)
     unit = Unit.find(unit_id)
     unit.save
-    if (hidden_ua_ids.any?) && (new_uas.none?)
-      unit.hide_if_no_visible_unit_activities
-    end
+    unit.hide_if_no_visible_unit_activities
     AssignActivityWorker.perform_async(current_user_id, unit_id)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-
 end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms_with_students/ClassroomsWithStudents.jsx
@@ -16,37 +16,34 @@ export default class ClassroomsWithStudents extends React.Component {
   }
 
   classroomUpdates = () => {
-    const classrooms_data = [];
-    let classroomsWithNoAssignedStudents = 0;
-    this.props.classrooms.forEach((classy) => {
-      if (classy.edited) {
-        const class_data = { id: classy.id, };
-        if (classy.allSelected) {
-          class_data.student_ids = classy.students.map(s => s.id);
-          class_data.assign_on_join = true;
+    const classroomsData = []
+
+    this.props.classrooms.forEach((classroom) => {
+      if (classroom.edited) {
+        const classroomData = { id: classroom.id, }
+
+        if (classroom.allSelected) {
+          classroomData.student_ids = classroom.students.map(s => s.id)
+          classroomData.assign_on_join = true
         } else {
-          const student_ids_arr = [];
-          class_data.assign_on_join = false;
-          classy.students.forEach((stud) => {
-            if (stud.isSelected) {
-              student_ids_arr.push(stud.id);
-            }
-          });
-          if (student_ids_arr.length > 0) {
-            class_data.student_ids = student_ids_arr;
+          const studentIds = []
+
+          classroomData.assign_on_join = false
+          classroom.students.forEach((student) => { if (student.isSelected) { studentIds.push(student.id) } })
+
+          if (studentIds.length > 0) {
+            classroomData.student_ids = studentIds
           } else {
-            class_data.student_ids = false;
-            classroomsWithNoAssignedStudents += 1;
+            classroomData.student_ids = false
           }
         }
-        classrooms_data.push(class_data);
-      }			else if (classy.noneSelected) {
-        classroomsWithNoAssignedStudents += 1;
+
+        classroomsData.push(classroomData)
       }
     }
-    );
-    return classrooms_data;
-  };
+    )
+    return classroomsData
+  }
 
   createButton() {
     if (!this.props.isSaveButtonEnabled) { return null }

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -295,10 +295,15 @@ describe Teachers::UnitsController, type: :controller do
 
     it "sends a 200 status code when it is passed valid data" do
       activity = unit_activity.activity
-      put :update_activities, params: { id: unit.id.to_s, data: {
+      put :update_activities,
+        params: {
+          id: unit.id,
+          data: {
             unit_id: unit.id,
-            activities_data: [{id: activity.id, due_date: nil}]
-          } }
+            activities_data: [{ id: activity.id, due_date: nil }]
+          }
+        }
+
       expect(response.status).to eq(200)
     end
 

--- a/services/QuillLMS/spec/factories/unit_activities.rb
+++ b/services/QuillLMS/spec/factories/unit_activities.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :unit_activity do
-    unit            { create(:unit) }
-    activity        { create(:activity, :production) }
+    unit
+    activity { create(:activity, :production) }
 
     factory :unit_activity_with_activity do
       activity { Activity.first || create(:activity) }

--- a/services/QuillLMS/spec/services/analytics/classroom_unit_updater_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/classroom_unit_updater_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomUnitUpdater do
+  let(:classroom) { create(:classroom) }
+  let(:assigned_student_ids) { [] }
+  let(:classroom_unit) { create(:classroom_unit, assigned_student_ids: assigned_student_ids, classroom: classroom) }
+
+  let(:student_ids) { assigned_student_ids }
+  let(:assign_on_join) { false }
+  let(:classroom_data) { { assign_on_join: assign_on_join, student_ids: student_ids } }
+
+  let(:concatenate_existing_student_ids) { true }
+
+  subject { described_class.run(classroom_data, classroom_unit, concatenate_existing_student_ids) }
+
+  context 'student_ids is false' do
+    let(:student_ids) { false }
+
+    it { expect { subject }.to change { classroom_unit.reload.visible }.from(true).to(false) }
+
+    context 'classroom_unit is archived' do
+      before { classroom_unit.update(visible: false) }
+
+      it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(false) }
+    end
+  end
+
+  context 'student_ids different than assigned_student_ids' do
+    let(:student1) { create(:students_classrooms, classroom: classroom).student }
+    let(:student2) { create(:students_classrooms, classroom: classroom).student }
+    let(:concatenate_existing_student_ids) { true }
+    let(:assigned_student_ids) { [student1.id] }
+    let(:student_ids) { [student2.id] }
+
+    it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to [student1.id, student2.id] }
+    it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(true) }
+    it { unarchives_an_archived_classroom_unit }
+
+    context 'concatenate_existing_student_ids is false' do
+      let(:concatenate_existing_student_ids) { false }
+
+      it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to [student2.id] }
+      it { unarchives_an_archived_classroom_unit }
+    end
+  end
+
+  context 'assign_on_join changed from false to true' do
+    let(:assign_on_join) { true }
+
+    before { classroom_unit.update!(assign_on_join: false) }
+
+    it { expect { subject }.to change { classroom_unit.reload.assign_on_join }.from(false).to(true) }
+    it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(true) }
+    it { unarchives_an_archived_classroom_unit }
+  end
+
+  it { unarchives_an_archived_classroom_unit }
+
+  def unarchives_an_archived_classroom_unit
+    classroom_unit.update(visible: false)
+
+    expect { subject }.to change { classroom_unit.reload.visible}.from(false).to(true)
+  end
+end

--- a/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
+++ b/services/QuillLMS/spec/services/classroom_units_saver_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomUnitsSaver do
+  let(:classroom1) { create(:classroom) }
+  let(:classroom_data1) { { id: classroom1.id, assign_on_join: true, student_ids: [] } }
+  let(:concatenate_existing_student_ids) { true }
+  let(:unit) { create(:unit) }
+
+  subject { described_class.run(classrooms_data, concatenate_existing_student_ids, unit.id) }
+
+  context 'classroom_data1 with symbol based keys' do
+    let(:classrooms_data) { [classroom_data1] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with string based keys' do
+    let(:classrooms_data) { [classroom_data1.stringify_keys] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with duplicates' do
+    let(:classrooms_data) { [classroom_data1, classroom_data1] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(1) }
+  end
+
+  context 'classroom_data1 with nil id' do
+    let(:classrooms_data) { [classroom_data1.merge(id: nil)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'classroom_data1 with no id' do
+    let(:classrooms_data) { [classroom_data1.except(:id)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'classroom_data1 with student_ids = false and assign_on_join = false' do
+    let(:classrooms_data) { [classroom_data1.merge(student_ids: false, assign_on_join: false)] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(0) }
+  end
+
+  context 'two classroom_data1' do
+    let(:classroom2) { create(:classroom) }
+    let(:classroom_data2) { classroom_data1.merge(id: classroom2.id) }
+    let(:classrooms_data) { [classroom_data1, classroom_data2] }
+
+    it { expect { subject }.to change(ClassroomUnit, :count).from(0).to(2) }
+  end
+
+  context 'classroom_unit already exists' do
+    let!(:classroom_unit) { create(:classroom_unit, classroom: classroom1, unit: unit) }
+    let(:classrooms_data) { [classroom_data1] }
+
+    it { expect { subject }.not_to change(ClassroomUnit, :count).from(1) }
+
+    it do
+      expect(ClassroomUnitsSaver).to receive(:run).once
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/unit_activities_saver_spec.rb
+++ b/services/QuillLMS/spec/services/unit_activities_saver_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UnitActivitiesSaver do
+  let(:due_date) { 1.day.from_now }
+
+  let(:activity1) { create(:activity) }
+  let(:activity2) { create(:activity) }
+
+  let(:activity_data1) { { "id" => activity1.id.to_s, "due_date" => due_date } }
+  let(:activity_data2) { { id: activity2.id, due_date: due_date } }
+  let(:activity_data3) { activity_data2 }
+  let(:activity_data4) { { id: nil, due_date: due_date }}
+  let(:activity_data5) { { due_date: due_date }}
+
+  let(:activities_data) { [activity_data1, activity_data2, activity_data3, activity_data4, activity_data5] }
+  let(:unit) { create(:unit) }
+
+  subject { described_class.run(activities_data, unit.id) }
+
+  it { expect { subject }.to change(UnitActivity, :count).from(0).to(2) }
+  it { expect { subject }.not_to change { unit.reload.visible }.from(true) }
+
+  context 'unit activity already exists' do
+    let!(:unit_activity) { create(:unit_activity, activity: activity1, unit: unit, visible: false) }
+    let!(:orig_due_date) { unit_activity.due_date }
+
+    it { expect { subject }.to change(UnitActivity, :count).from(1).to(2) }
+    it { expect { subject }.to change { unit_activity.reload.visible }.from(false).to(true) }
+    it { expect { subject }.to change { unit_activity.reload.due_date}.from(orig_due_date) }
+
+    context 'no due date is set' do
+      let(:due_date) { nil }
+
+      it { expect { subject }.not_to change { unit_activity.reload.due_date }.from(orig_due_date) }
+    end
+  end
+end

--- a/services/QuillLMS/spec/support/shared/unit_assignments_variables.rb
+++ b/services/QuillLMS/spec/support/shared/unit_assignments_variables.rb
@@ -16,9 +16,25 @@ shared_context 'Unit Assignments Variables' do
   let!(:unit_template2) { create(:unit_template, activities: [activity2], author: author) }
   let!(:unit_template3) { create(:unit_template, activities: [activity3], author: author) }
   let!(:unit_template4) { create(:unit_template, activities: [activity4], author: author) }
-  let!(:classroom_unit) { create(:classroom_unit, classroom_id: classroom.id, assigned_student_ids: [student.id], assign_on_join: false)}
+
+  let!(:classroom_unit) do
+    create(:classroom_unit,
+      classroom_id: classroom.id,
+      assigned_student_ids: [student.id],
+      assign_on_join: false
+    )
+  end
+
   let!(:unit_activity) { create(:unit_activity, activity_id: activity.id)}
-  let(:activity_session) {create(:activity_session, classroom_unit_id: classroom_unit.id, activity_id: activity.id, user_id: student.id, state: 'finished')}
+
+  let(:activity_session) do
+    create(:activity_session,
+      classroom_unit_id: classroom_unit.id,
+      activity_id: activity.id,
+      user_id: student.id,
+      state: 'finished'
+    )
+  end
 
   def unit_templates_have_a_corresponding_unit?(unit_template_ids)
     names_from_templates = UnitTemplate.where(id: unit_template_ids).pluck(:name)
@@ -29,6 +45,4 @@ shared_context 'Unit Assignments Variables' do
     names_from_templates = UnitTemplate.where(id: unit_template_ids).pluck(:name)
     (UnitActivity.all.map(&:unit).map(&:name).flatten & names_from_templates).length == names_from_templates.length
   end
-
-
 end


### PR DESCRIPTION
## WHAT
The original prework [PR](https://github.com/empirical-org/Empirical-Core/pull/9691) had a [regression](https://sentry.io/organizations/quillorg-5s/issues/3593475873/?project=11238&referrer=slack) which led to a quick revert.

This particular code addresses the regression (along with including the original PR)

## WHY
This prework facilitates understanding of the supporting code for Staggered Release.

## HOW
I won't repeat the original [PR](https://github.com/empirical-org/Empirical-Core/pull/9691) details here.  As far as the regression is concerned, the activities_data and classroom_data objects that were being passed to `Units::Updater.run` were missing some strong parameters `permit` calls.  Once those were added in, the symbolize_keys regression went away.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
