### PR TITLE
Nightly data calculation and caching for Evidence Prompt Health (#10007)

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class RuleFeedbackHistory
-  def self.generate_report(conjunction:, activity_id:, start_date: nil, end_date: nil)
-    sql_result = exec_query(conjunction: conjunction, activity_id: activity_id, start_date: start_date, end_date: end_date)
+  def self.generate_report(conjunction:, activity_id:, start_date: nil, end_date: nil, activity_version: nil)
+    sql_result = exec_query(conjunction: conjunction, activity_id: activity_id, start_date: start_date, end_date: end_date, activity_version: activity_version)
     format_sql_results(sql_result)
   end
 
-  def self.exec_query(conjunction:, activity_id:, start_date:, end_date:)
+  def self.exec_query(conjunction:, activity_id:, start_date:, end_date:, activity_version: nil)
     query = Evidence::Rule.select(<<~SELECT
       comprehension_rules.id,
       comprehension_rules.uid AS rules_uid,
@@ -34,6 +34,7 @@ class RuleFeedbackHistory
     .includes(:feedbacks)
     query = query.where("feedback_histories.time >= ?", start_date) if start_date
     query = query.where("feedback_histories.time <= ?", end_date) if end_date
+    query = query.where("feedback_histories.activity_version = ?", activity_version) if activity_version
     query
   end
 

--- a/services/QuillLMS/app/queries/prompt_feedback_history.rb
+++ b/services/QuillLMS/app/queries/prompt_feedback_history.rb
@@ -18,12 +18,6 @@ class PromptFeedbackHistory
       COUNT(DISTINCT CASE WHEN flag = 'repeated-non-consecutive' THEN feedback_histories.feedback_session_uid END) AS num_sessions_non_consecutive_repeated,
       COUNT(DISTINCT CASE WHEN attempt = 1 AND optimal = true THEN feedback_histories.feedback_session_uid END) AS num_first_attempt_optimal,
       COUNT(DISTINCT CASE WHEN attempt = 1 AND optimal = false THEN feedback_histories.feedback_session_uid END) AS num_first_attempt_not_optimal,
-      AVG(CAST(CASE
-        WHEN comprehension_prompts.conjunction = 'because' THEN (data->>'time_tracking')::json->>'because'
-        WHEN comprehension_prompts.conjunction = 'but' THEN (data->>'time_tracking')::json->>'but'
-        WHEN comprehension_prompts.conjunction = 'so' THEN (data->>'time_tracking')::json->>'so'
-        ELSE '0'
-      END AS int)) AS avg_time_spent,
       AVG(CAST((feedback_histories.metadata->>'api')::json->>'confidence' AS float)) AS avg_confidence
     SELECT
     )
@@ -40,8 +34,39 @@ class PromptFeedbackHistory
     query
   end
 
-  def self.serialize_results(results)
-    results.to_h { |result| [result.prompt_id, ResultSerializer.new(result).run] }
+  def self.average_time_spent_query(prompt_id:, start_date: nil, end_date: nil, activity_version: nil)
+    inner_query = ActivitySession.unscoped.select(<<~SELECT
+      CAST(CASE
+        WHEN comprehension_prompts.conjunction = 'because' THEN (activity_sessions.data->>'time_tracking')::json->>'because'
+        WHEN comprehension_prompts.conjunction = 'but' THEN (activity_sessions.data->>'time_tracking')::json->>'but'
+        WHEN comprehension_prompts.conjunction = 'so' THEN (activity_sessions.data->>'time_tracking')::json->>'so'
+        ELSE '0'
+      END AS int) AS time_spent
+    SELECT
+    )
+      .joins('RIGHT JOIN feedback_sessions ON feedback_sessions.activity_session_uid = activity_sessions.uid')
+      .joins('RIGHT JOIN feedback_histories ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
+      .joins('RIGHT JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')
+      .where('feedback_histories.used = true')
+      .where('feedback_histories.prompt_id = ?', prompt_id)
+      .group('activity_sessions.id, comprehension_prompts.conjunction')
+
+    inner_query = inner_query.where("feedback_histories.activity_version = ?", activity_version) if activity_version
+    inner_query = inner_query.where("feedback_histories.created_at >= ?", start_date) if start_date
+    inner_query = inner_query.where("feedback_histories.created_at <= ?", end_date) if end_date
+    inner_query = inner_query.to_sql
+
+    time_spent = ActivitySession.unscoped.select('avg(time_spent) agg_sessions').from(
+      "(#{inner_query}) as agg_sessions"
+    ).to_a
+
+    time_spent[0]['agg_sessions']
+  end
+
+  def self.serialize_results(results, start_date: nil, end_date: nil, activity_version: nil)
+    results.to_h { |result|
+      [result.prompt_id, ResultSerializer.new(result, average_time_spent_query(prompt_id: result.prompt_id, start_date: start_date, end_date: end_date, activity_version: activity_version)).run]
+    }
   end
 
   class ResultSerializer
@@ -59,10 +84,11 @@ class PromptFeedbackHistory
       :total_responses
     ]
 
-    attr_reader :payload, :result
+    attr_reader :payload, :result, :time_spent
 
-    def initialize(result)
+    def initialize(result, time_spent)
       @result = result
+      @time_spent = time_spent
       @payload = result.serializable_hash(only: SERIALIZED_ATTRIBUTES, include: [])
     end
 
@@ -70,9 +96,9 @@ class PromptFeedbackHistory
       payload.merge(
         'avg_attempts' => avg_attempts,
         'avg_confidence' => avg_confidence,
-        'avg_time_spent' => avg_time_spent,
         'num_sessions_with_consecutive_repeated_rule' =>  result.num_sessions_consecutive_repeated,
-        'num_sessions_with_non_consecutive_repeated_rule' => result.num_sessions_non_consecutive_repeated
+        'num_sessions_with_non_consecutive_repeated_rule' => result.num_sessions_non_consecutive_repeated,
+        'avg_time_spent' => time_spent && Utils::Numeric.seconds_to_human_readable_time(time_spent)
       )
     end
 
@@ -82,10 +108,6 @@ class PromptFeedbackHistory
 
     def avg_confidence
       payload['avg_confidence'] ? payload['avg_confidence'].round(2) * 100 : 0
-    end
-
-    def avg_time_spent
-      payload['avg_time_spent'] ? Utils::Numeric.seconds_to_human_readable_time(payload['avg_time_spent']) : 0
     end
   end
 

--- a/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
 class SerializeEvidenceActivityHealth
+  attr_reader :activity, :prompt_feedback_history
 
-  def initialize(activity)
+  def initialize(activity, prompt_feedback_history)
     @activity = activity
+    @prompt_feedback_history = prompt_feedback_history
   end
 
   def data
     {
-      name: @activity.title,
-      flag: @activity.flag.to_s,
-      activity_id: @activity.id,
-      version: @activity.version,
-      version_plays: FeedbackHistory.get_total_count({activity_id: @activity.id, activity_version: @activity.version}),
-      total_plays: FeedbackHistory.get_total_count({activity_id: @activity.id}),
+      name: activity.title,
+      flag: activity.flag.to_s,
+      activity_id: activity.id,
+      version: activity.version,
+      version_plays: FeedbackHistory.get_total_count({activity_id: activity.id, activity_version: activity.version}),
+      total_plays: FeedbackHistory.get_total_count({activity_id: activity.id}),
       completion_rate: activity_feedback_history[:average_completion_rate],
       because_final_optimal: percent_final_optimal_for_conjunction(FeedbackHistory::BECAUSE),
       but_final_optimal: percent_final_optimal_for_conjunction(FeedbackHistory::BUT),
@@ -23,23 +25,21 @@ class SerializeEvidenceActivityHealth
   end
 
   def prompt_data
-    # TODO: fill this in to return serialized prompt health objects
-    []
+    prompts = activity.prompts
+    return [] if prompts.empty?
+
+    prompts.map {|p| SerializeEvidencePromptHealth.new(p, prompt_feedback_history).data }
   end
 
   private def percent_final_optimal_for_conjunction(conjunction)
-    prompt = @activity.prompts.find_by(conjunction: conjunction)
+    prompt = activity.prompts.find_by(conjunction: conjunction)
     return nil unless prompt && prompt_feedback_history[prompt.id]
 
     ((prompt_feedback_history[prompt.id]["num_final_attempt_optimal"].to_f / prompt_feedback_history[prompt.id]["session_count"]) * 100).round
   end
 
   private def activity_feedback_history
-    @activity_feedback_history ||= ActivityFeedbackHistory.run({activity_id: @activity.id, activity_version: @activity.version})
-  end
-
-  private def prompt_feedback_history
-    @prompt_feedback_history ||= PromptFeedbackHistory.run({activity_id: @activity.id, activity_version: @activity.version})
+    @activity_feedback_history ||= ActivityFeedbackHistory.run({activity_id: activity.id, activity_version: activity.version})
   end
 
 end

--- a/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class SerializeEvidencePromptHealth
+
+  attr_accessor :prompt, :prompt_feedback_history
+
+  def initialize(prompt, prompt_feedback_history)
+    @prompt = prompt
+    @prompt_feedback_history = prompt_feedback_history
+  end
+
+  def data
+    {
+      prompt_id: prompt.id,
+      activity_short_name: prompt.activity.notes,
+      text: prompt.text,
+      current_version: prompt.activity.version,
+      version_responses: prompt_feedback_history[prompt.id]["total_responses"],
+      first_attempt_optimal: num_first_attempts > 0 ? ((prompt_feedback_history[prompt.id]["num_first_attempt_optimal"] / num_first_attempts.to_f) * 100).round : nil,
+      final_attempt_optimal: num_final_attempts > 0 ? ((prompt_feedback_history[prompt.id]["num_final_attempt_optimal"] / num_final_attempts.to_f) * 100).round : nil,
+      avg_attempts: prompt_feedback_history[prompt.id]["avg_attempts"].round(1),
+      confidence: prompt_feedback_history[prompt.id]["avg_confidence"] ? prompt_feedback_history[prompt.id]["avg_confidence"] / 100 : nil,
+      percent_automl_consecutive_repeated: percent_automl_consecutive_repeated,
+      percent_automl: percent_responses_for_api(FeedbackHistory::AUTO_ML),
+      percent_plagiarism: percent_responses_for_api(FeedbackHistory::PLAGIARISM),
+      percent_opinion: percent_responses_for_api(FeedbackHistory::OPINION),
+      percent_grammar: percent_responses_for_api(FeedbackHistory::GRAMMAR),
+      percent_spelling: percent_responses_for_api(FeedbackHistory::SPELLING),
+      avg_time_spent_per_prompt: prompt_feedback_history[prompt.id]["avg_time_spent"] ? Utils::Numeric.human_readable_time_to_seconds(prompt_feedback_history[prompt.id]["avg_time_spent"]) : nil
+    }
+  end
+
+  private def rule_feedback_histories
+    @rule_feedback_histories ||= RuleFeedbackHistory.generate_report({activity_id: prompt.activity.id, conjunction: prompt.conjunction, activity_version: prompt.activity.version})
+  end
+
+  private def total_responses
+    @total_responses ||= rule_feedback_histories.map { |fh| fh[:total_responses] }.sum || 0
+  end
+
+  private def num_first_attempts
+    prompt_feedback_history[prompt.id]["num_first_attempt_optimal"] + prompt_feedback_history[prompt.id]["num_first_attempt_not_optimal"]
+  end
+
+  private def num_final_attempts
+    prompt_feedback_history[prompt.id]["num_final_attempt_optimal"] + prompt_feedback_history[prompt.id]["num_final_attempt_not_optimal"]
+  end
+
+  private def percent_responses_for_api(api_type)
+    return nil if total_responses == 0
+
+    (((rule_feedback_histories.select {|fh| fh[:api_name] == api_type }.map { |fh| fh[:total_responses]}.sum || 0) / total_responses.to_f) * 100).round
+  end
+
+  private def percent_automl_consecutive_repeated
+    automl_histories = rule_feedback_histories.select {|fh| fh[:api_name] == FeedbackHistory::AUTO_ML }
+    return nil if automl_histories.empty?
+
+    total_responses = automl_histories.map { |fh| fh[:total_responses] }.sum
+    repeated_consecutive = automl_histories.map { |fh| fh[:repeated_consecutive_responses] }.sum
+
+    ((repeated_consecutive / total_responses.to_f) * 100).round
+  end
+
+end

--- a/services/QuillLMS/app/workers/populate_aggregated_evidence_activity_healths_worker.rb
+++ b/services/QuillLMS/app/workers/populate_aggregated_evidence_activity_healths_worker.rb
@@ -3,15 +3,16 @@
 class PopulateAggregatedEvidenceActivityHealthsWorker
   include Sidekiq::Worker
 
-  INTERVAL = 180 # 3 minutes
+  INTERVAL = 120 # 3 minutes
 
   def perform
     Evidence::ActivityHealth.destroy_all
     # execute this command to start primary key indices back from 1
     ActiveRecord::Base.connection.execute("TRUNCATE evidence_activity_healths RESTART IDENTITY CASCADE")
 
+    evidence_activities = Evidence::Activity.all.reject { |a| a.flag == Flags::ARCHIVED.to_sym }
     # spread these, to cut down on DB resource contention.
-    Evidence::Activity.pluck(:id).each.with_index do |id, index|
+    evidence_activities.pluck(:id).each.with_index do |id, index|
       PopulateEvidenceActivityHealthWorker.perform_in(index * INTERVAL, id)
     end
   end

--- a/services/QuillLMS/app/workers/populate_evidence_activity_health_worker.rb
+++ b/services/QuillLMS/app/workers/populate_evidence_activity_health_worker.rb
@@ -7,13 +7,14 @@ class PopulateEvidenceActivityHealthWorker
   def perform(id)
     @activity = Evidence::Activity.find(id)
 
-    serializer = SerializeEvidenceActivityHealth.new(@activity)
+    prompt_feedback_history = PromptFeedbackHistory.run(activity_id: @activity.id, activity_version: @activity.version)
+    serializer = SerializeEvidenceActivityHealth.new(@activity, prompt_feedback_history)
     activity_health = Evidence::ActivityHealth.create(serializer.data)
 
     return unless activity_health.valid?
 
     serializer.prompt_data&.each do |prompt_data|
-      Evidence::PromptHealth.create!(prompt_data.merge({activity_health: activity_health}))
+      Evidence::PromptHealth.create!(prompt_data.merge({evidence_activity_health_id: activity_health.id}))
     end
   end
 end

--- a/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe PromptFeedbackHistory, type: :model do
       generate_feedback_history(@prompt1.id, time_spent: 60)
       generate_feedback_history(@prompt1.id, time_spent: 120)
 
-      result = PromptFeedbackHistory.prompt_health_query(activity_id: @main_activity.id)
+      result = PromptFeedbackHistory.average_time_spent_query(prompt_id: @prompt1.id)
 
-      expect(result.all[0].avg_time_spent).to eq(90)
+      expect(result).to eq(90)
     end
 
     it 'should calculate the average confidence spent as confidence' do

--- a/services/QuillLMS/spec/services/serialize_evidence_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_activity_health_spec.rb
@@ -10,9 +10,9 @@ describe 'SerializeEvidenceActivityHealth' do
     @previous_version = @activity.version
     @activity.increment_version!
 
-    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @but_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @so_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
+    @but_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'but', text: 'Some feedback text but', max_attempts_feedback: 'Feedback')
+    @so_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'so', text: 'Some feedback text so', max_attempts_feedback: 'Feedback')
 
     @activity_session1 = create(:activity_session, state: "finished", timespent: 600)
     @activity_session2 = create(:activity_session, state: "finished", timespent: 300)
