### PR TITLE
Add more examples fields to Synthetic Data Seed data (#10038)

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -4,7 +4,7 @@ import ReactHtmlParser from 'react-html-parser'
 
 import SubmissionModal from '../shared/submissionModal';
 import { fetchActivity, createSeedData } from '../../../utils/evidence/activityAPIs';
-import { renderHeader } from "../../../helpers/evidence/renderHelpers";
+import { renderHeader, quillCloseX } from "../../../helpers/evidence/renderHelpers";
 import { Input, Spinner } from '../../../../Shared/index';
 import { TITLE, BECAUSE, BUT, SO } from "../../../../../constants/evidence";
 
@@ -18,7 +18,7 @@ const SeedDataForm = ({ history, match }) => {
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
-  const blankLabelConfig = { label: '', examples: ['',''], };
+  const blankLabelConfig = { label: '', examples: ['','',''], };
   const blankLabelConfigs = { [BECAUSE] : [], [BUT] : [], [SO] : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
@@ -40,6 +40,29 @@ const SeedDataForm = ({ history, match }) => {
     conjunctionData[index].examples[exampleIndex] = event.target.value;
     data[conjunction] = conjunctionData;
 
+    setLabelConfigs(data)
+  }
+
+  function removeExample(conjunction, index, exampleIndex) {
+    const data = {...labelConfigs}
+    const exampleData = data[conjunction][index].examples
+
+    exampleData.splice(exampleIndex, 1)
+    data[conjunction][index].examples = exampleData
+
+    setLabelConfigs(data)
+  }
+
+  function onAddExample(e) {
+    const { target } = e;
+    const { id, value } = target;
+    addExample(value, id);
+  }
+
+  function addExample(conjunction, index) {
+    const data = {...labelConfigs}
+
+    data[conjunction][index].examples.push('')
     setLabelConfigs(data)
   }
 
@@ -112,11 +135,20 @@ const SeedDataForm = ({ history, match }) => {
 
   function renderExample(value, index, conjunction, exampleIndex) {
     return (
-      <Input
-        handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
-        label={`Example ${exampleIndex + 1}`}
-        value={value}
-      />
+      <div className='example-container'>
+        <Input
+          className="example-input"
+          handleChange={e => handleExampleChange(e, index, conjunction, exampleIndex)}
+          label={`Example ${exampleIndex + 1}`}
+          value={value}
+        />
+        <button
+          className='x-button'
+          onClick={() => removeExample(conjunction, index, exampleIndex)}
+        >
+          <img alt="quill-circle-checkmark" src={quillCloseX} />
+        </button>
+      </div>
     );
   }
 
@@ -140,7 +172,16 @@ const SeedDataForm = ({ history, match }) => {
           />
         </div>
         {labelConfig.examples.map((example, exampleIndex) => renderExample(example, index, conjunction, exampleIndex))}
+        <button
+          className='quill-button fun secondary outlined'
+          id={index}
+          onClick={onAddExample}
+          value={conjunction}
+        >
+          <span className='plus'>+</span>
 
+          &nbsp;Add Example
+        </button>
       </div>
     );
   }

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/renderHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/renderHelpers.tsx
@@ -8,6 +8,8 @@ import { RULE_TYPE_TO_ROUTE_PART, RULE_TYPE_TO_NAME } from "../../../../constant
 const quillCheckmark = `/images/green_check.svg`;
 const quillX = '/images/red_x.svg';
 
+export const quillCloseX = '/images/x.svg';
+
 export const getCheckIcon = (value: boolean) => {
   if(value) {
     return (<img alt="quill-circle-checkmark" src={quillCheckmark} />)

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -25,6 +25,15 @@
     width: 25%;
     min-width: 100px;
   }
+  .example-container {
+    position: relative
+  }
+  .x-button {
+    position: absolute;
+    right: 0;
+    bottom: 20px;
+    z-index: 1;
+  }
   .plus {
     font-size: 30px;
   }


### PR DESCRIPTION
* Default to 3 examples for seed data.

* Add Add Example button.

* Add Remove button, working version.

* Remove unneeded props and params.

* Fix missing param.

* Remove unused onRemoveExample since I couldn’t get it working.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
