### PR TITLE
Evidence activity versioning/ create initial version change logs for activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/versionHistory/versionHistory.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/versionHistory/versionHistory.tsx
@@ -130,7 +130,7 @@ const VersionHistory = ({ history, match }) => {
       />
 
       <div className="button-and-id-container">
-        <button className="quill-button fun primary contained focus-on-light" id="activity-submit-button" onClick={handleUpdateActivity} type="submit">Increment version to {activity?.version + 1}</button>
+        <button className="quill-button fun primary contained focus-on-light" id="activity-submit-button" onClick={handleUpdateActivity} type="submit">Increment version to {activity?.version}</button>
       </div>
       <br />
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/versionHistory/versionHistory.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/versionHistory/versionHistory.tsx
@@ -130,7 +130,7 @@ const VersionHistory = ({ history, match }) => {
       />
 
       <div className="button-and-id-container">
-        <button className="quill-button fun primary contained focus-on-light" id="activity-submit-button" onClick={handleUpdateActivity} type="submit">Increment version to {activity?.version}</button>
+        <button className="quill-button fun primary contained focus-on-light" id="activity-submit-button" onClick={handleUpdateActivity} type="submit">Increment version to {activity?.version + 1}</button>
       </div>
       <br />
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -26,6 +26,7 @@ module Evidence
           action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
           changed_record_type: 'Evidence::Activity',
           changed_record_id: @activity.id,
+          user_id: current_user.id,
           explanation: "Activity Created",
           changed_attribute: 'version',
           previous_value: "0",

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -26,7 +26,7 @@ module Evidence
           action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
           changed_record_type: 'Evidence::Activity',
           changed_record_id: @activity.id,
-          user_id: current_user.id,
+          user_id: lms_user_id,
           explanation: "Activity Created",
           changed_attribute: 'version',
           previous_value: "0",

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -22,6 +22,16 @@ module Evidence
     # POST /activities.json
     def create
       if @activity.save
+        changelog_params = {
+          action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
+          changed_record_type: 'Evidence::Activity',
+          changed_record_id: @activity.id,
+          explanation: "Activity Created",
+          changed_attribute: 'version',
+          previous_value: "0",
+          new_value: "1"
+        }
+        Evidence.change_log_class.create!(changelog_params)
         render json: @activity, status: :created
       else
         render json: @activity.errors, status: :unprocessable_entity

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -117,6 +117,7 @@ module Evidence
         @activity = Evidence::Activity.find(params[:id])
       else
         @activity = Evidence::Activity.new(activity_params)
+        @activity.version = 1
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -62,6 +62,7 @@ module Evidence
         expect(response.code.to_i).to(eq(201))
         expect(parsed_response["title"]).to(eq("First Activity"))
         expect(parsed_response["notes"]).to(eq("First Activity - Notes"))
+        expect(parsed_response["version"]).to(eq(1))
         expect(Activity.count).to(eq(1))
       end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -283,8 +283,9 @@ module Evidence
 
         expect(response.code.to_i).to(eq(200))
         expect(parsed_response.select {|cl| cl["changed_record_type"] == 'Evidence::Passage'}.count).to(eq(1))
-        expect(parsed_response.select {|cl| cl["changed_record_type"] == 'Evidence::Activity'}.count).to(eq(1))
+        expect(parsed_response.select {|cl| cl["changed_record_type"] == 'Evidence::Activity'}.count).to(eq(2))
         expect(parsed_response.select {|cl| cl["changed_record_type"] == 'Evidence::Prompt'}.count).to(eq(1))
+        expect(parsed_response.select {|cl| cl["changed_attribute"] == 'version'}.count).to(eq(1))
 
       end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -74,7 +74,7 @@ module Evidence
         expect(change_log.user_id).to(eq(1))
         expect(change_log.changed_record_type).to(eq("Evidence::Activity"))
         expect(change_log.changed_record_id).to(eq(new_activity.id))
-        expect(change_log.new_value).to(eq(nil))
+        expect(change_log.new_value).to(eq("1"))
       end
 
       it 'should not create an invalid record and return errors as json' do

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -3,24 +3,33 @@
 namespace :create_initial_change_log_for_evidence_activities do
   desc 'create change log for all Evidence activities with no initial version'
   task :run => :environment do
+    rake_task_user = User.find_or_create_by(name: 'Rake Robot', role: 'staff')
     Evidence::Activity.all.each do |activity|
-      initial_version = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity').empty?
-      if initial_version
-        changelog_params = {
-          action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
-          changed_record_type: 'Evidence::Activity',
-          changed_record_id: activity.id,
-          # this is the user_id associated with our hello@quill.org staff account
-          user_id: 188146,
-          explanation: "Activity Created",
-          changed_attribute: 'version',
-          previous_value: "0",
-          new_value: "1",
-          created_at: activity.created_at,
-          updated_at: activity.created_at
-        }
-        Evidence.change_log_class.create!(changelog_params)
+      changelog_params = {
+        action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
+        changed_record_type: 'Evidence::Activity',
+        changed_record_id: activity.id,
+        user_id: rake_task_user.id,
+        explanation: "Activity Created",
+        changed_attribute: 'version',
+        previous_value: "0",
+        new_value: "1",
+        created_at: activity.created_at,
+        updated_at: activity.created_at
+      }
+
+      change_logs = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity')
+
+      if change_logs.any?
+        changes_logs.each do |change_log|
+          change_log.previous_value = "#{change_log.previous_value.to_i + 1}"
+          change_log.new_value = "#{change_log.new_value.to_i + 1}"
+          change_log.save!
+        end
       end
+
+      activity.update_columns(version: activity.version + 1)
+      Evidence.change_log_class.create!(changelog_params)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -10,6 +10,8 @@ namespace :create_initial_change_log_for_evidence_activities do
           action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
           changed_record_type: 'Evidence::Activity',
           changed_record_id: activity.id,
+          # this is the user_id associated with our hello@quill.org staff account
+          user_id: 188146,
           explanation: "Activity Created",
           changed_attribute: 'version',
           previous_value: "0",

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -22,8 +22,8 @@ namespace :create_initial_change_log_for_evidence_activities do
 
       if change_logs.any?
         change_logs.each do |change_log|
-          change_log.previous_value = "#{change_log.previous_value.to_i + 1}"
-          change_log.new_value = "#{change_log.new_value.to_i + 1}"
+          change_log.previous_value = (change_log.previous_value.to_i + 1).to_s
+          change_log.new_value = (change_log.new_value.to_i + 1).to_s
           change_log.save!
         end
       end

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -21,7 +21,7 @@ namespace :create_initial_change_log_for_evidence_activities do
       change_logs = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity')
 
       if change_logs.any?
-        changes_logs.each do |change_log|
+        change_logs.each do |change_log|
           change_log.previous_value = "#{change_log.previous_value.to_i + 1}"
           change_log.new_value = "#{change_log.new_value.to_i + 1}"
           change_log.save!

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -4,7 +4,7 @@ namespace :create_initial_change_log_for_evidence_activities do
   desc 'create change log for all Evidence activities with no initial version'
   task :run => :environment do
     Evidence::Activity.all.each do |activity|
-      initial_version = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity').length == 0
+      initial_version = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity').empty?
       if initial_version
         changelog_params = {
           action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :update_schools_with_4_digit_zipcodes do
+  desc 'create change log for all Evidence activities with no initial version'
+  task :run => :environment do
+    Evidence::Activity.all.each do |activity|
+      initial_version = Evidence.change_log_class.where(changed_record_id: activity.id, changed_attribute: 'version', changed_record_type: 'Evidence::Activity').length == 0
+      if initial_version
+        changelog_params = {
+          action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],
+          changed_record_type: 'Evidence::Activity',
+          changed_record_id: activity.id,
+          explanation: "Activity Created",
+          changed_attribute: 'version',
+          previous_value: "0",
+          new_value: "1",
+          created_at: activity.created_at,
+          updated_at: activity.created_at
+        }
+        Evidence.change_log_class.create!(changelog_params)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -3,7 +3,7 @@
 namespace :create_initial_change_log_for_evidence_activities do
   desc 'create change log for all Evidence activities with no initial version'
   task :run => :environment do
-    rake_task_user = User.find_by(name: "Rake Robot")
+    rake_task_user = User.find_by(email: ENV['RAKE_ROBOT_EMAIL'])
     Evidence::Activity.all.each do |activity|
       changelog_params = {
         action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-namespace :update_schools_with_4_digit_zipcodes do
+namespace :create_initial_change_log_for_evidence_activities do
   desc 'create change log for all Evidence activities with no initial version'
   task :run => :environment do
     Evidence::Activity.all.each do |activity|

--- a/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
+++ b/services/QuillLMS/lib/tasks/create_initial_change_log_for_evidence_activities.rake
@@ -3,7 +3,7 @@
 namespace :create_initial_change_log_for_evidence_activities do
   desc 'create change log for all Evidence activities with no initial version'
   task :run => :environment do
-    rake_task_user = User.find_or_create_by(name: 'Rake Robot', role: 'staff')
+    rake_task_user = User.find_by(name: "Rake Robot")
     Evidence::Activity.all.each do |activity|
       changelog_params = {
         action: Evidence.change_log_class::EVIDENCE_ACTIONS[:create],


### PR DESCRIPTION
## WHAT
create initial version change logs for Evidence activities

## WHY
Curriculum would like activities to be created with an initial version 1

## HOW
add logic to create a change log entry after activity creation and add a rake task to create version change logs for all activities that are currently without a version

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Version-Control-Update-Adding-Version-Filter-to-Internal-Tool-9e2d89d9e8e74f6391f1b3eb1a239aec

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
