### PR TITLE
Add a 7-day reminder for upcoming Stripe renewals

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -129,7 +129,7 @@ class Subscription < ApplicationRecord
   scope :paid_with_card, -> { where.not(stripe_invoice_id: nil).or(where(payment_method: 'Credit Card')) }
   scope :for_schools, -> { where(account_type: OFFICIAL_SCHOOL_TYPES) }
   scope :for_teachers, -> { where(account_type: OFFICIAL_TEACHER_TYPES) }
-  scope :expiring, -> (date) { where(expiration: date) }
+  scope :expiring, ->(date) { where(expiration: date) }
 
   def self.create_and_attach_subscriber(subscription_attrs, subscriber)
     if !subscription_attrs[:expiration]

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -127,6 +127,9 @@ class Subscription < ApplicationRecord
   scope :not_stripe, -> { where(stripe_invoice_id: nil) }
   scope :started, -> { where("start_date <= ?", Date.current) }
   scope :paid_with_card, -> { where.not(stripe_invoice_id: nil).or(where(payment_method: 'Credit Card')) }
+  scope :for_schools, -> { where(account_type: OFFICIAL_SCHOOL_TYPES) }
+  scope :for_teachers, -> { where(account_type: OFFICIAL_TEACHER_TYPES) }
+  scope :expiring, -> (date) { where(expiration: date) }
 
   def self.create_and_attach_subscriber(subscription_attrs, subscriber)
     if !subscription_attrs[:expiration]

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -47,8 +47,10 @@ module SegmentIo
     PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
     TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
     TEACHER_SCHOOL_NOT_LISTED = 'Teacher school not listed'
-    TEACHER_SUB_WILL_RENEW = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
-    SCHOOL_SUB_WILL_RENEW = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    # renewing subscriptions
+    TEACHER_SUB_WILL_RENEW_IN_30 = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
+    SCHOOL_SUB_WILL_RENEW_IN_30 = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    # expiring subscriptions
     TEACHER_SUB_WILL_EXPIRE_IN_30 = 'Teacher Premium Expires in 30 Days | Automatic Renewal Off'
     SCHOOL_SUB_WILL_EXPIRE_IN_30 = 'School Premium Expires in 30 Days | Automatic Renewal Off'
     TEACHER_SUB_WILL_EXPIRE_IN_14 = 'Teacher Premium Expires in 14 Days | Automatic Renewal Off'

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -50,6 +50,8 @@ module SegmentIo
     # renewing subscriptions
     TEACHER_SUB_WILL_RENEW_IN_30 = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
     SCHOOL_SUB_WILL_RENEW_IN_30 = 'School Premium Renews in 30 Days | Automatic Renewal On'
+    TEACHER_SUB_WILL_RENEW_IN_7 = 'Teacher Premium Renews in 7 Days | Automatic Renewal On'
+    SCHOOL_SUB_WILL_RENEW_IN_7 = 'School Premium Renews in 7 Days | Automatic Renewal On'
     # expiring subscriptions
     TEACHER_SUB_WILL_EXPIRE_IN_30 = 'Teacher Premium Expires in 30 Days | Automatic Renewal Off'
     SCHOOL_SUB_WILL_EXPIRE_IN_30 = 'School Premium Expires in 30 Days | Automatic Renewal Off'

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -14,30 +14,33 @@ class AlertSoonToExpireSubscriptionsWorker
   SCHOOL_EXPIRE_IN_30 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30
   SCHOOL_EXPIRE_IN_14 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14
 
+  # Send a segment event for each credit card subscription that is expiring soon
+  # to trigger specific reminder emails from Intercom
+  # Events/emails differ on time, school/teacher, and whether auto-renew is on (renewing vs. expiring)
   def perform
     current_time = Time.current
     in_30_days = current_time + 30.days
     in_14_days = current_time + 14.days
     in_7_days = current_time + 7.days
 
-    # renewing
-    track_teachers(paid_renewing_subs.for_teachers.expiring(in_30_days), TEACHER_RENEW_IN_30)
-    track_teachers(paid_renewing_subs.for_teachers.expiring(in_7_days), TEACHER_RENEW_IN_7)
-    track_schools(paid_renewing_subs.for_schools.expiring(in_30_days), SCHOOL_RENEW_IN_30)
-    track_schools(paid_renewing_subs.for_schools.expiring(in_7_days), SCHOOL_RENEW_IN_7)
+    # renewing subscriptions (credit card only)
+    track_teachers(renewing_subs.for_teachers.expiring(in_30_days), TEACHER_RENEW_IN_30)
+    track_teachers(renewing_subs.for_teachers.expiring(in_7_days), TEACHER_RENEW_IN_7)
+    track_schools(renewing_subs.for_schools.expiring(in_30_days), SCHOOL_RENEW_IN_30)
+    track_schools(renewing_subs.for_schools.expiring(in_7_days), SCHOOL_RENEW_IN_7)
 
