### PR TITLE
allow Quill staff to embed videos in Teacher Center articles

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/cms/cms.scss
@@ -215,7 +215,7 @@
         margin: 0 3px;
         text-align: center;
         transition: all 0.3s ease-out;
-        width: 30px;
+        width: min-content;
 
         &:hover {
           box-shadow: 0 2px 1px rgba(0, 0, 0, 0.1);

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/create_or_edit_blog_post.jsx
@@ -183,7 +183,7 @@ export default class CreateOrEditBlogPost extends React.Component {
         body: data
       })
         .then(response => response.json()) // if the response is a JSON object
-        .then(response => this.setState({uploadedImageLink: response.url})); // Handle the success response object
+        .then(response => this.setState({uploadedMediaLink: response.url})); // Handle the success response object
     });
   }
 
@@ -208,6 +208,8 @@ export default class CreateOrEditBlogPost extends React.Component {
   handleInsertBold = () => this.insertMarkdown('**', '**')
 
   handleInsertFileImage = () => this.insertMarkdown('![', '](http://cultofthepartyparrot.com/parrots/hd/parrot.gif)')
+
+  handleInsertIFrame = () => this.insertMarkdown('<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>')
 
   handleInsertH1 = () => this.insertMarkdown('# ')
 
@@ -558,6 +560,7 @@ export default class CreateOrEditBlogPost extends React.Component {
         <i className="fas fa-quote-left" onClick={this.handleInsertQuote} />
         <i className="fas fa-link" onClick={this.handleInsertLink} />
         <i className="fas fa-file-image" onClick={this.handleInsertFileImage} />
+        <i className="fas fa-video" onClick={this.handleInsertIFrame} />
         <i className="fas fa-square" onClick={this.handleInsertPrimaryButton} />
         <i className="far fa-square" onClick={this.handleInsertSecondaryButton} />
       </div>)
@@ -711,7 +714,7 @@ export default class CreateOrEditBlogPost extends React.Component {
       author_id,
       topic,
       externalLink,
-      uploadedImageLink,
+      uploadedMediaLink,
       preview_card_content,
       premium,
       centerImages,
@@ -759,11 +762,11 @@ export default class CreateOrEditBlogPost extends React.Component {
           </div>
 
           <div>
-            <label>Click the square below or drag an image into it to upload an image:</label>
+            <label>Click the square below or drag an image into it to upload an image or video:</label>
             <Dropzone onDrop={this.handleDrop} />
-            <label style={{marginTop: '10px'}}>Here is the link to your uploaded image:</label>
-            <input style={{marginBottom: '0px'}} value={uploadedImageLink} />
-            <a className="link" href="/cms/images" style={{marginBottom: '10px'}} target="_blank">All Uploaded Images</a>
+            <label style={{marginTop: '10px'}}>Here is the link to your uploaded image or video:</label>
+            <input style={{marginBottom: '0px'}} value={uploadedMediaLink} />
+            <a className="link" href="/cms/images" style={{marginBottom: '10px'}} target="_blank">All Uploaded Media</a>
           </div>
 
           <div className="side-by-side">

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -18,7 +18,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.stripe.com",
       "https://youtube.com",
       "https://*.youtube.com",
-      "https://*.amazonaws.com"
+      "https://*.amazonaws.com",
+      "https://loom.com"
     ],
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -19,7 +19,7 @@ SecureHeaders::Configuration.default do |config|
       "https://youtube.com",
       "https://*.youtube.com",
       "https://*.amazonaws.com",
-      "https://loom.com"
+      "https://*.loom.com"
     ],
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -17,7 +17,8 @@ SecureHeaders::Configuration.default do |config|
       "https://stripe.com",
       "https://*.stripe.com",
       "https://youtube.com",
-      "https://*.youtube.com"
+      "https://*.youtube.com",
+      "https://*.amazonaws.com"
     ],
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>


### PR DESCRIPTION
## WHAT
Allow Quill staff to embed videos in Teacher Center articles.

## WHY
This is a requested feature.

## HOW
- whitelist AWS so we can use videos that were directly uploaded there in iFrames
- update copy around uploading media to make it clear that you can also upload videos
- add button in editor to insert iframe code

### Screenshots
<img width="608" alt="Screen Shot 2022-11-29 at 2 40 38 PM" src="https://user-images.githubusercontent.com/18669014/204638691-bdaee9d0-2c2e-4b65-b9f0-0f900bf5387f.png">
<img width="1440" alt="Screen Shot 2022-11-29 at 2 40 10 PM" src="https://user-images.githubusercontent.com/18669014/204638693-f3f2e5f9-cbe8-4400-904f-17075a4775a8.png">

### Notion Card Links
https://www.notion.so/quill/Embedding-Videos-in-Teacher-Center-Articles-cbb1f553d9a44a34a6d7bf0cf2e29383

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Not yet - deploying tomorrow
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
