### PR TITLE
Add rake task to remove duplicate student accounts that have no data

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -676,6 +676,15 @@ class User < ApplicationRecord
     end
   end
 
+  def self.duplicate_empty_student_accounts(id, email)
+    return none unless exists?(id: id)
+
+    student
+      .where(email: email)
+      .where.not(id: id)
+      .where.missing(:activity_sessions, :students_classrooms)
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -676,10 +676,9 @@ class User < ApplicationRecord
     end
   end
 
-  def self.duplicate_empty_student_accounts(id, email)
-    return none unless exists?(id: id)
-
-    student
+  def duplicate_empty_student_accounts
+    User
+      .student
       .where(email: email)
       .where.not(id: id)
       .where.missing(:activity_sessions, :students_classrooms)

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
@@ -3,27 +3,15 @@
 require_relative '../progress_bar'
 
 namespace :students do
-  desc 'Remove duplicate student users with same email'
   task remove_users_with_same_email: :environment do
-    duplicate_emails =
-      User
-        .student
-        .where
-        .not(email: [nil, ""])
-        .group(:email)
-        .having("count(email) > 1")
-        .pluck(:email)
+
+    duplicate_emails = User.student.where.not(email: [nil, ""]).group(:email).having("count(email) > 1").pluck(:email)
 
     progress_bar = ProgessBar.new(duplicate_emails.size)
 
-    [].tap do |ids_for_deletion|
-      duplicate_emails.each do |email|
-        student = User.find_by(email: email)
-        ids_for_deletion << student.duplicate_empty_student_accounts.pluck(:id)
-        progress_bar.increment
-      end
-
-      User.where(id: ids_for_deletion).destroy_all
+    duplicate_emails.each do |email|
+      User.find_by(email: email).duplicate_empty_student_accounts.destroy_all
+      progress_bar.increment
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative './progress_bar'
+require_relative '../progress_bar'
 
 namespace :students do
+  desc 'Remove duplicate student users with same email'
   task remove_users_with_same_email: :environment do
-
     duplicate_emails =
       User
         .student

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
@@ -19,7 +19,7 @@ namespace :students do
     [].tap do |ids_for_deletion|
       duplicate_emails.each do |email|
         student = User.find_by(email: email)
-        ids_for_deletion << student.duplicate_student_accounts.pluck(:id)
+        ids_for_deletion << student.duplicate_empty_student_accounts.pluck(:id)
         progress_bar.increment
       end
 

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rb
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './progress_bar'
+
+namespace :students do
+  task remove_users_with_same_email: :environment do
+
+    duplicate_emails = User.student.where.not(email: [nil, ""]).group(:email).having("count(email) > 1").pluck(:email)
+    progress_bar = ProgessBar.new(duplicate_emails.size)
+
+    [].tap do |ids_for_deletion|
+      duplicate_emails.each do |email|
+        student = User.find_by(email: email)
+        ids_for_deletion << student.duplicate_student_accounts.pluck(:id)
+        progress_bar.increment
+      end
+
+      User.where(id: ids_for_deletion).destroy_all
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rb
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rb
@@ -5,7 +5,15 @@ require_relative './progress_bar'
 namespace :students do
   task remove_users_with_same_email: :environment do
 
-    duplicate_emails = User.student.where.not(email: [nil, ""]).group(:email).having("count(email) > 1").pluck(:email)
+    duplicate_emails =
+      User
+        .student
+        .where
+        .not(email: [nil, ""])
+        .group(:email)
+        .having("count(email) > 1")
+        .pluck(:email)
+
     progress_bar = ProgessBar.new(duplicate_emails.size)
 
     [].tap do |ids_for_deletion|

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1478,13 +1478,18 @@ describe User, type: :model do
     end
   end
 
-  describe '.duplicate_empty_student_accounts' do
-    subject { described_class.duplicate_empty_student_accounts(id, email) }
+  describe '#duplicate_empty_student_accounts' do
+    subject { student.duplicate_empty_student_accounts }
 
     let(:student) { create(:student) }
     let(:id) { student.id }
     let(:email) { student.email }
-    let(:duplicate) { create(:student) }
+
+    let(:duplicate) do
+      s = build(:student, email: student.email)
+      s.save(validate: false)
+      s
+    end
 
     context 'nil id' do
       let(:id) { nil }
@@ -1500,7 +1505,6 @@ describe User, type: :model do
 
     context 'duplicates exist' do
       let(:student_ids) { [student.id, duplicate.id] }
-      let(:email) { [student.email, duplicate.email] } # HACK: using array obviates the email uniqueness constraint
 
       it { expect(subject).to eq [duplicate] }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1439,7 +1439,7 @@ describe User, type: :model do
   describe '#duplicate_empty_student_accounts' do
     subject { student.duplicate_empty_student_accounts }
 
-    let(:student) { create(:student) }
+    let(:student) { create(:student, id: described_class::EMAIL_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1) }
 
     it { expect(subject).to be_empty }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1453,7 +1453,7 @@ describe User, type: :model do
       it { expect(subject).to eq [duplicate] }
 
       context 'duplicate is not a student' do
