### PR TITLE
Labeled Synthetic - Add spelling errors to validation/test data.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
@@ -54,18 +54,22 @@ module Evidence
       end
 
       def run
-        generators.each do |type, generator|
-          results_hash = generator.run(results_to_train.map(&:text), languages: languages, passage: passage)
-
-          results_to_train.each do |result|
-            result.generated[type] = results_hash[result.text] || {}
-          end
-        end
+        run_generators(generators, results_training)
 
         self
       end
 
-      def results_to_train
+      def run_generators(generator_hash, results_set)
+        generator_hash.each do |type, generator|
+          results_hash = generator.run(results_set.map(&:text), languages: languages, passage: passage)
+
+          results_set.each do |result|
+            result.generated[type] = results_hash[result.text] || {}
+          end
+        end
+      end
+
+      def results_training
         return results unless manual_types
 
         results.select {|r| r.type == TYPE_TRAIN}

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
@@ -85,7 +85,6 @@ module Evidence
         generators.slice(*TEST_GENERATOR_KEYS)
       end
 
-
       def results_test_validation
         return results unless manual_types
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
@@ -20,6 +20,8 @@ module Evidence
         spelling_passage_specific: Synthetic::Generators::SpellingPassageSpecific
       }
 
+      TEST_GENERATOR_KEYS = [:spelling_passage_specific]
+
       FREE_GENERATORS = GENERATORS.except(:translations)
       DEFAULT_LANGUAGES = Evidence::Synthetic::Generators::Translation::TRAIN_LANGUAGES.keys
 
@@ -56,6 +58,10 @@ module Evidence
       def run
         run_generators(generators, results_training)
 
+        if manual_types
+          run_generators(test_generators, results_test_validation)
+        end
+
         self
       end
 
@@ -73,6 +79,17 @@ module Evidence
         return results unless manual_types
 
         results.select {|r| r.type == TYPE_TRAIN}
+      end
+
+      def test_generators
+        generators.slice(*TEST_GENERATOR_KEYS)
+      end
+
+
+      def results_test_validation
+        return results unless manual_types
+
+        results.select {|r| r.type == TYPE_VALIDATION || r.type == TYPE_TEST}
       end
 
       LABEL_FILE = 'synthetic'


### PR DESCRIPTION
## WHAT
We currently generate spelling errors for `TRAINING` data, but not `TEST` and `VALIDATION` data. This adds passage-specific spelling errors to the `TEST` and `VALIDATION` data.
## WHY

We've been restricting the synthetic data to only the TRAINING set for now, out of concern that if the synthetic data shifts too much from the label, it might have an outsized impact on the smaller `TEST` and `VALIDATION` sets (5-10% of the data each). The spelling synthetic data is a little more controlled (we're basically 100% confident the label is accurate), so we can be more confident validating the model with it.

Also, generally speaking, the student data will have spelling errors in it, so our `TEST` and `VALIDATION` sets should have it to make our model stronger and out scoring more accurate.

## HOW

Make the `run` code a little more generic and specific `TEST_GENERATORS` for a second pass

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