@@ -40,54 +40,75 @@ describe 'SerializeEvidenceActivityHealth' do
     create(:feedback_history_flag, feedback_history: @first_session_feedback1, flag: FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE)
     create(:feedback_history_rating, user_id: @user.id, rating: true, feedback_history_id: @first_session_feedback3.id)
     create(:feedback_history_rating, user_id: @user.id, rating: false, feedback_history_id: @first_session_feedback4.id)
+
+    @prompt_feedback_history = PromptFeedbackHistory.run({activity_id: @activity.id, activity_version: @activity.version})
   end
 
   it 'gets the correct basic data for that activity' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:name]).to eq(@activity.title)
     expect(data[:flag]).to eq(@activity.flag.to_s)
     expect(data[:version]).to eq(@activity.version)
     expect(data[:activity_id]).to eq(@activity.id)
   end
 
+  it 'returns prompt data for the activity' do
+    prompt_data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).prompt_data
+    expect(prompt_data.size).to eq(3)
+
+    because_data = prompt_data.select {|pd| pd[:prompt_id] == @because_prompt1.id}.first
+    but_data = prompt_data.select {|pd| pd[:prompt_id] == @but_prompt1.id}.first
+    so_data = prompt_data.select {|pd| pd[:prompt_id] == @so_prompt1.id}.first
+
+    expect(because_data).to be
+    expect(because_data[:text]).to eq(@because_prompt1.text)
+    expect(because_data[:current_version]).to eq(@activity.version)
+    expect(because_data[:version_responses]).to eq(3)
+    expect(but_data[:first_attempt_optimal]).to eq(100)
+    expect(so_data[:first_attempt_optimal]).to eq(0)
+    expect(so_data[:final_attempt_optimal]).to eq(0)
+    expect(because_data[:avg_attempts]).to eq(1.5)
+  end
+
   it 'gets the correct data for version plays' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:version_plays]).to eq(2)
   end
 
   it 'gets the correct data for total plays' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:total_plays]).to eq(3)
   end
 
   it 'gets the correct completion rate' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:completion_rate]).to eq(50)
   end
 
   it 'gets the correct because_final_optimal percent' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:because_final_optimal]).to eq(50)
   end
 
   it 'gets the correct but_final_optimal percent' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:but_final_optimal]).to eq(100)
   end
 
   it 'gets the correct so_final_optimal percent' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:so_final_optimal]).to eq(0)
   end
 
   it 'gets the correct average completion time' do
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    data = SerializeEvidenceActivityHealth.new(@activity, @prompt_feedback_history).data
     expect(data[:avg_completion_time]).to eq(400)
   end
 
   it 'returns nil for relevent columns if there are no feedback histories yet' do
     @activity.increment_version!
