### PR TITLE
Fix null function bug in Evidence Activity Stats page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activityStats/activityStats.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activityStats/activityStats.tsx
@@ -29,6 +29,8 @@ const ActivityStats: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
   const [startDateForQuery, setStartDate] = React.useState<string>(initialStartDateString);
   const [endDate, onEndDateChange] = React.useState<Date>(initialEndDate);
   const [endDateForQuery, setEndDate] = React.useState<string>(initialEndDateString);
+  const [responsesForScoring, setResponsesForScoring] = React.useState<boolean>(false);
+  const [responsesForScoringForQuery, setResponsesForScoringForQuery] = React.useState<boolean>(false);
 
   // get cached activity data to pass to rule
   const { data: activityHealthData } = useQuery({
@@ -78,7 +80,7 @@ const ActivityStats: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ hist
 
 
   function handleFilterClick(e: React.SyntheticEvent, passedVersionOption?: DropdownObjectInterface) {
-    handlePageFilterClick({ startDate, endDate, versionOption: passedVersionOption || versionOption, setStartDate, setEndDate, setPageNumber: null, storageKey: ACTIVITY_STATS });
+    handlePageFilterClick({ startDate, endDate, versionOption: passedVersionOption || versionOption, setStartDate, setEndDate, setPageNumber: null, responsesForScoring, setResponsesForScoringForQuery, storageKey: ACTIVITY_STATS,  });
   }
 
   const formattedRows = promptHealth && promptHealth.prompts && Object.values(promptHealth.prompts).map((prompt: PromptHealthInterface) => {


### PR DESCRIPTION
## WHAT
Fix a bug that was breaking the Evidence Activity Stats page.

## WHY
So staff members can use this page to see stats for any Evidence Activity.

## HOW
With this [last round of changes](https://github.com/empirical-org/Empirical-Core/pull/9939), this page didn't get updated. I'm adding the two variables that were newly added to the function so that we don't get a nil error on these variables.

### Screenshots
![Screen Shot 2022-11-01 at 5 33 19 PM](https://user-images.githubusercontent.com/57366100/200820181-11dc9607-d6d1-42f5-81ce-170c63ef3a97.png)


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