-        let(:duplicate) { create(:teacher) }
+        before { duplicate.update_columns(role: 'teacher') }
 
         it { expect(subject).to be_empty }
       end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1436,6 +1436,42 @@ describe User, type: :model do
     end
   end
 
+  describe '#duplicate_empty_student_accounts' do
+    subject { student.duplicate_empty_student_accounts }
+
+    let(:student) { create(:student) }
+
+    it { expect(subject).to be_empty }
+
+    context 'duplicates exist' do
+      let!(:duplicate) do
+        s = build(:student, email: student.email)
+        s.save(validate: false)
+        s
+      end
+
+      it { expect(subject).to eq [duplicate] }
+
+      context 'duplicate is not a student' do
+        let(:duplicate) { create(:teacher) }
+
+        it { expect(subject).to be_empty }
+      end
+
+      context 'duplicate has activity session' do
+        before { create(:activity_session, user: duplicate) }
+
+        it { expect(subject).to be_empty}
+      end
+
+      context 'duplicate has students_classrooms' do
+        before { create(:students_classrooms, student: duplicate) }
+
+        it { expect(subject).to be_empty }
+      end
+    end
+  end
+
   describe '.find_by_stripe_customer_id_or_email!' do
     subject { User.find_by_stripe_customer_id_or_email!(stripe_customer_id, email) }
 
@@ -1477,55 +1513,4 @@ describe User, type: :model do
       end
     end
   end
-
-  describe '#duplicate_empty_student_accounts' do
-    subject { student.duplicate_empty_student_accounts }
-
-    let(:student) { create(:student) }
-    let(:id) { student.id }
-    let(:email) { student.email }
-
-    let(:duplicate) do
-      s = build(:student, email: student.email)
-      s.save(validate: false)
-      s
-    end
-
-    context 'nil id' do
-      let(:id) { nil }
-
-      it { expect(subject).to be_empty }
-    end
-
-    context 'no duplicates' do
-      let(:student_ids) { [student.id] }
-
-      it { expect(subject).to be_empty }
-    end
-
-    context 'duplicates exist' do
-      let(:student_ids) { [student.id, duplicate.id] }
-
-      it { expect(subject).to eq [duplicate] }
-
-      context 'duplicate is not a student' do
-        let(:duplicate) { create(:teacher) }
-
-        it { expect(subject).to be_empty }
-      end
-
-      context 'duplicate has activity session' do
-        before { create(:activity_session, user: duplicate) }
-
-        it { expect(subject).to be_empty}
-      end
-
-      context 'duplicate has students_classrooms' do
-        before { create(:students_classrooms, student: duplicate) }
-
-        it { expect(subject).to be_empty }
-      end
-    end
-  end
-
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1485,49 +1485,41 @@ describe User, type: :model do
     let(:id) { student.id }
     let(:email) { student.email }
     let(:duplicate) { create(:student) }
-    let(:results) { User.where(id: result_ids).to_a }
 
     context 'nil id' do
       let(:id) { nil }
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to be_empty }
     end
 
     context 'no duplicates' do
       let(:student_ids) { [student.id] }
-      let(:result_ids) { [] }
 
-      it { expect(subject).to eq results }
+      it { expect(subject).to be_empty }
     end
 
     context 'duplicates exist' do
       let(:student_ids) { [student.id, duplicate.id] }
-      let(:result_ids) { [duplicate.id] }
       let(:email) { [student.email, duplicate.email] } # HACK: using array obviates the email uniqueness constraint
 
-      it { expect(subject).to eq results }
+      it { expect(subject).to eq [duplicate] }
 
       context 'duplicate is not a student' do
         let(:duplicate) { create(:teacher) }
-        let(:result_ids) { [] }
 
-        it { expect(subject).to eq results }
+        it { expect(subject).to be_empty }
       end
 
       context 'duplicate has activity session' do
-        let(:result_ids) { [] }
-
         before { create(:activity_session, user: duplicate) }
 
-        it { expect(subject).to eq results }
+        it { expect(subject).to be_empty}
       end
 
       context 'duplicate has students_classrooms' do
-        let(:result_ids) { [] }
-
         before { create(:students_classrooms, student: duplicate) }
 
-        it { expect(subject).to eq results }
+        it { expect(subject).to be_empty }
       end
     end
   end


### PR DESCRIPTION
## WHAT
There's a [bug](https://www.notion.so/quill/GoogleStudentImporterWorker-perform-Validation-failed-Email-That-email-is-taken-Try-another-Use-b02bc2dc7d74433698f914371ded840f) with google student importing when the importer attempts to update a student account where there exist multiple users with the same email, username, etc.   This rake task goes in and removes those duplicate users.

## WHY
These duplicate users are a huge gotcha, breaking assumptions about data integrity.

## HOW
Find email addresses that occur on multiple user accounts
Use the `User.find_by(email: email)` as the canonical account and then destroy other accounts that are lacking activity sessions and student classrooms (based on the student merge [operation](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/concerns/student.rb#L121)).

FYI:  This won't clean all of the duplicate emails (there are ~70000).
Based on a survey of staging, this script will remove 54111 accounts. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/GoogleStudentImporterWorker-perform-Validation-failed-Email-That-email-is-taken-Try-another-Use-b02bc2dc7d74433698f914371ded840f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now! 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
