### PR TITLE
Synthetic Seed Data - Backend for Paraphrasing Examples

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -90,7 +90,7 @@ module Evidence
       render json: @activity&.activity_versions
     end
 
-    # params [:id, nouns:]
+    # params [:id, nouns:, labels]
     def seed_data
       nouns_array = params[:nouns]
         .split(',')
@@ -98,7 +98,10 @@ module Evidence
         .map(&:strip)
         .uniq
 
-      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array)
+      # TODO: Fill in label_configs in frontend PR
+      label_configs = {}
+
+      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
 
       head :no_content
     end

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -5,8 +5,8 @@ module Evidence
     include Evidence.sidekiq_module
     sidekiq_options retry: 0
 
-    def perform(activity_id, nouns)
-      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, nouns: nouns)
+    def perform(activity_id, nouns, label_configs)
+      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, nouns: nouns, label_configs: label_configs)
 
       activity = Evidence::Activity.find(activity_id)
       subject = "Evidence Seed Data: Activity #{activity_id} - #{activity.title}"

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
@@ -20,14 +20,14 @@ module Evidence
       STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
       MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
 
-      attr_accessor :prompt, :temperature, :count, :model_key, :options_hash
+      attr_accessor :prompt, :temperature, :count, :model_key, :options
 
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options_hash: {})
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options: {})
         @prompt = prompt
         @temperature = temperature
         @count = count
         @model_key = model_key
-        @options_hash = options_hash
+        @options = options
       end
 
       def endpoint
@@ -44,7 +44,7 @@ module Evidence
           n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
           max_tokens: MAX_TOKENS,
           stop: STOP_TOKENS
-        }.merge(options_hash)
+        }.merge(options)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
@@ -3,5 +3,7 @@
 module Evidence
   module Synthetic
     EMAIL = ENV.fetch('SYNTHETIC_DATA_EMAIL', '')
+
+    SeedLabelConfig = Struct.new(:label, :examples, keyword_init: true)
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -4,7 +4,6 @@ module Evidence
   module Synthetic
     class SeedDataGenerator
       Result = Struct.new(:text, :seed, keyword_init: true)
-      LabelConfig = Struct.new(:label, :examples, keyword_init: true)
 
       WORD_SPLIT_COUNT = 70
       SPACE = ' '
@@ -52,7 +51,7 @@ module Evidence
       attr_reader :passage, :stem, :conjunction, :nouns, :results, :label_configs
 
       # returns a hash of the form {'csv name' => CSVString, 'csv name2' =>...}
-      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil)
+      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil, label_configs: {})
         activity = Evidence::Activity.find(activity_id)
         passage = activity.passages.first.text
         prompts = conjunctions.present? ? activity.prompts.where(conjunction: conjunctions) : activity.prompts
@@ -61,14 +60,15 @@ module Evidence
 
         csvs = {}
 
-        prompts.each.with_index do |prompt, index|
+        prompts.each do |prompt|
           csv_name = "#{short_name}_#{prompt.conjunction}#{CSV_SUFFIX}"
 
           generator = new(
             passage: passage,
             stem: prompt.text,
             conjunction: prompt.conjunction,
-            nouns: nouns
+            nouns: nouns,
+            label_configs: label_configs[prompt.conjunction] || []
           )
           generator.run
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -18,7 +18,7 @@ module Evidence
 
       TEMPS_PASSAGE = [0.8, 0.7, 0.5, 0.4]
       TEMP_SECTION = 0.4 # give a lower temp (creativity) when it has less info
-      TEMP_PARAPHRASE = 0.9
+      TEMP_PARAPHRASE = 1
       OPTIONS_PARAPHRASE = {max_tokens: 40}
 
       STEM_KEY = '%<stem>s'
@@ -115,6 +115,12 @@ module Evidence
         end
 
         # label examples to paraphrase
+        generate_label_paraphrases
+
+        results
+      end
+
+      private def generate_label_paraphrases
         label_configs.each do |label_config|
           label_config.examples.each.with_index do |example, index|
             prompt = PARAPHRASE_INSTRUCTION + example
@@ -127,8 +133,6 @@ module Evidence
             )
           end
         end
-
-        results
       end
 
       private def run_prompt(prompt:, count:, seed:, noun: nil, temperature: 1, options: {})

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -16,8 +16,14 @@ namespace :synthetic do
     run_number = args[:run_number]
     conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
 