-    data = SerializeEvidenceActivityHealth.new(@activity).data
+    prompt_feedback_history = PromptFeedbackHistory.run({activity_id: @activity.id, activity_version: @activity.version})
+    data = SerializeEvidenceActivityHealth.new(@activity, prompt_feedback_history).data
     expect(data[:name]).to eq(@activity.title)
     expect(data[:flag]).to eq(@activity.flag.to_s)
     expect(data[:version]).to eq(@activity.version)

--- a/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'SerializeEvidencePromptHealth' do
+
+  before do
+    @activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @activity.update(flag: "production")
+    @previous_version = @activity.version
+    @activity.increment_version!
+
+    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
+    @activity_session1 = create(:activity_session, state: "finished", data: {time_tracking: {because: 600}})
+    @activity_session2 = create(:activity_session, state: "finished", data: {time_tracking: {because: 250}})
+    @activity_session3 = create(:activity_session, state: "started", data: {time_tracking: {because: 200}})
+    @activity_session4 = create(:activity_session, state: "finished")
+    @activity_session5 = create(:activity_session, state: "finished", data: {time_tracking: {because: 100}})
+    @activity_session1_uid = @activity_session1.uid
+    @feedback_session1_uid = FeedbackSession.get_uid_for_activity_session(@activity_session1_uid)
+    @activity_session2_uid = @activity_session2.uid
+    @feedback_session2_uid = FeedbackSession.get_uid_for_activity_session(@activity_session2_uid)
+    @activity_session3_uid = @activity_session3.uid
+    @feedback_session3_uid = FeedbackSession.get_uid_for_activity_session(@activity_session3_uid)
+    @activity_session4_uid = @activity_session4.uid
+    @feedback_session4_uid = FeedbackSession.get_uid_for_activity_session(@activity_session4_uid)
+    @activity_session5_uid = @activity_session5.uid
+    @feedback_session5_uid = FeedbackSession.get_uid_for_activity_session(@activity_session5_uid)
+    @comprehension_turking_round = create(:comprehension_turking_round_activity_session, activity_session_uid: @activity_session1_uid)
+
+    @automl_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_AUTOML)
+    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @automl_rule)
+    @plagiarism_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_PLAGIARISM)
+    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @plagiarism_rule)
+    @opinion_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_OPINION)
+    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @opinion_rule)
+    @grammar_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_GRAMMAR)
+    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @grammar_rule)
+    @spelling_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_SPELLING)
+    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @spelling_rule)
+
+    @user = create(:user)
+    @first_session_feedback1 = create(:feedback_history, feedback_session_uid: @activity_session1_uid, prompt_id: @because_prompt1.id, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.99}}, rule_uid: @automl_rule.uid)
+    @first_session_feedback2 = create(:feedback_history, feedback_session_uid: @activity_session1_uid, prompt_id: @because_prompt1.id, attempt: 2, optimal: true, activity_version: @activity.version, metadata: {api: {confidence: 0.87}}, rule_uid: @plagiarism_rule.uid)
+
+    @second_session_feedback = create(:feedback_history, feedback_session_uid: @activity_session2_uid, prompt_id: @because_prompt1.id, optimal: true, activity_version: @activity.version, rule_uid: @spelling_rule.uid)
+
+    @third_session_feedback1 = create(:feedback_history, feedback_session_uid: @activity_session3_uid, prompt_id: @because_prompt1.id, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.65}}, rule_uid: @grammar_rule.uid)
+    @third_session_feedback2 = create(:feedback_history, feedback_session_uid: @activity_session3_uid, prompt_id: @because_prompt1.id, attempt: 2, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.44}}, rule_uid: @automl_rule.uid)
+    @third_session_feedback3 = create(:feedback_history, feedback_session_uid: @activity_session3_uid, prompt_id: @because_prompt1.id, attempt: 3, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.99}}, rule_uid: @grammar_rule.uid)
+    @third_session_feedback4 = create(:feedback_history, feedback_session_uid: @activity_session3_uid, prompt_id: @because_prompt1.id, attempt: 4, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.99}}, rule_uid: @opinion_rule.uid)
+    @third_session_feedback5 = create(:feedback_history, feedback_session_uid: @activity_session3_uid, prompt_id: @because_prompt1.id, attempt: 5, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.99}}, rule_uid: @automl_rule.uid)
+
+    @fourth_session_feedback = create(:feedback_history, feedback_session_uid: @activity_session4_uid, prompt_id: @because_prompt1.id, optimal: true, activity_version: @previous_version, metadata: {api: {confidence: 0.99}}, rule_uid: @grammar_rule.uid)
+    create(:feedback_history, feedback_session_uid: @activity_session4_uid, prompt_id: @because_prompt1.id, attempt: 2, optimal: false, activity_version: @previous_version, metadata: {api: {confidence: 0.99}}, rule_uid: @grammar_rule.uid)
+
+    @fifth_session_feedback = create(:feedback_history, feedback_session_uid: @activity_session5_uid, prompt_id: @because_prompt1.id, optimal: false, activity_version: @activity.version, rule_uid: @opinion_rule.uid)
+    @fifth_session_feedback2 = create(:feedback_history, feedback_session_uid: @activity_session5_uid, prompt_id: @because_prompt1.id, attempt: 2, optimal: true, activity_version: @activity.version, rule_uid: @grammar_rule.uid)
+
+    @prompt_feedback_history = PromptFeedbackHistory.run({activity_id: @activity.id, activity_version: @activity.version})
+  end
+
+  let(:expected_results) do
+    {
+      prompt_id: @because_prompt1.id,
+      activity_short_name: @activity.notes,
+      text: @because_prompt1.text,
+      current_version: @activity.version,
+      version_responses: 10,
+      first_attempt_optimal: 25,
+      final_attempt_optimal: 75,
+      avg_attempts: 2.5,
+      confidence: 0.85,
+      percent_automl_consecutive_repeated: 0,
+      percent_automl: 30,
+      percent_plagiarism: 10,
+      percent_opinion: 20,
+      percent_grammar: 30,
+      percent_spelling: 10,
+      avg_time_spent_per_prompt: 287
+    }
+  end
+
+  it 'correct basic data for that prompt' do
+    prompt = @because_prompt1
+    data = SerializeEvidencePromptHealth.new(prompt, @prompt_feedback_history).data
+    expect(data).to eq expected_results
+  end
+end

