### PR TITLE
Add left alignment for username column

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -92,6 +92,9 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
   attributeAlignment(attributeName): CSS.TextAlignProperty {
     const { rows, } = this.props
     const numbersRegex = new RegExp(/^[\d#%\.\$]+$/)
+
+    if (attributeName === 'username') { return left }
+
     return rows.every(row => numbersRegex.test(row[attributeName]) || !row[attributeName]) ? right : left
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/__tests__/__snapshots__/view_as_student_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/__tests__/__snapshots__/view_as_student_modal.test.jsx.snap
@@ -2254,7 +2254,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                 style={
                   Object {
                     "minWidth": "361px",
-                    "textAlign": "right",
+                    "textAlign": "left",
                     "width": "361px",
                   }
                 }
@@ -2299,7 +2299,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                   style={
                     Object {
                       "minWidth": "361px",
-                      "textAlign": "right",
+                      "textAlign": "left",
                       "width": "361px",
                     }
                   }
@@ -4778,7 +4778,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                 style={
                   Object {
                     "minWidth": "361px",
-                    "textAlign": "right",
+                    "textAlign": "left",
                     "width": "361px",
                   }
                 }
@@ -4823,7 +4823,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                   style={
                     Object {
                       "minWidth": "361px",
-                      "textAlign": "right",
+                      "textAlign": "left",
                       "width": "361px",
                     }
                   }
@@ -4871,7 +4871,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                   style={
                     Object {
                       "minWidth": "361px",
-                      "textAlign": "right",
+                      "textAlign": "left",
                       "width": "361px",
                     }
                   }
@@ -4919,7 +4919,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                   style={
                     Object {
                       "minWidth": "361px",
-                      "textAlign": "right",
+                      "textAlign": "left",
                       "width": "361px",
                     }
                   }
@@ -4967,7 +4967,7 @@ exports[`ViewAsStudentModal component without a defaultClassroomId should render
                   style={
                     Object {
                       "minWidth": "361px",
-                      "textAlign": "right",
+                      "textAlign": "left",
                       "width": "361px",
                     }
                   }


### PR DESCRIPTION
## WHAT
Fix a bug with that right aligns usernames that can be parsed as integers.

## WHY
Some usernames can be parsed as integers when in fact they should be displayed as a string.  

## HOW
Add an override for username column that returns `left` for the username column.

### Screenshots
![Screen Shot 2022-11-10 at 11 26 30 AM](https://user-images.githubusercontent.com/2057805/201174501-8774298f-2ae1-4706-81b9-47c5e0e2e1ad.png)

### Notion Card Links
https://www.notion.so/quill/Usernames-Clever-IDs-are-not-centered-on-the-username-column-for-Clever-Secure-Sync-classes-bf7be2449a4148c9bc75b39c7894ae8c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
