### PR TITLE
Add more logging to clever login

### DIFF
--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -28,8 +28,9 @@ module Auth
       else
         ErrorNotifier.report(
           CleverAccountConflictError.new, {
+            clever_redirect: session[ApplicationController::CLEVER_REDIRECT],
             current_user_email: current_user&.email,
-            auth_hash_email: auth_hash['info']['email'],
+            new_email: auth_hash['info']['email'],
             validation_errors: current_user&.errors&.full_messages&.join('|')
           }
         )


### PR DESCRIPTION
## WHAT
Rename logged variable `auth_hash_email` to `new_email`
Add logging for `session[CLEVER_REDIRECT]`.

## WHY
The auth_hash_email value is scrubbed in [sentry](https://sentry.io/organizations/quillorg-5s/issues/3683081307/?project=11238&query=is%3Aunresolved+clever&referrer=issue-stream&statsPeriod=14d), so let's rename it to `new_email`
![Screenshot 2022-12-06 at 7 03 52 AM](https://user-images.githubusercontent.com/2057805/205907115-16cfdc4d-b4e7-4857-a992-0a99b981832c.png)

This information should be helpful in understanding an outstanding [bug](https://www.notion.so/quill/Admin-cannot-link-account-to-Clever-14509384f99e447b9b1f1bfc907197fa)

## HOW
Rename logged variable.  

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Admin-cannot-link-account-to-Clever-14509384f99e447b9b1f1bfc907197fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
