### PR TITLE
Copy change/ fix typo on Springboard page

### DIFF
--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -428,7 +428,7 @@ module PagesHelper
                 cb_anchor_tag: '1984'
               },
               {
-                title: 'Sentence Combining: Except from The Night Circus by Erin Morgenstern',
+                title: 'Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern',
                 description: 'Explore how second-person point of view sets up a fantastical world',
                 unit_template_id: '233',
                 cb_anchor_tag: 'the-night-circus'
@@ -438,7 +438,7 @@ module PagesHelper
           {
             activities: [
               {
-                title: 'Sentence Combining: Except from Out of My Mind by Sharon M. Draper',
+                title: 'Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper',
                 description: 'Explore how first-person point of view efficiently establishes a narrator’s experience',
                 unit_template_id: '234',
                 cb_anchor_tag: 'out-of-my-mind'

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               Object {
                 "cb_anchor_tag": "the-night-circus",
                 "description": "Explore how second-person point of view sets up a fantastical world",
-                "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                 "unit_template_id": 233,
               },
             ],
@@ -168,7 +168,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               Object {
                 "cb_anchor_tag": "out-of-my-mind",
                 "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                 "unit_template_id": 234,
               },
               Object {
@@ -328,7 +328,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
                       </p>
                     </div>
                     <img
@@ -471,7 +471,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -519,7 +519,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -629,7 +629,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -728,7 +728,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -807,7 +807,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -886,7 +886,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -985,7 +985,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -1064,7 +1064,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -1143,7 +1143,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -1242,7 +1242,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -1296,7 +1296,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                                     tabindex="-1"
                                     target="_blank"
                                   >
-                                    Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                                    Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -1321,7 +1321,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -1344,7 +1344,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                                     tabindex="-1"
                                     target="_blank"
                                   >
-                                    Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                                    Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -1400,7 +1400,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -1495,7 +1495,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
                       </p>
                     </div>
                     <img
@@ -2203,7 +2203,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2253,7 +2253,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2303,7 +2303,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2389,7 +2389,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
             </p>
           </div>
           <img
@@ -2597,7 +2597,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -2647,7 +2647,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -2761,7 +2761,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -2915,7 +2915,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -2997,7 +2997,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3079,7 +3079,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3233,7 +3233,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -3315,7 +3315,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3397,7 +3397,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3458,7 +3458,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       Object {
                         "cb_anchor_tag": "the-night-circus",
                         "description": "Explore how second-person point of view sets up a fantastical world",
-                        "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                        "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                         "unit_template_id": 233,
                       },
                     ],
@@ -3468,7 +3468,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       Object {
                         "cb_anchor_tag": "out-of-my-mind",
                         "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                        "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                        "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                         "unit_template_id": 234,
                       },
                       Object {
@@ -3551,7 +3551,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -3607,7 +3607,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             tabIndex={-1}
                             target="_blank"
                           >
-                            Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                            Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -3633,7 +3633,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3657,7 +3657,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             tabIndex={-1}
                             target="_blank"
                           >
-                            Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                            Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -3715,7 +3715,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3825,7 +3825,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
             </p>
           </div>
           <img
@@ -4121,7 +4121,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -4182,7 +4182,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -4232,7 +4232,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -4285,7 +4285,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
                     </p>
                     <p>
                       <a
@@ -4295,7 +4295,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves. 
+                       explains how you can use deadlines to help students pace themselves.
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -4338,7 +4338,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    Quill has a variety of reports to help you track your students' performance and progress. In the
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -4346,7 +4346,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -4354,7 +4354,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and 
+                     shows you which report to go to for particular information, and
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -4457,7 +4457,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
                           <strong>
                             Note
                           </strong>
@@ -4506,7 +4506,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -4567,7 +4567,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -4595,7 +4595,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email 
+                       Having a technical issue? Email
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -4812,7 +4812,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               Object {
                 "cb_anchor_tag": "the-night-circus",
                 "description": "Explore how second-person point of view sets up a fantastical world",
-                "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                 "unit_template_id": 233,
               },
             ],
@@ -4822,7 +4822,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               Object {
                 "cb_anchor_tag": "out-of-my-mind",
                 "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                 "unit_template_id": 234,
               },
               Object {
@@ -4974,7 +4974,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
                       </p>
                     </div>
                     <img
@@ -5117,7 +5117,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5165,7 +5165,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5275,7 +5275,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5374,7 +5374,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5453,7 +5453,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5532,7 +5532,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5631,7 +5631,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5710,7 +5710,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5789,7 +5789,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5888,7 +5888,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5942,7 +5942,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                                     tabindex="-1"
                                     target=""
                                   >
-                                    Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                                    Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -5967,7 +5967,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5990,7 +5990,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                                     tabindex="-1"
                                     target=""
                                   >
-                                    Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                                    Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -6046,7 +6046,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -6141,7 +6141,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
                       </p>
                     </div>
                     <img
@@ -6849,7 +6849,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6899,7 +6899,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6949,7 +6949,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -7035,7 +7035,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
             </p>
           </div>
           <img
@@ -7244,7 +7244,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7294,7 +7294,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -7408,7 +7408,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -7563,7 +7563,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7645,7 +7645,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -7727,7 +7727,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -7882,7 +7882,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7964,7 +7964,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -8046,7 +8046,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -8108,7 +8108,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       Object {
                         "cb_anchor_tag": "the-night-circus",
                         "description": "Explore how second-person point of view sets up a fantastical world",
-                        "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                        "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                         "unit_template_id": 233,
                       },
                     ],
@@ -8118,7 +8118,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       Object {
                         "cb_anchor_tag": "out-of-my-mind",
                         "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                        "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                        "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                         "unit_template_id": 234,
                       },
                       Object {
@@ -8201,7 +8201,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -8257,7 +8257,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             tabIndex={-1}
                             target=""
                           >
-                            Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                            Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -8283,7 +8283,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -8307,7 +8307,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             tabIndex={-1}
                             target=""
                           >
-                            Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                            Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -8365,7 +8365,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -8475,7 +8475,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
             </p>
           </div>
           <img
@@ -8771,7 +8771,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -8832,7 +8832,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -8882,7 +8882,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -8935,7 +8935,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
                     </p>
                     <p>
                       <a
@@ -8945,7 +8945,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves. 
+                       explains how you can use deadlines to help students pace themselves.
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -8988,7 +8988,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    Quill has a variety of reports to help you track your students' performance and progress. In the
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -8996,7 +8996,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -9004,7 +9004,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and 
+                     shows you which report to go to for particular information, and
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -9107,7 +9107,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
                           <strong>
                             Note
                           </strong>
@@ -9156,7 +9156,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -9217,7 +9217,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -9245,7 +9245,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email 
+                       Having a technical issue? Email
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -9433,7 +9433,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
                       </p>
                     </div>
                     <img
@@ -9571,7 +9571,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
                       </p>
                     </div>
                     <img
@@ -10279,7 +10279,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10329,7 +10329,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10379,7 +10379,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10465,7 +10465,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
             </p>
           </div>
           <img
@@ -10628,7 +10628,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
             </p>
           </div>
           <img
@@ -10924,7 +10924,7 @@ exports[`PreAp component should render with no units 1`] = `
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -10985,7 +10985,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -11035,7 +11035,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -11088,7 +11088,7 @@ exports[`PreAp component should render with no units 1`] = `
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
                     </p>
                     <p>
                       <a
@@ -11098,7 +11098,7 @@ exports[`PreAp component should render with no units 1`] = `
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves. 
+                       explains how you can use deadlines to help students pace themselves.
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -11141,7 +11141,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    Quill has a variety of reports to help you track your students' performance and progress. In the
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -11149,7 +11149,7 @@ exports[`PreAp component should render with no units 1`] = `
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -11157,7 +11157,7 @@ exports[`PreAp component should render with no units 1`] = `
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and 
+                     shows you which report to go to for particular information, and
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -11260,7 +11260,7 @@ exports[`PreAp component should render with no units 1`] = `
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
                           <strong>
                             Note
                           </strong>
@@ -11309,7 +11309,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -11370,7 +11370,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -11398,7 +11398,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email 
+                       Having a technical issue? Email
                       <a
                         href="mailto:support@quill.org"
                       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/pre_ap.test.jsx.snap
@@ -328,7 +328,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
                       </p>
                     </div>
                     <img
@@ -471,7 +471,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -519,7 +519,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -629,7 +629,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -728,7 +728,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -807,7 +807,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -886,7 +886,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -985,7 +985,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -1064,7 +1064,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -1143,7 +1143,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -1242,7 +1242,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -1321,7 +1321,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -1400,7 +1400,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -1495,7 +1495,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
                       </p>
                     </div>
                     <img
@@ -2203,7 +2203,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2253,7 +2253,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2303,7 +2303,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2389,7 +2389,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
             </p>
           </div>
           <img
@@ -2597,7 +2597,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -2647,7 +2647,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -2761,7 +2761,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -2915,7 +2915,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -2997,7 +2997,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3079,7 +3079,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3233,7 +3233,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -3315,7 +3315,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3397,7 +3397,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3551,7 +3551,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -3633,7 +3633,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3715,7 +3715,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3825,7 +3825,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
             </p>
           </div>
           <img
@@ -4121,7 +4121,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -4182,7 +4182,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -4232,7 +4232,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -4285,7 +4285,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
                     </p>
                     <p>
                       <a
@@ -4295,7 +4295,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -4338,7 +4338,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -4346,7 +4346,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -4354,7 +4354,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and
+                     shows you which report to go to for particular information, and 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -4457,7 +4457,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
                           <strong>
                             Note
                           </strong>
@@ -4506,7 +4506,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -4567,7 +4567,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -4595,7 +4595,7 @@ exports[`PreAp component should render when it is not part of the assignment flo
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email
+                       Having a technical issue? Email 
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -4974,7 +4974,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
                       </p>
                     </div>
                     <img
@@ -5117,7 +5117,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5165,7 +5165,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5275,7 +5275,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5374,7 +5374,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5453,7 +5453,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5532,7 +5532,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5631,7 +5631,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5710,7 +5710,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5789,7 +5789,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5888,7 +5888,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5967,7 +5967,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -6046,7 +6046,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -6141,7 +6141,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
                       </p>
                     </div>
                     <img
@@ -6849,7 +6849,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6899,7 +6899,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6949,7 +6949,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -7035,7 +7035,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
             </p>
           </div>
           <img
@@ -7244,7 +7244,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7294,7 +7294,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -7408,7 +7408,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -7563,7 +7563,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7645,7 +7645,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -7727,7 +7727,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -7882,7 +7882,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7964,7 +7964,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -8046,7 +8046,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -8201,7 +8201,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -8283,7 +8283,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -8365,7 +8365,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -8475,7 +8475,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
             </p>
           </div>
           <img
@@ -8771,7 +8771,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -8832,7 +8832,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -8882,7 +8882,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -8935,7 +8935,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
                     </p>
                     <p>
                       <a
@@ -8945,7 +8945,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -8988,7 +8988,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -8996,7 +8996,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -9004,7 +9004,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and
+                     shows you which report to go to for particular information, and 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -9107,7 +9107,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
                           <strong>
                             Note
                           </strong>
@@ -9156,7 +9156,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -9217,7 +9217,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -9245,7 +9245,7 @@ exports[`PreAp component should render when it is part of the assignment flow 1`
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email
+                       Having a technical issue? Email 
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -9433,7 +9433,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <p
                         class="info-blurb-text"
                       >
-                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+                        After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
                       </p>
                     </div>
                     <img
@@ -9571,7 +9571,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <p
                         class="info-blurb-text"
                       >
-                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+                        In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
                       </p>
                     </div>
                     <img
@@ -10279,7 +10279,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10329,7 +10329,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10379,7 +10379,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -10465,7 +10465,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="info-blurb-text"
             >
-              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process.
+              After your students complete a Pre-AP Writing Skills Survey, Quill will use the results to recommend a set of independent practice activities. You can choose to assign all the practice at once, or you can pick and choose the activities that best fit your instructional and students’ needs. As students complete the practice, they’ll receive instant feedback on their writing that guides them through the revising and editing process. 
             </p>
           </div>
           <img
@@ -10628,7 +10628,7 @@ exports[`PreAp component should render with no units 1`] = `
             <p
               className="info-blurb-text"
             >
-              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills.
+              In these sentence-combining items, students are free to use any grammatically correct method of combining the sentences they choose. However, each item is written to provide opportunities for students to practice the skills from the course framework. No matter which method students choose to use, they will receive instant, targeted feedback on up to five revisions to help them strengthen their sentence and build their writing skills. 
             </p>
           </div>
           <img
@@ -10924,7 +10924,7 @@ exports[`PreAp component should render with no units 1`] = `
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -10985,7 +10985,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey.
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, an AP teacher would likely assign the AP Writing Skills Survey in lieu of the Advanced Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard courses to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -11035,7 +11035,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content.
+                    Each Pre-AP recommended pack contains between 4 and 7 activities, each of which are designed to take between 10 and 15 minutes each. There are also additional practice packs for students who finish the Pre-AP recommended packs: same skills, new content. 
                     <a
                       href="https://support.quill.org/en/articles/4579893-how-do-i-assign-additional-practice-packs-for-pre-ap-skills-surveys"
                       rel="noopener noreferrer"
@@ -11088,7 +11088,7 @@ exports[`PreAp component should render with no units 1`] = `
                       You can assign all the recommended packs in one click, or you can pick and choose, revisiting the recommendations report to assign more packs as needed.
                     </p>
                     <p>
-                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency.
+                      In general, we've found that students make progress when they are completing 2-4 activities on Quill per week. Since each Pre-AP recommended pack contains between 4 and 7 activities, teachers generally expect a recommended pack to be completed in 1-2 weeks. Of course, students may need more or less time depending on the amount of activities in the pack, their level of difficulty, and students' level of proficiency. 
                     </p>
                     <p>
                       <a
@@ -11098,7 +11098,7 @@ exports[`PreAp component should render with no units 1`] = `
                       >
                         This article
                       </a>
-                       explains how you can use deadlines to help students pace themselves.
+                       explains how you can use deadlines to help students pace themselves. 
                     </p>
                   </div>,
                   "question": "How many Pre-AP Writing Practice packs should I assign to my students and how long will it take them to complete a pack?",
@@ -11141,7 +11141,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Quill has a variety of reports to help you track your students' performance and progress. In the
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -11149,7 +11149,7 @@ exports[`PreAp component should render with no units 1`] = `
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -11157,7 +11157,7 @@ exports[`PreAp component should render with no units 1`] = `
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and
+                     shows you which report to go to for particular information, and 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -11260,7 +11260,7 @@ exports[`PreAp component should render with no units 1`] = `
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
                           <strong>
                             Note
                           </strong>
@@ -11309,7 +11309,7 @@ exports[`PreAp component should render with no units 1`] = `
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in Pre-AP courses other than English I. If you would like to see activities like these for another course, please us know 
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -11370,7 +11370,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -11398,7 +11398,7 @@ exports[`PreAp component should render with no units 1`] = `
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email
+                       Having a technical issue? Email 
                       <a
                         href="mailto:support@quill.org"
                       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/springboard.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/springboard.test.jsx.snap
@@ -463,7 +463,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -511,7 +511,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -621,7 +621,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -725,7 +725,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -804,7 +804,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -883,7 +883,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -987,7 +987,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -1066,7 +1066,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -1145,7 +1145,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -1249,7 +1249,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -1328,7 +1328,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -1407,7 +1407,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -2007,7 +2007,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               <p
                 className="activity-sub-text"
               >
-                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components.
+                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components. 
               </p>
               <p
                 className="activity-sub-header"
@@ -2065,7 +2065,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2.
+              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2. 
             </p>
             <p
               className="activity-sub-header"
@@ -2217,7 +2217,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2267,7 +2267,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2317,7 +2317,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2610,7 +2610,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -2660,7 +2660,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -2774,7 +2774,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -2940,7 +2940,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -3022,7 +3022,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3104,7 +3104,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3270,7 +3270,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -3352,7 +3352,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3434,7 +3434,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3600,7 +3600,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -3682,7 +3682,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -3764,7 +3764,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -3980,7 +3980,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are
+                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are 
                       <a
                         href="https://www.quill.org/tools/lessons"
                         rel="noopener noreferrer"
@@ -4039,7 +4039,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -4097,7 +4097,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey.
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -4254,7 +4254,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill has a variety of reports to help you track your students' performance and progress. In the
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -4262,7 +4262,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -4270,7 +4270,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and
+                     shows you which report to go to for particular information, and 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -4373,7 +4373,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
                           <strong>
                             Note
                           </strong>
@@ -4422,7 +4422,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know 
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -4483,7 +4483,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -4511,7 +4511,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email
+                       Having a technical issue? Email 
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -5030,7 +5030,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5078,7 +5078,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5188,7 +5188,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5292,7 +5292,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5371,7 +5371,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5450,7 +5450,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5554,7 +5554,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5633,7 +5633,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5712,7 +5712,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -5816,7 +5816,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               1
                             </p>
                             <div
@@ -5895,7 +5895,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               2
                             </p>
                             <div
@@ -5974,7 +5974,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle
+                              Learning Cycle 
                               3
                             </p>
                             <div
@@ -6574,7 +6574,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               <p
                 className="activity-sub-text"
               >
-                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components.
+                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components. 
               </p>
               <p
                 className="activity-sub-header"
@@ -6632,7 +6632,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2.
+              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2. 
             </p>
             <p
               className="activity-sub-header"
@@ -6784,7 +6784,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6834,7 +6834,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6884,7 +6884,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -7178,7 +7178,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7228,7 +7228,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -7342,7 +7342,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -7509,7 +7509,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7591,7 +7591,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -7673,7 +7673,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -7840,7 +7840,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -7922,7 +7922,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -8004,7 +8004,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -8171,7 +8171,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       1
                     </p>
                     <div
@@ -8253,7 +8253,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       2
                     </p>
                     <div
@@ -8335,7 +8335,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle
+                      Learning Cycle 
                       3
                     </p>
                     <div
@@ -8551,7 +8551,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are
+                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are 
                       <a
                         href="https://www.quill.org/tools/lessons"
                         rel="noopener noreferrer"
@@ -8610,7 +8610,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -8668,7 +8668,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey.
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey. 
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -8825,7 +8825,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill has a variety of reports to help you track your students' performance and progress. In the
+                    Quill has a variety of reports to help you track your students' performance and progress. In the 
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -8833,7 +8833,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -8841,7 +8841,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and
+                     shows you which report to go to for particular information, and 
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -8944,7 +8944,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
                           <strong>
                             Note
                           </strong>
@@ -8993,7 +8993,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know 
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -9054,7 +9054,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -9082,7 +9082,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email
+                       Having a technical issue? Email 
                       <a
                         href="mailto:support@quill.org"
                       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/springboard.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/__snapshots__/springboard.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               Object {
                 "cb_anchor_tag": "the-night-circus",
                 "description": "Explore how second-person point of view sets up a fantastical world",
-                "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                 "unit_template_id": 233,
               },
             ],
@@ -168,7 +168,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               Object {
                 "cb_anchor_tag": "out-of-my-mind",
                 "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                 "unit_template_id": 234,
               },
               Object {
@@ -463,7 +463,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -511,7 +511,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -621,7 +621,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -725,7 +725,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -804,7 +804,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -883,7 +883,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -987,7 +987,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -1066,7 +1066,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -1145,7 +1145,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -1249,7 +1249,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -1303,7 +1303,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                                     tabindex="-1"
                                     target="_blank"
                                   >
-                                    Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                                    Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -1328,7 +1328,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -1351,7 +1351,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                                     tabindex="-1"
                                     target="_blank"
                                   >
-                                    Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                                    Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -1407,7 +1407,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -2007,7 +2007,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               <p
                 className="activity-sub-text"
               >
-                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components. 
+                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components.
               </p>
               <p
                 className="activity-sub-header"
@@ -2065,7 +2065,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2. 
+              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2.
             </p>
             <p
               className="activity-sub-header"
@@ -2217,7 +2217,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2267,7 +2267,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2317,7 +2317,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -2610,7 +2610,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -2660,7 +2660,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -2774,7 +2774,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -2940,7 +2940,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -3022,7 +3022,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3104,7 +3104,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3270,7 +3270,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -3352,7 +3352,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3434,7 +3434,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3495,7 +3495,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       Object {
                         "cb_anchor_tag": "the-night-circus",
                         "description": "Explore how second-person point of view sets up a fantastical world",
-                        "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                        "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                         "unit_template_id": 233,
                       },
                     ],
@@ -3505,7 +3505,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       Object {
                         "cb_anchor_tag": "out-of-my-mind",
                         "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                        "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                        "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                         "unit_template_id": 234,
                       },
                       Object {
@@ -3600,7 +3600,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -3656,7 +3656,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             tabIndex={-1}
                             target="_blank"
                           >
-                            Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                            Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -3682,7 +3682,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -3706,7 +3706,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                             tabIndex={-1}
                             target="_blank"
                           >
-                            Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                            Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -3764,7 +3764,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -3980,7 +3980,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are 
+                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are
                       <a
                         href="https://www.quill.org/tools/lessons"
                         rel="noopener noreferrer"
@@ -4039,7 +4039,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -4097,7 +4097,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey.
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -4254,7 +4254,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    Quill has a variety of reports to help you track your students' performance and progress. In the
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -4262,7 +4262,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -4270,7 +4270,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and 
+                     shows you which report to go to for particular information, and
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -4373,7 +4373,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
                           <strong>
                             Note
                           </strong>
@@ -4422,7 +4422,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know 
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -4483,7 +4483,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -4511,7 +4511,7 @@ exports[`SpringBoard component should render when it is not part of the assignme
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email 
+                       Having a technical issue? Email
                       <a
                         href="mailto:support@quill.org"
                       >
@@ -4733,7 +4733,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               Object {
                 "cb_anchor_tag": "the-night-circus",
                 "description": "Explore how second-person point of view sets up a fantastical world",
-                "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                 "unit_template_id": 233,
               },
             ],
@@ -4743,7 +4743,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               Object {
                 "cb_anchor_tag": "out-of-my-mind",
                 "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                 "unit_template_id": 234,
               },
               Object {
@@ -5030,7 +5030,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5078,7 +5078,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5188,7 +5188,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5292,7 +5292,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5371,7 +5371,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5450,7 +5450,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5554,7 +5554,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5633,7 +5633,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5712,7 +5712,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -5816,7 +5816,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               1
                             </p>
                             <div
@@ -5870,7 +5870,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                                     tabindex="-1"
                                     target=""
                                   >
-                                    Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                                    Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -5895,7 +5895,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               2
                             </p>
                             <div
@@ -5918,7 +5918,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                                     tabindex="-1"
                                     target=""
                                   >
-                                    Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                                    Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                                   </a>
                                   <a
                                     class="quill-button medium primary outlined focus-on-light"
@@ -5974,7 +5974,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             <p
                               class="learning-cycle-header"
                             >
-                              Learning Cycle 
+                              Learning Cycle
                               3
                             </p>
                             <div
@@ -6574,7 +6574,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               <p
                 className="activity-sub-text"
               >
-                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components. 
+                Students complete a 25 item survey to gauge their understanding of key writing skills, fundamental grammatical elements, common editing mistakes, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the grammar instruction featured in the SpringBoard Language and Writer’s Craft and Language Checkpoint lesson components.
               </p>
               <p
                 className="activity-sub-header"
@@ -6632,7 +6632,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2. 
+              Students complete a 12 item survey their understanding of key writing skills, fundamental grammatical elements, and compound/complex sentence constructions. The skills addressed in this survey are aligned to the Pre-AP English High School Course Framework for English 1 and English 2.
             </p>
             <p
               className="activity-sub-header"
@@ -6784,7 +6784,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging 
+              ELL students complete a 22 item survey to gauge their mastery of foundational English grammar. This survey is most appropriate for students who are in the Entering or Emerging
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6834,7 +6834,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar. This survey is most appropriate for students who are in the Emerging or Developing
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -6884,7 +6884,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
             <p
               className="activity-sub-text"
             >
-              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding 
+              ELL students complete a 23 item survey to gauge their mastery of English grammar, specifically in areas that are challenging for non-native English speakers. This survey is most appropriate for students who are in the Developing or Expanding
               <a
                 className="underlined_link"
                 href="https://wida.wisc.edu/sites/default/files/resource/CanDo-KeyUses-Gr-9-12.pdf"
@@ -7178,7 +7178,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7228,7 +7228,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -7342,7 +7342,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -7509,7 +7509,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7591,7 +7591,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -7673,7 +7673,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -7840,7 +7840,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -7922,7 +7922,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -8004,7 +8004,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -8066,7 +8066,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       Object {
                         "cb_anchor_tag": "the-night-circus",
                         "description": "Explore how second-person point of view sets up a fantastical world",
-                        "title": "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+                        "title": "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
                         "unit_template_id": 233,
                       },
                     ],
@@ -8076,7 +8076,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       Object {
                         "cb_anchor_tag": "out-of-my-mind",
                         "description": "Explore how first-person point of view efficiently establishes a narrator’s experience",
-                        "title": "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+                        "title": "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
                         "unit_template_id": 234,
                       },
                       Object {
@@ -8171,7 +8171,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       1
                     </p>
                     <div
@@ -8227,7 +8227,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             tabIndex={-1}
                             target=""
                           >
-                            Sentence Combining: Except from The Night Circus by Erin Morgenstern
+                            Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -8253,7 +8253,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       2
                     </p>
                     <div
@@ -8277,7 +8277,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                             tabIndex={-1}
                             target=""
                           >
-                            Sentence Combining: Except from Out of My Mind by Sharon M. Draper
+                            Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper
                           </a>
                           <a
                             className="quill-button medium primary outlined focus-on-light"
@@ -8335,7 +8335,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="learning-cycle-header"
                     >
-                      Learning Cycle 
+                      Learning Cycle
                       3
                     </p>
                     <div
@@ -8551,7 +8551,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are 
+                      Teachers generally begin by having students complete a writing skills survey during class time. The practice that is recommended once students complete a survey can be completed by students independently and at their own pace, or can also be completed during class time. Some teachers ask students to complete recommended activities during a “Do Now,” during another portion of class time, or as homework. Since SpringBoard’s Language and Writer’s Craft elements of activities feature focused practice on specific grammatical skills, you may also find that there are
                       <a
                         href="https://www.quill.org/tools/lessons"
                         rel="noopener noreferrer"
@@ -8610,7 +8610,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     <p
                       className="college-board-q-and-a-text"
                     >
-                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill 
+                      It is recommended that you and your students create free accounts on Quill.org. Creating an account will give you access to the two skills surveys and recommended practice; creating an account also allows you to track your students’ progress and view data reports. You can create an account by visiting the Quill
                       <a
                         href="https://www.quill.org/sign-up/teacher"
                         rel="noopener noreferrer"
@@ -8668,7 +8668,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey. 
+                    Quill's writing skills surveys can be used in lieu of Quill's general diagnostics. For example, a 7th grade SpringBoard ELA teacher would likely assign the SpringBoard Writing Skills Survey in lieu of the Starter or Intermediate Diagnostic. Keep in mind, however, that teachers may want ELL students in Pre-AP, AP, or SpringBoard classes to begin with one of the ELL Diagnostics instead of a writing skills survey.
                     <a
                       href="https://support.quill.org/en/articles/2554430-what-are-the-differences-between-the-various-diagnostic-assessments"
                       rel="noopener noreferrer"
@@ -8825,7 +8825,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                   "answer": <p
                     className="college-board-q-and-a-text"
                   >
-                    Quill has a variety of reports to help you track your students' performance and progress. In the 
+                    Quill has a variety of reports to help you track your students' performance and progress. In the
                     <a
                       href="https://support.quill.org/en/articles/1140159-how-does-the-activity-summary-work"
                       rel="noopener noreferrer"
@@ -8833,7 +8833,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     >
                       Activity Summary report
                     </a>
-                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well. 
+                    , you can quickly see which activities your students have completed, along with color-coded icons indicating proficiency. Quill has several other reports as well.
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Quill_Reports_Cheat_Sheet_Updated04_08_20.pdf"
                       rel="noopener noreferrer"
@@ -8841,7 +8841,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                     >
                       This cheat sheet
                     </a>
-                     shows you which report to go to for particular information, and 
+                     shows you which report to go to for particular information, and
                     <a
                       href="http://s3.amazonaws.com/quill-image-uploads/uploads/files/Getting_Started_-_Student_Data_Reports__Basic_.mp4"
                       rel="noopener noreferrer"
@@ -8944,7 +8944,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                         <p
                           className="college-board-q-and-a-text"
                         >
-                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results. 
+                          Students complete an activity designed to help teachers determine which skills students need to work on. After students complete a Quill Diagnostic activity, Quill recommends writing activities for students based on their results.
                           <strong>
                             Note
                           </strong>
@@ -8993,7 +8993,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
               qa={
                 Object {
                   "answer": <p>
-                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know 
+                    Unfortunately, at this time, there are no sentence combining activities aligned to texts in SpringBoard ELA courses other than SpringBoard ELA Grade 9. If you would like to see activities like these for another course, please us know
                     <a
                       href="https://quillorg.canny.io/content-feedback"
                       rel="noopener noreferrer"
@@ -9054,7 +9054,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       <strong>
                         Quill Instructional Coach:
                       </strong>
-                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at 
+                       You can reach out directly to Sherry Lewkowicz, Quill's coach dedicated to supporting College Board teachers, at
                       <a
                         href="mailto:sherry@quill.org"
                       >
@@ -9082,7 +9082,7 @@ exports[`SpringBoard component should render when it is part of the assignment f
                       <strong>
                         Support:
                       </strong>
-                       Having a technical issue? Email 
+                       Having a technical issue? Email
                       <a
                         href="mailto:support@quill.org"
                       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/data.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/college_board/__tests__/data.ts
@@ -174,7 +174,7 @@ export const units = [
           },
           {
             title:
-              "Sentence Combining: Except from The Night Circus by Erin Morgenstern",
+              "Sentence Combining: Excerpt from The Night Circus by Erin Morgenstern",
             description:
               "Explore how second-person point of view sets up a fantastical world",
             unit_template_id: 233,
@@ -186,7 +186,7 @@ export const units = [
         activities: [
           {
             title:
-              "Sentence Combining: Except from Out of My Mind by Sharon M. Draper",
+              "Sentence Combining: Excerpt from Out of My Mind by Sharon M. Draper",
             description:
               "Explore how first-person point of view efficiently establishes a narrator’s experience",
             unit_template_id: 234,


### PR DESCRIPTION
## WHAT
fix typo on Springboard page

## WHY
we want the copy to be correct

## HOW
just fix instances where we had "except" instead of "excerpt"

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Typos-on-SpringBoard-Landing-Page-468bde5def4b4850b695d95aad53c378

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
