### PR TITLE
surface flagset on user detail page instead of flags

### DIFF
--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -64,8 +64,8 @@
     <p><%= @user.username || 'N/A' %></p>
     <br />
 
-    <p style='font-weight: 700;'>Flags</p>
-    <p><%= @user.flags.any? ? @user.flags : 'None' %></p>
+    <p style='font-weight: 700;'>Flagset</p>
+    <p><%= @user&.flagset %></p>
     <br />
 
     <p style='font-weight: 700;'>Role</p>


### PR DESCRIPTION
## WHAT
User detail page should surface flagset instead of flags 

## WHY
We surface flagsets instead of flags everywhere. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Flag-showing-up-incorrectly-in-a-user-s-Details-in-LMS-62a9aaca59d548d1aedf3b46ea965863

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - logic reduced, not added
Have you deployed to Staging? | currently
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
