### PR TITLE
Increase error notification in clever login flow

### DIFF
--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -4,7 +4,7 @@ module Auth
   class CleverController < ApplicationController
     around_action :force_writer_db_role, only: [:clever]
 
-    class CleverAccountConflictError < StandardError ; end
+    class CleverAccountConflictError < StandardError; end
 
     def clever
       update_current_user_email
@@ -30,7 +30,7 @@ module Auth
           CleverAccountConflictError.new, {
             current_user_email: current_user&.email,
             auth_hash_email: auth_hash['info']['email'],
-            validation_errors: current_user&.errors.full_messages.join('|')
+            validation_errors: current_user&.errors&.full_messages&.join('|')
           }
         )
         flash[:error] = t('clever.account_conflict')

--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -4,6 +4,8 @@ module Auth
   class CleverController < ApplicationController
     around_action :force_writer_db_role, only: [:clever]
 
+    class CleverAccountConflictError < StandardError ; end
+
     def clever
       update_current_user_email
       result = CleverIntegration::SignUp::Main.run(auth_hash)
@@ -24,6 +26,13 @@ module Auth
       if current_user.update(email: auth_hash['info']['email'])
         session[ApplicationController::GOOGLE_OR_CLEVER_JUST_SET] = true
       else
+        ErrorNotifier.report(
+          CleverAccountConflictError.new, {
+            current_user_email: current_user&.email,
+            auth_hash_email: auth_hash['info']['email'],
+            validation_errors: current_user&.errors.full_messages.join('|')
+          }
+        )
         flash[:error] = t('clever.account_conflict')
         flash.keep(:error)
       end

--- a/services/QuillLMS/spec/controllers/auth/clever_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/clever_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Auth::CleverController, type: :controller do
+
+  describe '#update_current_user_email' do
+    let(:user) { create(:user) }
+    before do
+      allow(controller).to receive(:current_user) { user }
+
+      request.env['omniauth.auth'] = OmniAuth::AuthHash.new({
+        info: {
+          email: 'omniauth@email.com',
+          user_type: 'school_admin'
+        }
+      })
+    end
+
+    context 'validation success' do
+      it 'should not invoke ErrorNotifier' do
+        allow_any_instance_of(ApplicationController).to receive(:route_redirects_to_my_account?).and_return true
+        allow(CleverIntegration::SignUp::SchoolAdmin).to receive(:run).and_return({type: 'user_success', data: user})
+        expect(ErrorNotifier).to receive(:report).exactly(0).times
+        expect { get 'clever' }.to_not raise_error
+      end
+    end
+
+    context 'validation failure' do
+      it 'should invoke ErrorNotifier' do
+        allow_any_instance_of(ApplicationController).to receive(:route_redirects_to_my_account?).and_return true
+        allow(CleverIntegration::SignUp::SchoolAdmin).to receive(:run).and_return({type: 'user_success', data: user})
+        allow(user).to receive(:update).and_return false
+        expect(ErrorNotifier).to receive(:report).once
+        expect { get 'clever' }.to_not raise_error
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/controllers/auth/clever_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/clever_controller_spec.rb
@@ -6,6 +6,7 @@ describe Auth::CleverController, type: :controller do
 
   describe '#update_current_user_email' do
     let(:user) { create(:user) }
+
     before do
       allow(controller).to receive(:current_user) { user }
 


### PR DESCRIPTION
## WHAT
Add error notification when `user.update` fails validations. 

## WHY
[To help diagnose this clever login support issue](https://www.notion.so/quill/Admin-cannot-link-account-to-Clever-14509384f99e447b9b1f1bfc907197fa)

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
