### PR TITLE
Bug fix/ CB landing pages scroll widget

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/college_board.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/college_board.scss
@@ -4,7 +4,8 @@
     position: fixed;
     background-color: white;
     width: 306px;
-    margin: 32px 32px 118px 24px;
+    bottom: 0;
+    margin: 32px 32px 32px 24px;
     padding: 16px 0 8px;
     border-radius: 8px;
     border: solid 1px #e0e0e0;


### PR DESCRIPTION
## WHAT
fix scroll widget on CB landing pages

## WHY
the bottom part was being cutoff and we want users to be able to see the full widget

## HOW
update CSS for widget

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1427" alt="Screen Shot 2022-11-01 at 1 12 56 PM" src="https://user-images.githubusercontent.com/25959584/199310110-0c31ad45-3cd0-4055-a8ce-f664a17f1dae.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Scroll-widget-cut-off-for-College-Board-landing-pages-0ca3022d4fc342f7b941538ec3b8dce9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  CSS change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
