### PR TITLE
Staggered Release Endpoints Part 8

### DIFF
--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -75,7 +75,13 @@ class ActivitiesController < ApplicationController
     return redirect_to profile_path unless current_user.student?
 
     if authorized_activity_access?
-      redirect_to activity_session_from_classroom_unit_and_activity_path(classroom_unit, activity)
+      if activity.locked_user_pack_sequence_item?(current_user)
+        flash[:error] = t('activity_link.errors.activity_locked')
+        flash.keep(:error)
+        redirect_to classes_path
+      else
+        redirect_to activity_session_from_classroom_unit_and_activity_path(classroom_unit, activity)
+      end
     else
       flash[:error] = t('activity_link.errors.activity_not_assigned')
       flash.keep(:error)

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -76,7 +76,7 @@ class ActivitiesController < ApplicationController
 
     if authorized_activity_access?
       if activity.locked_user_pack_sequence_item?(current_user)
-        flash[:error] = t('activity_link.errors.activity_locked')
+        flash[:error] = t('activity_link.errors.user_pack_sequence_item_locked')
         flash.keep(:error)
         redirect_to classes_path
       else

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -44,6 +44,7 @@ class Unit < ApplicationRecord
   has_many :activities, through: :unit_activities
   has_many :standards, through: :activities
   has_many :pack_sequence_items, dependent: :destroy
+  has_many :user_pack_sequence_items, through: :pack_sequence_items
 
   default_scope { where(visible: true)}
 

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -39,6 +39,9 @@ class UserPackSequenceItem < ApplicationRecord
 
   delegate :classroom, to: :pack_sequence_item
 
+  scope :locked, -> { where(status: LOCKED) }
+  scope :unlocked, -> { where(status: UNLOCKED) }
+
   def save_user_pack_sequence_items
     SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id)
   end

--- a/services/QuillLMS/config/locales/en.yml
+++ b/services/QuillLMS/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
     errors:
       activity_not_assigned: 'Sorry, you do not have access to this activity because it has not been assigned to you. Please contact your teacher.'
       activity_pack_not_assigned: 'Sorry, you do not have access to this activity pack because it has not been assigned to you. Please contact your teacher.'
+      activity_locked: 'Sorry, you do not have access to this activity as it is locked.  Please contact your teacher.'
   clever:
     account_conflict: "This Clever account is already associated with another Quill account. Contact support@quill.org for further assistance."
   actioncontroller:

--- a/services/QuillLMS/config/locales/en.yml
+++ b/services/QuillLMS/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
     errors:
       activity_not_assigned: 'Sorry, you do not have access to this activity because it has not been assigned to you. Please contact your teacher.'
       activity_pack_not_assigned: 'Sorry, you do not have access to this activity pack because it has not been assigned to you. Please contact your teacher.'
-      activity_locked: 'Sorry, you do not have access to this activity as it is locked.  Please contact your teacher.'
+      user_pack_sequence_item_locked: 'Sorry, this activity is locked.  To unlock it, you will have to complete the activity packs that come before it.'
   clever:
     account_conflict: "This Clever account is already associated with another Quill account. Contact support@quill.org for further assistance."
   actioncontroller:

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -120,7 +120,7 @@ describe ActivitiesController, type: :controller, redis: true do
           it 'redirects and raises an error' do
             subject
             expect(response).to redirect_to classes_path
-            expect(flash[:error]).to eq I18n.t('activity_link.errors.activity_locked')
+            expect(flash[:error]).to match I18n.t('activity_link.errors.user_pack_sequence_item_locked')
           end
         end
 

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -107,6 +107,32 @@ describe ActivitiesController, type: :controller, redis: true do
         subject
         expect(response).to redirect_to activity_session_from_classroom_unit_and_activity_path(classroom_unit, activity)
       end
+
+      context 'check for locked user_pack_sequence_item' do
+        before do
+          allow(Activity).to receive(:find_by_id_or_uid).with(activity.id.to_s).and_return(activity)
+          allow(activity).to receive(:locked_user_pack_sequence_item?).and_return(locked)
+        end
+
+        context 'activity is locked' do
+          let(:locked) { true }
+
+          it 'redirects and raises an error' do
+            subject
+            expect(response).to redirect_to classes_path
+            expect(flash[:error]).to eq I18n.t('activity_link.errors.activity_locked')
+          end
+        end
+
+        context 'activity is unlocked' do
+          let(:locked) { false }
+
+          it 'redirects the appropriate activity session' do
+            subject
+            expect(response).to redirect_to activity_session_from_classroom_unit_and_activity_path(classroom_unit, activity)
+          end
+        end
+      end
     end
 
     context 'student is not assigned to classroom_unit' do
@@ -129,9 +155,10 @@ describe ActivitiesController, type: :controller, redis: true do
     context 'unit activity does not exist' do
       let(:another_activity) { create(:activity) }
 
-      it 'redirects to the classrooms page' do
+      it 'redirects and raises an error' do
         get :activity_session, params: { id: another_activity.id, classroom_unit_id: classroom_unit.id }
         expect(response).to redirect_to classes_path
+        expect(flash[:error]).to match I18n.t('activity_link.errors.activity_not_assigned')
       end
     end
   end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -702,4 +702,33 @@ describe Activity, type: :model, redis: true do
       end
     end
   end
+
+  describe '#locked_user_pack_sequence_item?' do
+    subject { activity.locked_user_pack_sequence_item?(user) }
+
+    let(:user) { create(:student) }
+
+    context 'no user_pack_sequence_items' do
+      it { expect(subject).to eq false }
+    end
+
+    context 'user_pack_sequence_item exists' do
+      let(:unit) { create(:unit_activity, activity: activity).unit }
+      let(:pack_sequence_item) { create(:pack_sequence_item, unit: unit) }
+
+      before { create(:user_pack_sequence_item, status, user: user, pack_sequence_item: pack_sequence_item) }
+
+      context 'user_pack_sequence_item is locked' do
+        let(:status) { :locked }
+
+        it { expect(subject).to eq true }
+      end
+
+      context 'user_pack_sequence_item is unlocked' do
+        let(:status) { :unlocked }
+
+        it { expect(subject).to eq false }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Add redirection to activity links for students who have not unlocked a particular activity.

## WHY
Teachers share activity links with their students, but some might be locked based on a particular student's current progress.  If it is locked, redirect the user.

## HOW
Add a check `activity.locked_user_pack_sequence_item?(user)` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Staggered-release-for-diagnostic-recommendations-7b11a96525d847f5b7e2ec5280a32f70#1e086610d85847a09533cadefcd5b5f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | 'YES'
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
