### PR TITLE
Staggered Release Endpoints Part 7

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -605,11 +605,11 @@ class ActivitySession < ApplicationRecord
     exists?(classroom_unit_id: classroom_unit_id_or_ids, activity_id: activity_id_or_ids, state: STATE_STARTED)
   end
 
-  private def record_teacher_activity_feed
-    teachers.each { |teacher| TeacherActivityFeed.add(teacher.id, id) }
+  def save_user_pack_sequence_items
+    SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id)
   end
 
-  private def save_user_pack_sequence_items
-    SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id)
+  private def record_teacher_activity_feed
+    teachers.each { |teacher| TeacherActivityFeed.add(teacher.id, id) }
   end
 end

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -210,7 +210,10 @@ class Classroom < ApplicationRecord
     return 'Clever' if clever_classroom?
   end
 
-  # Clever integration
+  def save_user_pack_sequence_items
+    students.each { |student| SaveUserPackSequenceItemsWorker.perform_async(id, student.id) }
+  end
+
   private def clever_classroom
     Clever::Section.retrieve(clever_id, teacher.districts.first.token)
   end
@@ -224,9 +227,5 @@ class Classroom < ApplicationRecord
     teachers.each do |teacher|
       TeacherActivityFeedRefillWorker.perform_async(teacher.id)
     end
-  end
-
-  private def save_user_pack_sequence_items
-    students.each { |student| SaveUserPackSequenceItemsWorker.perform_async(id, student.id) }
   end
 end

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -33,7 +33,7 @@ class PackSequenceItem < ApplicationRecord
 
   delegate :classroom, to: :pack_sequence
 
-  private def save_user_pack_sequence_items
+  def save_user_pack_sequence_items
     users.each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id) }
   end
 end

--- a/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
+++ b/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
@@ -73,10 +73,11 @@ class IndependentPracticePacksAssigner < ApplicationService
   end
 
   private def selections_with_students
-    @selections_with_students ||=
+    @selections_with_students ||= begin
       selections
         .select { |selection| selection[:classrooms][0][:student_ids]&.compact&.any? }
         .map { |selection| selection.permit(:id, classrooms: [:id, :order, student_ids: []]).to_h }
+    end
   end
 
   private def set_diagnostic_recommendations_start_time

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -6,17 +6,15 @@ class AssignRecommendationsWorker
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def perform(options={})
-    options = options.with_indifferent_access
-
-    assign_on_join = options[:assign_on_join] || false
-    assigning_all_recommendations = options[:assigning_all_recommendations] || false
-    classroom_id = options[:classroom_id]
-    is_last_recommendation = options[:is_last_recommendation]
-    lesson = options[:lesson]
-    order = options[:order]
-    pack_sequence_id = options[:pack_sequence_id]
-    student_ids = options[:student_ids]
-    unit_template_id = options[:unit_template_id]
+    assign_on_join = options['assign_on_join'] || false
+    assigning_all_recommendations = options['assigning_all_recommendations'] || false
+    classroom_id = options['classroom_id']
+    is_last_recommendation = options['is_last_recommendation']
+    lesson = options['lesson']
+    order = options['order']
+    pack_sequence_id = options['pack_sequence_id']
+    student_ids = options['student_ids']
+    unit_template_id = options['unit_template_id']
 
     classroom = Classroom.find(classroom_id)
     teacher = classroom.owner

