### PR TITLE
Labeled data - strip out nil text

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
@@ -39,6 +39,7 @@ module Evidence
 
         clean_text_and_labels = texts_and_labels
           .keep_if(&:last) # remove blank labels
+          .keep_if(&:first) # remove blank texts
           .uniq(&:first) # remove duplicate texts
 
         @labels = clean_text_and_labels.map(&:last).uniq

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/labeled_data_generator.rb
@@ -37,10 +37,7 @@ module Evidence
         @generators = GENERATORS.slice(*generators)
         @passage = passage if passage
 
-        clean_text_and_labels = texts_and_labels
-          .keep_if(&:last) # remove blank labels
-          .keep_if(&:first) # remove blank texts
-          .uniq(&:first) # remove duplicate texts
+        clean_text_and_labels = labeled_data_cleaner(texts_and_labels)
 
         @labels = clean_text_and_labels.map(&:last).uniq
 
@@ -146,6 +143,13 @@ module Evidence
           .map(&:to_detail_rows)
           .flatten(1)
           .reject(&:empty?)
+      end
+
+      private def labeled_data_cleaner(texts_and_labels)
+        texts_and_labels
+          .keep_if(&:last) # remove blank labels
+          .keep_if(&:first) # remove blank texts
+          .uniq(&:first) # remove duplicate texts
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
@@ -7,6 +7,7 @@ describe Evidence::Synthetic::LabeledDataGenerator do
   let(:label1) {'label_5'}
   let(:text2) {'other text'}
   let(:labeled_data) { [[text1, label1], [text2, 'label_11']] }
+
   let(:mock_translator) { double }
 
   let(:translation_response) do
@@ -23,18 +24,32 @@ describe Evidence::Synthetic::LabeledDataGenerator do
   end
 
   describe '#new' do
-    let(:generator) { described_class.new(labeled_data, languages: [:es])}
+    subject { described_class.new(labeled_data, languages: [:es])}
 
     it 'should setup properly with empty translations' do
-      expect(generator.languages.count).to eq 1
-      expect(generator.results.count).to eq 2
-      expect(generator.manual_types).to be false
+      expect(subject.languages.count).to eq 1
+      expect(subject.results.count).to eq 2
+      expect(subject.manual_types).to be false
 
-      first_result = generator.results.first
+      first_result = subject.results.first
 
       expect(first_result.text).to eq 'text string'
       expect(first_result.label).to eq 'label_5'
       expect(first_result.generated).to eq({})
+    end
+
+    context 'nil entries' do
+      let(:labeled_data) { [[text1, label1], [nil, 'label_11'], [text2, nil]] }
+
+      it 'should remove empty results and load' do
+        expect(subject.results.count).to eq 1
+
+        first_result = subject.results.first
+
+        expect(first_result.text).to eq 'text string'
+        expect(first_result.label).to eq 'label_5'
+        expect(first_result.generated).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
## WHAT
Getting `nil` errors down stream, but the fix is that the `text` and `label` both should be non-nil before processing labeled data.
## WHY
Bug fix to let the labeled synthetic data go through. Also, it doesn't make sense for either the `label` or `text` to be blank in this data set, so it's a better product with this in place.
## HOW
`.keep_if(&:first)`
### Screenshots
![Screen Shot 2022-11-17 at 3 05 56 PM](https://user-images.githubusercontent.com/1304933/202548533-f62cfb9b-bd08-443b-8199-861a1a63982d.png)


### Notion Card Links
https://www.notion.so/quill/Unable-to-generate-labeled-synthetic-data-b2a34b1b6d45491ab165cdf18ab70bf1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | NO - tiny change, tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
