### PR TITLE
put jest code in the right file

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/finish_set_up/__tests__/finish_set_up.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/finish_set_up/__tests__/finish_set_up.test.tsx
@@ -4,6 +4,12 @@ import { mount } from 'enzyme';
 
 import FinishSetUp from '../finish_set_up';
 
+jest.mock('qs', () => ({
+  default: {
+    parse: jest.fn(() => ({}))
+  }
+}))
+
 describe('FinishSetUp component', () => {
   const props = {
     email: 'emilia@quill.org',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/finish_set_up/finish_set_up.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/finish_set_up/finish_set_up.tsx
@@ -10,12 +10,6 @@ import { requestPut, } from '../../../../../modules/request/index'
 const SCHOOL_ADMIN = 'school admin'
 const DISTRICT_ADMIN = 'district admin'
 
-jest.mock('qs', () => ({
-  default: {
-    parse: jest.fn(() => ({}))
-  }
-}))
-
 const accountTypeCopy = (accountType) => {
   switch(accountType) {
     case SCHOOL_ADMIN:


### PR DESCRIPTION
## WHAT
In the PR that just went out, as I was writing tests, I accidentally put some code that referenced jest in the file being tested rather than the test file. The tests passed but in the production `env`, `jest` was undefined, causing an error.

## WHY
We want the sign up flow to load.

## HOW
Just move this definition to the correct file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES