### PR TITLE
lms/use-visible-activity-sessions-for-lessons

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
     activity          = Activity.find_by(uid: params[:activity_id])
     activity_sessions = ActivitySession.includes(:user).where(
       activity: activity,
-      classroom_unit_id: params[:classroom_unit_id]
+      classroom_unit_id: params[:classroom_unit_id],
+      visible: true
     )
 
     render json: assigned_students(activity_sessions)


### PR DESCRIPTION
## WHAT
Use only visible ActivitySessions for Lesson student rosters
## WHY
We use ActivitySession UIDs to validate that a given student is supposed to join a given Lesson, but we ran into a bug where a student had a deleted (visible == false) ActivitySession in the db that was getting used instead of the active session.  This meant that the student was being told that they weren't supposed to join the Lesson because of the mismatch in uids.
## HOW
Just add a `visible: true` to the `where` clause that pulls the relevant `ActivitySession` records

### Notion Card Links
https://www.notion.so/quill/Student-unable-to-join-Quill-Lesson-5316c1aa5e0a4bab867a0747259beebc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