-    puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}..."
-    csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions)
+    label_config1 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label11', examples: ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."])
+    label_config2 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."])
+    label_config3 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."])
+
+    label_configs = {'because' => [label_config1, label_config2, label_config3]}
+
+    puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}, Label config #{label_configs}..."
+    csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions, label_configs: label_configs)
 
     path = ENV.fetch('SYNTHETIC_LOCAL_PATH', '~/Documents/')
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -331,16 +331,18 @@ module Evidence
 
     context "#seed_data" do
       let(:activity) { create(:evidence_activity) }
+      # TODO: fill out test when frontend is complete
+      let(:label_configs) {{}}
 
       it "should call background worker" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [])
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
         post :seed_data, params: { id: activity.id, nouns: "" }
 
         expect(response).to have_http_status(:success)
       end
 
       it "should call background worker with noun string converted to array" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'])
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs)
         post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3" }
 
         expect(response).to have_http_status(:success)

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -8,7 +8,7 @@ module Evidence
     let(:temperature) { 0.9 }
     let(:count) { 10 }
     let(:model_key) { :curie }
-    let(:options_hash) {{key: 'value'}}
+    let(:options) {{key: 'value'}}
     let(:endpoint) {'https://api.openai.com/v1/completions'}
 
     let(:sample_response_body) do
@@ -37,7 +37,7 @@ module Evidence
           temperature: temperature,
           count: count,
           model_key: model_key,
-          options_hash: options_hash)
+          options: options)
     end
 
     describe "#new" do
@@ -46,7 +46,7 @@ module Evidence
         expect(completion.temperature).to eq(temperature)
         expect(completion.count).to eq(count)
         expect(completion.model_key).to eq(model_key)
-        expect(completion.options_hash).to eq(options_hash)
+        expect(completion.options).to eq(options)
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -35,7 +35,7 @@ module Evidence
 
     let(:example) {'Example to paraphrase.'}
     let(:label) { 'label1' }
-    let(:label_config) {described_class::LabelConfig.new(label: label, examples: [example])}
+    let(:label_config) {::Evidence::Synthetic::SeedLabelConfig.new(label: label, examples: [example])}
     let(:example_prompt) { "rephrase with some synonyms:\n\nExample to paraphrase." }
     let(:example_response) { ["Example to rephrase."] }
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -50,7 +50,7 @@ module Evidence
         "full_passage_noun_noun1",
         "text_chunk_1_temp0.4_but",
         "text_chunk_2_temp0.4_but",
-        "label_label1_example1_temp0.9"
+        "label_label1_example1_temp1"
       ]
     end
 
@@ -150,7 +150,7 @@ module Evidence
 
         # label example
         expect(Evidence::OpenAI::Completion).to receive(:run)
-          .with(prompt: example_prompt, count: 1, temperature: 0.9, options: {max_tokens: 40})
+          .with(prompt: example_prompt, count: 1, temperature: 1, options: {max_tokens: 40})
           .and_return(example_response)
 
         subject.run

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -18,17 +18,18 @@ module Evidence
       let(:generator_response) { double }
       let(:email_subject) {"Evidence Seed Data: Activity #{activity.id} - #{activity.title}"}
       let(:mailer) { double('mailer', deliver_now!: true) }
+      let(:label_configs) {{'key' => 'value'}}
 
       it 'call generate and call file_mailer' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
-          .with(activity_id: activity.id, nouns: nouns)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)
           .with(email, email_subject, generator_response)
           .and_return(mailer)
 
-        subject.perform(activity.id, nouns)
+        subject.perform(activity.id, nouns, label_configs)
       end
     end
   end


### PR DESCRIPTION
## WHAT
We want to allow the curriculum team to supply a few example answers for each label and then paraphrase them a few times for seed data. This is the backend for that.
## WHY
To help ensure this is a minimum amount of data for each label.
## HOW
Lots of experimenting with the OpenAI completion and Edit endpoints, resulted in this command that works pretty well for our use case: `"rephrase with some synonyms:\n\n"`

Add some code to pass along the label configs (frontend to come).
### Screenshots
Rephrasing for `"students can easily be distracted by their phones."` (Note, we can likely also use a version of this for Labeled data generation, with a slightly lower temperature, since the changes are subtle).

![Screen Shot 2022-10-21 at 3 22 02 PM](https://user-images.githubusercontent.com/1304933/197273647-bb1bc73f-699f-49fc-afe1-069d9aa3d339.png)


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'.
Have you deployed to Staging? |  No - this is only the backend, will do that with the frontend code.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
