### PR TITLE
Fix intermittent failing specs

### DIFF
--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -157,7 +157,9 @@ class UnitTemplate < ApplicationRecord
         .where("classroom_units.classroom_id IN (?)", current_user&.classrooms_i_teach&.map(&:id))
         .where("unit_activities.activity_id = ?", id)
         .where("units.visible AND classroom_units.visible AND unit_activities.visible = ?", true)
+        .order("units.created_at")
         .uniq
+
       next if units.empty?
 
       results[id] = units.map do |unit|


### PR DESCRIPTION
## WHAT
1. Fix intermittent failing [specs](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/19215/workflows/f27fd811-914d-4e9c-9596-9e1cada78026/jobs/251416) involving teachers classrooms controller.

2. Fix an intermittent failing [spec](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/19215/workflows/14279e91-8228-471e-bb7e-1e554c4b527f/jobs/251430) involving unit_template query

## WHY
1.  
2. Units get pulled in via a query that is nondeterministic in its ordering

## HOW
1. Adjust specs to sort_by classrooms created_at instead of how they are listed in spec.
2. Add order clause in querying for units to ensure deterministic behavior

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