-    # expiring
-    track_teachers(paid_expiring_subs.for_teachers.expiring(in_30_days), TEACHER_EXPIRE_IN_30)
-    track_teachers(paid_expiring_subs.for_teachers.expiring(in_14_days), TEACHER_EXPIRE_IN_14)
-    track_schools(paid_expiring_subs.for_schools.expiring(in_30_days), SCHOOL_EXPIRE_IN_30)
-    track_schools(paid_expiring_subs.for_schools.expiring(in_14_days), SCHOOL_EXPIRE_IN_14)
+    # expiring subscriptions (credit card only)
+    track_teachers(expiring_subs.for_teachers.expiring(in_30_days), TEACHER_EXPIRE_IN_30)
+    track_teachers(expiring_subs.for_teachers.expiring(in_14_days), TEACHER_EXPIRE_IN_14)
+    track_schools(expiring_subs.for_schools.expiring(in_30_days), SCHOOL_EXPIRE_IN_30)
+    track_schools(expiring_subs.for_schools.expiring(in_14_days), SCHOOL_EXPIRE_IN_14)
   end
 
-  private def paid_renewing_subs
+  private def renewing_subs
     Subscription.paid_with_card.recurring
   end
 
-  private def paid_expiring_subs
+  private def expiring_subs
     Subscription.paid_with_card.not_recurring
   end
 

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -24,16 +24,16 @@ class AlertSoonToExpireSubscriptionsWorker
     in_7_days = current_time + 7.days
 
     # renewing subscriptions (credit card only)
-    track_teachers(renewing_subs.for_teachers.expiring(in_30_days), TEACHER_RENEW_IN_30)
-    track_teachers(renewing_subs.for_teachers.expiring(in_7_days), TEACHER_RENEW_IN_7)
-    track_schools(renewing_subs.for_schools.expiring(in_30_days), SCHOOL_RENEW_IN_30)
-    track_schools(renewing_subs.for_schools.expiring(in_7_days), SCHOOL_RENEW_IN_7)
+    track_teachers(renewing_subs.expiring(in_30_days), TEACHER_RENEW_IN_30)
+    track_teachers(renewing_subs.expiring(in_7_days), TEACHER_RENEW_IN_7)
+    track_schools(renewing_subs.expiring(in_30_days), SCHOOL_RENEW_IN_30)
+    track_schools(renewing_subs.expiring(in_7_days), SCHOOL_RENEW_IN_7)
 
     # expiring subscriptions (credit card only)
-    track_teachers(expiring_subs.for_teachers.expiring(in_30_days), TEACHER_EXPIRE_IN_30)
-    track_teachers(expiring_subs.for_teachers.expiring(in_14_days), TEACHER_EXPIRE_IN_14)
-    track_schools(expiring_subs.for_schools.expiring(in_30_days), SCHOOL_EXPIRE_IN_30)
-    track_schools(expiring_subs.for_schools.expiring(in_14_days), SCHOOL_EXPIRE_IN_14)
+    track_teachers(expiring_subs.expiring(in_30_days), TEACHER_EXPIRE_IN_30)
+    track_teachers(expiring_subs.expiring(in_14_days), TEACHER_EXPIRE_IN_14)
+    track_schools(expiring_subs.expiring(in_30_days), SCHOOL_EXPIRE_IN_30)
+    track_schools(expiring_subs.expiring(in_14_days), SCHOOL_EXPIRE_IN_14)
   end
 
   private def renewing_subs
@@ -49,10 +49,10 @@ class AlertSoonToExpireSubscriptionsWorker
   end
 
   private def track_teachers(finder, event)
-    finder.each {|sub| analytics.track_teacher_subscription(sub, event) }
+    finder.for_teachers.each {|sub| analytics.track_teacher_subscription(sub, event) }
   end
 
   private def track_schools(finder, event)
-    finder.each {|sub| analytics.track_school_subscription(sub, event) }
+    finder.for_schools.each {|sub| analytics.track_school_subscription(sub, event) }
   end
 end

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -6,6 +6,8 @@ class AlertSoonToExpireSubscriptionsWorker
 
   TEACHER_RENEW_IN_30 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30
   SCHOOL_RENEW_IN_30 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30
+  TEACHER_RENEW_IN_7 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_7
+  SCHOOL_RENEW_IN_7 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_7
 
   TEACHER_EXPIRE_IN_30 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30
   TEACHER_EXPIRE_IN_14 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14
@@ -20,7 +22,9 @@ class AlertSoonToExpireSubscriptionsWorker
 
     # renewing
     track_teachers(paid_renewing_subs.for_teachers.expiring(in_30_days), TEACHER_RENEW_IN_30)
+    track_teachers(paid_renewing_subs.for_teachers.expiring(in_7_days), TEACHER_RENEW_IN_7)
     track_schools(paid_renewing_subs.for_schools.expiring(in_30_days), SCHOOL_RENEW_IN_30)
+    track_schools(paid_renewing_subs.for_schools.expiring(in_7_days), SCHOOL_RENEW_IN_7)
 
     # expiring
     track_teachers(paid_expiring_subs.for_teachers.expiring(in_30_days), TEACHER_EXPIRE_IN_30)

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -16,8 +16,8 @@ class AlertSoonToExpireSubscriptionsWorker
     school_subs_expiring_in_fourteen = Subscription.paid_with_card.where(account_type: Subscription::OFFICIAL_SCHOOL_TYPES, expiration: current_time + 14.days, recurring: false)
 
     analytics = SegmentAnalytics.new
