### PR TITLE
finish_lesson endpoint speedup 

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -26,15 +26,16 @@
 #
 # Indexes
 #
-#  index_activity_sessions_on_activity_id            (activity_id)
-#  index_activity_sessions_on_classroom_activity_id  (classroom_activity_id)
-#  index_activity_sessions_on_classroom_unit_id      (classroom_unit_id)
-#  index_activity_sessions_on_completed_at           (completed_at)
-#  index_activity_sessions_on_pairing_id             (pairing_id)
-#  index_activity_sessions_on_started_at             (started_at)
-#  index_activity_sessions_on_state                  (state)
-#  index_activity_sessions_on_uid                    (uid) UNIQUE
-#  index_activity_sessions_on_user_id                (user_id)
+#  index_activity_sessions_on_activity_id                        (activity_id)
+#  index_activity_sessions_on_activity_id_and_classroom_unit_id  (activity_id,classroom_unit_id)
+#  index_activity_sessions_on_classroom_activity_id              (classroom_activity_id)
+#  index_activity_sessions_on_classroom_unit_id                  (classroom_unit_id)
+#  index_activity_sessions_on_completed_at                       (completed_at)
+#  index_activity_sessions_on_pairing_id                         (pairing_id)
+#  index_activity_sessions_on_started_at                         (started_at)
+#  index_activity_sessions_on_state                              (state)
+#  index_activity_sessions_on_uid                                (uid) UNIQUE
+#  index_activity_sessions_on_user_id                            (user_id)
 #
 require 'newrelic_rpm'
 require 'new_relic/agent'

--- a/services/QuillLMS/app/serializers/activity_session_serializer.rb
+++ b/services/QuillLMS/app/serializers/activity_session_serializer.rb
@@ -26,15 +26,16 @@
 #
 # Indexes
 #
-#  index_activity_sessions_on_activity_id            (activity_id)
-#  index_activity_sessions_on_classroom_activity_id  (classroom_activity_id)
-#  index_activity_sessions_on_classroom_unit_id      (classroom_unit_id)
-#  index_activity_sessions_on_completed_at           (completed_at)
-#  index_activity_sessions_on_pairing_id             (pairing_id)
-#  index_activity_sessions_on_started_at             (started_at)
-#  index_activity_sessions_on_state                  (state)
-#  index_activity_sessions_on_uid                    (uid) UNIQUE
-#  index_activity_sessions_on_user_id                (user_id)
+#  index_activity_sessions_on_activity_id                        (activity_id)
+#  index_activity_sessions_on_activity_id_and_classroom_unit_id  (activity_id,classroom_unit_id)
+#  index_activity_sessions_on_classroom_activity_id              (classroom_activity_id)
+#  index_activity_sessions_on_classroom_unit_id                  (classroom_unit_id)
+#  index_activity_sessions_on_completed_at                       (completed_at)
+#  index_activity_sessions_on_pairing_id                         (pairing_id)
+#  index_activity_sessions_on_started_at                         (started_at)
+#  index_activity_sessions_on_state                              (state)
+#  index_activity_sessions_on_uid                                (uid) UNIQUE
+#  index_activity_sessions_on_user_id                            (user_id)
 #
 class ActivitySessionSerializer < ApplicationSerializer
   attributes :uid, :percentage, :state, :completed_at, :data, :temporary,

--- a/services/QuillLMS/db/migrate/20221028153344_add_classroom_unit_id_activity_id_index_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20221028153344_add_classroom_unit_id_activity_id_index_to_activity_sessions.rb
@@ -1,0 +1,5 @@
+class AddClassroomUnitIdActivityIdIndexToActivitySessions < ActiveRecord::Migration[6.1]
+  def change
+    add_index :activity_sessions, [:activity_id, :classroom_unit_id]
+  end
+end

--- a/services/QuillLMS/db/migrate/20221028153344_add_classroom_unit_id_activity_id_index_to_activity_sessions.rb
+++ b/services/QuillLMS/db/migrate/20221028153344_add_classroom_unit_id_activity_id_index_to_activity_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddClassroomUnitIdActivityIdIndexToActivitySessions < ActiveRecord::Migration[6.1]
   def change
     add_index :activity_sessions, [:activity_id, :classroom_unit_id]

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -56,6 +56,18 @@ CREATE FUNCTION public.blog_posts_search_trigger() RETURNS trigger
 
 
 --
+-- Name: my_jsonb_to_hstore(jsonb); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.my_jsonb_to_hstore(jsonb) RETURNS public.hstore
+    LANGUAGE sql IMMUTABLE STRICT
+    AS $_$
+            SELECT hstore(array_agg(key), array_agg(value))
+            FROM   jsonb_each_text($1)
+          $_$;
+
+
+--
 -- Name: old_timespent_teacher(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -762,8 +774,8 @@ ALTER SEQUENCE public.app_settings_id_seq OWNED BY public.app_settings.id;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -958,8 +970,8 @@ CREATE TABLE public.change_logs (
     id integer NOT NULL,
     explanation text,
     action character varying NOT NULL,
-    changed_record_type character varying NOT NULL,
     changed_record_id integer,
+    changed_record_type character varying NOT NULL,
     user_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1189,7 +1201,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
-    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY ((ARRAY['owner'::character varying, 'coteacher'::character varying])::text[])) AND (role IS NOT NULL)))
+    CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
 );
 
 
@@ -2053,8 +2065,8 @@ CREATE TABLE public.credit_transactions (
     id integer NOT NULL,
     amount integer NOT NULL,
     user_id integer NOT NULL,
-    source_type character varying,
     source_id integer,
+    source_type character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -2306,8 +2318,8 @@ ALTER SEQUENCE public.evidence_hints_id_seq OWNED BY public.evidence_hints.id;
 CREATE TABLE public.feedback_histories (
     id integer NOT NULL,
     feedback_session_uid text,
-    prompt_type character varying,
     prompt_id integer,
+    prompt_type character varying,
     concept_uid text,
     attempt integer NOT NULL,
     entry text NOT NULL,
@@ -6028,14 +6040,6 @@ ALTER TABLE ONLY public.sales_stages
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
 -- Name: school_subscriptions school_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6371,6 +6375,13 @@ CREATE UNIQUE INDEX index_activity_classifications_on_uid ON public.activity_cla
 --
 
 CREATE INDEX index_activity_sessions_on_activity_id ON public.activity_sessions USING btree (activity_id);
+
+
+--
+-- Name: index_activity_sessions_on_activity_id_and_classroom_unit_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_activity_sessions_on_activity_id_and_classroom_unit_id ON public.activity_sessions USING btree (activity_id, classroom_unit_id);
 
 
 --
@@ -7746,6 +7757,13 @@ CREATE UNIQUE INDEX unique_index_users_on_username ON public.users USING btree (
 
 
 --
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
+
+
+--
 -- Name: user_activity_classification_unique_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8716,6 +8734,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221014103417'),
 ('20221014103843'),
 ('20221019184933'),
-('20221019185354');
+('20221019185354'),
+('20221028153344');
 
 


### PR DESCRIPTION
## WHAT
Adds index to speed up certain ActivitySession queries

## WHY
So that the `finish_lesson` endpoint is faster.  

Benchmark script: 
```
Benchmark.realtime { 1000.times { ActivitySession.unscoped.where(classroom_unit_id: rand(highest_c_u_id), activity_id: rand(highest_a_s_id)) } }
```
- Time (before): .11, .098
- Time (after): .075, .085

Note: I'm considering Sidekiq-ifying the meat of this endpoint in a separate PR, depending on post-deployment performance. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
