### PR TITLE
rescue handling of invalid authenticity token

### DIFF
--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   include DemoAccountBannerLinkGenerator
   include SchoolSelectionReminderMilestone
 
+  rescue_from ActionController::InvalidAuthenticityToken,
+    with: :handle_invalid_authenticity_token
+
   # session keys
   CLEVER_REDIRECT = :clever_redirect
   EXPIRED_SESSION_REDIRECT = :expired_session_redirect
@@ -122,6 +125,15 @@ class ApplicationController < ActionController::Base
       route_redirects_to_classrooms_index?(route) ||
       route_redirects_to_diagnostic?(route)
     )
+  end
+
+  private def handle_invalid_authenticity_token
+    flash[:error] = t('actioncontroller.errors.invalid_authenticity_token')
+
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: root_path) }
+      format.json { render json: { redirect: URI.parse(request.referer).path }, status: 303 }
+    end
   end
 
   protected def check_staff_for_extended_session


### PR DESCRIPTION
## WHAT
A [PR](https://github.com/empirical-org/Empirical-Core/pull/9582) from a couple months ago removed handling of invalid authenticity token due to a bug involving users being forced to reauthorize google accounts constantly.  I suspected that the code in that PR was the culprit so I removed it.  I'd like to add that code back in since I now believe it was actually correct.

## WHY
I found the real [bug](https://github.com/empirical-org/Empirical-Core/pull/9847) last week.

## HOW
`git revert e11cd32783c4d435be2b348fde7693827c696396`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