-    teacher_subs_renewing_in_thirty.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW) }
-    school_subs_renewing_in_thirty.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW) }
+    teacher_subs_renewing_in_thirty.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30) }
+    school_subs_renewing_in_thirty.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30) }
     teacher_subs_expiring_in_thirty.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30) }
     school_subs_expiring_in_thirty.each { |sub| analytics.track_school_subscription(sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30) }
     teacher_subs_expiring_in_fourteen.each { |sub| analytics.track_teacher_subscription(sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14) }

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -138,9 +138,9 @@ describe 'SegmentAnalytics' do
     let!(:other_user_subscription) { create(:user_subscription, user: teacher, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_teacher_subscription(subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      analytics.track_teacher_subscription(subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end
@@ -162,7 +162,7 @@ describe 'SegmentAnalytics' do
     let!(:other_school_subscription) { create(:school_subscription, school: school, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
@@ -179,7 +179,7 @@ describe 'SegmentAnalytics' do
     end
 
     it 'sends an event with anonymous ID if there is no purchaser id' do
-      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:user_id]).to eq(nil)
       expect(track_calls[0][:anonymous_id]).to be

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -164,7 +164,7 @@ describe 'SegmentAnalytics' do
     it 'sends an event with information about the subscription for recurring subscriptions' do
       analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -27,8 +27,8 @@ describe AlertSoonToExpireSubscriptionsWorker do
     end
 
     it 'should trigger the teacher subscription will renew event in segment' do
-      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
-      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
@@ -48,7 +48,7 @@ describe AlertSoonToExpireSubscriptionsWorker do
     it 'should not trigger the event for subscriptions that are not paid for with credit card' do
       renewing_teacher_subscription.update(payment_method: 'Invoice')
 
-      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       subject.perform
     end
   end

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -9,14 +9,16 @@ describe AlertSoonToExpireSubscriptionsWorker do
     let(:analytics) { double(:analytics).as_null_object }
     let!(:user) { create(:user) }
     let(:school) { create(:school)}
-    let!(:renewing_teacher_subscription) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
-    let!(:renewing_school_subscription) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:renewing_teacher_subscription30) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:renewing_school_subscription30) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 30.days)}
+    let!(:renewing_teacher_subscription7) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: true, expiration: Time.zone.today + 7.days)}
+    let!(:renewing_school_subscription7) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: true, expiration: Time.zone.today + 7.days)}
     let!(:expiring_30_teacher_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 30.days)}
     let!(:expiring_30_school_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 30.days)}
     let!(:expiring_14_teacher_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'Teacher Paid', recurring: false, expiration: Time.zone.today + 14.days)}
     let!(:expiring_14_school_sub) { create(:subscription, payment_method: 'Credit Card', account_type: 'School Paid', recurring: false, expiration: Time.zone.today + 14.days)}
-    let(:user_subscription) { create(:user_subscription, user: user, subscription: renewing_teacher_subscription)}
-    let(:school_subscription) { create(:school_subscription, school: school, subscription: renewing_school_subscription)}
+    let(:user_subscription) { create(:user_subscription, user: user, subscription: renewing_teacher_subscription30)}
+    let(:school_subscription) { create(:school_subscription, school: school, subscription: renewing_school_subscription30)}
     let(:user_subscription_two) { create(:user_subscription, user: user, subscription: expiring_30_teacher_subscription)}
     let(:school_subscription_two) { create(:school_subscription, school: school, subscription: expiring_30_school_subscription)}
     let(:user_subscription_three) { create(:user_subscription, user: user, subscription: expiring_14_teacher_subscription)}
@@ -27,8 +29,11 @@ describe AlertSoonToExpireSubscriptionsWorker do
     end
 
     it 'should trigger the teacher subscription will renew event in segment' do
-      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
-      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription30, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription7, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_7)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription7, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_7)
+
       expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
@@ -46,9 +51,9 @@ describe AlertSoonToExpireSubscriptionsWorker do
     end
 
     it 'should not trigger the event for subscriptions that are not paid for with credit card' do
-      renewing_teacher_subscription.update(payment_method: 'Invoice')
+      renewing_teacher_subscription30.update(payment_method: 'Invoice')
 
-      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       subject.perform
     end
   end


### PR DESCRIPTION
## WHAT
Add a 7-day reminder for upcoming Stripe renewals by sending another segment event. DRY up the code a little bit since we keep adding to this.
## WHY
Partnerships thinks another reminder will be helpful 7 days out.
## HOW
Small refactor, but just send the specific segment event for the subset of teachers and schools with expirations in 7 days.
### Screenshots


### Notion Card Links
https://www.notion.so/PS-Add-additional-Segment-events-related-to-automatic-subscription-renewals-7-days-out-83996fa6a5b8472e98b3ee2df68ecf70

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
