### PR TITLE
switch to using local ip database instead of making external calls

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -50,6 +50,7 @@ gem 'tzinfo'
 gem 'tzinfo-data'
 gem 'ziptz'
 gem 'geocoder'
+gem 'maxminddb'
 
 # OTHERS
 gem 'global'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -400,6 +400,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
+    maxminddb (0.1.22)
     memoist (0.16.2)
     method_source (1.0.0)
     mime-types (3.3.1)
@@ -831,6 +832,7 @@ DEPENDENCIES
   kaminari (~> 1.2.1)
   letter_opener
   lograge
+  maxminddb
   mini_racer (= 0.4.0)
   newrelic_rpm (~> 7.2)
   nokogiri (>= 1.13.2)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -664,7 +664,7 @@ class User < ApplicationRecord
       self.time_zone = school_timezone
     else
       geocoder_results = Geocoder.search(ip_address.to_s)
-      self.time_zone = geocoder_results.first&.data && geocoder_results.first.data['location'] ? geocoder_results.first.data['location']['time_zone'] : nil
+      self.time_zone = (geocoder_results.first&.data && geocoder_results.first.data['location']) ? geocoder_results.first.data['location']['time_zone'] : nil
     end
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -664,7 +664,7 @@ class User < ApplicationRecord
       self.time_zone = school_timezone
     else
       geocoder_results = Geocoder.search(ip_address.to_s)
-      self.time_zone = (geocoder_results.first&.data && geocoder_results.first.data['location']) ? geocoder_results.first.data['location']['time_zone'] : nil
+      self.time_zone = geocoder_results.first ? geocoder_results.first.data.dig('location', 'time_zone') : nil
     end
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -663,7 +663,7 @@ class User < ApplicationRecord
     if school_timezone.present?
       self.time_zone = school_timezone
     else
-      geocoder_results = Geocoder.search(ip_address)
+      geocoder_results = Geocoder.search(ip_address.to_s)
       self.time_zone = geocoder_results.first&.data ? geocoder_results.first.data['timezone'] : nil
     end
   end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -664,7 +664,7 @@ class User < ApplicationRecord
       self.time_zone = school_timezone
     else
       geocoder_results = Geocoder.search(ip_address.to_s)
-      self.time_zone = geocoder_results.first&.data ? geocoder_results.first.data['timezone'] : nil
+      self.time_zone = geocoder_results.first&.data && geocoder_results.first.data['location'] ? geocoder_results.first.data['location']['time_zone'] : nil
     end
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -183,7 +183,7 @@ class User < ApplicationRecord
   before_validation :generate_student_username_if_absent
   before_validation :prep_authentication_terms
   before_save :capitalize_name
-  before_save :set_time_zone, unless: :time_zone, if: proc { teacher? }
+  before_save :set_time_zone, unless: :time_zone
   after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -664,7 +664,7 @@ class User < ApplicationRecord
       self.time_zone = school_timezone
     else
       geocoder_results = Geocoder.search(ip_address.to_s)
-      self.time_zone = geocoder_results.first ? geocoder_results.first.data.dig('location', 'time_zone') : nil
+      self.time_zone = geocoder_results.first&.data&.dig('location', 'time_zone')
     end
   end
 

--- a/services/QuillLMS/config/initializers/geocoder.rb
+++ b/services/QuillLMS/config/initializers/geocoder.rb
@@ -26,5 +26,6 @@ Geocoder.configure(
   #   expiration: 2.days,
   #   prefix: 'geocoder:'
   # }
-  api_key: ENV.fetch('IPINFO_IO_KEY', '')               # API key for geocoding service
+  ip_lookup: :geoip2,
+  geoip2: { file: File.join('lib/data/GeoLite2-City_20221004', 'GeoLite2-City.mmdb') }
 )

--- a/services/QuillLMS/lib/data/GeoLite2-City_20221004/COPYRIGHT.txt
+++ b/services/QuillLMS/lib/data/GeoLite2-City_20221004/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Database and Contents Copyright (c) 2022 MaxMind, Inc.

--- a/services/QuillLMS/lib/data/GeoLite2-City_20221004/LICENSE.txt
+++ b/services/QuillLMS/lib/data/GeoLite2-City_20221004/LICENSE.txt
@@ -1,0 +1,3 @@
+Use of this MaxMind product is governed by MaxMind's GeoLite2 End User License Agreement, which can be viewed at https://www.maxmind.com/en/geolite2/eula.
+
+This database incorporates GeoNames [https://www.geonames.org] geographical data, which is made available under the Creative Commons Attribution 4.0 License. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/.

--- a/services/QuillLMS/lib/data/GeoLite2-City_20221004/README.txt
+++ b/services/QuillLMS/lib/data/GeoLite2-City_20221004/README.txt
@@ -1,0 +1,1 @@
+Latitude and longitude are not precise and should not be used to identify a particular street address or household.

--- a/services/QuillLMS/spec/support/geocoder.rb
+++ b/services/QuillLMS/spec/support/geocoder.rb
@@ -5,7 +5,7 @@ Geocoder.configure(lookup: :test, ip_lookup: :test)
 Geocoder::Lookup::Test.set_default_stub(
   [
     {
-      data: { 'timezone' => 'America/New_York' }
+      data: { 'location' => {'time_zone' => 'America/New_York' } }
     }
   ]
 )


### PR DESCRIPTION
## WHAT
Switch to using a local ip address database for the ip-to-timezone lookup calls, instead of an external api.

## WHY
The IP lookup site we were using rate-limited us to 50k calls a month. That's enough to keep up with assigning time zones to new teachers, but not enough to retroactively add them for old ones or to assign them to students. 

## HOW
Just update the config for `geocoder`, and then update the method itself to work against the new api.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Scale-up-IP-search-to-work-for-students-as-well-1632554835d64f339aab55ded03b1b10

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES (the Geocoder stub, the tests themselves didn't need updating)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
