### PR TITLE
lms/clear-flagged-unit-template-cache

### DIFF
--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -240,13 +240,14 @@ describe UnitTemplate, redis: true, type: :model do
       expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(0)
     end
 
-    it "deletes the cache of the saved unit's flag, or production before and after save" do
+    it "deletes the cache of all flags before and after save" do
       expect(exist_count).to eq(4)
       unit_template.update(flag: 'beta')
-      expect(exist_count).to eq(3)
-      expect($redis.exists('alpha_unit_templates')).to eq(1)
+      expect(exist_count).to eq(0)
+      expect($redis.exists('alpha_unit_templates')).to eq(0)
+      $redis.set('alpha_unit_templates', 'some test nonsense')
       unit_template.update(flag: 'alpha')
-      expect(exist_count).to eq(2)
+      expect(exist_count).to eq(0)
     end
   end
 


### PR DESCRIPTION
## WHAT
Clear all flag-based caching when a UnitTemplate flag changes
## WHY
We were just clearing the cache for the flag's new value, but flag logic cascades (changing a flag from 'production' to 'beta' changes the values in 'production' and 'gamma', which wasn't being accounted for before).
## HOW
We already had some logic for clearing all the flag-based caches in `self.delete-all_caches` method, so copy that logic into the `delete_relevant_caches` method.

### Notion Card Links
https://www.notion.so/quill/Activity-Pack-flagged-as-In-Production-but-not-showing-up-on-the-featured-activity-pack-page-2fd87ba9781a4150bf89690cb385c0f9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A