### PR TITLE
Fix bug with nested markup and highlighting

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -467,19 +467,24 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     callSaveActiveActivitySession()
   }, [studentHighlights])
 
+  function stringifiedInnerElementsHelper(node) {
+    if (node.data) { return node.data }
+    if (node.children.length > 0) { return node.children.map(n => stringifiedInnerElementsHelper(n)).join(''); }
+    return ''
+  }
+
   function transformMarkTags(node) {
     const { activeStep } = session;
     const strippedPassageHighlights = getStrippedPassageHighlights({ activities, session, activeStep });
 
     if (['p'].includes(node.name) && activeStep > 1 && strippedPassageHighlights && strippedPassageHighlights.length) {
-      const stringifiedInnerElements = node.children.map(n => {
-        if (n.data) { return n.data }
-        if (n.children[0]) { return n.children[0].data}
-        return ''
-      }).join('')
+      const stringifiedInnerElements = node.children.map(n => stringifiedInnerElementsHelper(n)).join('');
+
       if (!stringifiedInnerElements) { return }
+
       const highlightIncludesElement = strippedPassageHighlights.find(ph => ph.includes(stringifiedInnerElements)) // handles case where passage highlight spans more than one paragraph
       const elementIncludesHighlight = strippedPassageHighlights.find(ph => stringifiedInnerElements.includes(ph)) // handles case where passage highlight is only part of paragraph
+
       if (highlightIncludesElement) {
         return (
           <p>
@@ -501,11 +506,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     if (node.name === 'mark') {
       const shouldBeHighlightable = !doneHighlighting && !showReadTheDirectionsButton && hasStartedReadPassageStep
       let innerElements = node.children.map((n, i) => convertNodeToElement(n, i, transformMarkTags))
-      const stringifiedInnerElements = node.children.map(n => {
-        if (n.data) { return n.data }
-        if (n.children[0]) { return n.children[0].data}
-        return ''
-      }).join('')
+      const stringifiedInnerElements = node.children.map(n => stringifiedInnerElementsHelper(n)).join('');
       let className = ''
       const highlighted = studentHighlights.includes(stringifiedInnerElements)
       if(activeStep === 1 && highlighted) {


### PR DESCRIPTION
## WHAT
Fix an evidence bug involving highlighted passages that contain italicized text.

## WHY
It's preventing highlighting from being shown in some evidence activities.

## HOW
If a node's children have an `<em>` tag, the `node.children[0].data` will cut-off the italic text and anything after it.  Instead, add a recursive method that pulls out the `.data` from children nodes and then joins them together.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Second-layer-highlighting-issue-missing-parts-of-the-passage-da94fd9cf84f4c8390e775aa2f71b956

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
