### PR TITLE
Synthetic Seed Data - Remove Opinions

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -112,19 +112,18 @@ module Evidence
 
       private def run_prompt(prompt:, count:, seed:, noun: nil, temperature: 1)
         api_results = Evidence::OpenAI::Completion.run(prompt: prompt, count: count, temperature: temperature)
+        current_result_texts = results.map(&:text)
 
-        new_results = parse_completion_api_results(api_results, noun: noun, seed: seed)
+        new_results = parse_completion_api_results(api_results, current_texts: current_result_texts, noun: noun, seed: seed)
 
         @results += new_results
       end
 
-      private def parse_completion_api_results(api_results, noun: nil, seed:)
-        current_result_texts = results.map(&:text)
-
+      private def parse_completion_api_results(api_results, current_texts:, seed:, noun: nil)
         api_results
-          .map {|s| Result.new(text: noun.nil? ? s.lstrip : [noun, s].join(SPACE), seed: seed)}
+          .map {|s| Result.new(text: [noun, s].join(SPACE).strip, seed: seed)}
           .uniq {|r| r.text }
-          .reject {|r| r.text.in?(current_result_texts)}
+          .reject {|r| r.text.in?(current_texts)}
           .reject {|r| regex_exclude?(r.text) }
           .reject {|r| opinion_api_flagged?(r.text) }
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -168,11 +168,8 @@ module Evidence
         conjunction_exclusions.any?{|regex| regex.match(text.strip) }
       end
 
-      # Use a struct since Opinion API calls .text on the prompt
-      MockPrompt = Struct.new(:text, keyword_init: true)
-
       private def opinion_api_flagged?(text)
-        response = ::Evidence::Check::Opinion.run(text, MockPrompt.new(text: stem), nil)
+        response = ::Evidence::Check::Opinion.run(text, ::Evidence::Prompt.new(text: stem), nil)
 
         response.success? && !response.optimal?
       end


### PR DESCRIPTION
## WHAT
Similar to this PR https://github.com/empirical-org/Empirical-Core/pull/9864, we want to remove items that would be flagged by the opinion API from the seed data.
## WHY
Evidence has multiple feedback algorithms/APIs that run before the ML one. One is the opinion check. Since, in practice, the live model will never see entries of this type, we want to exclude them from the training data.
## HOW
Reject responses flagged by the Opinion API.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
