### PR TITLE
lms/ensure-numerical-classroom-id

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
@@ -37,7 +37,7 @@ export default class ClassroomLessons extends React.Component {
       if (classrooms.length > 0) {
         const localStorageSelectedClassroomId = window.localStorage.getItem(PROGRESS_REPORTS_SELECTED_CLASSROOM_ID)
         const classroomFromLocalStorageClassroomId = classrooms.find(c => Number(c.id) === Number(localStorageSelectedClassroomId))
-        const classroomIdToUse = classroomFromLocalStorageClassroomId && !classroomId ? localStorageSelectedClassroomId : classroomId
+        const classroomIdToUse = classroomFromLocalStorageClassroomId && !classroomId ? Number(localStorageSelectedClassroomId) : classroomId
         this.setState({ classrooms, selectedClassroomId: classroomIdToUse || classrooms[0].id, }, () => this.getAllLessons());
       } else {
         this.setState({ empty: true, loaded: true, });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/classroom_lessons.jsx
@@ -35,9 +35,9 @@ export default class ClassroomLessons extends React.Component {
     request.get(`${process.env.DEFAULT_URL}/teachers/classrooms_i_teach_with_lessons`, (error, httpStatus, body) => {
       const classrooms = JSON.parse(body).classrooms;
       if (classrooms.length > 0) {
-        const localStorageSelectedClassroomId = window.localStorage.getItem(PROGRESS_REPORTS_SELECTED_CLASSROOM_ID)
-        const classroomFromLocalStorageClassroomId = classrooms.find(c => Number(c.id) === Number(localStorageSelectedClassroomId))
-        const classroomIdToUse = classroomFromLocalStorageClassroomId && !classroomId ? Number(localStorageSelectedClassroomId) : classroomId
+        const localStorageSelectedClassroomId = Number(window.localStorage.getItem(PROGRESS_REPORTS_SELECTED_CLASSROOM_ID))
+        const classroomFromLocalStorageClassroomId = classrooms.find(c => Number(c.id) === localStorageSelectedClassroomId)
+        const classroomIdToUse = classroomFromLocalStorageClassroomId && !classroomId ? localStorageSelectedClassroomId : classroomId
         this.setState({ classrooms, selectedClassroomId: classroomIdToUse || classrooms[0].id, }, () => this.getAllLessons());
       } else {
         this.setState({ empty: true, loaded: true, });


### PR DESCRIPTION
## WHAT
Make sure to consistently cast localStorage ID values to Number
## WHY
We were casting to a Number in one part of the code, but not another.  This was resulting in strict comparisons later on in the code between string and Number representations of a value ("8" === 8) and failing to find matches we wanted.
## HOW
Cast the value to `Number` when it comes out of `localStorage` rather than casting the value extracted in one place and not another.

### Notion Card Links
https://www.notion.so/quill/Lessons-in-Launch-Lessons-tab-not-showing-7e7a7d4945ed41fa9b011bf0ff47dddd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on the TYPE of this value
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
