### PR TITLE
Update NewRelic::Agent.notice_error reporting to ErrorNotifier.run

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -119,11 +119,12 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     return if timespent.nil?
     return if timespent <= 3600
 
-    begin
-      raise ActivitySession::LongTimeTrackingError, "#{timespent} seconds for user #{user_id} and activity session #{activity_session_id}"
-    rescue => e
-      ErrorNotifier.report(e)
-    end
+    ErrorNotifier.report(
+      ActivitySession::LongTimeTrackingError.new,
+      activity_session_id: activity_session_id,
+      timespent: timespent,
+      user_id: user_id
+    )
   end
 
   private def transform_incoming_request

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -43,7 +43,7 @@ class Cms::RostersController < Cms::CmsController
     end
 
     render json: {}
-  rescue StandardError => e
+  rescue => e
     render json: {errors: e.message}, status: 422
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/ortto_integration/webhooks_controller.rb
@@ -11,18 +11,14 @@ module OrttoIntegration
       email = params[:email]
 
       if email.nil?
-        ErrorNotifier.report(
-          OrttoWebhookBadRequestException.new("Bad request with params: #{params}")
-        )
+        ErrorNotifier.report(OrttoWebhookBadRequestException.new, params: params)
         return head 202
       end
 
       user = User.find_by_email(email)
 
       if user.nil?
-        ErrorNotifier.report(
-          OrttoWebhookBadRequestException.new("Bad request with params: #{params}")
-        )
+        ErrorNotifier.report(OrttoWebhookBadRequestException.new, params: params)
         return head 202
       end
 

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -6,6 +6,8 @@ require 'new_relic/agent'
 class SessionsController < ApplicationController
   include CleverAuthable
 
+  class OriginalRouteStillInUseError < StandardError; end
+
   CLEAR_ANALYTICS_SESSION_KEY = "clear_analytics_session"
 
   around_action :force_writer_db_role, only: [:destroy]
@@ -142,10 +144,6 @@ class SessionsController < ApplicationController
   end
 
   private def report_that_route_is_still_in_use
-    begin
-      raise 'sessions/create original route still being called here'
-    rescue => e
-      NewRelic::Agent.notice_error(e)
-    end
+    ErrorNotifier.report(OriginalRouteStillInUseError.new)
   end
 end

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -25,7 +25,6 @@
 #  fk_rails_...  (unit_id => units.id)
 #
 class ClassroomUnit < ApplicationRecord
-  include ::NewRelic::Agent
   include Archivable
   include AtomicArrays
 

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -280,14 +280,6 @@ class Subscription < ApplicationRecord
     { expiration: today + CB_LIFETIME_DURATION, start_date: today }
   end
 
-  protected def report_to_new_relic(error)
-    begin
-      raise error
-    rescue => e
-      NewRelic::Agent.notice_error(e)
-    end
-  end
-
   protected def set_null_start_date_to_today
     return if start_date
 

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -26,7 +26,6 @@
 #  fk_rails_...  (unit_id => units.id)
 #
 class UnitActivity < ApplicationRecord
-  include ::NewRelic::Agent
   include CheckboxCallback
 
   belongs_to :unit, touch: true

--- a/services/QuillLMS/app/services/clever_integration/teacher_classrooms_cache_hydrator.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_classrooms_cache_hydrator.rb
@@ -18,8 +18,8 @@ module CleverIntegration
       load_teacher
       cache_classrooms_data
       notify_pusher
-    rescue StandardError => e
-      NewRelic::Agent.notice_error(e, user_id: teacher.id)
+    rescue => e
+      ErrorNotifier.report(e, user_id: teacher.id)
     end
 
     private def cache_classrooms_data

--- a/services/QuillLMS/app/services/clever_integration/teacher_integration.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_integration.rb
@@ -20,8 +20,8 @@ module CleverIntegration
       hydrate_teacher_classrooms_cache
       update_existing_teacher_classrooms
       { type: 'user_success', data: teacher }
