### PR TITLE
update activity summary to show scheduled activities

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
@@ -73,12 +73,17 @@
 		}
 	}
 
-	.in-progress-symbol, .attempt-symbol {
+	.in-progress-symbol, .attempt-symbol, .scheduled-symbol {
 		vertical-align: middle;
 		position: absolute;
 		top: -8px;
 		right: -8px;
 	}
+
+  .scheduled-symbol {
+    height: 16px;
+    background-color: #f7f5f5;
+  }
 
 	.missed-indicator {
 		height: 38px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -107,7 +107,7 @@ export default class ActivityIconWithTooltip extends React.Component {
   statusIndicator() {
     const { data, } = this.props
     const { started, completed_attempts, scheduled, } = data
-    if (scheduled && !completed_attempts.length) {
+    if (scheduled && completed_attempts < 1) {
       return <img alt="" className="scheduled-symbol" src={scheduledIcon.src} />
     } else if (started) {
       return <img alt="" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -107,7 +107,7 @@ export default class ActivityIconWithTooltip extends React.Component {
   statusIndicator() {
     const { data, } = this.props
     const { started, completed_attempts, scheduled, } = data
-    if (scheduled) {
+    if (scheduled && !completed_attempts.length) {
       return <img alt="" className="scheduled-symbol" src={scheduledIcon.src} />
     } else if (started) {
       return <img alt="" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -6,6 +6,7 @@ import request from 'request';
 import gradeColor from '../modules/grade_color.js';
 import { nonRelevantActivityClassificationIds, } from '../../../../modules/activity_classifications'
 import activityFromClassificationId from '../modules/activity_from_classification_id.js';
+import { scheduledIcon, } from '../../../Shared/index'
 
 export default class ActivityIconWithTooltip extends React.Component {
   constructor(props) {
@@ -104,8 +105,11 @@ export default class ActivityIconWithTooltip extends React.Component {
   };
 
   statusIndicator() {
-    const {started, completed_attempts} = this.props.data
-    if (started) {
+    const { data, } = this.props
+    const { started, completed_attempts, scheduled, } = data
+    if (scheduled) {
+      return <img alt="" className="scheduled-symbol" src={scheduledIcon.src} />
+    } else if (started) {
       return <img alt="" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />
     } else if (completed_attempts > 1) {
       const completedNumber = completed_attempts > 9 ? '+' : completed_attempts

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
@@ -38,7 +38,7 @@ export default class ScorebookTooltip extends React.Component {
     const { data } = this.props;
     if (data.marked_complete && data.completed_attempts === 0) {
       return <span>This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it.</span>
-    } else if (data.scheduled) {
+    } else if (data.scheduled && !data.completed_attempts) {
       return <span>This scheduled activity has not been published.</span>;
     } else if (!data.completed_attempts) {
       return <span>This activity has not been completed.</span>;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
@@ -38,6 +38,8 @@ export default class ScorebookTooltip extends React.Component {
     const { data } = this.props;
     if (data.marked_complete && data.completed_attempts === 0) {
       return <span>This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it.</span>
+    } else if (data.scheduled) {
+      return <span>This scheduled activity has not been published.</span>;
     } else if (!data.completed_attempts) {
       return <span>This activity has not been completed.</span>;
     } else if (data.concept_results && data.concept_results.length) {


### PR DESCRIPTION
## WHAT
Just update the activity summary to display the calendar icon and update the copy for scheduled activities.

## WHY
So teachers understand why their students haven't completed them at a glance.

## HOW
Small React/CSS change.

### Screenshots
<img width="527" alt="Screen Shot 2022-10-17 at 12 17 57 PM" src="https://user-images.githubusercontent.com/18669014/196230010-0819082c-4643-4572-80ca-42e159b9a9e5.png">

### Notion Card Links
https://www.notion.so/quill/Changes-to-the-activity-summary-report-to-represent-scheduled-activities-9c6c688ecce14faf83be636f373e4c90

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
