### PR TITLE
Display IP Location for Users in Quill CMS and Vitally

### DIFF
--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -57,6 +57,8 @@ class SerializeVitallySalesUser
         state: state,
         zipcode: zipcode,
         district: district,
+        ip_city: @user.ip_location&.city,
+        ip_state: @user.ip_location&.state,
         total_students: @user.students.count,
         active_students: active_students,
         activities_assigned: activities_assigned,

--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -108,6 +108,13 @@
     <p><%= @user.ip_address || 'N/A' %></p>
     <br />
 
+    <p style='font-weight: 700;'>IP City</p>
+    <p><%= @user.ip_location&.city || 'N/A' %></p>
+    <br />
+
+    <p style='font-weight: 700;'>IP State</p>
+    <p><%= @user.ip_location&.state || 'N/A' %></p>
+    <br />
 
     <p style='font-weight: 700;'>Created</p>
     <p><%= @user.created_at || 'N/A' %></p>

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -59,6 +59,7 @@ describe 'SerializeVitallySalesUser' do
       email: 'teach@teaching.edu',
       school: school
     )
+    ip_location = create(:ip_location, user: teacher)
 
     teacher_data = SerializeVitallySalesUser.new(teacher).data
 
@@ -81,6 +82,8 @@ describe 'SerializeVitallySalesUser' do
       completed_activities_per_student: 0,
       completed_activities_per_student_this_year: 0,
       frl: 13,
+      ip_city: ip_location.city,
+      ip_state: ip_location.state,
       teacher_link: "https://www.quill.org/cms/users/#{teacher.id}/sign_in",
       city: school.city,
       state: school.state


### PR DESCRIPTION
## WHAT
Display a user's IP Location City and State in two places: Quill User CMS and Vitally.

## WHY
So Partnerships can have more info about users to make better informed decisions.

## HOW
Use the has_one relationship with `ip_location` to just display or send a user's ip location city and state in these two places.

### Screenshots
<img width="252" alt="Screen Shot 2022-10-18 at 2 40 47 PM" src="https://user-images.githubusercontent.com/57366100/196355171-2d45b469-99e4-4519-8165-7fca633095e2.png">


### Notion Card Links
https://www.notion.so/quill/Show-IP-City-IP-State-in-User-Manager-and-Vitally-38445418cccb4fa590fd216a2965ab1e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
