### PR TITLE
lms/refactor-error-notifier-on-rate-limit

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_organization_worker.rb
@@ -23,7 +23,7 @@ class SyncVitallyOrganizationWorker
   end
 
   private def requeue_after_rate_limit(district_id)
-    ErrorNotifier.report(VitallyApiRateLimitException.new("Hit the Vitally REST API rate limit trying to sync District ##{district_id}.  Automatically enqueueing to retry."))
+    ErrorNotifier.report(VitallyApiRateLimitException.new("Hit the Vitally REST API rate limit trying to sync Districts.  Automatically enqueueing to retry."), {district_id: district_id})
     delay = rand(MINIMUM_REQUEUE_WAIT_MINUTES..MAXIMUM_REQUEUE_WAIT_MINUTES)
     SyncVitallyOrganizationWorker.perform_in(delay.minutes, district_id)
   end

--- a/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_organization_worker_spec.rb
@@ -31,8 +31,8 @@ describe SyncVitallyOrganizationWorker do
       end
 
       it 'should report an error to Sentry and NewRelic whenever we hit an API rate limit' do
-        expected_error = SyncVitallyOrganizationWorker::VitallyApiRateLimitException.new("Hit the Vitally REST API rate limit trying to sync District ##{district.id}.  Automatically enqueueing to retry.")
-        expect(ErrorNotifier).to receive(:report).with(expected_error)
+        expected_error = SyncVitallyOrganizationWorker::VitallyApiRateLimitException.new("Hit the Vitally REST API rate limit trying to sync Districts.  Automatically enqueueing to retry.")
+        expect(ErrorNotifier).to receive(:report).with(expected_error, {district_id: district.id})
 
         subject.perform(district.id)
       end


### PR DESCRIPTION
## WHAT
Refactor the use of ErrorNotifier to not parameterize messages
## WHY
To clean up error aggregation in Sentry and NewRelic
## HOW
Pass parameters in as options to `ErrorNotifier` rather than making the parameters part of the error message

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
