### PR TITLE
Fix a testing bug with local development timezones

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -202,7 +202,7 @@ class Activity < ApplicationRecord
   end
 
   def self.clear_activity_search_cache
-    UserFlagset::FLAGSETS.keys.map{|x| "#{x}_"}.push("").each do |flagset|
+    User::FLAGSETS.keys.map{|x| "#{x}_"}.push("").each do |flagset|
       $redis.del("default_#{flagset}activity_search")
     end
   end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1226,7 +1226,7 @@ CREATE TABLE public.comprehension_activities (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     notes character varying,
-    version smallint DEFAULT 0 NOT NULL
+    version smallint DEFAULT 1 NOT NULL
 );
 
 
@@ -2320,7 +2320,7 @@ CREATE TABLE public.feedback_histories (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rule_uid character varying,
-    activity_version smallint DEFAULT 0 NOT NULL
+    activity_version smallint DEFAULT 1 NOT NULL
 );
 
 
@@ -8714,6 +8714,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220920190724'),
 ('20220927124042'),
 ('20221014103417'),
-('20221014103843');
+('20221014103843'),
+('20221019184933'),
+('20221019185354');
 
 

--- a/services/QuillLMS/spec/models/change_log_spec.rb
+++ b/services/QuillLMS/spec/models/change_log_spec.rb
@@ -4,7 +4,7 @@
 #
 # Table name: change_logs
 #
-#  id                  :integer          not null
+#  id                  :integer          not null, primary key
 #  action              :string           not null
 #  changed_attribute   :string
 #  changed_record_type :string           not null
@@ -15,6 +15,15 @@
 #  updated_at          :datetime
 #  changed_record_id   :integer
 #  user_id             :integer
+#
+# Indexes
+#
+#  index_change_logs_on_changed_record_type_and_changed_record_id  (changed_record_type,changed_record_id)
+#  index_change_logs_on_user_id                                    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -301,8 +301,9 @@ describe UnitActivity, type: :model, redis: true do
         # have to do update_columns here because otherwise the publish date is offset by a callback
         unit_activity.update_columns(publish_date: publish_date)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
-        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_time.strftime('%a %b %d %H:%M:%S %Z %Y'))
-          .to eq((publish_date + teacher.utc_offset).to_time.strftime('%a %b %d %H:%M:%S %Z %Y'))
+        publish_date_result = unit_activities.find { |ua| ua['ua_id'].to_i == unit_activity.id }['publish_date']
+
+        expect(publish_date_result.in_time_zone(tz_string).to_i).to eq publish_date.to_i
       end
 
       it 'leaves the publish date in utc if the teacher does not have a time zone' do
@@ -311,7 +312,9 @@ describe UnitActivity, type: :model, redis: true do
         publish_date = Time.now.utc - 1.hour
         unit_activity.update(publish_date: publish_date)
         unit_activities = UnitActivity.get_classroom_user_profile(classroom.id, student.id)
-        expect(unit_activities.find{ |ua| ua['ua_id'].to_i == unit_activity.id}['publish_date'].to_time.strftime('%a %b %d %H:%M:%S %Z %Y')).to eq(publish_date.to_time.strftime('%a %b %d %H:%M:%S %Z %Y'))
+        publish_date_result = unit_activities.find { |ua| ua['ua_id'].to_i == unit_activity.id }['publish_date']
+
+        expect(publish_date_result.in_time_zone.to_i).to eq publish_date.to_i
       end
 
     end


### PR DESCRIPTION
## WHAT
Fix a bug with the testing of setting publish dates based on what a user's timezone is.

## WHY
There's a discrepancy between testing locally and on circleci

## HOW
The `to_time` on `String` [method](https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activesupport/lib/active_support/core_ext/string/conversions.rb#L22) permits either `:local` or `:utc` as a parameter, with `:local` being the default parameter.  In the case of our specs, calling `to_time` on circleci calls `to_time(:local)` behind the scenes, but it has `:local` set to `:utc`.  When calling `to_time` in a local environment, however, it will use the local time (e.g. EDT).  This results in a couple specs failing.  Instead use `in_time_zone` [method](https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activesupport/lib/active_support/core_ext/string/zones.rb#L9) and pass it the `tz_string` where applicable to set the time zone of the string.

Also, fix replace `UserFlagset::FLAGSETS` with  `User::FLAGSETS` since `UserFlagset` might not be loaded when running Activity specs locally, yielding an uninitialized constant UserFlagset::FLAGSETS false positive.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
