### PR TITLE
Fix bug with nil access_token check on reset_session

### DIFF
--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -57,7 +57,7 @@ class AuthCredential < ApplicationRecord
   end
 
   def refresh_token_expires_at
-    return nil if !google_provider?
+    return nil if !google_provider? || expires_at.nil?
 
     expires_at + GOOGLE_EXPIRATION_DURATION
   end

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -34,7 +34,7 @@ describe AuthCredential, type: :model do
   context described_class::GOOGLE_PROVIDER do
     let(:factory) { :google_auth_credential }
 
-    context '#google_authorized?' do
+    describe '#google_authorized?' do
       context 'nil expires_at' do
         before { auth_credential.update(expires_at: nil) }
 
@@ -56,6 +56,16 @@ describe AuthCredential, type: :model do
 
         it { should_not_be_clever_authorized}
         it { should_not_be_google_authorized }
+      end
+    end
+
+    describe '#refresh_token_expires_at' do
+      it { expect(auth_credential.refresh_token_expires_at).not_to be_nil }
+
+      context 'nil expires_at' do
+        before { auth_credential.update(expires_at: nil) }
+
+        it { expect(auth_credential.refresh_token_expires_at).to be_nil }
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3649678571/?project=11238&query=is%3Aunresolved&statsPeriod=14d) with reset_session logging where a user has a nil access_token.

## WHY
A nil access token prevents the `refresh_token_expires_at` from being computed properly.

## HOW
Add a guard clause to check for nil `expires_at`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
