### PR TITLE
allow use of ampersands in rules analysis search

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -182,7 +182,8 @@ const RuleAnalysis = ({ match }) => {
   function filterResponsesBySearch(r) {
     if (search.length) {
       try {
-        return new RegExp(search, 'i').test(r.entry) || new RegExp(search, 'i').test(r.api?.original_rule_name)
+        const searchParticles = search.split('&&');
+        return searchParticles.every(sp => new RegExp(sp, 'i').test(r.entry) || new RegExp(sp, 'i').test(r.api?.original_rule_name))
       } catch (e) {
         return false
       }


### PR DESCRIPTION
## WHAT
Allow use of double ampersand to mean `must include both` in regex search on rules analysis.

## WHY
Rachel requested this feature because it is consistent with what we do elsewhere.

## HOW
Just add some logic that splits on the `&&` and requires all fragments to be present.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Missing-from-Regex-abilities-in-Evidence-Rules-Analysis-search-3cb81015a99d4df2a3a3717a36ffa02f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
