### PR TITLE
Fix spacing on admin dashboard page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -281,6 +281,7 @@
             border: 1px solid #C0C0C0;
             border-radius: 8px;
             padding: 16px;
+            margin-bottom: 8px;
             img {
               width: 21px;
               height: auto;


### PR DESCRIPTION
## WHAT
Fix spacing on admin dashboard page.

## WHY
There is no spacing between shools

## HOW
Adding margin-bottom: 

### Screenshots
![Screen Shot 2022-11-16 at 8 12 12 AM](https://user-images.githubusercontent.com/2057805/202190666-69358673-5d2d-4f9c-b68a-b94bff49d24f.png)

### Notion Card Links
https://www.notion.so/quill/Fix-Minor-UI-Issue-on-New-Admin-Dashboard-Page-67c4c929b79844bb9f4f198d3d2a1d0a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
