### PR TITLE
Update redis-namespace so sidekiq UI shows running jobs.

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -92,7 +92,7 @@ gem 'sidekiq', '~> 5.2.10'
 gem 'sidekiq-retries', require: false
 gem 'sidekiq-unique-jobs'
 gem 'redis', '~> 4.5'
-gem 'redis-namespace'
+gem 'redis-namespace', '~> 1.8'
 gem 'redis-rails'
 gem 'redis-rack-cache'
 gem 'actionpack-action_caching'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -613,7 +613,7 @@ GEM
     redis-activesupport (5.3.0)
       activesupport (>= 3, < 8)
       redis-store (>= 1.3, < 2)
-    redis-namespace (1.6.0)
+    redis-namespace (1.8.1)
       redis (>= 3.0.4)
     redis-rack (2.1.4)
       rack (>= 2.0.8, < 3)
@@ -884,7 +884,7 @@ DEPENDENCIES
   react_on_rails (= 11.3.0)
   redcarpet (~> 3.5.1)
   redis (~> 4.5)
-  redis-namespace
+  redis-namespace (~> 1.8)
   redis-rack-cache
   redis-rails
   responders


### PR DESCRIPTION
## WHAT
Currently our sidekiq admin panel isn't showing running jobs. It seems to be because we are on a version of `redis-namespace` that doesn't support `.exists?`

[Github thread](https://github.com/mperham/sidekiq/issues/5262#issuecomment-1085074609) (Fun fact, this commenter was running our exact version of `sidekiq`, `sidekiq-pro`, and `redis-namespace` and had a clear fix and reason. I feel like I found a four-leaf clover or something, that never happens).

[Gem changelog](https://github.com/resque/redis-namespace/blob/master/CHANGELOG.md#181)
## WHY
It's really helpful for debugging to see the running jobs in the sidekiq UI.
## HOW
Bump redis-namespace to `~-> 1.8` from `1.6`
### Screenshots
**Current Prod**
![Screen Shot 2022-11-16 at 1 21 54 PM](https://user-images.githubusercontent.com/1304933/202262246-54c573e7-239e-4b2c-8a6f-bd162c1d57ae.png)

**With change locally**
![Screen Shot 2022-11-16 at 1 23 55 PM](https://user-images.githubusercontent.com/1304933/202262279-2737d7da-ba71-4e89-a006-e52846092db4.png)

### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, config change
Have you deployed to Staging? | Deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
