### PR TITLE
lms/restrict-vitally-district-sync

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -47,6 +47,6 @@ class SyncVitallyWorker
   end
 
   def districts_to_sync
-    schools_to_sync.map(&:district).compact.uniq
+    schools_to_sync.map(&:district).compact.uniq.select { |district| district&.schools&.any?(&:subscription) }
   end
 end

--- a/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
@@ -11,9 +11,11 @@ describe SyncVitallyWorker, type: :worker do
       stub_const('ENV', {'SYNC_TO_VITALLY' => 'true'})
     end
 
-    it "make queries for schools and users and enqueue them for further jobs" do
+    it "make queries for schools, users, and districts and enqueue them for further jobs" do
       district = create(:district)
       school = create(:school, district: district)
+      subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
+      create(:school_subscription, school: school, subscription: subscription)
       user = create(:user, role: 'teacher')
       SchoolsUsers.create(school: school, user: user)
 
@@ -40,6 +42,18 @@ describe SyncVitallyWorker, type: :worker do
     it 'does not kick off job for districts without schools with teachers' do
       district = create(:district)
       school = create(:school, district: district)
+      subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
+      create(:school_subscription, school: school, subscription: subscription)
+
+      expect(SyncVitallyOrganizationWorker).not_to receive(:perform_async).with([district.id])
+      worker.perform
+    end
+
+    it 'does not kick off job for districts that have 0 schools with current subscriptions attached to them' do
+      district = create(:district)
+      school = create(:school, district: district)
+      user = create(:user, role: 'teacher')
+      SchoolsUsers.create(school: school, user: user)
 
       expect(SyncVitallyOrganizationWorker).not_to receive(:perform_async).with([district.id])
       worker.perform
@@ -51,6 +65,8 @@ describe SyncVitallyWorker, type: :worker do
       (SyncVitallyWorker::ORGANIZATION_RATE_LIMIT_PER_MINUTE * 3).times do
         district = create(:district)
         school = create(:school, district: district)
+        subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
+        create(:school_subscription, school: school, subscription: subscription)
         user = create(:user, role: 'teacher')
         SchoolsUsers.create(school: school, user: user)
       end


### PR DESCRIPTION
## WHAT
Do not include districts with no paid schools for sync to Vitally
## WHY
We only want to manage districts ("Organizations") in Vitally if we have some sort of paid relationship with them because Vitally charges us for every Organization we manage with them.  So we should stop sending them data about districts we don't have paid relationships with.
## HOW
Just add an extra `select` to the code that retrieves the list of districts to sync to filter out any districts without paid schools in them (which is the vast majority).

### Notion Card Links
https://www.notion.so/quill/Overview-Only-Send-Vitally-Districts-for-Schools-in-Districts-that-Contain-Paying-Schools-10f355b54d494679b9e1510192bd34e5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
