### PR TITLE
Support/ allow existing student users to be a part of roster upload

### DIFF
--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -30,10 +30,7 @@ class Cms::RostersController < Cms::CmsController
 
         password = s[:password].present? ? s[:password] : s[:name].split[1]
         student = User.find_by(email: s[:email])
-
-        if !student
-          student = User.create!(name: s[:name], email: s[:email], password: password, password_confirmation: password, role: 'student')
-        end
+        student ||= User.create!(name: s[:name], email: s[:email.downcase], password: password, password_confirmation: password, role: 'student')
 
         teacher = User.find_by(email: s[:teacher_email])
         classroom = Classroom.joins(:classrooms_teachers).where("classrooms_teachers.user_id = ?", teacher.id).where(name: s[:classroom]).first


### PR DESCRIPTION
## WHAT
allow for existing student users to be processed during student roster uploads

## WHY
currently, this upload feature will error out if there are any existing accounts with supplied student user data. Partnerships would like for these existing users to be part of the upload process and added to the designated classrooms in the spreadsheet

## HOW
remove raised error when existing student user is found and only conditionally create a new student account when there is no account found

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Unable-to-bulk-upload-student-rosters-due-to-email-error-d77da4bc1a9a462aa8a44a0f339d72e5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
