### PR TITLE
move now() query into ruby

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -342,7 +342,7 @@ class Teachers::UnitsController < ApplicationController
       else
         unit['number_of_assigned_students'] = 0
       end
-      unit['scheduled'] = unit['ua_publish_date'].to_time(:utc) >= time_now_utc
+      unit['scheduled'] = unit['ua_publish_date']&.to_time(:utc) >= time_now_utc
       unit
     end
   end

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -261,6 +261,7 @@ class Teachers::UnitsController < ApplicationController
             ELSE ua.created_at #{user_timezone_offset_string}
           END AS publish_date,
           state.completed,
+          ua.publish_date AS ua_publish_date,
           activities.id AS activity_id,
           activities.uid as activity_uid,
           #{scores}
@@ -341,7 +342,7 @@ class Teachers::UnitsController < ApplicationController
       else
         unit['number_of_assigned_students'] = 0
       end
-      unit['scheduled'] = unit['publish_date'].to_time >= time_now_utc
+      unit['scheduled'] = unit['ua_publish_date'].to_time(:utc) >= time_now_utc
       unit
     end
   end

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -260,7 +260,6 @@ class Teachers::UnitsController < ApplicationController
             THEN ua.publish_date #{user_timezone_offset_string}
             ELSE ua.created_at #{user_timezone_offset_string}
           END AS publish_date,
-          ua.publish_date >= NOW() AS scheduled,
           state.completed,
           activities.id AS activity_id,
           activities.uid as activity_uid,
@@ -332,6 +331,8 @@ class Teachers::UnitsController < ApplicationController
       SQL
     ).to_a
 
+    time_now_utc = Time.now.utc
+
     units.map do |unit|
       classroom_student_ids = Classroom.find(unit['classroom_id']).students.ids
       if unit['assigned_student_ids'] && classroom_student_ids
@@ -340,6 +341,7 @@ class Teachers::UnitsController < ApplicationController
       else
         unit['number_of_assigned_students'] = 0
       end
+      unit['scheduled'] = unit['publish_date'].to_time >= time_now_utc
       unit
     end
   end

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -342,7 +342,7 @@ class Teachers::UnitsController < ApplicationController
       else
         unit['number_of_assigned_students'] = 0
       end
-      unit['scheduled'] = unit['ua_publish_date']&.to_time(:utc) >= time_now_utc
+      unit['scheduled'] = unit['ua_publish_date'].nil? ? nil : unit['ua_publish_date'].to_time(:utc) >= time_now_utc
       unit
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -277,7 +277,6 @@ describe Teachers::UnitsController, type: :controller do
         unit_activity.update_columns(publish_date: publish_date)
         response = get :index, params: { report: false }
         parsed_response = JSON.parse(response.body)
-        # this one here
         expect(parsed_response[0]['scheduled']).to eq(false)
       end
     end

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -277,6 +277,7 @@ describe Teachers::UnitsController, type: :controller do
         unit_activity.update_columns(publish_date: publish_date)
         response = get :index, params: { report: false }
         parsed_response = JSON.parse(response.body)
+        # this one here
         expect(parsed_response[0]['scheduled']).to eq(false)
       end
     end


### PR DESCRIPTION
## WHAT
Move a calculation of `scheduled` out of postgres and into ruby.

## WHY
the presence of now() is preventing the query from being cached.

## HOW
Add a new select column for `ua.publish_date` and then use that value to make the comparison outside the query.  

NB `[string].time_now` without a parameter defaults to `:local`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
