### PR TITLE
make sure incorrect concept results for Connect get rolled up correctly

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
@@ -25,6 +25,10 @@ export function getConceptResultsForAttempt(question, attemptIndex, question_typ
     conceptResults = hashToCollection(conceptResultObject) || [];
   }
 
+  if (conceptResults.length === 0 && question_type === 'sentence-fragment-expansion') {
+    return;
+  }
+
   if (conceptResults.length === 0) {
     conceptResults = [{
       conceptUID: question.conceptID,

--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
@@ -17,8 +17,10 @@ export function getConceptResultsForAttempt(question, attemptIndex, question_typ
   const answer = question.attempts[attemptIndex].response.text;
   const attemptNumber = attemptIndex + 1;
   let conceptResults = [];
-  if (question.attempts[attemptIndex].response) {
-    conceptResults = hashToCollection(question.attempts[attemptIndex].response.conceptResults) || [];
+  if (question.attempts[attemptIndex].response?.conceptResults) {
+    conceptResults = hashToCollection(question.attempts[attemptIndex].response.conceptResults) || hashToCollection(question.attempts[attemptIndex].response.concept_results) || [];
+  } else if (question.attempts[attemptIndex].response?.concept_results) {
+    conceptResults = hashToCollection(question.attempts[attemptIndex].response.concept_results) || [];
   }
   if (conceptResults.length === 0 && question_type === 'sentence-fragment-expansion') {
     return;

--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/sharedConceptResultsFunctions.js
@@ -16,25 +16,22 @@ export function getConceptResultsForAttempt(question, attemptIndex, question_typ
   const prompt = question.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '');
   const answer = question.attempts[attemptIndex].response.text;
   const attemptNumber = attemptIndex + 1;
+  const { response, } = question.attempts[attemptIndex]
+
   let conceptResults = [];
-  if (question.attempts[attemptIndex].response?.conceptResults) {
-    conceptResults = hashToCollection(question.attempts[attemptIndex].response.conceptResults) || hashToCollection(question.attempts[attemptIndex].response.concept_results) || [];
-  } else if (question.attempts[attemptIndex].response?.concept_results) {
-    conceptResults = hashToCollection(question.attempts[attemptIndex].response.concept_results) || [];
+
+  if (response) {
+    const conceptResultObject = response.conceptResults || response.concept_results
+    conceptResults = hashToCollection(conceptResultObject) || [];
   }
-  if (conceptResults.length === 0 && question_type === 'sentence-fragment-expansion') {
-    return;
-  }
+
   if (conceptResults.length === 0) {
-    let score;
-    if (question.attempts[attemptIndex].response) {
-      score = question.attempts[attemptIndex].response.optimal;
-    }
     conceptResults = [{
       conceptUID: question.conceptID,
-      correct: score || false,
+      correct: response?.optimal || false,
     }];
   }
+
   return conceptResults.map(conceptResult => ({
     concept_uid: conceptResult.conceptUID,
     question_type,


### PR DESCRIPTION
## WHAT
Fix bug where concept results that were keyed as `.concept_results`, rather than `.conceptResults`, were getting ignored by the concept result rollup function and thus not saved to the LMS.

## WHY
It's important that we show teachers the accurate concept results for their students' responses.

## HOW
I traced back the concept result saving methods from the bug report til I realized where the data issue was coming from here. I couldn't figure out when this bug was introduced - I know it did used to work as expected, but "git blame" etc didn't turn up anything in relevant files. Since questions do generally have `concept_ids` associated with them, teachers would still generally see a negative concept result, just the one belonging to the question and not specific to the error the student made, so this may have been going on for quite a long time. I patched this part of the code to work similarly to how it does in [Grammar](https://github.com/empirical-org/Empirical-Core/blob/fix/make-sure-response-specific-concept-results-get-rolled-up-correctly/services/QuillLMS/client/app/bundles/Grammar/helpers/conceptResultsGenerator.ts#L32), and [made a card on the bug board](https://www.notion.so/quill/Standardize-conceptResults-vs-concept_results-coming-out-of-grading-module-ad0539c4ee9c4478859671c66c78f631) to dive into a refactor of this chunk of the codebase in general, because this is a pretty serious bug and a pretty serious instance of tech debt that I don't want to bite us again. That refactoring, however, will be a pretty significant undertaking.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Incorrect-Submissions-missing-from-Activity-Analysis-2189703c7b994ba58711b9b5208153e3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