-    rescue StandardError => e
-      NewRelic::Agent.notice_error(e, teacher_clever_id: info_hash.id)
+    rescue => e
+      ErrorNotifier.report(e, teacher_clever_id: info_hash.id)
       { type: 'user_failure', data: "Error: #{e.message}" }
     end
 

--- a/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
@@ -20,7 +20,7 @@ module GoogleIntegration
       cache_classrooms_data
       notify_pusher
     rescue *ACCESS_TOKEN_ERRORS => e
-      NewRelic::Agent.notice_error(e, user_id: user_id)
+      ErrorNotifier.report(e, user_id: user_id)
       e.message
     end
 

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -102,7 +102,7 @@ class AssignRecommendationsWorker
       begin
         raise "#{elapsed_time} seconds for user #{teacher_id} to assign #{lesson_text} recommendations"
       rescue => e
-        NewRelic::Agent.notice_error(e)
+        ErrorNotifier.report(e)
       end
     else
       diagnostic_recommendations_under_ten_seconds_count = $redis.get("diagnostic_recommendations_under_ten_seconds_count")

--- a/services/QuillLMS/app/workers/classroom_activities_to_unit_activities_and_classroom_units_worker.rb
+++ b/services/QuillLMS/app/workers/classroom_activities_to_unit_activities_and_classroom_units_worker.rb
@@ -45,7 +45,7 @@ class ClassroomActivitiesToUnitActivitiesAndClassroomUnitsWorker
               completed: ca.completed
             )
           end
-        rescue StandardError => e
+        rescue => e
           puts e.message
         end
 

--- a/services/QuillLMS/app/workers/clever_integration/import_classroom_students_worker.rb
+++ b/services/QuillLMS/app/workers/clever_integration/import_classroom_students_worker.rb
@@ -13,8 +13,8 @@ module CleverIntegration
 
       TeacherClassroomsStudentsImporter.run(teacher, classroom_ids)
       PusherTrigger.run(teacher_id, PUSHER_EVENT, "clever classroom students imported for #{teacher_id}.")
-    rescue StandardError => e
-      NewRelic::Agent.notice_error(e, user_id: teacher_id)
+    rescue => e
+      ErrorNotifier.report(e, user_id: teacher_id)
     end
   end
 end

--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -70,7 +70,7 @@ class ConceptReplacementConnectWorker
         end
       end
     rescue => e
-      NewRelic::Agent.notice_error(e)
+      ErrorNotifier.report(e)
     end
     new_fp_obj
   end
@@ -98,7 +98,7 @@ class ConceptReplacementConnectWorker
         end
       end
     rescue => e
-      NewRelic::Agent.notice_error(e)
+      ErrorNotifier.report(e)
     end
     new_is_array
   end

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -69,7 +69,7 @@ class ConceptReplacementGrammarWorker
         end
       end
     rescue => e
-      NewRelic::Agent.notice_error(e)
+      ErrorNotifier.report(e)
     end
     new_fp_or_is
   end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -175,7 +175,7 @@ class GetConceptsInUseIndividualConceptWorker
       end
       $redis.set("CONCEPTS_IN_USE", concepts_in_use.to_json)
       $redis.unwatch
-    rescue StandardError => e
+    rescue => e
       set_concepts_in_use_cache
     end
   end

--- a/services/QuillLMS/app/workers/google_student_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_classroom_worker.rb
@@ -9,7 +9,7 @@ class GoogleStudentClassroomWorker
     return unless student.google_authorized?
 
     GoogleIntegration::Classroom::Main.join_existing_google_classrooms(student)
-  rescue StandardError => e
-    NewRelic::Agent.notice_error(e, context: "Auth::GoogleController")
+  rescue => e
+    ErrorNotifier.report(e, context: "Auth::GoogleController")
   end
 end

