### PR TITLE
lms/update-login-error-messages

### DIFF
--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -19,12 +19,15 @@ class SessionsController < ApplicationController
     if @user.nil?
       report_that_route_is_still_in_use
       login_failure_message
-    elsif @user.signed_up_with_google
+    elsif @user.signed_up_with_google || @user.google_id
       report_that_route_is_still_in_use
       login_failure 'You signed up with Google, please log in with Google using the link above.'
+    elsif @user.clever_id
+      report_that_route_is_still_in_use
+      login_failure 'You signed up with Clever, please log in with Clever using the link above.'
     elsif @user.password_digest.nil?
       report_that_route_is_still_in_use
-      login_failure 'Login failed. Did you sign up with Google? If so, please log in with Google using the link above.'
+      login_failure 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.'
     elsif @user.authenticate(params[:user][:password])
       sign_in(@user)
       if session[ApplicationController::POST_AUTH_REDIRECT].present?

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -32,6 +32,18 @@ describe SessionsController, type: :controller do
       end
     end
 
+    context 'when user has signed up with clever' do
+      before do
+        allow_any_instance_of(User).to receive(:clever_id) { 1 }
+      end
+
+      it 'should report login failiure' do
+        post :create, params: { user: { email: user.email } }
+        expect(flash[:error]).to eq 'You signed up with Clever, please log in with Clever using the link above.'
+        expect(response).to redirect_to "/session/new"
+      end
+    end
+
     context 'when user has no password digest' do
       before do
         allow_any_instance_of(User).to receive(:password_digest) { nil }
@@ -39,7 +51,7 @@ describe SessionsController, type: :controller do
 
       it 'should report login failiure' do
         post :create, params: { user: { email: user.email } }
-        expect(flash[:error]).to eq 'Login failed. Did you sign up with Google? If so, please log in with Google using the link above.'
+        expect(flash[:error]).to eq 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.'
         expect(response).to redirect_to "/session/new"
       end
     end


### PR DESCRIPTION
## WHAT
Update the login error messaging in our `session#create` action
## WHY
Our current error messages are confusing and inaccurate

Also, we have some number of users getting their passwords set to `nil` for some reason, and the error message they get when trying to log in is wrong.  It thinks they may be Google users, but we can give better messages.
## HOW
Tweak the error messaging conditions to cover cases more cleanly

### Notion Card Links
https://www.notion.so/quill/Teachers-cannot-login-manually-email-recognized-as-Google-email-c8b7a261fde84867a4082cca52573f4f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
