### PR TITLE
Update clever-omniauth gem

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -24,7 +24,7 @@ gem 'bcrypt', '~> 3.1.12'
 gem "doorkeeper", "5.0.3"
 gem 'omniauth', '~> 1.9'
 gem 'omniauth-google-oauth2', '0.6.0'
-gem 'omniauth-clever', '~> 1.2'
+gem 'omniauth-clever', git: 'https://github.com/cm-studios/omniauth-clever'
 gem 'omniauth-rails_csrf_protection'
 gem 'cancancan', '~> 2.3'
 gem 'firebase_token_generator'

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -24,7 +24,7 @@ gem 'bcrypt', '~> 3.1.12'
 gem "doorkeeper", "5.0.3"
 gem 'omniauth', '~> 1.9'
 gem 'omniauth-google-oauth2', '0.6.0'
-gem 'omniauth-clever', git: 'https://github.com/cm-studios/omniauth-clever'
+gem 'omniauth-clever', git: 'https://github.com/Pioneer-Valley-Books/omniauth-clever'
 gem 'omniauth-rails_csrf_protection'
 gem 'cancancan', '~> 2.3'
 gem 'firebase_token_generator'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/cm-studios/omniauth-clever
+  revision: 9b32b15a3daca46aee1011e18e578fd61ec9c23e
+  specs:
+    omniauth-clever (1.1.1)
+      omniauth-oauth2 (~> 1.2)
+
 PATH
   remote: engines/evidence
   specs:
@@ -439,8 +446,6 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth-clever (1.2.2)
-      omniauth-oauth2 (>= 1.1, <= 1.5)
     omniauth-google-oauth2 (0.6.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -845,7 +850,7 @@ DEPENDENCIES
   newrelic_rpm (~> 7.2)
   nokogiri (>= 1.13.2)
   omniauth (~> 1.9)
-  omniauth-clever (~> 1.2)
+  omniauth-clever!
   omniauth-google-oauth2 (= 0.6.0)
   omniauth-rails_csrf_protection
   paperclip

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/cm-studios/omniauth-clever
-  revision: 9b32b15a3daca46aee1011e18e578fd61ec9c23e
+  remote: https://github.com/Pioneer-Valley-Books/omniauth-clever
+  revision: 62d7266cf2d6ac75011af7c72aacc05395d3f467
   specs:
-    omniauth-clever (1.1.1)
-      omniauth-oauth2 (~> 1.2)
+    omniauth-clever (1.2.2)
+      omniauth-oauth2 (>= 1.1)
 
 PATH
   remote: engines/evidence

--- a/services/QuillLMS/config/initializers/omniauth.rb
+++ b/services/QuillLMS/config/initializers/omniauth.rb
@@ -25,6 +25,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever,
     Clever::CLIENT_ID,
     Clever::CLIENT_SECRET,
+    get_user_info: true,
     provider_ignores_state: true
 
   provider :google_oauth2,


### PR DESCRIPTION
## WHAT
Move clever-omniauth gem to a forked repo.

## WHY
Clever is [deprecating](https://dev.clever.com/docs/api-v1-deprecation) API v1 in December 2022.

## HOW
Point the source of the git repo to the fork's url.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-omniauth-clever-with-a-fork-25d408640837417eba4b86d3816e9b46

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Configuration change.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
