### PR TITLE
Time track max

### DIFF
--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -44,13 +44,19 @@ class TimeTrackingCleaner < ApplicationService
   end
 
   private def max_outliers
-    time_tracking
-      .except(*median_outliers.keys)
-      .select {|_,v| v > MAX_TIME_SECTION }
+    @max_outliers ||= begin
+      time_tracking
+        .except(*median_outliers.keys)
+        .select {|_,v| v > MAX_TIME_SECTION }
+    end
   end
 
   private def median_outliers
-    @median_outliers ||= time_tracking.select {|_, v| v > median_outlier_threshold}.except(*IGNORE_MEDIAN_KEYS)
+    @median_outliers ||= begin
+      time_tracking
+        .except(*IGNORE_MEDIAN_KEYS)
+        .select {|_, v| v > median_outlier_threshold}
+    end
   end
 
   private def median_value

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -2,9 +2,11 @@
 
 class TimeTrackingCleaner < ApplicationService
   OUTLIER_MULTIPLIER = 40
+  MAX_TIME_SECTION = 10.minutes.to_i
+
   # There are some keys that it doesn't make sense to use the median as a backfill
   # So skipping them for now, until we have a more robust solution.
-  IGNORE_KEYS = ['proofreading_the_passage']
+  IGNORE_MEDIAN_KEYS = ['proofreading_the_passage']
 
   attr_reader :time_tracking, :data_params, :time_tracking_edits
 
@@ -20,27 +22,27 @@ class TimeTrackingCleaner < ApplicationService
   # this is a backstop against a bug in the frontend time tracking with resumed sessions
   def run
     return data_params unless time_tracking.respond_to?(:values)
-    return data_params if outliers.empty?
+    return data_params if median_outliers.empty?
 
     data_params.merge(
       ActivitySession::TIME_TRACKING_KEY => time_tracking_outliers_replaced,
-      ActivitySession::TIME_TRACKING_EDITS_KEY => time_tracking_edits.merge(outliers)
+      ActivitySession::TIME_TRACKING_EDITS_KEY => time_tracking_edits.merge(median_outliers)
     )
   end
 
   private def time_tracking_outliers_replaced
-    time_tracking.merge(outliers.transform_values {|_| median_value})
+    time_tracking.merge(median_outliers.transform_values {|_| median_value})
   end
 
-  private def outliers
-    @outliers ||= time_tracking.select {|_, v| v > outlier_threshold}.except(*IGNORE_KEYS)
+  private def median_outliers
+    @median_outliers ||= time_tracking.select {|_, v| v > median_outlier_threshold}.except(*IGNORE_MEDIAN_KEYS)
   end
 
   private def median_value
     @median_value ||= time_tracking.values.compact.median.to_i
   end
 
-  private def outlier_threshold
+  private def median_outlier_threshold
     @outlier_threshold ||= median_value * OUTLIER_MULTIPLIER
   end
 end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -192,32 +192,14 @@ describe Api::V1::ActivitySessionsController, type: :controller do
       end
 
       it 'should log long session' do
+        # lots of keys to hit Tracking error but avoid time_tracking cleaner
         data = {
-          'time_tracking' => {
-            'so' => 9999,
-            'but' => 9999,
-            'because' => 9999
-          }
+          'time_tracking' => ('a'..'z').to_h {|k| [k,600]}
         }
 
         expect(ErrorNotifier).to receive(:report).with(ActivitySession::LongTimeTrackingError).once
 
         put :update, params: { id: activity_session.uid, data: data }, as: :json
-      end
-
-      describe 'the total time tracking value is larger than the maximum 4-byte integer size' do
-        it 'saves timespent with the maximum 4-byte integer size' do
-          data = {
-            'time_tracking' => {
-              'so' => 2147483648
-            }
-          }
-
-          put :update, params: { id: activity_session.uid, data: data }, as: :json
-          activity_session.reload
-
-          expect(activity_session.timespent).to eq 2147483647
-        end
       end
     end
 

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -218,10 +218,11 @@ describe TimeTrackingCleaner do
            'prompt_4'=>23,
            'prompt_5'=>17,
            'prompt_6'=>42,
-           'proofreading_the_passage'=>99999
+           'proofreading_the_passage'=>600
          },
           'time_tracking_edits' => {
-            'prompt_3'=>9999999
+            'prompt_3'=>9999999,
+            'proofreading_the_passage'=>99999
           }
         }
       end


### PR DESCRIPTION
## WHAT
For time tracking, add a maximum value per section
## WHY
There still seems to be an issue with sessions having very long times on a given section, e.g. the prompts would have times of 50 seconds, 70 seconds, 3 hours, 40 seconds, etc. We originally added code to replace large outliers (40x the median), but we left out some sections (like `proofreading the passage`) and some times are still very long given this high bar of 40x the median. This adds a second pass to cap section time at `10.minutes`.

We think this will be a more accurate representation of `timespent` on activities and more helpful for teachers.

Note, Partnerships gave their feedback and felt that `10.minutes` max for a question seems reasonable.
## HOW
Do a separate `median_outlier` pass followed by a `max_outlier` pass on time tracking data.
### Screenshots
![Screen Shot 2022-10-25 at 12 02 36 PM](https://user-images.githubusercontent.com/1304933/197824706-b76262f0-e2f4-4b3f-9cff-fd24328fd56d.png)
![Screen Shot 2022-10-25 at 12 02 02 PM](https://user-images.githubusercontent.com/1304933/197824710-9ed96bff-8848-4ff4-ad93-30b752dd3945.png)
![Screen Shot 2022-10-25 at 12 00 40 PM](https://user-images.githubusercontent.com/1304933/197824712-9307d508-6579-43c8-af65-f3457071aa82.png)


### Notion Card Links

https://www.notion.so/quill/ActivitySession-LongTimeTrackingError-1dd92449d3d047b08a4708cc86355ddd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A Yes)
