### PR TITLE
Synthetic Labels Frontend

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -43,12 +43,24 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(labelConfigs => ({...data}));
   }
 
+  function onAddLabelConfigs(e) {
+    const { target } = e;
+    const { value } = target;
+    addLabelConfigs(value);
+  }
+
   function addLabelConfigs(conjunction) {
     const data = labelConfigs
     const conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
     data[conjunction] = conjunctionData
     setLabelConfigs(labelConfigs => ({...data}))
+  }
+
+  function onRemoveLabelConfig(e) {
+    const { target } = e;
+    const { id, value } = target;
+    removeLabelConfig(id, value);
   }
 
   function removeLabelConfig(index, conjunction) {
@@ -112,7 +124,9 @@ const SeedDataForm = ({ history, match }) => {
       <div className="seed-label-form" key={index}>
         <button
           className='right quill-button fun secondary outlined'
-          onClick={() => removeLabelConfig(index, conjunction)}
+          id={index}
+          onClick={onRemoveLabelConfig}
+          value={conjunction}
         >
           Remove
         </button>
@@ -139,7 +153,11 @@ const SeedDataForm = ({ history, match }) => {
           &nbsp;Label Examples
         </h4>
         {labelConfigs[conjunction].map((labelConfig, index) => renderLabelConfig(labelConfig, index, conjunction))}
-        <button className='quill-button small primary outlined' onClick={e => addLabelConfigs(conjunction)}>
+        <button
+          className='quill-button small primary outlined'
+          onClick={onAddLabelConfigs}
+          value={conjunction}
+        >
           <span className='plus'>+</span>
 
           &nbsp;Add {capitalizeConjunction} Label

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -18,7 +18,6 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
-
   const because = 'because';
   const but = 'but';
   const so = 'so';
@@ -116,24 +115,36 @@ const SeedDataForm = ({ history, match }) => {
 
   const renderLabelConfig = (labelConfig, index, conjunction) => {
     return (
-      <div key={index}>
-        <Input
-          label='Label'
-          handleChange={e => handleLabelConfigsChange(e, index, conjunction, 'label')}
-          value={labelConfig.label}
-        />
+      <div key={index} className="seed-label-form">
+        <button onClick={() => removeLabelConfig(index, conjunction)} className='right quill-button fun secondary outlined'>
+          Remove
+        </button>
+        <div>
+          <Input
+            label='Label'
+            className="label-input"
+            handleChange={e => handleLabelConfigsChange(e, index, conjunction, 'label')}
+            value={labelConfig.label}
+          />
+        </div>
         {labelConfig.examples.map((example, exampleIndex) => renderExample(example, index, conjunction, exampleIndex))}
-        <button onClick={() => removeLabelConfig(index, conjunction)}>Remove</button>
+
       </div>
     );
   }
 
   const renderLabelSection = (conjunction) => {
+    let capitalizeConjunction = conjunction.charAt(0).toUpperCase() + conjunction.substring(1)
     return (
-      <div>
-        <h4>{conjunction.toUpperCase()} Label Examples</h4>
+      <div className='label-section'>
+        <h4 className='bg-quillteal label-title'>
+          <span className='highlight'>{capitalizeConjunction}</span>
+          &nbsp;Label Examples
+        </h4>
         {labelConfigs[conjunction].map((labelConfig, index) => renderLabelConfig(labelConfig, index, conjunction))}
-        <button onClick={e => addLabelConfigs(conjunction)}>Add {conjunction} Label</button>
+        <button className='quill-button small primary outlined' onClick={e => addLabelConfigs(conjunction)}>
+          Add {capitalizeConjunction} Label Example
+        </button>
       </div>
     );
   }
@@ -150,7 +161,7 @@ const SeedDataForm = ({ history, match }) => {
         {activity && activity.prompts.map((prompt, i) => <li key={i}>{prompt.text}</li>)}
       </ul>
       <details>
-        <summary className="quill-button fun secondary outlined focus-on-light">Toggle Passage</summary>
+        <summary className="quill-button fun primary outlined focus-on-light">Toggle Passage</summary>
         <br />
         <div className="passage">{ReactHtmlParser(activity && activity.passages[0].text)}</div>
       </details>
@@ -165,7 +176,7 @@ const SeedDataForm = ({ history, match }) => {
       {renderLabelSection(because)}
       {renderLabelSection(but)}
       {renderLabelSection(so)}
-
+      <br />
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">
           <span aria-label="robot" role="img">🤖</span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -113,7 +113,7 @@ const SeedDataForm = ({ history, match }) => {
 
   const renderLabelConfig = (labelConfig, index, conjunction) => {
     return (
-      <div key={index} className="seed-label-form">
+      <div className="seed-label-form" key={index}>
         <button
           className='right quill-button fun secondary outlined'
           onClick={() => removeLabelConfig(index, conjunction)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -22,13 +22,10 @@ const SeedDataForm = ({ history, match }) => {
   const but = 'but';
   const so = 'so';
 
-  const blankLabelConfig = { label: '', examples: ['',''] };
+  const blankLabelConfig = { label: '', examples: ['',''],};
+  const blankLabelConfigs = {because : [], but : [], so : [],};
 
-  const [labelConfigs, setLabelConfigs] = React.useState({
-    because : [],
-    but : [],
-    so : [],
-  });
+  const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 
   const handleLabelConfigsChange = (event, index, conjunction, key) => {
     let data = labelConfigs
@@ -83,6 +80,7 @@ const SeedDataForm = ({ history, match }) => {
         setErrors([]);
         setErrorOrSuccessMessage('Seed Data started! You will receive an email with the csv files');
         setActivityNouns('');
+        setLabelConfigs({...blankLabelConfigs});
         toggleSubmissionModal();
       }
     });
@@ -106,8 +104,8 @@ const SeedDataForm = ({ history, match }) => {
   const renderExample = (value, index, conjunction, exampleIndex) => {
     return (
       <Input
-        label={`Example${exampleIndex + 1}`}
         handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
+        label={`Example ${exampleIndex + 1}`}
         value={value}
       />
     );
@@ -116,14 +114,17 @@ const SeedDataForm = ({ history, match }) => {
   const renderLabelConfig = (labelConfig, index, conjunction) => {
     return (
       <div key={index} className="seed-label-form">
-        <button onClick={() => removeLabelConfig(index, conjunction)} className='right quill-button fun secondary outlined'>
+        <button
+          className='right quill-button fun secondary outlined'
+          onClick={() => removeLabelConfig(index, conjunction)}
+        >
           Remove
         </button>
         <div>
           <Input
-            label='Label'
             className="label-input"
             handleChange={e => handleLabelConfigsChange(e, index, conjunction, 'label')}
+            label='Label'
             value={labelConfig.label}
           />
         </div>
@@ -143,7 +144,9 @@ const SeedDataForm = ({ history, match }) => {
         </h4>
         {labelConfigs[conjunction].map((labelConfig, index) => renderLabelConfig(labelConfig, index, conjunction))}
         <button className='quill-button small primary outlined' onClick={e => addLabelConfigs(conjunction)}>
-          Add {capitalizeConjunction} Label Example
+          <span className='plus'>+</span>
+
+          &nbsp;Add {capitalizeConjunction} Label
         </button>
       </div>
     );

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -30,7 +30,7 @@ const SeedDataForm = ({ history, match }) => {
     conjunctionData[index][key] = event.target.value;
     data[conjunction] = conjunctionData;
 
-    setLabelConfigs(labelConfigs => ({...data}));
+    setLabelConfigs({...data});
   }
 
   function handleExampleChange(event, index, conjunction, exampleIndex) {
@@ -40,7 +40,7 @@ const SeedDataForm = ({ history, match }) => {
     conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
 
-    setLabelConfigs(labelConfigs => ({...data}));
+    setLabelConfigs({...data});
   }
 
   function onAddLabelConfigs(e) {
@@ -54,7 +54,7 @@ const SeedDataForm = ({ history, match }) => {
     const conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
     data[conjunction] = conjunctionData
-    setLabelConfigs(labelConfigs => ({...data}))
+    setLabelConfigs({...data})
   }
 
   function onRemoveLabelConfig(e) {
@@ -69,7 +69,7 @@ const SeedDataForm = ({ history, match }) => {
     conjunctionData.splice(index, 1)
     data[conjunction] = conjunctionData
 
-    setLabelConfigs(labelConfigs => ({...data}))
+    setLabelConfigs({...data})
   }
 
   const { data: activityData } = useQuery({

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -24,8 +24,8 @@ const SeedDataForm = ({ history, match }) => {
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 
   const handleLabelConfigsChange = (event, index, conjunction, key) => {
-    let data = labelConfigs
-    let conjunctionData = [...data[conjunction]];
+    const data = labelConfigs
+    const conjunctionData = [...data[conjunction]];
 
     conjunctionData[index][key] = event.target.value;
     data[conjunction] = conjunctionData;
@@ -34,8 +34,8 @@ const SeedDataForm = ({ history, match }) => {
   }
 
   const handleExampleChange = (event, index, conjunction, exampleIndex) => {
-    let data = labelConfigs
-    let conjunctionData = [...data[conjunction]];
+    const data = labelConfigs
+    const conjunctionData = [...data[conjunction]];
 
     conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
@@ -44,16 +44,16 @@ const SeedDataForm = ({ history, match }) => {
   }
 
   const addLabelConfigs = (conjunction) => {
-    let data = labelConfigs
-    let conjunctionData = [...data[conjunction], {...blankLabelConfig}];
+    const data = labelConfigs
+    const conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
     data[conjunction] = conjunctionData
     setLabelConfigs(labelConfigs => ({...data}))
   }
 
   const removeLabelConfig = (index, conjunction) => {
-    let data = labelConfigs
-    let conjunctionData = [...data[conjunction]]
+    const data = labelConfigs
+    const conjunctionData = [...data[conjunction]]
     conjunctionData.splice(index, 1)
     data[conjunction] = conjunctionData
 
@@ -131,7 +131,7 @@ const SeedDataForm = ({ history, match }) => {
   }
 
   const renderLabelSection = (conjunction) => {
-    let capitalizeConjunction = conjunction.charAt(0).toUpperCase() + conjunction.substring(1)
+    const capitalizeConjunction = conjunction.charAt(0).toUpperCase() + conjunction.substring(1)
     return (
       <div className='label-section'>
         <h4 className='bg-quillteal label-title'>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -22,8 +22,8 @@ const SeedDataForm = ({ history, match }) => {
   const but = 'but';
   const so = 'so';
 
-  const blankLabelConfig = { label: '', examples: ['',''],};
-  const blankLabelConfigs = {because : [], but : [], so : [],};
+  const blankLabelConfig = { label: '', examples: ['',''], };
+  const blankLabelConfigs = { because : [], but : [], so : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -23,7 +23,7 @@ const SeedDataForm = ({ history, match }) => {
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 
-  const handleLabelConfigsChange = (event, index, conjunction, key) => {
+  function handleLabelConfigsChange(event, index, conjunction, key) {
     const data = labelConfigs
     const conjunctionData = [...data[conjunction]];
 
@@ -33,7 +33,7 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(labelConfigs => ({...data}));
   }
 
-  const handleExampleChange = (event, index, conjunction, exampleIndex) => {
+  function handleExampleChange(event, index, conjunction, exampleIndex) {
     const data = labelConfigs
     const conjunctionData = [...data[conjunction]];
 
@@ -43,7 +43,7 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(labelConfigs => ({...data}));
   }
 
-  const addLabelConfigs = (conjunction) => {
+  function addLabelConfigs(conjunction) {
     const data = labelConfigs
     const conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
@@ -51,7 +51,7 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(labelConfigs => ({...data}))
   }
 
-  const removeLabelConfig = (index, conjunction) => {
+  function removeLabelConfig(index, conjunction) {
     const data = labelConfigs
     const conjunctionData = [...data[conjunction]]
     conjunctionData.splice(index, 1)
@@ -65,7 +65,7 @@ const SeedDataForm = ({ history, match }) => {
     queryFn: fetchActivity
   });
 
-  const handleCreateSeedData = () => {
+  function handleCreateSeedData() {
     if (!confirm('⚠️ Are you sure you want to generate seed data?')) return
 
     createSeedData(activityNouns, labelConfigs, activityId).then((response) => {
@@ -82,7 +82,7 @@ const SeedDataForm = ({ history, match }) => {
     });
   }
 
-  const toggleSubmissionModal = () => setShowSubmissionModal(!showSubmissionModal);
+  function toggleSubmissionModal() { setShowSubmissionModal(!showSubmissionModal) };
 
   function renderSubmissionModal() {
     const message = errorOrSuccessMessage || 'Seed Data started!';
@@ -97,7 +97,7 @@ const SeedDataForm = ({ history, match }) => {
     );
   }
 
-  const renderExample = (value, index, conjunction, exampleIndex) => {
+  function renderExample(value, index, conjunction, exampleIndex) {
     return (
       <Input
         handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
@@ -107,7 +107,7 @@ const SeedDataForm = ({ history, match }) => {
     );
   }
 
-  const renderLabelConfig = (labelConfig, index, conjunction) => {
+  function renderLabelConfig(labelConfig, index, conjunction) {
     return (
       <div className="seed-label-form" key={index}>
         <button
@@ -130,7 +130,7 @@ const SeedDataForm = ({ history, match }) => {
     );
   }
 
-  const renderLabelSection = (conjunction) => {
+  function renderLabelSection(conjunction) {
     const capitalizeConjunction = conjunction.charAt(0).toUpperCase() + conjunction.substring(1)
     return (
       <div className='label-section'>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -23,7 +23,7 @@ const SeedDataForm = ({ history, match }) => {
   const but = 'but';
   const so = 'so';
 
-  const blankLabelConfig = { label: '', example1: '', example2: '' };
+  const blankLabelConfig = { label: '', examples: ['',''] };
 
   const [labelConfigs, setLabelConfigs] = React.useState({
     because : [ {...blankLabelConfig}],
@@ -31,11 +31,21 @@ const SeedDataForm = ({ history, match }) => {
     so : [{...blankLabelConfig}],
   });
 
-  const handleLabelConfigsChange = (event, index, conjunction) => {
+  const handleLabelConfigsChange = (event, index, conjunction, key) => {
     let data = labelConfigs
     let conjunctionData = [...data[conjunction]];
 
-    conjunctionData[index][event.target.id] = event.target.value;
+    conjunctionData[index][key] = event.target.value;
+    data[conjunction] = conjunctionData;
+
+    setLabelConfigs(labelConfigs => ({...data}));
+  }
+
+  const handleExampleChange = (event, index, conjunction, exampleIndex) => {
+    let data = labelConfigs
+    let conjunctionData = [...data[conjunction]];
+
+    conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
 
     setLabelConfigs(labelConfigs => ({...data}));
@@ -94,27 +104,25 @@ const SeedDataForm = ({ history, match }) => {
     );
   }
 
-  const renderLabelConfig = (form, index, conjunction) => {
+  const renderExample = (value, index, conjunction, exampleIndex) => {
+    return (
+      <Input
+        label={`Example${exampleIndex + 1}`}
+        handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
+        value={value}
+      />
+    );
+  }
+
+  const renderLabelConfig = (labelConfig, index, conjunction) => {
     return (
       <div key={index}>
         <Input
-          id='label'
           label='Label'
-          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
-          value={form.label}
+          handleChange={e => handleLabelConfigsChange(e, index, conjunction, 'label')}
+          value={labelConfig.label}
         />
-        <Input
-          id='example1'
-          label='Example1'
-          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
-          value={form.example1}
-        />
-        <Input
-          id='example2'
-          label='Example2'
-          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
-          value={form.example2}
-        />
+        {labelConfig.examples.map((example, exampleIndex) => renderExample(example, index, conjunction, exampleIndex))}
         <button onClick={() => removeLabelConfig(index, conjunction)}>Remove</button>
       </div>
     );
@@ -124,7 +132,7 @@ const SeedDataForm = ({ history, match }) => {
     return (
       <div>
         <h4>{conjunction.toUpperCase()} Label Examples</h4>
-        {labelConfigs[conjunction].map((form, index) => renderLabelConfig(form, index, conjunction))}
+        {labelConfigs[conjunction].map((labelConfig, index) => renderLabelConfig(labelConfig, index, conjunction))}
         <button onClick={e => addLabelConfigs(conjunction)}>Add {conjunction} Label</button>
       </div>
     );

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -18,28 +18,45 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
-  const [labelConfigs, setLabelConfigs] = React.useState<any>([
-    { label: '', example1: '', example2: '' },
-  ]);
 
-  const handleLabelConfigsChange = (event, index) => {
-    let data = [...labelConfigs];
-    data[index][event.target.id] = event.target.value;
-    setLabelConfigs(data);
+  const because = 'because';
+  const but = 'but';
+  const so = 'so';
+
+  const blankLabelConfig = { label: '', example1: '', example2: '' };
+
+  const [labelConfigs, setLabelConfigs] = React.useState({
+    because : [ {...blankLabelConfig}],
+    but : [{...blankLabelConfig}],
+    so : [{...blankLabelConfig}],
+  });
+
+  const handleLabelConfigsChange = (event, index, conjunction) => {
+    let data = labelConfigs
+    let conjunctionData = [...data[conjunction]];
+
+    conjunctionData[index][event.target.id] = event.target.value;
+    data[conjunction] = conjunctionData;
+
+    setLabelConfigs(labelConfigs => ({...data}));
   }
 
-  const addLabelConfigs = () => {
-    let object = { label: '', example1: '', example2: '' }
+  const addLabelConfigs = (conjunction) => {
+    let data = labelConfigs
+    let conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
-    setLabelConfigs([...labelConfigs, object])
+    data[conjunction] = conjunctionData
+    setLabelConfigs(labelConfigs => ({...data}))
   }
 
-  const removeLabelConfig = (index) => {
-    let data = [...labelConfigs];
-    data.splice(index, 1);
-    setLabelConfigs(data);
-  }
+  const removeLabelConfig = (index, conjunction) => {
+    let data = labelConfigs
+    let conjunctionData = [...data[conjunction]]
+    conjunctionData.splice(index, 1)
+    data[conjunction] = conjunctionData
 
+    setLabelConfigs(labelConfigs => ({...data}))
+  }
 
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
@@ -77,6 +94,42 @@ const SeedDataForm = ({ history, match }) => {
     );
   }
 
+  const renderLabelConfig = (form, index, conjunction) => {
+    return (
+      <div key={index}>
+        <Input
+          id='label'
+          label='Label'
+          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
+          value={form.label}
+        />
+        <Input
+          id='example1'
+          label='Example1'
+          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
+          value={form.example1}
+        />
+        <Input
+          id='example2'
+          label='Example2'
+          handleChange={e => handleLabelConfigsChange(e, index, conjunction)}
+          value={form.example2}
+        />
+        <button onClick={() => removeLabelConfig(index, conjunction)}>Remove</button>
+      </div>
+    );
+  }
+
+  const renderLabelSection = (conjunction) => {
+    return (
+      <div>
+        <h4>{conjunction.toUpperCase()} Label Examples</h4>
+        {labelConfigs[conjunction].map((form, index) => renderLabelConfig(form, index, conjunction))}
+        <button onClick={e => addLabelConfigs(conjunction)}>Add {conjunction} Label</button>
+      </div>
+    );
+  }
+
   const { activity } = activityData
 
   return(
@@ -100,34 +153,11 @@ const SeedDataForm = ({ history, match }) => {
         label="Optional: Noun list comma separated"
         value={activityNouns}
       />
-      <h4>Label Examples</h4>
-      {labelConfigs.map((form, index) => {
-          return (
-            <div key={index}>
-              <Input
-                id='label'
-                label='Label'
-                handleChange={e => handleLabelConfigsChange(e, index)}
-                value={labelConfigs[index].label}
-              />
-              <Input
-                id='example1'
-                label='Example1'
-                handleChange={e => handleLabelConfigsChange(e, index)}
-                value={form.example1}
-              />
-              <Input
-                id='example2'
-                label='Example2'
-                handleChange={e => handleLabelConfigsChange(e, index)}
-                value={form.example2}
-              />
-              <button onClick={() => removeLabelConfig(index)}>Remove</button>
-            </div>
-          )
-        })
-      }
-      <button onClick={addLabelConfigs}>Add Label</button>
+
+      {renderLabelSection(because)}
+      {renderLabelSection(but)}
+      {renderLabelSection(so)}
+
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">
           <span aria-label="robot" role="img">🤖</span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -6,7 +6,7 @@ import SubmissionModal from '../shared/submissionModal';
 import { fetchActivity, createSeedData } from '../../../utils/evidence/activityAPIs';
 import { renderHeader } from "../../../helpers/evidence/renderHelpers";
 import { Input, Spinner } from '../../../../Shared/index';
-import { TITLE } from "../../../../../constants/evidence";
+import { TITLE, BECAUSE, BUT, SO } from "../../../../../constants/evidence";
 
 const SeedDataForm = ({ history, match }) => {
   const { params } = match;
@@ -18,12 +18,8 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
-  const because = 'because';
-  const but = 'but';
-  const so = 'so';
-
   const blankLabelConfig = { label: '', examples: ['',''], };
-  const blankLabelConfigs = { because : [], but : [], so : [], };
+  const blankLabelConfigs = { [BECAUSE] : [], [BUT] : [], [SO] : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 
@@ -176,9 +172,9 @@ const SeedDataForm = ({ history, match }) => {
         value={activityNouns}
       />
 
-      {renderLabelSection(because)}
-      {renderLabelSection(but)}
-      {renderLabelSection(so)}
+      {renderLabelSection(BECAUSE)}
+      {renderLabelSection(BUT)}
+      {renderLabelSection(SO)}
       <br />
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -25,9 +25,9 @@ const SeedDataForm = ({ history, match }) => {
   const blankLabelConfig = { label: '', examples: ['',''] };
 
   const [labelConfigs, setLabelConfigs] = React.useState({
-    because : [ {...blankLabelConfig}],
-    but : [{...blankLabelConfig}],
-    so : [{...blankLabelConfig}],
+    because : [],
+    but : [],
+    so : [],
   });
 
   const handleLabelConfigsChange = (event, index, conjunction, key) => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -18,6 +18,29 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
+  const [labelConfigs, setLabelConfigs] = React.useState<any>([
+    { label: '', example1: '', example2: '' },
+  ]);
+
+  const handleLabelConfigsChange = (event, index) => {
+    let data = [...labelConfigs];
+    data[index][event.target.id] = event.target.value;
+    setLabelConfigs(data);
+  }
+
+  const addLabelConfigs = () => {
+    let object = { label: '', example1: '', example2: '' }
+
+    setLabelConfigs([...labelConfigs, object])
+  }
+
+  const removeLabelConfig = (index) => {
+    let data = [...labelConfigs];
+    data.splice(index, 1);
+    setLabelConfigs(data);
+  }
+
+
   const { data: activityData } = useQuery({
     queryKey: [`activity-${activityId}`, activityId],
     queryFn: fetchActivity
@@ -26,7 +49,7 @@ const SeedDataForm = ({ history, match }) => {
   const handleCreateSeedData = () => {
     if (!confirm('⚠️ Are you sure you want to generate seed data?')) return
 
-    createSeedData(activityNouns, activityId).then((response) => {
+    createSeedData(activityNouns, labelConfigs, activityId).then((response) => {
       const { errors } = response;
       if(errors && errors.length) {
         setErrors(errors);
@@ -77,6 +100,34 @@ const SeedDataForm = ({ history, match }) => {
         label="Optional: Noun list comma separated"
         value={activityNouns}
       />
+      <h4>Label Examples</h4>
+      {labelConfigs.map((form, index) => {
+          return (
+            <div key={index}>
+              <Input
+                id='label'
+                label='Label'
+                handleChange={e => handleLabelConfigsChange(e, index)}
+                value={labelConfigs[index].label}
+              />
+              <Input
+                id='example1'
+                label='Example1'
+                handleChange={e => handleLabelConfigsChange(e, index)}
+                value={form.example1}
+              />
+              <Input
+                id='example2'
+                label='Example2'
+                handleChange={e => handleLabelConfigsChange(e, index)}
+                value={form.example2}
+              />
+              <button onClick={() => removeLabelConfig(index)}>Remove</button>
+            </div>
+          )
+        })
+      }
+      <button onClick={addLabelConfigs}>Add Label</button>
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">
           <span aria-label="robot" role="img">🤖</span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -24,23 +24,23 @@ const SeedDataForm = ({ history, match }) => {
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
 
   function handleLabelConfigsChange(event, index, conjunction, key) {
-    const data = labelConfigs
+    const data = {...labelConfigs}
     const conjunctionData = [...data[conjunction]];
 
     conjunctionData[index][key] = event.target.value;
     data[conjunction] = conjunctionData;
 
-    setLabelConfigs({...data});
+    setLabelConfigs(data);
   }
 
   function handleExampleChange(event, index, conjunction, exampleIndex) {
-    const data = labelConfigs
+    const data = {...labelConfigs}
     const conjunctionData = [...data[conjunction]];
 
     conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
 
-    setLabelConfigs({...data});
+    setLabelConfigs(data)
   }
 
   function onAddLabelConfigs(e) {
@@ -50,11 +50,11 @@ const SeedDataForm = ({ history, match }) => {
   }
 
   function addLabelConfigs(conjunction) {
-    const data = labelConfigs
+    const data = {...labelConfigs}
     const conjunctionData = [...data[conjunction], {...blankLabelConfig}];
 
     data[conjunction] = conjunctionData
-    setLabelConfigs({...data})
+    setLabelConfigs(data)
   }
 
   function onRemoveLabelConfig(e) {
@@ -64,12 +64,13 @@ const SeedDataForm = ({ history, match }) => {
   }
 
   function removeLabelConfig(index, conjunction) {
-    const data = labelConfigs
+    const data = {...labelConfigs}
     const conjunctionData = [...data[conjunction]]
+
     conjunctionData.splice(index, 1)
     data[conjunction] = conjunctionData
 
-    setLabelConfigs({...data})
+    setLabelConfigs(data)
   }
 
   const { data: activityData } = useQuery({

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -25,5 +25,8 @@
     width: 25%;
     min-width: 100px;
   }
+  .plus {
+    font-size: 30px;
+  }
 }
 

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -1,0 +1,29 @@
+.seed-data-form-container {
+  .label-section {
+    margin: 20px 0;
+  }
+  .seed-label-form {
+    border: 1px solid #f7f5f5;
+    padding: 10px;
+    margin: 20px 0;
+    border-radius: 20px;
+  }
+  .label-title {
+    padding: 10px 10px;
+    color: white;
+    border-radius: 10px;
+    font-weight: 700;
+  }
+  .highlight {
+    color: #ffff8d;
+  }
+
+  .right {
+    float: right;
+  }
+  .label-input {
+    width: 25%;
+    min-width: 100px;
+  }
+}
+

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -3,7 +3,7 @@
     margin: 20px 0;
   }
   .seed-label-form {
-    border: 1px solid #f7f5f5;
+    border: 1px solid #b0bec5;
     padding: 10px;
     margin: 20px 0;
     border-radius: 20px;
@@ -11,7 +11,7 @@
   .label-title {
     padding: 10px 10px;
     color: white;
-    border-radius: 10px;
+    border-radius: 4px;
     font-weight: 700;
   }
   .highlight {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -6,7 +6,7 @@
     border: 1px solid #b0bec5;
     padding: 10px;
     margin: 20px 0;
-    border-radius: 20px;
+    border-radius: 16px;
   }
   .label-title {
     padding: 10px 10px;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
@@ -30,6 +30,7 @@
 @import './evidence_manager/rule_form.scss';
 @import './evidence_manager/rules.scss';
 @import './evidence_manager/rule.scss';
+@import './evidence_manager/seed_data.scss';
 @import './evidence_manager/semantic_labels.scss';
 @import './evidence_manager/semantic_label_form.scss';
 @import './evidence_manager/turk_sessions.scss';

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -53,10 +53,10 @@ export const updateActivityVersion = async (activityNote: string, activityId: st
   return { errors: [] };
 }
 
-export const createSeedData = async (nouns: string, activityId: string) => {
+export const createSeedData = async (nouns: string, labelConfigs: Array<any>, activityId: string) => {
   const response = await apiFetch(`activities/${activityId}/seed_data`, {
     method: 'POST',
-    body: JSON.stringify({nouns: nouns})
+    body: JSON.stringify({nouns: nouns, label_configs: labelConfigs})
   });
   const { status } = response;
 

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -53,7 +53,7 @@ export const updateActivityVersion = async (activityNote: string, activityId: st
   return { errors: [] };
 }
 
-export const createSeedData = async (nouns: string, labelConfigs: Array<any>, activityId: string) => {
+export const createSeedData = async (nouns: string, labelConfigs: object, activityId: string) => {
   const response = await apiFetch(`activities/${activityId}/seed_data`, {
     method: 'POST',
     body: JSON.stringify({nouns: nouns, label_configs: labelConfigs})

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -98,7 +98,7 @@ module Evidence
         .map(&:strip)
         .uniq
 
-      label_configs = seed_data_params[:label_configs] || {}
+      label_configs = seed_data_params[:label_configs]&.to_h || {}
 
       Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -90,7 +90,7 @@ module Evidence
       render json: @activity&.activity_versions
     end
 
-    # params [:id, nouns:]
+    # params [:id, nouns:, labels]
     def seed_data
       nouns_array = params[:nouns]
         .split(',')
@@ -98,7 +98,10 @@ module Evidence
         .map(&:strip)
         .uniq
 
-      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array)
+      # TODO: Fill in label_configs in frontend PR
+      label_configs = {}
+
+      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
 
       head :no_content
     end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -98,11 +98,9 @@ module Evidence
         .map(&:strip)
         .uniq
 
-      label_configs = seed_data_params[:label_configs]
-        &.to_h
-        &.transform_values {|label_config| parse_seed_config(label_config) }
+      label_configs = seed_data_params[:label_configs] || {}
 
-      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs || {})
+      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
 
       head :no_content
     end
@@ -148,17 +146,6 @@ module Evidence
         passages_attributes: [:id, :text, :image_link, :image_alt_text, :image_caption, :image_attribution, :highlight_prompt, :essential_knowledge_text],
         prompts_attributes: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback, :first_strong_example, :second_strong_example]
       )
-    end
-
-    EXAMPLES_KEY = 'examples'
-    EXAMPLE1_KEY = 'example1'
-    EXAMPLE2_KEY = 'example2'
-    LABEL_KEY = 'label'
-
-    private def parse_seed_config(label_config)
-      label_config
-        &.map{|lc| lc.merge(EXAMPLES_KEY => lc.to_h.fetch_values(EXAMPLE1_KEY, EXAMPLE2_KEY).map(&:strip).uniq.select(&:present?))}
-        &.map{|lc| lc.slice(LABEL_KEY, EXAMPLES_KEY)}
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -5,8 +5,8 @@ module Evidence
     include Evidence.sidekiq_module
     sidekiq_options retry: 0
 
-    def perform(activity_id, nouns)
-      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, nouns: nouns)
+    def perform(activity_id, nouns, label_configs)
+      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, nouns: nouns, label_configs: label_configs)
 
       activity = Evidence::Activity.find(activity_id)
       subject = "Evidence Seed Data: Activity #{activity_id} - #{activity.title}"

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -6,7 +6,11 @@ module Evidence
     sidekiq_options retry: 0
 
     def perform(activity_id, nouns, label_configs)
-      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, nouns: nouns, label_configs: label_configs)
+      csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(
+        activity_id: activity_id,
+        nouns: nouns,
+        label_configs: label_configs
+      )
 
       activity = Evidence::Activity.find(activity_id)
       subject = "Evidence Seed Data: Activity #{activity_id} - #{activity.title}"

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/completion.rb
@@ -20,14 +20,14 @@ module Evidence
       STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
       MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
 
-      attr_accessor :prompt, :temperature, :count, :model_key, :options_hash
+      attr_accessor :prompt, :temperature, :count, :model_key, :options
 
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options_hash: {})
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options: {})
         @prompt = prompt
         @temperature = temperature
         @count = count
         @model_key = model_key
-        @options_hash = options_hash
+        @options = options
       end
 
       def endpoint
@@ -44,7 +44,7 @@ module Evidence
           n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
           max_tokens: MAX_TOKENS,
           stop: STOP_TOKENS
-        }.merge(options_hash)
+        }.merge(options)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
@@ -3,7 +3,5 @@
 module Evidence
   module Synthetic
     EMAIL = ENV.fetch('SYNTHETIC_DATA_EMAIL', '')
-
-    SeedLabelConfig = Struct.new(:label, :examples, keyword_init: true)
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic.rb
@@ -3,5 +3,7 @@
 module Evidence
   module Synthetic
     EMAIL = ENV.fetch('SYNTHETIC_DATA_EMAIL', '')
+
+    SeedLabelConfig = Struct.new(:label, :examples, keyword_init: true)
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -4,7 +4,6 @@ module Evidence
   module Synthetic
     class SeedDataGenerator
       Result = Struct.new(:text, :seed, keyword_init: true)
-      LabelConfig = Struct.new(:label, :examples, keyword_init: true)
 
       WORD_SPLIT_COUNT = 70
       SPACE = ' '
@@ -52,7 +51,7 @@ module Evidence
       attr_reader :passage, :stem, :conjunction, :nouns, :results, :label_configs
 
       # returns a hash of the form {'csv name' => CSVString, 'csv name2' =>...}
-      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil)
+      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil, label_configs: {})
         activity = Evidence::Activity.find(activity_id)
         passage = activity.passages.first.text
         prompts = conjunctions.present? ? activity.prompts.where(conjunction: conjunctions) : activity.prompts
@@ -61,14 +60,15 @@ module Evidence
 
         csvs = {}
 
-        prompts.each.with_index do |prompt, index|
+        prompts.each do |prompt|
           csv_name = "#{short_name}_#{prompt.conjunction}#{CSV_SUFFIX}"
 
           generator = new(
             passage: passage,
             stem: prompt.text,
             conjunction: prompt.conjunction,
-            nouns: nouns
+            nouns: nouns,
+            label_configs: label_configs[prompt.conjunction] || []
           )
           generator.run
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -120,14 +120,17 @@ module Evidence
         results
       end
 
+      LABEL_KEY = 'label'
+      EXAMPLES_KEY = 'examples'
+
       private def generate_label_paraphrases
         label_configs.each do |label_config|
-          label_config.examples.map(&:strip).uniq.each.with_index do |example, index|
+          label_config[EXAMPLES_KEY].map(&:strip).uniq.compact.each.with_index do |example, index|
             prompt = PARAPHRASE_INSTRUCTION + example
             run_prompt(
               prompt: prompt,
               count: EXAMPLE_COUNT,
-              seed: "label_#{label_config.label}_example#{index + 1}_temp#{TEMP_PARAPHRASE}",
+              seed: "label_#{label_config[LABEL_KEY]}_example#{index + 1}_temp#{TEMP_PARAPHRASE}",
               temperature: TEMP_PARAPHRASE,
               options: OPTIONS_PARAPHRASE
             )

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -18,7 +18,7 @@ module Evidence
 
       TEMPS_PASSAGE = [0.8, 0.7, 0.5, 0.4]
       TEMP_SECTION = 0.4 # give a lower temp (creativity) when it has less info
-      TEMP_PARAPHRASE = 0.9
+      TEMP_PARAPHRASE = 1
       OPTIONS_PARAPHRASE = {max_tokens: 40}
 
       STEM_KEY = '%<stem>s'
@@ -115,6 +115,12 @@ module Evidence
         end
 
         # label examples to paraphrase
+        generate_label_paraphrases
+
+        results
+      end
+
+      private def generate_label_paraphrases
         label_configs.each do |label_config|
           label_config.examples.each.with_index do |example, index|
             prompt = PARAPHRASE_INSTRUCTION + example
@@ -127,8 +133,6 @@ module Evidence
             )
           end
         end
-
-        results
       end
 
       private def run_prompt(prompt:, count:, seed:, noun: nil, temperature: 1, options: {})

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -122,7 +122,7 @@ module Evidence
 
       private def generate_label_paraphrases
         label_configs.each do |label_config|
-          label_config.examples.each.with_index do |example, index|
+          label_config.examples.map(&:strip).uniq.each.with_index do |example, index|
             prompt = PARAPHRASE_INSTRUCTION + example
             run_prompt(
               prompt: prompt,

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -16,9 +16,9 @@ namespace :synthetic do
     run_number = args[:run_number]
     conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
 
-    label_config1 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label11', examples: ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."])
-    label_config2 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."])
-    label_config3 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."])
+    label_config1 = {'label' => 'label11', 'examples' => ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."])}
+    label_config2 = {'label' => 'label7', 'examples' => ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."])}
+    label_config3 = {'label' => 'label7', 'examples' => ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."])}
 
     label_configs = {'because' => [label_config1, label_config2, label_config3]}
 

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -16,9 +16,9 @@ namespace :synthetic do
     run_number = args[:run_number]
     conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
 
-    label_config1 = {'label' => 'label11', 'examples' => ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."])}
-    label_config2 = {'label' => 'label7', 'examples' => ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."])}
-    label_config3 = {'label' => 'label7', 'examples' => ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."])}
+    label_config1 = {'label' => 'label11', 'examples' => ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."]}
+    label_config2 = {'label' => 'label7', 'examples' => ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."]}
+    label_config3 = {'label' => 'label7', 'examples' => ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."]}
 
     label_configs = {'because' => [label_config1, label_config2, label_config3]}
 

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -16,8 +16,14 @@ namespace :synthetic do
     run_number = args[:run_number]
     conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
 
-    puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}..."
-    csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions)
+    label_config1 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label11', examples: ["it allows officials to view the same play from different angles.", "coaches and players trust the officials to make the correct call."])
+    label_config2 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["66\% of public schools in the U.S. ban cell phone use anyway.", "students can easily be distracted by their phones."])
+    label_config3 = Evidence::Synthetic::SeedLabelConfig.new(label: 'label7', examples: ["the International Handball Federation rewrote its rules in 2022 to allow players on women’s teams to wear tank tops and shorts.", "the Norwegian team protested."])
+
+    label_configs = {'because' => [label_config1, label_config2, label_config3]}
+
+    puts "Fetching data for #{activity_id}, conjunctions: #{conjunctions}, Run #{run_number}, Label config #{label_configs}..."
+    csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(activity_id: activity_id, conjunctions: conjunctions, label_configs: label_configs)
 
     path = ENV.fetch('SYNTHETIC_LOCAL_PATH', '~/Documents/')
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -347,6 +347,18 @@ module Evidence
 
         expect(response).to have_http_status(:success)
       end
+
+      context 'with label_configs' do
+        let(:label_configs) {[]}
+
+      it "should call background worker" do
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
+        post :seed_data, params: { id: activity.id, nouns: "" }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      end
     end
 
     context "#labeled_synthetic_data" do

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -357,21 +357,8 @@ module Evidence
         let(:label_config2) {{'label' => label2, 'example1' => example1, 'example2' => example2}}
         let(:label_configs) {{'so' => [label_config1, label_config2], 'because' => [label_config2]}}
 
-        let(:label_configs_converted) do
-          {
-            'so' => [
-              {'label' => label1, 'examples' => [example1, example2]},
-              {'label' => label2, 'examples' => [example1, example2]}
-            ],
-            'because' => [
-               {'label' => label2, 'examples' => [example1, example2]}
-            ]
-          }
-
-        end
-
         it "should call background worker" do
-          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs_converted)
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
           post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs }
 
           expect(response).to have_http_status(:success)

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -349,14 +349,33 @@ module Evidence
       end
 
       context 'with label_configs' do
-        let(:label_configs) {[]}
+        let(:label1) {'label1'}
+        let(:label2) {'label2'}
+        let(:example1) {'some sentence'}
+        let(:example2) {'sentence other'}
+        let(:label_config1) {{'label' => label1, 'example1' => example1, 'example2' => example2}}
+        let(:label_config2) {{'label' => label2, 'example1' => example1, 'example2' => example2}}
+        let(:label_configs) {{'so' => [label_config1, label_config2], 'because' => [label_config2]}}
 
-      it "should call background worker" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
-        post :seed_data, params: { id: activity.id, nouns: "" }
+        let(:label_configs_converted) do
+          {
+            'so' => [
+              {'label' => label1, 'examples' => [example1, example2]},
+              {'label' => label2, 'examples' => [example1, example2]}
+            ],
+            'because' => [
+               {'label' => label2, 'examples' => [example1, example2]}
+            ]
+          }
 
-        expect(response).to have_http_status(:success)
-      end
+        end
+
+        it "should call background worker" do
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs_converted)
+          post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs }
+
+          expect(response).to have_http_status(:success)
+        end
 
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -331,16 +331,18 @@ module Evidence
 
     context "#seed_data" do
       let(:activity) { create(:evidence_activity) }
+      # TODO: fill out test when frontend is complete
+      let(:label_configs) {{}}
 
       it "should call background worker" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [])
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
         post :seed_data, params: { id: activity.id, nouns: "" }
 
         expect(response).to have_http_status(:success)
       end
 
       it "should call background worker with noun string converted to array" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'])
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs)
         post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3" }
 
         expect(response).to have_http_status(:success)

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -8,7 +8,7 @@ module Evidence
     let(:temperature) { 0.9 }
     let(:count) { 10 }
     let(:model_key) { :curie }
-    let(:options_hash) {{key: 'value'}}
+    let(:options) {{key: 'value'}}
     let(:endpoint) {'https://api.openai.com/v1/completions'}
 
     let(:sample_response_body) do
@@ -37,7 +37,7 @@ module Evidence
           temperature: temperature,
           count: count,
           model_key: model_key,
-          options_hash: options_hash)
+          options: options)
     end
 
     describe "#new" do
@@ -46,7 +46,7 @@ module Evidence
         expect(completion.temperature).to eq(temperature)
         expect(completion.count).to eq(count)
         expect(completion.model_key).to eq(model_key)
-        expect(completion.options_hash).to eq(options_hash)
+        expect(completion.options).to eq(options)
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -35,7 +35,7 @@ module Evidence
 
     let(:example) {'Example to paraphrase.'}
     let(:label) { 'label1' }
-    let(:label_config) {described_class::LabelConfig.new(label: label, examples: [example])}
+    let(:label_config) {::Evidence::Synthetic::SeedLabelConfig.new(label: label, examples: [example])}
     let(:example_prompt) { "rephrase with some synonyms:\n\nExample to paraphrase." }
     let(:example_response) { ["Example to rephrase."] }
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -35,7 +35,7 @@ module Evidence
 
     let(:example) {'Example to paraphrase.'}
     let(:label) { 'label1' }
-    let(:label_config) {::Evidence::Synthetic::SeedLabelConfig.new(label: label, examples: [example])}
+    let(:label_config) {{'label' => label, 'examples' => [example]}}
     let(:example_prompt) { "rephrase with some synonyms:\n\nExample to paraphrase." }
     let(:example_response) { ["Example to rephrase."] }
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -50,7 +50,7 @@ module Evidence
         "full_passage_noun_noun1",
         "text_chunk_1_temp0.4_but",
         "text_chunk_2_temp0.4_but",
-        "label_label1_example1_temp0.9"
+        "label_label1_example1_temp1"
       ]
     end
 
@@ -150,7 +150,7 @@ module Evidence
 
         # label example
         expect(Evidence::OpenAI::Completion).to receive(:run)
-          .with(prompt: example_prompt, count: 1, temperature: 0.9, options: {max_tokens: 40})
+          .with(prompt: example_prompt, count: 1, temperature: 1, options: {max_tokens: 40})
           .and_return(example_response)
 
         subject.run

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -18,17 +18,18 @@ module Evidence
       let(:generator_response) { double }
       let(:email_subject) {"Evidence Seed Data: Activity #{activity.id} - #{activity.title}"}
       let(:mailer) { double('mailer', deliver_now!: true) }
+      let(:label_configs) {{'key' => 'value'}}
 
       it 'call generate and call file_mailer' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
-          .with(activity_id: activity.id, nouns: nouns)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)
           .with(email, email_subject, generator_response)
           .and_return(mailer)
 
-        subject.perform(activity.id, nouns)
+        subject.perform(activity.id, nouns, label_configs)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -18,7 +18,7 @@ module Evidence
       let(:generator_response) { double }
       let(:email_subject) {"Evidence Seed Data: Activity #{activity.id} - #{activity.title}"}
       let(:mailer) { double('mailer', deliver_now!: true) }
-      let(:label_configs) {{'key' => 'value'}}
+      let(:label_configs) {{'because' => [{'label' => 'Label1', 'examples' => ['hello', 'goodbye']}]}}
 
       it 'call generate and call file_mailer' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)


### PR DESCRIPTION
## WHAT
Front end for the [Synthetic Label examples PR](https://github.com/empirical-org/Empirical-Core/pull/9880) 

This adds a form to the Seed Data create page to add label examples for paraphrasing.

(Note, this is a PR on that PR, not `develop`. [This](https://github.com/empirical-org/Empirical-Core/compare/synthetic_labels_fe) is the diff on `develop` if you want that for reference.
## WHY
We want to make sure we have some seed data for all labels. This UI allows the team to submit some examples per label that we will paraphrase for them.
## HOW
Somewhat open-ended form for each prompt.
- No validation, to give the team complete flexibility
- Making this 2 examples per label for now consistency/simplicity (easy to expand later, it's just an array)
### Screenshots
![Screen Shot 2022-11-02 at 4 14 34 PM](https://user-images.githubusercontent.com/1304933/199594697-9a1bb050-7336-4cdd-b409-625aabc1cb85.png)


### Notion Card Links
https://www.notion.so/quill/Synthetic-Data-V2-6205ada84ba4445eac0cdf179435d584

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
