### PR TITLE
Bug-fix/ add words to whitelist for Quokka Selfies activity

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -28,7 +28,9 @@ module Evidence
       'kanaka',
       'kānaka',
       'worldwatch',
-      'wilmut'
+      'wilmut',
+      '#quokkaselfie',
+      '#quokkaselfies',
     ]
 
     attr_reader :entry

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -29,8 +29,8 @@ module Evidence
       'kānaka',
       'worldwatch',
       'wilmut',
-      '#quokkaselfie',
-      '#quokkaselfies'
+      'quokkaselfie',
+      'quokkaselfies'
     ]
 
     attr_reader :entry

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -30,7 +30,7 @@ module Evidence
       'worldwatch',
       'wilmut',
       '#quokkaselfie',
-      '#quokkaselfies',
+      '#quokkaselfies'
     ]
 
     attr_reader :entry


### PR DESCRIPTION
## WHAT
add "#quokkaselfie" and "#quokkaselfies" to whitelist for Quokka Selfies activity

## WHY
we don't want these words to trigger a spelling error

## HOW
just add the two words to our whitelist (note: the Bing API strips the hashtag when processing so we just add the base words without the hashtag)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Whitelist-QuokkaSelfie-and-QuokkaSelfies-from-the-spelling-feedback-b3e344356ffe4ce4ab891d2f8a995356

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
