### PR TITLE
Staggered Release Endpoints part 3

### DIFF
--- a/services/QuillLMS/app/models/pack_sequence.rb
+++ b/services/QuillLMS/app/models/pack_sequence.rb
@@ -33,6 +33,7 @@ class PackSequence < ApplicationRecord
   belongs_to :diagnostic_activity, class_name: 'Activity'
 
   has_many :pack_sequence_items, dependent: :destroy
+  has_many :user_pack_sequence_items, through: :pack_sequence_items
 
   validates :release_method, inclusion: { in: RELEASE_METHODS }
 end

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -8,8 +8,8 @@
 #  status                :string           default("locked")
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  pack_sequence_item_id :bigint
-#  user_id               :bigint
+#  pack_sequence_item_id :bigint           not null
+#  user_id               :bigint           not null
 #
 # Indexes
 #
@@ -31,4 +31,6 @@ class UserPackSequenceItem < ApplicationRecord
   belongs_to :pack_sequence_item
 
   validates :status, inclusion: { in: STATUSES }
+  validates :pack_sequence_item, presence: true
+  validates :user, presence: true
 end

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_pack_sequence_items
+#
+#  id                    :bigint           not null, primary key
+#  status                :string           default("locked")
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  pack_sequence_item_id :bigint
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_pack_sequence_items_on_pack_sequence_item_id  (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pack_sequence_item_id => pack_sequence_items.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class UserPackSequenceItem < ApplicationRecord
+  STATUSES = [
+    LOCKED = 'locked',
+    UNLOCKED = 'unlocked'
+  ]
+
+  belongs_to :user
+  belongs_to :pack_sequence_item
+
+  validates :status, inclusion: { in: STATUSES }
+end

--- a/services/QuillLMS/db/migrate/20221020131338_create_user_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221020131338_create_user_pack_sequence_items.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateUserPackSequenceItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_pack_sequence_items do |t|
+      t.references :user, foreign_key: true
+      t.references :pack_sequence_item, foreign_key: true
+      t.string :status, default: UserPackSequenceItem::LOCKED
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20221020131338_create_user_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221020131338_create_user_pack_sequence_items.rb
@@ -3,8 +3,8 @@
 class CreateUserPackSequenceItems < ActiveRecord::Migration[6.1]
   def change
     create_table :user_pack_sequence_items do |t|
-      t.references :user, foreign_key: true
-      t.references :pack_sequence_item, foreign_key: true
+      t.references :user, foreign_key: true, null: false
+      t.references :pack_sequence_item, foreign_key: true, null: false
       t.string :status, default: UserPackSequenceItem::LOCKED
 
       t.timestamps

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -4354,8 +4354,8 @@ ALTER SEQUENCE public.user_milestones_id_seq OWNED BY public.user_milestones.id;
 
 CREATE TABLE public.user_pack_sequence_items (
     id bigint NOT NULL,
-    user_id bigint,
-    pack_sequence_item_id bigint,
+    user_id bigint NOT NULL,
+    pack_sequence_item_id bigint NOT NULL,
     status character varying DEFAULT 'locked'::character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -4349,6 +4349,39 @@ ALTER SEQUENCE public.user_milestones_id_seq OWNED BY public.user_milestones.id;
 
 
 --
+-- Name: user_pack_sequence_items; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_pack_sequence_items (
+    id bigint NOT NULL,
+    user_id bigint,
+    pack_sequence_item_id bigint,
+    status character varying DEFAULT 'locked'::character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: user_pack_sequence_items_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_pack_sequence_items_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_pack_sequence_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_pack_sequence_items_id_seq OWNED BY public.user_pack_sequence_items.id;
+
+
+--
 -- Name: user_subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5284,6 +5317,13 @@ ALTER TABLE ONLY public.user_activity_classifications ALTER COLUMN id SET DEFAUL
 --
 
 ALTER TABLE ONLY public.user_milestones ALTER COLUMN id SET DEFAULT nextval('public.user_milestones_id_seq'::regclass);
+
+
+--
+-- Name: user_pack_sequence_items id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_pack_sequence_items ALTER COLUMN id SET DEFAULT nextval('public.user_pack_sequence_items_id_seq'::regclass);
 
 
 --
@@ -6249,6 +6289,14 @@ ALTER TABLE ONLY public.user_activity_classifications
 
 ALTER TABLE ONLY public.user_milestones
     ADD CONSTRAINT user_milestones_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_pack_sequence_items user_pack_sequence_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_pack_sequence_items
+    ADD CONSTRAINT user_pack_sequence_items_pkey PRIMARY KEY (id);
 
 
 --
@@ -7585,6 +7633,20 @@ CREATE UNIQUE INDEX index_user_milestones_on_user_id_and_milestone_id ON public.
 
 
 --
+-- Name: index_user_pack_sequence_items_on_pack_sequence_item_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_pack_sequence_items_on_pack_sequence_item_id ON public.user_pack_sequence_items USING btree (pack_sequence_item_id);
+
+
+--
+-- Name: index_user_pack_sequence_items_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_pack_sequence_items_on_user_id ON public.user_pack_sequence_items USING btree (user_id);
+
+
+--
 -- Name: index_user_subscriptions_on_subscription_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8032,6 +8094,14 @@ ALTER TABLE ONLY public.standards
 
 
 --
+-- Name: user_pack_sequence_items fk_rails_8011bf338d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_pack_sequence_items
+    ADD CONSTRAINT fk_rails_8011bf338d FOREIGN KEY (pack_sequence_item_id) REFERENCES public.pack_sequence_items(id);
+
+
+--
 -- Name: activities fk_rails_8b159cf902; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8109,6 +8179,14 @@ ALTER TABLE ONLY public.criteria
 
 ALTER TABLE ONLY public.unit_activities
     ADD CONSTRAINT fk_rails_b921d87b04 FOREIGN KEY (activity_id) REFERENCES public.activities(id);
+
+
+--
+-- Name: user_pack_sequence_items fk_rails_ba92ed65d8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_pack_sequence_items
+    ADD CONSTRAINT fk_rails_ba92ed65d8 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -8714,6 +8792,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220920190724'),
 ('20220927124042'),
 ('20221014103417'),
-('20221014103843');
+('20221014103843'),
+('20221020131338');
 
 

--- a/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
@@ -8,8 +8,8 @@
 #  status                :string           default("locked")
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  pack_sequence_item_id :bigint
-#  user_id               :bigint
+#  pack_sequence_item_id :bigint           not null
+#  user_id               :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_pack_sequence_items
+#
+#  id                    :bigint           not null, primary key
+#  status                :string           default("locked")
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  pack_sequence_item_id :bigint
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_pack_sequence_items_on_pack_sequence_item_id  (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pack_sequence_item_id => pack_sequence_items.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :user_pack_sequence_item do
+    pack_sequence_item
+    user
+    status { UserPackSequenceItem::LOCKED }
+
+    trait(:locked) { status UserPackSequenceItem::LOCKED }
+    trait(:unlocked) { status UserPackSequenceItem::UNLOCKED }
+  end
+end

--- a/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_pack_sequence_items
+#
+#  id                    :bigint           not null, primary key
+#  status                :string           default("locked")
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  pack_sequence_item_id :bigint
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_pack_sequence_items_on_pack_sequence_item_id  (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pack_sequence_item_id => pack_sequence_items.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe UserPackSequenceItem, type: :model do
+
+  context 'validation' do
+    it { expect(create(:user_pack_sequence_item)).to be_valid }
+    it { expect(create(:user_pack_sequence_item, :locked)).to be_valid }
+    it { expect(create(:user_pack_sequence_item, :unlocked)).to be_valid }
+
+    it { expect { create(:user_pack_sequence_item, status: 'new status') }.to raise_error ActiveRecord::RecordInvalid }
+  end
+end

--- a/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
@@ -8,8 +8,8 @@
 #  status                :string           default("locked")
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  pack_sequence_item_id :bigint
-#  user_id               :bigint
+#  pack_sequence_item_id :bigint           not null
+#  user_id               :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
## WHAT
Add a new model an database table `UserPackSequenceItem`.

## WHY
We need a new table to model individual user's locked status on a particular item in a pack sequence.  Otherwise, we'll be forced to dynamically recalculate the status in various places, specifically teacher facing pages, which depending on the number of students, could be a bottleneck.

## HOW
`rails g model UserPackSequenceItem`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
