### PR TITLE
use new env var for sidekiq max threads

### DIFF
--- a/services/QuillLMS/config/sidekiq.yml
+++ b/services/QuillLMS/config/sidekiq.yml
@@ -1,9 +1,9 @@
 ---
-:concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
+:concurrency: <%= ENV.fetch("SIDEKIQ_PROCESS_MAX_THREADS", 5).to_i - 1 %>
 staging:
-  :concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
+  :concurrency: <%= ENV.fetch("SIDEKIQ_PROCESS_MAX_THREADS", 5).to_i - 1 %>
 production:
-  :concurrency: <%= ENV.fetch("MAX_THREADS", 5).to_i - 1 %>
+  :concurrency: <%= ENV.fetch("SIDEKIQ_PROCESS_MAX_THREADS", 5).to_i - 1 %>
 :queues:
   - critical
   - default


### PR DESCRIPTION
## WHAT
- adds environment variable to control sidekiq thread concurrency 

## WHY
- so that we can tailor this parameter in production without a deployment
- decided on using a new environment variable since MAX_THREADS is already used by puma and database.yml

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
