### PR TITLE
Bug fix/ add default page size for Evidence rules analysis

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/rulesAnalysis.tsx
@@ -215,6 +215,8 @@ const RulesAnalysis: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
           columns={dataTableFields}
           data={formattedRows ? formattedRows : []}
           defaultGroupBy={["apiName"]}
+          // the first row will be the toggle rule identifier row, so we need to increment by 1
+          defaultPageSize={formattedRows && formattedRows.length < 100 ? (formattedRows.length + 1) : 100}
           defaultSorted={sorted}
           manualSortBy
           onSortedChange={setSorted}


### PR DESCRIPTION
## WHAT
add default page size for Evidence rules analysis

## WHY
not having this prop was causing results to be cut off

## HOW
rather than default to `data.length`, explicitly pass `defaultPageSize` to `ReactTable` instance (note: since this is a table with toggled rows, the first row for the `page` variable produced by `useTable` will always be the parent toggle row-- therefore, we need to increment by 1 for these instances)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Evidence-Internal-Tool-Rules-Analysis-Display-Issue-76367d7a60514c92b8e114dda8dcca3c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
