### PR TITLE
lms/update-links-to-sales-forms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -115,7 +115,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -215,7 +215,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -241,7 +241,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -341,7 +341,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -367,7 +367,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -472,7 +472,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -498,7 +498,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -592,7 +592,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>
@@ -618,7 +618,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="/request_quote"
         >
           Request a quote
         </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
@@ -26,7 +26,7 @@ const SchoolSelectionStage = ({ eligibleSchools, selectedSchool, goToStripeWithS
             placeholder="Select school"
             value={selectedSchool}
           />
-          <p>Your account is linked to multiple schools. To purchase multiple school subscriptions, please complete the purchase checkout for each school, or contact us at sales@quill.org for one invoice for multiple schools.</p>
+          <p>Your account is linked to multiple schools. To purchase multiple school subscriptions, please complete the purchase checkout for each school, or <a href="/request_quote">contact us</a> for one invoice for multiple schools.</p>
           <div className="form-buttons">
             <button className="quill-button outlined secondary medium focus-on-light" onClick={closeModal} type="button">Cancel</button>
             {continueButton}
@@ -122,7 +122,7 @@ const SchoolAndDistrictPremiumModal = ({ stripeSchoolPlan, eligibleSchools, hand
   }
 
   if (stage === PLAN_SELECTION_STAGE_NUMBER) {
-    const requestAQuoteButton = <a className="quill-button outlined medium secondary focus-on-light" href="https://quillpremium.wufoo.com/forms/quill-premium-quote/">Request a quote</a>
+    const requestAQuoteButton = <a className="quill-button outlined medium secondary focus-on-light" href="/request_quote">Request a quote</a>
     let schoolBuyNowButton = <button className="quill-button contained medium primary focus-on-light" onClick={goToSchoolSelectionStage} type="button">Buy now</button>
 
     if (!userIsSignedIn) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -171,7 +171,7 @@ const SubscriptionStatus = ({
         content.buttonOrDate = (
           <a
             className={CTA_BUTTON_CLASSNAME}
-            href="mailto:sales@quill.org"
+            href="/request_renewal"
           >
             Contact us to renew
           </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -281,7 +281,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                   </a>
                    or 
                   <a
-                    href="mailto:sales@quill.org"
+                    href="/request_renewal"
                   >
                     the Quill team
                   </a>
@@ -564,7 +564,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                   </a>
                    or 
                   <a
-                    href="mailto:sales@quill.org"
+                    href="/request_renewal"
                   >
                     the Quill team
                   </a>
@@ -832,7 +832,7 @@ exports[`CurrentSubscription container when there is a current subscription shou
                   </a>
                    or 
                   <a
-                    href="mailto:sales@quill.org"
+                    href="/request_renewal"
                   >
                     the Quill team
                   </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -43,7 +43,7 @@ export default class CurrentSubscription extends React.Component {
       return <span>{baseText} To renew your subscription for next year, <a href="https://quill.org/request_renewal" rel="noopener noreferrer">contact us</a>.</span>
     }
     if (payment_method !== CREDIT_CARD && !authorityLevel) {
-      return <span>{baseText} To renew your subscription for next year, contact the purchaser at <a href={`mailto:${purchaser_email}`}>{purchaser_email}</a> or <a href="mailto:sales@quill.org">the Quill team</a>.</span>
+      return <span>{baseText} To renew your subscription for next year, contact the purchaser at <a href={`mailto:${purchaser_email}`}>{purchaser_email}</a> or <a href="/request_renewal">the Quill team</a>.</span>
     }
     return baseText
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
@@ -403,7 +403,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       </a>
                        or 
                       <a
-                        href="mailto:sales@quill.org"
+                        href="/request_renewal"
                       >
                         the Quill team
                       </a>
@@ -790,7 +790,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           </div>
           <a
             className="quill-button medium contained primary focus-on-light"
-            href="mailto:sales@quill.org"
+            href="/request_renewal"
           >
             Contact us to renew
           </a>
@@ -1972,7 +1972,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           </div>
           <a
             className="quill-button medium contained primary focus-on-light"
-            href="mailto:sales@quill.org"
+            href="/request_renewal"
           >
             Contact us to renew
           </a>
@@ -4895,7 +4895,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       </a>
                        or 
                       <a
-                        href="mailto:sales@quill.org"
+                        href="/request_renewal"
                       >
                         the Quill team
                       </a>


### PR DESCRIPTION
## WHAT
Update a bunch of mailto:sales@quill.org links with our new forms
## WHY
Since we want to send users through our forms which are integrated with Vitally instead of having them email us in a way that might get lost.
## HOW
Replace the `mailto` `href`s with links to the new forms.  A couple of small copy tweaks when the email address itself was part of the copy.

### Notion Card Links
https://www.notion.so/quill/PS-Link-to-new-sales-forms-instead-of-sales-quill-org-549c09018d3e4f0198f57adec99d2a5f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
