### PR TITLE
remove unused logic from scorebook query

### DIFF
--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -2,13 +2,10 @@
 
 # SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS act_id
 class Scorebook::Query
-  SCORES_PER_PAGE = 10000
-
-  def self.run(classroom_id, current_page=1, unit_id=nil, begin_date=nil, end_date=nil, offset=0)
+  def self.run(classroom_id, current_page=1, unit_id=nil, begin_date=nil, end_date=nil, utc_offset=0)
     first_unit = units(unit_id) ? units(unit_id).first : nil
     last_unit = units(unit_id) ? units(unit_id).last : nil
-    user_timezone_offset = "+ INTERVAL '#{offset}' SECOND"
-    offset_clause = current_page ? "OFFSET (#{(current_page.to_i - 1) * SCORES_PER_PAGE})" : nil
+    user_timezone_offset = "+ INTERVAL '#{utc_offset}' SECOND"
 
     RawSqlRunner.execute(
       <<-SQL
@@ -50,7 +47,7 @@ class Scorebook::Query
           AND cu.visible
           AND sc.visible
           #{last_unit}
-          #{date_conditional_string(begin_date, end_date, offset)}
+          #{date_conditional_string(begin_date, end_date, utc_offset)}
         GROUP BY
           students.id,
           students.name,
@@ -65,8 +62,6 @@ class Scorebook::Query
           MIN(acts.completed_at),
           CASE WHEN SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) > 0 THEN true ELSE false END DESC,
           cu.created_at ASC
-          #{offset_clause}
-          FETCH NEXT #{SCORES_PER_PAGE} ROWS ONLY
       SQL
     ).to_a
   end


### PR DESCRIPTION
## WHAT
- removes unused `FETCH NEXT` aka `LIMIT` directive from scorebook query 
- renames `offset` param to `utc_offset`, as the term `offset` is overloaded in this file. 

This is an extension of: https://github.com/empirical-org/Empirical-Core/pull/9824

## WHY
Teachers with > 10000 scores are seeing their scores truncated. This is an edge case, but a human has complained about it, so we should give them a good  user experience. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-s-Activity-Summary-Report-is-cutting-off-students-at-end-of-alphabet-9be98a92f1c2401d9ac9ee48e4861560

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
