### PR TITLE
Add Premium Status to District Manager and fix some bugs

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
@@ -106,24 +106,6 @@
   }
 }
 
-.cms-districts-table {
-  background-color: white;
-  .rt-thead {
-    background-color: #fafafa;
-    font-size: 14px;
-    font-weight: 600;
-    color: #3b3b3b;
-    text-align: left;
-    padding-left: 14px;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-  }
-}
-
 .cms-author-avatar {
   border-radius: 50%;
   height: 80px;

--- a/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
@@ -106,6 +106,24 @@
   }
 }
 
+.cms-districts-table {
+  background-color: white;
+  .rt-thead {
+    background-color: #fafafa;
+    font-size: 14px;
+    font-weight: 600;
+    color: #3b3b3b;
+    text-align: left;
+    padding-left: 14px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+  }
+}
+
 .cms-author-avatar {
   border-radius: 50%;
   height: 80px;

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -76,6 +76,7 @@ class Cms::DistrictsController < Cms::CmsController
 
   private def text_search_inputs
     @text_search_inputs = ['district_name', 'district_city', 'district_state', 'district_zip', 'district_name', 'nces_id']
+    @district_premium_types = Subscription::OFFICIAL_DISTRICT_TYPES
   end
 
   private def all_search_inputs
@@ -98,7 +99,7 @@ class Cms::DistrictsController < Cms::CmsController
       result = result.order("total_students DESC")
     end
 
-    result = add_where_conditions(result).select(:id, :name, :city, :state, :zipcode, :phone, :total_students, :total_schools, :nces_id)
+    result = add_where_conditions(result).joins(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id')
   end
 
   private def add_where_conditions(districts)
@@ -107,6 +108,7 @@ class Cms::DistrictsController < Cms::CmsController
     districts = districts.by_state(district_query_params[:district_state]) if district_query_params[:district_state].present?
     districts = districts.by_zipcode(district_query_params[:district_zipcode]) if district_query_params[:district_zipcode].present?
     districts = districts.by_nces_id(district_query_params[:nces_id]) if district_query_params[:nces_id].present?
+    districts = districts.by_premium_status(district_query_params[:premium_status]) if district_query_params[:premium_status].present?
     districts
   end
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -156,6 +156,8 @@ class Cms::DistrictsController < Cms::CmsController
       .left_joins(:schools_users)
       .left_joins(:schools_admins)
       .left_joins(school_subscriptions: :subscription)
+      .where("subscriptions.expiration IS NULL OR subscriptions.expiration > ?", Date.current)
+      .where("subscriptions.de_activated_date IS NULL")
       .group('schools.name, schools.id, subscriptions.account_type')
   end
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -26,6 +26,10 @@ class Cms::DistrictsController < Cms::CmsController
     @subscription = @district&.subscription
     @school_data = school_query
     @admins = DistrictAdmin.includes(:user).where(district_id: params[:id].to_i)
+    @district_subscription_info = {
+      'District Premium Type' => @district&.subscription&.account_type,
+      'Expiration' => @district&.subscription&.expiration&.strftime('%b %d, %Y')
+    }
   end
 
   def new

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -77,7 +77,6 @@ class Cms::DistrictsController < Cms::CmsController
 
   private def text_search_inputs
     @text_search_inputs = ['district_name', 'district_city', 'district_state', 'district_zip', 'district_name', 'nces_id']
-    @district_premium_types = Subscription::OFFICIAL_DISTRICT_TYPES
   end
 
   private def all_search_inputs
@@ -104,7 +103,7 @@ class Cms::DistrictsController < Cms::CmsController
       result = result.order("total_students DESC")
     end
 
-    result = add_where_conditions(result).includes(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id').references(:subscriptions)
+    result = add_where_conditions(result).select(:id, :name, :city, :state, :zipcode, :phone, :total_students, :total_schools, :nces_id)
   end
 
   private def add_where_conditions(districts)
@@ -113,7 +112,6 @@ class Cms::DistrictsController < Cms::CmsController
     districts = districts.by_state(district_query_params[:district_state]) if district_query_params[:district_state].present?
     districts = districts.by_zipcode(district_query_params[:district_zipcode]) if district_query_params[:district_zipcode].present?
     districts = districts.by_nces_id(district_query_params[:nces_id]) if district_query_params[:nces_id].present?
-    districts = districts.by_premium_status(district_query_params[:premium_status]) if district_query_params[:premium_status].present?
     districts
   end
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -6,6 +6,7 @@ class Cms::DistrictsController < Cms::CmsController
   before_action :subscription_data, only: [:new_subscription, :edit_subscription]
 
   DISTRICTS_PER_PAGE = 30
+  PREMIUM_STATUS_SORT = 'premium_status'
 
   def index
     @district_search_query = {}
@@ -17,7 +18,7 @@ class Cms::DistrictsController < Cms::CmsController
     district_search_query = district_query_params
     district_search_query_results = district_query(district_query_params)
     district_search_query_results ||= []
-    number_of_pages = (district_search_query_results.count / DISTRICTS_PER_PAGE.to_f).ceil
+    number_of_pages = (district_search_query_results.size / DISTRICTS_PER_PAGE.to_f).ceil
     render json: {numberOfPages: number_of_pages, districtSearchQueryResults: district_search_query_results}
   end
 
@@ -76,6 +77,7 @@ class Cms::DistrictsController < Cms::CmsController
 
   private def text_search_inputs
     @text_search_inputs = ['district_name', 'district_city', 'district_state', 'district_zip', 'district_name', 'nces_id']
+    @district_premium_types = Subscription::OFFICIAL_DISTRICT_TYPES
   end
 
   private def all_search_inputs
@@ -93,12 +95,16 @@ class Cms::DistrictsController < Cms::CmsController
     sort = district_query_params[:sort]
     sort_direction = district_query_params[:sort_direction]
     if sort && sort_direction && sort != 'undefined' && sort_direction != 'undefined'
-      result = result.order("#{sort} #{sort_direction}")
+      if sort == PREMIUM_STATUS_SORT
+        result = result.includes(:subscriptions).order("subscriptions.account_type #{sort_direction}")
+      else
+        result = result.order("#{sort} #{sort_direction}")
+      end
     else
       result = result.order("total_students DESC")
     end
 
-    result = add_where_conditions(result).joins(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id')
+    result = add_where_conditions(result).includes(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id').references(:subscriptions)
   end
 
   private def add_where_conditions(districts)
@@ -107,6 +113,7 @@ class Cms::DistrictsController < Cms::CmsController
     districts = districts.by_state(district_query_params[:district_state]) if district_query_params[:district_state].present?
     districts = districts.by_zipcode(district_query_params[:district_zipcode]) if district_query_params[:district_zipcode].present?
     districts = districts.by_nces_id(district_query_params[:nces_id]) if district_query_params[:nces_id].present?
+    districts = districts.by_premium_status(district_query_params[:premium_status]) if district_query_params[:premium_status].present?
     districts
   end
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -6,6 +6,7 @@ class Cms::DistrictsController < Cms::CmsController
   before_action :subscription_data, only: [:new_subscription, :edit_subscription]
 
   DISTRICTS_PER_PAGE = 30
+  PREMIUM_STATUS_SORT = 'premium_status'
 
   def index
     @district_search_query = {}
@@ -17,7 +18,7 @@ class Cms::DistrictsController < Cms::CmsController
     district_search_query = district_query_params
     district_search_query_results = district_query(district_query_params)
     district_search_query_results ||= []
-    number_of_pages = (district_search_query_results.count / DISTRICTS_PER_PAGE.to_f).ceil
+    number_of_pages = (district_search_query_results.size / DISTRICTS_PER_PAGE.to_f).ceil
     render json: {numberOfPages: number_of_pages, districtSearchQueryResults: district_search_query_results}
   end
 
@@ -94,12 +95,16 @@ class Cms::DistrictsController < Cms::CmsController
     sort = district_query_params[:sort]
     sort_direction = district_query_params[:sort_direction]
     if sort && sort_direction && sort != 'undefined' && sort_direction != 'undefined'
-      result = result.order("#{sort} #{sort_direction}")
+      if sort == PREMIUM_STATUS_SORT
+        result = result.includes(:subscriptions).order("subscriptions.account_type #{sort_direction}")
+      else
+        result = result.order("#{sort} #{sort_direction}")
+      end
     else
       result = result.order("total_students DESC")
     end
 
-    result = add_where_conditions(result).joins(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id')
+    result = add_where_conditions(result).includes(:subscriptions).select('subscriptions.account_type AS premium_status, districts.id, districts.name, districts.city, districts.state, districts.zipcode, districts.phone, districts.total_students, districts.total_schools, districts.nces_id').references(:subscriptions)
   end
 
   private def add_where_conditions(districts)

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -244,7 +244,7 @@ class Cms::SchoolsController < Cms::CmsController
 
   private def where_query_string_builder
     conditions = [
-      "subscriptions.expiration IS NULL OR subscriptions.expiration > '#{Date.current}'",
+      "(subscriptions.expiration IS NULL OR subscriptions.expiration > '#{Date.current}')",
       "subscriptions.de_activated_date IS NULL"
     ]
     # This converts all of the search inputs into strings so we can iterate

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -244,7 +244,10 @@ class Cms::SchoolsController < Cms::CmsController
 
   # rubocop:disable Metrics/CyclomaticComplexity
   private def where_query_string_builder
-    conditions = []
+    conditions = [
+      "subscriptions.expiration IS NULL OR subscriptions.expiration > '#{Date.current}'",
+      "subscriptions.de_activated_date IS NULL"
+    ]
     # This converts all of the search inputs into strings so we can iterate
     # over them and grab the value from params. The weird ternary here is in
     # case we have arrays as inputs (e.g. the 'premium_status' field).
@@ -255,7 +258,7 @@ class Cms::SchoolsController < Cms::CmsController
       end
     end
     conditions = conditions.reject(&:nil?)
-    "WHERE #{conditions.join(' AND ')}" unless conditions.empty?
+    "WHERE #{conditions.join(' AND ')}"
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -242,7 +242,6 @@ class Cms::SchoolsController < Cms::CmsController
     'HAVING COUNT(schools_users.*) != 0'
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   private def where_query_string_builder
     conditions = [
       "subscriptions.expiration IS NULL OR subscriptions.expiration > '#{Date.current}'",
@@ -260,7 +259,6 @@ class Cms::SchoolsController < Cms::CmsController
     conditions = conditions.reject(&:nil?)
     "WHERE #{conditions.join(' AND ')}"
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def where_query_string_clause_for(param, param_value)
     # Potential params by which to search:

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -40,6 +40,7 @@ class District < ApplicationRecord
   scope :by_state, ->(state) { where(state: state.upcase) }
   scope :by_zipcode, ->(zipcode) { where(zipcode: zipcode) }
   scope :by_nces_id, ->(nces_id) { where(nces_id: nces_id) }
+  scope :by_premium_status, ->(premium_status) { joins(:district_subscriptions).joins(:subscriptions).where("subscriptions.account_type=?", premium_status) }
 
   def attach_subscription(subscription)
     district_subscriptions.create(subscription: subscription)

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -40,6 +40,7 @@ class District < ApplicationRecord
   scope :by_state, ->(state) { where(state: state.upcase) }
   scope :by_zipcode, ->(zipcode) { where(zipcode: zipcode) }
   scope :by_nces_id, ->(nces_id) { where(nces_id: nces_id) }
+  scope :by_premium_status, ->(premium_status) { joins(:subscriptions).where("subscriptions.account_type = ?", premium_status) }
 
   def attach_subscription(subscription)
     district_subscriptions.create(subscription: subscription)

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -40,7 +40,6 @@ class District < ApplicationRecord
   scope :by_state, ->(state) { where(state: state.upcase) }
   scope :by_zipcode, ->(zipcode) { where(zipcode: zipcode) }
   scope :by_nces_id, ->(nces_id) { where(nces_id: nces_id) }
-  scope :by_premium_status, ->(premium_status) { joins(:district_subscriptions).joins(:subscriptions).where("subscriptions.account_type=?", premium_status) }
 
   def attach_subscription(subscription)
     district_subscriptions.create(subscription: subscription)

--- a/services/QuillLMS/app/views/cms/districts/index.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/index.html.erb
@@ -7,7 +7,7 @@
       </h1>
     </div>
     <div class='cms-container-meta'>
-      <%= react_component('CmsDistrictIndexApp', props: {queryResults: @district_search_query_results, query: @district_search_query}) %>
+      <%= react_component('CmsDistrictIndexApp', props: {queryResults: @district_search_query_results, query: @district_search_query, districtPremiumTypes: @district_premium_types}) %>
     </div>
   </article>
 </div>

--- a/services/QuillLMS/app/views/cms/districts/index.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/index.html.erb
@@ -7,7 +7,7 @@
       </h1>
     </div>
     <div class='cms-container-meta'>
-      <%= react_component('CmsDistrictIndexApp', props: {queryResults: @district_search_query_results, query: @district_search_query, districtPremiumTypes: @district_premium_types}) %>
+      <%= react_component('CmsDistrictIndexApp', props: {queryResults: @district_search_query_results, query: @district_search_query}) %>
     </div>
   </article>
 </div>

--- a/services/QuillLMS/app/views/cms/districts/show.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/show.html.erb
@@ -7,9 +7,19 @@
     <h2>District Subscription</h2>
     <br />
     <% if @subscription %>
-      <%= link_to 'Edit Subscription', edit_cms_subscription_path(@subscription), class: 'btn button-green' %>
+      <% if @subscription.stripe? %>
+        <%= link_to 'View in Stripe', edit_cms_subscription_path(@subscription), class: 'btn button-green', target: '_blank' %>
+      <% else %>
+        <%= link_to 'Edit Subscription', edit_cms_subscription_path(@subscription), class: 'btn button-green' %>
+      <% end %>
     <% end %>
     <%= link_to 'New Subscription', new_subscription_cms_district_path(params[:id]), class: 'btn button-green' %>
+    <br />
+    <% @district_subscription_info.each do |k,v| %>
+      <br />
+      <p><strong><%= k %></strong></p>
+      <p><%= v || 'N/A' %></p>
+    <% end %>
     <br /> <br />
     <h2>District Info</h2>
     <br />

--- a/services/QuillLMS/app/views/cms/schools/show.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/show.html.erb
@@ -53,9 +53,9 @@
     <br />
     <% if @subscription %>
       <% if @subscription.stripe? %>
-        <%= link_to 'Edit Subscription', edit_cms_subscription_path(@subscription), class: 'btn button-green' %>
-      <% else %>
         <%= link_to 'View in Stripe', edit_cms_subscription_path(@subscription), class: 'btn button-green', target: '_blank' %>
+      <% else %>
+        <%= link_to 'Edit Subscription', edit_cms_subscription_path(@subscription), class: 'btn button-green' %>
       <% end %>
     <% end %>
     <%= link_to 'New Subscription', new_subscription_cms_school_path(params[:id]), class: 'btn button-green' %>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -49,10 +49,6 @@ export default class CmsDistrictIndex extends React.Component {
         resizable: false,
         minWidth: 80
       }, {
-        Header: "Premium?",
-        accessor: 'premium_status',
-        minWidth: 90,
-      }, {
         Header: "Schools",
         accessor: 'total_schools',
         resizable: false,
@@ -137,18 +133,6 @@ export default class CmsDistrictIndex extends React.Component {
     this.setState(newState, this.search)
   };
 
-  handleUpdatePremiumStatus = e => {
-    const selectedOptions = []
-    Array.from(e.target.options).forEach(o => {
-      if (o.selected) {
-        selectedOptions.push(o.value)
-      }
-    })
-    const newState = { ...this.state }
-    newState.query.premium_status = selectedOptions
-    this.setState(newState)
-  };
-
   renderPageSelector() {
     const { query, numberOfPages } = this.state
 
@@ -162,16 +146,6 @@ export default class CmsDistrictIndex extends React.Component {
         </form>
         <a onClick={() => this.updatePage(totalPages)}>Last</a>
       </div>
-    )
-  }
-
-  renderPremiumStatusSelect() {
-    const { districtPremiumTypes } = this.props
-    const options = districtPremiumTypes.map((o, i) => <option key={i} value={o}>{o}</option>)
-    return (
-      <select className="premium-select" multiple={true} onChange={this.handleUpdatePremiumStatus}>
-        {options}
-      </select>
     )
   }
 
@@ -242,11 +216,6 @@ export default class CmsDistrictIndex extends React.Component {
             </div>
 
             <div className='cms-meta-right districts-meta-right'>
-              <div className='cms-form-row'>
-                <label htmlFor="premium-select">Premium Status</label>
-                {this.renderPremiumStatusSelect()}
-              </div>
-
               <div className='cms-submit-row'>
                 <input type="submit" value="Submit" />
               </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -49,6 +49,10 @@ export default class CmsDistrictIndex extends React.Component {
         resizable: false,
         minWidth: 80
       }, {
+        Header: "Premium?",
+        accessor: 'premium_status',
+        minWidth: 90,
+      }, {
         Header: "Schools",
         accessor: 'total_schools',
         resizable: false,
@@ -133,6 +137,18 @@ export default class CmsDistrictIndex extends React.Component {
     this.setState(newState, this.search)
   };
 
+  handleUpdatePremiumStatus = e => {
+    const selectedOptions = []
+    Array.from(e.target.options).forEach(o => {
+      if (o.selected) {
+        selectedOptions.push(o.value)
+      }
+    })
+    const newState = { ...this.state }
+    newState.query.premium_status = selectedOptions
+    this.setState(newState)
+  };
+
   renderPageSelector() {
     const { query, numberOfPages } = this.state
 
@@ -146,6 +162,16 @@ export default class CmsDistrictIndex extends React.Component {
         </form>
         <a onClick={() => this.updatePage(totalPages)}>Last</a>
       </div>
+    )
+  }
+
+  renderPremiumStatusSelect() {
+    const { districtPremiumTypes } = this.props
+    const options = districtPremiumTypes.map((o, i) => <option key={i} value={o}>{o}</option>)
+    return (
+      <select className="premium-select" multiple={true} onChange={this.handleUpdatePremiumStatus}>
+        {options}
+      </select>
     )
   }
 
@@ -216,6 +242,11 @@ export default class CmsDistrictIndex extends React.Component {
             </div>
 
             <div className='cms-meta-right districts-meta-right'>
+              <div className='cms-form-row'>
+                <label htmlFor="premium-select">Premium Status</label>
+                {this.renderPremiumStatusSelect()}
+              </div>
+
               <div className='cms-submit-row'>
                 <input type="submit" value="Submit" />
               </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -49,6 +49,10 @@ export default class CmsDistrictIndex extends React.Component {
         resizable: false,
         minWidth: 80
       }, {
+        Header: "Premium?",
+        accessor: 'premium_status',
+        minWidth: 90,
+      }, {
         Header: "Schools",
         accessor: 'total_schools',
         resizable: false,
@@ -133,6 +137,18 @@ export default class CmsDistrictIndex extends React.Component {
     this.setState(newState, this.search)
   };
 
+  handleUpdatePremiumStatus = e => {
+    const selectedOptions = []
+    Array.from(e.target.options).forEach(o => {
+      if (o.selected) {
+        selectedOptions.push(o.value)
+      }
+    })
+    const newState = { ...this.state }
+    newState.query.premium_status = selectedOptions
+    this.setState(newState)
+  };
+
   renderPageSelector() {
     const { query, numberOfPages } = this.state
 
@@ -146,6 +162,16 @@ export default class CmsDistrictIndex extends React.Component {
         </form>
         <a onClick={() => this.updatePage(totalPages)}>Last</a>
       </div>
+    )
+  }
+
+  renderPremiumStatusSelect() {
+    const { districtPremiumTypes } = this.props
+    const options = districtPremiumTypes.map((o, i) => <option key={i} value={o}>{o}</option>)
+    return (
+      <select className="premium-select" multiple={true} onChange={this.handleUpdatePremiumStatus}>
+        {options}
+      </select>
     )
   }
 
@@ -165,7 +191,7 @@ export default class CmsDistrictIndex extends React.Component {
     return (
       <div>
         <ReactTable
-          className='progress-report activity-scores-table'
+          className='cms-districts-table'
           columns={columns}
           data={data}
           defaultPageSize={100}
@@ -216,6 +242,11 @@ export default class CmsDistrictIndex extends React.Component {
             </div>
 
             <div className='cms-meta-right districts-meta-right'>
+              <div className='cms-form-row'>
+                <label htmlFor="premium-select">Premium Status</label>
+                {this.renderPremiumStatusSelect()}
+              </div>
+
               <div className='cms-submit-row'>
                 <input type="submit" value="Submit" />
               </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -191,7 +191,7 @@ export default class CmsDistrictIndex extends React.Component {
     return (
       <div>
         <ReactTable
-          className='progress-report activity-scores-table'
+          className='cms-districts-table'
           columns={columns}
           data={data}
           defaultPageSize={100}

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/CmsDistrictIndexAppClient.tsx
@@ -165,7 +165,7 @@ export default class CmsDistrictIndex extends React.Component {
     return (
       <div>
         <ReactTable
-          className='cms-districts-table'
+          className='progress-report activity-scores-table'
           columns={columns}
           data={data}
           defaultPageSize={100}

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -96,7 +96,7 @@ describe Cms::DistrictsController do
     context 'when the district has schools with some expired subscriptions' do
       it 'should show only one record of each school' do
         school = create(:school, district: district)
-        expired_sub = create(:subscription, expiration: Time.current - 1.year)
+        expired_sub = create(:subscription, expiration: 15.days.ago.to_date)
         active_sub = create(:subscription)
         create(:school_subscription, school: school, subscription: expired_sub)
         create(:school_subscription, school: school, subscription: active_sub)

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -92,6 +92,20 @@ describe Cms::DistrictsController do
         'Expiration' => district.subscription.expiration.strftime('%b %d, %Y')
        })
     end
+
+    context 'when the district has schools with some expired subscriptions' do
+      it 'should show only one record of each school' do
+        school = create(:school, district: district)
+        expired_sub = create(:subscription, expiration: Date.today - 1.year)
+        active_sub = create(:subscription)
+        create(:school_subscription, school: school, subscription: expired_sub)
+        create(:school_subscription, school: school, subscription: active_sub)
+
+        get :show, params: { id: district.id }
+        expect(assigns(:school_data)[0]).to eq(school)
+        expect(assigns(:school_data).length).to eq(1)
+      end
+    end
   end
 
   describe '#edit' do

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -96,7 +96,7 @@ describe Cms::DistrictsController do
     context 'when the district has schools with some expired subscriptions' do
       it 'should show only one record of each school' do
         school = create(:school, district: district)
-        expired_sub = create(:subscription, expiration: Date.today - 1.year)
+        expired_sub = create(:subscription, expiration: Time.zone.current - 1.year)
         active_sub = create(:subscription)
         create(:school_subscription, school: school, subscription: expired_sub)
         create(:school_subscription, school: school, subscription: active_sub)

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -25,6 +25,11 @@ describe Cms::DistrictsController do
       expect(assigns(:district_search_query_results)).to eq []
       expect(assigns(:number_of_pages)).to eq 0
     end
+
+    it 'should assign the correct default values' do
+      get :index
+      expect(assigns(:district_premium_types)).to match_array(Subscription::OFFICIAL_DISTRICT_TYPES)
+    end
   end
 
   describe '#search' do
@@ -66,8 +71,10 @@ describe Cms::DistrictsController do
 
   describe '#show' do
     let!(:district) { create(:district) }
+    let!(:subscription) { create(:subscription, account_type: Subscription::OFFICIAL_DISTRICT_TYPES.first)}
 
     it 'should assign the correct values' do
+      create(:district_subscription, district: district, subscription: subscription)
       get :show, params: { id: district.id }
       expect(assigns(:district)).to eq(district)
       expect(assigns(:school_data)).to eq([])
@@ -80,6 +87,10 @@ describe Cms::DistrictsController do
         }
       end
       )
+      expect(assigns(:district_subscription_info)).to eq({
+        'District Premium Type' => district.subscription.account_type,
+        'Expiration' => district.subscription.expiration.strftime('%b %d, %Y')
+       })
     end
   end
 

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -96,7 +96,7 @@ describe Cms::DistrictsController do
     context 'when the district has schools with some expired subscriptions' do
       it 'should show only one record of each school' do
         school = create(:school, district: district)
-        expired_sub = create(:subscription, expiration: Time.zone.current - 1.year)
+        expired_sub = create(:subscription, expiration: Time.current - 1.year)
         active_sub = create(:subscription)
         create(:school_subscription, school: school, subscription: expired_sub)
         create(:school_subscription, school: school, subscription: active_sub)

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -40,6 +40,18 @@ describe Cms::SchoolsController do
       get :search
       expect(response.body).to eq({numberOfPages: 0, schoolSearchQueryResults: [school_hash]}.to_json)
     end
+
+    context 'when a school has an expired subscription and an active subscription' do
+      it 'should only one record of that school, without duplicates' do
+        school = create(:school)
+        expired_sub = create(:subscription, expiration: Date.today - 1.year)
+        active_sub = create(:subscription)
+        create(:school_subscription, school: school, subscription: expired_sub)
+        create(:school_subscription, school: school, subscription: active_sub)
+        get :search, params: {:school_name => school.name}
+        expect(JSON.parse(response.body)['schoolSearchQueryResults'].size).to eq(1)
+      end
+    end
   end
 
   describe '#show' do

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -44,7 +44,7 @@ describe Cms::SchoolsController do
     context 'when a school has an expired subscription and an active subscription' do
       it 'should only one record of that school, without duplicates' do
         school = create(:school)
-        expired_sub = create(:subscription, expiration: Date.today - 1.year)
+        expired_sub = create(:subscription, expiration: Time.zone.current - 1.year)
         active_sub = create(:subscription)
         create(:school_subscription, school: school, subscription: expired_sub)
         create(:school_subscription, school: school, subscription: active_sub)

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -44,7 +44,7 @@ describe Cms::SchoolsController do
     context 'when a school has an expired subscription and an active subscription' do
       it 'should only one record of that school, without duplicates' do
         school = create(:school)
-        expired_sub = create(:subscription, expiration: Time.zone.current - 1.year)
+        expired_sub = create(:subscription, expiration: 15.days.ago.to_date)
         active_sub = create(:subscription)
         create(:school_subscription, school: school, subscription: expired_sub)
         create(:school_subscription, school: school, subscription: active_sub)


### PR DESCRIPTION
## WHAT
Fix some bugs in School Manager and District Manager tools. Add the ability to search for Districts by premium status and display premium status as a column in the Search results.

## WHY
To make these tools work effectively and accurately for Quill staff.

## HOW
Add in the React components to display District Premium Status.
In the SQL queries, restrict results to only active subscriptions (to prevent multiple rows containing expired subscriptions).

### Screenshots
![Screen Shot 2022-10-13 at 1 46 18 PM](https://user-images.githubusercontent.com/57366100/195527374-93586312-0693-4dec-af6b-a5c1404c2454.png)
![Screen Shot 2022-10-13 at 2 24 26 PM](https://user-images.githubusercontent.com/57366100/195527405-5c730f73-1cec-4ec7-8ec4-11924709be07.png)
![Screen Shot 2022-10-13 at 2 26 25 PM](https://user-images.githubusercontent.com/57366100/195527417-0aa359e4-3590-475d-a1da-d773481e824d.png)
![Screen Shot 2022-10-13 at 2 27 49 PM](https://user-images.githubusercontent.com/57366100/195527431-af06c9ca-6399-4d57-b73d-26efefd3a4f0.png)




### Notion Card Links
https://www.notion.so/quill/School-Manager-and-District-Manager-updates-and-bug-fixes-a0b35a512f5c4a2cb5f63086eaac15e2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
