### PR TITLE
evidence - second layer feedback for grammar

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -77,6 +77,8 @@ module Evidence
     end
 
     def determine_feedback_from_history(feedback_history)
+      return feedbacks.order(:order).first if feedback_history.blank?
+
       relevant_history = feedback_history.filter { |fb| fb['feedback_type'] == rule_type }
       relevant_feedback_text = relevant_history.map { |fb| fb['feedback'] }
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/grammar.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/grammar.rb
@@ -5,7 +5,9 @@ module Evidence
 
     def run
       grammar_client = ::Evidence::Grammar::Client.new(entry: entry, prompt_text: prompt.text)
-      @response = ::Evidence::Grammar::FeedbackAssembler.run(grammar_client.post)
+      @response = ::Evidence::Grammar::FeedbackAssembler.run(
+        client_response: grammar_client.post, previous_feedback: previous_feedback
+      )
     end
 
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
@@ -3,7 +3,7 @@
 module Evidence
   class FeedbackAssembler
     def self.error_to_rule_uid
-      raise NotImplementedError, 'Cannot call #error_to_rule_uid on abstract class FeedbakAssembler'
+      raise NotImplementedError, 'Cannot call #error_to_rule_uid on abstract class FeedbackAssembler'
     end
 
     def self.run(client_response)


### PR DESCRIPTION
## WHAT
Adds second layer feedback to grammar checks. 

## WHY
Product request - we don't want students to get hung up on the same repeating feedback. 

See it work by triggering this postman: https://quill-org.postman.co/workspace/Quill-Team-Workspace~be8cf879-9fa6-4dc5-8544-630985cdf233/request/14211978-44c0549f-6c64-4015-9c49-8dd611163752

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=684267d8a6d140b480a80a1619de80e4&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
