### PR TITLE
lms/clear-cache-on-activity-session-teacher-fix

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -71,6 +71,10 @@ class TeacherFixController < ApplicationController
           recovered_assigned_students = activity_sessions.map(&:user_id)
           cu.update(visible: true, assigned_student_ids: cu.assigned_student_ids.union(recovered_assigned_students))
           activity_sessions.update_all(visible: true)
+          # update_all bypasses ActiveRecord callbacks, and thus doesn't
+          # trigger the `touch` bubble-up that we use for cache invalidation.
+          # So we need to do the touches manually.
+          activity_sessions.each(&:touch)
         end
         render json: {}, status: 200
       else

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -161,6 +161,11 @@ describe TeacherFixController do
           post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
           expect(classroom_unit.reload.assigned_student_ids).to include(another_user.id, other_student.id)
         end
+
+        it 'should touch ActivitySessions to bubble up touch for cache invalidation purposes' do
+          expect_any_instance_of(ClassroomUnit).to receive(:touch) 
+          post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
+        end
       end
 
       context 'when unit does not exist' do

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -163,7 +163,7 @@ describe TeacherFixController do
         end
 
         it 'should touch ActivitySessions to bubble up touch for cache invalidation purposes' do
-          expect_any_instance_of(ClassroomUnit).to receive(:touch) 
+          expect_any_instance_of(ClassroomUnit).to receive(:touch)
           post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
         end
       end

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -163,6 +163,7 @@ describe TeacherFixController do
         end
 
         it 'should touch ActivitySessions to bubble up touch for cache invalidation purposes' do
+          # Testing that a ClassroomUnit gets a touch bubbled up to it from the underlying ActivitySession
           expect_any_instance_of(ClassroomUnit).to receive(:touch)
           post :recover_activity_sessions, params: { email: user.email, unit_name: "some name" }
         end


### PR DESCRIPTION
## WHAT
Manually touch the ActivitySessions that we update to clear cache
## WHY
The `update_all` call we use in this code bypasses normal ActiveRecord callbacks so the `touch` call that should bubble up to Classroom to clear report caching doesn't happen and it's not clear that the teacher fix works (even though it does)
## HOW
Add a `.each(&:touch)` after the `.update_all` call

### Notion Card Links
https://www.notion.so/quill/Can-t-recover-student-data-with-the-restore-activity-sessions-fix-5fb30953412b48e39145cf41c17799b9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
