### PR TITLE
Add rake task to remove duplicate student accounts that have no data …

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -676,6 +676,14 @@ class User < ApplicationRecord
     end
   end
 
+  def duplicate_empty_student_accounts
+    User
+      .student
+      .where(email: email)
+      .where.not(id: id)
+      .where.missing(:activity_sessions, :students_classrooms)
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../progress_bar'
+
+namespace :students do
+  task remove_users_with_same_email: :environment do
+
+    duplicate_emails = User.student.where.not(email: [nil, ""]).group(:email).having("count(email) > 1").pluck(:email)
+
+    progress_bar = ProgessBar.new(duplicate_emails.size)
+
+    duplicate_emails.each do |email|
+      User.find_by(email: email).duplicate_empty_student_accounts.destroy_all
+      progress_bar.increment
+    end
+  end
+end


### PR DESCRIPTION
…(#9906)

* Add rake task to remove duplicate student accounts that have no data

* Make specs cleaner

* Skip validations of models

* Remove unnecessary spec

* Rename extension from .rake to .rb

* Fix rake task

* Fix spec to test for student scope

* Fix spec to reflect uniqueness constraints

* Do destroy_all incrementally

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
