### PR TITLE
lms/update-ortto-urls

### DIFF
--- a/services/QuillLMS/app/views/application/_ortto.html.erb
+++ b/services/QuillLMS/app/views/application/_ortto.html.erb
@@ -5,10 +5,10 @@
     ap3c.cmd = ap3c.cmd || [];
 
     ap3c.cmd.push(function() {
-        ap3c.init('<%= ENV["ORTTO_KEY"] %>', 'https://capture-api.autopilotapp.com/');
+        ap3c.init('<%= ENV["ORTTO_KEY"] %>', 'https://track.quill.org/');
         ap3c.track({"v":0,"email":"<%= raw(current_user&.email) %>","first":"<%= raw(current_user&.first_name) %>","last":"<%= raw(current_user&.last_name) %>"});
     });
     ap3c.activity = function(act) { ap3c.act = (ap3c.act || []); ap3c.act.push(act); };
-    var s, t; s = document.createElement('script'); s.type = 'text/javascript'; s.src = "https://cdn3l.ink/app.js";
+    var s, t; s = document.createElement('script'); s.type = 'text/javascript'; s.src = "https://track.quill.org/app.js";
     t = document.getElementsByTagName('script')[0]; t.parentNode.insertBefore(s, t);
 </script>

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -55,9 +55,7 @@ SecureHeaders::Configuration.default do |config|
       "https://*.intercomcdn.com",
       "https://*.coview.com",
       "https://*.sentry.io",
-      "https://*.heapanalytics.com",
-      "https://cdn3l.ink/app.js",
-      "https://capture-api.ap3prod.com"
+      "https://*.heapanalytics.com"
     ],
 
     font_src: [


### PR DESCRIPTION
## WHAT
Update Ortto to use Quill.org domains
## WHY
This is a new Ortto feature designed to make it less likely for Ortto tracking to be blocked by ad-blockers and firewalls.
## HOW
Just update the URLs referenced in our Ortto tracking snippet.

### Notion Card Links
https://www.notion.so/quill/PS-Update-Ortto-tracking-code-with-custom-URLs-a6814e7b28c7459f9338ca3e30489456

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on code snippets
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
