### PR TITLE
Small style tweak in Evidence Banner

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/evidence_promotion_card.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/evidence_promotion_card.scss
@@ -5,6 +5,9 @@
   border: 1px solid rgba(44, 127, 155, 0.15);
   border-radius: 8px;
   background: rgba(44, 127, 155, 0.1);
+  background-image: url("https://assets.quill.org/images/pages/dashboard/books-on-shelf.svg");
+  background-repeat: no-repeat;
+  background-position: 92% 50%;
   .badge-section {
     display: inline-block;
     height: 20px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/evidence_promotion_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/evidence_promotion_card.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 
 import { arrowPointingRightIcon } from '../../../Shared/index'
 
-const bookIllustrationSrc = `${process.env.CDN_URL}/images/pages/dashboard/books-on-shelf.svg`
-
 const EvidencePromotionCard = () => {
 
   return (
@@ -20,7 +18,6 @@ const EvidencePromotionCard = () => {
           <a href={`${process.env.DEFAULT_URL}/tools/evidence`}><span>See tool demo</span><img alt={arrowPointingRightIcon.alt} src={arrowPointingRightIcon.src} /></a>
         </div>
       </div>
-      <img alt="Books on a shelf" className="book-illustration" src={bookIllustrationSrc} />
     </section>
   )
 }


### PR DESCRIPTION
## WHAT
Jack noticed that the Evidence Banner's background image margin is a little too narrow at certain screen sizes, so I'm tweaking it so the margin is consistent throughout all screen sizes.

## WHY
We want the site styling to be consistent and look good across all screen sizes.

## HOW
Change the background image from a static image with `position: absolute` to a CSS background image with a relative positioning based on the size of its container.

### Screenshots
![Screen Shot 2022-11-08 at 3 33 00 PM](https://user-images.githubusercontent.com/57366100/200501902-8f25f0ee-bc89-4380-a13e-54369a06427c.png)


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
