### PR TITLE
Demo - Hide classroom rather than destroy.

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -132,6 +132,7 @@ Lint/AmbiguousBlockAssociation:
   Enabled: true
   IgnoredMethods:
     - change
+    - not_change
 
 Lint/AmbiguousOperatorPrecedence:
   Enabled: true

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -315,7 +315,7 @@ module Demo::ReportDemoCreator
 
       # Note, you can't early return within a transaction in Rails 6.1+
       if teacher && demo_classroom_modified?(teacher)
-        demo_classroom(teacher)&.destroy
+        demo_classroom(teacher)&.update(visible: false)
         create_demo_classroom_data(teacher, teacher_demo: true)
       end
     end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -305,11 +305,15 @@ module Demo::ReportDemoCreator
     teacher.auth_credential&.destroy
     teacher.update(google_id: nil, clever_id: nil)
 
+    reset_demo_classroom_if_needed(teacher_id)
+  end
+
+  def self.reset_demo_classroom_if_needed(teacher_id)
     # Wrap the lookup and actions within a transaction to avoid race conditions
     ActiveRecord::Base.transaction do
       teacher = User.find_by(id: teacher_id, role: User::TEACHER)
-      # Note, you can't early return within a transaction in Rails 6.1+
 
+      # Note, you can't early return within a transaction in Rails 6.1+
       if teacher && demo_classroom_modified?(teacher)
         demo_classroom(teacher)&.destroy
         create_demo_classroom_data(teacher, teacher_demo: true)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -315,7 +315,7 @@ module Demo::ReportDemoCreator
 
       # Note, you can't early return within a transaction in Rails 6.1+
       if teacher && demo_classroom_modified?(teacher)
-        demo_classroom(teacher)&.update(visible: false)
+        demo_classroom(teacher)&.update(visible: false, code: nil)
         create_demo_classroom_data(teacher, teacher_demo: true)
       end
     end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -301,12 +301,7 @@ module Demo::ReportDemoCreator
 
     return unless teacher
 
-    non_demo_classrooms(teacher).each do |classroom|
-      # mimic classroom#hide controller action
-      classroom.visible = false
-      classroom.save(validate: false)
-    end
-
+    non_demo_classrooms(teacher).each {|c| c.update(visible: false)}
     teacher.auth_credential&.destroy
     teacher.update(google_id: nil, clever_id: nil)
 

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -291,9 +291,6 @@ module Demo::ReportDemoCreator
   end
 
   def self.reset_units(teacher)
-    teacher.units.reload # this relation is empty until it is reloaded for some reason
-    return teacher.units if teacher.units.count == UNITS_COUNT
-
     teacher.units&.destroy_all
 
     create_units(teacher)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -315,6 +315,7 @@ module Demo::ReportDemoCreator
 
       # Note, you can't early return within a transaction in Rails 6.1+
       if teacher && demo_classroom_modified?(teacher)
+        # mark as invisible and reset class code (since the demo logic uses a specific class code)
         demo_classroom(teacher)&.update(visible: false, code: nil)
         create_demo_classroom_data(teacher, teacher_demo: true)
       end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -305,7 +305,7 @@ module Demo::ReportDemoCreator
       teacher = User.find_by(id: teacher_id, role: User::TEACHER)
       # Note, you can't early return within a transaction in Rails 6.1+
       if teacher
-        non_demo_classrooms(teacher).each(&:destroy)
+        non_demo_classrooms(teacher).each {|c| c.update(visible: false)}
         teacher.auth_credential&.destroy
         teacher.update(google_id: nil, clever_id: nil)
 

--- a/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
@@ -3,7 +3,8 @@
 # destroy demo account and recreates it from scratch
 class Demo::RecreateAccountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::LOW
+  sidekiq_options queue: SidekiqQueue::LOW, retry: false
+
   STAFF_DEMO_EMAIL = "hello+demoteacher+staff@quill.org"
 
   def perform

--- a/services/QuillLMS/app/workers/demo/reset_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/reset_account_worker.rb
@@ -3,7 +3,7 @@
 # Keeps Demo Account, but attempts to rollback user changes
 class Demo::ResetAccountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL, retry: false
 
   def perform(teacher_id)
     return if teacher_id.nil?

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -204,13 +204,16 @@ RSpec.describe Demo::ReportDemoCreator do
 
       subject { Demo::ReportDemoCreator.reset_account(teacher.id) }
 
