### PR TITLE
Add logging for reset google session

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -153,6 +153,7 @@ class ApplicationController < ActionController::Base
   end
 
   protected def reset_session_and_redirect_to_sign_in
+    log_google_auth_credential
     reset_session
     session[EXPIRED_SESSION_REDIRECT] = true
 
@@ -168,4 +169,15 @@ class ApplicationController < ActionController::Base
 
     current_user.inactive_too_long?
   end
+
+  protected def log_google_auth_credential
+    return unless current_user.google_access_expired?
+
+    LogGoogleAuthCredentialWorker.perform_async(
+      current_user.id,
+      current_user.auth_credential&.id,
+      current_user.auth_credential&.refresh_token_expires_at
+    )
+  end
 end
+

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,7 +100,8 @@ class ChangeLog < ApplicationRecord
     show: 'Visited User Admin Page',
     edit: 'Visited User Edit Page',
     update: 'Edited User',
-    skipped_import: 'Skipped User import'
+    skipped_import: 'Skipped User import',
+    google_access_expired_reset_session: 'User session reset due to expired google access'
   }
 
   GENERIC_USER_ACTIONS = [

--- a/services/QuillLMS/app/workers/log_google_auth_credential_worker.rb
+++ b/services/QuillLMS/app/workers/log_google_auth_credential_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class LogGoogleAuthCredentialWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+  def perform(user_id, auth_credential_id, refresh_token_expires_at)
+    ChangeLog.create!(
+      action: ChangeLog::USER_ACTIONS[:google_access_expired_reset_session],
+      changed_record: User.find_by(id: user_id),
+      explanation: refresh_token_expires_at,
+      previous_value: auth_credential_id
+    )
+  end
+end

--- a/services/QuillLMS/app/workers/log_google_auth_credential_worker.rb
+++ b/services/QuillLMS/app/workers/log_google_auth_credential_worker.rb
@@ -7,9 +7,12 @@ class LogGoogleAuthCredentialWorker
   def perform(user_id, auth_credential_id, refresh_token_expires_at)
     ChangeLog.create!(
       action: ChangeLog::USER_ACTIONS[:google_access_expired_reset_session],
-      changed_record: User.find_by(id: user_id),
+      changed_attribute: :auth_credential,
+      changed_record_id: user_id,
+      changed_record_type: 'User',
       explanation: refresh_token_expires_at,
-      previous_value: auth_credential_id
+      previous_value: auth_credential_id,
+      user_id: user_id
     )
   end
 end


### PR DESCRIPTION
## WHAT
Add logging of google auth_credential information before reset users session

## WHY
There's an outstanding [bug](https://www.notion.so/quill/Google-synced-users-asked-to-reauthorize-account-every-time-they-log-in-c0420e9ec6cb4dcc9ef3067a6d380fbc) where some google users are asked to re-authorize multiple times.  I haven't been able to figure out what's causing this, so  I'd like to log the auth credential information before resetting the session to ensure that there's not something wrong with access_token.

## HOW
I'm using a worker here rather than an inline method.  Otherwise, the `ChangeLog.create` will raise readonly errors for various GET controller actions.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No. This is just logging information.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