--- a/services/QuillLMS/app/workers/google_student_importer_worker.rb
+++ b/services/QuillLMS/app/workers/google_student_importer_worker.rb
@@ -16,7 +16,7 @@ class GoogleStudentImporterWorker
     else
       PusherTrigger.run(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
     end
-  rescue StandardError => e
-    NewRelic::Agent.notice_error(e, context: context)
+  rescue => e
+    ErrorNotifier.report(e, context: context)
   end
 end

--- a/services/QuillLMS/app/workers/ortto_integration/update_newsletter_subscription_status_worker.rb
+++ b/services/QuillLMS/app/workers/ortto_integration/update_newsletter_subscription_status_worker.rb
@@ -28,7 +28,7 @@ module OrttoIntegration
           'find_strategy': 0
         }.to_json
       end
-    rescue StandardError => e
+    rescue => e
       ErrorNotifier.report(e)
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -61,7 +61,7 @@ module Evidence
       end
       log_activation
       self
-    rescue StandardError => e
+    rescue => e
       raise e unless e.is_a?(ActiveRecord::RecordInvalid)
 
       return false

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -197,7 +197,13 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           'time_tracking' => ('a'..'z').to_h {|k| [k,600]}
         }
 
-        expect(ErrorNotifier).to receive(:report).with(ActivitySession::LongTimeTrackingError).once
+        reporting_params = {
+          activity_session_id: activity_session.id,
+          timespent: 15600,
+          user_id: activity_session.user_id
+        }
+
+        expect(ErrorNotifier).to receive(:report).with(ActivitySession::LongTimeTrackingError, reporting_params).once
 
         put :update, params: { id: activity_session.uid, data: data }, as: :json
       end

--- a/services/QuillLMS/spec/controllers/stripe_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/stripe_integration/webhooks_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe StripeIntegration::WebhooksController, type: :controller do
 
       it 'unexpected errors' do
         expect(handle_event_worker).not_to receive(:perform_async)
-        expect(NewRelic::Agent).to receive(:notice_error)
+        expect(ErrorNotifier).to receive(:report)
         post :create
         expect(response.status).to eq 400
       end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_classrooms_cache_hydrator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_classrooms_cache_hydrator_spec.rb
@@ -28,7 +28,7 @@ describe CleverIntegration::TeacherClassroomsCacheHydrator do
     it 'does not cache any teacher classrooms and it reports an error' do
       expect(CleverIntegration::TeacherClassroomsCache).not_to receive(:write)
       expect(PusherTrigger).not_to receive(:run)
-      expect(NewRelic::Agent).to receive(:notice_error)
+      expect(ErrorNotifier).to receive(:report)
       subject
     end
   end
@@ -39,7 +39,7 @@ describe CleverIntegration::TeacherClassroomsCacheHydrator do
     it 'does not cache any teacher classrooms and it reports an error' do
       expect(CleverIntegration::TeacherClassroomsCache).not_to receive(:write)
       expect(PusherTrigger).not_to receive(:run)
-      expect(NewRelic::Agent).to receive(:notice_error)
+      expect(ErrorNotifier).to receive(:report)
       subject
     end
   end


### PR DESCRIPTION
## WHAT
Use the more general `ErrorNotifier.report` instead of `NewRelic::Agent.notice_error`

## WHY
I'm hoping that Sentry will give more information than NewRelic for some undefined method include? for NilClass errors with Google and Clever Importing.
 
## HOW
Replace `NewRelic::Agent.notice_error` with `ErrorNotifier.report` 
Also update some of the reporting calls to pass arguments rather than strings containing said arguments.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/GoogleStudentClassroomWorker-undefined-method-include-for-nil-NilClass-f5e6cd4618ec42398a8e66e83cb06992
https://www.notion.so/quill/CleverIntegration-ImportClassroomStudentsWorker-undefined-method-include-for-nil-NilClass-8cef083fc1e246f38d34ed0ba8bacfbe

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.
Have you deployed to Staging? | Not yet - deploying now!, NO - non-app change, NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