--- a/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class BatchAssignRecommendationsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  def perform(assigning_all_recommendations, pack_sequence_id, selections_with_students)
+    return if selections_with_students.empty?
+
+    last_recommendation_index = selections_with_students.length - 1
+
+    batch = Sidekiq::Batch.new
+    batch.on(:success, self.class, pack_sequence_id: pack_sequence_id)
+
+    batch.jobs do
+      selections_with_students.each_with_index do |selection, index|
+        classroom = selection['classrooms'][0]
+
+        AssignRecommendationsWorker.perform_async(
+          {
+            'assigning_all_recommendations' => assigning_all_recommendations,
+            'classroom_id' => classroom['id'],
+            'is_last_recommendation' => index == last_recommendation_index,
+            'lesson' => false,
+            'order' => classroom['order'],
+            'pack_sequence_id' => pack_sequence_id,
+            'student_ids' => classroom['student_ids'].compact,
+            'unit_template_id' => selection['id']
+          }
+        )
+      end
+    end
+  end
+
+  def on_success(_status, options)
+    return if options['pack_sequence_id'].nil?
+
+    PackSequence
+      .find(options['pack_sequence_id'])
+      &.save_user_pack_sequence_items
+  end
+end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+require 'sidekiq/pro/web'
 require 'staff_constraint'
 
 EmpiricalGrammar::Application.routes.draw do

--- a/services/QuillLMS/spec/services/independent_practice_packs_assigner_spec.rb
+++ b/services/QuillLMS/spec/services/independent_practice_packs_assigner_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe IndependentPracticePacksAssigner do
 
     it { expect { subject }.to change(Unit, :count).from(0).to(1) }
 
-    it 'assigns no recommendations' do
-      expect(AssignRecommendationsWorker).not_to receive(:perform_async)
+    it 'initiates BatchAssignRecommendationsWorker' do
+      expect(BatchAssignRecommendationsWorker).not_to receive(:perform_async)
       subject
     end
   end
@@ -74,8 +74,8 @@ RSpec.describe IndependentPracticePacksAssigner do
 
     it { expect { subject }.to change(Unit, :count).from(0).to(2) }
 
-    it 'assigns two recommendations' do
-      expect(AssignRecommendationsWorker).to receive(:perform_async).twice
+    it 'initiates BatchAssignRecommendationsWorker' do
+      expect(BatchAssignRecommendationsWorker).to receive(:perform_async)
       subject
     end
   end

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -18,14 +18,14 @@ describe AssignRecommendationsWorker do
 
   let(:args) do
     {
-      pack_sequence_id: pack_sequence_id,
-      assigning_all_recommendations: assigning_all_recommendations,
-      classroom_id: classroom.id,
-      is_last_recommendation: is_last_recommendation,
-      lesson: lesson,
-      order: order,
-      student_ids: [student.id],
-      unit_template_id: unit_template.id
+      'assigning_all_recommendations' => assigning_all_recommendations,
+      'classroom_id' => classroom['id'],
+      'is_last_recommendation' => is_last_recommendation,
+      'lesson' => lesson,
+      'order' => order,
+      'pack_sequence_id' => pack_sequence_id,
+      'student_ids' => [student.id],
+      'unit_template_id' => unit_template.id
     }
   end
 


### PR DESCRIPTION
## WHAT
Add batch processing of AssignRecommendationWorkers for independent practice activity packs.

## WHY
Recommendations are currently [assigned](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb#L325) via a loop of AssignRecommendationWorkers. 

Once all of the recommendations have been assigned, (i.e. each worker is finished), the PackSequence object should to recompute all UserPackSequenceItem statuses, but not before all Recommendations Workers are finished otherwise there might be activity packs assigned to a classroom that haven't been included in the calculation of locked and unlocked.

## HOW
Sidekiq Pro has a [batch](https://github.com/mperham/sidekiq/wiki/Batches) mode that triggers actions that depend on asynchronous jobs completing via [callbacks](https://github.com/mperham/sidekiq/wiki/Batches#callbacks). 

1) Create a batch `batch = Sidekiq::Batch.new`
2) Add a callback for on success: `batch.on(:success, BatchAssignRecommendationWorker, { pack_sequence_id: pack_sequence_id })`
3) Wrap the jobs in a batch: `batch.jobs { AssignRecommendationWorker.perform... }`
4) After the jobs complete, `BatchAssignRecommendationsWorker.new.on_success(status, options)` is called.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Staggered-release-for-diagnostic-recommendations-7b11a96525d847f5b7e2ec5280a32f70

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