--- a/services/QuillLMS/spec/workers/populate_aggregated_evidence_activity_healths_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_aggregated_evidence_activity_healths_worker_spec.rb
@@ -13,6 +13,8 @@ describe PopulateAggregatedEvidenceActivityHealthsWorker do
   let(:connect_activity) { create(:activity, activity_classification_id: connect.id) }
   let(:evidence_activity) { Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1) }
   let(:evidence_activity_two) { Evidence::Activity.create!(notes: 'Title_2', title: 'Title 2', parent_activity_id: 1, target_level: 1) }
+  let(:parent_archived_activity) { create(:activity, flag: "archived")}
+  let(:archived_evidence_activity) { Evidence::Activity.create!(notes: 'Title_3', title: 'Title 3', parent_activity_id: parent_archived_activity.id, target_level: 1) }
 
   it 'should kick off populate activity health worker jobs spread out by interval' do
     stub_const("PopulateEvidenceActivityHealthsWorker::INTERVAL", 5)
@@ -38,5 +40,14 @@ describe PopulateAggregatedEvidenceActivityHealthsWorker do
     subject.perform
     expect(Evidence::ActivityHealth.count).to eq(0)
     expect(Evidence::ActivityHealth.create(name: "title1", activity_id: 1, flag: "alpha", version: 1, version_plays: 0, total_plays: 0).id).to eq(1)
+  end
+
+  it 'should not run for archived evidence activity' do
+    stub_const("PopulateEvidenceActivityHealthsWorker::INTERVAL", 5)
+
+    expect(PopulateEvidenceActivityHealthWorker).to receive(:perform_in).with(0, evidence_activity.id).once
+    expect(PopulateEvidenceActivityHealthWorker).not_to receive(:perform_in).with(a_multiple_of(5), archived_evidence_activity.id)
+
+    subject.perform
   end
 end


### PR DESCRIPTION
* Revert "style change"

This reverts commit 80e86ccfed84b509b26a8978db61e696c5c551a3.

* first files

* perform nightly

* pk comments

* fix broken test

* extra file removed

* pk comments

* basic serializer class added with no tests

* add first specs

* add spec for prompt health

* do not run for archived activities

* linting

* brendan changes

* last brendan changes

* reduce the interval

* put the interval back to 180

* change query for activity time spent

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
