### PR TITLE
Synthetic Seed Data filter out common regex.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -159,7 +159,7 @@ module Evidence
       private def regex_exclude?(text)
         return false if conjunction_exclusions.empty?
 
-        conjunction_exclusions.any?{|regex| regex.match(text) }
+        conjunction_exclusions.any?{|regex| regex.match(text.strip) }
       end
 
       private def conjunction_exclusions

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -19,19 +19,29 @@ module Evidence
       TEMP_SECTION = 0.4 # give a lower temp (creativity) when it has less info
 
       STEM_KEY = '%<stem>s'
-
+      CONJUNCTIONS = [
+        SO = 'so',
+        BUT = 'but',
+        BECAUSE = 'because'
+      ]
       # Config for Conjunction alternates
       # Use a plain 'string' for direct swap of conjunction
       # e.g. "It is so" => "It is thus"
       # Use 'Start string %<stem>s end string' for more complex forms
       # e.g. "It is so" => "Because It is thus" via 'Because %<stem>s thus'
       CONJUNCTION_SUBS = {
-        'so' => ["Since #{STEM_KEY}", "Because #{STEM_KEY}"],
-        'but' => ['but the counter argument is that', "Even though #{STEM_KEY}"],
-        'because' => ['for the reason that', 'owing to the fact that']
+        SO => ["Since #{STEM_KEY}", "Because #{STEM_KEY}"],
+        BUT => ['but the counter argument is that', "Even though #{STEM_KEY}"],
+        BECAUSE => ['for the reason that', 'owing to the fact that']
       }
-      CONJUNCTIONS = CONJUNCTION_SUBS.keys
+
       class InvalidConjunctionError < StandardError; end
+
+      CONJUNCTION_EXCLUSIONS = {
+        SO => [/^that/],
+        BUT => [],
+        BECAUSE => [/^of/],
+      }
 
       attr_reader :passage, :stem, :conjunction, :nouns, :results
 
@@ -108,6 +118,7 @@ module Evidence
           .map {|s| Result.new(text: noun.nil? ? s.lstrip : [noun, s].join(SPACE), seed: seed)}
           .uniq {|r| r.text }
           .reject {|r| r.text.in?(current_result_texts)}
+          .reject {|r| regex_exclude?(r.text) }
 
         @results += new_results
       end
@@ -143,6 +154,16 @@ module Evidence
         end
 
         stem_without_conjunction + alternate
+      end
+
+      private def regex_exclude?(text)
+        return false if conjunction_exclusions.empty?
+
+        conjunction_exclusions.any?{|regex| regex.match(text) }
+      end
+
+      private def conjunction_exclusions
+        CONJUNCTION_EXCLUSIONS[conjunction]
       end
 
       def results_csv_string

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -194,6 +194,7 @@ module Evidence
 
       it "should be true for matching regex" do
         expect(because.send(:regex_exclude?, "of the reason")).to be true
+        expect(because.send(:regex_exclude?, "  of the reason")).to be true
         expect(so.send(:regex_exclude?, "that happened")).to be true
       end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -149,6 +149,7 @@ module Evidence
 
       context 'response in exclude regex' do
         let(:response) {['of getting excluded']}
+
         subject { because.send(:run_prompt, prompt: '', count: 1, seed: '') }
 
         it "should reject response" do
@@ -158,6 +159,7 @@ module Evidence
 
       context 'response not in exclude regex' do
         let(:response) {['it would not be excluded']}
+
         subject { because.send(:run_prompt, prompt: '', count: 1, seed: '') }
 
         it "should reject response" do
@@ -169,7 +171,6 @@ module Evidence
     describe "#stem_variants_hash" do
       let(:conjunction) {'thus'}
       let(:stem) {"It is true, #{conjunction}"}
-
       let(:conjunction_config) { {conjunction => ['therefore', 'Since %<stem>s this is']}}
 
       before do


### PR DESCRIPTION
## WHAT
We want to exclude data that matches common regexes from our seed data.

## WHY
Evidence has multiple feedback algorithms/APIs that run before the ML one. One is a regex check that flags `because of` and `so that` (these responses that are always incorrect). Since, in practice, the live model will never see entries of this type, we want to exclude them from the training data.
## HOW
Add another config setup, add the two current regexes. Add tests.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
