### PR TITLE
Demo - Hide classroom rather than destroy. (#9796)

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -132,6 +132,7 @@ Lint/AmbiguousBlockAssociation:
   Enabled: true
   IgnoredMethods:
     - change
+    - not_change
 
 Lint/AmbiguousOperatorPrecedence:
   Enabled: true

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -291,28 +291,33 @@ module Demo::ReportDemoCreator
   end
 
   def self.reset_units(teacher)
-    teacher.units.reload # this relation is empty until it is reloaded for some reason
-    return teacher.units if teacher.units.count == UNITS_COUNT
-
     teacher.units&.destroy_all
 
     create_units(teacher)
   end
 
   def self.reset_account(teacher_id)
+    teacher = User.find_by(id: teacher_id, role: User::TEACHER)
+
+    return unless teacher
+
+    non_demo_classrooms(teacher).each {|c| c.update(visible: false)}
+    teacher.auth_credential&.destroy
+    teacher.update(google_id: nil, clever_id: nil)
+
+    reset_demo_classroom_if_needed(teacher_id)
+  end
+
+  def self.reset_demo_classroom_if_needed(teacher_id)
     # Wrap the lookup and actions within a transaction to avoid race conditions
     ActiveRecord::Base.transaction do
       teacher = User.find_by(id: teacher_id, role: User::TEACHER)
-      # Note, you can't early return within a transaction in Rails 6.1+
-      if teacher
-        non_demo_classrooms(teacher).each(&:destroy)
-        teacher.auth_credential&.destroy
-        teacher.update(google_id: nil, clever_id: nil)
 
-        if demo_classroom_modified?(teacher)
-          demo_classroom(teacher)&.destroy
-          create_demo_classroom_data(teacher, teacher_demo: true)
-        end
+      # Note, you can't early return within a transaction in Rails 6.1+
+      if teacher && demo_classroom_modified?(teacher)
+        # mark as invisible and reset class code (since the demo logic uses a specific class code)
+        demo_classroom(teacher)&.update(visible: false, code: nil)
+        create_demo_classroom_data(teacher, teacher_demo: true)
       end
     end
   rescue ActiveRecord::RecordInvalid
@@ -461,7 +466,13 @@ module Demo::ReportDemoCreator
         classroom_unit = ClassroomUnit.find_by(classroom: classroom, unit: unit)
         act_sessions = activity_pack[:activity_sessions]
         act_sessions[num].each do |clone_activity_id, clone_user_id|
-          clone_activity_session(student.id, classroom_unit.id, clone_user_id, clone_activity_id, session_data)
+          clone_activity_session(
+            student.id,
+            classroom_unit.id,
+            clone_user_id,
+            clone_activity_id,
+            session_data
+          )
         end
       end
     end

--- a/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
@@ -3,7 +3,8 @@
 # destroy demo account and recreates it from scratch
 class Demo::RecreateAccountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::LOW
+  sidekiq_options queue: SidekiqQueue::LOW, retry: false
+
   STAFF_DEMO_EMAIL = "hello+demoteacher+staff@quill.org"
 
   def perform

--- a/services/QuillLMS/app/workers/demo/reset_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/reset_account_worker.rb
@@ -3,7 +3,7 @@
 # Keeps Demo Account, but attempts to rollback user changes
 class Demo::ResetAccountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL, retry: false
 
   def perform(teacher_id)
     return if teacher_id.nil?

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -204,13 +204,16 @@ RSpec.describe Demo::ReportDemoCreator do
 
       subject { Demo::ReportDemoCreator.reset_account(teacher.id) }
 
-      context "untouched demo account" do
-        it { expect{ subject }.to_not change{teacher.reload.google_id}.from(nil) }
-        it { expect{ subject }.to_not change{teacher.reload.clever_id}.from(nil) }
-        it { expect{ subject }.to_not change{teacher.classrooms_i_teach.count}.from(1) }
-        it { expect{ subject }.to_not change{teacher.classrooms_i_teach.map(&:id)} }
-        it { expect{ subject }.to_not change{teacher.reload.auth_credential}.from(nil) }
+
+      it "should create expected counts for untouched account" do
+        expect{ subject }
+          .to not_change{teacher.reload.google_id}.from(nil)
+          .and not_change{teacher.reload.clever_id}.from(nil)
+          .and not_change{teacher.classrooms_i_teach.count}.from(1)
+          .and not_change{teacher.classrooms_i_teach.map(&:id)}
+          .and not_change{teacher.reload.auth_credential}.from(nil)
       end
+
 
       context "teacher account has added data" do
         let(:teacher) {create(:teacher, google_id: 1234, clever_id: 5678)}
@@ -218,11 +221,16 @@ RSpec.describe Demo::ReportDemoCreator do
         let(:classroom) {create(:classroom)}
         let!(:classrooms_teacher) {create(:classrooms_teacher, classroom: classroom, user: teacher)}
 
-        it { expect{ subject }.to change{teacher.reload.google_id}.from("1234").to(nil) }
-        it { expect{ subject }.to change{teacher.reload.clever_id}.from("5678").to(nil) }
-        it { expect{ subject }.to change {teacher.reload.classrooms_i_teach.count}.from(2).to(1) }
-        it { expect{ subject }.to change(AuthCredential, :count).from(1).to(0) }
-        it { expect{ subject }.to_not change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id} }
+        it "should create expected counts" do
+          expect{ subject }
+            .to change{teacher.reload.google_id}.from("1234").to(nil)
+            .and change{teacher.reload.clever_id}.from("5678").to(nil)
+            .and change {teacher.reload.classrooms_i_teach.count}.from(2).to(1)
+            .and change(AuthCredential, :count).from(1).to(0)
+            .and change(Classroom.where(id: classroom.id), :count).from(1).to(0)
+            .and not_change(Classroom.unscoped.where(id: classroom.id), :count).from(1)
+            .and not_change{Demo::ReportDemoCreator.demo_classroom(teacher.reload).id}
+        end
       end
 
       context "demo classroom changed" do


### PR DESCRIPTION
* Hide classroom rather than destroy.

* Slight refactor for test speed.

* Update linter with negative method.

* Don’t retry reset_account.

* Don’t reuse the units.

* Move teacher reset items out of transaction.

* Don’t skip validations.

* Move session reset to separate method for less complexity.

* Use update(visible:false) for demo classroom.

* Reset the classroom code, since the demo class reuses it.

* Add comment.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