-      context "untouched demo account" do
-        it { expect{ subject }.to_not change{teacher.reload.google_id}.from(nil) }
-        it { expect{ subject }.to_not change{teacher.reload.clever_id}.from(nil) }
-        it { expect{ subject }.to_not change{teacher.classrooms_i_teach.count}.from(1) }
-        it { expect{ subject }.to_not change{teacher.classrooms_i_teach.map(&:id)} }
-        it { expect{ subject }.to_not change{teacher.reload.auth_credential}.from(nil) }
+
+      it "should create expected counts for untouched account" do
+        expect{ subject }
+          .to not_change{teacher.reload.google_id}.from(nil)
+          .and not_change{teacher.reload.clever_id}.from(nil)
+          .and not_change{teacher.classrooms_i_teach.count}.from(1)
+          .and not_change{teacher.classrooms_i_teach.map(&:id)}
+          .and not_change{teacher.reload.auth_credential}.from(nil)
       end
+
 
       context "teacher account has added data" do
         let(:teacher) {create(:teacher, google_id: 1234, clever_id: 5678)}
@@ -218,13 +221,16 @@ RSpec.describe Demo::ReportDemoCreator do
         let(:classroom) {create(:classroom)}
         let!(:classrooms_teacher) {create(:classrooms_teacher, classroom: classroom, user: teacher)}
 
-        it { expect{ subject }.to change{teacher.reload.google_id}.from("1234").to(nil) }
-        it { expect{ subject }.to change{teacher.reload.clever_id}.from("5678").to(nil) }
-        it { expect{ subject }.to change {teacher.reload.classrooms_i_teach.count}.from(2).to(1) }
-        it { expect{ subject }.to change(AuthCredential, :count).from(1).to(0) }
-        it { expect{ subject }.to change(Classroom.where(id: classroom.id), :count).from(1).to(0) }
-        it { expect{ subject }.to_not change(Classroom.unscoped.where(id: classroom.id), :count).from(1) }
-        it { expect{ subject }.to_not change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
+        it "should create expected counts" do
+          expect{ subject }
+            .to change{teacher.reload.google_id}.from("1234").to(nil)
+            .and change{teacher.reload.clever_id}.from("5678").to(nil)
+            .and change {teacher.reload.classrooms_i_teach.count}.from(2).to(1)
+            .and change(AuthCredential, :count).from(1).to(0)
+            .and change(Classroom.where(id: classroom.id), :count).from(1).to(0)
+            .and not_change(Classroom.unscoped.where(id: classroom.id), :count).from(1)
+            .and not_change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id}
+        end
       end
 
       context "demo classroom changed" do

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -222,6 +222,8 @@ RSpec.describe Demo::ReportDemoCreator do
         it { expect{ subject }.to change{teacher.reload.clever_id}.from("5678").to(nil) }
         it { expect{ subject }.to change {teacher.reload.classrooms_i_teach.count}.from(2).to(1) }
         it { expect{ subject }.to change(AuthCredential, :count).from(1).to(0) }
+        it { expect{ subject }.to change(Classroom.where(id: classroom.id), :count).from(1).to(0) }
+        it { expect{ subject }.to_not change(Classroom.unscoped.where(id: classroom.id), :count).from(1) }
         it { expect{ subject }.to_not change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
       end
 


### PR DESCRIPTION
## WHAT
There seems to be some callback issues with destroying a classroom, so instead, I'm going to hide the demo classrooms in the callback. Also, don't retry this job if it fails.
## WHY
The [reset-job is falling](https://sentry.io/organizations/quillorg-5s/issues/3639965126/?project=11238&query=is%3Aunresolved) for a dependent-destroy foreign-key conflict. 
## HOW
`.update(visible: false)` instead of `.destroy`

There are likely some `dependent: destroy`'s that are needed on the `classroom.destroy`, but I ran into issues making that work (it doesn't seem to be common to destroy a classroom in our codebase). Instead, I mimicked the 'archive' function which teachers use, which marks a `classroom` as `visible=false`.

Note, I also refactored a few slow tests (call the slow setup once, and chain within test with `.and`)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'. 
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
