### PR TITLE
Update Synthetic Model, Stop Tokens, and add rake task

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
@@ -22,7 +22,7 @@ module Evidence
 
       attr_accessor :response, :prompt, :temperature, :count, :model_key, :options_hash
 
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :babbage, options_hash: {})
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options_hash: {})
         @prompt = prompt
         @temperature = temperature
         @count = count

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
@@ -17,7 +17,7 @@ module Evidence
         davinci: 'text-davinci-002'
       }
       BLANK = ''
-      STOP_TOKENS = [". ", ", "]
+      STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
       MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
 
       attr_accessor :response, :prompt, :temperature, :count, :model_key, :options_hash
@@ -38,6 +38,7 @@ module Evidence
       end
 
       def request_body
+        # NB: 'suffix' key in documentation is not a valid key, will raise error
         {
           model: MODELS[model_key],
           temperature: temperature,

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -26,7 +26,7 @@ module Evidence
       def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil)
         activity = Evidence::Activity.find(activity_id)
         passage = activity.passages.first.text
-        prompts = activity.prompts
+        prompts = conjunctions.present? ? activity.prompts.where(conjunction: conjunctions) : activity.prompts
         short_name = activity.title.first(20).gsub(' ', '_')
         passage_csv_name = "#{short_name}_passage_chunks#{CSV_SUFFIX}"
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -18,10 +18,12 @@ module Evidence
       TEMPS_PASSAGE = [1, 0.9, 0.7, 0.5]
       TEMP_SECTION = 0.5 # give a lower temp (creativity) when it has less info
 
+      CONJUNCTIONS = ['because', 'but', 'so']
+
       attr_reader :passage, :stem, :nouns, :results
 
       # returns a hash of the form {'csv name' => CSVString, 'csv name2' =>...}
-      def self.csvs_for_activity(activity_id:, nouns: [])
+      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil)
         activity = Evidence::Activity.find(activity_id)
         passage = activity.passages.first.text
         prompts = activity.prompts

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -9,7 +9,6 @@ namespace :synthetic do
   # Run: bundle exec rake synthetic:generate_seed_data\[262,1\]
   # Some conjunctions (NB: don't leave spaces after commas)
   # Run: bundle exec rake synthetic:generate_seed_data\[262,1,'but','so'\]
-
   desc "generate seed data to local files"
   task :generate_seed_data, [:activity_id, :run_number] => :environment do |t, args|
     activity_id = args[:activity_id]

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -7,14 +7,14 @@ namespace :synthetic do
   # Specify a run_number (1 in this example) - for iteration to prevent overwriting older files
   # All conjunctions
   # Run: bundle exec rake synthetic:generate_seed_data\[262,1\]
-  # Some conjunctions
+  # Some conjunctions (NB: don't leave spaces after commas)
   # Run: bundle exec rake synthetic:generate_seed_data\[262,1,'but','so'\]
 
   desc "generate seed data to local files"
   task :generate_seed_data, [:activity_id, :run_number] => :environment do |t, args|
     activity_id = args[:activity_id]
     run_number = args[:run_number]
-    conjunctions = args.extras.present? ? args.extras : Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
+    conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
 
     puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}..."
     csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions)

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :synthetic do
+
+  # set SYNTHETIC_LOCAL_PATH in .env
+  # Find an activity_id (262 in this example)
+  # Specify a run_number (1 in this example) - for iteration to prevent overwriting older files
+  # All conjunctions
+  # Run: bundle exec rake synthetic:generate_seed_data\[262,1\]
+  # Some conjunctions
+  # Run: bundle exec rake synthetic:generate_seed_data\[262,1,'but','so'\]
+
+  desc "generate seed data to local files"
+  task :generate_seed_data, [:activity_id, :run_number] => :environment do |t, args|
+    activity_id = args[:activity_id]
+    run_number = args[:run_number]
+    conjunctions = args.extras.present? ? args.extras : Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
+
+    puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}..."
+    csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions)
+
+    path = ENV.fetch('SYNTHETIC_LOCAL_PATH', '~/Documents/')
+
+    csv_hash.each do |filename, contents|
+      File.write("#{path}#{run_number}_#{filename}", contents)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
The major change here is changing the default OpenAI model from `babbage` to `curie`. I've also updated the stop words (when to stop generating), and a rake task to make local iterative testing earlier.
## WHY
During some of my experimentation in a different branch, I found that this more powerful model (`curie`) gives better results overall for many of the texts I'm testing (and doesn't give worse results). So I broke off that change to push out while I continue to experiment.

Also, according to the docs, Curie is better at `text summarization`, which is closest to our use case.
## HOW
Change the default model
Add a rake task to generate local files which can focus on a particular activity, conjunction(s), and run number (to make comparing two runs easier)
### Screenshots

![Screen Shot 2022-10-17 at 12 47 51 PM](https://user-images.githubusercontent.com/1304933/196236415-66e18754-370c-4904-8f21-4cae9050f06a.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, tiny change.
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
