### PR TITLE
Roster uploads/ add downcasing to emails

### DIFF
--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -43,7 +43,7 @@ class Cms::RostersController < Cms::CmsController
           ClassroomsTeacher.create!(user: teacher, classroom: classroom, role: 'owner')
         end
 
-        StudentsClassrooms.create!(student: student, classroom: classroom)
+        StudentsClassrooms.create!(student: student, classroom: classroom) if StudentsClassrooms.find_by(student: student, classroom: classroom).nil?
       end
     end
 

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -27,7 +27,7 @@ class Cms::RostersController < Cms::CmsController
         teacher_email = s[:teacher_email].downcase
         student_email = s[:email].downcase
         next unless student_email
-        raise "Teacher with email #{s[:teacher_email]} does not exist." if User.find_by(email: teacher_email).blank?
+        raise "Teacher with email #{teacher_email} does not exist." if User.find_by(email: teacher_email).blank?
         raise "Please provide a last name or password for student #{s[:name]}, otherwise this account will have no password." if s[:password].blank? && s[:name].split[1].blank?
 
         password = s[:password].present? ? s[:password] : s[:name].split[1]

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -14,7 +14,7 @@ class Cms::RostersController < Cms::CmsController
 
     ActiveRecord::Base.transaction do
       params[:teachers]&.each do |t|
-        email = t[:email].downcase
+        email = t[:email]&.downcase
         next unless email
         raise "Teacher with email #{email} already exists." if User.find_by(email: email).present?
         raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
@@ -25,8 +25,8 @@ class Cms::RostersController < Cms::CmsController
       end
 
       params[:students]&.each do |s|
-        teacher_email = s[:teacher_email].downcase
-        student_email = s[:email].downcase
+        teacher_email = s[:teacher_email]&.downcase
+        student_email = s[:email]&.downcase
         next unless student_email
         raise "Teacher with email #{teacher_email} does not exist." if User.find_by(email: teacher_email).blank?
         raise "Please provide a last name or password for student #{s[:name]}, otherwise this account will have no password." if s[:password].blank? && s[:name].split[1].blank?

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -18,6 +18,7 @@ class Cms::RostersController < Cms::CmsController
         next unless email
         raise "Teacher with email #{email} already exists." if User.find_by(email: email).present?
         raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
+
         password = t[:password].present? ? t[:password] : t[:name].split[1]
         teacher = User.create!(name: t[:name], email: email, password: password, password_confirmation: password, role: 'teacher')
         SchoolsUsers.create!(school: school, user: teacher)

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -14,25 +14,27 @@ class Cms::RostersController < Cms::CmsController
 
     ActiveRecord::Base.transaction do
       params[:teachers]&.each do |t|
-        next unless t[:email]
-        raise "Teacher with email #{t[:email]} already exists." if User.find_by(email: t[:email]).present?
+        email = t[:email].downcase
+        next unless email
+        raise "Teacher with email #{email} already exists." if User.find_by(email: email).present?
         raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
-
         password = t[:password].present? ? t[:password] : t[:name].split[1]
-        teacher = User.create!(name: t[:name], email: t[:email], password: password, password_confirmation: password, role: 'teacher')
+        teacher = User.create!(name: t[:name], email: email, password: password, password_confirmation: password, role: 'teacher')
         SchoolsUsers.create!(school: school, user: teacher)
       end
 
       params[:students]&.each do |s|
-        next unless s[:email]
-        raise "Teacher with email #{s[:teacher_email]} does not exist." if User.find_by(email: s[:teacher_email]).blank?
+        teacher_email = s[:teacher_email].downcase
+        student_email = s[:email].downcase
+        next unless student_email
+        raise "Teacher with email #{s[:teacher_email]} does not exist." if User.find_by(email: teacher_email).blank?
         raise "Please provide a last name or password for student #{s[:name]}, otherwise this account will have no password." if s[:password].blank? && s[:name].split[1].blank?
 
         password = s[:password].present? ? s[:password] : s[:name].split[1]
-        student = User.find_by(email: s[:email])
-        student ||= User.create!(name: s[:name], email: s[:email.downcase], password: password, password_confirmation: password, role: 'student')
+        student = User.find_by(email: student_email)
+        student ||= User.create!(name: s[:name], email: student_email, password: password, password_confirmation: password, role: 'student')
 
-        teacher = User.find_by(email: s[:teacher_email])
+        teacher = User.find_by(email: teacher_email)
         classroom = Classroom.joins(:classrooms_teachers).where("classrooms_teachers.user_id = ?", teacher.id).where(name: s[:classroom]).first
 
         if !classroom

--- a/services/QuillLMS/spec/controllers/cms/rosters_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/rosters_controller_spec.rb
@@ -14,9 +14,12 @@ describe Cms::RostersController do
     let!(:existing_student) { create(:student) }
 
     it 'should create teachers and students based on the data provided, and it should ignore empty items in payload arrays' do
-      teacher_email = "email@test.org"
-      student_email = "studentemail@test.org"
+      teacher_email = "Email@test.org"
+      student_email = "StudentEmail@test.org"
       another_student_email = "anotheremail@test.org"
+      teacher_email_downcased = teacher_email.downcase
+      student_email_downcased = student_email.downcase
+      another_student_email_downcased = another_student_email.downcase
       classroom_name = "Class A"
       post :upload_teachers_and_students, params: {
         school_id: school.id,
@@ -49,15 +52,15 @@ describe Cms::RostersController do
         ]
       }
 
-      teacher = User.find_by(email: teacher_email)
-      student = User.find_by(email: student_email)
-      another_student = User.find_by(email: another_student_email)
+      teacher = User.find_by(email: teacher_email_downcased)
+      student = User.find_by(email: student_email_downcased)
+      another_student = User.find_by(email: another_student_email_downcased)
       classroom = Classroom.find_by(name: classroom_name)
       expect(teacher).to be
       expect(student).to be
       expect(another_student).to be
-      expect(teacher.email).to eq(teacher_email)
-      expect(student.email).to eq(student_email)
+      expect(teacher.email).to eq(teacher_email_downcased)
+      expect(student.email).to eq(student_email_downcased)
       expect(SchoolsUsers.find_by(school: school, user: teacher)).to be
       expect(classroom).to be
       expect(ClassroomsTeacher.find_by(classroom: classroom, user: teacher)).to be


### PR DESCRIPTION
## WHAT
add downcasing to emails in roster uploads

## WHY
this was causing an issue where a user may have been previously created with an email like `Test@email.com`, but the upload may have email `test@email.com` and the query for the existing user would fail due to casing mismatch

## HOW
create email variables with `.downcase` and use them for email fields
 
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Unable-to-bulk-upload-student-rosters-due-to-email-error-d77da4bc1a9a462aa8a44a0f339d72e5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
