### PR TITLE
Make explicit in testing the uniqueness constraints on user model

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -324,11 +324,11 @@ class User < ApplicationRecord
   def username_cannot_be_an_email
     return unless username =~ VALID_EMAIL_REGEX
 
-    if persisted?
+    if new_record?
+      errors.add(:username, :invalid)
+    else
       db_self = User.find(id)
       errors.add(:username, :invalid) unless db_self.username == username
-    else
-      errors.add(:username, :invalid)
     end
   end
 
@@ -709,7 +709,7 @@ class User < ApplicationRecord
 
   private def clever_id_present_and_has_changed?
     return false if !clever_id
-    return true if !persisted?
+    return true if new_record?
 
     existing_user = User.find_by_id(id)
     existing_user.clever_id != clever_id

--- a/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/users_controller_spec.rb
@@ -132,10 +132,9 @@ describe Cms::UsersController do
     let(:new_user) { build(:user) }
 
     it 'should create the user with the given params' do
-      post :create, params: { user: new_user.attributes.merge({password: "test123"}) }
+      post :create, params: { user: new_user.attributes.merge(password: "test123") }
       expect(response).to redirect_to cms_users_path
-      expect(User.last.email).to eq new_user.email
-      expect(User.last.role).to eq new_user.role
+      expect(User.exists?(email: new_user.email, role: new_user.role)).to be true
     end
   end
 

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -57,6 +57,7 @@
 #
 FactoryBot.define do
   factory :simple_user, class: 'User' do
+    sequence(:id) { |n| n + User::UNIQUENESS_CONSTRAINT_MINIMUM_ID }
     name 'Jane Doe'
     email 'fake@example.com'
     password 'password'
@@ -64,6 +65,7 @@ FactoryBot.define do
   end
 
   factory :user do
+    sequence(:id) { |n| n + User::UNIQUENESS_CONSTRAINT_MINIMUM_ID }
     sequence(:name) { |n| "FirstName LastName #{n}" }
     username   { name.gsub(' ', '-') }
     password   { "password" }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -64,9 +64,6 @@ describe User, type: :model do
   it { is_expected.to callback(:prep_authentication_terms).before(:validation) }
   it { is_expected.to callback(:check_for_school).after(:save) }
 
-  #TODO: the validation uses a proc, figure out how to stub that
-  #it { is_expected.to callback(:update_invitiee_email_address).after(:save).if(proc) }
-
   it { should have_many(:checkboxes) }
   it { should have_many(:invitations).with_foreign_key('inviter_id') }
   it { should have_many(:objectives).through(:checkboxes) }
@@ -91,12 +88,6 @@ describe User, type: :model do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:password) }
-
-  #TODO: matchers don't support if conditions
-  #it { should validate_presence_of(:email).on(:create) }
-  #it { should validate_uniqueness_of(:email).on(:create) }
-  #it { should validate_presence_of(:username).on(:create) }
-  #it { should validate_uniqueness_of(:username).on(:create) }
 
   it { should validate_presence_of(:username).on(:create) }
   it { should validate_length_of(:username).is_at_most(User::CHAR_FIELD_MAX_LENGTH) }
@@ -905,8 +896,20 @@ describe User, type: :model do
         expect(user).to_not be_valid
       end
 
-      it 'is valid when email is not unique' do
-        user = build(:user,  email: 'unique@test.lan')
+      it 'is does not save records with non unique emails' do
+        create(:user, email: 'test@test.lan')
+        user = build(:user,  email: 'test@test.lan')
+        expect { user.save!(validate: false) }.to raise_error ActiveRecord::RecordNotSaved
+      end
+
+      it 'is does save for records below the uniqueness constraint minimum' do
+        create(:user, id: described_class::EMAIL_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1, email: 'test@test.lan')
+        user = build(:user,  email: 'test@test.lan')
+        expect { user.save!(validate: false) }.to change(User, :count).from(1).to(2)
+      end
+
+      it 'is valid when email is unique' do
+        user = build(:user, email: 'unique@test.lan')
         expect(user).to be_valid
       end
 
@@ -957,6 +960,18 @@ describe User, type: :model do
         create(:user, username: 'testtest.lan')
         user = build(:user, username: 'testtest.lan')
         expect(user).to_not be_valid
+      end
+
+      it 'is does not save records with non unique usernames' do
+        user1 = create(:user)
+        user2 = build(:user, username: user1.username)
+        expect { user2.save!(validate: false) }.to raise_error ActiveRecord::RecordNotSaved
+      end
+
+      it 'is does save for records below the uniqueness constraint minimum' do
+        user1 = create(:user, id: described_class::USERNAME_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1)
+        user2 = build(:user, username: user1.username)
+        expect { user2.save!(validate: false) }.to change(User, :count).from(1).to(2)
       end
 
       it 'uniqueness is enforced on existing users changing to an existing username' do
@@ -1177,12 +1192,18 @@ describe User, type: :model do
       expect(new_user.valid?).not_to be
     end
 
-    it 'should pass the validation if the user already exists and has not changed their clever id, even if another user already has it' do
-      create(:teacher, clever_id: 'already_used')
+    it 'should pass the validation if the user already exists and is and has not changed their clever id, even if another user already has it' do
+      create(:teacher, id: described_class::CLEVER_ID_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1, clever_id: 'already_used')
       second_user = build(:teacher, clever_id: 'already_used')
       second_user.save!(validate: false)
       second_user.name = 'Clever User'
-      expect(second_user.valid?).to be
+      expect(second_user).to be_valid
+    end
+
+    it 'should not pass the validation if the user already exists and a duplicate clever_id is attempted to be saved' do
+      create(:teacher, clever_id: 'already_used')
+      second_user = build(:teacher, clever_id: 'already_used')
+      expect { second_user.save!(validate: false) }.to raise_error ActiveRecord::RecordNotSaved
     end
 
     it 'should not pass the validation if the user already exists and is changing their clever id to a non-unique one' do
@@ -1212,11 +1233,17 @@ describe User, type: :model do
     end
 
     it 'should pass the validation if the user already exists and has not changed their google id, even if another user already has it' do
-      create(:teacher, google_id: 'already_used')
+      create(:teacher, id: described_class::GOOGLE_ID_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1, google_id: 'already_used')
       second_user = build(:teacher, google_id: 'already_used')
       second_user.save!(validate: false)
       second_user.name = 'google User'
-      expect(second_user.valid?).to be
+      expect(second_user).to be_valid
+    end
+
+    it 'should not pass the validation if the user already exists and a duplicate google_id is attempted to be saved' do
+      create(:teacher, google_id: 'already_used')
+      second_user = build(:teacher, google_id: 'already_used')
+      expect { second_user.save!(validate: false) }.to raise_error ActiveRecord::RecordNotSaved
     end
 
     it 'should pass the validation if the user already exists and changes their google id to a unique one' do


### PR DESCRIPTION
## WHAT
Make uniqueness constraints from the User model explicit in testing.

## WHY
There are uniqueness on constraints on the User model that rely on a hardcoded user id:

* unique_index_users_on_clever_id:    id > 5593155
* unique_index_users_on_email:  id > 1641954
* unique_index_users_on_google_id: id > 1641954
* unique_index_users_on_username: id > 1641954

In our specs, the IDs never get into the millions so these constraints are never actually tested.

## HOW
Update the factories to use the minimum values as the starting point.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet, deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
