### PR TITLE
visual bug fixes: navbar menus stay open on hover, Evidence logo resize, dashboard tables aligned correctly in Safari

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
@@ -73,11 +73,10 @@
 
       .data-table {
         overflow: visible;
-        padding: 0px 20px;
-        overflow: visible;
 
         .data-table-row, .data-table-headers {
           padding: 0px 8px;
+          margin: 0px 20px;
         }
       }
 

--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -511,6 +511,8 @@ nav.q-navbar-home {
 .navbar-tooltip-trigger {
   cursor: pointer;
   position: relative;
+  margin-bottom: -40px;
+  padding-bottom: 40px;
   span {
     color: #fff;
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/Header.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/Header.tsx
@@ -10,7 +10,7 @@ import { Tooltip, READ_PASSAGE_STEP_NUMBER, BECAUSE_PASSAGE_STEP_NUMBER, BUT_PAS
 import { onMobile } from '../helpers/containerActionHelpers';
 
 const logoSrc = `${process.env.CDN_URL}/images/logos/quill-logo-white-2022.svg`
-const mobileLogoSrc = `${process.env.CDN_URL}/images/logos/quill-logo-white-2022-mobile.svg`
+const mobileLogoSrc = `${process.env.CDN_URL}/images/logos/quill-logo-white-mobile.svg`
 const helpIcon = `${process.env.CDN_URL}/images/icons/icons-help-white.svg`
 const checkIcon = <img alt={whiteCheckGreenBackgroundIcon.alt} src={whiteCheckGreenBackgroundIcon.src} />;
 

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
             <img
               alt="Quill.org logo"
               className="hide-on-desktop"
-              src="undefined/images/logos/quill-logo-white-2022-mobile.svg"
+              src="undefined/images/logos/quill-logo-white-mobile.svg"
             />
             <img
               alt="Quill.org logo"


### PR DESCRIPTION
## WHAT
Fixes for the following issues:

- navbar menus disappear when you scroll into them unless you've clicked the trigger
- Evidence logo showing up too small in the navbar
- tables on teacher dashboard aren't aligned correctly on Safari

## WHY
We want the site to look nice.

## HOW
Just CSS/HTML changes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/On-our-website-menus-allow-a-user-to-hover-and-then-select-an-item-i-e-not-have-to-click-e1ef0910b19842399c33e627b57af3a0
https://www.notion.so/quill/Minor-UI-alignment-issue-on-the-Home-Overview-page-3dee4b737af14f97afb0140121d4703a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES