### PR TITLE
scorebook long data fix

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -8,6 +8,8 @@ class Scorebook::Query
     first_unit = units(unit_id) ? units(unit_id).first : nil
     last_unit = units(unit_id) ? units(unit_id).last : nil
     user_timezone_offset = "+ INTERVAL '#{offset}' SECOND"
+    offset_clause = current_page ? "OFFSET (#{(current_page.to_i - 1) * SCORES_PER_PAGE})" : nil
+
     RawSqlRunner.execute(
       <<-SQL
         SELECT
@@ -63,7 +65,7 @@ class Scorebook::Query
           MIN(acts.completed_at),
           CASE WHEN SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
           cu.created_at ASC
-          OFFSET (#{(current_page.to_i - 1) * SCORES_PER_PAGE})
+          #{offset_clause}
           FETCH NEXT #{SCORES_PER_PAGE} ROWS ONLY
       SQL
     ).to_a

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
@@ -40,7 +40,6 @@ export default createReactClass({
       beginDate: null,
       premium_state: premium_state,
       endDate: null,
-      currentPage: 0,
       loading: false,
       is_last_page: false,
       noLoadHasEverOccurredYet: true,
@@ -132,15 +131,13 @@ export default createReactClass({
 
   fetchData() {
     const {
-      currentPage,
       selectedClassroom,
       selectedUnit,
       beginDate,
       endDate,
       noLoadHasEverOccurredYet,
     } = this.state
-    const newCurrentPage = currentPage + 1;
-    this.setState({ loading: true, currentPage: newCurrentPage, });
+    this.setState({ loading: true });
     if (!selectedClassroom) {
       this.setState({ missing: 'classrooms', loading: false, });
       return;
@@ -148,7 +145,6 @@ export default createReactClass({
     $.ajax({
       url: '/teachers/classrooms/scores',
       data: {
-        current_page: newCurrentPage,
         classroom_id: selectedClassroom.value,
         unit_id: selectedUnit.value,
         begin_date: this.formatDate(beginDate),
@@ -241,7 +237,6 @@ export default createReactClass({
   selectUnit(option) {
     this.setState({
       scores: new Map(),
-      currentPage: 0,
       selectedUnit: option,
     }, this.fetchData);
   },
@@ -251,7 +246,6 @@ export default createReactClass({
     this.getUpdatedUnits(option.value);
     this.setState({
       scores: new Map(),
-      currentPage: 0,
       selectedClassroom: option,
     }, this.fetchData
     );
@@ -262,7 +256,6 @@ export default createReactClass({
     window.localStorage.setItem('scorebookDateFilterName', dateFilterName);
     this.setState({
       scores: new Map(),
-      currentPage: 0,
       beginDate,
       endDate,
       dateFilterName,

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/Scorebook.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/Scorebook.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-
 import moment from 'moment';
 import request from 'request'
 
@@ -192,7 +191,6 @@ describe('Scorebook component', () => {
     it('should set state and call fetchData on callback', () => {
       wrapper.instance().selectDates(beginDate, endDate);
       expect(wrapper.state().scores).toEqual(new Map());
-      expect(wrapper.state().currentPage).toBe(0);
       expect(wrapper.state().beginDate).toBe(beginDate);
       expect(wrapper.state().endDate).toBe(endDate);
       expect(wrapper.instance().fetchData).toHaveBeenCalled();


### PR DESCRIPTION
## WHAT
Some teachers have such a large number of activity scores that it overflows "page 1" of the paginated API.

- Remove 'currentPage' from API query. 
- allow API to handle non-paginated requests 

This component was not constructed with pagination, although we may decide that the product should have pagination in the future. 

Note: this query is cached.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-s-Activity-Summary-Report-is-cutting-off-students-at-end-of-alphabet-9be98a92f1c2401d9ac9ee48e4861560

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
