### PR TITLE
Add more examples fields to Synthetic Data Seed data

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -151,9 +151,7 @@ const SeedDataForm = ({ history, match }) => {
         />
         <button
           className='x-button'
-          id={index}
-          onClick={e => removeExample(conjunction, index, exampleIndex}
-          value={conjunction}
+          onClick={() => removeExample(conjunction, index, exampleIndex}
         >
           <img alt="quill-circle-checkmark" src={quillCloseX} />
         </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -43,6 +43,19 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(data)
   }
 
+  function onAddExample(e) {
+    const { target } = e;
+    const { id, value } = target;
+    addExample(value, id);
+  }
+
+  function addExample(conjunction, index) {
+    const data = {...labelConfigs}
+
+    data[conjunction][index].examples.push('')
+    setLabelConfigs(data)
+  }
+
   function onAddLabelConfigs(e) {
     const { target } = e;
     const { value } = target;
@@ -140,7 +153,16 @@ const SeedDataForm = ({ history, match }) => {
           />
         </div>
         {labelConfig.examples.map((example, exampleIndex) => renderExample(example, index, conjunction, exampleIndex))}
+        <button
+          className='quill-button fun secondary outlined'
+          id={index}
+          onClick={onAddExample}
+          value={conjunction}
+        >
+          <span className='plus'>+</span>
 
+          &nbsp;Add Example
+        </button>
       </div>
     );
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -151,7 +151,7 @@ const SeedDataForm = ({ history, match }) => {
         />
         <button
           className='x-button'
-          onClick={() => removeExample(conjunction, index, exampleIndex}
+          onClick={() => removeExample(conjunction, index, exampleIndex)}
         >
           <img alt="quill-circle-checkmark" src={quillCloseX} />
         </button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -18,7 +18,7 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
-  const blankLabelConfig = { label: '', examples: ['',''], };
+  const blankLabelConfig = { label: '', examples: ['','',''], };
   const blankLabelConfigs = { [BECAUSE] : [], [BUT] : [], [SO] : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -43,13 +43,6 @@ const SeedDataForm = ({ history, match }) => {
     setLabelConfigs(data)
   }
 
-  function onRemoveExample(e) {
-    const { target } = e;
-    const { id, name, value, } = target;
-
-    removeExample(value, id, name);
-  }
-
   function removeExample(conjunction, index, exampleIndex) {
     const data = {...labelConfigs}
     const exampleData = data[conjunction][index].examples

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -4,7 +4,7 @@ import ReactHtmlParser from 'react-html-parser'
 
 import SubmissionModal from '../shared/submissionModal';
 import { fetchActivity, createSeedData } from '../../../utils/evidence/activityAPIs';
-import { renderHeader } from "../../../helpers/evidence/renderHelpers";
+import { renderHeader, quillCloseX } from "../../../helpers/evidence/renderHelpers";
 import { Input, Spinner } from '../../../../Shared/index';
 import { TITLE, BECAUSE, BUT, SO } from "../../../../../constants/evidence";
 
@@ -39,6 +39,23 @@ const SeedDataForm = ({ history, match }) => {
 
     conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
+
+    setLabelConfigs(data)
+  }
+
+  function onRemoveExample(e) {
+    const { target } = e;
+    const { id, name, value, } = target;
+
+    removeExample(value, id, name);
+  }
+
+  function removeExample(conjunction, index, exampleIndex) {
+    const data = {...labelConfigs}
+    const exampleData = data[conjunction][index].examples
+
+    exampleData.splice(exampleIndex, 1)
+    data[conjunction][index].examples = exampleData
 
     setLabelConfigs(data)
   }
@@ -125,11 +142,22 @@ const SeedDataForm = ({ history, match }) => {
 
   function renderExample(value, index, conjunction, exampleIndex) {
     return (
-      <Input
-        handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
-        label={`Example ${exampleIndex + 1}`}
-        value={value}
-      />
+      <div className='example-container'>
+        <Input
+          className="example-input"
+          handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
+          label={`Example ${exampleIndex + 1}`}
+          value={value}
+        />
+        <button
+          className='x-button'
+          id={index}
+          onClick={e => removeExample(conjunction, index, exampleIndex}
+          value={conjunction}
+        >
+          <img alt="quill-circle-checkmark" src={quillCloseX} />
+        </button>
+      </div>
     );
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/renderHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/renderHelpers.tsx
@@ -8,6 +8,8 @@ import { RULE_TYPE_TO_ROUTE_PART, RULE_TYPE_TO_NAME } from "../../../../constant
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
 
+export const quillCloseX = '/images/x.svg';
+
 export const getCheckIcon = (value: boolean) => {
   if(value) {
     return (<img alt="quill-circle-checkmark" src={quillCheckmark} />)

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -25,6 +25,15 @@
     width: 25%;
     min-width: 100px;
   }
+  .example-container {
+    position: relative
+  }
+  .x-button {
+    position: absolute;
+    right: 0;
+    bottom: 20px;
+    z-index: 1;
+  }
   .plus {
     font-size: 30px;
   }


### PR DESCRIPTION
## WHAT
Increase seed label examples from 2 to 3 and add the ability to add more examples and remove examples.
## WHY
The Curriculum Team usually needs a little more data than the 2 examples provide, so we're adding a third. Plus they'd prefer controls to add more/less examples if needed.
## HOW
1. Increase default
2. Add a "Add Example button"
3. Add an `X` button to remove an example.
### Screenshots
![Screenshot 2022-12-07 at 1 18 24 PM](https://user-images.githubusercontent.com/1304933/206264199-cdef0b7c-affe-4156-92c6-4470cd72ba0a.png)


### Notion Card Links

https://www.notion.so/quill/Synthetic-Data-Increase-Number-of-example-fields-allow-add-remove-examples-b115ac81dc1a412198d3750c24176cf4
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'NO', just form changes, backend didn't change
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
