### PR TITLE
don't let admins impersonating admins see school dashboards

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard-header.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard-header.scss
@@ -2,7 +2,7 @@
   background-color: white;
   border-bottom: 10px solid #00c2a2;
   .admin-nav-bar {
-    max-width: 950px;
+    max-width: $sitewidepagewidth;
     margin: 0 auto;
   }
   h4 {

--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_dashboard/admin-dashboard.scss
@@ -1,5 +1,12 @@
 #admin-dashboard {
 
+  .sub-container {
+    section {
+      padding: 0;
+      border-bottom: none;
+    }
+  }
+
   .error, .message {
     font-size: 16px;
     margin-top: 15px;
@@ -16,11 +23,6 @@
   h2 {
     font-size: 26px;
     font-weight: 700;
-  }
-
-  section {
-    padding: 0;
-    border-bottom: none;
   }
 
   .blur {

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -56,7 +56,7 @@ class ProfilesController < ApplicationController
   end
 
   def teacher
-    if @user.schools_admins.any?
+    if @user.schools_admins.any? && !admin_impersonating_user?(@user)
       redirect_to teachers_admin_dashboard_path
     else
       redirect_to dashboard_teachers_classrooms_path

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -74,7 +74,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def dashboard
-    if current_user.classrooms_i_teach.empty? && current_user.archived_classrooms.none? && !current_user.has_outstanding_coteacher_invitation? && current_user.schools_admins.any?
+    if current_user.classrooms_i_teach.empty? && current_user.archived_classrooms.none? && !current_user.has_outstanding_coteacher_invitation? && current_user.schools_admins.any? && !admin_impersonating_user?(current_user)
       redirect_to teachers_admin_dashboard_path
     end
 

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -61,7 +61,7 @@ class TeachersController < ApplicationController
   end
 
   def admin_dashboard
-    if current_user.present? && current_user.admin?
+    if current_user.present? && current_user.admin? && !admin_impersonating_user?(current_user)
       render 'admin'
     else
       redirect_to profile_path

--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -73,4 +73,9 @@ module NavigationHelper
   def should_render_subnav?
     home_page_should_be_active? || classes_page_should_be_active? || student_reports_page_should_be_active?
   end
+
+  # this is a duplicate of the QuillAuthentication method, used here because we can't import it directly
+  def admin_impersonating_user?(user)
+    session[:admin_id].present? && session[:admin_id] != user.id
+  end
 end

--- a/services/QuillLMS/app/views/application/_admin_dashboard_header.html.erb
+++ b/services/QuillLMS/app/views/application/_admin_dashboard_header.html.erb
@@ -1,0 +1,12 @@
+<% if admin_impersonating_user?(current_user) %>
+  <div class="teacher-dashboard" id="admin-dashboard-header">
+    <div class="admin-nav-bar">
+      <h4>
+        <%= link_to("Administrator Dashboard", "/session") %>
+        <i class="fa fa-chevron-right"></i>
+        <%= "#{current_user.name} Account" %>
+      </h4>
+    </div>
+    <hr>
+  </div>
+<% end %>

--- a/services/QuillLMS/app/views/teachers/shared/_scorebook_tabs.html.erb
+++ b/services/QuillLMS/app/views/teachers/shared/_scorebook_tabs.html.erb
@@ -9,7 +9,7 @@
           <%= link_to 'Home', dashboard_teachers_classrooms_path %>
         </li>
 
-        <% if current_user.admin? %>
+        <% if current_user.admin? && !admin_impersonating_user?(current_user) %>
           <li class="admin-tab <%= 'active' if admin_page_should_be_active? %>">
             <%= link_to 'School Dashboard', teachers_admin_dashboard_path, role: 'tab' %>
           </li>


### PR DESCRIPTION
## WHAT
Hide School Dashboard tab from admins who are impersonating other admins, and redirect if they end up on the `admin_dashboard` anyway.

## WHY
This prevents a security issue where a school admin could access another school admin's account via their own admin dashboard, but if that second admin has access to additional schools, the first admin would have access to those as well.

## HOW
Use an existing helper function as necessary to prevent access to and avoid redirects to that page.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Prevent-admins-from-seeing-other-admin-dashboards-4354ffab987a443eb6489897fd10266f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES