### PR TITLE
lms/update-ajax-login-error-messages

### DIFF
--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -51,12 +51,12 @@ class SessionsController < ApplicationController
     @user =  User.find_by_username_or_email(email_or_username)
     if @user.nil? || @user.sales_contact?
       render json: {message: 'An account with this email or username does not exist. Try again.', type: 'email'}, status: :unauthorized
-    elsif @user.signed_up_with_google
+    elsif @user.signed_up_with_google || @user.google_id
       render json: {message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}, status: :unauthorized
     elsif @user.clever_id
       render json: {message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email'}, status: :unauthorized
     elsif @user.password_digest.nil?
-      render json: {message: 'Did you sign up with Google? If so, please log in with Google using the link above.', type: 'email'}, status: :unauthorized
+      render json: {message: 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.', type: 'email'}, status: :unauthorized
     elsif @user.authenticate(params[:user][:password])
       sign_in(@user)
 

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -118,7 +118,7 @@ describe SessionsController, type: :controller do
 
       it 'should report login failiure' do
         post :login_through_ajax, params: { user: { email: user.email } }, as: :json
-        expect(response.body).to eq({message: 'Did you sign up with Google? If so, please log in with Google using the link above.', type: 'email'}.to_json)
+        expect(response.body).to eq({message: 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.', type: 'email'}.to_json)
       end
     end
 


### PR DESCRIPTION
## WHAT
Update AJAX-based login error messages to match non-AJAX messages
## WHY
We updated the messaging for non-AJAX logins, but didn't update the AJAX messaging which is more widely used in our current code-base, so we need to update this.
## HOW
Just copy the logic from our non-AJAX messaging to our AJAX-messaging

### Notion Card Links
https://www.notion.so/quill/Teachers-cannot-login-manually-email-recognized-as-Google-email-c8b7a261fde84867a4082cca52573f4f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
