### PR TITLE
Bug fix/ remove added &nbsp; in Evidence response

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -192,7 +192,9 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
     const regex = this.promptAsRegex()
     const caretPosition = EditCaretPositioning.saveSelection(this.editor)
     if (text.match(regex)) {
-      this.setState({ html: value, }, () => EditCaretPositioning.restoreSelection(this.editor, caretPosition))
+      // when a user deletes the last period, a &nbsp; gets appended as the end of the string so we need to remove this
+      const lastSpaceCorrectedValue = value.replace(/&nbsp;<\/p>/, ' </p>')
+      this.setState({ html: lastSpaceCorrectedValue, }, () => EditCaretPositioning.restoreSelection(this.editor, caretPosition))
       // if the student has deleted everything, we want to remove everything but the prompt stem
     } else if (!text.length) {
       this.resetText()


### PR DESCRIPTION
## WHAT
fix bug where in some cases, a `&nbsp;` was being added by the Text Editor when students backspaced on a period

## WHY
we don't want this behavior

## HOW
strip the `&nbsp;` before updating state 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Reading-for-Evidence-bug-Series-of-characters-appear-when-backspace-is-pressed-ca51b484807d410cb0b5ff2c1527b508

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
