### PR TITLE
lms/revert-vitally-district-filter

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -47,6 +47,6 @@ class SyncVitallyWorker
   end
 
   def districts_to_sync
-    schools_to_sync.map(&:district).compact.uniq.select { |district| district&.schools&.any?(&:subscription) }
+    schools_to_sync.map(&:district).compact.uniq
   end
 end

--- a/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
@@ -11,11 +11,9 @@ describe SyncVitallyWorker, type: :worker do
       stub_const('ENV', {'SYNC_TO_VITALLY' => 'true'})
     end
 
-    it "make queries for schools, users, and districts and enqueue them for further jobs" do
+    it "make queries for schools and users and enqueue them for further jobs" do
       district = create(:district)
       school = create(:school, district: district)
-      subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
-      create(:school_subscription, school: school, subscription: subscription)
       user = create(:user, role: 'teacher')
       SchoolsUsers.create(school: school, user: user)
 
@@ -42,18 +40,6 @@ describe SyncVitallyWorker, type: :worker do
     it 'does not kick off job for districts without schools with teachers' do
       district = create(:district)
       school = create(:school, district: district)
-      subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
-      create(:school_subscription, school: school, subscription: subscription)
-
-      expect(SyncVitallyOrganizationWorker).not_to receive(:perform_async).with([district.id])
-      worker.perform
-    end
-
-    it 'does not kick off job for districts that have 0 schools with current subscriptions attached to them' do
-      district = create(:district)
-      school = create(:school, district: district)
-      user = create(:user, role: 'teacher')
-      SchoolsUsers.create(school: school, user: user)
 
       expect(SyncVitallyOrganizationWorker).not_to receive(:perform_async).with([district.id])
       worker.perform
@@ -65,8 +51,6 @@ describe SyncVitallyWorker, type: :worker do
       (SyncVitallyWorker::ORGANIZATION_RATE_LIMIT_PER_MINUTE * 3).times do
         district = create(:district)
         school = create(:school, district: district)
-        subscription = create(:subscription, account_type: Subscription::SCHOOL_PAID)
-        create(:school_subscription, school: school, subscription: subscription)
         user = create(:user, role: 'teacher')
         SchoolsUsers.create(school: school, user: user)
       end


### PR DESCRIPTION
## WHAT
Revert "Do not include districts with no paid schools for sync to Vitally (#9827)"
## WHY
This code was introduced around the time that we started experiencing some issues syncing data to Vitally, and while it's not a guarantee that this is causing the issues, the reason we introduced this code isn't currently an issue, so we want to revert it to see if it does fix things.  (Eventually we'll want to re-introduce either this code, or code with a similar purpose, when this does become a valid issue for us.)
## HOW
This reverts commit 28244fd1fcc70b94b982f572fc165ff7bea50f2d.

### Notion Card Links
https://www.notion.so/quill/Vitally-API-Data-Not-Syncing-4a66e71e91e742fc93e563c5f7a6f5c2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, a tiny change that should only impact production
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A