### PR TITLE
lms/student-classrooms-race-conditions

### DIFF
--- a/services/QuillLMS/app/controllers/students_classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/students_classrooms_controller.rb
@@ -18,7 +18,7 @@ class StudentsClassroomsController < ApplicationController
         # rubocop:enable Style/GuardClause
       end
       Associators::StudentsToClassrooms.run(@user, classroom)
-      render json: classroom.attributes
+      render json: classroom.reload.attributes
     else
       render status: 403, json: {error: "Student not logged in."}, text: "Student not logged in."
     end

--- a/services/QuillLMS/spec/services/associators/students_to_classrooms.rb
+++ b/services/QuillLMS/spec/services/associators/students_to_classrooms.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Associators::StudentsToClassrooms do
-  let(:subject) { described_class }
+  subject { described_class }
 
   let!(:user) { create(:user, role: User::STUDENT) }
   let!(:classroom) { create(:classroom) }

--- a/services/QuillLMS/spec/services/associators/students_to_classrooms.rb
+++ b/services/QuillLMS/spec/services/associators/students_to_classrooms.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Associators::StudentsToClassrooms do
+  let(:subject) { described_class }
+
+  let!(:user) { create(:user, role: User::STUDENT) }
+  let!(:classroom) { create(:classroom) }
+
+  it 'should handle a race condition where two simultaneous calls go down the init side of a find_or_initialize_by call' do
+    # While twenty parallel calls does feel a bit excessive, testing locally
+    # suggests that that's about the level required to trigger the race
+    # condition on 90% of test runs.
+    call_count = 20
+    wait_to_start = true
+
+    threads = call_count.times.map do |i|
+      Thread.new do
+        true while wait_to_start
+        subject.run(user, classroom)
+      end
+    end
+    wait_to_start = false
+    expect { threads.each(&:join) }.to_not raise_error
+  end
+end


### PR DESCRIPTION
## WHAT
Refactor to handle a race condition and add specs for it
## WHY
While this isn't really impacting user experience (or I don't think it is?) since the error only occurs if the data we care about has already been saved, we don't want to clutter up our logs with errors that are easily preventable.
## HOW
I first explored trying more holistic fixes like using `create_or_find_by` instead of this weird logic here, but then realized that this Associator gets called in an `after_save` callback on the model (which, funnily enough, means that the associator calls itself if it has to create a new record), and that enough other code paths create models that it would have taken considerable effort to trace through all of the code paths and ensure that the new logic did what each of them needed.

So I went with the simplest possible solution: wrap the `find_of_initialize_by ... save` code in a block with a `rescue ... retry` on `RecordNotUnique` errors.

### Notion Card Links
https://www.notion.so/quill/StudentClassrooms-ActiveRecord-RecordNotUnique-42cbec4b457542a28e8e646b576fcde1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
