### PR TITLE
evidence/fix-multiple-rule-deletes

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -45,6 +45,8 @@ module Evidence
 
     # DELETE /rules/1.json
     def destroy
+      return head :not_found unless @rule
+
       @rule.destroy
       head :no_content
     end
@@ -95,6 +97,10 @@ module Evidence
     end
 
     private def set_lms_user_id
+      # If the ID provided to :update or :destroy doesn't correspond to an
+      # existing Rule, there's no need to try to set the user_id
+      return unless @rule
+
       @rule.lms_user_id = lms_user_id
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/rules_controller_spec.rb
@@ -750,6 +750,12 @@ module Evidence
         expect(rule.id).to(be_truthy)
         expect(Rule.find_by_id(rule.id)).to(be_nil)
       end
+
+      it 'should not error if provided an ID that does not exist' do
+        expect do
+          delete(:destroy, :params => ({ :id => 'not_a_real_id' }))
+        end.not_to raise_error
+      end
     end
 
     context 'should update_rule_order' do


### PR DESCRIPTION
## WHAT
Add some code to handle cases where a rule_id is deleted more than once
## WHY
We got a batch of Sentry errors
## HOW
Add guard clauses to make sure the Rule flagged for deletion actually exists before running commands that will crash if it doesn't

### Notion Card Links
Not a Notion link, but here's a Sentry report: https://sentry.io/organizations/quillorg-5s/issues/3713243274/events/latest/?project=11238&referrer=latest-event

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
