### PR TITLE
Very last style tweaks to Evidence Banner

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/evidence_promotion_card.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/evidence_promotion_card.scss
@@ -7,7 +7,7 @@
   background: rgba(44, 127, 155, 0.1);
   background-image: url("https://assets.quill.org/images/pages/dashboard/books-on-shelf.svg");
   background-repeat: no-repeat;
-  background-position: 92% 50%;
+  background-position: 97% 50%;
   .badge-section {
     display: inline-block;
     height: 20px;
@@ -47,7 +47,7 @@
     line-height: 26px;
     font-weight: 700;
     margin-top: 13px;
-    max-width: 511px;
+    max-width: 606px;
   }
   a {
     margin-top: 32px;
@@ -87,5 +87,11 @@
     .book-illustration {
       display: none;
     }
+  }
+}
+
+@media (max-width: 755px) {
+  .post-checklist-container main section.evidence-promotion-card {
+    background-position: 93% 50%;
   }
 }


### PR DESCRIPTION
## WHAT
We wanted to make one last round of edits to this banner -- change the header to one line instead of two and tweak the margin a little for small screen sizes.

## WHY
We want the banner to look as nice as possible.

## HOW
Increase the width of the banner text and the margin size when the screen is below 755 px.

### Screenshots
![Screen Shot 2022-11-10 at 12 40 10 PM](https://user-images.githubusercontent.com/57366100/201002166-4963d11d-1a9e-428d-8abf-7cc8db0c2b50.png)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tiny changes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
