### PR TITLE
Add sidekiq-unique-jobs gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -90,6 +90,7 @@ source "https://gems.contribsys.com/" do
 end
 gem 'sidekiq', '~> 5.2.10'
 gem 'sidekiq-retries', require: false
+gem 'sidekiq-unique-jobs'
 gem 'redis', '~> 4.5'
 gem 'redis-namespace'
 gem 'redis-rails'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -139,6 +139,9 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     brakeman (4.1.1)
+    brpoplpush-redis_script (0.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, < 6)
     builder (3.2.4)
     bulk_insert (1.9.0)
       activerecord (>= 3.2.0)
@@ -695,6 +698,11 @@ GEM
       redis (~> 4.5, < 4.6.0)
     sidekiq-retries (0.4.0)
       sidekiq (>= 3.2.4)
+    sidekiq-unique-jobs (7.1.27)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 5.0, < 8.0)
+      thor (>= 0.20, < 3.0)
     signet (0.12.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -895,6 +903,7 @@ DEPENDENCIES
   sidekiq (~> 5.2.10)
   sidekiq-pro!
   sidekiq-retries
+  sidekiq-unique-jobs
   slim-rails
   spring
   spring-commands-rspec

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -4,10 +4,17 @@ sidekiq_url = ENV['SIDEKIQ_REDIS_URL'] || 'redis://localhost:6379'
 
 Sidekiq.configure_server do |config|
   config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
+
+  config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }
+  config.server_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Server }
+
+  SidekiqUniqueJobs::Server.configure(config)
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
+
+  config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }
 end
 
 module SidekiqQueue

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -84,6 +84,8 @@ RSpec.configure do |config|
   config.silence_filter_announcements = true
   config.run_all_when_everything_filtered = true
 
+  config.before { SidekiqUniqueJobs.config.enabled = false }
+
   config.around(:each, :caching) do |example|
     caching = ActionController::Base.perform_caching
     ActionController::Base.perform_caching = example.metadata[:caching]


### PR DESCRIPTION
## WHAT
Add the sidekiq-unique-jobs gem to our stack.

## WHY 
The staggered release [backend](https://github.com/empirical-org/Empirical-Core/pull/9936) will call the job  `SaveUserPackSequenceItemsWorker` for various [reasons](https://www.notion.so/quill/Modeling-UserPackSequenceItem-status-in-the-db-684d74ffc765408fadcfd8aaf5007813) (15 and counting...).  While the jobs are idempotent, the query is complex and not really worth running multiple times.  This gem will give us options for handling non unique jobs from running simultaneously.

## HOW
Add the library to the Gemfile and configure the sidekiq server and client.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just adding a library.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
