### PR TITLE
Featured activity packs/ fix grade level range for activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMini.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMini.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`UnitTemplateMini component should render activity_info has html 1`] = `
 >
   <Tooltip
     isTabbable={false}
-    tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td></td></tr></tbody></table>"
+    tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td>4th-5th</td></tr></tbody></table>"
     tooltipTriggerText={
       <button
         className="unit-template-mini interactive-wrapper focus-on-light"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMinisTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMinisTable.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`UnitTemplateMinisTable component should render activity_info has html 1
           "link": "/activities/packs/3",
           "packName": <Tooltip
             isTabbable={true}
-            tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td></td></tr></tbody></table>"
+            tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td>4th-5th</td></tr></tbody></table>"
             tooltipTriggerText="Test Activity Pack"
             tooltipTriggerTextClass="activity-pack-name"
           />,
@@ -321,7 +321,7 @@ exports[`UnitTemplateMinisTable component should render activity_info has html 1
             >
               <Tooltip
                 isTabbable={true}
-                tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td></td></tr></tbody></table>"
+                tooltipText="<table class=\\"activity-tooltip-table\\" data-reactroot=\\"\\"><tbody><tr><th>Activity</th><th>Tool</th><th>Grade Level Range</th></tr><tr><td>Their, They&#x27;re, There</td><td>Quill Grammar</td><td>4th-5th</td></tr></tbody></table>"
                 tooltipTriggerText="Test Activity Pack"
                 tooltipTriggerTextClass="activity-pack-name"
               >

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/unitTemplates.test.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/unitTemplates.test.ts
@@ -1,0 +1,35 @@
+import { renderActivityPackTooltipElement } from '../unitTemplates';
+
+const data = {
+  activities: [
+    {
+      name: 'Activity One',
+      readability: '4th-6th',
+      classification: {
+        name: 'Quill Connect'
+      }
+    },
+    {
+      name: 'Activity Two',
+      readability: '4th-6th',
+      classification: {
+        name: 'Quill Grammar'
+      }
+    }
+  ]
+}
+
+describe('Unit Templates helper functions', () => {
+
+  describe('#renderActivityPackTooltipElement', () => {
+    it('should render the expected activity details', () => {
+      const tooltipElementString = renderActivityPackTooltipElement(data);
+      const containsActivityName = tooltipElementString.includes('Activity One') && tooltipElementString.includes('Activity Two');
+      const containsActivityReadability = tooltipElementString.includes('4th-6th') && tooltipElementString.includes('4th-6th');
+      const containsActivityClassification = tooltipElementString.includes('Quill Connect') && tooltipElementString.includes('Quill Grammar');
+      expect(containsActivityName).toBeTruthy();
+      expect(containsActivityReadability).toBeTruthy();
+      expect(containsActivityClassification).toBeTruthy();
+    })
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
@@ -144,12 +144,12 @@ export const renderActivityPackTooltipElement = (data) => {
           <th>Grade Level Range</th>
         </tr>
         {activities && activities.length && activities.map((activity: Activity) => {
-          const { name, grade_level_range, classification } = activity
+          const { name, readability, classification } = activity
           return(
             <tr>
               <td>{name}</td>
               <td>{classification.name}</td>
-              <td>{grade_level_range}</td>
+              <td>{readability}</td>
             </tr>
           )
         })}

--- a/services/QuillLMS/client/app/interfaces/activity.ts
+++ b/services/QuillLMS/client/app/interfaces/activity.ts
@@ -4,6 +4,7 @@ export interface Activity {
   description: string,
   standard_level_name: string,
   grade_level_range: string,
+  readability: string,
   standard: {
     id: string,
     name: string,


### PR DESCRIPTION
## WHAT
fix grade level range for activities in tooltip on the featured activity pack page

## WHY
we want to display this values when the tooltip renders

## HOW
use `readability` instead of `grade_level_range` from the unit template activities data (the `grade_level_range` property is for the entire unit template whereas `readability` is used for individual activities)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Daily-Proofreading-activity-pack-types-not-showing-up-on-the-featured-activity-pack-page-42e0123123b7475e8644ed10eabf4c21

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
