### PR TITLE
add warning icon next to disabled actions dropdown

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -406,9 +406,17 @@
       }
     }
   }
+  .student-actions-dropdown-wrapper {
+    display: flex;
+    align-items: center;
+    margin-bottom: 32px;
+    .quill-tooltip-trigger {
+      margin-top: 12px;
+      margin-left: 10px;
+    }
+  }
   .student-actions-dropdown {
     width: 200px;
-    height: 91px;
     justify-content: flex-start;
     .dropdown {
       font-size: 16px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -418,6 +418,7 @@
   .student-actions-dropdown {
     width: 200px;
     justify-content: flex-start;
+    min-height: 59px !important;
     .dropdown {
       font-size: 16px;
     }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
@@ -79,24 +79,38 @@ exports[`ClassroomStudentSection component with students should render 1`] = `
       </div>
     </div>
   </div>
-  <DropdownInput
-    className="student-actions-dropdown"
-    disabled={true}
-    handleChange={[Function]}
-    label="Actions"
-    options={
-      Array [
-        Object {
-          "label": "View as student",
-          "value": undefined,
-        },
-        Object {
-          "label": "Remove from class",
-          "value": [Function],
-        },
-      ]
-    }
-  />
+  <div
+    className="student-actions-dropdown-wrapper"
+  >
+    <DropdownInput
+      className="student-actions-dropdown"
+      disabled={true}
+      handleChange={[Function]}
+      label="Actions"
+      options={
+        Array [
+          Object {
+            "label": "View as student",
+            "value": undefined,
+          },
+          Object {
+            "label": "Remove from class",
+            "value": [Function],
+          },
+        ]
+      }
+    />
+    <Tooltip
+      isTabbable={true}
+      tooltipText="Please select students from the list below to take action"
+      tooltipTriggerText={
+        <img
+          alt="Warning icon"
+          src="undefined/images/icons/warning-icon.svg"
+        />
+      }
+    />
+  </div>
   <DataTable
     averageFontWidth={7}
     checkAllRows={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -7,7 +7,7 @@ import MergeStudentAccountsModal from './merge_student_accounts_modal'
 import MoveStudentsModal from './move_students_modal'
 import RemoveStudentsModal from './remove_students_modal'
 
-import { DropdownInput, DataTable, Tooltip, helpIcon } from '../../../Shared/index'
+import { DropdownInput, DataTable, Tooltip, helpIcon, warningIcon, } from '../../../Shared/index'
 
 const emptyDeskSrc = `${process.env.CDN_URL}/images/illustrations/empty-desks.svg`
 const bulbSrc = `${process.env.CDN_URL}/images/illustrations/bulb.svg`
@@ -410,13 +410,19 @@ export default class ClassroomStudentSection
       return null
     } else {
       return (
-        <DropdownInput
-          className="student-actions-dropdown"
-          disabled={selectedStudentIds.length === 0}
-          handleChange={this.selectAction}
-          label="Actions"
-          options={this.optionsForStudentActions()}
-        />
+        <div className="student-actions-dropdown-wrapper">
+          <DropdownInput
+            className="student-actions-dropdown"
+            disabled={selectedStudentIds.length === 0}
+            handleChange={this.selectAction}
+            label="Actions"
+            options={this.optionsForStudentActions()}
+          />
+          {selectedStudentIds.length === 0 && <Tooltip
+            tooltipText="Please select students from the list below to take action"
+            tooltipTriggerText={<img alt={warningIcon.alt} src={warningIcon.src} />}
+          />}
+        </div>
       )
     }
   }


### PR DESCRIPTION
## WHAT
Add a warning icon and tooltip next to the student actions dropdown when it is disabled.

## WHY
It was unclear to some users why the actions dropdown wouldn't open.

## HOW
Just add the relevant HTML and CSS.

### Screenshots
<img width="805" alt="Screen Shot 2022-10-12 at 1 13 12 PM" src="https://user-images.githubusercontent.com/18669014/195410004-c244337d-75de-4d18-a65b-fbc0ec4c78d9.png">

### Notion Card Links
https://www.notion.so/quill/Actions-dropdown-on-the-classes-page-does-not-work-65c69052a6934df0a80fcbadc530617a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
